### PR TITLE
Cache AWS S3 backup metadata on disk

### DIFF
--- a/homeassistant/components/aws_s3/backup.py
+++ b/homeassistant/components/aws_s3/backup.py
@@ -21,7 +21,7 @@ from homeassistant.core import HomeAssistant, callback
 
 from . import S3ConfigEntry
 from .const import CONF_BUCKET, CONF_PREFIX, DATA_BACKUP_AGENT_LISTENERS, DOMAIN
-from .helpers import async_list_backups_from_s3
+from .helpers import async_list_backups_from_s3, metadata_cache_dir
 
 _LOGGER = logging.getLogger(__name__)
 CACHE_TTL = 300
@@ -95,6 +95,7 @@ class S3BackupAgent(BackupAgent):
     def __init__(self, hass: HomeAssistant, entry: S3ConfigEntry) -> None:
         """Initialize the S3 agent."""
         super().__init__()
+        self._hass = hass
         self._client = entry.runtime_data.client
         self._bucket: str = entry.data[CONF_BUCKET]
         self.name = entry.title
@@ -102,6 +103,7 @@ class S3BackupAgent(BackupAgent):
         self._backup_cache: dict[str, AgentBackup] = {}
         self._cache_expiration = time()
         self._prefix: str = entry.data.get(CONF_PREFIX, "")
+        self._metadata_cache_dir = metadata_cache_dir(hass, entry.entry_id)
 
     def _with_prefix(self, key: str) -> str:
         """Add prefix to a key if configured."""
@@ -340,7 +342,11 @@ class S3BackupAgent(BackupAgent):
             return self._backup_cache
 
         backups_list = await async_list_backups_from_s3(
-            self._client, self._bucket, self._prefix
+            self._hass,
+            self._client,
+            self._bucket,
+            self._prefix,
+            self._metadata_cache_dir,
         )
         self._backup_cache = {b.backup_id: b for b in backups_list}
         self._cache_expiration = time() + CACHE_TTL

--- a/homeassistant/components/aws_s3/coordinator.py
+++ b/homeassistant/components/aws_s3/coordinator.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import CONF_BUCKET, CONF_PREFIX, DOMAIN
-from .helpers import async_list_backups_from_s3
+from .helpers import async_list_backups_from_s3, metadata_cache_dir
 
 SCAN_INTERVAL = timedelta(hours=6)
 
@@ -52,12 +52,17 @@ class S3DataUpdateCoordinator(DataUpdateCoordinator[SensorData]):
         self.client = client
         self._bucket: str = entry.data[CONF_BUCKET]
         self._prefix: str = entry.data.get(CONF_PREFIX, "")
+        self._metadata_cache_dir = metadata_cache_dir(hass, entry.entry_id)
 
     async def _async_update_data(self) -> SensorData:
         """Fetch data from AWS S3."""
         try:
             backups = await async_list_backups_from_s3(
-                self.client, self._bucket, self._prefix
+                self.hass,
+                self.client,
+                self._bucket,
+                self._prefix,
+                self._metadata_cache_dir,
             )
         except BotoCoreError as error:
             raise UpdateFailed(

--- a/homeassistant/components/aws_s3/diagnostics.py
+++ b/homeassistant/components/aws_s3/diagnostics.py
@@ -15,7 +15,7 @@ from .const import (
     DOMAIN,
 )
 from .coordinator import S3ConfigEntry
-from .helpers import async_list_backups_from_s3
+from .helpers import async_list_backups_from_s3, metadata_cache_dir
 
 TO_REDACT = (CONF_ACCESS_KEY_ID, CONF_SECRET_ACCESS_KEY)
 
@@ -28,9 +28,11 @@ async def async_get_config_entry_diagnostics(
     coordinator = entry.runtime_data
     backup_manager = hass.data[BACKUP_DATA_MANAGER]
     backups = await async_list_backups_from_s3(
+        hass,
         coordinator.client,
         bucket=entry.data[CONF_BUCKET],
         prefix=entry.data.get(CONF_PREFIX, ""),
+        cache_dir=metadata_cache_dir(hass, entry.entry_id),
     )
 
     data = {

--- a/homeassistant/components/aws_s3/helpers.py
+++ b/homeassistant/components/aws_s3/helpers.py
@@ -1,21 +1,148 @@
 """Helpers for the AWS S3 integration."""
 
+from collections.abc import Iterable
+import hashlib
 import json
 import logging
+from pathlib import Path
 from typing import Any
 
 from aiobotocore.client import AioBaseClient as S3Client
 from botocore.exceptions import BotoCoreError
 
 from homeassistant.components.backup import AgentBackup
+from homeassistant.core import HomeAssistant
+from homeassistant.util import slugify
+from homeassistant.util.file import WriteError, write_utf8_file
+
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
+METADATA_CACHE_DIR = "backup_metadata"
+METADATA_CACHE_SUFFIX = ".json"
+METADATA_CACHE_NAME_MAX_LENGTH = 80
+
+
+def metadata_cache_dir(hass: HomeAssistant, entry_id: str) -> Path:
+    """Return the metadata cache directory for a config entry."""
+    return Path(hass.config.cache_path(DOMAIN, METADATA_CACHE_DIR, entry_id))
+
+
+def _metadata_cache_path(cache_dir: Path, metadata_file: dict[str, Any]) -> Path:
+    """Return the cache path for a listed S3 metadata object."""
+    # ETag is not guaranteed to be a content MD5 for every S3 object, so include
+    # other list metadata that changes when the object is replaced.
+    metadata_key = str(metadata_file.get("Key", ""))
+    identity = "|".join(
+        (
+            metadata_key,
+            str(metadata_file.get("ETag", "")),
+            str(metadata_file.get("Size", "")),
+            str(metadata_file.get("LastModified", "")),
+        )
+    )
+    readable_name = slugify(Path(metadata_key).name.removesuffix(".metadata.json"))[
+        :METADATA_CACHE_NAME_MAX_LENGTH
+    ]
+    digest = hashlib.blake2s(identity.encode(), digest_size=8).hexdigest()
+    return cache_dir / f"{readable_name}_{digest}{METADATA_CACHE_SUFFIX}"
+
+
+def _read_metadata_cache(cache_path: Path) -> bytes | None:
+    """Read metadata bytes from the cache."""
+    try:
+        if not cache_path.is_file():
+            return None
+        return cache_path.read_bytes()
+    except OSError as err:
+        _LOGGER.debug("Failed to read cached metadata file %s: %s", cache_path, err)
+        return None
+
+
+def _write_metadata_cache(cache_path: Path, metadata_content: bytes) -> None:
+    """Write metadata bytes to the cache."""
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        write_utf8_file(str(cache_path), metadata_content, private=True, mode="wb")
+    except (OSError, WriteError) as err:
+        _LOGGER.debug("Failed to write cached metadata file %s: %s", cache_path, err)
+
+
+def _delete_metadata_cache(cache_path: Path) -> None:
+    """Delete a metadata cache file."""
+    try:
+        cache_path.unlink(missing_ok=True)
+    except OSError as err:
+        _LOGGER.debug("Failed to delete cached metadata file %s: %s", cache_path, err)
+
+
+def _prune_metadata_cache(cache_dir: Path, used_cache_paths: Iterable[Path]) -> None:
+    """Delete cache files that are not part of the latest S3 listing."""
+    used_cache_paths = set(used_cache_paths)
+    try:
+        cache_files = list(cache_dir.glob(f"*{METADATA_CACHE_SUFFIX}"))
+    except OSError as err:
+        _LOGGER.debug("Failed to list metadata cache directory %s: %s", cache_dir, err)
+        return
+
+    for cache_file in cache_files:
+        if cache_file in used_cache_paths:
+            continue
+        _delete_metadata_cache(cache_file)
+
+
+def _backup_from_metadata_content(
+    metadata_content: bytes, metadata_key: str, *, log_warning: bool
+) -> AgentBackup | None:
+    """Parse backup metadata content."""
+    try:
+        metadata_json = json.loads(metadata_content)
+    except (json.JSONDecodeError, UnicodeDecodeError) as err:
+        if log_warning:
+            _LOGGER.warning(
+                "Failed to process metadata file %s: %s",
+                metadata_key,
+                err,
+            )
+        return None
+
+    try:
+        return AgentBackup.from_dict(metadata_json)
+    except (KeyError, TypeError, ValueError) as err:
+        if log_warning:
+            _LOGGER.warning(
+                "Failed to parse metadata in file %s: %s",
+                metadata_key,
+                err,
+            )
+        return None
+
+
+async def _async_download_metadata_content(
+    client: S3Client,
+    bucket: str,
+    metadata_key: str,
+) -> bytes | None:
+    """Download a metadata file from S3."""
+    try:
+        metadata_response = await client.get_object(Bucket=bucket, Key=metadata_key)
+        return await metadata_response["Body"].read()
+    except BotoCoreError as err:
+        _LOGGER.warning(
+            "Failed to process metadata file %s: %s",
+            metadata_key,
+            err,
+        )
+        return None
+
 
 async def async_list_backups_from_s3(
+    hass: HomeAssistant,
     client: S3Client,
     bucket: str,
     prefix: str,
+    cache_dir: Path,
 ) -> list[AgentBackup]:
     """List backups from an S3 bucket by reading metadata files."""
     paginator = client.get_paginator("list_objects_v2")
@@ -33,29 +160,52 @@ async def async_list_backups_from_s3(
         )
 
     backups: list[AgentBackup] = []
+    used_cache_paths: set[Path] = set()
     for metadata_file in metadata_files:
-        try:
-            metadata_response = await client.get_object(
-                Bucket=bucket, Key=metadata_file["Key"]
+        metadata_key = metadata_file["Key"]
+        cache_path = _metadata_cache_path(cache_dir, metadata_file)
+        used_cache_paths.add(cache_path)
+
+        metadata_content = await hass.async_add_executor_job(
+            _read_metadata_cache, cache_path
+        )
+        content_from_cache = metadata_content is not None
+
+        if metadata_content is None:
+            metadata_content = await _async_download_metadata_content(
+                client, bucket, metadata_key
             )
-            metadata_content = await metadata_response["Body"].read()
-            metadata_json = json.loads(metadata_content)
-        except (BotoCoreError, json.JSONDecodeError) as err:
-            _LOGGER.warning(
-                "Failed to process metadata file %s: %s",
-                metadata_file["Key"],
-                err,
+            if metadata_content is None:
+                continue
+
+        backup = _backup_from_metadata_content(
+            metadata_content, metadata_key, log_warning=not content_from_cache
+        )
+
+        if backup is None and content_from_cache:
+            # Cached metadata can be safely discarded; S3 remains the source of truth.
+            await hass.async_add_executor_job(_delete_metadata_cache, cache_path)
+            metadata_content = await _async_download_metadata_content(
+                client, bucket, metadata_key
             )
+            if metadata_content is None:
+                continue
+            content_from_cache = False
+            backup = _backup_from_metadata_content(
+                metadata_content, metadata_key, log_warning=True
+            )
+
+        if backup is None:
             continue
-        try:
-            backup = AgentBackup.from_dict(metadata_json)
-        except (KeyError, TypeError, ValueError) as err:
-            _LOGGER.warning(
-                "Failed to parse metadata in file %s: %s",
-                metadata_file["Key"],
-                err,
+
+        if not content_from_cache:
+            await hass.async_add_executor_job(
+                _write_metadata_cache, cache_path, metadata_content
             )
-            continue
+
         backups.append(backup)
 
+    await hass.async_add_executor_job(
+        _prune_metadata_cache, cache_dir, used_cache_paths
+    )
     return backups

--- a/tests/components/aws_s3/test_backup.py
+++ b/tests/components/aws_s3/test_backup.py
@@ -3,6 +3,8 @@
 from collections.abc import AsyncGenerator
 from io import StringIO
 import json
+from pathlib import Path
+import shutil
 from time import time
 from unittest.mock import ANY, AsyncMock, Mock, call, patch
 
@@ -21,6 +23,7 @@ from homeassistant.components.aws_s3.const import (
     DATA_BACKUP_AGENT_LISTENERS,
     DOMAIN,
 )
+from homeassistant.components.aws_s3.helpers import metadata_cache_dir
 from homeassistant.components.backup import (
     DATA_MANAGER,
     DOMAIN as BACKUP_DOMAIN,
@@ -37,6 +40,16 @@ from tests.common import MockConfigEntry
 from tests.typing import ClientSessionGenerator, MagicMock, WebSocketGenerator
 
 
+def _metadata_cache_files(hass: HomeAssistant, entry: MockConfigEntry) -> list[Path]:
+    """Return cached metadata files for an entry."""
+    return list(metadata_cache_dir(hass, entry.entry_id).glob("*.json"))
+
+
+def _clear_metadata_cache(hass: HomeAssistant, entry: MockConfigEntry) -> None:
+    """Clear cached metadata files for an entry."""
+    shutil.rmtree(metadata_cache_dir(hass, entry.entry_id), ignore_errors=True)
+
+
 @pytest.fixture(autouse=True)
 async def setup_backup_integration(
     hass: HomeAssistant,
@@ -48,6 +61,7 @@ async def setup_backup_integration(
         patch("homeassistant.components.backup.store.STORE_DELAY_SAVE", 0),
     ):
         assert await async_setup_component(hass, BACKUP_DOMAIN, {})
+        _clear_metadata_cache(hass, mock_config_entry)
         await setup_integration(hass, mock_config_entry)
 
         await hass.async_block_till_done()
@@ -410,8 +424,8 @@ async def test_agents_download(
     )
     assert resp.status == 200
     assert await resp.content.read() == b"backup data"
-    # Coordinator first refresh reads metadata (1) + download reads metadata (1) + tar (1)
-    assert mock_client.get_object.call_count == 3
+    # Coordinator first refresh reads metadata (1) + download reads tar (1)
+    assert mock_client.get_object.call_count == 2
 
 
 async def test_error_during_delete(
@@ -450,12 +464,14 @@ async def test_cache_expiration(
     """Test that the cache expires correctly."""
     # Mock the entry
     mock_entry = MockConfigEntry(
+        entry_id="cache-test",
         domain=DOMAIN,
         data={"bucket": "test-bucket"},
         unique_id="test-unique-id",
         title="Test S3",
     )
     mock_entry.runtime_data = MagicMock(client=mock_client)
+    _clear_metadata_cache(hass, mock_entry)
 
     # Create agent
     agent = S3BackupAgent(hass, mock_entry)
@@ -484,6 +500,9 @@ async def test_cache_expiration(
     await agent.async_list_backups()
     assert mock_client.get_paginator.call_count == 1
     assert mock_client.get_object.call_count == 1
+    cache_filename = _metadata_cache_files(hass, mock_entry)[0].name
+    assert cache_filename.startswith("test_")
+    assert len(cache_filename.removeprefix("test_").removesuffix(".json")) == 16
 
     # Second call should use cache
     await agent.async_list_backups()
@@ -493,9 +512,172 @@ async def test_cache_expiration(
     # Set cache to expire
     agent._cache_expiration = time() - 1
 
-    # Third call should query S3 again
+    # Third call should list S3 again and reuse the disk metadata cache
     await agent.async_list_backups()
     assert mock_client.get_paginator.call_count == 2
+    assert mock_client.get_object.call_count == 1
+
+
+async def test_metadata_disk_cache_refreshes_when_fingerprint_changes(
+    hass: HomeAssistant,
+    mock_client: MagicMock,
+    mock_agent_backup: AgentBackup,
+) -> None:
+    """Test metadata is downloaded when the listed object fingerprint changes."""
+    mock_entry = MockConfigEntry(
+        entry_id="fingerprint-cache-test",
+        domain=DOMAIN,
+        data={"bucket": "test-bucket"},
+        unique_id="fingerprint-cache-test",
+        title="Test S3",
+    )
+    mock_entry.runtime_data = MagicMock(client=mock_client)
+    _clear_metadata_cache(hass, mock_entry)
+    agent = S3BackupAgent(hass, mock_entry)
+    mock_client.reset_mock()
+
+    first_content = json.dumps(mock_agent_backup.as_dict()).encode()
+    second_content = json.dumps(
+        mock_agent_backup.as_dict() | {"name": "Updated backup"}
+    ).encode()
+    first_body = AsyncMock()
+    first_body.read.return_value = first_content
+    second_body = AsyncMock()
+    second_body.read.return_value = second_content
+    mock_client.get_object.side_effect = [
+        {"Body": first_body},
+        {"Body": second_body},
+    ]
+
+    mock_client.get_paginator.return_value.paginate.return_value.__aiter__.return_value = [
+        {
+            "Contents": [
+                {
+                    "Key": "test.metadata.json",
+                    "ETag": '"first"',
+                    "Size": len(first_content),
+                    "LastModified": "2023-01-01T00:00:00+00:00",
+                }
+            ]
+        }
+    ]
+    await agent.async_list_backups()
+
+    agent._cache_expiration = time() - 1
+    mock_client.get_paginator.return_value.paginate.return_value.__aiter__.return_value = [
+        {
+            "Contents": [
+                {
+                    "Key": "test.metadata.json",
+                    "ETag": '"second"',
+                    "Size": len(second_content),
+                    "LastModified": "2023-01-01T00:00:00+00:00",
+                }
+            ]
+        }
+    ]
+
+    backups = await agent.async_list_backups()
+
+    assert backups[0].name == "Updated backup"
+    assert mock_client.get_object.call_count == 2
+
+
+async def test_metadata_disk_cache_prunes_stale_files(
+    hass: HomeAssistant,
+    mock_client: MagicMock,
+    mock_agent_backup: AgentBackup,
+) -> None:
+    """Test metadata cache files are pruned after they disappear from S3 listings."""
+    mock_entry = MockConfigEntry(
+        entry_id="prune-cache-test",
+        domain=DOMAIN,
+        data={"bucket": "test-bucket"},
+        unique_id="prune-cache-test",
+        title="Test S3",
+    )
+    mock_entry.runtime_data = MagicMock(client=mock_client)
+    _clear_metadata_cache(hass, mock_entry)
+    agent = S3BackupAgent(hass, mock_entry)
+    mock_client.reset_mock()
+
+    metadata_content = json.dumps(mock_agent_backup.as_dict()).encode()
+    mock_body = AsyncMock()
+    mock_body.read.return_value = metadata_content
+    mock_client.get_object.return_value = {"Body": mock_body}
+    mock_client.get_paginator.return_value.paginate.return_value.__aiter__.return_value = [
+        {
+            "Contents": [
+                {
+                    "Key": "test.metadata.json",
+                    "LastModified": "2023-01-01T00:00:00+00:00",
+                }
+            ]
+        }
+    ]
+
+    await agent.async_list_backups()
+    assert len(_metadata_cache_files(hass, mock_entry)) == 1
+
+    agent._cache_expiration = time() - 1
+    mock_client.get_paginator.return_value.paginate.return_value.__aiter__.return_value = [
+        {"Contents": []}
+    ]
+    await agent.async_list_backups()
+
+    assert _metadata_cache_files(hass, mock_entry) == []
+
+
+async def test_metadata_disk_cache_refetches_corrupt_cache(
+    hass: HomeAssistant,
+    mock_client: MagicMock,
+    mock_agent_backup: AgentBackup,
+) -> None:
+    """Test corrupt cached metadata is replaced from S3."""
+    mock_entry = MockConfigEntry(
+        entry_id="corrupt-cache-test",
+        domain=DOMAIN,
+        data={"bucket": "test-bucket"},
+        unique_id="corrupt-cache-test",
+        title="Test S3",
+    )
+    mock_entry.runtime_data = MagicMock(client=mock_client)
+    _clear_metadata_cache(hass, mock_entry)
+    agent = S3BackupAgent(hass, mock_entry)
+    mock_client.reset_mock()
+
+    first_content = json.dumps(mock_agent_backup.as_dict()).encode()
+    second_content = json.dumps(
+        mock_agent_backup.as_dict() | {"name": "Recovered backup"}
+    ).encode()
+    first_body = AsyncMock()
+    first_body.read.return_value = first_content
+    second_body = AsyncMock()
+    second_body.read.return_value = second_content
+    mock_client.get_object.side_effect = [
+        {"Body": first_body},
+        {"Body": second_body},
+    ]
+    mock_client.get_paginator.return_value.paginate.return_value.__aiter__.return_value = [
+        {
+            "Contents": [
+                {
+                    "Key": "test.metadata.json",
+                    "LastModified": "2023-01-01T00:00:00+00:00",
+                }
+            ]
+        }
+    ]
+
+    await agent.async_list_backups()
+    cache_file = _metadata_cache_files(hass, mock_entry)[0]
+    cache_file.write_text("{invalid", encoding="utf-8")
+
+    agent._cache_expiration = time() - 1
+    backups = await agent.async_list_backups()
+
+    assert backups[0].name == "Recovered backup"
+    assert cache_file.read_bytes() == second_content
     assert mock_client.get_object.call_count == 2
 
 


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

@harrisonhjones, this keeps the existing short in-memory listing cache for AWS S3 backups, but changes cold listings to use a read-through disk cache for backup metadata files. I originally thought about the metadata caching possibility in https://github.com/home-assistant/core/pull/144628#discussion_r2687491901, but never got around to making a PR with the change. Here it is.

Today, once the in-memory cache expires, `aws_s3` lists the bucket and downloads every `*.metadata.json` file again. For users with hundreds or thousands of retained backups, that means hundreds or thousands of serial metadata downloads after each cache expiry. A small daily backup setup with an S3 lifecycle policy retaining one year of backups already produces at least 365 metadata files.

This PR still lists S3 after the in-memory cache expires, but it only downloads metadata files whose listed object fingerprint is not already cached locally. Cached metadata is keyed from the S3 object key, ETag, size, and last modified timestamp. The local filename keeps a sanitized, readable form of the S3 metadata object name and appends a short fingerprint suffix, so the files are easier to inspect while still changing automatically when S3 reports a replaced object. Stale local cache files are pruned after each listing.

This was developed by OpenAI Codex under supervision.

## Implementation notes

- The existing short in-memory listing cache is retained.
- The disk cache is read-through only. Uploads do not pre-seed metadata into the disk cache.
- S3 remains the source of truth. A corrupt local metadata cache file is discarded and refetched.
- Cache files live under Home Assistant's cache path for this config entry.
- Cache filenames use a sanitized metadata object name plus a 16-character BLAKE2s fingerprint.
- The in-memory listing cache remains at 5 minutes for this PR to keep the behavior change small. If we assume this Home Assistant instance is the only writer of the backup storage, this could likely be raised to hours because successful uploads and deletes already invalidate the listing cache.
- The change is contained within `aws_s3`.

## Other backup components

| Component | Could benefit | Notes |
| --- | --- | --- |
| `cloudflare_r2` | Yes | S3-compatible shape; stores separate metadata objects similarly to `aws_s3`. |
| `idrive_e2` | Yes | S3-compatible shape; likely a direct follow-up candidate. |
| `backblaze_b2` | Maybe | Uses separate metadata files; could use a similar read-through cache keyed by file metadata. |
| `webdav` | Maybe | Downloads separate metadata files; benefit depends on stable listing metadata such as ETag or modified time. |
| `onedrive` | Maybe | Downloads metadata files and has item IDs; could cache by item ID and eTag. |
| `onedrive_for_business` | Maybe | Same general approach as `onedrive`. |
| `dropbox` | Maybe | Lists and downloads metadata files; could cache by path, revision, or content hash. |
| `synology_dsm` | Maybe | Remote-ish backup listing with metadata fetches; needs component-specific review. |
| `sftp_storage` | Maybe | Depends on whether remote listing exposes stable file attributes cheaply enough. |
| `azure_storage` | No | Listing already includes blob metadata containing backup metadata. |
| `google_drive` | No | Client returns backup metadata from provider-side listing behavior. |
| `cloud` | No | Cloud API listing already returns metadata. |

Should separate PRs be opened for the S3-compatible components first (`cloudflare_r2` and `idrive_e2`) before considering the less direct providers?

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to discussion: https://github.com/home-assistant/core/pull/144628#discussion_r2687491901
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the development checklist.
- [x] I have followed the perfect PR recommendations.
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`).
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for www.home-assistant.io.

If the code communicates with devices, web services, or third-party tools:

- [ ] The manifest file has all fields filled out correctly.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other open pull requests in this repository.

EDIT: Updated the targeted user. I had mixed up who I actually spoke with back then. Sorry @tomasbedrich.