### PR TITLE
Drop _spec_hub helper in nobo_hub init tests

### DIFF
--- a/tests/components/nobo_hub/test_init.py
+++ b/tests/components/nobo_hub/test_init.py
@@ -1,6 +1,6 @@
 """Tests for the Nobø Ecohub integration setup."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from pynobo import nobo as pynobo_nobo
 import pytest
@@ -24,25 +24,6 @@ from tests.common import MockConfigEntry
 NEW_IP = "192.168.1.55"
 
 
-def _spec_hub(connect_exc: BaseException | None = None) -> MagicMock:
-    """Build a minimal spec'd pynobo hub for rediscovery tests."""
-    hub = MagicMock(spec=pynobo_nobo)
-    if connect_exc is not None:
-        hub.connect.side_effect = connect_exc
-    hub.hub_serial = SERIAL
-    hub.hub_info = {
-        "name": "My Eco Hub",
-        "serial": SERIAL,
-        "software_version": "115",
-        "hardware_version": "hw",
-    }
-    hub.zones = {}
-    hub.components = {}
-    hub.week_profiles = {}
-    hub.overrides = {}
-    return hub
-
-
 async def test_setup_uses_stored_ip(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -62,57 +43,69 @@ async def test_setup_uses_stored_ip(
 async def test_setup_rediscovery_updates_ip(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
+    mock_nobo_class: MagicMock,
 ) -> None:
     """A failed direct connect falls back to rediscovery and persists the new IP."""
     mock_config_entry.add_to_hass(hass)
-    with patch("homeassistant.components.nobo_hub.nobo", autospec=True) as mock_cls:
-        mock_cls.side_effect = [
-            _spec_hub(connect_exc=OSError("Unreachable")),
-            _spec_hub(),
-        ]
-        mock_cls.async_discover_hubs.return_value = {(NEW_IP, SERIAL)}
-        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
+    failing_hub = MagicMock(spec=pynobo_nobo)
+    failing_hub.connect.side_effect = OSError("Unreachable")
+    mock_nobo_class.side_effect = [failing_hub, mock_nobo_class.return_value]
+    mock_nobo_class.async_discover_hubs.return_value = {(NEW_IP, SERIAL)}
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
     assert mock_config_entry.data[CONF_IP_ADDRESS] == NEW_IP
-    assert mock_cls.call_count == 2
-    assert mock_cls.call_args_list[0].kwargs["ip"] == STORED_IP
-    assert mock_cls.call_args_list[1].kwargs["ip"] == NEW_IP
+    assert mock_nobo_class.call_count == 2
+    assert mock_nobo_class.call_args_list[0].kwargs["ip"] == STORED_IP
+    assert mock_nobo_class.call_args_list[1].kwargs["ip"] == NEW_IP
 
 
-@pytest.mark.parametrize(
-    ("discovered_hubs", "second_exc", "expected_placeholders"),
-    [
-        (set(), None, {"serial": SERIAL, "ip": STORED_IP}),
-        (
-            {(NEW_IP, SERIAL)},
-            OSError("Unreachable"),
-            {"serial": SERIAL, "ip": NEW_IP},
-        ),
-    ],
-    ids=["rediscovery_empty", "rediscovered_ip_fails"],
-)
-async def test_setup_rediscovery_failure(
+async def test_setup_aborts_when_rediscovery_finds_nothing(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    discovered_hubs: set[tuple[str, str]],
-    second_exc: BaseException | None,
-    expected_placeholders: dict[str, str],
+    mock_nobo_class: MagicMock,
 ) -> None:
-    """Setup raises cannot_connect when rediscovery can't recover."""
+    """Setup raises cannot_connect when the stored IP fails and rediscovery is empty."""
     mock_config_entry.add_to_hass(hass)
-    with patch("homeassistant.components.nobo_hub.nobo", autospec=True) as mock_cls:
-        mock_cls.side_effect = [
-            _spec_hub(connect_exc=OSError("Unreachable")),
-            _spec_hub(connect_exc=second_exc),
-        ]
-        mock_cls.async_discover_hubs.return_value = discovered_hubs
-        with pytest.raises(ConfigEntryNotReady) as exc_info:
-            await async_setup_entry(hass, mock_config_entry)
+    failing_hub = MagicMock(spec=pynobo_nobo)
+    failing_hub.connect.side_effect = OSError("Unreachable")
+    mock_nobo_class.side_effect = [failing_hub]
+    mock_nobo_class.async_discover_hubs.return_value = set()
+
+    with pytest.raises(ConfigEntryNotReady) as exc_info:
+        await async_setup_entry(hass, mock_config_entry)
 
     assert exc_info.value.translation_key == "cannot_connect"
-    assert exc_info.value.translation_placeholders == expected_placeholders
+    assert exc_info.value.translation_placeholders == {
+        "serial": SERIAL,
+        "ip": STORED_IP,
+    }
+
+
+async def test_setup_aborts_when_rediscovered_ip_also_fails(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_nobo_class: MagicMock,
+) -> None:
+    """Setup raises cannot_connect when both the stored and rediscovered IPs fail."""
+    mock_config_entry.add_to_hass(hass)
+    first_failing_hub = MagicMock(spec=pynobo_nobo)
+    first_failing_hub.connect.side_effect = OSError("Unreachable")
+    second_failing_hub = MagicMock(spec=pynobo_nobo)
+    second_failing_hub.connect.side_effect = OSError("Unreachable")
+    mock_nobo_class.side_effect = [first_failing_hub, second_failing_hub]
+    mock_nobo_class.async_discover_hubs.return_value = {(NEW_IP, SERIAL)}
+
+    with pytest.raises(ConfigEntryNotReady) as exc_info:
+        await async_setup_entry(hass, mock_config_entry)
+
+    assert exc_info.value.translation_key == "cannot_connect"
+    assert exc_info.value.translation_placeholders == {
+        "serial": SERIAL,
+        "ip": NEW_IP,
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/components/nobo_hub/test_init.py
+++ b/tests/components/nobo_hub/test_init.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock
 from pynobo import nobo as pynobo_nobo
 import pytest
 
-from homeassistant.components.nobo_hub import async_setup_entry
 from homeassistant.components.nobo_hub.const import (
     CONF_OVERRIDE_TYPE,
     CONF_SERIAL,
@@ -14,7 +13,6 @@ from homeassistant.components.nobo_hub.const import (
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_IP_ADDRESS, CONF_MAC
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 
 from .conftest import SERIAL, STORED_IP
@@ -67,18 +65,19 @@ async def test_setup_aborts_when_rediscovery_finds_nothing(
     mock_config_entry: MockConfigEntry,
     mock_nobo_class: MagicMock,
 ) -> None:
-    """Setup raises cannot_connect when the stored IP fails and rediscovery is empty."""
+    """Setup retries with cannot_connect when the stored IP fails and rediscovery is empty."""
     mock_config_entry.add_to_hass(hass)
     failing_hub = MagicMock(spec=pynobo_nobo)
     failing_hub.connect.side_effect = OSError("Unreachable")
     mock_nobo_class.side_effect = [failing_hub]
     mock_nobo_class.async_discover_hubs.return_value = set()
 
-    with pytest.raises(ConfigEntryNotReady) as exc_info:
-        await async_setup_entry(hass, mock_config_entry)
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
-    assert exc_info.value.translation_key == "cannot_connect"
-    assert exc_info.value.translation_placeholders == {
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert mock_config_entry.error_reason_translation_key == "cannot_connect"
+    assert mock_config_entry.error_reason_translation_placeholders == {
         "serial": SERIAL,
         "ip": STORED_IP,
     }
@@ -89,7 +88,7 @@ async def test_setup_aborts_when_rediscovered_ip_also_fails(
     mock_config_entry: MockConfigEntry,
     mock_nobo_class: MagicMock,
 ) -> None:
-    """Setup raises cannot_connect when both the stored and rediscovered IPs fail."""
+    """Setup retries with cannot_connect when both the stored and rediscovered IPs fail."""
     mock_config_entry.add_to_hass(hass)
     first_failing_hub = MagicMock(spec=pynobo_nobo)
     first_failing_hub.connect.side_effect = OSError("Unreachable")
@@ -98,11 +97,12 @@ async def test_setup_aborts_when_rediscovered_ip_also_fails(
     mock_nobo_class.side_effect = [first_failing_hub, second_failing_hub]
     mock_nobo_class.async_discover_hubs.return_value = {(NEW_IP, SERIAL)}
 
-    with pytest.raises(ConfigEntryNotReady) as exc_info:
-        await async_setup_entry(hass, mock_config_entry)
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
-    assert exc_info.value.translation_key == "cannot_connect"
-    assert exc_info.value.translation_placeholders == {
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert mock_config_entry.error_reason_translation_key == "cannot_connect"
+    assert mock_config_entry.error_reason_translation_placeholders == {
         "serial": SERIAL,
         "ip": NEW_IP,
     }

--- a/tests/components/nobo_hub/test_init.py
+++ b/tests/components/nobo_hub/test_init.py
@@ -60,7 +60,7 @@ async def test_setup_rediscovery_updates_ip(
     assert mock_nobo_class.call_args_list[1].kwargs["ip"] == NEW_IP
 
 
-async def test_setup_aborts_when_rediscovery_finds_nothing(
+async def test_setup_retries_when_rediscovery_finds_nothing(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_nobo_class: MagicMock,
@@ -83,7 +83,7 @@ async def test_setup_aborts_when_rediscovery_finds_nothing(
     }
 
 
-async def test_setup_aborts_when_rediscovered_ip_also_fails(
+async def test_setup_retries_when_rediscovered_ip_also_fails(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_nobo_class: MagicMock,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Drop `_spec_hub` helper in `nobo_hub` init tests.

Discovered during review of PR https://github.com/home-assistant/core/pull/168638

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
