### PR TITLE
Automatically start flow for first topic subentry in ntfy integration

### DIFF
--- a/homeassistant/components/ntfy/config_flow.py
+++ b/homeassistant/components/ntfy/config_flow.py
@@ -18,10 +18,13 @@ from yarl import URL
 
 from homeassistant import data_entry_flow
 from homeassistant.config_entries import (
+    SOURCE_USER,
     ConfigEntry,
     ConfigFlow,
     ConfigFlowResult,
     ConfigSubentryFlow,
+    FlowType,
+    SubentryFlowContext,
     SubentryFlowResult,
 )
 from homeassistant.const import (
@@ -54,6 +57,7 @@ from .const import (
     DOMAIN,
     SECTION_AUTH,
     SECTION_FILTER,
+    SUBENTRY_TYPE_TOPIC,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -164,7 +168,7 @@ class NtfyConfigFlow(ConfigFlow, domain=DOMAIN):
         cls, config_entry: ConfigEntry
     ) -> dict[str, type[ConfigSubentryFlow]]:
         """Return subentries supported by this integration."""
-        return {"topic": TopicSubentryFlowHandler}
+        return {SUBENTRY_TYPE_TOPIC: TopicSubentryFlowHandler}
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -228,6 +232,18 @@ class NtfyConfigFlow(ConfigFlow, domain=DOMAIN):
             ),
             errors=errors,
         )
+
+    async def async_on_create_entry(self, result: ConfigFlowResult) -> ConfigFlowResult:
+        """Start subentry flow after creating main entry."""
+        subentry_result = await self.hass.config_entries.subentries.async_init(
+            (result["result"].entry_id, SUBENTRY_TYPE_TOPIC),
+            context=SubentryFlowContext(source=SOURCE_USER),
+        )
+        result["next_flow"] = (
+            FlowType.CONFIG_SUBENTRIES_FLOW,
+            subentry_result["flow_id"],
+        )
+        return result
 
     async def async_step_reauth(
         self, entry_data: Mapping[str, Any]

--- a/homeassistant/components/ntfy/const.py
+++ b/homeassistant/components/ntfy/const.py
@@ -13,3 +13,5 @@ CONF_TAGS = "filter_tags"
 SECTION_AUTH = "auth"
 SECTION_FILTER = "filter"
 NTFY_EVENT = "ntfy_event"
+
+SUBENTRY_TYPE_TOPIC = "topic"

--- a/tests/components/ntfy/conftest.py
+++ b/tests/components/ntfy/conftest.py
@@ -9,7 +9,12 @@ from aiontfy import Account, AccountTokenResponse, Event, Notification, Version
 from aiontfy.update import LatestRelease
 import pytest
 
-from homeassistant.components.ntfy.const import CONF_TOPIC, DEFAULT_URL, DOMAIN
+from homeassistant.components.ntfy.const import (
+    CONF_TOPIC,
+    DEFAULT_URL,
+    DOMAIN,
+    SUBENTRY_TYPE_TOPIC,
+)
 from homeassistant.config_entries import ConfigSubentryData
 from homeassistant.const import CONF_TOKEN, CONF_URL, CONF_USERNAME, CONF_VERIFY_SSL
 
@@ -140,7 +145,7 @@ def mock_config_entry() -> MockConfigEntry:
             ConfigSubentryData(
                 data={CONF_TOPIC: "mytopic"},
                 subentry_id="ABCDEF",
-                subentry_type="topic",
+                subentry_type=SUBENTRY_TYPE_TOPIC,
                 title="mytopic",
                 unique_id="mytopic",
             )

--- a/tests/components/ntfy/test_config_flow.py
+++ b/tests/components/ntfy/test_config_flow.py
@@ -22,8 +22,9 @@ from homeassistant.components.ntfy.const import (
     DOMAIN,
     SECTION_AUTH,
     SECTION_FILTER,
+    SUBENTRY_TYPE_TOPIC,
 )
-from homeassistant.config_entries import SOURCE_USER, ConfigSubentry
+from homeassistant.config_entries import SOURCE_USER, ConfigSubentry, FlowType
 from homeassistant.const import (
     CONF_NAME,
     CONF_PASSWORD,
@@ -88,6 +89,28 @@ async def test_form(
     assert result["title"] == "ntfy.sh"
     assert result["data"] == entry_data
     assert len(mock_setup_entry.mock_calls) == 1
+
+    await hass.async_block_till_done(wait_background_tasks=True)
+    subentry_flows = hass.config_entries.subentries.async_progress()
+    assert len(subentry_flows) == 1
+    assert result["next_flow"][0] == FlowType.CONFIG_SUBENTRIES_FLOW
+    result = await hass.config_entries.subentries.async_configure(
+        result["next_flow"][1], {"next_step_id": "add_topic"}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "add_topic"
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_TOPIC: "mytopic",
+            SECTION_FILTER: {},
+        },
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "mytopic"
+    assert result["data"] == {CONF_TOPIC: "mytopic"}
 
 
 @pytest.mark.parametrize(
@@ -196,7 +219,7 @@ async def test_add_topic_flow(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     result = await hass.config_entries.subentries.async_init(
-        (config_entry.entry_id, "topic"),
+        (config_entry.entry_id, SUBENTRY_TYPE_TOPIC),
         context={"source": SOURCE_USER},
     )
 
@@ -236,7 +259,7 @@ async def test_add_topic_flow(hass: HomeAssistant) -> None:
                 CONF_MESSAGE: "triggered",
             },
             subentry_id=subentry_id,
-            subentry_type="topic",
+            subentry_type=SUBENTRY_TYPE_TOPIC,
             title="mytopic",
             unique_id="mytopic",
         )
@@ -258,7 +281,7 @@ async def test_generated_topic(hass: HomeAssistant, mock_random: AsyncMock) -> N
     await hass.async_block_till_done()
 
     result = await hass.config_entries.subentries.async_init(
-        (config_entry.entry_id, "topic"),
+        (config_entry.entry_id, SUBENTRY_TYPE_TOPIC),
         context={"source": SOURCE_USER},
     )
 
@@ -299,7 +322,7 @@ async def test_generated_topic(hass: HomeAssistant, mock_random: AsyncMock) -> N
         subentry_id: ConfigSubentry(
             data={CONF_TOPIC: "randomtopic"},
             subentry_id=subentry_id,
-            subentry_type="topic",
+            subentry_type=SUBENTRY_TYPE_TOPIC,
             title="mytopic",
             unique_id="randomtopic",
         )
@@ -319,7 +342,7 @@ async def test_invalid_topic(hass: HomeAssistant, mock_random: AsyncMock) -> Non
     await hass.async_block_till_done()
 
     result = await hass.config_entries.subentries.async_init(
-        (config_entry.entry_id, "topic"),
+        (config_entry.entry_id, SUBENTRY_TYPE_TOPIC),
         context={"source": SOURCE_USER},
     )
 
@@ -360,7 +383,7 @@ async def test_invalid_topic(hass: HomeAssistant, mock_random: AsyncMock) -> Non
         subentry_id: ConfigSubentry(
             data={CONF_TOPIC: "mytopic"},
             subentry_id=subentry_id,
-            subentry_type="topic",
+            subentry_type=SUBENTRY_TYPE_TOPIC,
             title="mytopic",
             unique_id="mytopic",
         )
@@ -380,7 +403,7 @@ async def test_topic_already_configured(
     await hass.async_block_till_done()
 
     result = await hass.config_entries.subentries.async_init(
-        (config_entry.entry_id, "topic"),
+        (config_entry.entry_id, SUBENTRY_TYPE_TOPIC),
         context={"source": SOURCE_USER},
     )
     assert result["type"] is FlowResultType.MENU
@@ -789,7 +812,7 @@ async def test_topic_reconfigure_flow(hass: HomeAssistant) -> None:
                     CONF_MESSAGE: "triggered",
                 },
                 subentry_id="subentry_id",
-                subentry_type="topic",
+                subentry_type=SUBENTRY_TYPE_TOPIC,
                 title="mytopic",
                 unique_id="mytopic",
             )
@@ -826,7 +849,7 @@ async def test_topic_reconfigure_flow(hass: HomeAssistant) -> None:
                 CONF_MESSAGE: None,
             },
             subentry_id="subentry_id",
-            subentry_type="topic",
+            subentry_type=SUBENTRY_TYPE_TOPIC,
             title="mytopic",
             unique_id="mytopic",
         )


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

After creating a config entry automatically initiate a subentry flow to create the first topic 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
