### PR TITLE
Enhance WebDAV metadata download with concurrency

### DIFF
--- a/homeassistant/components/webdav/backup.py
+++ b/homeassistant/components/webdav/backup.py
@@ -20,6 +20,7 @@ from homeassistant.components.backup import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.json import json_dumps
+from homeassistant.util.async_ import gather_with_limited_concurrency
 from homeassistant.util.json import JSON_DECODE_EXCEPTIONS, json_loads_object
 
 from . import WebDavConfigEntry
@@ -29,6 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 
 BACKUP_TIMEOUT = ClientTimeout(connect=10, total=43200)
 CACHE_TTL = 300
+METADATA_DOWNLOAD_CONCURRENCY = 4
 
 
 async def async_get_backup_agents(
@@ -237,11 +239,18 @@ class WebDavBackupAgent(BackupAgent):
         async def _list_metadata_files() -> dict[str, AgentBackup]:
             """List metadata files."""
             files = await self._client.list_files(self._backup_path)
+            metadata_contents = await gather_with_limited_concurrency(
+                METADATA_DOWNLOAD_CONCURRENCY,
+                *(
+                    _download_metadata(file_name)
+                    for file_name in files
+                    if file_name.endswith(".metadata.json")
+                ),
+            )
             return {
                 metadata_content.backup_id: metadata_content
-                for file_name in files
-                if file_name.endswith(".metadata.json")
-                if (metadata_content := await _download_metadata(file_name))
+                for metadata_content in metadata_contents
+                if metadata_content
             }
 
         self._cache_metadata_files = await _list_metadata_files()

--- a/tests/components/webdav/test_backup.py
+++ b/tests/components/webdav/test_backup.py
@@ -1,7 +1,7 @@
 """Test the backups for WebDAV."""
 
 import asyncio
-from collections.abc import AsyncGenerator, AsyncIterator, Awaitable
+from collections.abc import AsyncGenerator, AsyncIterator
 from copy import deepcopy
 from io import StringIO
 from unittest.mock import Mock, patch
@@ -10,7 +10,10 @@ from aiowebdav2.exceptions import UnauthorizedError, WebDavError
 import pytest
 
 from homeassistant.components.backup import DOMAIN as BACKUP_DOMAIN, AgentBackup
-from homeassistant.components.webdav.backup import async_register_backup_agents_listener
+from homeassistant.components.webdav.backup import (
+    async_get_backup_agents,
+    async_register_backup_agents_listener,
+)
 from homeassistant.components.webdav.const import DATA_BACKUP_AGENT_LISTENERS, DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.json import json_dumps
@@ -503,7 +506,6 @@ async def test_agents_list_backups_skips_invalid_metadata_file(
 
 async def test_agents_list_backups_downloads_metadata_in_four_streams(
     hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
     webdav_client: AsyncMock,
 ) -> None:
     """Test listing backups downloads metadata files four at a time."""
@@ -514,38 +516,44 @@ async def test_agents_list_backups_downloads_metadata_in_four_streams(
         backup["backup_id"] = f"backup-{idx}"
         backup["name"] = f"Backup {idx}"
         metadata_by_path[metadata_path] = backup
+    concurrent_downloads = 0
+    max_concurrent_downloads = 0
+    four_downloads_started = asyncio.Event()
+    release_downloads = asyncio.Event()
 
     async def _download_metadata(
         path: str, timeout: object = None
     ) -> AsyncIterator[bytes]:
-        yield json_dumps(metadata_by_path[path]).encode()
+        nonlocal concurrent_downloads, max_concurrent_downloads
 
-    async def _gather_with_limited_concurrency(
-        limit: int,
-        *tasks: Awaitable[AgentBackup | None],
-        return_exceptions: bool = False,
-    ) -> list[AgentBackup | None]:
-        assert limit == 4
-        assert len(tasks) == len(metadata_paths)
-        assert not return_exceptions
-        return await asyncio.gather(*tasks)
+        concurrent_downloads += 1
+        max_concurrent_downloads = max(max_concurrent_downloads, concurrent_downloads)
+        if concurrent_downloads == 4:
+            four_downloads_started.set()
+
+        await release_downloads.wait()
+
+        try:
+            yield json_dumps(metadata_by_path[path]).encode()
+        finally:
+            concurrent_downloads -= 1
 
     webdav_client.list_files.return_value = ["/backup-0.tar", *metadata_paths]
     webdav_client.download_iter.side_effect = _download_metadata
 
-    with patch(
-        "homeassistant.components.webdav.backup.gather_with_limited_concurrency",
-        side_effect=_gather_with_limited_concurrency,
-    ) as gather_mock:
-        client = await hass_ws_client(hass)
-        await client.send_json_auto_id({"type": "backup/info"})
-        response = await client.receive_json()
+    [agent] = await async_get_backup_agents(hass)
+    list_backups_task = asyncio.create_task(agent.async_list_backups())
 
-    assert response["success"]
-    assert response["result"]["agent_errors"] == {}
+    try:
+        await asyncio.wait_for(four_downloads_started.wait(), timeout=1)
+        await asyncio.sleep(0)
+        assert max_concurrent_downloads == 4
+    finally:
+        release_downloads.set()
 
-    assert gather_mock.call_count == 1
+    backups = await list_backups_task
     assert webdav_client.download_iter.call_count == len(metadata_paths)
-    assert {backup["backup_id"] for backup in response["result"]["backups"]} == {
+    assert max_concurrent_downloads == 4
+    assert {backup.backup_id for backup in backups} == {
         f"backup-{idx}" for idx in range(5)
     }

--- a/tests/components/webdav/test_backup.py
+++ b/tests/components/webdav/test_backup.py
@@ -1,6 +1,7 @@
 """Test the backups for WebDAV."""
 
-from collections.abc import AsyncGenerator, AsyncIterator
+import asyncio
+from collections.abc import AsyncGenerator, AsyncIterator, Awaitable
 from copy import deepcopy
 from io import StringIO
 from unittest.mock import Mock, patch
@@ -498,3 +499,53 @@ async def test_agents_list_backups_skips_invalid_metadata_file(
             "with_automatic_settings": None,
         }
     ]
+
+
+async def test_agents_list_backups_downloads_metadata_in_four_streams(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    webdav_client: AsyncMock,
+) -> None:
+    """Test listing backups downloads metadata files four at a time."""
+    metadata_paths = [f"/backup-{idx}.metadata.json" for idx in range(5)]
+    metadata_by_path = {}
+    for idx, metadata_path in enumerate(metadata_paths):
+        backup = deepcopy(BACKUP_METADATA)
+        backup["backup_id"] = f"backup-{idx}"
+        backup["name"] = f"Backup {idx}"
+        metadata_by_path[metadata_path] = backup
+
+    async def _download_metadata(
+        path: str, timeout: object = None
+    ) -> AsyncIterator[bytes]:
+        yield json_dumps(metadata_by_path[path]).encode()
+
+    async def _gather_with_limited_concurrency(
+        limit: int,
+        *tasks: Awaitable[AgentBackup | None],
+        return_exceptions: bool = False,
+    ) -> list[AgentBackup | None]:
+        assert limit == 4
+        assert len(tasks) == len(metadata_paths)
+        assert not return_exceptions
+        return await asyncio.gather(*tasks)
+
+    webdav_client.list_files.return_value = ["/backup-0.tar", *metadata_paths]
+    webdav_client.download_iter.side_effect = _download_metadata
+
+    with patch(
+        "homeassistant.components.webdav.backup.gather_with_limited_concurrency",
+        side_effect=_gather_with_limited_concurrency,
+    ) as gather_mock:
+        client = await hass_ws_client(hass)
+        await client.send_json_auto_id({"type": "backup/info"})
+        response = await client.receive_json()
+
+    assert response["success"]
+    assert response["result"]["agent_errors"] == {}
+
+    assert gather_mock.call_count == 1
+    assert webdav_client.download_iter.call_count == len(metadata_paths)
+    assert {backup["backup_id"] for backup in response["result"]["backups"]} == {
+        f"backup-{idx}" for idx in range(5)
+    }

--- a/tests/components/webdav/test_backup.py
+++ b/tests/components/webdav/test_backup.py
@@ -1,6 +1,5 @@
 """Test the backups for WebDAV."""
 
-import asyncio
 from collections.abc import AsyncGenerator, AsyncIterator
 from copy import deepcopy
 from io import StringIO
@@ -10,10 +9,7 @@ from aiowebdav2.exceptions import UnauthorizedError, WebDavError
 import pytest
 
 from homeassistant.components.backup import DOMAIN as BACKUP_DOMAIN, AgentBackup
-from homeassistant.components.webdav.backup import (
-    async_get_backup_agents,
-    async_register_backup_agents_listener,
-)
+from homeassistant.components.webdav.backup import async_register_backup_agents_listener
 from homeassistant.components.webdav.const import DATA_BACKUP_AGENT_LISTENERS, DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.json import json_dumps
@@ -502,58 +498,3 @@ async def test_agents_list_backups_skips_invalid_metadata_file(
             "with_automatic_settings": None,
         }
     ]
-
-
-async def test_agents_list_backups_downloads_metadata_in_four_streams(
-    hass: HomeAssistant,
-    webdav_client: AsyncMock,
-) -> None:
-    """Test listing backups downloads metadata files four at a time."""
-    metadata_paths = [f"/backup-{idx}.metadata.json" for idx in range(5)]
-    metadata_by_path = {}
-    for idx, metadata_path in enumerate(metadata_paths):
-        backup = deepcopy(BACKUP_METADATA)
-        backup["backup_id"] = f"backup-{idx}"
-        backup["name"] = f"Backup {idx}"
-        metadata_by_path[metadata_path] = backup
-    concurrent_downloads = 0
-    max_concurrent_downloads = 0
-    four_downloads_started = asyncio.Event()
-    release_downloads = asyncio.Event()
-
-    async def _download_metadata(
-        path: str, timeout: object = None
-    ) -> AsyncIterator[bytes]:
-        nonlocal concurrent_downloads, max_concurrent_downloads
-
-        concurrent_downloads += 1
-        max_concurrent_downloads = max(max_concurrent_downloads, concurrent_downloads)
-        if concurrent_downloads == 4:
-            four_downloads_started.set()
-
-        await release_downloads.wait()
-
-        try:
-            yield json_dumps(metadata_by_path[path]).encode()
-        finally:
-            concurrent_downloads -= 1
-
-    webdav_client.list_files.return_value = ["/backup-0.tar", *metadata_paths]
-    webdav_client.download_iter.side_effect = _download_metadata
-
-    [agent] = await async_get_backup_agents(hass)
-    list_backups_task = asyncio.create_task(agent.async_list_backups())
-
-    try:
-        await asyncio.wait_for(four_downloads_started.wait(), timeout=1)
-        await asyncio.sleep(0)
-        assert max_concurrent_downloads == 4
-    finally:
-        release_downloads.set()
-
-    backups = await list_backups_task
-    assert webdav_client.download_iter.call_count == len(metadata_paths)
-    assert max_concurrent_downloads == 4
-    assert {backup.backup_id for backup in backups} == {
-        f"backup-{idx}" for idx in range(5)
-    }


### PR DESCRIPTION
## Proposed change
Enhance the WebDAV metadata download with concurrency to improve the performance when listing backups with a cold cache.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
