### PR TITLE
Add config flow connection check to easyEnergy integration

### DIFF
--- a/homeassistant/components/easyenergy/config_flow.py
+++ b/homeassistant/components/easyenergy/config_flow.py
@@ -2,7 +2,11 @@
 
 from typing import Any
 
+from easyenergy import EasyEnergy, EasyEnergyConnectionError
+
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 
@@ -16,14 +20,22 @@ class EasyEnergyFlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
+        errors = {}
 
         await self.async_set_unique_id(DOMAIN)
         self._abort_if_unique_id_configured()
 
-        if user_input is None:
-            return self.async_show_form(step_id="user")
+        if user_input is not None:
+            easyenergy = EasyEnergy(session=async_get_clientsession(self.hass))
+            today = dt_util.now().date()
+            try:
+                await easyenergy.energy_prices(start_date=today, end_date=today)
+            except EasyEnergyConnectionError:
+                errors["base"] = "cannot_connect"
+            else:
+                return self.async_create_entry(
+                    title="easyEnergy",
+                    data={},
+                )
 
-        return self.async_create_entry(
-            title="easyEnergy",
-            data={},
-        )
+        return self.async_show_form(step_id="user", errors=errors)

--- a/homeassistant/components/easyenergy/config_flow.py
+++ b/homeassistant/components/easyenergy/config_flow.py
@@ -20,7 +20,7 @@ class EasyEnergyFlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-        errors = {}
+        errors: dict[str, str] = {}
 
         await self.async_set_unique_id(DOMAIN)
         self._abort_if_unique_id_configured()

--- a/homeassistant/components/easyenergy/strings.json
+++ b/homeassistant/components/easyenergy/strings.json
@@ -3,6 +3,9 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
     "step": {
       "user": {
         "description": "[%key:common::config_flow::description::confirm_setup%]"

--- a/tests/components/easyenergy/test_config_flow.py
+++ b/tests/components/easyenergy/test_config_flow.py
@@ -1,6 +1,8 @@
 """Test the easyEnergy config flow."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+
+from easyenergy import EasyEnergyConnectionError
 
 from homeassistant.components.easyenergy.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
@@ -12,27 +14,59 @@ from tests.common import MockConfigEntry
 
 async def test_full_user_flow(
     hass: HomeAssistant,
+    mock_easyenergy: MagicMock,
     mock_setup_entry: MagicMock,
 ) -> None:
     """Test the full user configuration flow."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
+    with patch(
+        "homeassistant.components.easyenergy.config_flow.EasyEnergy",
+        return_value=mock_easyenergy,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
 
-    assert result.get("type") is FlowResultType.FORM
-    assert result.get("step_id") == "user"
-    assert "flow_id" in result
+        assert result.get("type") is FlowResultType.FORM
+        assert result.get("step_id") == "user"
+        assert "flow_id" in result
 
-    result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input={},
-    )
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={},
+        )
 
     assert result2.get("type") is FlowResultType.CREATE_ENTRY
     assert result2.get("title") == "easyEnergy"
     assert result2.get("data") == {}
 
+    assert mock_easyenergy.energy_prices.call_count == 1
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_user_flow_cannot_connect(
+    hass: HomeAssistant,
+    mock_easyenergy: MagicMock,
+    mock_setup_entry: MagicMock,
+) -> None:
+    """Test we handle connection errors."""
+    mock_easyenergy.energy_prices.side_effect = EasyEnergyConnectionError
+
+    with patch(
+        "homeassistant.components.easyenergy.config_flow.EasyEnergy",
+        return_value=mock_easyenergy,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={},
+        )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["errors"] == {"base": "cannot_connect"}
+    assert len(mock_setup_entry.mock_calls) == 0
 
 
 async def test_single_instance(

--- a/tests/components/easyenergy/test_config_flow.py
+++ b/tests/components/easyenergy/test_config_flow.py
@@ -48,8 +48,11 @@ async def test_user_flow_cannot_connect(
     mock_easyenergy: MagicMock,
     mock_setup_entry: MagicMock,
 ) -> None:
-    """Test we handle connection errors."""
-    mock_easyenergy.energy_prices.side_effect = EasyEnergyConnectionError
+    """Test we handle connection errors and recover."""
+    mock_easyenergy.energy_prices.side_effect = [
+        EasyEnergyConnectionError,
+        mock_easyenergy.energy_prices.return_value,
+    ]
 
     with patch(
         "homeassistant.components.easyenergy.config_flow.EasyEnergy",
@@ -59,14 +62,25 @@ async def test_user_flow_cannot_connect(
             DOMAIN, context={"source": SOURCE_USER}
         )
 
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={},
         )
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["errors"] == {"base": "cannot_connect"}
-    assert len(mock_setup_entry.mock_calls) == 0
+        assert result["type"] is FlowResultType.FORM
+        assert result["errors"] == {"base": "cannot_connect"}
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={},
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "easyEnergy"
+    assert result["data"] == {}
+
+    assert mock_easyenergy.energy_prices.call_count == 2
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_single_instance(

--- a/tests/components/easyenergy/test_init.py
+++ b/tests/components/easyenergy/test_init.py
@@ -2,7 +2,8 @@
 
 from unittest.mock import MagicMock, patch
 
-from easyenergy import EasyEnergyConnectionError
+from easyenergy import EasyEnergyConnectionError, EasyEnergyNoDataError
+import pytest
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -24,6 +25,25 @@ async def test_load_unload_config_entry(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+@pytest.mark.freeze_time("2026-04-19 14:00:00+00:00")
+async def test_load_config_entry_without_tomorrow_energy_data(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_easyenergy: MagicMock
+) -> None:
+    """Test the entry loads when tomorrow's energy data is not available yet."""
+    mock_easyenergy.energy_prices.side_effect = [
+        mock_easyenergy.energy_prices.return_value,
+        EasyEnergyNoDataError,
+    ]
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert mock_easyenergy.energy_prices.call_count == 2
+    assert mock_config_entry.runtime_data.data.energy_tomorrow is None
 
 
 @patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds the easyEnergy config flow connection check required by the Integration Quality Scale. The flow now tests the easyEnergy API before creating the entry and shows `cannot_connect` when the service cannot be reached.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
