### PR TITLE
Fix nobo_hub NoboProfileSelector class-level mutable defaults

### DIFF
--- a/homeassistant/components/nobo_hub/select.py
+++ b/homeassistant/components/nobo_hub/select.py
@@ -109,7 +109,7 @@ class NoboProfileSelector(NoboBaseEntity, SelectEntity):
         """Initialize the week profile selector."""
         super().__init__(hub)
         self._id = zone_id
-        self._profiles: dict[int, str] = {}
+        self._profiles: dict[str, str] = {}
         self._attr_options: list[str] = []
         self._attr_unique_id = f"{hub.hub_serial}:{zone_id}:profile"
         self._attr_device_info = DeviceInfo(

--- a/homeassistant/components/nobo_hub/select.py
+++ b/homeassistant/components/nobo_hub/select.py
@@ -103,14 +103,14 @@ class NoboProfileSelector(NoboBaseEntity, SelectEntity):
     """Week profile selector for Nobø zones."""
 
     _attr_translation_key = "week_profile"
-    _profiles: dict[int, str] = {}
-    _attr_options: list[str] = []
     _attr_current_option: str | None = None
 
     def __init__(self, zone_id: str, hub: nobo) -> None:
         """Initialize the week profile selector."""
         super().__init__(hub)
         self._id = zone_id
+        self._profiles: dict[int, str] = {}
+        self._attr_options: list[str] = []
         self._attr_unique_id = f"{hub.hub_serial}:{zone_id}:profile"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, f"{hub.hub_serial}:{zone_id}")},

--- a/tests/components/nobo_hub/test_select.py
+++ b/tests/components/nobo_hub/test_select.py
@@ -6,7 +6,6 @@ from pynobo import nobo
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.nobo_hub.select import NoboProfileSelector
 from homeassistant.components.select import (
     ATTR_OPTION,
     DOMAIN as SELECT_DOMAIN,
@@ -148,15 +147,3 @@ async def test_zone_removed_marks_week_profile_unavailable(
     mock_nobo_hub.zones.pop("1")
     await fire_hub_update(hass, mock_nobo_hub)
     assert hass.states.get(PROFILE_ENTITY).state == STATE_UNAVAILABLE
-
-
-def test_profile_selector_state_is_per_instance(mock_nobo_hub: MagicMock) -> None:
-    """NoboProfileSelector mutable state must live on the instance, not the class.
-
-    Mutable defaults at class level would be shared across every selector
-    in the integration (multi-zone, multi-hub).
-    """
-    selector_a = NoboProfileSelector("1", mock_nobo_hub)
-    selector_b = NoboProfileSelector("1", mock_nobo_hub)
-    assert selector_a._profiles is not selector_b._profiles
-    assert selector_a._attr_options is not selector_b._attr_options

--- a/tests/components/nobo_hub/test_select.py
+++ b/tests/components/nobo_hub/test_select.py
@@ -6,6 +6,7 @@ from pynobo import nobo
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.nobo_hub.select import NoboProfileSelector
 from homeassistant.components.select import (
     ATTR_OPTION,
     DOMAIN as SELECT_DOMAIN,
@@ -147,3 +148,15 @@ async def test_zone_removed_marks_week_profile_unavailable(
     mock_nobo_hub.zones.pop("1")
     await fire_hub_update(hass, mock_nobo_hub)
     assert hass.states.get(PROFILE_ENTITY).state == STATE_UNAVAILABLE
+
+
+def test_profile_selector_state_is_per_instance(mock_nobo_hub: MagicMock) -> None:
+    """NoboProfileSelector mutable state must live on the instance, not the class.
+
+    Mutable defaults at class level would be shared across every selector
+    in the integration (multi-zone, multi-hub).
+    """
+    selector_a = NoboProfileSelector("1", mock_nobo_hub)
+    selector_b = NoboProfileSelector("1", mock_nobo_hub)
+    assert selector_a._profiles is not selector_b._profiles
+    assert selector_a._attr_options is not selector_b._attr_options


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix nobo_hub `NoboProfileSelector` class-level mutable defaults.
The class fields were never mutated, so this is just a hygiene fix.

Discovered during review of PR #168638

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
