### PR TITLE
Add `ZWaveNodeBaseEntity` for Z-Wave node-level entities

### DIFF
--- a/homeassistant/components/zwave_js/button.py
+++ b/homeassistant/components/zwave_js/button.py
@@ -9,10 +9,9 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, LOGGER
+from .const import DOMAIN
 from .discovery import ZwaveDiscoveryInfo
-from .entity import ZWaveBaseEntity
-from .helpers import get_device_info, get_valueless_base_unique_id
+from .entity import ZWaveBaseEntity, ZWaveNodeBaseEntity
 from .models import ZwaveJSConfigEntry
 
 PARALLEL_UPDATES = 0
@@ -78,54 +77,16 @@ class ZwaveBooleanNodeButton(ZWaveBaseEntity, ButtonEntity):
         await self._async_set_value(self.info.primary_value, True)
 
 
-class ZWaveNodePingButton(ButtonEntity):
+class ZWaveNodePingButton(ZWaveNodeBaseEntity, ButtonEntity):
     """Representation of a ping button entity."""
 
-    _attr_should_poll = False
     _attr_entity_category = EntityCategory.CONFIG
-    _attr_has_entity_name = True
     _attr_translation_key = "ping"
 
     def __init__(self, driver: Driver, node: ZwaveNode) -> None:
         """Initialize a ping Z-Wave device button entity."""
-        self.node = node
-
-        # Entity class attributes
-        self._base_unique_id = get_valueless_base_unique_id(driver, node)
+        super().__init__(driver, node)
         self._attr_unique_id = f"{self._base_unique_id}.ping"
-        # device may not be precreated in main handler yet
-        self._attr_device_info = get_device_info(driver, node)
-
-    async def async_poll_value(self, _: bool) -> None:
-        """Poll a value."""
-        # We log an error instead of raising an exception because this service call occurs
-        # in a separate task since it is called via the dispatcher and we don't want to
-        # raise the exception in that separate task because it is confusing to the user.
-        LOGGER.error(
-            "There is no value to refresh for this entity so the zwave_js.refresh_value"
-            " service won't work for it"
-        )
-
-    async def async_added_to_hass(self) -> None:
-        """Call when entity is added."""
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                f"{DOMAIN}_{self.unique_id}_poll_value",
-                self.async_poll_value,
-            )
-        )
-
-        # we don't listen for `remove_entity_on_ready_node` signal because this entity
-        # is created when the node is added which occurs before ready. It only needs to
-        # be removed if the node is removed from the network.
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                f"{DOMAIN}_{self._base_unique_id}_remove_entity",
-                self.async_remove,
-            )
-        )
 
     async def async_press(self) -> None:
         """Press the button."""

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from zwave_js_server.exceptions import BaseZwaveJSServerError
 from zwave_js_server.model.driver import Driver
+from zwave_js_server.model.node import Node as ZwaveNode
 from zwave_js_server.model.value import (
     SetValueResult,
     Value as ZwaveValue,
@@ -28,7 +29,12 @@ from .const import (
     LOGGER,
 )
 from .discovery_data_template import BaseDiscoverySchemaDataTemplate
-from .helpers import get_device_id, get_unique_id, get_valueless_base_unique_id
+from .helpers import (
+    get_device_id,
+    get_device_info,
+    get_unique_id,
+    get_valueless_base_unique_id,
+)
 from .models import PlatformZwaveDiscoveryInfo, ZwaveDiscoveryInfo, ZwaveJSConfigEntry
 
 
@@ -426,3 +432,64 @@ class ZWaveBaseEntity(Entity):
             raise HomeAssistantError(
                 f"Unable to set value {value.value_id}: {err}"
             ) from err
+
+
+class ZWaveNodeBaseEntity(Entity):
+    """Base entity class for Z-Wave node-level (non-value) entities.
+
+    Used for entities that exist for the whole node rather than a specific
+    Z-Wave Value (e.g. firmware update, ping button, node status sensor).
+    """
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    # Subclasses can opt in to also being removed when a node starts a
+    # reinterview. Useful for entities whose existence depends on CCs that
+    # may disappear during reinterview.
+    _remove_on_reinterview = False
+
+    def __init__(self, driver: Driver, node: ZwaveNode) -> None:
+        """Initialize a Z-Wave node-level entity."""
+        self.driver = driver
+        self.node = node
+
+        self._base_unique_id = get_valueless_base_unique_id(driver, node)
+        # device may not be precreated in main handler yet
+        self._attr_device_info = get_device_info(driver, node)
+
+    async def async_poll_value(self, _: bool) -> None:
+        """Poll a value (no-op for entities not backed by a Z-Wave Value)."""
+        # We log an error instead of raising an exception because this service
+        # call occurs in a separate task since it is called via the dispatcher
+        # and we don't want to raise the exception in that separate task because
+        # it is confusing to the user.
+        LOGGER.error(
+            "There is no value to refresh for this entity so the zwave_js.refresh_value"
+            " service won't work for it"
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Call when entity is added."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{DOMAIN}_{self.unique_id}_poll_value",
+                self.async_poll_value,
+            )
+        )
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{DOMAIN}_{self._base_unique_id}_remove_entity",
+                self.async_remove,
+            )
+        )
+        if self._remove_on_reinterview:
+            self.async_on_remove(
+                async_dispatcher_connect(
+                    self.hass,
+                    f"{DOMAIN}_{self._base_unique_id}_remove_entity_on_interview_started",
+                    self.async_remove,
+                )
+            )

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -465,8 +465,9 @@ class ZWaveNodeBaseEntity(Entity):
         # and we don't want to raise the exception in that separate task because
         # it is confusing to the user.
         LOGGER.error(
-            "There is no value to refresh for this entity so the zwave_js.refresh_value"
-            " service won't work for it"
+            "There is no value to refresh for %s so the zwave_js.refresh_value"
+            " service won't work for it",
+            self.entity_id,
         )
 
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -116,8 +116,7 @@ from .discovery_data_template import (
     NumericSensorDataTemplate,
     NumericSensorDataTemplateData,
 )
-from .entity import NewZwaveDiscoveryInfo, ZWaveBaseEntity
-from .helpers import get_device_info, get_valueless_base_unique_id
+from .entity import NewZwaveDiscoveryInfo, ZWaveBaseEntity, ZWaveNodeBaseEntity
 from .migrate import async_migrate_statistics_sensors
 from .models import (
     NewZWaveDiscoverySchema,
@@ -1033,36 +1032,19 @@ class ZWaveConfigParameterSensor(ZWaveListSensor):
         return {ATTR_VALUE: value}
 
 
-class ZWaveNodeStatusSensor(SensorEntity):
+class ZWaveNodeStatusSensor(ZWaveNodeBaseEntity, SensorEntity):
     """Representation of a node status sensor."""
 
-    _attr_should_poll = False
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_has_entity_name = True
     _attr_translation_key = "node_status"
 
     def __init__(
         self, config_entry: ZwaveJSConfigEntry, driver: Driver, node: ZwaveNode
     ) -> None:
         """Initialize a generic Z-Wave device entity."""
+        super().__init__(driver, node)
         self.config_entry = config_entry
-        self.node = node
-
-        # Entity class attributes
-        self._base_unique_id = get_valueless_base_unique_id(driver, node)
         self._attr_unique_id = f"{self._base_unique_id}.node_status"
-        # device may not be precreated in main handler yet
-        self._attr_device_info = get_device_info(driver, node)
-
-    async def async_poll_value(self, _: bool) -> None:
-        """Poll a value."""
-        # We log an error instead of raising an exception because this service call occurs
-        # in a separate task since it is called via the dispatcher and we don't want to
-        # raise the exception in that separate task because it is confusing to the user.
-        LOGGER.error(
-            "There is no value to refresh for this entity so the zwave_js.refresh_value"
-            " service won't work for it"
-        )
 
     @callback
     def _status_changed(self, _: dict) -> None:
@@ -1072,60 +1054,27 @@ class ZWaveNodeStatusSensor(SensorEntity):
 
     async def async_added_to_hass(self) -> None:
         """Call when entity is added."""
-        # Add value_changed callbacks.
+        await super().async_added_to_hass()
         for evt in ("wake up", "sleep", "dead", "alive"):
             self.async_on_remove(self.node.on(evt, self._status_changed))
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                f"{DOMAIN}_{self.unique_id}_poll_value",
-                self.async_poll_value,
-            )
-        )
-        # we don't listen for `remove_entity_on_ready_node` signal because this entity
-        # is created when the node is added which occurs before ready. It only needs to
-        # be removed if the node is removed from the network.
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                f"{DOMAIN}_{self._base_unique_id}_remove_entity",
-                self.async_remove,
-            )
-        )
         self._attr_native_value: str = self.node.status.name.lower()
         self.async_write_ha_state()
 
 
-class ZWaveControllerStatusSensor(SensorEntity):
+class ZWaveControllerStatusSensor(ZWaveNodeBaseEntity, SensorEntity):
     """Representation of a controller status sensor."""
 
-    _attr_should_poll = False
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_has_entity_name = True
     _attr_translation_key = "controller_status"
 
     def __init__(self, config_entry: ZwaveJSConfigEntry, driver: Driver) -> None:
         """Initialize a generic Z-Wave device entity."""
-        self.config_entry = config_entry
         self.controller = driver.controller
         node = self.controller.own_node
         assert node
-
-        # Entity class attributes
-        self._base_unique_id = get_valueless_base_unique_id(driver, node)
+        super().__init__(driver, node)
+        self.config_entry = config_entry
         self._attr_unique_id = f"{self._base_unique_id}.controller_status"
-        # device may not be precreated in main handler yet
-        self._attr_device_info = get_device_info(driver, node)
-
-    async def async_poll_value(self, _: bool) -> None:
-        """Poll a value."""
-        # We log an error instead of raising an exception because this service call occurs
-        # in a separate task since it is called via the dispatcher and we don't want to
-        # raise the exception in that separate task because it is confusing to the user.
-        LOGGER.error(
-            "There is no value to refresh for this entity so the zwave_js.refresh_value"
-            " service won't work for it"
-        )
 
     @callback
     def _status_changed(self, _: dict) -> None:
@@ -1135,34 +1084,16 @@ class ZWaveControllerStatusSensor(SensorEntity):
 
     async def async_added_to_hass(self) -> None:
         """Call when entity is added."""
-        # Add value_changed callbacks.
+        await super().async_added_to_hass()
         self.async_on_remove(self.controller.on("status changed", self._status_changed))
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                f"{DOMAIN}_{self.unique_id}_poll_value",
-                self.async_poll_value,
-            )
-        )
-        # we don't listen for `remove_entity_on_ready_node` signal because this is not
-        # a regular node
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                f"{DOMAIN}_{self._base_unique_id}_remove_entity",
-                self.async_remove,
-            )
-        )
         self._attr_native_value: str = self.controller.status.name.lower()
 
 
-class ZWaveStatisticsSensor(SensorEntity):
+class ZWaveStatisticsSensor(ZWaveNodeBaseEntity, SensorEntity):
     """Representation of a node/controller statistics sensor."""
 
     entity_description: ZWaveJSStatisticsSensorEntityDescription
-    _attr_should_poll = False
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -1172,8 +1103,6 @@ class ZWaveStatisticsSensor(SensorEntity):
         description: ZWaveJSStatisticsSensorEntityDescription,
     ) -> None:
         """Initialize a Z-Wave statistics entity."""
-        self.entity_description = description
-        self.config_entry = config_entry
         self.statistics_src = statistics_src
         node = (
             statistics_src.own_node
@@ -1181,22 +1110,10 @@ class ZWaveStatisticsSensor(SensorEntity):
             else statistics_src
         )
         assert node
-
-        # Entity class attributes
-        self._base_unique_id = get_valueless_base_unique_id(driver, node)
+        super().__init__(driver, node)
+        self.entity_description = description
+        self.config_entry = config_entry
         self._attr_unique_id = f"{self._base_unique_id}.statistics_{description.key}"
-        # device may not be precreated in main handler yet
-        self._attr_device_info = get_device_info(driver, node)
-
-    async def async_poll_value(self, _: bool) -> None:
-        """Poll a value."""
-        # We log an error instead of raising an exception because this service call occurs
-        # in a separate task since it is called via the dispatcher and we don't want to
-        # raise the exception in that separate task because it is confusing to the user.
-        LOGGER.error(
-            "There is no value to refresh for this entity so the zwave_js.refresh_value"
-            " service won't work for it"
-        )
 
     @callback
     def _statistics_updated(self, event_data: dict) -> None:
@@ -1226,20 +1143,7 @@ class ZWaveStatisticsSensor(SensorEntity):
 
     async def async_added_to_hass(self) -> None:
         """Call when entity is added."""
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                f"{DOMAIN}_{self.unique_id}_poll_value",
-                self.async_poll_value,
-            )
-        )
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                f"{DOMAIN}_{self._base_unique_id}_remove_entity",
-                self.async_remove,
-            )
-        )
+        await super().async_added_to_hass()
         self.async_on_remove(
             self.statistics_src.on("statistics updated", self._statistics_updated)
         )

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -34,7 +34,7 @@ from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.restore_state import ExtraStoredData
 
 from .const import API_KEY_FIRMWARE_UPDATE_SERVICE, DOMAIN, LOGGER
-from .helpers import get_device_info, get_valueless_base_unique_id
+from .entity import ZWaveNodeBaseEntity
 from .models import ZwaveJSConfigEntry
 
 PARALLEL_UPDATES = 1
@@ -162,12 +162,10 @@ async def async_setup_entry(
     )
 
 
-class ZWaveFirmwareUpdateEntity(UpdateEntity):
+class ZWaveFirmwareUpdateEntity(ZWaveNodeBaseEntity, UpdateEntity):
     """Representation of a firmware update entity."""
 
-    driver: Driver
     entity_description: ZWaveUpdateEntityDescription
-    node: ZwaveNode
     _attr_entity_category = EntityCategory.CONFIG
     _attr_device_class = UpdateDeviceClass.FIRMWARE
     _attr_supported_features = (
@@ -175,8 +173,7 @@ class ZWaveFirmwareUpdateEntity(UpdateEntity):
         | UpdateEntityFeature.RELEASE_NOTES
         | UpdateEntityFeature.PROGRESS
     )
-    _attr_has_entity_name = True
-    _attr_should_poll = False
+    _remove_on_reinterview = True
 
     def __init__(
         self,
@@ -186,9 +183,8 @@ class ZWaveFirmwareUpdateEntity(UpdateEntity):
         entity_description: ZWaveUpdateEntityDescription,
     ) -> None:
         """Initialize a Z-Wave device firmware update entity."""
-        self.driver = driver
+        super().__init__(driver, node)
         self.entity_description = entity_description
-        self.node = node
         self._latest_version_firmware: FirmwareUpdateInfo | None = None
         self._poll_unsub: Callable[[], None] | None = None
         self._progress_unsub: Callable[[], None] | None = None
@@ -199,11 +195,8 @@ class ZWaveFirmwareUpdateEntity(UpdateEntity):
 
         # Entity class attributes
         self._attr_name = "Firmware"
-        self._base_unique_id = get_valueless_base_unique_id(driver, node)
         self._attr_unique_id = f"{self._base_unique_id}.firmware_update"
         self._attr_installed_version = node.firmware_version
-        # device may not be precreated in main handler yet
-        self._attr_device_info = get_device_info(driver, node)
 
     @property
     def extra_restore_state_data(self) -> ZWaveFirmwareUpdateExtraStoredData:
@@ -345,41 +338,9 @@ class ZWaveFirmwareUpdateEntity(UpdateEntity):
         self._latest_version_firmware = None
         self._unsub_firmware_events_and_reset_progress()
 
-    async def async_poll_value(self, _: bool) -> None:
-        """Poll a value."""
-        # We log an error instead of raising an exception because this service call occurs
-        # in a separate task since it is called via the dispatcher and we don't want to
-        # raise the exception in that separate task because it is confusing to the user.
-        LOGGER.error(
-            "There is no value to refresh for this entity so the zwave_js.refresh_value"
-            " service won't work for it"
-        )
-
     async def async_added_to_hass(self) -> None:
         """Call when entity is added."""
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                f"{DOMAIN}_{self.unique_id}_poll_value",
-                self.async_poll_value,
-            )
-        )
-
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                f"{DOMAIN}_{self._base_unique_id}_remove_entity",
-                self.async_remove,
-            )
-        )
-
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                f"{DOMAIN}_{self._base_unique_id}_remove_entity_on_interview_started",
-                self.async_remove,
-            )
-        )
+        await super().async_added_to_hass()
 
         # Make sure these variables are set for the elif evaluation
         state = None

--- a/tests/components/zwave_js/test_button.py
+++ b/tests/components/zwave_js/test_button.py
@@ -64,7 +64,9 @@ async def test_ping_entity(
         blocking=True,
     )
     await hass.async_block_till_done()
-    assert "There is no value to refresh for" in caplog.text
+    assert (
+        "There is no value to refresh for button.z_wave_thermostat_ping" in caplog.text
+    )
 
     # Assert a node ping button entity is not created for the controller
     driver = client.driver

--- a/tests/components/zwave_js/test_button.py
+++ b/tests/components/zwave_js/test_button.py
@@ -64,7 +64,7 @@ async def test_ping_entity(
         blocking=True,
     )
     await hass.async_block_till_done()
-    assert "There is no value to refresh for this entity" in caplog.text
+    assert "There is no value to refresh for" in caplog.text
 
     # Assert a node ping button entity is not created for the controller
     driver = client.driver

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -505,7 +505,7 @@ async def test_node_status_sensor_not_ready(
         blocking=True,
     )
     await hass.async_block_till_done()
-    assert "There is no value to refresh for" in caplog.text
+    assert f"There is no value to refresh for {node_status_entity_id}" in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -505,7 +505,7 @@ async def test_node_status_sensor_not_ready(
         blocking=True,
     )
     await hass.async_block_till_done()
-    assert "There is no value to refresh for this entity" in caplog.text
+    assert "There is no value to refresh for" in caplog.text
 
 
 @pytest.mark.parametrize(
@@ -1125,7 +1125,7 @@ async def test_statistics_sensors(
                 blocking=True,
             )
     await hass.async_block_till_done()
-    assert caplog.text.count("There is no value to refresh for this entity") == len(
+    assert caplog.text.count("There is no value to refresh for") == len(
         [
             *CONTROLLER_STATISTICS_SUFFIXES,
             *CONTROLLER_STATISTICS_SUFFIXES_UNKNOWN,

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -220,7 +220,7 @@ async def test_update_entity_states(
         blocking=True,
     )
     await hass.async_block_till_done()
-    assert "There is no value to refresh for this entity" in caplog.text
+    assert "There is no value to refresh for" in caplog.text
 
     client.async_send_command.return_value = {"updates": []}
 

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -220,7 +220,7 @@ async def test_update_entity_states(
         blocking=True,
     )
     await hass.async_block_till_done()
-    assert "There is no value to refresh for" in caplog.text
+    assert f"There is no value to refresh for {entity_id}" in caplog.text
 
     client.async_send_command.return_value = {"updates": []}
 


### PR DESCRIPTION
## Proposed change

This PR introduces a `ZWaveNodeBaseEntity` and migrates the existing classes to use that.
That change is a small part of a refactor for node-based Z-Wave entities, suggested here: https://github.com/home-assistant/core/pull/170111#discussion_r3208817619

I can add the (bigger) rest suggested in that comment to this PR, but I think it makes sense to have this initial small PR (to already create the base class and clean up the other existing classes a bit), then do the rest in one or more follow-up PRs.


<details><summary>AI summary (click to expand)</summary>
<p>

First step of the Z-Wave node-level entity refactor [in core#170111](https://github.com/home-assistant/core/pull/170111#discussion_r2553046519). Introduces a shared base class for entities that exist for a Z-Wave node as a whole (rather than for a specific Z-Wave Value), and migrates the existing five node-level entities onto it.

Until now each node-level entity (firmware update, ping button, node status sensor, controller status sensor, statistics sensor) reimplemented essentially the same boilerplate independently:
- `_attr_should_poll = False`
- `_attr_has_entity_name = True`
- `_base_unique_id = get_valueless_base_unique_id(driver, node)`
- `_attr_device_info = get_device_info(driver, node)`
- A no-op `async_poll_value` that just logs an error
- An `async_added_to_hass` that subscribes to `_remove_entity` and (sometimes) `_remove_entity_on_interview_started`

This PR consolidates that into `ZWaveNodeBaseEntity`. Subclasses opt in to the reinterview removal signal via a single class attribute (`_remove_on_reinterview = True`).

</p>
</details> 


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
