### PR TITLE
Improve iaqualink 429 handling

### DIFF
--- a/homeassistant/components/iaqualink/coordinator.py
+++ b/homeassistant/components/iaqualink/coordinator.py
@@ -1,11 +1,13 @@
 """Data update coordinator for iaqualink."""
 
+from datetime import timedelta
 import logging
 from typing import Any
 
 import httpx
 from iaqualink.exception import (
     AqualinkServiceException,
+    AqualinkServiceThrottledException,
     AqualinkServiceUnauthorizedException,
 )
 
@@ -17,6 +19,8 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import DOMAIN, UPDATE_INTERVAL_BY_SYSTEM_TYPE, UPDATE_INTERVAL_DEFAULT
 
 _LOGGER = logging.getLogger(__name__)
+
+BACKOFF_MULTIPLIER = 1.5
 
 
 class AqualinkDataUpdateCoordinator(DataUpdateCoordinator[None]):
@@ -44,9 +48,26 @@ class AqualinkDataUpdateCoordinator(DataUpdateCoordinator[None]):
             await self.system.update()
         except AqualinkServiceUnauthorizedException as err:
             raise ConfigEntryAuthFailed("Invalid credentials for iAquaLink") from err
+        except AqualinkServiceThrottledException:
+            current_interval = self.update_interval or UPDATE_INTERVAL
+            self.update_interval = timedelta(
+                seconds=current_interval.total_seconds() * BACKOFF_MULTIPLIER
+            )
+            _LOGGER.debug(
+                "iAquaLink system %s is rate-limited, increasing update interval to %ss",
+                self.system.serial,
+                self.update_interval.total_seconds(),
+            )
+            return
         except (AqualinkServiceException, httpx.HTTPError) as err:
             raise UpdateFailed(
                 f"Unable to update iAquaLink system {self.system.serial}: {err}"
             ) from err
         if self.system.online is not True:
             raise UpdateFailed(f"iAquaLink system {self.system.serial} is offline")
+        if self.update_interval != UPDATE_INTERVAL:
+            _LOGGER.debug(
+                "iAquaLink system %s rate limit cleared, resetting update interval",
+                self.system.serial,
+            )
+            self.update_interval = UPDATE_INTERVAL

--- a/homeassistant/components/iaqualink/coordinator.py
+++ b/homeassistant/components/iaqualink/coordinator.py
@@ -1,6 +1,5 @@
 """Data update coordinator for iaqualink."""
 
-from datetime import timedelta
 import logging
 from typing import Any
 
@@ -19,8 +18,6 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import DOMAIN, UPDATE_INTERVAL_BY_SYSTEM_TYPE, UPDATE_INTERVAL_DEFAULT
 
 _LOGGER = logging.getLogger(__name__)
-
-BACKOFF_MULTIPLIER = 1.5
 
 
 class AqualinkDataUpdateCoordinator(DataUpdateCoordinator[None]):
@@ -49,14 +46,9 @@ class AqualinkDataUpdateCoordinator(DataUpdateCoordinator[None]):
         except AqualinkServiceUnauthorizedException as err:
             raise ConfigEntryAuthFailed("Invalid credentials for iAquaLink") from err
         except AqualinkServiceThrottledException:
-            current_interval = self.update_interval or UPDATE_INTERVAL
-            self.update_interval = timedelta(
-                seconds=current_interval.total_seconds() * BACKOFF_MULTIPLIER
-            )
-            _LOGGER.debug(
-                "iAquaLink system %s is rate-limited, increasing update interval to %ss",
+            _LOGGER.warning(
+                "Rate limited by iAquaLink system %s, will retry later",
                 self.system.serial,
-                self.update_interval.total_seconds(),
             )
             return
         except (AqualinkServiceException, httpx.HTTPError) as err:
@@ -65,9 +57,3 @@ class AqualinkDataUpdateCoordinator(DataUpdateCoordinator[None]):
             ) from err
         if self.system.online is not True:
             raise UpdateFailed(f"iAquaLink system {self.system.serial} is offline")
-        if self.update_interval != UPDATE_INTERVAL:
-            _LOGGER.debug(
-                "iAquaLink system %s rate limit cleared, resetting update interval",
-                self.system.serial,
-            )
-            self.update_interval = UPDATE_INTERVAL

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -17,11 +17,11 @@ from iaqualink.systems.iaqua.device import (
     IaquaThermostat,
 )
 from iaqualink.systems.iaqua.system import IaquaSystem
+import pytest
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.components.iaqualink.const import UPDATE_INTERVAL_BY_SYSTEM_TYPE
-from homeassistant.components.iaqualink.coordinator import BACKOFF_MULTIPLIER
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
@@ -113,8 +113,9 @@ async def test_system_rate_limited_keeps_entities_available(
     config_entry: MockConfigEntry,
     client: AqualinkClient,
     freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test a rate-limited update keeps entities at their last known state and backs off."""
+    """Test a rate-limited update keeps entities at their last known state."""
     config_entry.add_to_hass(hass)
 
     system = get_aqualink_system(client, cls=IaquaSystem)
@@ -148,12 +149,6 @@ async def test_system_rate_limited_keeps_entities_available(
     assert state is not None
     assert state.state == STATE_ON
 
-    coordinators = list(config_entry.runtime_data.coordinators.values())
-    assert len(coordinators) == 1
-    coordinator = coordinators[0]
-
-    assert coordinator.update_interval == update_interval
-
     system.update = AsyncMock(side_effect=AqualinkServiceThrottledException)
 
     await _advance_coordinator_time(hass, freezer)
@@ -161,15 +156,7 @@ async def test_system_rate_limited_keeps_entities_available(
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.state == STATE_ON
-    assert coordinator.update_interval == update_interval * BACKOFF_MULTIPLIER
-
-    system.update = AsyncMock()
-
-    freezer.tick(delta=coordinator.update_interval)
-    async_fire_time_changed(hass, dt_util.utcnow())
-    await hass.async_block_till_done(wait_background_tasks=True)
-
-    assert coordinator.update_interval == update_interval
+    assert "Rate limited by iAquaLink" in caplog.text
 
 
 async def test_light_service_calls_update_entity_state(

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -6,6 +6,7 @@ from freezegun.api import FrozenDateTimeFactory
 from iaqualink.client import AqualinkClient
 from iaqualink.exception import (
     AqualinkServiceException,
+    AqualinkServiceThrottledException,
     AqualinkServiceUnauthorizedException,
 )
 from iaqualink.systems.iaqua.device import (
@@ -20,6 +21,7 @@ from iaqualink.systems.iaqua.system import IaquaSystem
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.components.iaqualink.const import UPDATE_INTERVAL_BY_SYSTEM_TYPE
+from homeassistant.components.iaqualink.coordinator import BACKOFF_MULTIPLIER
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
@@ -46,7 +48,9 @@ async def _advance_coordinator_time(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:
     """Advance time to trigger coordinator update interval."""
-    freezer.tick(delta=UPDATE_INTERVAL_BY_SYSTEM_TYPE["iaqua"])
+    update_interval = UPDATE_INTERVAL_BY_SYSTEM_TYPE["iaqua"]
+
+    freezer.tick(delta=update_interval)
     async_fire_time_changed(hass, dt_util.utcnow())
     await hass.async_block_till_done(wait_background_tasks=True)
 
@@ -102,6 +106,70 @@ async def test_system_refresh_failure_marks_entities_unavailable(
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
+
+
+async def test_system_rate_limited_keeps_entities_available(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    client: AqualinkClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a rate-limited update keeps entities at their last known state and backs off."""
+    config_entry.add_to_hass(hass)
+
+    system = get_aqualink_system(client, cls=IaquaSystem)
+    system.online = True
+    system.update = AsyncMock()
+    systems = {system.serial: system}
+    light = get_aqualink_device(
+        system, name="aux_1", cls=IaquaLightSwitch, data={"state": "1"}
+    )
+    devices = {light.name: light}
+    system.get_devices = AsyncMock(return_value=devices)
+
+    with (
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.login",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.iaqualink.AqualinkClient.get_systems",
+            return_value=systems,
+        ),
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    entity_ids = hass.states.async_entity_ids(LIGHT_DOMAIN)
+    assert len(entity_ids) == 1
+    entity_id = entity_ids[0]
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_ON
+
+    coordinators = list(config_entry.runtime_data.coordinators.values())
+    assert len(coordinators) == 1
+    coordinator = coordinators[0]
+
+    assert coordinator.update_interval == update_interval
+
+    system.update = AsyncMock(side_effect=AqualinkServiceThrottledException)
+
+    await _advance_coordinator_time(hass, freezer)
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_ON
+    assert coordinator.update_interval == update_interval * BACKOFF_MULTIPLIER
+
+    system.update = AsyncMock()
+
+    freezer.tick(delta=coordinator.update_interval)
+    async_fire_time_changed(hass, dt_util.utcnow())
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert coordinator.update_interval == update_interval
 
 
 async def test_light_service_calls_update_entity_state(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Improve handling of 429 ratelimited requests. Don't mark the integration as unavailable, simply log the temporary error.

Please merge in release branch for the next patch release.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #152517
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
