### PR TITLE
prusalink: add quality_scale.yaml as a tracked roadmap

### DIFF
--- a/homeassistant/components/prusalink/quality_scale.yaml
+++ b/homeassistant/components/prusalink/quality_scale.yaml
@@ -23,7 +23,12 @@ rules:
       No custom service actions are registered (see `action-setup`).
   docs-high-level-description: done
   docs-installation-instructions: done
-  docs-removal-instructions: done
+  docs-removal-instructions:
+    status: todo
+    comment: |
+      No removal instructions in
+      https://www.home-assistant.io/integrations/prusalink/. Add a
+      "Removing the integration" section in the docs PR.
   entity-event-setup:
     status: exempt
     comment: |
@@ -106,7 +111,15 @@ rules:
   docs-data-update: todo
   docs-examples: todo
   docs-known-limitations: todo
-  docs-supported-devices: todo
+  docs-supported-devices:
+    status: todo
+    comment: |
+      A device list already exists in the docs; status stays `todo`
+      pending a full docs-side QA pass to confirm it covers the current
+      Buddy-firmware lineup (Core One/Core One L/Core One+/MK4/MK4S/
+      MK3.9(S)/MK3.5(S)) and to surface firmware caveats (XL 6.4.x,
+      MINI 6.4.0 lack the `printer.firmware` field). Done as part of
+      the upcoming docs PR.
   docs-supported-functions: todo
   docs-troubleshooting: todo
   docs-use-cases: todo

--- a/homeassistant/components/prusalink/quality_scale.yaml
+++ b/homeassistant/components/prusalink/quality_scale.yaml
@@ -3,92 +3,99 @@ rules:
   action-setup:
     status: exempt
     comment: |
-      The integration does not register any custom service actions. Printer
-      control (cancel/pause/resume/continue) is exposed as button entities
-      whose enablement is bound to the printer state, and there are no
-      parameter-taking operations on the public API today.
+      No custom service actions.
   appropriate-polling: done
   brands: done
   common-modules: done
-  config-flow-test-coverage: done
+  config-flow-test-coverage:
+    status: todo
+    comment: |
+      - `test_form` has a stale name/docstring.
+      - Use a `mock_setup_entry` fixture instead of patching inline.
+      - Typo `resultn` should reuse `result`.
+      - Merge `test_form_invalid_auth` and `test_form_unknown` with
+        `pytest.mark.parametrize`, and have every flow test end in
+        `CREATE_ENTRY` by repatching the mock to verify recovery.
   config-flow:
     status: todo
     comment: |
-      `data_description` is missing in `strings.json` for the `user` step's
-      host/username/password fields; the rule explicitly requires it.
+      Add `data_description` in `strings.json` for the host/username/
+      password fields on the user step.
   dependency-transparency: done
   docs-actions:
     status: exempt
     comment: |
-      No custom service actions are registered (see `action-setup`).
+      No custom service actions.
   docs-high-level-description: done
   docs-installation-instructions: done
-  docs-removal-instructions:
-    status: todo
-    comment: |
-      No removal instructions in
-      https://www.home-assistant.io/integrations/prusalink/. Add a
-      "Removing the integration" section in the docs PR.
+  docs-removal-instructions: todo
   entity-event-setup:
     status: exempt
     comment: |
-      Entities inherit `CoordinatorEntity` and are updated solely via
-      `DataUpdateCoordinator` polling. There are no integration-library
-      events that would need an `async_added_to_hass` subscription.
+      Coordinator-polled; no library events to subscribe to.
   entity-unique-id: done
   has-entity-name: done
   runtime-data: done
   test-before-configure: done
-  test-before-setup:
-    status: done
-    comment: |
-      `coordinator.async_config_entry_first_refresh()` runs for every
-      coordinator before platforms are forwarded, so unreachable or
-      misconfigured printers raise `ConfigEntryNotReady` at setup time.
+  test-before-setup: done
   unique-config-entry:
     status: todo
     comment: |
-      The config flow does not call `set_unique_id`, so the same printer can
-      be added twice. Use the serial number from `/api/v1/info` (already
-      fetched during validation) as the unique_id.
+      Config flow does not call `set_unique_id`. Use the serial number
+      from `/api/v1/info` (already fetched during validation) — and
+      reuse it as the device identifier and entity unique_id prefix in
+      place of `entry_id`.
 
   # Silver
   action-exceptions:
-    status: exempt
+    status: todo
     comment: |
-      No custom service actions are registered (see `action-setup`).
+      Button presses raise `HomeAssistantError("Action conflicts with
+      current printer state")` with a hard-coded English string when
+      the printer rejects the action. We don't register custom service
+      actions, but button presses are user-triggered actions in spirit
+      so this rule applies. Switch to `translation_key` (tracked
+      alongside `exception-translations`).
   config-entry-unloading: done
   docs-configuration-parameters:
     status: exempt
     comment: |
-      The integration does not provide an options flow. Host, username, and
-      password are captured during initial setup; there are no runtime
-      configuration parameters.
+      No options flow; host/username/password are captured at setup.
   docs-installation-parameters:
     status: todo
     comment: |
-      Same gap as `config-flow` — needs `data_description` for each input
-      field in the `user` step of `strings.json`.
+      Same gap as `config-flow`: needs `data_description`.
   entity-unavailable: done
   integration-owner:
     status: todo
     comment: |
-      No codeowner is currently assigned in `manifest.json`.
-  log-when-unavailable:
-    status: done
-    comment: |
-      Handled by `DataUpdateCoordinator`: it logs once on the transition to
-      unavailable and once on recovery.
+      Assign a codeowner in `manifest.json`.
+  log-when-unavailable: done
   parallel-updates:
     status: todo
     comment: |
-      `PARALLEL_UPDATES` is not declared on any platform module.
+      Declare `PARALLEL_UPDATES` on each platform module.
   reauthentication-flow:
     status: todo
     comment: |
-      Add `async_step_reauth` so users can re-enter credentials without
-      removing the config entry when authentication starts failing.
-  test-coverage: done
+      `InvalidAuth` currently surfaces as `UpdateFailed`; should trigger
+      `async_step_reauth` instead so the user can re-enter credentials
+      without removing the entry.
+  test-coverage:
+    status: todo
+    comment: |
+      - Use `snapshot_platform` to fixate entities instead of asserting
+        manually.
+      - Replace per-method `patch(...)` calls with a single `PrusaLink`
+        patch (see `mealie` for the pattern).
+      - Use `freezegun`/`freezer` in `test_failed_update` rather than
+        firing time changes directly.
+      - Introduce `CONF_HOST`-style constants for fixture values rather
+        than literal strings.
+      - Set up the config entry via
+        `hass.config_entries.async_setup(entry.entry_id)` instead of
+        `async_setup_component(hass, "prusalink", {})`.
+
   # Gold
   devices: done
   diagnostics:
@@ -99,44 +106,37 @@ rules:
   discovery-update-info:
     status: todo
     comment: |
-      Depends on `discovery` being implemented first; once `async_step_dhcp`
-      exists it should also update the stored host so users with dynamic
-      IPs don't end up with stale configurations.
+      Once `async_step_dhcp` lands (`discovery`), also update the
+      stored host on rediscovery so dynamic-IP printers don't drift.
   discovery:
     status: todo
     comment: |
-      `manifest.json` declares a DHCP MAC-prefix matcher, but the config
-      flow has no `async_step_dhcp` handler — discovery is detected but not
-      onboarded.
+      `manifest.json` declares a DHCP MAC-prefix matcher but the config
+      flow has no `async_step_dhcp` — DHCP-discovered printers should
+      onboard without prompting for an IP.
   docs-data-update: todo
   docs-examples: todo
   docs-known-limitations: todo
   docs-supported-devices:
     status: todo
     comment: |
-      A device list already exists in the docs; status stays `todo`
-      pending a full docs-side QA pass to confirm it covers the current
+      Existing device list needs a refresh against the current
       Buddy-firmware lineup (Core One/Core One L/Core One+/MK4/MK4S/
-      MK3.9(S)/MK3.5(S)) and to surface firmware caveats (XL 6.4.x,
-      MINI 6.4.0 lack the `printer.firmware` field). Done as part of
-      the upcoming docs PR.
+      MK3.9(S)/MK3.5(S)) and the firmware-field caveats (XL 6.4.x,
+      MINI 6.4.0 lack the `printer.firmware` field).
   docs-supported-functions: todo
   docs-troubleshooting: todo
   docs-use-cases: todo
   dynamic-devices:
     status: exempt
     comment: |
-      A config entry represents a single PrusaLink-managed printer. Storage
-      devices, cameras and other sub-resources are not modelled as separate
-      HA devices — they are entities on the printer device — so there is
-      nothing to discover dynamically after setup.
+      One printer per config entry; sub-resources are entities on that
+      device.
   entity-category:
     status: todo
     comment: |
-      Static-config sensors that don't change with use (e.g. nozzle
-      diameter, minimum extrusion temperature) should carry
-      `EntityCategory.DIAGNOSTIC`. Operational sensors (temperatures, axis
-      positions, fan speeds) stay primary.
+      Mark static-config sensors (nozzle diameter, min extrusion temp)
+      as `EntityCategory.DIAGNOSTIC`. Operational sensors stay primary.
   entity-device-class: done
   entity-disabled-by-default: done
   entity-translations: done
@@ -144,37 +144,25 @@ rules:
     status: todo
     comment: |
       Buttons raise `HomeAssistantError("Action conflicts with current
-      printer state")` with a hard-coded English string; should use
-      `translation_key` instead.
+      printer state")` with a hard-coded English string; switch to
+      `translation_key`.
   icon-translations: done
   reconfiguration-flow:
     status: todo
     comment: |
-      Add a reconfigure step so users can update host/credentials without
-      deleting and re-adding the integration.
-  repair-issues:
-    status: done
-    comment: |
-      `firmware_5_1_required` is raised via the issue registry when a printer
-      runs unsupported firmware, with `translation_key` and
-      `translation_placeholders` providing localised update guidance.
+      Add `async_step_reconfigure` so host/credentials can change
+      without re-adding the entry.
+  repair-issues: done
   stale-devices:
     status: exempt
     comment: |
-      One printer per config entry, no sub-devices. Removing the printer is
-      done by removing the config entry.
+      One printer per config entry; sub-resources are entities.
 
   # Platinum
   async-dependency: done
-  inject-websession:
-    status: done
-    comment: |
-      `PrusaLink` is constructed with HA's shared httpx client via
-      `get_async_client(hass)`, so the integration shares the platform's
-      connection pool rather than creating its own.
+  inject-websession: done
   strict-typing:
     status: todo
     comment: |
-      `pyprusalink` is gaining strict mypy via
-      home-assistant-libs/pyprusalink#167 (released as 2.2.1). Once HA pins
-      that version, this becomes claimable.
+      Claimable once HA pins `pyprusalink>=3.0.0` (ships `py.typed` and
+      `mypy --strict` in CI).

--- a/homeassistant/components/prusalink/quality_scale.yaml
+++ b/homeassistant/components/prusalink/quality_scale.yaml
@@ -84,7 +84,6 @@ rules:
       Add `async_step_reauth` so users can re-enter credentials without
       removing the config entry when authentication starts failing.
   test-coverage: done
-
   # Gold
   devices: done
   diagnostics:

--- a/homeassistant/components/prusalink/quality_scale.yaml
+++ b/homeassistant/components/prusalink/quality_scale.yaml
@@ -1,0 +1,168 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: |
+      The integration does not register any custom service actions. Printer
+      control (cancel/pause/resume/continue) is exposed as button entities
+      whose enablement is bound to the printer state, and there are no
+      parameter-taking operations on the public API today.
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow:
+    status: todo
+    comment: |
+      `data_description` is missing in `strings.json` for the `user` step's
+      host/username/password fields; the rule explicitly requires it.
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: |
+      No custom service actions are registered (see `action-setup`).
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  entity-event-setup:
+    status: exempt
+    comment: |
+      Entities inherit `CoordinatorEntity` and are updated solely via
+      `DataUpdateCoordinator` polling. There are no integration-library
+      events that would need an `async_added_to_hass` subscription.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup:
+    status: done
+    comment: |
+      `coordinator.async_config_entry_first_refresh()` runs for every
+      coordinator before platforms are forwarded, so unreachable or
+      misconfigured printers raise `ConfigEntryNotReady` at setup time.
+  unique-config-entry:
+    status: todo
+    comment: |
+      The config flow does not call `set_unique_id`, so the same printer can
+      be added twice. Use the serial number from `/api/v1/info` (already
+      fetched during validation) as the unique_id.
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: |
+      No custom service actions are registered (see `action-setup`).
+  config-entry-unloading: done
+  docs-configuration-parameters:
+    status: exempt
+    comment: |
+      The integration does not provide an options flow. Host, username, and
+      password are captured during initial setup; there are no runtime
+      configuration parameters.
+  docs-installation-parameters:
+    status: todo
+    comment: |
+      Same gap as `config-flow` — needs `data_description` for each input
+      field in the `user` step of `strings.json`.
+  entity-unavailable: done
+  integration-owner:
+    status: todo
+    comment: |
+      No codeowner is currently assigned in `manifest.json`.
+  log-when-unavailable:
+    status: done
+    comment: |
+      Handled by `DataUpdateCoordinator`: it logs once on the transition to
+      unavailable and once on recovery.
+  parallel-updates:
+    status: todo
+    comment: |
+      `PARALLEL_UPDATES` is not declared on any platform module.
+  reauthentication-flow:
+    status: todo
+    comment: |
+      Add `async_step_reauth` so users can re-enter credentials without
+      removing the config entry when authentication starts failing.
+  test-coverage: done
+
+  # Gold
+  devices: done
+  diagnostics:
+    status: todo
+    comment: |
+      Add `diagnostics.py` returning the latest coordinator data with
+      sensitive fields redacted.
+  discovery-update-info:
+    status: todo
+    comment: |
+      Depends on `discovery` being implemented first; once `async_step_dhcp`
+      exists it should also update the stored host so users with dynamic
+      IPs don't end up with stale configurations.
+  discovery:
+    status: todo
+    comment: |
+      `manifest.json` declares a DHCP MAC-prefix matcher, but the config
+      flow has no `async_step_dhcp` handler — discovery is detected but not
+      onboarded.
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices:
+    status: exempt
+    comment: |
+      A config entry represents a single PrusaLink-managed printer. Storage
+      devices, cameras and other sub-resources are not modelled as separate
+      HA devices — they are entities on the printer device — so there is
+      nothing to discover dynamically after setup.
+  entity-category:
+    status: todo
+    comment: |
+      Static-config sensors that don't change with use (e.g. nozzle
+      diameter, minimum extrusion temperature) should carry
+      `EntityCategory.DIAGNOSTIC`. Operational sensors (temperatures, axis
+      positions, fan speeds) stay primary.
+  entity-device-class: done
+  entity-disabled-by-default: done
+  entity-translations: done
+  exception-translations:
+    status: todo
+    comment: |
+      Buttons raise `HomeAssistantError("Action conflicts with current
+      printer state")` with a hard-coded English string; should use
+      `translation_key` instead.
+  icon-translations: done
+  reconfiguration-flow:
+    status: todo
+    comment: |
+      Add a reconfigure step so users can update host/credentials without
+      deleting and re-adding the integration.
+  repair-issues:
+    status: done
+    comment: |
+      `firmware_5_1_required` is raised via the issue registry when a printer
+      runs unsupported firmware, with `translation_key` and
+      `translation_placeholders` providing localised update guidance.
+  stale-devices:
+    status: exempt
+    comment: |
+      One printer per config entry, no sub-devices. Removing the printer is
+      done by removing the config entry.
+
+  # Platinum
+  async-dependency: done
+  inject-websession:
+    status: done
+    comment: |
+      `PrusaLink` is constructed with HA's shared httpx client via
+      `get_async_client(hass)`, so the integration shares the platform's
+      connection pool rather than creating its own.
+  strict-typing:
+    status: todo
+    comment: |
+      `pyprusalink` is gaining strict mypy via
+      home-assistant-libs/pyprusalink#167 (released as 2.2.1). Once HA pins
+      that version, this becomes claimable.

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -752,7 +752,6 @@ INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE = [
     "prowl",
     "proximity",
     "proxmoxve",
-    "prusalink",
     "ps4",
     "pulseaudio_loopback",
     "pure_energie",


### PR DESCRIPTION
## Proposed change

Adds `homeassistant/components/prusalink/quality_scale.yaml` with an honest current-state assessment of the integration against the [quality scale rules](https://www.home-assistant.io/docs/quality_scale/).

This PR makes **no behavioural changes** — it only formalises where the integration stands so we can iterate toward Bronze/Silver/Gold without accidentally claiming compliance we don't have.

### Method

For each rule I checked the actual code/manifest/strings.json against the rule's definition, not just the rule name. A rule is `done` only when the integration genuinely meets it. `exempt` is reserved for rules that are not applicable (e.g. `action-setup` when there are no custom service actions). Otherwise it's `todo`, with a comment describing what specifically is needed so the file doubles as a roadmap.

### Notable findings while auditing

- `config-flow` requires `data_description` in `strings.json` (the rule docs explicitly say so) — we don't have it, so this is `todo`
- `discovery` looked done from `manifest.json` (DHCP MAC-prefix matcher) but the config flow has no `async_step_dhcp`, so discovery is detected but not onboarded — `todo`
- `unique-config-entry` is missing entirely — the same printer can be added twice today
- `repair-issues` is genuinely `done` because of the `firmware_5_1_required` issue handler

### Manifest

The manifest's `quality_scale` field is intentionally not set; there are too many `todo`s to claim a tier yet. The integration stays in `INTEGRATIONS_WITHOUT_SCALE`. `prusalink` is removed from `INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE` so hassfest stops complaining about a missing file.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (non-breaking change which fixes an issue)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally
- [x] Local tests pass (31 passed)
- [x] Lint (ruff), mypy, and hassfest all pass
- [x] There is no commented out code in this PR