### PR TITLE
Use standby for HDMI-CEC turn off

### DIFF
--- a/homeassistant/components/hdmi_cec/media_player.py
+++ b/homeassistant/components/hdmi_cec/media_player.py
@@ -4,6 +4,7 @@ import logging
 
 from pycec.commands import CecCommand, KeyPressCommand, KeyReleaseCommand
 from pycec.const import (
+    CMD_STANDBY,
     KEY_BACKWARD,
     KEY_FORWARD,
     KEY_MUTE_TOGGLE,
@@ -93,7 +94,7 @@ class CecPlayerEntity(CecEntity, MediaPlayerEntity):
 
     async def async_turn_off(self) -> None:
         """Turn device off."""
-        self._device.turn_off()
+        self._device.send_command(CecCommand(CMD_STANDBY, dst=self._logical_address))
         self._attr_state = MediaPlayerState.OFF
         self.async_write_ha_state()
 

--- a/homeassistant/components/hdmi_cec/switch.py
+++ b/homeassistant/components/hdmi_cec/switch.py
@@ -3,7 +3,8 @@
 import logging
 from typing import Any
 
-from pycec.const import POWER_OFF, POWER_ON
+from pycec.commands import CecCommand
+from pycec.const import CMD_STANDBY, POWER_OFF, POWER_ON
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN, SwitchEntity
 from homeassistant.core import HomeAssistant
@@ -50,7 +51,7 @@ class CecSwitchEntity(CecEntity, SwitchEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn device off."""
-        self._device.turn_off()
+        self._device.send_command(CecCommand(CMD_STANDBY, dst=self._logical_address))
         self._attr_is_on = False
         self.async_write_ha_state()
 

--- a/tests/components/hdmi_cec/__init__.py
+++ b/tests/components/hdmi_cec/__init__.py
@@ -2,7 +2,11 @@
 
 from unittest.mock import AsyncMock, Mock
 
-from homeassistant.components.hdmi_cec import KeyPressCommand, KeyReleaseCommand
+from homeassistant.components.hdmi_cec import (
+    CecCommand,
+    KeyPressCommand,
+    KeyReleaseCommand,
+)
 
 
 class MockHDMIDevice:
@@ -49,3 +53,12 @@ def assert_key_press_release(fnc, count=0, *, dst, key):
     assert press_arg.dst == dst
     assert isinstance(release_arg, KeyReleaseCommand)
     assert release_arg.dst == dst
+
+
+def assert_cec_command(fnc, *, cmd, dst):
+    """Assert that correct CecCommand was sent."""
+    fnc.assert_called_once()
+    command = fnc.call_args.args[0]
+    assert isinstance(command, CecCommand)
+    assert command.cmd == cmd
+    assert command.dst == dst

--- a/tests/components/hdmi_cec/test_media_player.py
+++ b/tests/components/hdmi_cec/test_media_player.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from pycec.const import (
+    CMD_STANDBY,
     DEVICE_TYPE_NAMES,
     KEY_BACKWARD,
     KEY_FORWARD,
@@ -54,7 +55,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from . import MockHDMIDevice, assert_key_press_release
+from . import MockHDMIDevice, assert_cec_command, assert_key_press_release
 from .conftest import CecEntityCreator, HDMINetworkCreator
 
 
@@ -148,7 +149,12 @@ async def test_service_off(
         blocking=True,
     )
 
-    mock_hdmi_device.turn_off.assert_called_once_with()
+    mock_hdmi_device.turn_off.assert_not_called()
+    assert_cec_command(
+        mock_hdmi_device.send_command,
+        cmd=CMD_STANDBY,
+        dst=mock_hdmi_device.logical_address,
+    )
 
     state = hass.states.get("media_player.hdmi_3")
     assert state.state == STATE_OFF

--- a/tests/components/hdmi_cec/test_switch.py
+++ b/tests/components/hdmi_cec/test_switch.py
@@ -1,6 +1,13 @@
 """Tests for the HDMI-CEC switch platform."""
 
-from pycec.const import POWER_OFF, POWER_ON, STATUS_PLAY, STATUS_STILL, STATUS_STOP
+from pycec.const import (
+    CMD_STANDBY,
+    POWER_OFF,
+    POWER_ON,
+    STATUS_PLAY,
+    STATUS_STILL,
+    STATUS_STOP,
+)
 from pycec.network import PhysicalAddress
 import pytest
 
@@ -16,7 +23,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from . import MockHDMIDevice
+from . import MockHDMIDevice, assert_cec_command
 from .conftest import CecEntityCreator, HDMINetworkCreator
 
 
@@ -107,7 +114,12 @@ async def test_service_off(
         blocking=True,
     )
 
-    mock_hdmi_device.turn_off.assert_called_once_with()
+    mock_hdmi_device.turn_off.assert_not_called()
+    assert_cec_command(
+        mock_hdmi_device.send_command,
+        cmd=CMD_STANDBY,
+        dst=mock_hdmi_device.logical_address,
+    )
 
     state = hass.states.get("switch.hdmi_3")
     assert state.state == STATE_OFF


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
The HDMI-CEC `turn_off` command for both the `switch` and `media_player` has changed to use the CEC _standby_ command. This is probably what you want to turn off your TV or other equipment! 
If you need the old behavior you can send the _key press_ command: `0x44` with the _power off_ attribute `0x6c` to your device.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This changes HDMI-CEC `turn_off` handling for both `media_player` and `switch` entities to send the HDMI-CEC `STANDBY` command directly to the configured logical device address instead of using `device.turn_off()`.

The current implementation does not work reliably for TVs. In practice, consumer HDMI-CEC devices are usually not powered off in the sense of cutting power or shutting down the device. When using the normal remote control, these devices are put into standby. Sending the HDMI-CEC standby command matches that expected behavior and also matches the existing `hdmi_cec.standby` action, which works for the reported setup.

This also avoids a more problematic interpretation of “power off” in an HDMI-CEC environment. A true power-off style command can mean disconnecting or shutting down the connected device. For example, an HDMI-connected Raspberry Pi may shut down instead of putting the display path into standby. That is not what a Home Assistant user would normally expect when turning off a media player or switch entity; the entity should behave like a normal controllable device becoming off/standby, not disappearing from the HDMI-CEC bus or terminating its connection.

Using `CMD_STANDBY` makes `turn_off` align with how HDMI-CEC devices are normally controlled and with what users expect from Home Assistant.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170177
- This PR is related to issue: #57586
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr