### PR TITLE
Add device_tracker for ecovacs mower position (GPS)

### DIFF
--- a/homeassistant/components/ecovacs/__init__.py
+++ b/homeassistant/components/ecovacs/__init__.py
@@ -15,6 +15,7 @@ from .services import async_setup_services
 PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
+    Platform.DEVICE_TRACKER,
     Platform.EVENT,
     Platform.IMAGE,
     Platform.LAWN_MOWER,

--- a/homeassistant/components/ecovacs/device_tracker.py
+++ b/homeassistant/components/ecovacs/device_tracker.py
@@ -1,0 +1,98 @@
+"""Ecovacs device_tracker entities (mower position)."""
+
+from __future__ import annotations
+
+from math import cos, radians
+
+from deebot_client.capabilities import Capabilities
+from deebot_client.device import Device
+from deebot_client.events import PositionsEvent
+from deebot_client.events.map import PositionType
+
+from homeassistant.components.device_tracker import SourceType, TrackerEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityDescription
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import EcovacsConfigEntry
+from .entity import EcovacsEntity
+
+# Approximation: 1° of latitude is ~111.32 km. Good enough for a single
+# garden where the rover stays within ~100 m of the dock; the small
+# error introduced near the poles is irrelevant at this scale.
+_M_PER_DEG_LAT = 111_320.0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: EcovacsConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Add ecovacs device_tracker entities (one per mower with a position capability)."""
+    controller = config_entry.runtime_data
+    trackers: list[EcovacsMowerTracker] = [
+        EcovacsMowerTracker(device, hass)
+        for device in controller.devices
+        if device.capabilities.position is not None
+    ]
+    if trackers:
+        async_add_entities(trackers)
+
+
+class EcovacsMowerTracker(EcovacsEntity[Capabilities], TrackerEntity):
+    """Mower GPS tracker derived from PositionsEvent.
+
+    Mower coordinates (`deebotPos.x` / `y`, in centimetres relative to
+    the dock) are converted to latitude/longitude using the Home
+    Assistant home zone as the dock anchor. The mower's local frame is
+    assumed to be north-aligned (no rotation correction yet); a future
+    follow-up can expose the dock anchor and orientation as config
+    options for non-default setups.
+    """
+
+    _attr_translation_key = "position"
+    _attr_source_type = SourceType.GPS
+
+    entity_description = EntityDescription(key="position")
+
+    def __init__(self, device: Device, hass: HomeAssistant) -> None:
+        """Initialize the tracker."""
+        super().__init__(device, device.capabilities)
+        self._anchor_lat: float = hass.config.latitude
+        self._anchor_lng: float = hass.config.longitude
+        self._lat: float | None = None
+        self._lng: float | None = None
+
+    @property
+    def latitude(self) -> float | None:
+        """Return latitude value of the device."""
+        return self._lat
+
+    @property
+    def longitude(self) -> float | None:
+        """Return longitude value of the device."""
+        return self._lng
+
+    async def async_added_to_hass(self) -> None:
+        """Set up the event listeners now that hass is ready."""
+        await super().async_added_to_hass()
+
+        async def on_positions(event: PositionsEvent) -> None:
+            mower_pos = next(
+                (p for p in event.positions if p.type is PositionType.DEEBOT),
+                None,
+            )
+            if mower_pos is None:
+                return
+
+            # Mower frame: x = East offset (cm), y = North offset (cm).
+            delta_east_m = mower_pos.x / 100.0
+            delta_north_m = mower_pos.y / 100.0
+
+            self._lat = self._anchor_lat + (delta_north_m / _M_PER_DEG_LAT)
+            self._lng = self._anchor_lng + (
+                delta_east_m / (_M_PER_DEG_LAT * cos(radians(self._anchor_lat)))
+            )
+            self.async_write_ha_state()
+
+        self._subscribe(self._capability.position.event, on_positions)

--- a/homeassistant/components/ecovacs/strings.json
+++ b/homeassistant/components/ecovacs/strings.json
@@ -37,6 +37,11 @@
     }
   },
   "entity": {
+    "device_tracker": {
+      "position": {
+        "name": "Position"
+      }
+    },
     "binary_sensor": {
       "water_mop_attached": {
         "name": "Mop attached"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a GPS \`device_tracker\` for any mower that exposes the new \`Capabilities.position\` from \`deebot-client\` (currently the GOAT family).

The mower's local x/y coordinates (centimetres relative to the dock) are converted to latitude/longitude using the Home Assistant home zone as the dock anchor; the mower frame is assumed to be north-aligned.

Lets users plot the mower trajectory on a HA map card the same way a person tracker is plotted. A future follow-up can expose the dock anchor and orientation as config options for non-default setups (dock not at home, frame rotated vs true north).

Library counterpart: DeebotUniverse/client.py#1588. Manifest stays at \`deebot-client==18.3.0\` here; bump will be a one-line follow-up commit on this branch when the release with #1588 ships. CI failures (pylint/mypy on \`Capabilities.position\`) are expected until then.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an \`x\` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass** *(no local HA Core venv on this machine; relying on CI once the deebot-client release is out)*
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (\`ruff format homeassistant tests\`)
- [ ] Tests have been added to verify that the new code works. *(Tracker tests will follow once the deebot-client release with Capabilities.position is shipped and the manifest pin is bumped.)*
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: \`python3 -m script.hassfest\`.
- [x] New or updated dependencies have been added to \`requirements_all.txt\`.
      Updated by running \`python3 -m script.gen_requirements_all\`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr