### PR TITLE
prusalink: add continue-job button for ATTENTION state

### DIFF
--- a/homeassistant/components/prusalink/button.py
+++ b/homeassistant/components/prusalink/button.py
@@ -56,6 +56,14 @@ BUTTONS: dict[str, tuple[PrusaLinkButtonEntityDescription, ...]] = {
                 bool, data["printer"]["state"] == PrinterState.PAUSED.value
             ),
         ),
+        PrusaLinkButtonEntityDescription[PrinterStatus](
+            key="job.continue_job",
+            translation_key="continue_job",
+            press_fn=lambda api: api.continue_job,
+            available_fn=lambda data: cast(
+                bool, data["printer"]["state"] == PrinterState.ATTENTION.value
+            ),
+        ),
     ),
 }
 

--- a/homeassistant/components/prusalink/icons.json
+++ b/homeassistant/components/prusalink/icons.json
@@ -4,6 +4,9 @@
       "cancel_job": {
         "default": "mdi:cancel"
       },
+      "continue_job": {
+        "default": "mdi:play-circle"
+      },
       "pause_job": {
         "default": "mdi:pause"
       },

--- a/homeassistant/components/prusalink/strings.json
+++ b/homeassistant/components/prusalink/strings.json
@@ -26,6 +26,9 @@
       "cancel_job": {
         "name": "Cancel job"
       },
+      "continue_job": {
+        "name": "Continue job"
+      },
       "pause_job": {
         "name": "Pause job"
       },

--- a/tests/components/prusalink/conftest.py
+++ b/tests/components/prusalink/conftest.py
@@ -188,6 +188,15 @@ def mock_job_api_paused(
 
 
 @pytest.fixture
+def mock_job_api_attention(
+    mock_get_status_printing: dict[str, Any], mock_job_api_printing: dict[str, Any]
+) -> None:
+    """Mock PrusaLink printing in ATTENTION state (e.g. timelapse capture)."""
+    mock_job_api_printing["state"] = "ATTENTION"
+    mock_get_status_printing["printer"]["state"] = "ATTENTION"
+
+
+@pytest.fixture
 def mock_api(
     mock_version_api: dict[str, str],
     mock_info_api: dict[str, Any],

--- a/tests/components/prusalink/test_button.py
+++ b/tests/components/prusalink/test_button.py
@@ -116,3 +116,59 @@ async def test_button_resume_cancel(
             {"entity_id": entity_id},
             blocking=True,
         )
+
+
+async def test_button_continue(
+    hass: HomeAssistant,
+    mock_config_entry,
+    mock_api,
+    hass_client: ClientSessionGenerator,
+    mock_job_api_attention,
+) -> None:
+    """Test continue button is enabled in ATTENTION state and calls continue_job."""
+    entity_id = "button.mock_title_continue_job"
+    assert await async_setup_component(hass, "prusalink", {})
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "unknown"
+
+    with (
+        patch("pyprusalink.PrusaLink.continue_job") as mock_meth,
+        patch(
+            "homeassistant.components.prusalink.coordinator.PrusaLinkUpdateCoordinator._fetch_data"
+        ),
+    ):
+        await hass.services.async_call(
+            "button",
+            "press",
+            {"entity_id": entity_id},
+            blocking=True,
+        )
+
+    assert len(mock_meth.mock_calls) == 1
+
+    # Verify error handling — Conflict raised by API surfaces as HomeAssistantError
+    with (
+        pytest.raises(HomeAssistantError),
+        patch("pyprusalink.PrusaLink.continue_job", side_effect=Conflict),
+    ):
+        await hass.services.async_call(
+            "button",
+            "press",
+            {"entity_id": entity_id},
+            blocking=True,
+        )
+
+
+async def test_button_continue_unavailable_when_printing(
+    hass: HomeAssistant,
+    mock_config_entry,
+    mock_api,
+    mock_job_api_printing,
+    mock_get_status_printing,
+) -> None:
+    """Continue button is unavailable when printer is not in ATTENTION state."""
+    assert await async_setup_component(hass, "prusalink", {})
+    state = hass.states.get("button.mock_title_continue_job")
+    assert state is not None
+    assert state.state == "unavailable"


### PR DESCRIPTION
## Proposed change

Adds a Continue button to the PrusaLink integration. The button calls `api.continue_job()` (available in pyprusalink 2.2.0) and is enabled when the printer is in the **ATTENTION** state — for example when paused for a timelapse capture or awaiting user intervention after a filament event.

### Why this is a separate button from "Resume"

`Resume` and `Continue` look superficially similar but map to different printer states and different API endpoints:

| | Resume | Continue |
|---|---|---|
| API endpoint | `PUT /api/v1/job/{id}/resume` | `PUT /api/v1/job/{id}/continue` |
| Enabled when | `state == PAUSED` | `state == ATTENTION` |
| Use cases | Manual pause (user pressed pause), error pause | Timelapse capture pause, printer-initiated pauses awaiting user acknowledgement |

These are distinct state transitions in the firmware — `ATTENTION` means the printer needs explicit user acknowledgement to proceed, while `PAUSED` is a normal pause. Only one of the two buttons is enabled at any given time, depending on the current printer state.

### Note on user docs

The user-facing docs at `home-assistant/home-assistant.io` (`source/_integrations/prusalink.markdown`) will be updated in a separate PR after this lands, covering this distinction along with the other recent integration changes (new sensors, location → suggested area, etc.).

This is part of a series of incremental improvements to the prusalink integration; #169309, #169312, #170092, #170099, and #170105 are already merged. Depends on the `continue_job` method introduced in pyprusalink 2.2.0 which was wired up by #170105.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (non-breaking change which fixes an issue)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally
- [x] Local tests pass (33 passed, 2 new)
- [x] Lint (ruff), mypy, and hassfest all pass
- [x] There is no commented out code in this PR