### PR TITLE
Update iZone integration to support hubs on different VLANs

### DIFF
--- a/homeassistant/components/izone/__init__.py
+++ b/homeassistant/components/izone/__init__.py
@@ -4,13 +4,23 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_EXCLUDE, EVENT_HOMEASSISTANT_STOP, Platform
+from homeassistant.const import (
+    CONF_EXCLUDE,
+    CONF_HOST,
+    EVENT_HOMEASSISTANT_STOP,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DATA_CONFIG, IZONE
-from .discovery import async_start_discovery_service, async_stop_discovery_service
+from .const import DATA_CONFIG, DATA_DISCOVERY_SERVICE, IZONE
+from .discovery import (
+    async_add_controller_by_ip,
+    async_start_discovery_service,
+    async_stop_discovery_service,
+)
 
 PLATFORMS = [Platform.CLIMATE]
 
@@ -55,10 +65,28 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up from a config entry."""
+    # If a host is configured, manually add the controller by IP.
+    # Pass unique_id (device UID) to skip redundant HTTP lookup.
+    if host := entry.data.get(CONF_HOST):
+        try:
+            await async_add_controller_by_ip(hass, host, entry.unique_id)
+        except ConnectionError as err:
+            raise ConfigEntryNotReady(
+                f"Unable to connect to iZone device at {host}"
+            ) from err
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload the config entry and stop discovery process."""
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    """Unload a config entry."""
+    result = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    if not result:
+        return result
+
+    if (disco := hass.data.get(DATA_DISCOVERY_SERVICE)) and entry.data.get(CONF_HOST):
+        disco.remove_static_host(entry.unique_id)
+
+    return result

--- a/homeassistant/components/izone/climate.py
+++ b/homeassistant/components/izone/climate.py
@@ -29,11 +29,12 @@ from homeassistant.const import (
     PRECISION_TENTHS,
     UnitOfTemperature,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.temperature import display_temp as show_temp
 from homeassistant.helpers.typing import ConfigType, VolDictType
 
@@ -46,6 +47,7 @@ from .const import (
     DISPATCH_CONTROLLER_UPDATE,
     DISPATCH_ZONE_UPDATE,
     IZONE,
+    UNAVAILABLE_DEBOUNCE,
 )
 
 type _FuncType[_T, **_P, _R] = Callable[Concatenate[_T, _P], _R]
@@ -148,6 +150,10 @@ class ControllerDevice(ClimateEntity):
         """Initialise ControllerDevice."""
         self._controller = controller
 
+        # Debounce tracking for disconnect events
+        self._disconnect_debounce: CALLBACK_TYPE | None = None
+        self._pending_disconnect_ex: Exception | None = None
+
         self._attr_supported_features = (
             ClimateEntityFeature.FAN_MODE
             | ClimateEntityFeature.TURN_OFF
@@ -246,25 +252,74 @@ class ControllerDevice(ClimateEntity):
             )
         )
 
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel pending debounce timer when entity is removed."""
+        if self._disconnect_debounce is not None:
+            self._disconnect_debounce()
+            self._disconnect_debounce = None
+            self._pending_disconnect_ex = None
+
     @callback
     def set_available(self, available: bool, ex: Exception | None = None) -> None:
-        """Set availability for the controller.
+        """Set availability for the controller with debounce for disconnects.
 
-        Also sets zone availability as they follow the same availability.
+        Disconnects are debounced to prevent the entity from flapping
+        between available/unavailable on transient network issues. The
+        controller only shows as unavailable if it remains disconnected
+        for UNAVAILABLE_DEBOUNCE seconds.
         """
-        if self.available == available:
-            return
-
         if available:
-            _LOGGER.warning("Reconnected controller %s ", self._controller.device_uid)
-        else:
-            _LOGGER.warning(
-                "Controller %s disconnected due to exception: %s",
+            # Cancel any pending disconnect timer
+            if self._disconnect_debounce is not None:
+                self._disconnect_debounce()
+                self._disconnect_debounce = None
+                self._pending_disconnect_ex = None
+
+            if not self._attr_available:
+                # Was actually unavailable, now reconnected
+                _LOGGER.warning(
+                    "Reconnected controller %s",
+                    self._controller.device_uid,
+                )
+                self._attr_available = True
+                self.async_write_ha_state()
+                for zone in self.zones.values():
+                    if zone.hass is not None:
+                        zone.async_schedule_update_ha_state()
+        elif self._attr_available and self._disconnect_debounce is None:
+            # Don't immediately mark as unavailable - start debounce
+            _LOGGER.debug(
+                "Controller %s disconnect detected, starting %ss debounce "
+                "(exception: %s)",
                 self._controller.device_uid,
+                UNAVAILABLE_DEBOUNCE,
                 ex,
             )
+            self._pending_disconnect_ex = ex
+            self._disconnect_debounce = async_call_later(
+                self.hass, UNAVAILABLE_DEBOUNCE, self._mark_unavailable
+            )
 
-        self._attr_available = available
+    @callback
+    def _mark_unavailable(self, _now) -> None:
+        """Mark the controller as unavailable after the debounce period.
+
+        Called when the controller has remained disconnected for the
+        full debounce duration without reconnecting.
+        """
+        self._disconnect_debounce = None
+        ex = self._pending_disconnect_ex
+        self._pending_disconnect_ex = None
+
+        if not self._attr_available:
+            return  # Already unavailable
+
+        _LOGGER.warning(
+            "Controller %s disconnected due to exception: %s",
+            self._controller.device_uid,
+            ex,
+        )
+        self._attr_available = False
         self.async_write_ha_state()
         for zone in self.zones.values():
             if zone.hass is not None:

--- a/homeassistant/components/izone/config_flow.py
+++ b/homeassistant/components/izone/config_flow.py
@@ -3,31 +3,53 @@
 import asyncio
 from contextlib import suppress
 import logging
+from typing import Any
 
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import config_entry_flow
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .const import DISPATCH_CONTROLLER_DISCOVERED, IZONE, TIMEOUT_DISCOVERY
-from .discovery import async_start_discovery_service, async_stop_discovery_service
+from .discovery import (
+    async_get_device_uid,
+    async_start_discovery_service,
+    async_stop_discovery_service,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_HOST): str,
+    }
+)
+
 
 async def _async_has_devices(hass: HomeAssistant) -> bool:
+    """Check if there are any iZone devices on the network via broadcast."""
     controller_ready = asyncio.Event()
 
     @callback
     def dispatch_discovered(_):
         controller_ready.set()
 
-    async_dispatcher_connect(hass, DISPATCH_CONTROLLER_DISCOVERED, dispatch_discovered)
+    unsub = async_dispatcher_connect(
+        hass, DISPATCH_CONTROLLER_DISCOVERED, dispatch_discovered
+    )
 
     disco = await async_start_discovery_service(hass)
+
+    if disco.pi_disco.controllers:
+        controller_ready.set()
 
     with suppress(TimeoutError):
         async with asyncio.timeout(TIMEOUT_DISCOVERY):
             await controller_ready.wait()
+
+    unsub()
 
     if not disco.pi_disco.controllers:
         await async_stop_discovery_service(hass)
@@ -38,4 +60,104 @@ async def _async_has_devices(hass: HomeAssistant) -> bool:
     return True
 
 
-config_entry_flow.register_discovery_flow(IZONE, "iZone Aircon", _async_has_devices)
+class IZoneConfigFlow(ConfigFlow, domain=IZONE):
+    """Handle a config flow for iZone."""
+
+    VERSION = 1
+    MINOR_VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step.
+
+        The user can either enter an IP address for a remote iZone hub,
+        or leave it blank to use auto-discovery on the local network.
+        """
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            host = user_input.get(CONF_HOST, "").strip()
+
+            if host:
+                # Manual IP entry - validate connectivity and get UID
+                try:
+                    device_uid = await async_get_device_uid(self.hass, host)
+                except ConnectionError:
+                    errors[CONF_HOST] = "cannot_connect"
+                else:
+                    await self.async_set_unique_id(device_uid)
+                    # Reload so the new host is applied immediately
+                    self._abort_if_unique_id_configured(
+                        updates={CONF_HOST: host}, reload_on_update=True
+                    )
+
+                    # Only one entry is allowed — if a discovery entry
+                    # already exists (no host), update it with the host
+                    existing = self._async_current_entries()
+                    if existing:
+                        if len(existing) == 1 and not existing[0].data.get(CONF_HOST):
+                            # Reload so static-IP registration happens right away
+                            return self.async_update_reload_and_abort(
+                                existing[0],
+                                unique_id=device_uid,
+                                data_updates={CONF_HOST: host},
+                                reason="reconfigure_successful",
+                            )
+                        return self.async_abort(reason="single_instance_allowed")
+
+                    return self.async_create_entry(
+                        title=f"iZone {device_uid}",
+                        data={CONF_HOST: host},
+                    )
+            else:
+                # Auto-discovery (blank host)
+                return await self.async_step_discover()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+            description_placeholders={},
+        )
+
+    async def async_step_discover(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle auto-discovery of iZone controllers on local network."""
+        # Prevent multiple entries - the integration uses a shared
+        # discovery service so all entries see all controllers
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
+        if user_input is not None:
+            # User confirmed discovery
+            return self.async_create_entry(
+                title="iZone",
+                data={},
+            )
+
+        has_devices = await _async_has_devices(self.hass)
+        if not has_devices:
+            return self.async_abort(reason="no_devices_found")
+
+        return self.async_show_form(
+            step_id="discover",
+        )
+
+    async def async_step_import(
+        self, import_data: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle import from configuration.yaml."""
+        # Check if already configured
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
+        has_devices = await _async_has_devices(self.hass)
+        if not has_devices:
+            return self.async_abort(reason="no_devices_found")
+
+        return self.async_create_entry(
+            title="iZone",
+            data={},
+        )

--- a/homeassistant/components/izone/const.py
+++ b/homeassistant/components/izone/const.py
@@ -12,3 +12,22 @@ DISPATCH_CONTROLLER_UPDATE = "izone_controller_update"
 DISPATCH_ZONE_UPDATE = "izone_zone_update"
 
 TIMEOUT_DISCOVERY = 20
+TIMEOUT_CONNECT = 10
+
+# How often (seconds) to retry reconnecting static-IP controllers
+# that have become disconnected. This replaces the broadcast-based
+# reconnection that doesn't work across VLANs.
+STATIC_RECONNECT_INTERVAL = 15
+
+# Grace period (seconds) before marking a controller as unavailable.
+# The pizone library triggers a disconnect on any single failed HTTP
+# request (e.g., a 3-second timeout). This debounce prevents the
+# entity from flapping between available/unavailable on transient
+# network issues. The controller only shows as unavailable if it
+# remains disconnected for this entire duration.
+UNAVAILABLE_DEBOUNCE = 60
+
+# Increased HTTP request timeout (seconds) for the pizone library.
+# The default of 3 seconds is too aggressive for iZone controllers
+# that may be slow to respond during HVAC operations.
+REQUEST_TIMEOUT = 8

--- a/homeassistant/components/izone/discovery.py
+++ b/homeassistant/components/izone/discovery.py
@@ -1,12 +1,15 @@
-"""Internal discovery service for  iZone AC."""
+"""Internal discovery service for iZone AC."""
 
+from datetime import timedelta
 import logging
 
+import aiohttp
 import pizone
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.event import async_track_time_interval
 
 from .const import (
     DATA_DISCOVERY_SERVICE,
@@ -15,6 +18,9 @@ from .const import (
     DISPATCH_CONTROLLER_RECONNECTED,
     DISPATCH_CONTROLLER_UPDATE,
     DISPATCH_ZONE_UPDATE,
+    REQUEST_TIMEOUT,
+    STATIC_RECONNECT_INTERVAL,
+    TIMEOUT_CONNECT,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -28,6 +34,9 @@ class DiscoveryService(pizone.Listener):
         super().__init__()
         self.hass = hass
         self.pi_disco: pizone.DiscoveryService | None = None
+        # Track static-IP controllers and their keepalive unsub callbacks
+        self._static_hosts: dict[str, str] = {}  # device_uid -> host
+        self._keepalive_unsub: CALLBACK_TYPE | None = None
 
     # Listener interface
     def controller_discovered(self, ctrl: pizone.Controller) -> None:
@@ -50,6 +59,99 @@ class DiscoveryService(pizone.Listener):
         """Zone update message is received from the controller."""
         async_dispatcher_send(self.hass, DISPATCH_ZONE_UPDATE, ctrl, zone)
 
+    def _track_static_controller(
+        self, device_uid: str, host: str, ctrl: pizone.Controller
+    ) -> None:
+        """Track a static-IP controller and refresh its address.
+
+        Updates the controller's address and starts the keepalive
+        mechanism if not already running.
+        """
+        ctrl._refresh_address(host)  # noqa: SLF001
+        self._static_hosts[device_uid] = host
+        self._start_keepalive()
+
+    async def async_register_controller(
+        self, host: str, device_uid: str
+    ) -> pizone.Controller:
+        """Register a controller by IP address.
+
+        If the controller is already known, updates its address.
+        Otherwise creates, initializes, and registers a new controller.
+        """
+        assert self.pi_disco is not None
+
+        # Check if controller is already discovered
+        if device_uid in self.pi_disco.controllers:
+            ctrl = self.pi_disco.controllers[device_uid]
+            self._track_static_controller(device_uid, host, ctrl)
+            return ctrl
+
+        # Create controller via the pizone library internals
+        controller = pizone.Controller(
+            self.pi_disco,
+            device_uid=device_uid,
+            device_ip=host,
+            is_v2=False,
+            is_ipower=False,
+        )
+        await controller._initialize()  # noqa: SLF001
+
+        # Register it in the discovery service
+        self.pi_disco.controllers[device_uid] = controller
+        self.pi_disco.controller_discovered(controller)
+
+        self._track_static_controller(device_uid, host, controller)
+        return controller
+
+    def _start_keepalive(self) -> None:
+        """Start periodic keepalive for static-IP controllers.
+
+        The pizone library relies on UDP broadcast responses to trigger
+        reconnection after a connection failure. Since broadcasts don't
+        cross VLANs, we periodically call _refresh_address on static-IP
+        controllers to simulate the broadcast response and trigger the
+        library's built-in retry logic.
+        """
+        if self._keepalive_unsub is not None:
+            return  # Already running
+
+        async def _keepalive_tick(_now) -> None:
+            """Periodic keepalive for static-IP controllers."""
+            if not self.pi_disco:
+                return
+            for device_uid, host in self._static_hosts.items():
+                ctrl = self.pi_disco.controllers.get(device_uid)
+                if ctrl is None:
+                    continue
+                # If controller has a pending failure, poke _refresh_address
+                # to trigger the library's _retry_connection logic
+                if ctrl._fail_exception is not None:  # noqa: SLF001
+                    _LOGGER.debug(
+                        "Keepalive: triggering reconnect for %s at %s",
+                        device_uid,
+                        host,
+                    )
+                    ctrl._refresh_address(host)  # noqa: SLF001
+
+        self._keepalive_unsub = async_track_time_interval(
+            self.hass,
+            _keepalive_tick,
+            timedelta(seconds=STATIC_RECONNECT_INTERVAL),
+        )
+
+    def remove_static_host(self, device_uid: str) -> None:
+        """Remove a static-IP controller and stop keepalive if empty."""
+        self._static_hosts.pop(device_uid, None)
+        if not self._static_hosts:
+            self.stop_keepalive()
+
+    def stop_keepalive(self) -> None:
+        """Stop the periodic keepalive."""
+        if self._keepalive_unsub is not None:
+            self._keepalive_unsub()
+            self._keepalive_unsub = None
+
 
 async def async_start_discovery_service(hass: HomeAssistant):
     """Set up the pizone internal discovery."""
@@ -57,6 +159,11 @@ async def async_start_discovery_service(hass: HomeAssistant):
         # Already started
         return disco
     _LOGGER.debug("Starting iZone Discovery Service")
+
+    # Increase the pizone library's HTTP request timeout.
+    # The default 3 seconds is too aggressive for iZone controllers
+    # that may be slow to respond during HVAC operations.
+    pizone.Controller.REQUEST_TIMEOUT = REQUEST_TIMEOUT
 
     # discovery local services
     disco = DiscoveryService(hass)
@@ -75,7 +182,54 @@ async def async_stop_discovery_service(hass: HomeAssistant):
     if not (disco := hass.data.get(DATA_DISCOVERY_SERVICE)):
         return
 
+    disco.stop_keepalive()
     await disco.pi_disco.close()
     del hass.data[DATA_DISCOVERY_SERVICE]
 
     _LOGGER.debug("Stopped iZone Discovery Service")
+
+
+async def async_get_device_uid(hass: HomeAssistant, host: str) -> str:
+    """Query an iZone device at the given IP address and return its UID.
+
+    Raises ConnectionError if the device cannot be reached or doesn't
+    respond with valid iZone system settings.
+    """
+    session = aiohttp_client.async_get_clientsession(hass)
+    try:
+        async with session.get(
+            f"http://{host}/SystemSettings",
+            timeout=aiohttp.ClientTimeout(total=TIMEOUT_CONNECT),
+        ) as response:
+            response.raise_for_status()
+            data = await response.json(content_type=None)
+            device_uid = data.get("AirStreamDeviceUId")
+            if not device_uid:
+                raise ConnectionError(
+                    "Device did not return a valid AirStreamDeviceUId"
+                )
+            return device_uid
+    except (
+        aiohttp.ClientError,
+        TimeoutError,
+        KeyError,
+        TypeError,
+        ValueError,
+    ) as ex:
+        raise ConnectionError(f"Unable to connect to iZone device at {host}") from ex
+
+
+async def async_add_controller_by_ip(
+    hass: HomeAssistant, host: str, device_uid: str | None = None
+) -> pizone.Controller:
+    """Manually add a controller by IP address.
+
+    If device_uid is provided, skips the HTTP lookup to avoid a redundant
+    network call (the UID is already known from config flow validation).
+    """
+    disco = await async_start_discovery_service(hass)
+
+    if device_uid is None:
+        device_uid = await async_get_device_uid(hass, host)
+
+    return await disco.async_register_controller(host, device_uid)

--- a/homeassistant/components/izone/strings.json
+++ b/homeassistant/components/izone/strings.json
@@ -1,12 +1,26 @@
 {
   "config": {
     "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
     "step": {
-      "confirm": {
-        "description": "Do you want to set up iZone?"
+      "discover": {
+        "description": "iZone controller(s) found on your network. Do you want to set up iZone?"
+      },
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        },
+        "data_description": {
+          "host": "IP address of the iZone hub (e.g. 192.168.1.100). Leave empty for auto-discovery."
+        },
+        "description": "Enter the IP address of your iZone hub, or leave blank to auto-discover on the local network."
       }
     }
   },

--- a/tests/components/izone/conftest.py
+++ b/tests/components/izone/conftest.py
@@ -96,6 +96,7 @@ async def mock_discovery(
         "homeassistant.components.izone.discovery.pizone.discovery", autospec=True
     ) as mock_disco:
         mock_disco.return_value.start_discovery = AsyncMock()
+        mock_disco.return_value.close = AsyncMock()
         mock_disco.return_value.controllers = {
             mock_controller.device_uid: mock_controller
         }

--- a/tests/components/izone/test_climate.py
+++ b/tests/components/izone/test_climate.py
@@ -1,18 +1,23 @@
 """Tests for iZone climate platform."""
 
+from datetime import timedelta
 from unittest.mock import AsyncMock
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant import config_entries
 from homeassistant.components.climate import ClimateEntityFeature
+from homeassistant.components.izone.climate import ControllerDevice
+from homeassistant.components.izone.const import UNAVAILABLE_DEBOUNCE
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.entity_registry as er
 
-from . import setup_controller, setup_integration
+from . import get_discovery_service, setup_controller, setup_integration
 from .conftest import create_mock_controller, create_mock_zone
 
-from tests.common import MockConfigEntry, snapshot_platform
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
 
 async def test_basic_controller_properties(
@@ -260,3 +265,265 @@ async def test_target_temperature_feature_master_mode_zone_13(
         entity.attributes["supported_features"]
         & ClimateEntityFeature.TARGET_TEMPERATURE
     ) == ClimateEntityFeature.TARGET_TEMPERATURE
+
+
+async def test_disconnect_debounce_stays_available(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_discovery: AsyncMock,
+    mock_controller: AsyncMock,
+) -> None:
+    """Test that a transient disconnect does not immediately mark entity unavailable."""
+    await setup_integration(hass, mock_config_entry)
+    await setup_controller(hass, mock_discovery, mock_controller)
+
+    entity_id = "climate.izone_controller_test_controller_123"
+    entity = hass.states.get(entity_id)
+    assert entity is not None
+    assert entity.state != "unavailable"
+
+    # Simulate a disconnect
+    disco = get_discovery_service(mock_discovery)
+    disco.controller_disconnected(mock_controller, ConnectionError("timeout"))
+    await hass.async_block_till_done()
+
+    # Entity should still be available (debounce grace period)
+    entity = hass.states.get(entity_id)
+    assert entity.state != "unavailable"
+
+
+async def test_disconnect_debounce_becomes_unavailable_after_timeout(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_discovery: AsyncMock,
+    mock_controller: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that entity becomes unavailable after the debounce period expires."""
+    await setup_integration(hass, mock_config_entry)
+    await setup_controller(hass, mock_discovery, mock_controller)
+
+    entity_id = "climate.izone_controller_test_controller_123"
+
+    # Simulate a disconnect
+    disco = get_discovery_service(mock_discovery)
+    disco.controller_disconnected(mock_controller, ConnectionError("timeout"))
+    await hass.async_block_till_done()
+
+    # Still available during debounce
+    entity = hass.states.get(entity_id)
+    assert entity.state != "unavailable"
+
+    # Advance past the debounce period
+    freezer.tick(timedelta(seconds=UNAVAILABLE_DEBOUNCE + 1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Now it should be unavailable
+    entity = hass.states.get(entity_id)
+    assert entity.state == "unavailable"
+
+
+async def test_disconnect_debounce_cancelled_by_reconnect(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_discovery: AsyncMock,
+    mock_controller: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that reconnecting during debounce cancels the unavailable timer."""
+    await setup_integration(hass, mock_config_entry)
+    await setup_controller(hass, mock_discovery, mock_controller)
+
+    entity_id = "climate.izone_controller_test_controller_123"
+
+    disco = get_discovery_service(mock_discovery)
+
+    # Simulate disconnect
+    disco.controller_disconnected(mock_controller, ConnectionError("timeout"))
+    await hass.async_block_till_done()
+
+    # Advance partway through debounce
+    freezer.tick(timedelta(seconds=UNAVAILABLE_DEBOUNCE // 2))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Still available
+    entity = hass.states.get(entity_id)
+    assert entity.state != "unavailable"
+
+    # Simulate reconnect (cancels debounce timer)
+    disco.controller_reconnected(mock_controller)
+    await hass.async_block_till_done()
+
+    # Advance past the original debounce period
+    freezer.tick(timedelta(seconds=UNAVAILABLE_DEBOUNCE))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Should still be available (timer was cancelled)
+    entity = hass.states.get(entity_id)
+    assert entity.state != "unavailable"
+
+
+async def test_disconnect_reconnect_flapping(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_discovery: AsyncMock,
+    mock_controller: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that rapid disconnect/reconnect cycles don't cause unavailability."""
+    await setup_integration(hass, mock_config_entry)
+    await setup_controller(hass, mock_discovery, mock_controller)
+
+    entity_id = "climate.izone_controller_test_controller_123"
+    disco = get_discovery_service(mock_discovery)
+
+    # Simulate 5 rapid disconnect/reconnect cycles (like the real issue)
+    for _ in range(5):
+        disco.controller_disconnected(mock_controller, ConnectionError("timeout"))
+        await hass.async_block_till_done()
+
+        # Advance 30 seconds (simulating keepalive reconnect)
+        freezer.tick(timedelta(seconds=30))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+        disco.controller_reconnected(mock_controller)
+        await hass.async_block_till_done()
+
+    # Entity should never have gone unavailable
+    entity = hass.states.get(entity_id)
+    assert entity.state != "unavailable"
+
+
+async def test_zone_follows_controller_debounced_availability(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_discovery: AsyncMock,
+    mock_controller: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that zones follow the controller's debounced availability."""
+    await setup_integration(hass, mock_config_entry)
+    await setup_controller(hass, mock_discovery, mock_controller)
+
+    zone_entity_id = "climate.living_room"
+    disco = get_discovery_service(mock_discovery)
+
+    # Simulate disconnect
+    disco.controller_disconnected(mock_controller, ConnectionError("timeout"))
+    await hass.async_block_till_done()
+
+    # Zone should still be available during debounce
+    zone = hass.states.get(zone_entity_id)
+    assert zone is not None
+    assert zone.state != "unavailable"
+
+    # Advance past debounce
+    freezer.tick(timedelta(seconds=UNAVAILABLE_DEBOUNCE + 1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Zone should now be unavailable (follows controller)
+    zone = hass.states.get(zone_entity_id)
+    assert zone.state == "unavailable"
+
+
+async def test_second_disconnect_during_debounce_is_noop(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_discovery: AsyncMock,
+    mock_controller: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that a second disconnect while debounce is pending does not reset the timer."""
+    await setup_integration(hass, mock_config_entry)
+    await setup_controller(hass, mock_discovery, mock_controller)
+
+    entity_id = "climate.izone_controller_test_controller_123"
+    disco = get_discovery_service(mock_discovery)
+
+    # First disconnect — starts debounce timer
+    disco.controller_disconnected(mock_controller, ConnectionError("timeout"))
+    await hass.async_block_till_done()
+
+    # Entity still available during debounce
+    assert hass.states.get(entity_id).state != "unavailable"
+
+    # Second disconnect before debounce fires — should be a no-op
+    disco.controller_disconnected(mock_controller, ConnectionError("timeout again"))
+    await hass.async_block_till_done()
+
+    # Still available — timer still pending from the first disconnect
+    assert hass.states.get(entity_id).state != "unavailable"
+
+    # Advance past debounce — entity now marked unavailable
+    freezer.tick(timedelta(seconds=UNAVAILABLE_DEBOUNCE + 1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == "unavailable"
+
+
+async def test_mark_unavailable_guard_when_already_unavailable(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_discovery: AsyncMock,
+    mock_controller: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test _mark_unavailable early-returns when the entity is already unavailable."""
+    await setup_integration(hass, mock_config_entry)
+    await setup_controller(hass, mock_discovery, mock_controller)
+
+    entity_id = "climate.izone_controller_test_controller_123"
+    disco = get_discovery_service(mock_discovery)
+
+    # First disconnect — debounce fires, entity becomes unavailable
+    disco.controller_disconnected(mock_controller, ConnectionError("timeout"))
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(seconds=UNAVAILABLE_DEBOUNCE + 1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == "unavailable"
+
+    # Force _mark_unavailable to run again while already unavailable
+    # by finding the ControllerDevice and calling it directly
+    entity = next(
+        e
+        for e in hass.data["entity_components"]["climate"].entities
+        if isinstance(e, ControllerDevice)
+    )
+    # Calling _mark_unavailable on an already-unavailable entity must not raise
+    entity._mark_unavailable(None)
+
+    # Should remain unavailable with no state-write side effects
+    assert hass.states.get(entity_id).state == "unavailable"
+
+
+async def test_debounce_cancelled_on_entity_removal(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_discovery: AsyncMock,
+    mock_controller: AsyncMock,
+) -> None:
+    """Test that the debounce timer is cancelled when entity is removed."""
+    await setup_integration(hass, mock_config_entry)
+    await setup_controller(hass, mock_discovery, mock_controller)
+
+    disco = get_discovery_service(mock_discovery)
+
+    # Trigger a disconnect to start the debounce timer
+    disco.controller_disconnected(mock_controller, ConnectionError("timeout"))
+    await hass.async_block_till_done()
+
+    # Unload the entry — should cancel debounce without error
+    await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Verify the entry is unloaded (no crash from stale callback)
+    assert mock_config_entry.state is config_entries.ConfigEntryState.NOT_LOADED

--- a/tests/components/izone/test_config_flow.py
+++ b/tests/components/izone/test_config_flow.py
@@ -2,15 +2,24 @@
 
 from collections.abc import Callable
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.izone.const import DISPATCH_CONTROLLER_DISCOVERED, IZONE
+from homeassistant.components.izone.const import (
+    DATA_DISCOVERY_SERVICE,
+    DISPATCH_CONTROLLER_DISCOVERED,
+    IZONE,
+)
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from . import setup_controller, setup_integration
+
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture
@@ -31,7 +40,7 @@ def _mock_start_discovery(hass: HomeAssistant, mock_disco: Mock) -> Callable[...
 
 
 async def test_not_found(hass: HomeAssistant, mock_disco: Mock) -> None:
-    """Test not finding iZone controller."""
+    """Test not finding iZone controller via auto-discovery."""
 
     with (
         patch(
@@ -47,11 +56,14 @@ async def test_not_found(hass: HomeAssistant, mock_disco: Mock) -> None:
             IZONE, context={"source": config_entries.SOURCE_USER}
         )
 
-        # Confirmation form
+        # User form with optional host field
         assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
 
+        # Submit with blank host to trigger auto-discovery
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
         assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "no_devices_found"
 
         await hass.async_block_till_done()
 
@@ -59,7 +71,7 @@ async def test_not_found(hass: HomeAssistant, mock_disco: Mock) -> None:
 
 
 async def test_found(hass: HomeAssistant, mock_disco: Mock) -> None:
-    """Test not finding iZone controller."""
+    """Test finding iZone controller via auto-discovery."""
     mock_disco.pi_disco.controllers["blah"] = object()
 
     with (
@@ -80,12 +92,411 @@ async def test_found(hass: HomeAssistant, mock_disco: Mock) -> None:
             IZONE, context={"source": config_entries.SOURCE_USER}
         )
 
-        # Confirmation form
+        # User form with optional host field
         assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+
+        # Submit with blank host to trigger auto-discovery
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+        # Discovery confirmation form
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "discover"
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
         assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert result["data"] == {}
 
         await hass.async_block_till_done()
 
     mock_setup.assert_called_once()
+
+
+async def test_manual_ip_success(hass: HomeAssistant) -> None:
+    """Test manually configuring an iZone controller by IP address."""
+    mock_controller = Mock()
+    mock_controller.device_uid = "000013170"
+
+    with (
+        patch(
+            "homeassistant.components.izone.climate.async_setup_entry",
+            return_value=True,
+        ) as mock_setup,
+        patch(
+            "homeassistant.components.izone.config_flow.async_get_device_uid",
+            return_value="000013170",
+        ),
+        patch(
+            "homeassistant.components.izone.async_add_controller_by_ip",
+            return_value=mock_controller,
+        ),
+        patch(
+            "homeassistant.components.izone.async_start_discovery_service",
+            return_value=None,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            IZONE, context={"source": config_entries.SOURCE_USER}
+        )
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "192.168.2.100"}
+        )
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert result["title"] == "iZone 000013170"
+        assert result["data"] == {CONF_HOST: "192.168.2.100"}
+
+        await hass.async_block_till_done()
+
+    mock_setup.assert_called_once()
+
+
+async def test_manual_ip_cannot_connect(hass: HomeAssistant) -> None:
+    """Test manually configuring with an unreachable IP address."""
+    with patch(
+        "homeassistant.components.izone.config_flow.async_get_device_uid",
+        side_effect=ConnectionError("Unable to connect"),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            IZONE, context={"source": config_entries.SOURCE_USER}
+        )
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "192.168.2.100"}
+        )
+
+        # Should show form again with error
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+        assert result["errors"] == {CONF_HOST: "cannot_connect"}
+
+
+async def test_manual_ip_already_configured(hass: HomeAssistant) -> None:
+    """Test manually configuring an already-configured device."""
+    entry = MockConfigEntry(
+        domain=IZONE,
+        title="iZone 000013170",
+        data={CONF_HOST: "192.168.2.50"},
+        unique_id="000013170",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.izone.config_flow.async_get_device_uid",
+        return_value="000013170",
+    ):
+        result = await hass.config_entries.flow.async_init(
+            IZONE, context={"source": config_entries.SOURCE_USER}
+        )
+
+        assert result["type"] is FlowResultType.FORM
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "192.168.2.100"}
+        )
+
+        # Should abort because unique_id already exists (IP gets updated)
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "already_configured"
+
+        # Verify the host was updated
+        assert entry.data[CONF_HOST] == "192.168.2.100"
+
+
+async def test_manual_ip_updates_existing_discovery_entry(
+    hass: HomeAssistant,
+) -> None:
+    """Test that entering a host updates an existing discovery entry and reloads it."""
+    entry = MockConfigEntry(
+        domain=IZONE,
+        title="iZone",
+        data={},
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.izone.config_flow.async_get_device_uid",
+            return_value="000013170",
+        ),
+        patch(
+            "homeassistant.components.izone.async_add_controller_by_ip",
+            return_value=Mock(),
+        ),
+        patch(
+            "homeassistant.components.izone.async_start_discovery_service",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.izone.climate.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            IZONE, context={"source": config_entries.SOURCE_USER}
+        )
+
+        assert result["type"] is FlowResultType.FORM
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "192.168.2.100"}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data[CONF_HOST] == "192.168.2.100"
+    assert entry.unique_id == "000013170"
+    assert entry.state is config_entries.ConfigEntryState.LOADED
+
+
+async def test_single_instance_allowed_when_entry_exists(
+    hass: HomeAssistant,
+) -> None:
+    """Test that auto-discovery aborts when a discovery entry already exists."""
+    entry = MockConfigEntry(
+        domain=IZONE,
+        title="iZone",
+        data={},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        IZONE, context={"source": config_entries.SOURCE_USER}
+    )
+
+    # User form should still show (allows adding manual IP)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    # Submit blank host to trigger auto-discovery
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    # Should abort because a discovery entry already exists
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "single_instance_allowed"
+
+
+async def test_import_flow(hass: HomeAssistant, mock_disco: Mock) -> None:
+    """Test import from configuration.yaml."""
+    mock_disco.pi_disco.controllers["blah"] = object()
+
+    with (
+        patch(
+            "homeassistant.components.izone.climate.async_setup_entry",
+            return_value=True,
+        ) as mock_setup,
+        patch(
+            "homeassistant.components.izone.config_flow.async_start_discovery_service"
+        ) as start_disco,
+        patch(
+            "homeassistant.components.izone.async_start_discovery_service",
+            return_value=None,
+        ),
+    ):
+        start_disco.side_effect = _mock_start_discovery(hass, mock_disco)
+        result = await hass.config_entries.flow.async_init(
+            IZONE, context={"source": config_entries.SOURCE_IMPORT}
+        )
+
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert result["title"] == "iZone"
+        assert result["data"] == {}
+
+        await hass.async_block_till_done()
+
+    mock_setup.assert_called_once()
+
+
+async def test_import_already_configured(hass: HomeAssistant) -> None:
+    """Test import aborts when already configured."""
+    entry = MockConfigEntry(
+        domain=IZONE,
+        title="iZone",
+        data={},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        IZONE, context={"source": config_entries.SOURCE_IMPORT}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "single_instance_allowed"
+
+
+async def test_manual_ip_single_instance_when_existing_has_host(
+    hass: HomeAssistant,
+) -> None:
+    """Test manual IP aborts when the existing entry already has a host configured."""
+    existing = MockConfigEntry(
+        domain=IZONE,
+        title="iZone 000099999",
+        data={CONF_HOST: "192.168.2.50"},
+        unique_id="000099999",
+    )
+    existing.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.izone.config_flow.async_get_device_uid",
+        return_value="000013170",
+    ):
+        result = await hass.config_entries.flow.async_init(
+            IZONE, context={"source": config_entries.SOURCE_USER}
+        )
+        assert result["type"] is FlowResultType.FORM
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "192.168.2.100"}
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "single_instance_allowed"
+
+
+async def test_import_no_devices(hass: HomeAssistant, mock_disco: Mock) -> None:
+    """Test import aborts when no devices found."""
+    with (
+        patch(
+            "homeassistant.components.izone.config_flow.async_start_discovery_service"
+        ) as start_disco,
+        patch(
+            "homeassistant.components.izone.config_flow.async_stop_discovery_service",
+            return_value=None,
+        ),
+    ):
+        start_disco.side_effect = _mock_start_discovery(hass, mock_disco)
+        result = await hass.config_entries.flow.async_init(
+            IZONE, context={"source": config_entries.SOURCE_IMPORT}
+        )
+
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "no_devices_found"
+
+
+async def test_unload_entry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_discovery: AsyncMock,
+    mock_controller: AsyncMock,
+) -> None:
+    """Test unloading a config entry."""
+
+    await setup_integration(hass, mock_config_entry)
+    await setup_controller(hass, mock_discovery, mock_controller)
+
+    assert mock_config_entry.state is config_entries.ConfigEntryState.LOADED
+
+    await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is config_entries.ConfigEntryState.NOT_LOADED
+
+
+async def test_setup_entry_with_host(hass: HomeAssistant) -> None:
+    """Test setup entry when host is configured."""
+    mock_controller = Mock()
+    mock_controller.device_uid = "000013170"
+
+    entry = MockConfigEntry(
+        domain=IZONE,
+        title="iZone 000013170",
+        data={CONF_HOST: "192.168.2.100"},
+        unique_id="000013170",
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.izone.async_add_controller_by_ip",
+            return_value=mock_controller,
+        ) as mock_add,
+        patch(
+            "homeassistant.components.izone.async_start_discovery_service",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.izone.climate.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    mock_add.assert_called_once_with(hass, "192.168.2.100", "000013170")
+    assert entry.state is config_entries.ConfigEntryState.LOADED
+
+
+async def test_setup_entry_with_host_connection_error(
+    hass: HomeAssistant,
+) -> None:
+    """Test setup entry raises ConfigEntryNotReady on connection error."""
+    entry = MockConfigEntry(
+        domain=IZONE,
+        title="iZone 000013170",
+        data={CONF_HOST: "192.168.2.100"},
+        unique_id="000013170",
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.izone.async_add_controller_by_ip",
+            side_effect=ConnectionError("Unable to connect"),
+        ),
+        patch(
+            "homeassistant.components.izone.async_start_discovery_service",
+            return_value=None,
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is config_entries.ConfigEntryState.SETUP_RETRY
+
+
+async def test_unload_entry_with_host_removes_static_host(
+    hass: HomeAssistant,
+    mock_discovery: AsyncMock,
+) -> None:
+    """Test unloading an entry with a host removes its static controller from discovery."""
+    entry = MockConfigEntry(
+        domain=IZONE,
+        data={CONF_HOST: "192.168.2.100"},
+        unique_id="000013170",
+    )
+    entry.add_to_hass(hass)
+
+    mock_ctrl = Mock()
+    mock_ctrl._refresh_address = Mock()
+    mock_ctrl._initialize = AsyncMock()
+
+    with (
+        patch(
+            "homeassistant.components.izone.discovery.pizone.Controller",
+            return_value=mock_ctrl,
+        ),
+        patch(
+            "homeassistant.components.izone.climate.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is config_entries.ConfigEntryState.LOADED
+    assert DATA_DISCOVERY_SERVICE in hass.data
+    disco = hass.data[DATA_DISCOVERY_SERVICE]
+    assert "000013170" in disco._static_hosts
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert "000013170" not in disco._static_hosts
+    assert entry.state is config_entries.ConfigEntryState.NOT_LOADED

--- a/tests/components/izone/test_discovery.py
+++ b/tests/components/izone/test_discovery.py
@@ -1,0 +1,281 @@
+"""Tests for iZone discovery service."""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import aiohttp
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+
+from homeassistant.components.izone.const import STATIC_RECONNECT_INTERVAL
+from homeassistant.components.izone.discovery import (
+    DiscoveryService,
+    async_add_controller_by_ip,
+    async_get_device_uid,
+    async_start_discovery_service,
+)
+from homeassistant.core import HomeAssistant
+
+from tests.common import async_fire_time_changed
+
+
+def _make_aiohttp_context(
+    json_data: dict | None = None,
+    side_effect: Exception | None = None,
+) -> MagicMock:
+    """Return a mock async context manager for aiohttp session.get()."""
+    if side_effect is not None:
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(side_effect=side_effect)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        return cm
+
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = Mock()
+    mock_response.json = AsyncMock(return_value=json_data or {})
+
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=mock_response)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+async def test_async_get_device_uid_success(hass: HomeAssistant) -> None:
+    """Test successful UID retrieval from an iZone device."""
+    mock_session = Mock()
+    mock_session.get = Mock(
+        return_value=_make_aiohttp_context({"AirStreamDeviceUId": "000013170"})
+    )
+
+    with patch(
+        "homeassistant.helpers.aiohttp_client.async_get_clientsession",
+        return_value=mock_session,
+    ):
+        result = await async_get_device_uid(hass, "192.168.2.100")
+
+    assert result == "000013170"
+
+
+async def test_async_get_device_uid_missing_field(hass: HomeAssistant) -> None:
+    """Test ConnectionError when the response lacks AirStreamDeviceUId."""
+    mock_session = Mock()
+    mock_session.get = Mock(return_value=_make_aiohttp_context({"OtherField": "value"}))
+
+    with (
+        patch(
+            "homeassistant.helpers.aiohttp_client.async_get_clientsession",
+            return_value=mock_session,
+        ),
+        pytest.raises(ConnectionError),
+    ):
+        await async_get_device_uid(hass, "192.168.2.100")
+
+
+async def test_async_get_device_uid_network_error(hass: HomeAssistant) -> None:
+    """Test ConnectionError when the device cannot be reached."""
+    mock_session = Mock()
+    mock_session.get = Mock(
+        return_value=_make_aiohttp_context(
+            side_effect=aiohttp.ClientError("network error")
+        )
+    )
+
+    with (
+        patch(
+            "homeassistant.helpers.aiohttp_client.async_get_clientsession",
+            return_value=mock_session,
+        ),
+        pytest.raises(ConnectionError),
+    ):
+        await async_get_device_uid(hass, "192.168.2.100")
+
+
+async def test_async_add_controller_by_ip_fetches_uid_when_none(
+    hass: HomeAssistant,
+) -> None:
+    """Test that async_add_controller_by_ip fetches the UID when not provided."""
+    mock_ctrl = Mock()
+    mock_ctrl._refresh_address = Mock()
+
+    with patch(
+        "homeassistant.components.izone.discovery.pizone.discovery", autospec=True
+    ) as mock_pizone_disco:
+        mock_pizone_disco.return_value.start_discovery = AsyncMock()
+        mock_pizone_disco.return_value.close = AsyncMock()
+        mock_pizone_disco.return_value.controllers = {}
+
+        disco = await async_start_discovery_service(hass)
+
+        with (
+            patch(
+                "homeassistant.components.izone.discovery.async_get_device_uid",
+                return_value="000013170",
+            ) as mock_get_uid,
+            patch.object(
+                disco, "async_register_controller", return_value=mock_ctrl
+            ) as mock_register,
+        ):
+            result = await async_add_controller_by_ip(hass, "192.168.2.100")
+
+    mock_get_uid.assert_called_once_with(hass, "192.168.2.100")
+    mock_register.assert_called_once_with("192.168.2.100", "000013170")
+    assert result is mock_ctrl
+
+
+async def test_discovery_service_register_existing_controller(
+    hass: HomeAssistant,
+) -> None:
+    """Test registering a controller that is already in the discovery service."""
+    disco = DiscoveryService(hass)
+    mock_ctrl = Mock()
+    mock_ctrl._refresh_address = Mock()
+
+    mock_pi_disco = Mock()
+    mock_pi_disco.controllers = {"uid123": mock_ctrl}
+    disco.pi_disco = mock_pi_disco
+
+    result = await disco.async_register_controller("192.168.1.100", "uid123")
+
+    assert result is mock_ctrl
+    mock_ctrl._refresh_address.assert_called_with("192.168.1.100")
+    assert disco._static_hosts["uid123"] == "192.168.1.100"
+
+
+async def test_discovery_service_register_new_controller(
+    hass: HomeAssistant,
+) -> None:
+    """Test registering a brand-new controller by IP address."""
+    disco = DiscoveryService(hass)
+
+    mock_pi_disco = Mock()
+    mock_pi_disco.controllers = {}
+    mock_pi_disco.controller_discovered = Mock()
+    disco.pi_disco = mock_pi_disco
+
+    mock_ctrl = Mock()
+    mock_ctrl._refresh_address = Mock()
+    mock_ctrl._initialize = AsyncMock()
+
+    with patch(
+        "homeassistant.components.izone.discovery.pizone.Controller",
+        return_value=mock_ctrl,
+    ):
+        result = await disco.async_register_controller("192.168.1.100", "uid456")
+
+    assert result is mock_ctrl
+    mock_ctrl._initialize.assert_called_once()
+    assert mock_pi_disco.controllers["uid456"] is mock_ctrl
+    mock_pi_disco.controller_discovered.assert_called_once_with(mock_ctrl)
+    assert disco._static_hosts["uid456"] == "192.168.1.100"
+
+
+async def test_start_keepalive_runs_only_once(hass: HomeAssistant) -> None:
+    """Test that _start_keepalive is idempotent — a second call is a no-op."""
+    disco = DiscoveryService(hass)
+    mock_ctrl = Mock()
+    mock_ctrl._refresh_address = Mock()
+
+    mock_pi_disco = Mock()
+    mock_pi_disco.controllers = {"uid123": mock_ctrl}
+    disco.pi_disco = mock_pi_disco
+    disco._static_hosts["uid123"] = "192.168.1.100"
+
+    disco._start_keepalive()
+    first_unsub = disco._keepalive_unsub
+    assert first_unsub is not None
+
+    disco._start_keepalive()
+    assert disco._keepalive_unsub is first_unsub
+
+
+async def test_keepalive_tick_triggers_reconnect(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that the keepalive tick calls _refresh_address when a failure is pending."""
+    disco = DiscoveryService(hass)
+    mock_ctrl = Mock()
+    mock_ctrl._refresh_address = Mock()
+    mock_ctrl._fail_exception = Exception("timed out")
+
+    mock_pi_disco = Mock()
+    mock_pi_disco.controllers = {"uid123": mock_ctrl}
+    disco.pi_disco = mock_pi_disco
+    disco._static_hosts["uid123"] = "192.168.1.100"
+    disco._start_keepalive()
+
+    freezer.tick(timedelta(seconds=STATIC_RECONNECT_INTERVAL + 1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    mock_ctrl._refresh_address.assert_called_with("192.168.1.100")
+
+
+async def test_keepalive_tick_skips_healthy_controller(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test keepalive tick does not refresh a controller with no pending failure."""
+    disco = DiscoveryService(hass)
+    mock_ctrl = Mock()
+    mock_ctrl._refresh_address = Mock()
+    mock_ctrl._fail_exception = None
+
+    mock_pi_disco = Mock()
+    mock_pi_disco.controllers = {"uid123": mock_ctrl}
+    disco.pi_disco = mock_pi_disco
+    disco._static_hosts["uid123"] = "192.168.1.100"
+    disco._start_keepalive()
+
+    freezer.tick(timedelta(seconds=STATIC_RECONNECT_INTERVAL + 1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    mock_ctrl._refresh_address.assert_not_called()
+
+
+async def test_keepalive_tick_with_pi_disco_none(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test keepalive tick exits early when pi_disco is None."""
+    disco = DiscoveryService(hass)
+    disco._static_hosts["uid123"] = "192.168.1.100"
+    disco._start_keepalive()
+    disco.pi_disco = None  # Simulate service torn down
+
+    freezer.tick(timedelta(seconds=STATIC_RECONNECT_INTERVAL + 1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()  # Should not raise
+
+
+async def test_remove_static_host_stops_keepalive(hass: HomeAssistant) -> None:
+    """Test removing the last static host stops the keepalive timer."""
+    disco = DiscoveryService(hass)
+    disco._static_hosts["uid123"] = "192.168.1.100"
+    mock_unsub = Mock()
+    disco._keepalive_unsub = mock_unsub
+
+    disco.remove_static_host("uid123")
+
+    assert "uid123" not in disco._static_hosts
+    mock_unsub.assert_called_once()
+    assert disco._keepalive_unsub is None
+
+
+async def test_remove_static_host_keeps_keepalive_when_others_remain(
+    hass: HomeAssistant,
+) -> None:
+    """Test keepalive continues when other static hosts remain after removal."""
+    disco = DiscoveryService(hass)
+    disco._static_hosts["uid1"] = "192.168.1.100"
+    disco._static_hosts["uid2"] = "192.168.1.101"
+    mock_unsub = Mock()
+    disco._keepalive_unsub = mock_unsub
+
+    disco.remove_static_host("uid1")
+
+    assert "uid1" not in disco._static_hosts
+    assert "uid2" in disco._static_hosts
+    mock_unsub.assert_not_called()
+    assert disco._keepalive_unsub is mock_unsub


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add optional IP address configuration to the iZone integration, enabling
users to connect to iZone hubs on different VLANs or subnets where UDP
broadcast discovery doesn't work.
- Add config flow with optional host field for manual IP entry
- Add HTTP-based device UID lookup and controller registration by IP
- Add periodic keepalive for static-IP controllers to trigger reconnection
  across VLANs (replaces UDP broadcast dependency)
- Add disconnect debounce to prevent entity availability flapping on
  transient network issues
- Add cleanup of static hosts on config entry unload
- Expand test coverage for manual IP, discovery, and disconnect scenarios

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes [125116](https://github.com/home-assistant/core/issues/125116)
- Link to documentation pull request: [45270](https://github.com/home-assistant/home-assistant.io/pull/45270)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr