### PR TITLE
homematicip_cloud: fix HmIP-FLC lock state polarity

### DIFF
--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -2,7 +2,12 @@
 
 from typing import Any
 
-from homematicip.base.enums import LockState, SmokeDetectorAlarmType, WindowState
+from homematicip.base.enums import (
+    BinaryBehaviorType,
+    LockState,
+    SmokeDetectorAlarmType,
+    WindowState,
+)
 from homematicip.base.functionalChannels import MultiModeInputChannel
 from homematicip.device import (
     AccelerationSensor,
@@ -352,7 +357,22 @@ class HomematicipFullFlushLockControllerLocked(
 
     @property
     def is_on(self) -> bool:
-        """Return true if the controlled lock is locked."""
+        """Return true if the controlled lock is unlocked.
+
+        Per HA's BinarySensorDeviceClass.LOCK contract, ON means
+        unlocked / open and OFF means locked / closed.
+
+        The mapping from the firmware-reported ``lockState`` depends on
+        the channel's ``binaryBehaviorType``. With the default
+        ``NORMALLY_OPEN`` wiring, the input goes ACTIVE (and lockState
+        flips to ``LOCKED``) when the contact closes — i.e. when a
+        magnetic door contact registers the door as closed. With
+        ``NORMALLY_CLOSE`` the same physical event puts the input into
+        the IDLE state (lockState ``UNLOCKED``). To present the same
+        HA semantics regardless of which way the user wired the
+        contact, ``lockState`` is interpreted relative to the
+        configured behavior.
+        """
         channel = _get_channel_by_role(
             self._device,
             "MULTI_MODE_LOCK_INPUT_CHANNEL",
@@ -361,7 +381,15 @@ class HomematicipFullFlushLockControllerLocked(
         if channel is None:
             return False
         lock_state = getattr(channel, "lockState", None)
-        return getattr(lock_state, "name", lock_state) == LockState.LOCKED.name
+        is_locked_state = (
+            getattr(lock_state, "name", lock_state) == LockState.LOCKED.name
+        )
+        binary_behavior = getattr(channel, "binaryBehaviorType", None)
+        normally_close = (
+            getattr(binary_behavior, "name", binary_behavior)
+            == BinaryBehaviorType.NORMALLY_CLOSE.name
+        )
+        return is_locked_state if normally_close else not is_locked_state
 
 
 class HomematicipFullFlushLockControllerGlassBreak(

--- a/tests/components/homematicip_cloud/test_binary_sensor.py
+++ b/tests/components/homematicip_cloud/test_binary_sensor.py
@@ -2,7 +2,13 @@
 
 from typing import Any
 
-from homematicip.base.enums import SmokeDetectorAlarmType, WindowState
+from homematicip.base.enums import (
+    BinaryBehaviorType,
+    LockState,
+    SmokeDetectorAlarmType,
+    WindowState,
+)
+import pytest
 
 from homeassistant.components.homematicip_cloud.binary_sensor import (
     ATTR_ACCELERATION_SENSOR_MODE,
@@ -48,7 +54,9 @@ async def test_hmip_full_flush_lock_controller_binary_sensors(
         "Universal Motorschloss Controller Locked",
         "HmIP-FLC",
     )
-    assert lock_state.state == STATE_ON
+    # Per BinarySensorDeviceClass.LOCK convention, ON means unlocked / open
+    # and OFF means locked / closed. Fixture initial state is LOCKED.
+    assert lock_state.state == STATE_OFF
 
     glass_entity_id = "binary_sensor.universal_motorschloss_controller_glass_break"
     glass_state, _ = get_and_check_entity_basics(
@@ -64,12 +72,59 @@ async def test_hmip_full_flush_lock_controller_binary_sensors(
     await async_manipulate_test_data(hass, hmip_device, "lockState", "UNLOCKED")
     lock_state = hass.states.get(lock_entity_id)
     assert lock_state
-    assert lock_state.state == STATE_OFF
+    assert lock_state.state == STATE_ON
 
     await async_manipulate_test_data(hass, hmip_device, "glassBroken", False)
     glass_state = hass.states.get(glass_entity_id)
     assert glass_state
     assert glass_state.state == STATE_OFF
+
+
+@pytest.mark.parametrize(
+    ("binary_behavior", "lock_state", "expected_state"),
+    [
+        # NORMALLY_OPEN: input ACTIVE (LOCKED) means contact closed = door
+        # closed in HA semantics → off; idle (UNLOCKED) = door open → on.
+        (BinaryBehaviorType.NORMALLY_OPEN, LockState.LOCKED, STATE_OFF),
+        (BinaryBehaviorType.NORMALLY_OPEN, LockState.UNLOCKED, STATE_ON),
+        # NORMALLY_CLOSE: polarity flipped — UNLOCKED reports the idle
+        # state (door closed) and LOCKED reports input active (door open).
+        (BinaryBehaviorType.NORMALLY_CLOSE, LockState.UNLOCKED, STATE_OFF),
+        (BinaryBehaviorType.NORMALLY_CLOSE, LockState.LOCKED, STATE_ON),
+    ],
+)
+async def test_hmip_full_flush_lock_controller_polarity(
+    hass: HomeAssistant,
+    default_mock_hap_factory: HomeFactory,
+    full_flush_lock_controller_device_data: dict[str, Any],
+    binary_behavior: BinaryBehaviorType,
+    lock_state: LockState,
+    expected_state: str,
+) -> None:
+    """Test FLC lock state respects binaryBehaviorType for both wirings."""
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["Universal Motorschloss Controller"],
+        extra_devices=[full_flush_lock_controller_device_data],
+    )
+
+    lock_entity_id = "binary_sensor.universal_motorschloss_controller_locked"
+    _, hmip_device = get_and_check_entity_basics(
+        hass,
+        mock_hap,
+        lock_entity_id,
+        "Universal Motorschloss Controller Locked",
+        "HmIP-FLC",
+    )
+    assert hmip_device is not None
+
+    await async_manipulate_test_data(
+        hass, hmip_device, "binaryBehaviorType", binary_behavior
+    )
+    await async_manipulate_test_data(hass, hmip_device, "lockState", lock_state.name)
+
+    state = hass.states.get(lock_entity_id)
+    assert state is not None
+    assert state.state == expected_state
 
 
 async def test_hmip_home_cloud_connection_sensor(


### PR DESCRIPTION
## Breaking change

## Proposed change

The HmIP-FLC `Locked` binary sensor returns the inverted state. It uses `BinarySensorDeviceClass.LOCK`, where the HA convention is ON = unlocked / open and OFF = locked / closed. The sensor currently returns ON when the API reports `LOCKED`, so it displays the opposite of the lock's actual state.

Reported on hahn-th/homematicip-rest-api#606 by a user with an HmIP-FLC. After receiving their diagnostics, the polarity turns out to depend on the channel's `binaryBehaviorType` configuration:

- `NORMALLY_OPEN` (default): contact closure (e.g. magnetic door contact registering door closed) puts the input in the active state, which the firmware reports as `lockState=LOCKED`. To present "door closed = off" in HA the value must be inverted.
- `NORMALLY_CLOSE`: the same physical event puts the input in the idle state, reported as `lockState=UNLOCKED`. Here the value must be used as-is.

The fix reads `binaryBehaviorType` from the channel and inverts conditionally, so HA shows the right state regardless of how the user wired the contact in the HmIP app. Tests cover all four combinations of `binaryBehaviorType × lockState`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes 
- This PR is related to issue: hahn-th/homematicip-rest-api#606
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
