### PR TITLE
Add reconfigure flow to Powerwall integration

### DIFF
--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -16,6 +16,7 @@ from tesla_powerwall import (
 import voluptuous as vol
 
 from homeassistant.config_entries import (
+    SOURCE_RECONFIGURE,
     ConfigEntry,
     ConfigEntryState,
     ConfigFlow,
@@ -209,6 +210,14 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
             },
         )
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of the Powerwall."""
+        reconfigure_entry = self._get_reconfigure_entry()
+        self.ip_address = reconfigure_entry.data[CONF_IP_ADDRESS]
+        return await self.async_step_user()
+
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -225,6 +234,13 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
                     await self.async_set_unique_id(
                         info["unique_id"], raise_on_progress=False
                     )
+                if self.source == SOURCE_RECONFIGURE:
+                    self._abort_if_unique_id_mismatch()
+                    return self.async_update_reload_and_abort(
+                        self._get_reconfigure_entry(),
+                        data_updates={**user_input, CONFIG_ENTRY_COOKIE: None},
+                    )
+                if info["unique_id"]:
                     self._abort_if_unique_id_configured(
                         updates={CONF_IP_ADDRESS: user_input[CONF_IP_ADDRESS]}
                     )

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -225,9 +225,7 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] | None = {}
         description_placeholders: dict[str, str] = {}
         if user_input is not None:
-            if self.source == SOURCE_RECONFIGURE and not user_input.get(
-                CONF_PASSWORD
-            ):
+            if self.source == SOURCE_RECONFIGURE and not user_input.get(CONF_PASSWORD):
                 user_input[CONF_PASSWORD] = self._get_reconfigure_entry().data[
                     CONF_PASSWORD
                 ]

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -225,6 +225,12 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] | None = {}
         description_placeholders: dict[str, str] = {}
         if user_input is not None:
+            if self.source == SOURCE_RECONFIGURE and not user_input.get(
+                CONF_PASSWORD
+            ):
+                user_input[CONF_PASSWORD] = self._get_reconfigure_entry().data[
+                    CONF_PASSWORD
+                ]
             errors, info, description_placeholders = await self._async_try_connect(
                 user_input
             )

--- a/homeassistant/components/powerwall/strings.json
+++ b/homeassistant/components/powerwall/strings.json
@@ -3,7 +3,9 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+      "unique_id_mismatch": "The configuration points to a different Powerwall than the original"
     },
     "error": {
       "cannot_connect": "A connection error occurred while connecting to the Powerwall: {error}",

--- a/homeassistant/components/powerwall/strings.json
+++ b/homeassistant/components/powerwall/strings.json
@@ -5,7 +5,7 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
-      "unique_id_mismatch": "The configuration points to a different Powerwall than the original"
+      "unique_id_mismatch": "The configuration points to a different Powerwall than the original."
     },
     "error": {
       "cannot_connect": "A connection error occurred while connecting to the Powerwall: {error}",

--- a/tests/components/powerwall/test_config_flow.py
+++ b/tests/components/powerwall/test_config_flow.py
@@ -326,6 +326,76 @@ async def test_dhcp_discovery_cannot_connect(hass: HomeAssistant) -> None:
     assert result["reason"] == "cannot_connect"
 
 
+async def test_reconfigure(hass: HomeAssistant) -> None:
+    """Test reconfigure flow updates ip address and password."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=VALID_CONFIG,
+        unique_id=MOCK_GATEWAY_DIN,
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {}
+
+    mock_powerwall = await _mock_powerwall_site_name(hass, "My site")
+
+    new_config = {CONF_IP_ADDRESS: "5.6.7.8", CONF_PASSWORD: "new-password"}
+
+    with (
+        patch(
+            "homeassistant.components.powerwall.config_flow.Powerwall",
+            return_value=mock_powerwall,
+        ),
+        patch(
+            "homeassistant.components.powerwall.async_setup_entry",
+            return_value=True,
+        ) as mock_setup_entry,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            new_config,
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.ABORT
+    assert result2["reason"] == "reconfigure_successful"
+    assert entry.data[CONF_IP_ADDRESS] == "5.6.7.8"
+    assert entry.data[CONF_PASSWORD] == "new-password"
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_reconfigure_cannot_connect(hass: HomeAssistant) -> None:
+    """Test reconfigure flow handles connection error."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=VALID_CONFIG,
+        unique_id=MOCK_GATEWAY_DIN,
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+
+    mock_powerwall = await _mock_powerwall_side_effect(
+        site_info=PowerwallUnreachableError
+    )
+
+    with patch(
+        "homeassistant.components.powerwall.config_flow.Powerwall",
+        return_value=mock_powerwall,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_IP_ADDRESS: "5.6.7.8", CONF_PASSWORD: "test-password"},
+        )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["errors"] == {CONF_IP_ADDRESS: "cannot_connect"}
+
+
 async def test_form_reauth(hass: HomeAssistant) -> None:
     """Test reauthenticate."""
 

--- a/tests/components/powerwall/test_config_flow.py
+++ b/tests/components/powerwall/test_config_flow.py
@@ -11,7 +11,7 @@ from tesla_powerwall import (
 )
 
 from homeassistant import config_entries
-from homeassistant.components.powerwall.const import DOMAIN
+from homeassistant.components.powerwall.const import CONFIG_ENTRY_COOKIE, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
@@ -331,7 +331,7 @@ async def test_reconfigure(hass: HomeAssistant) -> None:
 
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data=VALID_CONFIG,
+        data={**VALID_CONFIG, CONFIG_ENTRY_COOKIE: "old-cookie"},
         unique_id=MOCK_GATEWAY_DIN,
     )
     entry.add_to_hass(hass)
@@ -364,7 +364,72 @@ async def test_reconfigure(hass: HomeAssistant) -> None:
     assert result2["reason"] == "reconfigure_successful"
     assert entry.data[CONF_IP_ADDRESS] == "5.6.7.8"
     assert entry.data[CONF_PASSWORD] == "new-password"
+    assert entry.data[CONFIG_ENTRY_COOKIE] is None
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_reconfigure_ip_only(hass: HomeAssistant) -> None:
+    """Test reconfigure flow with only IP change keeps existing password."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=VALID_CONFIG,
+        unique_id=MOCK_GATEWAY_DIN,
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+
+    mock_powerwall = await _mock_powerwall_site_name(hass, "My site")
+
+    with (
+        patch(
+            "homeassistant.components.powerwall.config_flow.Powerwall",
+            return_value=mock_powerwall,
+        ),
+        patch(
+            "homeassistant.components.powerwall.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_IP_ADDRESS: "5.6.7.8"},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.ABORT
+    assert result2["reason"] == "reconfigure_successful"
+    assert entry.data[CONF_IP_ADDRESS] == "5.6.7.8"
+    assert entry.data[CONF_PASSWORD] == VALID_CONFIG[CONF_PASSWORD]
+
+
+async def test_reconfigure_unique_id_mismatch(hass: HomeAssistant) -> None:
+    """Test reconfigure flow aborts when pointing at a different Powerwall."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=VALID_CONFIG,
+        unique_id=MOCK_GATEWAY_DIN,
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+
+    mock_powerwall = await _mock_powerwall_site_name(hass, "Other site")
+    mock_powerwall.get_gateway_din.return_value = "999-0----9-000000000XXX"
+
+    with patch(
+        "homeassistant.components.powerwall.config_flow.Powerwall",
+        return_value=mock_powerwall,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_IP_ADDRESS: "5.6.7.8", CONF_PASSWORD: "test-password"},
+        )
+
+    assert result2["type"] is FlowResultType.ABORT
+    assert result2["reason"] == "unique_id_mismatch"
 
 
 async def test_reconfigure_cannot_connect(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Summary

- Adds a reconfigure flow to the Powerwall integration, allowing users to update the IP address and password via the UI (3-dot menu → Reconfigure)
- Invalidates the auth cookie on reconfigure to force a fresh login
- Includes unique ID mismatch protection to prevent accidentally pointing the entry at a different Powerwall
- Adds tests for successful reconfigure and connection error handling

Closes #169913

## Context

When a Powerwall gateway changes IP address (e.g., DHCP lease change), users currently have no way to update the IP through the Home Assistant UI. The only workaround is to manually edit the config entry JSON file inside the container, or delete and re-add the integration — both are poor experiences.

Other integrations (e.g., Reolink) already support reconfigure flows for this purpose. This PR follows the same pattern.

## Test plan

- [x] `test_reconfigure` — verifies IP and password update via reconfigure flow
- [x] `test_reconfigure_cannot_connect` — verifies error handling when new IP is unreachable
- [x] All 19 existing config flow tests still pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)