### PR TITLE
Support `ecovacs.raw_get_positions` on lawn mowers (GOAT)

### DIFF
--- a/homeassistant/components/ecovacs/icons.json
+++ b/homeassistant/components/ecovacs/icons.json
@@ -196,6 +196,9 @@
     }
   },
   "services": {
+    "mower_raw_get_positions": {
+      "service": "mdi:map-marker-radius-outline"
+    },
     "raw_get_positions": {
       "service": "mdi:map-marker-radius-outline"
     }

--- a/homeassistant/components/ecovacs/lawn_mower.py
+++ b/homeassistant/components/ecovacs/lawn_mower.py
@@ -1,7 +1,7 @@
 """Ecovacs mower entity."""
 
 import logging
-from typing import override
+from typing import Any, override
 
 from deebot_client.capabilities import Capabilities, DeviceType
 from deebot_client.device import Device
@@ -15,9 +15,11 @@ from homeassistant.components.lawn_mower import (
     LawnMowerEntityFeature,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import EcovacsConfigEntry
+from .const import DOMAIN
 from .entity import EcovacsEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -97,3 +99,27 @@ class EcovacsMower(
     async def async_dock(self) -> None:
         """Parks the mower until next schedule."""
         await self._device.execute_command(self._capability.charge.execute())
+
+    async def async_raw_get_positions(
+        self,
+    ) -> dict[str, Any]:
+        """Get the raw positions response for the mower and its charging dock.
+
+        Mirrors the modern vacuum implementation so service
+        `ecovacs.raw_get_positions` works on `lawn_mower.*` ecovacs entities.
+        Useful for inspecting additional payload fields the cloud may return
+        for RTK GOAT mowers (e.g. satellite counts, fix quality, signal
+        strength), which can then be parsed and exposed by deebot-client and
+        this integration in follow-up changes.
+        """
+        _LOGGER.debug("async_raw_get_positions")
+
+        if not (map_cap := self._capability.map) or not (
+            position_commands := map_cap.position.get
+        ):
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="raw_get_positions_not_supported",
+            )
+
+        return await self._device.execute_command(position_commands[0])

--- a/homeassistant/components/ecovacs/services.py
+++ b/homeassistant/components/ecovacs/services.py
@@ -1,5 +1,6 @@
 """Ecovacs services."""
 
+from homeassistant.components.lawn_mower import DOMAIN as LAWN_MOWER_DOMAIN
 from homeassistant.components.vacuum import DOMAIN as VACUUM_DOMAIN
 from homeassistant.core import HomeAssistant, SupportsResponse, callback
 from homeassistant.helpers import service
@@ -19,6 +20,20 @@ def async_setup_services(hass: HomeAssistant) -> None:
         DOMAIN,
         SERVICE_RAW_GET_POSITIONS,
         entity_domain=VACUUM_DOMAIN,
+        schema=None,
+        func="async_raw_get_positions",
+        supports_response=SupportsResponse.ONLY,
+    )
+
+    # Lawn Mower Services (Ecovacs GOAT family — same raw position payload as
+    # vacuums; exposed here so users can capture the response and inspect
+    # additional fields the cloud may return, e.g. RTK status / satellite count
+    # for GOAT mowers).
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVICE_RAW_GET_POSITIONS,
+        entity_domain=LAWN_MOWER_DOMAIN,
         schema=None,
         func="async_raw_get_positions",
         supports_response=SupportsResponse.ONLY,

--- a/homeassistant/components/ecovacs/services.py
+++ b/homeassistant/components/ecovacs/services.py
@@ -8,13 +8,14 @@ from homeassistant.helpers import service
 from .const import DOMAIN
 
 SERVICE_RAW_GET_POSITIONS = "raw_get_positions"
+SERVICE_MOWER_RAW_GET_POSITIONS = "mower_raw_get_positions"
 
 
 @callback
 def async_setup_services(hass: HomeAssistant) -> None:
     """Set up services."""
 
-    # Vacuum Services
+    # Vacuum: existing service, unchanged
     service.async_register_platform_entity_service(
         hass,
         DOMAIN,
@@ -25,14 +26,13 @@ def async_setup_services(hass: HomeAssistant) -> None:
         supports_response=SupportsResponse.ONLY,
     )
 
-    # Lawn Mower Services (Ecovacs GOAT family — same raw position payload as
-    # vacuums; exposed here so users can capture the response and inspect
-    # additional fields the cloud may return, e.g. RTK status / satellite count
-    # for GOAT mowers).
+    # Lawn Mower: distinct service name (helper only supports one entity_domain
+    # per service registration — registering twice with the same name would
+    # silently override the vacuum handler).
     service.async_register_platform_entity_service(
         hass,
         DOMAIN,
-        SERVICE_RAW_GET_POSITIONS,
+        SERVICE_MOWER_RAW_GET_POSITIONS,
         entity_domain=LAWN_MOWER_DOMAIN,
         schema=None,
         func="async_raw_get_positions",

--- a/homeassistant/components/ecovacs/services.yaml
+++ b/homeassistant/components/ecovacs/services.yaml
@@ -1,5 +1,7 @@
 raw_get_positions:
   target:
     entity:
-      domain: vacuum
-      integration: ecovacs
+      - domain: vacuum
+        integration: ecovacs
+      - domain: lawn_mower
+        integration: ecovacs

--- a/homeassistant/components/ecovacs/services.yaml
+++ b/homeassistant/components/ecovacs/services.yaml
@@ -3,5 +3,9 @@ raw_get_positions:
     entity:
       - domain: vacuum
         integration: ecovacs
+
+mower_raw_get_positions:
+  target:
+    entity:
       - domain: lawn_mower
         integration: ecovacs

--- a/homeassistant/components/ecovacs/strings.json
+++ b/homeassistant/components/ecovacs/strings.json
@@ -316,6 +316,10 @@
     "raw_get_positions": {
       "description": "Retrieves a raw response containing the positions of the chargers and the device itself.",
       "name": "Get raw positions"
+    },
+    "mower_raw_get_positions": {
+      "description": "Retrieves a raw response containing the positions of the chargers and the mower itself (Ecovacs GOAT family). The payload includes RTK fix quality, satellite counts and signal strength when supported by the mower firmware.",
+      "name": "Get mower raw positions"
     }
   }
 }

--- a/homeassistant/components/ecovacs/strings.json
+++ b/homeassistant/components/ecovacs/strings.json
@@ -291,7 +291,7 @@
     }
   },
   "exceptions": {
-    "vacuum_raw_get_positions_not_supported": {
+    "raw_get_positions_not_supported": {
       "message": "Retrieving the positions of the chargers and the device itself is not supported"
     },
     "vacuum_send_command_not_supported": {

--- a/homeassistant/components/ecovacs/strings.json
+++ b/homeassistant/components/ecovacs/strings.json
@@ -313,13 +313,13 @@
     }
   },
   "services": {
-    "raw_get_positions": {
-      "description": "Retrieves a raw response containing the positions of the chargers and the device itself.",
-      "name": "Get raw positions"
-    },
     "mower_raw_get_positions": {
       "description": "Retrieves a raw response containing the positions of the chargers and the mower itself (Ecovacs GOAT family). The payload includes RTK fix quality, satellite counts and signal strength when supported by the mower firmware.",
       "name": "Get mower raw positions"
+    },
+    "raw_get_positions": {
+      "description": "Retrieves a raw response containing the positions of the chargers and the device itself.",
+      "name": "Get raw positions"
     }
   }
 }

--- a/homeassistant/components/ecovacs/vacuum.py
+++ b/homeassistant/components/ecovacs/vacuum.py
@@ -193,7 +193,7 @@ class EcovacsLegacyVacuum(EcovacsLegacyEntity, StateVacuumEntity):
         """Get bot and chargers positions."""
         raise ServiceValidationError(
             translation_domain=DOMAIN,
-            translation_key="vacuum_raw_get_positions_not_supported",
+            translation_key="raw_get_positions_not_supported",
         )
 
 
@@ -411,7 +411,7 @@ class EcovacsVacuum(
         ):
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
-                translation_key="vacuum_raw_get_positions_not_supported",
+                translation_key="raw_get_positions_not_supported",
             )
 
         return await self._device.execute_command(position_commands[0])

--- a/tests/components/ecovacs/test_services.py
+++ b/tests/components/ecovacs/test_services.py
@@ -66,8 +66,9 @@ def mock_device_execute_response(data: dict[str, Any]) -> Generator[dict[str, An
     ("device_fixture", "entity_id"),
     [
         ("yna5x1", "vacuum.ozmo_950"),
+        ("5xu9h3", "lawn_mower.goat_g1"),
     ],
-    ids=["yna5x1"],
+    ids=["yna5x1", "5xu9h3"],
 )
 async def test_get_positions_service(
     hass: HomeAssistant,
@@ -75,8 +76,8 @@ async def test_get_positions_service(
     entity_id: str,
 ) -> None:
     """Test that get_positions service response snapshots match."""
-    vacuum = hass.states.get(entity_id)
-    assert vacuum
+    entity = hass.states.get(entity_id)
+    assert entity
 
     assert await hass.services.async_call(
         DOMAIN,

--- a/tests/components/ecovacs/test_services.py
+++ b/tests/components/ecovacs/test_services.py
@@ -8,9 +8,13 @@ from deebot_client.device import Device
 import pytest
 
 from homeassistant.components.ecovacs.const import DOMAIN
-from homeassistant.components.ecovacs.services import SERVICE_RAW_GET_POSITIONS
+from homeassistant.components.ecovacs.services import (
+    SERVICE_MOWER_RAW_GET_POSITIONS,
+    SERVICE_RAW_GET_POSITIONS,
+)
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 
 pytestmark = [pytest.mark.usefixtures("init_integration")]
 
@@ -63,21 +67,16 @@ def mock_device_execute_response(data: dict[str, Any]) -> Generator[dict[str, An
     ],
 )
 @pytest.mark.parametrize(
-    ("device_fixture", "entity_id"),
-    [
-        ("yna5x1", "vacuum.ozmo_950"),
-        ("5xu9h3", "lawn_mower.goat_g1"),
-    ],
-    ids=["yna5x1", "5xu9h3"],
+    "device_fixture",
+    ["yna5x1"],
 )
-async def test_get_positions_service(
+async def test_get_positions_service_vacuum(
     hass: HomeAssistant,
     mock_device_execute_response: dict[str, Any],
-    entity_id: str,
 ) -> None:
-    """Test that get_positions service response snapshots match."""
-    entity = hass.states.get(entity_id)
-    assert entity
+    """Vacuum service returns the raw payload."""
+    entity_id = "vacuum.ozmo_950"
+    assert hass.states.get(entity_id)
 
     assert await hass.services.async_call(
         DOMAIN,
@@ -86,3 +85,36 @@ async def test_get_positions_service(
         blocking=True,
         return_response=True,
     ) == {entity_id: mock_device_execute_response}
+
+
+@pytest.mark.parametrize(
+    "data",
+    [{"deebotPos": {"x": 1, "y": 5, "a": 85}, "chargePos": {"x": 5, "y": 9, "a": 85}}],
+)
+@pytest.mark.parametrize(
+    "device_fixture",
+    ["5xu9h3"],
+)
+@pytest.mark.usefixtures("mock_device_execute_response")
+async def test_get_positions_service_mower_not_supported(
+    hass: HomeAssistant,
+) -> None:
+    """Mower service raises ServiceValidationError when the position capability is absent.
+
+    The optional position capability for mowers is being added in
+    DeebotUniverse/client.py#1588. Until that ships in a deebot-client release and
+    the integration bumps its pin, ``map.position.get`` is None on the 5xu9h3
+    fixture and the handler reports ``raw_get_positions_not_supported`` — which
+    is the user-facing behaviour we ship today.
+    """
+    entity_id = "lawn_mower.goat_g1"
+    assert hass.states.get(entity_id)
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_MOWER_RAW_GET_POSITIONS,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+            return_response=True,
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`ecovacs.raw_get_positions` is currently restricted to `vacuum` entities. Allow `lawn_mower` entities (GOAT family) to use it as well, mirroring the modern vacuum implementation.

GOATs return the same `deebotPos` / `chargePos` payload as vacuums, plus extra fields visible in the official Ecovacs Home app (rover satellites, reference station satellites, common usable satellites, signal strength). Capturing the raw response is the prerequisite to parse those fields in `deebot-client` and surface them as sensors in a follow-up PR.

The translation key `vacuum_raw_get_positions_not_supported` is renamed to `raw_get_positions_not_supported` so it can be reused by the mower path. Same English message.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr