### PR TITLE
Add direction prefix to androidtv_remote send_command

### DIFF
--- a/homeassistant/components/androidtv_remote/remote.py
+++ b/homeassistant/components/androidtv_remote/remote.py
@@ -26,6 +26,7 @@ from .helpers import AndroidTVRemoteConfigEntry
 PARALLEL_UPDATES = 0
 
 PREFIX_SEPARATOR: Final[str] = ":"
+# Only direction prefixes are stripped; other colon conventions (e.g. text:) pass through to the library unchanged.
 VALID_PREFIXES: Final[frozenset[str]] = frozenset(
     {
         "SHORT",
@@ -126,18 +127,19 @@ class AndroidTVRemoteEntity(AndroidTVRemoteBaseEntity, RemoteEntity):
         for _ in range(num_repeats):
             for single_command in command:
                 key_code, direction = _parse_command(single_command)
-                if direction is not None and not key_code:
-                    raise ServiceValidationError(
-                        translation_domain=DOMAIN,
-                        translation_key="empty_key_code",
-                        translation_placeholders={"command": single_command},
-                    )
-                if direction is not None and hold_secs:
-                    raise ServiceValidationError(
-                        translation_domain=DOMAIN,
-                        translation_key="direction_prefix_with_hold_secs",
-                        translation_placeholders={"command": single_command},
-                    )
+                if direction is not None:
+                    if not key_code:
+                        raise ServiceValidationError(
+                            translation_domain=DOMAIN,
+                            translation_key="empty_key_code",
+                            translation_placeholders={"command": single_command},
+                        )
+                    if hold_secs:
+                        raise ServiceValidationError(
+                            translation_domain=DOMAIN,
+                            translation_key="direction_prefix_with_hold_secs",
+                            translation_placeholders={"command": single_command},
+                        )
                 if hold_secs:
                     self._send_key_command(key_code, "START_LONG")
                     await asyncio.sleep(hold_secs)

--- a/homeassistant/components/androidtv_remote/remote.py
+++ b/homeassistant/components/androidtv_remote/remote.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from collections.abc import Iterable
-from typing import Any, override
+from typing import Any, Final, override
 
 from homeassistant.components.remote import (
     ATTR_ACTIVITY,
@@ -23,6 +23,25 @@ from .entity import AndroidTVRemoteBaseEntity
 from .helpers import AndroidTVRemoteConfigEntry
 
 PARALLEL_UPDATES = 0
+
+PREFIX_SEPARATOR: Final[str] = ":"
+VALID_PREFIXES: Final[frozenset[str]] = frozenset(
+    {
+        "SHORT",
+        "START_LONG",
+        "END_LONG",
+    }
+)
+
+
+def _parse_command(single_command: str) -> tuple[str, str | None]:
+    """Split an optional prefix from the key code."""
+    prefix, separator, rest = single_command.partition(PREFIX_SEPARATOR)
+    if separator:
+        normalized = prefix.upper()
+        if normalized in VALID_PREFIXES:
+            return rest, normalized
+    return single_command, None
 
 
 async def async_setup_entry(
@@ -105,10 +124,11 @@ class AndroidTVRemoteEntity(AndroidTVRemoteBaseEntity, RemoteEntity):
 
         for _ in range(num_repeats):
             for single_command in command:
+                key_code, direction = _parse_command(single_command)
                 if hold_secs:
-                    self._send_key_command(single_command, "START_LONG")
+                    self._send_key_command(key_code, "START_LONG")
                     await asyncio.sleep(hold_secs)
-                    self._send_key_command(single_command, "END_LONG")
+                    self._send_key_command(key_code, "END_LONG")
                 else:
-                    self._send_key_command(single_command, "SHORT")
+                    self._send_key_command(key_code, direction or "SHORT")
                 await asyncio.sleep(delay_secs)

--- a/homeassistant/components/androidtv_remote/remote.py
+++ b/homeassistant/components/androidtv_remote/remote.py
@@ -16,9 +16,10 @@ from homeassistant.components.remote import (
     RemoteEntityFeature,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import CONF_APP_NAME
+from .const import CONF_APP_NAME, DOMAIN
 from .entity import AndroidTVRemoteBaseEntity
 from .helpers import AndroidTVRemoteConfigEntry
 
@@ -125,6 +126,18 @@ class AndroidTVRemoteEntity(AndroidTVRemoteBaseEntity, RemoteEntity):
         for _ in range(num_repeats):
             for single_command in command:
                 key_code, direction = _parse_command(single_command)
+                if direction is not None and not key_code:
+                    raise ServiceValidationError(
+                        translation_domain=DOMAIN,
+                        translation_key="empty_key_code",
+                        translation_placeholders={"command": single_command},
+                    )
+                if direction is not None and hold_secs:
+                    raise ServiceValidationError(
+                        translation_domain=DOMAIN,
+                        translation_key="direction_prefix_with_hold_secs",
+                        translation_placeholders={"command": single_command},
+                    )
                 if hold_secs:
                     self._send_key_command(key_code, "START_LONG")
                     await asyncio.sleep(hold_secs)

--- a/homeassistant/components/androidtv_remote/strings.json
+++ b/homeassistant/components/androidtv_remote/strings.json
@@ -56,6 +56,12 @@
     "connection_closed": {
       "message": "Connection to the Android TV device is closed"
     },
+    "direction_prefix_with_hold_secs": {
+      "message": "Command \"{command}\" combines a direction prefix with hold_secs; specify only one"
+    },
+    "empty_key_code": {
+      "message": "Command \"{command}\" is missing a key code after the direction prefix"
+    },
     "invalid_channel": {
       "message": "Channel must be numeric: {media_id}"
     },

--- a/tests/components/androidtv_remote/test_remote.py
+++ b/tests/components/androidtv_remote/test_remote.py
@@ -174,6 +174,151 @@ async def test_remote_send_command_with_hold_secs(
     ]
 
 
+@pytest.mark.parametrize(
+    ("command", "expected_call"),
+    [
+        ("start_long:DPAD_DOWN", call("DPAD_DOWN", "START_LONG")),
+        ("end_long:DPAD_DOWN", call("DPAD_DOWN", "END_LONG")),
+        ("short:DPAD_DOWN", call("DPAD_DOWN", "SHORT")),
+        ("START_LONG:DPAD_DOWN", call("DPAD_DOWN", "START_LONG")),
+    ],
+    ids=["start", "end", "short", "uppercase_prefix"],
+)
+async def test_remote_send_command_with_direction_prefix(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_api: MagicMock,
+    command: str,
+    expected_call: object,
+) -> None:
+    """Test remote.send_command emits a single directional event for prefixed commands."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    await hass.services.async_call(
+        "remote",
+        "send_command",
+        {
+            "entity_id": REMOTE_ENTITY,
+            "command": command,
+            "delay_secs": 0.01,
+        },
+        blocking=True,
+    )
+    assert mock_api.send_key_command.mock_calls == [expected_call]
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "text:hello world",
+        "voice:something",
+        "DPAD_DOWN:WITH_COLON",
+        ":leading_colon",
+    ],
+    ids=["text_prefix", "unknown_prefix", "embedded_colon", "leading_colon"],
+)
+async def test_remote_send_command_unknown_prefix_passes_through(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_api: MagicMock,
+    command: str,
+) -> None:
+    """Test that commands with non-direction colon prefixes are forwarded verbatim.
+
+    The integration only strips prefixes that match the allowlist;
+    other colon-using conventions (notably the lib's own ``text:`` prefix for
+    keyboard text) must reach the underlying library unchanged so it can apply
+    its own routing.
+    """
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    await hass.services.async_call(
+        "remote",
+        "send_command",
+        {
+            "entity_id": REMOTE_ENTITY,
+            "command": command,
+            "delay_secs": 0.01,
+        },
+        blocking=True,
+    )
+    assert mock_api.send_key_command.mock_calls == [call(command, "SHORT")]
+
+
+async def test_remote_send_command_direction_prefix_pair(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_api: MagicMock
+) -> None:
+    """Test that a press-down/release-up pair produces exactly two events.
+
+    This is the live-press scenario: a UI sends START_LONG on pointerdown and
+    END_LONG on pointerup as separate service calls. Together they must produce
+    no extra SHORT or sleep-driven events.
+    """
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    await hass.services.async_call(
+        "remote",
+        "send_command",
+        {
+            "entity_id": REMOTE_ENTITY,
+            "command": "start_long:DPAD_CENTER",
+            "delay_secs": 0.01,
+        },
+        blocking=True,
+    )
+    await hass.services.async_call(
+        "remote",
+        "send_command",
+        {
+            "entity_id": REMOTE_ENTITY,
+            "command": "end_long:DPAD_CENTER",
+            "delay_secs": 0.01,
+        },
+        blocking=True,
+    )
+    assert mock_api.send_key_command.mock_calls == [
+        call("DPAD_CENTER", "START_LONG"),
+        call("DPAD_CENTER", "END_LONG"),
+    ]
+
+
+async def test_remote_send_command_hold_secs_overrides_direction_prefix(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_api: MagicMock
+) -> None:
+    """Test that hold_secs takes precedence over an explicit direction prefix.
+
+    Mixing both is non-sensical; hold_secs is treated as the dominant signal
+    and runs the legacy START_LONG / sleep / END_LONG sandwich. The prefix is
+    still stripped from the key code so the underlying lib receives a clean
+    keycode rather than the raw service input.
+    """
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    await hass.services.async_call(
+        "remote",
+        "send_command",
+        {
+            "entity_id": REMOTE_ENTITY,
+            "command": "start_long:DPAD_RIGHT",
+            "delay_secs": 0.01,
+            "hold_secs": 0.01,
+        },
+        blocking=True,
+    )
+    assert mock_api.send_key_command.mock_calls == [
+        call("DPAD_RIGHT", "START_LONG"),
+        call("DPAD_RIGHT", "END_LONG"),
+    ]
+
+
 async def test_remote_connection_closed(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_api: MagicMock
 ) -> None:

--- a/tests/components/androidtv_remote/test_remote.py
+++ b/tests/components/androidtv_remote/test_remote.py
@@ -8,7 +8,7 @@ import pytest
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from tests.common import MockConfigEntry
 
@@ -288,35 +288,55 @@ async def test_remote_send_command_direction_prefix_pair(
     ]
 
 
-async def test_remote_send_command_hold_secs_overrides_direction_prefix(
+async def test_remote_send_command_direction_prefix_with_hold_secs_raises(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_api: MagicMock
 ) -> None:
-    """Test that hold_secs takes precedence over an explicit direction prefix.
-
-    Mixing both is non-sensical; hold_secs is treated as the dominant signal
-    and runs the legacy START_LONG / sleep / END_LONG sandwich. The prefix is
-    still stripped from the key code so the underlying lib receives a clean
-    keycode rather than the raw service input.
-    """
+    """Test that combining a direction prefix with hold_secs raises."""
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
-    await hass.services.async_call(
-        "remote",
-        "send_command",
-        {
-            "entity_id": REMOTE_ENTITY,
-            "command": "start_long:DPAD_RIGHT",
-            "delay_secs": 0.01,
-            "hold_secs": 0.01,
-        },
-        blocking=True,
-    )
-    assert mock_api.send_key_command.mock_calls == [
-        call("DPAD_RIGHT", "START_LONG"),
-        call("DPAD_RIGHT", "END_LONG"),
-    ]
+    with pytest.raises(
+        ServiceValidationError,
+        match='Command "start_long:DPAD_RIGHT" combines a direction prefix with hold_secs',
+    ):
+        await hass.services.async_call(
+            "remote",
+            "send_command",
+            {
+                "entity_id": REMOTE_ENTITY,
+                "command": "start_long:DPAD_RIGHT",
+                "delay_secs": 0.01,
+                "hold_secs": 0.01,
+            },
+            blocking=True,
+        )
+    assert mock_api.send_key_command.mock_calls == []
+
+
+async def test_remote_send_command_empty_key_code_raises(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_api: MagicMock
+) -> None:
+    """Test that a direction prefix without a key code raises."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    with pytest.raises(
+        ServiceValidationError,
+        match='Command "SHORT:" is missing a key code after the direction prefix',
+    ):
+        await hass.services.async_call(
+            "remote",
+            "send_command",
+            {
+                "entity_id": REMOTE_ENTITY,
+                "command": "SHORT:",
+                "delay_secs": 0.01,
+            },
+            blocking=True,
+        )
+    assert mock_api.send_key_command.mock_calls == []
 
 
 async def test_remote_connection_closed(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This change allows users to explicitly specify the `direction` of a command as an optional prefix. This enables proper button-hold interactions through home assistant with real-time response by the android tv. A button being pressed can now trigger a single command with the `START_LONG` direction, and later trigger a command with `END_LONG` direction as the button is released.

This addresses a pain point with the existing `hold_secs` functionality. Using `hold_secs` runs `START_LONG --> asyncio.sleep(hold_secs) --> END_LONG` atomically. This is helpful for scripting specific interactions, but it makes live human-controlled long-press actions clunky.

**Example usecase:**

A Zigbee dimmer (e.g. a Hue dimmer or IKEA STYRBAR) wired to the Android TV's volume keys. The dimmer emits one event when a button is pressed and another when it is released, which lets the volume ramp continuously while the button is held and stop the instant it is let go — same feel as a physical TV remote.

```yaml
# automations.yaml
- alias: TV volume up — start ramping on press
  trigger:
    - platform: event
      event_type: zha_event
      event_data:
        device_ieee: "00:0b:57:ff:fe:1a:2b:3c"
        command: button_press
        args: { button: up }
  action:
    - action: remote.send_command
      target: { entity_id: remote.living_room_tv }
      data: { command: "START_LONG:VOLUME_UP" }    # <-- START_LONG prefix

- alias: TV volume up — stop ramping on release
  trigger:
    - platform: event
      event_type: zha_event
      event_data:
        device_ieee: "00:0b:57:ff:fe:1a:2b:3c"
        command: button_release
        args: { button: up }
  action:
    - action: remote.send_command
      target: { entity_id: remote.living_room_tv }
      data: { command: "END_LONG:VOLUME_UP" }    # <-- END_LONG prefix
```

This same concept extends to any other physical button which fires separate 'press' and 'release' events. This includes a number of Zigbee, Z-wave, ESPHome or Wifi-enabled devices - as well as Web-UI integrations like the universal-remote-card (HACS) which exposes `momentary_start_action` and `momentary_end_action`.

**Implementation notes:**

- direction prefix is entirely optional
- prefix separator is `:` (colon)
- direction prefix is case-insensitive
- only known/valid directions are identified
  - allowlist: `SHORT:`, `START_LONG:`, `END_LONG:`
  - unknown prefixes are ignored and passed through verbatim --> notably, the [`text:`](https://github.com/tronikos/androidtvremote2/blob/main/src/androidtvremote2/remote.py#L144) prefix continues to work as before
- plain commands retain their current behavior and are sent with `SHORT` direction by default
- `hold_secs` functionality retains its current behavior. When `hold_secs` parameter supplied, it overrules the direction prefix.

**Prior art for the prefix shape:**

The [`broadlink/remote.py#L144`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/broadlink/remote.py#L144) implementation also uses a colon-separated prefix to trigger alternative behavior.

cc @tronikos @Drafteed

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45253
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
