### PR TITLE
Use VERSION from PrusaLinkConfigFlow in prusalink

### DIFF
--- a/homeassistant/components/prusalink/__init__.py
+++ b/homeassistant/components/prusalink/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.exceptions import ConfigEntryError
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.httpx_client import get_async_client
 
-from .config_flow import ConfigFlow
+from .config_flow import PrusaLinkConfigFlow
 from .const import DOMAIN
 from .coordinator import (
     InfoUpdateCoordinator,
@@ -67,7 +67,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: PrusaLinkConfigEntry) ->
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Migrate old entry."""
-    if config_entry.version > ConfigFlow.VERSION:
+    if config_entry.version > PrusaLinkConfigFlow.VERSION:
         # This means the user has downgraded from a future version
         return False
 

--- a/homeassistant/components/prusalink/__init__.py
+++ b/homeassistant/components/prusalink/__init__.py
@@ -67,7 +67,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: PrusaLinkConfigEntry) ->
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Migrate old entry."""
-    if config_entry.version > PrusaLinkConfigFlow.VERSION:
+    if (config_entry.version, config_entry.minor_version) > (
+        PrusaLinkConfigFlow.VERSION,
+        PrusaLinkConfigFlow.MINOR_VERSION,
+    ):
         # This means the user has downgraded from a future version
         return False
 

--- a/tests/components/prusalink/test_init.py
+++ b/tests/components/prusalink/test_init.py
@@ -8,7 +8,7 @@ from pyprusalink.types import InvalidAuth, PrusaLinkError
 import pytest
 
 from homeassistant.components.prusalink import DOMAIN
-from homeassistant.components.prusalink.config_flow import ConfigFlow
+from homeassistant.components.prusalink.config_flow import PrusaLinkConfigFlow
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
@@ -174,7 +174,7 @@ async def test_migration_fails_on_future_version(
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={},
-        version=ConfigFlow.VERSION + 1,
+        version=PrusaLinkConfigFlow.VERSION + 1,
     )
     entry.add_to_hass(hass)
 

--- a/tests/components/prusalink/test_init.py
+++ b/tests/components/prusalink/test_init.py
@@ -182,3 +182,21 @@ async def test_migration_fails_on_future_version(
     await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.MIGRATION_ERROR
+
+
+async def test_migration_fails_on_future_minor_version(
+    hass: HomeAssistant, issue_registry: ir.IssueRegistry
+) -> None:
+    """Test migrating fails on the current version with a higher minor version."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+        version=PrusaLinkConfigFlow.VERSION,
+        minor_version=PrusaLinkConfigFlow.MINOR_VERSION + 1,
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.MIGRATION_ERROR


### PR DESCRIPTION
## Proposed change

Fixes a latent bug in the migration version check.

`__init__.py` and `test_init.py` both did:
```python
from homeassistant.components.prusalink.config_flow import ConfigFlow
...
config_entry.version > ConfigFlow.VERSION
```

…but `ConfigFlow` here is `homeassistant.config_entries.ConfigFlow` (HA's base class, re-exported via our `config_flow` module), not the integration's actual subclass `PrusaLinkConfigFlow`. So the comparison reads HA's default `VERSION = 1`, not ours.

This works today **by coincidence** because both happen to be `1`. The check becomes silently wrong the moment `PrusaLinkConfigFlow.VERSION` is ever bumped: migration would refuse to load valid config entries created by the new code, and the `test_migration_fails_on_future_version` test would no longer be testing a "future" version.

While in there, the future-version guard now also covers `minor_version` — it compares `(version, minor_version)` as a tuple against the class constants, so a downgraded install can't accidentally accept entries created by a newer minor version. A regression test exercises the new branch.

### Note

There's no plan to bump `PrusaLinkConfigFlow.VERSION` right now — this is just removing a latent footgun before it bites.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (non-breaking change which fixes an issue)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally
- [x] Local tests pass (9 passed in tests/components/prusalink/test_init.py)
- [x] Lint (ruff) and mypy pass
- [x] There is no commented out code in this PR