### PR TITLE
Handle empty BSB-LAN heating circuits

### DIFF
--- a/homeassistant/components/bsblan/__init__.py
+++ b/homeassistant/components/bsblan/__init__.py
@@ -38,7 +38,14 @@ from homeassistant.helpers.device_registry import (
 )
 from homeassistant.helpers.typing import ConfigType
 
-from .const import CONF_HEATING_CIRCUITS, CONF_PASSKEY, DEFAULT_PORT, DOMAIN, LOGGER
+from .const import (
+    CONF_HEATING_CIRCUITS,
+    CONF_PASSKEY,
+    DEFAULT_HEATING_CIRCUITS,
+    DEFAULT_PORT,
+    DOMAIN,
+    LOGGER,
+)
 from .coordinator import BSBLanFastCoordinator, BSBLanSlowCoordinator
 from .services import async_setup_services
 
@@ -118,7 +125,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: BSBLanConfigEntry) -> bo
 
         # Read available heating circuits from config entry data
         # (populated by config flow or migration)
-        circuits: list[int] = entry.data[CONF_HEATING_CIRCUITS]
+        circuits: list[int] = entry.data[CONF_HEATING_CIRCUITS] or list(
+            DEFAULT_HEATING_CIRCUITS
+        )
 
         # Fetch required device metadata in parallel for faster startup
         device, info = await asyncio.gather(
@@ -229,7 +238,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: BSBLanConfigEntry) -> 
     # heating circuits from the device; fall back to [1] (pre-multi-circuit
     # default) if the device is unreachable or the endpoint is unsupported.
     if entry.version == 1 and entry.minor_version < 2:
-        circuits: list[int] = [1]
+        circuits: list[int] = list(DEFAULT_HEATING_CIRCUITS)
         config = BSBLANConfig(
             host=entry.data[CONF_HOST],
             passkey=entry.data[CONF_PASSKEY],
@@ -245,11 +254,18 @@ async def async_migrate_entry(hass: HomeAssistant, entry: BSBLanConfigEntry) -> 
         except (BSBLANError, TimeoutError) as err:
             LOGGER.warning(
                 "Circuit discovery during migration failed for %s (%s); "
-                "defaulting to single circuit [1]. Use Reconfigure to "
+                "defaulting to a single circuit. Use Reconfigure to "
                 "rediscover additional circuits later",
                 entry.data[CONF_HOST],
                 err,
             )
+        if not circuits:
+            LOGGER.warning(
+                "Circuit discovery during migration returned no heating circuits "
+                "for %s; defaulting to a single circuit",
+                entry.data[CONF_HOST],
+            )
+            circuits = list(DEFAULT_HEATING_CIRCUITS)
 
         hass.config_entries.async_update_entry(
             entry,
@@ -262,5 +278,23 @@ async def async_migrate_entry(hass: HomeAssistant, entry: BSBLanConfigEntry) -> 
             entry.minor_version,
             circuits,
         )
+
+    # 1.2 -> 1.3: Repair entries that stored an empty circuit list during
+    # discovery. Every BSB-LAN setup has at least one heating circuit.
+    if entry.version == 1 and entry.minor_version < 3:
+        if not entry.data[CONF_HEATING_CIRCUITS]:
+            LOGGER.warning(
+                "Stored heating circuits for %s are empty; defaulting to a "
+                "single circuit",
+                entry.data[CONF_HOST],
+            )
+            data = {
+                **entry.data,
+                CONF_HEATING_CIRCUITS: list(DEFAULT_HEATING_CIRCUITS),
+            }
+        else:
+            data = {**entry.data}
+
+        hass.config_entries.async_update_entry(entry, data=data, minor_version=3)
 
     return True

--- a/homeassistant/components/bsblan/config_flow.py
+++ b/homeassistant/components/bsblan/config_flow.py
@@ -13,21 +13,28 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
-from .const import CONF_HEATING_CIRCUITS, CONF_PASSKEY, DEFAULT_PORT, DOMAIN, LOGGER
+from .const import (
+    CONF_HEATING_CIRCUITS,
+    CONF_PASSKEY,
+    DEFAULT_HEATING_CIRCUITS,
+    DEFAULT_PORT,
+    DOMAIN,
+    LOGGER,
+)
 
 
 class BSBLANFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a BSBLAN config flow."""
 
     VERSION = 1
-    MINOR_VERSION = 2
+    MINOR_VERSION = 3
 
     def __init__(self) -> None:
         """Initialize BSBLan flow."""
         self.host: str = ""
         self.port: int = DEFAULT_PORT
         self.mac: str | None = None
-        self.circuits: list[int] = [1]
+        self.circuits: list[int] = list(DEFAULT_HEATING_CIRCUITS)
         self.passkey: str | None = None
         self.username: str | None = None
         self.password: str | None = None
@@ -384,6 +391,13 @@ class BSBLANFlowHandler(ConfigFlow, domain=DOMAIN):
         try:
             await bsblan.initialize()
             self.circuits = await bsblan.get_available_circuits()
+            if not self.circuits:
+                LOGGER.debug(
+                    "Circuit discovery returned no heating circuits for %s, "
+                    "defaulting to single circuit",
+                    self.host,
+                )
+                self.circuits = list(DEFAULT_HEATING_CIRCUITS)
         except (
             BSBLANError,
             TimeoutError,
@@ -392,4 +406,4 @@ class BSBLANFlowHandler(ConfigFlow, domain=DOMAIN):
                 "Circuit discovery not available for %s, defaulting to single circuit",
                 self.host,
             )
-            self.circuits = [1]
+            self.circuits = list(DEFAULT_HEATING_CIRCUITS)

--- a/homeassistant/components/bsblan/const.py
+++ b/homeassistant/components/bsblan/const.py
@@ -22,4 +22,5 @@ ATTR_OUTSIDE_TEMPERATURE: Final = "outside_temperature"
 CONF_PASSKEY: Final = "passkey"
 CONF_HEATING_CIRCUITS: Final = "heating_circuits"
 
+DEFAULT_HEATING_CIRCUITS: Final = (1,)
 DEFAULT_PORT: Final = 80

--- a/tests/components/bsblan/conftest.py
+++ b/tests/components/bsblan/conftest.py
@@ -41,7 +41,7 @@ def mock_config_entry() -> MockConfigEntry:
         },
         unique_id="00:80:41:19:69:90",
         version=1,
-        minor_version=2,
+        minor_version=3,
     )
 
 
@@ -61,7 +61,7 @@ def mock_config_entry_dual_circuit() -> MockConfigEntry:
         },
         unique_id="00:80:41:19:69:90",
         version=1,
-        minor_version=2,
+        minor_version=3,
     )
 
 

--- a/tests/components/bsblan/test_config_flow.py
+++ b/tests/components/bsblan/test_config_flow.py
@@ -213,6 +213,44 @@ async def test_circuit_discovery_failure_falls_back_to_default(
     )
 
 
+async def test_circuit_discovery_empty_result_falls_back_to_default(
+    hass: HomeAssistant,
+    mock_bsblan: MagicMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test that empty circuit discovery falls back to single circuit."""
+    mock_bsblan.get_available_circuits.return_value = []
+
+    result = await _init_user_flow(hass)
+    _assert_form_result(result, "user")
+
+    result = await _configure_flow(
+        hass,
+        result["flow_id"],
+        {
+            CONF_HOST: "127.0.0.1",
+            CONF_PORT: 80,
+            CONF_PASSKEY: "1234",
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "admin1234",
+        },
+    )
+
+    _assert_create_entry_result(
+        result,
+        "BSB-LAN",
+        {
+            CONF_HOST: "127.0.0.1",
+            CONF_PORT: 80,
+            CONF_PASSKEY: "1234",
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "admin1234",
+            CONF_HEATING_CIRCUITS: [1],
+        },
+        format_mac("00:80:41:19:69:90"),
+    )
+
+
 async def test_connection_error(
     hass: HomeAssistant,
     mock_bsblan: MagicMock,
@@ -1147,6 +1185,38 @@ async def test_reconfigure_flow_success(
     assert mock_config_entry.data[CONF_PASSKEY] == "new_passkey"
     assert mock_config_entry.data[CONF_USERNAME] == "new_admin"
     assert mock_config_entry.data[CONF_PASSWORD] == "new_password"
+    assert mock_config_entry.data[CONF_HEATING_CIRCUITS] == [1]
+
+
+async def test_reconfigure_flow_empty_circuit_discovery_falls_back(
+    hass: HomeAssistant,
+    mock_bsblan: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfigure stores single circuit when discovery returns no circuits."""
+    mock_config_entry.add_to_hass(hass)
+    mock_bsblan.get_available_circuits.return_value = []
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    _assert_form_result(result, "reconfigure")
+
+    result = await _configure_flow(
+        hass,
+        result["flow_id"],
+        {
+            CONF_HOST: "192.168.1.50",
+            CONF_PORT: 8080,
+            CONF_PASSKEY: "new_passkey",
+            CONF_USERNAME: "new_admin",
+            CONF_PASSWORD: "new_password",
+        },
+    )
+
+    _assert_abort_result(result, "reconfigure_successful")
+
+    assert mock_config_entry.data[CONF_HOST] == "192.168.1.50"
+    assert mock_config_entry.data[CONF_PORT] == 8080
     assert mock_config_entry.data[CONF_HEATING_CIRCUITS] == [1]
 
 

--- a/tests/components/bsblan/test_init.py
+++ b/tests/components/bsblan/test_init.py
@@ -373,8 +373,33 @@ async def test_migrate_entry_discovers_circuits(
 
     assert entry.state is ConfigEntryState.LOADED
     assert entry.version == 1
-    assert entry.minor_version == 2
+    assert entry.minor_version == 3
     assert entry.data[CONF_HEATING_CIRCUITS] == [1, 2]
+
+
+async def test_migrate_entry_empty_discovery_falls_back(
+    hass: HomeAssistant,
+    mock_bsblan: MagicMock,
+) -> None:
+    """Test migration falls back to [1] when discovery returns no circuits."""
+    mock_bsblan.get_available_circuits.return_value = []
+
+    entry = MockConfigEntry(
+        title="BSBLAN Setup",
+        domain=DOMAIN,
+        data=_legacy_entry_data(),
+        unique_id="00:80:41:19:69:90",
+        version=1,
+        minor_version=1,
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.version == 1
+    assert entry.minor_version == 3
+    assert entry.data[CONF_HEATING_CIRCUITS] == [1]
 
 
 async def test_migrate_entry_discovery_failure_falls_back(
@@ -398,7 +423,7 @@ async def test_migrate_entry_discovery_failure_falls_back(
 
     assert entry.state is ConfigEntryState.LOADED
     assert entry.version == 1
-    assert entry.minor_version == 2
+    assert entry.minor_version == 3
     assert entry.data[CONF_HEATING_CIRCUITS] == [1]
 
 
@@ -422,8 +447,33 @@ async def test_migrate_entry_discovery_timeout_falls_back(
     await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.LOADED
-    assert entry.minor_version == 2
+    assert entry.minor_version == 3
     assert entry.data[CONF_HEATING_CIRCUITS] == [1]
+
+
+async def test_migrate_entry_stored_empty_circuits_falls_back(
+    hass: HomeAssistant,
+    mock_bsblan: MagicMock,
+) -> None:
+    """Test migration repairs stored empty heating circuits."""
+    entry = MockConfigEntry(
+        title="BSBLAN Setup",
+        domain=DOMAIN,
+        data={**_legacy_entry_data(), CONF_HEATING_CIRCUITS: []},
+        unique_id="00:80:41:19:69:90",
+        version=1,
+        minor_version=2,
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.version == 1
+    assert entry.minor_version == 3
+    assert entry.data[CONF_HEATING_CIRCUITS] == [1]
+    assert entry.runtime_data.available_circuits == [1]
+    assert mock_bsblan.get_available_circuits.call_count == 0
 
 
 async def test_migrate_entry_future_version_aborts(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The previous python lib bump did solve the issue but would not trigger a reconfigure.
This update is a fix that checks if climate entity has an empty list and do a minor version bump.
As this is a bug fix I would like to have this in the next sub release. Thanks!

(generated)

<details>
<summary>Details</summary>

This pull request improves the robustness of the BSBLan integration by ensuring that heating circuit discovery always falls back to a safe default when no circuits are found, and by updating the configuration flow and migration logic to handle empty or missing circuit lists. It also bumps the config entry minor version to 3 and adds comprehensive test coverage for these scenarios.

**Core logic and configuration improvements:**

* Introduced a new constant `DEFAULT_HEATING_CIRCUITS` (set to `(1,)`) to consistently represent the default heating circuit, and updated all relevant logic to use this constant instead of hardcoded lists. [[1]](diffhunk://#diff-d42af52ecc261fe8da778ebe95a8d8bf1d8ae30fc2dae700066b961a48255528R25) [[2]](diffhunk://#diff-fe69e1abca9daf1aec997fb5ef29442939601724b4cb06174efe7b33a65463adL41-R48) [[3]](diffhunk://#diff-cc1ba2087fea0a7c195f72714952eded755c0482908d19bc3e3b0997156322edL16-R37)
* Updated the config flow and migration logic to fall back to `DEFAULT_HEATING_CIRCUITS` whenever circuit discovery returns an empty list or fails, ensuring every setup has at least one circuit. [[1]](diffhunk://#diff-fe69e1abca9daf1aec997fb5ef29442939601724b4cb06174efe7b33a65463adL121-R130) [[2]](diffhunk://#diff-cc1ba2087fea0a7c195f72714952eded755c0482908d19bc3e3b0997156322edR394-R400) [[3]](diffhunk://#diff-cc1ba2087fea0a7c195f72714952eded755c0482908d19bc3e3b0997156322edL395-R409) [[4]](diffhunk://#diff-fe69e1abca9daf1aec997fb5ef29442939601724b4cb06174efe7b33a65463adL232-R241) [[5]](diffhunk://#diff-fe69e1abca9daf1aec997fb5ef29442939601724b4cb06174efe7b33a65463adR262-R268)
* Added a migration step (minor version 1.3) to repair entries that have an empty circuit list, defaulting them to `[1]` and updating the minor version. [[1]](diffhunk://#diff-fe69e1abca9daf1aec997fb5ef29442939601724b4cb06174efe7b33a65463adR282-R299) [[2]](diffhunk://#diff-cc1ba2087fea0a7c195f72714952eded755c0482908d19bc3e3b0997156322edL16-R37)

**Testing improvements:**

* Added new tests to verify that the integration correctly falls back to the default circuit when circuit discovery returns an empty list, both during initial setup, reconfiguration, and migration. [[1]](diffhunk://#diff-45de426a823e0cf6a01ac72adae2d02683c3006c626141f9259210d0c33e2da2R216-R253) [[2]](diffhunk://#diff-45de426a823e0cf6a01ac72adae2d02683c3006c626141f9259210d0c33e2da2R1191-R1222) [[3]](diffhunk://#diff-204acf61a2d66c4ddaeeecafce3091a75ffbd6ec806339d72b3f7591313fca97L376-R404) [[4]](diffhunk://#diff-204acf61a2d66c4ddaeeecafce3091a75ffbd6ec806339d72b3f7591313fca97L425-R476)
* Updated existing tests and fixtures to reflect the new minor version and default circuit handling. [[1]](diffhunk://#diff-75a9935d2cfa130ae2018b6cb999bbd98582efa7ba03478836e062337ae22cc4L44-R44) [[2]](diffhunk://#diff-75a9935d2cfa130ae2018b6cb999bbd98582efa7ba03478836e062337ae22cc4L64-R64) [[3]](diffhunk://#diff-204acf61a2d66c4ddaeeecafce3091a75ffbd6ec806339d72b3f7591313fca97L401-R426)

These changes ensure that the BSBLan integration is more resilient to device quirks and configuration edge cases, and that users will always have at least one heating circuit configured.

</details>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170056 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
