### PR TITLE
Split Tractive entities into tracker-related and pet-related

### DIFF
--- a/homeassistant/components/tractive/binary_sensor.py
+++ b/homeassistant/components/tractive/binary_sensor.py
@@ -57,7 +57,6 @@ class TractiveBinarySensorEntityDescription(BinarySensorEntityDescription):
 SENSOR_TYPES = [
     TractiveBinarySensorEntityDescription(
         key=ATTR_BATTERY_CHARGING,
-        translation_key="tracker_battery_charging",
         device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
         entity_category=EntityCategory.DIAGNOSTIC,
         supported=lambda details: details.get("charging_state") is not None,

--- a/homeassistant/components/tractive/device_tracker.py
+++ b/homeassistant/components/tractive/device_tracker.py
@@ -33,6 +33,8 @@ async def async_setup_entry(
 class TractiveDeviceTracker(TractiveEntity, TrackerEntity):
     """Tractive device tracker."""
 
+    _attr_translation_key = "tracker"
+
     def __init__(self, client: TractiveClient, item: Trackables) -> None:
         """Initialize tracker entity."""
         super().__init__(

--- a/homeassistant/components/tractive/device_tracker.py
+++ b/homeassistant/components/tractive/device_tracker.py
@@ -33,8 +33,6 @@ async def async_setup_entry(
 class TractiveDeviceTracker(TractiveEntity, TrackerEntity):
     """Tractive device tracker."""
 
-    _attr_translation_key = "tracker"
-
     def __init__(self, client: TractiveClient, item: Trackables) -> None:
         """Initialize tracker entity."""
         super().__init__(

--- a/homeassistant/components/tractive/entity.py
+++ b/homeassistant/components/tractive/entity.py
@@ -3,7 +3,7 @@
 from typing import Any, Literal
 
 from homeassistant.core import callback
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 
@@ -30,12 +30,13 @@ class TractiveEntity(Entity):
                 identifiers={(DOMAIN, trackable["_id"])},
                 name=trackable["details"]["name"],
                 via_device=(DOMAIN, tracker_details["_id"]),
+                entry_type=DeviceEntryType.SERVICE,
             )
         else:
             self._attr_device_info = DeviceInfo(
                 configuration_url="https://my.tractive.com/",
                 identifiers={(DOMAIN, tracker_details["_id"])},
-                name=f"Tractive {tracker_details['model_number']}",
+                name=f"Tracker {tracker_details['_id']}",
                 manufacturer="Tractive GmbH",
                 sw_version=tracker_details["fw_version"],
                 model=tracker_details["model_number"],

--- a/homeassistant/components/tractive/entity.py
+++ b/homeassistant/components/tractive/entity.py
@@ -1,6 +1,6 @@
 """A entity class for Tractive integration."""
 
-from typing import Any
+from typing import Any, Literal
 
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -22,16 +22,24 @@ class TractiveEntity(Entity):
         trackable: dict[str, Any],
         tracker_details: dict[str, Any],
         dispatcher_signal: str,
+        device_type: Literal["tracker", "pet"] = "tracker",
     ) -> None:
         """Initialize tracker entity."""
-        self._attr_device_info = DeviceInfo(
-            configuration_url="https://my.tractive.com/",
-            identifiers={(DOMAIN, tracker_details["_id"])},
-            name=trackable["details"]["name"],
-            manufacturer="Tractive GmbH",
-            sw_version=tracker_details["fw_version"],
-            model=tracker_details["model_number"],
-        )
+        if device_type == "pet":
+            self._attr_device_info = DeviceInfo(
+                identifiers={(DOMAIN, trackable["_id"])},
+                name=trackable["details"]["name"],
+                via_device=(DOMAIN, tracker_details["_id"]),
+            )
+        else:
+            self._attr_device_info = DeviceInfo(
+                configuration_url="https://my.tractive.com/",
+                identifiers={(DOMAIN, tracker_details["_id"])},
+                name=f"Tractive {tracker_details['model_number']}",
+                manufacturer="Tractive GmbH",
+                sw_version=tracker_details["fw_version"],
+                model=tracker_details["model_number"],
+            )
         self._user_id = client.user_id
         self._tracker_id = tracker_details["_id"]
         self._client = client

--- a/homeassistant/components/tractive/entity.py
+++ b/homeassistant/components/tractive/entity.py
@@ -1,6 +1,6 @@
 """A entity class for Tractive integration."""
 
-from typing import Any, Literal
+from typing import Any
 
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
@@ -22,17 +22,10 @@ class TractiveEntity(Entity):
         trackable: dict[str, Any],
         tracker_details: dict[str, Any],
         dispatcher_signal: str,
-        device_type: Literal["tracker", "pet"] = "tracker",
+        hardware_entity: bool = True,
     ) -> None:
         """Initialize tracker entity."""
-        if device_type == "pet":
-            self._attr_device_info = DeviceInfo(
-                identifiers={(DOMAIN, trackable["_id"])},
-                name=trackable["details"]["name"],
-                via_device=(DOMAIN, tracker_details["_id"]),
-                entry_type=DeviceEntryType.SERVICE,
-            )
-        else:
+        if hardware_entity:
             self._attr_device_info = DeviceInfo(
                 configuration_url="https://my.tractive.com/",
                 identifiers={(DOMAIN, tracker_details["_id"])},
@@ -41,6 +34,14 @@ class TractiveEntity(Entity):
                 sw_version=tracker_details["fw_version"],
                 model=tracker_details["model_number"],
             )
+        else:
+            self._attr_device_info = DeviceInfo(
+                identifiers={(DOMAIN, trackable["_id"])},
+                name=trackable["details"]["name"],
+                via_device=(DOMAIN, tracker_details["_id"]),
+                entry_type=DeviceEntryType.SERVICE,
+            )
+
         self._user_id = client.user_id
         self._tracker_id = tracker_details["_id"]
         self._client = client

--- a/homeassistant/components/tractive/sensor.py
+++ b/homeassistant/components/tractive/sensor.py
@@ -87,7 +87,6 @@ class TractiveSensor(TractiveEntity, SensorEntity):
 SENSOR_TYPES: tuple[TractiveSensorEntityDescription, ...] = (
     TractiveSensorEntityDescription(
         key=ATTR_BATTERY_LEVEL,
-        translation_key="tracker_battery_level",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         signal_prefix=TRACKER_HARDWARE_STATUS_UPDATED,

--- a/homeassistant/components/tractive/sensor.py
+++ b/homeassistant/components/tractive/sensor.py
@@ -63,7 +63,11 @@ class TractiveSensor(TractiveEntity, SensorEntity):
         else:
             dispatcher_signal = f"{description.signal_prefix}-{item.trackable['_id']}"
         super().__init__(
-            client, item.trackable, item.tracker_details, dispatcher_signal
+            client,
+            item.trackable,
+            item.tracker_details,
+            dispatcher_signal,
+            device_type="tracker" if description.hardware_sensor else "pet",
         )
 
         self._attr_unique_id = f"{item.trackable['_id']}_{description.key}"

--- a/homeassistant/components/tractive/sensor.py
+++ b/homeassistant/components/tractive/sensor.py
@@ -67,7 +67,7 @@ class TractiveSensor(TractiveEntity, SensorEntity):
             item.trackable,
             item.tracker_details,
             dispatcher_signal,
-            device_type="tracker" if description.hardware_sensor else "pet",
+            description.hardware_sensor,
         )
 
         self._attr_unique_id = f"{item.trackable['_id']}_{description.key}"

--- a/homeassistant/components/tractive/strings.json
+++ b/homeassistant/components/tractive/strings.json
@@ -22,16 +22,8 @@
   },
   "entity": {
     "binary_sensor": {
-      "tracker_battery_charging": {
-        "name": "Tracker battery charging"
-      },
       "tracker_power_saving": {
-        "name": "Tracker power saving"
-      }
-    },
-    "device_tracker": {
-      "tracker": {
-        "name": "Tracker"
+        "name": "Power saving"
       }
     },
     "sensor": {
@@ -50,11 +42,8 @@
       "rest_time": {
         "name": "Rest time"
       },
-      "tracker_battery_level": {
-        "name": "Tracker battery"
-      },
       "tracker_state": {
-        "name": "Tracker state",
+        "name": "Status",
         "state": {
           "inaccurate_position": "Inaccurate position",
           "not_reporting": "Not reporting",
@@ -69,10 +58,10 @@
         "name": "Live tracking"
       },
       "tracker_buzzer": {
-        "name": "Tracker buzzer"
+        "name": "Buzzer"
       },
       "tracker_led": {
-        "name": "Tracker LED"
+        "name": "LED"
       }
     }
   },

--- a/tests/components/tractive/snapshots/test_binary_sensor.ambr
+++ b/tests/components/tractive/snapshots/test_binary_sensor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_binary_sensor[binary_sensor.test_pet_tracker_battery_charging-entry]
+# name: test_binary_sensor[binary_sensor.tractive_tg4422_tracker_battery_charging-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -13,7 +13,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.test_pet_tracker_battery_charging',
+    'entity_id': 'binary_sensor.tractive_tg4422_tracker_battery_charging',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -36,21 +36,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_binary_sensor[binary_sensor.test_pet_tracker_battery_charging-state]
+# name: test_binary_sensor[binary_sensor.tractive_tg4422_tracker_battery_charging-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'battery_charging',
-      'friendly_name': 'Test Pet Tracker battery charging',
+      'friendly_name': 'Tractive TG4422 Tracker battery charging',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.test_pet_tracker_battery_charging',
+    'entity_id': 'binary_sensor.tractive_tg4422_tracker_battery_charging',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_binary_sensor[binary_sensor.test_pet_tracker_power_saving-entry]
+# name: test_binary_sensor[binary_sensor.tractive_tg4422_tracker_power_saving-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -64,7 +64,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.test_pet_tracker_power_saving',
+    'entity_id': 'binary_sensor.tractive_tg4422_tracker_power_saving',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -87,13 +87,13 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_binary_sensor[binary_sensor.test_pet_tracker_power_saving-state]
+# name: test_binary_sensor[binary_sensor.tractive_tg4422_tracker_power_saving-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Test Pet Tracker power saving',
+      'friendly_name': 'Tractive TG4422 Tracker power saving',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.test_pet_tracker_power_saving',
+    'entity_id': 'binary_sensor.tractive_tg4422_tracker_power_saving',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/tractive/snapshots/test_binary_sensor.ambr
+++ b/tests/components/tractive/snapshots/test_binary_sensor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_binary_sensor[binary_sensor.tractive_tg4422_tracker_battery_charging-entry]
+# name: test_binary_sensor[binary_sensor.tracker_device_id_123_tracker_battery_charging-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -13,7 +13,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.tractive_tg4422_tracker_battery_charging',
+    'entity_id': 'binary_sensor.tracker_device_id_123_tracker_battery_charging',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -36,21 +36,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_binary_sensor[binary_sensor.tractive_tg4422_tracker_battery_charging-state]
+# name: test_binary_sensor[binary_sensor.tracker_device_id_123_tracker_battery_charging-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'battery_charging',
-      'friendly_name': 'Tractive TG4422 Tracker battery charging',
+      'friendly_name': 'Tracker device_id_123 Tracker battery charging',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.tractive_tg4422_tracker_battery_charging',
+    'entity_id': 'binary_sensor.tracker_device_id_123_tracker_battery_charging',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_binary_sensor[binary_sensor.tractive_tg4422_tracker_power_saving-entry]
+# name: test_binary_sensor[binary_sensor.tracker_device_id_123_tracker_power_saving-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -64,7 +64,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.tractive_tg4422_tracker_power_saving',
+    'entity_id': 'binary_sensor.tracker_device_id_123_tracker_power_saving',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -87,13 +87,13 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_binary_sensor[binary_sensor.tractive_tg4422_tracker_power_saving-state]
+# name: test_binary_sensor[binary_sensor.tracker_device_id_123_tracker_power_saving-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Tractive TG4422 Tracker power saving',
+      'friendly_name': 'Tracker device_id_123 Tracker power saving',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.tractive_tg4422_tracker_power_saving',
+    'entity_id': 'binary_sensor.tracker_device_id_123_tracker_power_saving',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/tractive/snapshots/test_binary_sensor.ambr
+++ b/tests/components/tractive/snapshots/test_binary_sensor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_binary_sensor[binary_sensor.tracker_device_id_123_tracker_battery_charging-entry]
+# name: test_binary_sensor[binary_sensor.tracker_device_id_123_charging-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -13,7 +13,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.tracker_device_id_123_tracker_battery_charging',
+    'entity_id': 'binary_sensor.tracker_device_id_123_charging',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -21,36 +21,36 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Tracker battery charging',
+    'object_id_base': 'Charging',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.BATTERY_CHARGING: 'battery_charging'>,
     'original_icon': None,
-    'original_name': 'Tracker battery charging',
+    'original_name': 'Charging',
     'platform': 'tractive',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'tracker_battery_charging',
+    'translation_key': None,
     'unique_id': 'pet_id_123_battery_charging',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_binary_sensor[binary_sensor.tracker_device_id_123_tracker_battery_charging-state]
+# name: test_binary_sensor[binary_sensor.tracker_device_id_123_charging-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'battery_charging',
-      'friendly_name': 'Tracker device_id_123 Tracker battery charging',
+      'friendly_name': 'Tracker device_id_123 Charging',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.tracker_device_id_123_tracker_battery_charging',
+    'entity_id': 'binary_sensor.tracker_device_id_123_charging',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_binary_sensor[binary_sensor.tracker_device_id_123_tracker_power_saving-entry]
+# name: test_binary_sensor[binary_sensor.tracker_device_id_123_power_saving-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -64,7 +64,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.tracker_device_id_123_tracker_power_saving',
+    'entity_id': 'binary_sensor.tracker_device_id_123_power_saving',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -72,12 +72,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Tracker power saving',
+    'object_id_base': 'Power saving',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Tracker power saving',
+    'original_name': 'Power saving',
     'platform': 'tractive',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -87,13 +87,13 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_binary_sensor[binary_sensor.tracker_device_id_123_tracker_power_saving-state]
+# name: test_binary_sensor[binary_sensor.tracker_device_id_123_power_saving-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Tracker device_id_123 Tracker power saving',
+      'friendly_name': 'Tracker device_id_123 Power saving',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.tracker_device_id_123_tracker_power_saving',
+    'entity_id': 'binary_sensor.tracker_device_id_123_power_saving',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/tractive/snapshots/test_device_tracker.ambr
+++ b/tests/components/tractive/snapshots/test_device_tracker.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_device_tracker[device_tracker.test_pet_tracker-entry]
+# name: test_device_tracker[device_tracker.tractive_tg4422_tracker-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -13,7 +13,7 @@
     'disabled_by': None,
     'domain': 'device_tracker',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'device_tracker.test_pet_tracker',
+    'entity_id': 'device_tracker.tractive_tg4422_tracker',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -36,11 +36,11 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_device_tracker[device_tracker.test_pet_tracker-state]
+# name: test_device_tracker[device_tracker.tractive_tg4422_tracker-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'battery_level': 88,
-      'friendly_name': 'Test Pet Tracker',
+      'friendly_name': 'Tractive TG4422 Tracker',
       'gps_accuracy': 99,
       'in_zones': list([
       ]),
@@ -49,7 +49,7 @@
       'source_type': <SourceType.GPS: 'gps'>,
     }),
     'context': <ANY>,
-    'entity_id': 'device_tracker.test_pet_tracker',
+    'entity_id': 'device_tracker.tractive_tg4422_tracker',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/tractive/snapshots/test_device_tracker.ambr
+++ b/tests/components/tractive/snapshots/test_device_tracker.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_device_tracker[device_tracker.tracker_device_id_123_tracker-entry]
+# name: test_device_tracker[device_tracker.tracker_device_id_123-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -13,7 +13,7 @@
     'disabled_by': None,
     'domain': 'device_tracker',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'device_tracker.tracker_device_id_123_tracker',
+    'entity_id': 'device_tracker.tracker_device_id_123',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -21,26 +21,26 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Tracker',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Tracker',
+    'original_name': None,
     'platform': 'tractive',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'tracker',
+    'translation_key': None,
     'unique_id': 'pet_id_123',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_device_tracker[device_tracker.tracker_device_id_123_tracker-state]
+# name: test_device_tracker[device_tracker.tracker_device_id_123-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'battery_level': 88,
-      'friendly_name': 'Tracker device_id_123 Tracker',
+      'friendly_name': 'Tracker device_id_123',
       'gps_accuracy': 99,
       'in_zones': list([
       ]),
@@ -49,7 +49,7 @@
       'source_type': <SourceType.GPS: 'gps'>,
     }),
     'context': <ANY>,
-    'entity_id': 'device_tracker.tracker_device_id_123_tracker',
+    'entity_id': 'device_tracker.tracker_device_id_123',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/tractive/snapshots/test_device_tracker.ambr
+++ b/tests/components/tractive/snapshots/test_device_tracker.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_device_tracker[device_tracker.tractive_tg4422_tracker-entry]
+# name: test_device_tracker[device_tracker.tracker_device_id_123_tracker-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -13,7 +13,7 @@
     'disabled_by': None,
     'domain': 'device_tracker',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'device_tracker.tractive_tg4422_tracker',
+    'entity_id': 'device_tracker.tracker_device_id_123_tracker',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -36,11 +36,11 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_device_tracker[device_tracker.tractive_tg4422_tracker-state]
+# name: test_device_tracker[device_tracker.tracker_device_id_123_tracker-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'battery_level': 88,
-      'friendly_name': 'Tractive TG4422 Tracker',
+      'friendly_name': 'Tracker device_id_123 Tracker',
       'gps_accuracy': 99,
       'in_zones': list([
       ]),
@@ -49,7 +49,7 @@
       'source_type': <SourceType.GPS: 'gps'>,
     }),
     'context': <ANY>,
-    'entity_id': 'device_tracker.tractive_tg4422_tracker',
+    'entity_id': 'device_tracker.tracker_device_id_123_tracker',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/tractive/snapshots/test_device_tracker.ambr
+++ b/tests/components/tractive/snapshots/test_device_tracker.ambr
@@ -31,7 +31,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'tracker',
     'unique_id': 'pet_id_123',
     'unit_of_measurement': None,
   })

--- a/tests/components/tractive/snapshots/test_sensor.ambr
+++ b/tests/components/tractive/snapshots/test_sensor.ambr
@@ -266,7 +266,7 @@
     'state': '122',
   })
 # ---
-# name: test_sensor[sensor.test_pet_tracker_battery-entry]
+# name: test_sensor[sensor.tractive_tg4422_tracker_battery-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -280,7 +280,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.test_pet_tracker_battery',
+    'entity_id': 'sensor.tractive_tg4422_tracker_battery',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -303,22 +303,22 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor[sensor.test_pet_tracker_battery-state]
+# name: test_sensor[sensor.tractive_tg4422_tracker_battery-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'battery',
-      'friendly_name': 'Test Pet Tracker battery',
+      'friendly_name': 'Tractive TG4422 Tracker battery',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.test_pet_tracker_battery',
+    'entity_id': 'sensor.tractive_tg4422_tracker_battery',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '88',
   })
 # ---
-# name: test_sensor[sensor.test_pet_tracker_state-entry]
+# name: test_sensor[sensor.tractive_tg4422_tracker_state-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -340,7 +340,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.test_pet_tracker_state',
+    'entity_id': 'sensor.tractive_tg4422_tracker_state',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -363,11 +363,11 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor[sensor.test_pet_tracker_state-state]
+# name: test_sensor[sensor.tractive_tg4422_tracker_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'enum',
-      'friendly_name': 'Test Pet Tracker state',
+      'friendly_name': 'Tractive TG4422 Tracker state',
       'options': list([
         'inaccurate_position',
         'not_reporting',
@@ -377,7 +377,7 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.test_pet_tracker_state',
+    'entity_id': 'sensor.tractive_tg4422_tracker_state',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/tractive/snapshots/test_sensor.ambr
+++ b/tests/components/tractive/snapshots/test_sensor.ambr
@@ -266,7 +266,7 @@
     'state': '122',
   })
 # ---
-# name: test_sensor[sensor.tracker_device_id_123_tracker_battery-entry]
+# name: test_sensor[sensor.tracker_device_id_123_battery-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -280,7 +280,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.tracker_device_id_123_tracker_battery',
+    'entity_id': 'sensor.tracker_device_id_123_battery',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -288,37 +288,37 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Tracker battery',
+    'object_id_base': 'Battery',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
     'original_icon': None,
-    'original_name': 'Tracker battery',
+    'original_name': 'Battery',
     'platform': 'tractive',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'tracker_battery_level',
+    'translation_key': None,
     'unique_id': 'pet_id_123_battery_level',
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor[sensor.tracker_device_id_123_tracker_battery-state]
+# name: test_sensor[sensor.tracker_device_id_123_battery-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'battery',
-      'friendly_name': 'Tracker device_id_123 Tracker battery',
+      'friendly_name': 'Tracker device_id_123 Battery',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.tracker_device_id_123_tracker_battery',
+    'entity_id': 'sensor.tracker_device_id_123_battery',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '88',
   })
 # ---
-# name: test_sensor[sensor.tracker_device_id_123_tracker_state-entry]
+# name: test_sensor[sensor.tracker_device_id_123_status-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -340,7 +340,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.tracker_device_id_123_tracker_state',
+    'entity_id': 'sensor.tracker_device_id_123_status',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -348,12 +348,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Tracker state',
+    'object_id_base': 'Status',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
     'original_icon': None,
-    'original_name': 'Tracker state',
+    'original_name': 'Status',
     'platform': 'tractive',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -363,11 +363,11 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor[sensor.tracker_device_id_123_tracker_state-state]
+# name: test_sensor[sensor.tracker_device_id_123_status-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'enum',
-      'friendly_name': 'Tracker device_id_123 Tracker state',
+      'friendly_name': 'Tracker device_id_123 Status',
       'options': list([
         'inaccurate_position',
         'not_reporting',
@@ -377,7 +377,7 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.tracker_device_id_123_tracker_state',
+    'entity_id': 'sensor.tracker_device_id_123_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/tractive/snapshots/test_sensor.ambr
+++ b/tests/components/tractive/snapshots/test_sensor.ambr
@@ -266,7 +266,7 @@
     'state': '122',
   })
 # ---
-# name: test_sensor[sensor.tractive_tg4422_tracker_battery-entry]
+# name: test_sensor[sensor.tracker_device_id_123_tracker_battery-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -280,7 +280,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.tractive_tg4422_tracker_battery',
+    'entity_id': 'sensor.tracker_device_id_123_tracker_battery',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -303,22 +303,22 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor[sensor.tractive_tg4422_tracker_battery-state]
+# name: test_sensor[sensor.tracker_device_id_123_tracker_battery-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'battery',
-      'friendly_name': 'Tractive TG4422 Tracker battery',
+      'friendly_name': 'Tracker device_id_123 Tracker battery',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.tractive_tg4422_tracker_battery',
+    'entity_id': 'sensor.tracker_device_id_123_tracker_battery',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '88',
   })
 # ---
-# name: test_sensor[sensor.tractive_tg4422_tracker_state-entry]
+# name: test_sensor[sensor.tracker_device_id_123_tracker_state-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -340,7 +340,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.tractive_tg4422_tracker_state',
+    'entity_id': 'sensor.tracker_device_id_123_tracker_state',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -363,11 +363,11 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor[sensor.tractive_tg4422_tracker_state-state]
+# name: test_sensor[sensor.tracker_device_id_123_tracker_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'enum',
-      'friendly_name': 'Tractive TG4422 Tracker state',
+      'friendly_name': 'Tracker device_id_123 Tracker state',
       'options': list([
         'inaccurate_position',
         'not_reporting',
@@ -377,7 +377,7 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.tractive_tg4422_tracker_state',
+    'entity_id': 'sensor.tracker_device_id_123_tracker_state',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/tractive/snapshots/test_switch.ambr
+++ b/tests/components/tractive/snapshots/test_switch.ambr
@@ -1,4 +1,104 @@
 # serializer version: 1
+# name: test_switch[switch.tracker_device_id_123_buzzer-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.tracker_device_id_123_buzzer',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Buzzer',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Buzzer',
+    'platform': 'tractive',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'tracker_buzzer',
+    'unique_id': 'pet_id_123_buzzer',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch[switch.tracker_device_id_123_buzzer-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Tracker device_id_123 Buzzer',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.tracker_device_id_123_buzzer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch[switch.tracker_device_id_123_led-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.tracker_device_id_123_led',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'LED',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'LED',
+    'platform': 'tractive',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'tracker_led',
+    'unique_id': 'pet_id_123_led',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch[switch.tracker_device_id_123_led-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Tracker device_id_123 LED',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.tracker_device_id_123_led',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_switch[switch.tracker_device_id_123_live_tracking-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -47,105 +147,5 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
-  })
-# ---
-# name: test_switch[switch.tracker_device_id_123_tracker_buzzer-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'switch',
-    'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.tracker_device_id_123_tracker_buzzer',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Tracker buzzer',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Tracker buzzer',
-    'platform': 'tractive',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'tracker_buzzer',
-    'unique_id': 'pet_id_123_buzzer',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_switch[switch.tracker_device_id_123_tracker_buzzer-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Tracker device_id_123 Tracker buzzer',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.tracker_device_id_123_tracker_buzzer',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'on',
-  })
-# ---
-# name: test_switch[switch.tracker_device_id_123_tracker_led-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'switch',
-    'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.tracker_device_id_123_tracker_led',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Tracker LED',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Tracker LED',
-    'platform': 'tractive',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'tracker_led',
-    'unique_id': 'pet_id_123_led',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_switch[switch.tracker_device_id_123_tracker_led-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Tracker device_id_123 Tracker LED',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.tracker_device_id_123_tracker_led',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
   })
 # ---

--- a/tests/components/tractive/snapshots/test_switch.ambr
+++ b/tests/components/tractive/snapshots/test_switch.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_switch[switch.test_pet_live_tracking-entry]
+# name: test_switch[switch.tractive_tg4422_live_tracking-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -13,7 +13,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.test_pet_live_tracking',
+    'entity_id': 'switch.tractive_tg4422_live_tracking',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -36,20 +36,20 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch[switch.test_pet_live_tracking-state]
+# name: test_switch[switch.tractive_tg4422_live_tracking-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Test Pet Live tracking',
+      'friendly_name': 'Tractive TG4422 Live tracking',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.test_pet_live_tracking',
+    'entity_id': 'switch.tractive_tg4422_live_tracking',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_switch[switch.test_pet_tracker_buzzer-entry]
+# name: test_switch[switch.tractive_tg4422_tracker_buzzer-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -63,7 +63,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.test_pet_tracker_buzzer',
+    'entity_id': 'switch.tractive_tg4422_tracker_buzzer',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -86,20 +86,20 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch[switch.test_pet_tracker_buzzer-state]
+# name: test_switch[switch.tractive_tg4422_tracker_buzzer-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Test Pet Tracker buzzer',
+      'friendly_name': 'Tractive TG4422 Tracker buzzer',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.test_pet_tracker_buzzer',
+    'entity_id': 'switch.tractive_tg4422_tracker_buzzer',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_switch[switch.test_pet_tracker_led-entry]
+# name: test_switch[switch.tractive_tg4422_tracker_led-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -113,7 +113,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.test_pet_tracker_led',
+    'entity_id': 'switch.tractive_tg4422_tracker_led',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -136,13 +136,13 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch[switch.test_pet_tracker_led-state]
+# name: test_switch[switch.tractive_tg4422_tracker_led-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Test Pet Tracker LED',
+      'friendly_name': 'Tractive TG4422 Tracker LED',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.test_pet_tracker_led',
+    'entity_id': 'switch.tractive_tg4422_tracker_led',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/tractive/snapshots/test_switch.ambr
+++ b/tests/components/tractive/snapshots/test_switch.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_switch[switch.tractive_tg4422_live_tracking-entry]
+# name: test_switch[switch.tracker_device_id_123_live_tracking-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -13,7 +13,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.tractive_tg4422_live_tracking',
+    'entity_id': 'switch.tracker_device_id_123_live_tracking',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -36,20 +36,20 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch[switch.tractive_tg4422_live_tracking-state]
+# name: test_switch[switch.tracker_device_id_123_live_tracking-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Tractive TG4422 Live tracking',
+      'friendly_name': 'Tracker device_id_123 Live tracking',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.tractive_tg4422_live_tracking',
+    'entity_id': 'switch.tracker_device_id_123_live_tracking',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_switch[switch.tractive_tg4422_tracker_buzzer-entry]
+# name: test_switch[switch.tracker_device_id_123_tracker_buzzer-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -63,7 +63,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.tractive_tg4422_tracker_buzzer',
+    'entity_id': 'switch.tracker_device_id_123_tracker_buzzer',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -86,20 +86,20 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch[switch.tractive_tg4422_tracker_buzzer-state]
+# name: test_switch[switch.tracker_device_id_123_tracker_buzzer-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Tractive TG4422 Tracker buzzer',
+      'friendly_name': 'Tracker device_id_123 Tracker buzzer',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.tractive_tg4422_tracker_buzzer',
+    'entity_id': 'switch.tracker_device_id_123_tracker_buzzer',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_switch[switch.tractive_tg4422_tracker_led-entry]
+# name: test_switch[switch.tracker_device_id_123_tracker_led-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -113,7 +113,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.tractive_tg4422_tracker_led',
+    'entity_id': 'switch.tracker_device_id_123_tracker_led',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -136,13 +136,13 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch[switch.tractive_tg4422_tracker_led-state]
+# name: test_switch[switch.tracker_device_id_123_tracker_led-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Tractive TG4422 Tracker LED',
+      'friendly_name': 'Tracker device_id_123 Tracker LED',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.tractive_tg4422_tracker_led',
+    'entity_id': 'switch.tracker_device_id_123_tracker_led',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/tractive/test_binary_sensor.py
+++ b/tests/components/tractive/test_binary_sensor.py
@@ -4,9 +4,10 @@ from unittest.mock import AsyncMock, patch
 
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.tractive.const import DOMAIN
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import init_integration
 
@@ -27,3 +28,28 @@ async def test_binary_sensor(
         mock_tractive_client.send_hardware_event(mock_config_entry)
         await hass.async_block_till_done()
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_binary_sensor_device_assignment(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    mock_tractive_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that binary sensor entities are assigned to the tracker device."""
+    with patch("homeassistant.components.tractive.PLATFORMS", [Platform.BINARY_SENSOR]):
+        await init_integration(hass, mock_config_entry)
+
+    tracker_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "device_id_123")}
+    )
+    assert tracker_device is not None
+
+    for entity_id in (
+        "binary_sensor.tracker_device_id_123_charging",
+        "binary_sensor.tracker_device_id_123_power_saving",
+    ):
+        entry = entity_registry.async_get(entity_id)
+        assert entry is not None
+        assert entry.device_id == tracker_device.id

--- a/tests/components/tractive/test_device_tracker.py
+++ b/tests/components/tractive/test_device_tracker.py
@@ -56,7 +56,9 @@ async def test_source_type_phone(
     await hass.async_block_till_done()
 
     assert (
-        hass.states.get("device_tracker.test_pet_tracker").attributes["source_type"]
+        hass.states.get("device_tracker.tractive_tg4422_tracker").attributes[
+            "source_type"
+        ]
         is SourceType.BLUETOOTH
     )
 
@@ -84,7 +86,9 @@ async def test_source_type_gps(
     await hass.async_block_till_done()
 
     assert (
-        hass.states.get("device_tracker.test_pet_tracker").attributes["source_type"]
+        hass.states.get("device_tracker.tractive_tg4422_tracker").attributes[
+            "source_type"
+        ]
         is SourceType.GPS
     )
 
@@ -105,6 +109,6 @@ async def test_device_tracker_with_empty_hw_info(
         mock_tractive_client.send_position_event(mock_config_entry)
         await hass.async_block_till_done()
 
-    state = hass.states.get("device_tracker.test_pet_tracker")
+    state = hass.states.get("device_tracker.tractive_tg4422_tracker")
     assert state is not None
     assert state.attributes.get("battery_level") is None

--- a/tests/components/tractive/test_device_tracker.py
+++ b/tests/components/tractive/test_device_tracker.py
@@ -56,7 +56,7 @@ async def test_source_type_phone(
     await hass.async_block_till_done()
 
     assert (
-        hass.states.get("device_tracker.tracker_device_id_123_tracker").attributes[
+        hass.states.get("device_tracker.tracker_device_id_123").attributes[
             "source_type"
         ]
         is SourceType.BLUETOOTH
@@ -86,7 +86,7 @@ async def test_source_type_gps(
     await hass.async_block_till_done()
 
     assert (
-        hass.states.get("device_tracker.tracker_device_id_123_tracker").attributes[
+        hass.states.get("device_tracker.tracker_device_id_123").attributes[
             "source_type"
         ]
         is SourceType.GPS
@@ -109,6 +109,6 @@ async def test_device_tracker_with_empty_hw_info(
         mock_tractive_client.send_position_event(mock_config_entry)
         await hass.async_block_till_done()
 
-    state = hass.states.get("device_tracker.tracker_device_id_123_tracker")
+    state = hass.states.get("device_tracker.tracker_device_id_123")
     assert state is not None
     assert state.attributes.get("battery_level") is None

--- a/tests/components/tractive/test_device_tracker.py
+++ b/tests/components/tractive/test_device_tracker.py
@@ -56,7 +56,7 @@ async def test_source_type_phone(
     await hass.async_block_till_done()
 
     assert (
-        hass.states.get("device_tracker.tractive_tg4422_tracker").attributes[
+        hass.states.get("device_tracker.tracker_device_id_123_tracker").attributes[
             "source_type"
         ]
         is SourceType.BLUETOOTH
@@ -86,7 +86,7 @@ async def test_source_type_gps(
     await hass.async_block_till_done()
 
     assert (
-        hass.states.get("device_tracker.tractive_tg4422_tracker").attributes[
+        hass.states.get("device_tracker.tracker_device_id_123_tracker").attributes[
             "source_type"
         ]
         is SourceType.GPS
@@ -109,6 +109,6 @@ async def test_device_tracker_with_empty_hw_info(
         mock_tractive_client.send_position_event(mock_config_entry)
         await hass.async_block_till_done()
 
-    state = hass.states.get("device_tracker.tractive_tg4422_tracker")
+    state = hass.states.get("device_tracker.tracker_device_id_123_tracker")
     assert state is not None
     assert state.attributes.get("battery_level") is None

--- a/tests/components/tractive/test_device_tracker.py
+++ b/tests/components/tractive/test_device_tracker.py
@@ -5,9 +5,10 @@ from unittest.mock import AsyncMock, patch
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.device_tracker import SourceType
+from homeassistant.components.tractive.const import DOMAIN
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import init_integration
 
@@ -112,3 +113,26 @@ async def test_device_tracker_with_empty_hw_info(
     state = hass.states.get("device_tracker.tracker_device_id_123")
     assert state is not None
     assert state.attributes.get("battery_level") is None
+
+
+async def test_device_tracker_device_assignment(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    mock_tractive_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that the device tracker entity is assigned to the tracker device."""
+    with patch(
+        "homeassistant.components.tractive.PLATFORMS", [Platform.DEVICE_TRACKER]
+    ):
+        await init_integration(hass, mock_config_entry)
+
+    tracker_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "device_id_123")}
+    )
+    assert tracker_device is not None
+
+    entry = entity_registry.async_get("device_tracker.tracker_device_id_123")
+    assert entry is not None
+    assert entry.device_id == tracker_device.id

--- a/tests/components/tractive/test_init.py
+++ b/tests/components/tractive/test_init.py
@@ -150,7 +150,7 @@ async def test_server_unavailable(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test states of the sensor."""
-    entity_id = "sensor.tractive_tg4422_tracker_battery"
+    entity_id = "sensor.tracker_device_id_123_tracker_battery"
 
     await init_integration(hass, mock_config_entry)
 

--- a/tests/components/tractive/test_init.py
+++ b/tests/components/tractive/test_init.py
@@ -150,7 +150,7 @@ async def test_server_unavailable(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test states of the sensor."""
-    entity_id = "sensor.test_pet_tracker_battery"
+    entity_id = "sensor.tractive_tg4422_tracker_battery"
 
     await init_integration(hass, mock_config_entry)
 

--- a/tests/components/tractive/test_init.py
+++ b/tests/components/tractive/test_init.py
@@ -150,7 +150,7 @@ async def test_server_unavailable(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test states of the sensor."""
-    entity_id = "sensor.tracker_device_id_123_tracker_battery"
+    entity_id = "sensor.tracker_device_id_123_battery"
 
     await init_integration(hass, mock_config_entry)
 

--- a/tests/components/tractive/test_sensor.py
+++ b/tests/components/tractive/test_sensor.py
@@ -4,9 +4,10 @@ from unittest.mock import AsyncMock, patch
 
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.tractive.const import DOMAIN
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import init_integration
 
@@ -28,3 +29,42 @@ async def test_sensor(
         mock_tractive_client.send_health_overview_event(mock_config_entry)
         await hass.async_block_till_done()
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_sensor_device_assignment(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    mock_tractive_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that hardware sensors are on the tracker device and health sensors on the pet device."""
+    with patch("homeassistant.components.tractive.PLATFORMS", [Platform.SENSOR]):
+        await init_integration(hass, mock_config_entry)
+
+    tracker_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "device_id_123")}
+    )
+    assert tracker_device is not None
+
+    pet_device = device_registry.async_get_device(identifiers={(DOMAIN, "pet_id_123")})
+    assert pet_device is not None
+
+    for entity_id in (
+        "sensor.tracker_device_id_123_battery",
+        "sensor.tracker_device_id_123_status",
+    ):
+        entry = entity_registry.async_get(entity_id)
+        assert entry is not None
+        assert entry.device_id == tracker_device.id
+
+    for entity_id in (
+        "sensor.test_pet_activity_time",
+        "sensor.test_pet_rest_time",
+        "sensor.test_pet_daily_goal",
+        "sensor.test_pet_day_sleep",
+        "sensor.test_pet_night_sleep",
+    ):
+        entry = entity_registry.async_get(entity_id)
+        assert entry is not None
+        assert entry.device_id == pet_device.id

--- a/tests/components/tractive/test_switch.py
+++ b/tests/components/tractive/test_switch.py
@@ -46,7 +46,7 @@ async def test_switch_on(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the switch can be turned on."""
-    entity_id = "switch.tracker_device_id_123_tracker_led"
+    entity_id = "switch.tracker_device_id_123_led"
 
     await init_integration(hass, mock_config_entry)
 
@@ -85,7 +85,7 @@ async def test_switch_off(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the switch can be turned off."""
-    entity_id = "switch.tracker_device_id_123_tracker_buzzer"
+    entity_id = "switch.tracker_device_id_123_buzzer"
 
     await init_integration(hass, mock_config_entry)
 
@@ -170,7 +170,7 @@ async def test_switch_on_with_exception(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the switch turn on with exception."""
-    entity_id = "switch.tracker_device_id_123_tracker_led"
+    entity_id = "switch.tracker_device_id_123_led"
 
     await init_integration(hass, mock_config_entry)
 
@@ -206,7 +206,7 @@ async def test_switch_off_with_exception(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the switch turn off with exception."""
-    entity_id = "switch.tracker_device_id_123_tracker_buzzer"
+    entity_id = "switch.tracker_device_id_123_buzzer"
 
     await init_integration(hass, mock_config_entry)
 
@@ -244,7 +244,7 @@ async def test_switch_unavailable(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the switch is navailable when the tracker is in the energy saving zone."""
-    entity_id = "switch.tracker_device_id_123_tracker_buzzer"
+    entity_id = "switch.tracker_device_id_123_buzzer"
 
     await init_integration(hass, mock_config_entry)
 

--- a/tests/components/tractive/test_switch.py
+++ b/tests/components/tractive/test_switch.py
@@ -46,7 +46,7 @@ async def test_switch_on(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the switch can be turned on."""
-    entity_id = "switch.test_pet_tracker_led"
+    entity_id = "switch.tractive_tg4422_tracker_led"
 
     await init_integration(hass, mock_config_entry)
 
@@ -85,7 +85,7 @@ async def test_switch_off(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the switch can be turned off."""
-    entity_id = "switch.test_pet_tracker_buzzer"
+    entity_id = "switch.tractive_tg4422_tracker_buzzer"
 
     await init_integration(hass, mock_config_entry)
 
@@ -125,7 +125,7 @@ async def test_live_tracking_switch(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the live_tracking switch."""
-    entity_id = "switch.test_pet_live_tracking"
+    entity_id = "switch.tractive_tg4422_live_tracking"
 
     await init_integration(hass, mock_config_entry)
 
@@ -170,7 +170,7 @@ async def test_switch_on_with_exception(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the switch turn on with exception."""
-    entity_id = "switch.test_pet_tracker_led"
+    entity_id = "switch.tractive_tg4422_tracker_led"
 
     await init_integration(hass, mock_config_entry)
 
@@ -206,7 +206,7 @@ async def test_switch_off_with_exception(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the switch turn off with exception."""
-    entity_id = "switch.test_pet_tracker_buzzer"
+    entity_id = "switch.tractive_tg4422_tracker_buzzer"
 
     await init_integration(hass, mock_config_entry)
 
@@ -244,7 +244,7 @@ async def test_switch_unavailable(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the switch is navailable when the tracker is in the energy saving zone."""
-    entity_id = "switch.test_pet_tracker_buzzer"
+    entity_id = "switch.tractive_tg4422_tracker_buzzer"
 
     await init_integration(hass, mock_config_entry)
 

--- a/tests/components/tractive/test_switch.py
+++ b/tests/components/tractive/test_switch.py
@@ -7,6 +7,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.components.tractive.const import DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_TURN_OFF,
@@ -16,8 +17,9 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     Platform,
 )
-from homeassistant.core import HomeAssistant, HomeAssistantError
-from homeassistant.helpers import entity_registry as er
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import init_integration
 
@@ -274,3 +276,29 @@ async def test_switch_unavailable(
     state = hass.states.get(entity_id)
     assert state
     assert state.state == STATE_ON
+
+
+async def test_switch_device_assignment(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    mock_tractive_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that switch entities are assigned to the tracker device."""
+    with patch("homeassistant.components.tractive.PLATFORMS", [Platform.SWITCH]):
+        await init_integration(hass, mock_config_entry)
+
+    tracker_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "device_id_123")}
+    )
+    assert tracker_device is not None
+
+    for entity_id in (
+        "switch.tracker_device_id_123_buzzer",
+        "switch.tracker_device_id_123_led",
+        "switch.tracker_device_id_123_live_tracking",
+    ):
+        entry = entity_registry.async_get(entity_id)
+        assert entry is not None
+        assert entry.device_id == tracker_device.id

--- a/tests/components/tractive/test_switch.py
+++ b/tests/components/tractive/test_switch.py
@@ -46,7 +46,7 @@ async def test_switch_on(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the switch can be turned on."""
-    entity_id = "switch.tractive_tg4422_tracker_led"
+    entity_id = "switch.tracker_device_id_123_tracker_led"
 
     await init_integration(hass, mock_config_entry)
 
@@ -85,7 +85,7 @@ async def test_switch_off(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the switch can be turned off."""
-    entity_id = "switch.tractive_tg4422_tracker_buzzer"
+    entity_id = "switch.tracker_device_id_123_tracker_buzzer"
 
     await init_integration(hass, mock_config_entry)
 
@@ -125,7 +125,7 @@ async def test_live_tracking_switch(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the live_tracking switch."""
-    entity_id = "switch.tractive_tg4422_live_tracking"
+    entity_id = "switch.tracker_device_id_123_live_tracking"
 
     await init_integration(hass, mock_config_entry)
 
@@ -170,7 +170,7 @@ async def test_switch_on_with_exception(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the switch turn on with exception."""
-    entity_id = "switch.tractive_tg4422_tracker_led"
+    entity_id = "switch.tracker_device_id_123_tracker_led"
 
     await init_integration(hass, mock_config_entry)
 
@@ -206,7 +206,7 @@ async def test_switch_off_with_exception(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the switch turn off with exception."""
-    entity_id = "switch.tractive_tg4422_tracker_buzzer"
+    entity_id = "switch.tracker_device_id_123_tracker_buzzer"
 
     await init_integration(hass, mock_config_entry)
 
@@ -244,7 +244,7 @@ async def test_switch_unavailable(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the switch is navailable when the tracker is in the energy saving zone."""
-    entity_id = "switch.tractive_tg4422_tracker_buzzer"
+    entity_id = "switch.tracker_device_id_123_tracker_buzzer"
 
     await init_integration(hass, mock_config_entry)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, all entities related to the pet and those related to the tracker are assigned to one device in HA, which causes confusion in the entity names and for example, the maintenance dashboard shows batteries for pets:
<img width="816" height="115" alt="tractive_before_2" src="https://github.com/user-attachments/assets/161ac119-2fa7-4680-b722-9ef1de0f2d99" />

This PR introduces a tracker device and a sub-device (service) representing the pet:
<img width="1025" height="921" alt="tractive_after" src="https://github.com/user-attachments/assets/ae85a141-ecc5-4ea7-9953-905135e15fd2" />
This introduces consistency in entity names and dashboard maintenance now displays the correct names
<img width="788" height="105" alt="tractive_after_2" src="https://github.com/user-attachments/assets/13ac96fa-5284-48bf-bafc-6e139ea850fa" />


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
