### PR TITLE
Fix local API incorrectly marking devices as unavailable in Overkiz

### DIFF
--- a/homeassistant/components/overkiz/entity.py
+++ b/homeassistant/components/overkiz/entity.py
@@ -2,7 +2,7 @@
 
 from typing import cast
 
-from pyoverkiz.enums import OverkizAttribute, OverkizState
+from pyoverkiz.enums import APIType, OverkizAttribute, OverkizCommandParam, OverkizState
 from pyoverkiz.models import Device
 
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -44,7 +44,18 @@ class OverkizEntity(CoordinatorEntity[OverkizDataUpdateCoordinator]):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        return self.device.available and super().available
+        if self.device.available:
+            return super().available
+
+        # Workaround: local API may incorrectly report available=False (Somfy-TaHoma-Developer-Mode#217)
+        if self.coordinator.client.api_type == APIType.LOCAL:
+            if status_state := self.device.states.get(OverkizState.CORE_STATUS):
+                return (
+                    status_state.value == OverkizCommandParam.AVAILABLE
+                    and super().available
+                )
+
+        return False
 
     @property
     def is_sub_device(self) -> bool:

--- a/homeassistant/components/overkiz/entity.py
+++ b/homeassistant/components/overkiz/entity.py
@@ -57,6 +57,8 @@ class OverkizEntity(CoordinatorEntity[OverkizDataUpdateCoordinator]):
                 and super().available
             )
 
+        return False
+
     @property
     def is_sub_device(self) -> bool:
         """Return True if device is a sub device."""

--- a/homeassistant/components/overkiz/entity.py
+++ b/homeassistant/components/overkiz/entity.py
@@ -48,14 +48,14 @@ class OverkizEntity(CoordinatorEntity[OverkizDataUpdateCoordinator]):
             return super().available
 
         # Workaround: local API may incorrectly report available=False (Somfy-TaHoma-Developer-Mode#217)
-        if self.coordinator.client.api_type == APIType.LOCAL:
-            if status_state := self.device.states.get(OverkizState.CORE_STATUS):
-                return (
-                    status_state.value == OverkizCommandParam.AVAILABLE
-                    and super().available
-                )
+        if self.coordinator.client.api_type != APIType.LOCAL:
+            return False
 
-        return False
+        if status_state := self.device.states.get(OverkizState.CORE_STATUS):
+            return (
+                status_state.value == OverkizCommandParam.AVAILABLE
+                and super().available
+            )
 
     @property
     def is_sub_device(self) -> bool:


### PR DESCRIPTION
## Proposed change
The Somfy TaHoma local API may report available=False at the device level for devices that are fully functional. Fall back to checking core:StatusState when using the local API to determine availability.

Fixes #167348
Related to https://github.com/Somfy-Developer/Somfy-TaHoma-Developer-Mode/issues/217

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
