### PR TITLE
Add RepairsFlowResult TypeAlias

### DIFF
--- a/homeassistant/components/anthropic/repairs.py
+++ b/homeassistant/components/anthropic/repairs.py
@@ -7,8 +7,7 @@ import anthropic
 from anthropic.resources.messages.messages import DEPRECATED_MODELS
 import voluptuous as vol
 
-from homeassistant import data_entry_flow
-from homeassistant.components.repairs import RepairsFlow
+from homeassistant.components.repairs import RepairsFlow, RepairsFlowResult
 from homeassistant.config_entries import ConfigEntryState, ConfigSubentry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -41,9 +40,7 @@ class ModelDeprecatedRepairFlow(RepairsFlow):
         self._current_subentry_id = None
         self._model_list_cache = None
 
-    async def async_step_init(
-        self, user_input: dict[str, str]
-    ) -> data_entry_flow.FlowResult:
+    async def async_step_init(self, user_input: dict[str, str]) -> RepairsFlowResult:
         """Handle the steps of a fix flow."""
         if user_input.get(CONF_CHAT_MODEL):
             self._async_update_current_subentry(user_input)

--- a/homeassistant/components/assist_pipeline/repair_flows.py
+++ b/homeassistant/components/assist_pipeline/repair_flows.py
@@ -5,8 +5,7 @@ from typing import cast
 import voluptuous as vol
 
 from homeassistant.components.assist_satellite import DOMAIN as ASSIST_SATELLITE_DOMAIN
-from homeassistant.components.repairs import RepairsFlow
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant.components.repairs import RepairsFlow, RepairsFlowResult
 from homeassistant.helpers import entity_registry as er
 
 REQUIRED_KEYS = ("entity_id", "entity_uuid", "integration_name")
@@ -21,14 +20,14 @@ class AssistInProgressDeprecatedRepairFlow(RepairsFlow):
             raise ValueError("Missing data")
         self._data = data
 
-    async def async_step_init(self, _: None = None) -> FlowResult:
+    async def async_step_init(self, _: None = None) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
         return await self.async_step_confirm_disable_entity()
 
     async def async_step_confirm_disable_entity(
         self,
         user_input: dict[str, str] | None = None,
-    ) -> FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the confirm step of a fix flow."""
         if user_input is not None:
             entity_registry = er.async_get(self.hass)

--- a/homeassistant/components/bthome/repairs.py
+++ b/homeassistant/components/bthome/repairs.py
@@ -2,8 +2,7 @@
 
 from typing import Any
 
-from homeassistant import data_entry_flow
-from homeassistant.components.repairs import RepairsFlow
+from homeassistant.components.repairs import RepairsFlow, RepairsFlowResult
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 
@@ -21,13 +20,13 @@ class EncryptionRemovedRepairFlow(RepairsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the initial step of the repair flow."""
         return await self.async_step_confirm()
 
     async def async_step_confirm(
         self, user_input: dict[str, Any] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle confirmation, remove the bindkey, and reload the entry."""
         if user_input is not None:
             entry = self.hass.config_entries.async_get_entry(self._entry_id)

--- a/homeassistant/components/cloud/repairs.py
+++ b/homeassistant/components/cloud/repairs.py
@@ -8,10 +8,10 @@ import voluptuous as vol
 from homeassistant.components.repairs import (
     ConfirmRepairFlow,
     RepairsFlow,
+    RepairsFlowResult,
     repairs_flow_manager,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import issue_registry as ir
 
 from .const import DATA_CLOUD, DOMAIN
@@ -50,14 +50,14 @@ class LegacySubscriptionRepairFlow(RepairsFlow):
     wait_task: asyncio.Task | None = None
     _data: SubscriptionInfo | None = None
 
-    async def async_step_init(self, _: None = None) -> FlowResult:
+    async def async_step_init(self, _: None = None) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
         return await self.async_step_confirm_change_plan()
 
     async def async_step_confirm_change_plan(
         self,
         user_input: dict[str, str] | None = None,
-    ) -> FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the confirm step of a fix flow."""
         if user_input is not None:
             return await self.async_step_change_plan()
@@ -66,7 +66,7 @@ class LegacySubscriptionRepairFlow(RepairsFlow):
             step_id="confirm_change_plan", data_schema=vol.Schema({})
         )
 
-    async def async_step_change_plan(self, _: None = None) -> FlowResult:
+    async def async_step_change_plan(self, _: None = None) -> RepairsFlowResult:
         """Wait for the user to authorize the app installation."""
 
         cloud = self.hass.data[DATA_CLOUD]
@@ -107,11 +107,11 @@ class LegacySubscriptionRepairFlow(RepairsFlow):
 
         return self.async_external_step_done(next_step_id="complete")
 
-    async def async_step_complete(self, _: None = None) -> FlowResult:
+    async def async_step_complete(self, _: None = None) -> RepairsFlowResult:
         """Handle the final step of a fix flow."""
         return self.async_create_entry(data={})
 
-    async def async_step_timeout(self, _: None = None) -> FlowResult:
+    async def async_step_timeout(self, _: None = None) -> RepairsFlowResult:
         """Handle the final step of a fix flow."""
         return self.async_abort(reason="operation_took_too_long")
 

--- a/homeassistant/components/doorbird/repairs.py
+++ b/homeassistant/components/doorbird/repairs.py
@@ -2,8 +2,7 @@
 
 import voluptuous as vol
 
-from homeassistant import data_entry_flow
-from homeassistant.components.repairs import RepairsFlow
+from homeassistant.components.repairs import RepairsFlow, RepairsFlowResult
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 
@@ -17,13 +16,13 @@ class DoorBirdReloadConfirmRepairFlow(RepairsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
         return await self.async_step_confirm()
 
     async def async_step_confirm(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the confirm step of a fix flow."""
         if user_input is not None:
             self.hass.config_entries.async_schedule_reload(self.entry_id)

--- a/homeassistant/components/esphome/repairs.py
+++ b/homeassistant/components/esphome/repairs.py
@@ -4,8 +4,7 @@ from typing import cast
 
 import voluptuous as vol
 
-from homeassistant import data_entry_flow
-from homeassistant.components.repairs import RepairsFlow
+from homeassistant.components.repairs import RepairsFlow, RepairsFlowResult
 from homeassistant.core import HomeAssistant
 
 from .manager import async_replace_device
@@ -43,7 +42,7 @@ class DeviceConflictRepair(ESPHomeRepair):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
         return self.async_show_menu(
             step_id="init",
@@ -52,7 +51,7 @@ class DeviceConflictRepair(ESPHomeRepair):
 
     async def async_step_migrate(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the migrate step of a fix flow."""
         if user_input is None:
             return self.async_show_form(
@@ -66,7 +65,7 @@ class DeviceConflictRepair(ESPHomeRepair):
 
     async def async_step_manual(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the manual step of a fix flow."""
         if user_input is None:
             return self.async_show_form(

--- a/homeassistant/components/hassio/repairs.py
+++ b/homeassistant/components/hassio/repairs.py
@@ -8,10 +8,9 @@ from aiohasupervisor import SupervisorError
 from aiohasupervisor.models import ContextType
 import voluptuous as vol
 
-from homeassistant.components.repairs import RepairsFlow
+from homeassistant.components.repairs import RepairsFlow, RepairsFlowResult
 from homeassistant.const import ATTR_NAME
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResult
 
 from . import get_addons_list
 from .const import (
@@ -77,7 +76,7 @@ class SupervisorIssueRepairFlow(RepairsFlow):
 
         return placeholders or None
 
-    def _async_form_for_suggestion(self, suggestion: Suggestion) -> FlowResult:
+    def _async_form_for_suggestion(self, suggestion: Suggestion) -> RepairsFlowResult:
         """Return form for suggestion."""
         return self.async_show_form(
             step_id=suggestion.key,
@@ -86,7 +85,7 @@ class SupervisorIssueRepairFlow(RepairsFlow):
             last_step=True,
         )
 
-    async def async_step_init(self, _: None = None) -> FlowResult:
+    async def async_step_init(self, _: None = None) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
         # Out of sync with supervisor, issue is resolved or not fixable. Remove it
         if not self.issue or not self.issue.suggestions:
@@ -108,7 +107,7 @@ class SupervisorIssueRepairFlow(RepairsFlow):
         # Always show a form for one suggestion to explain to user what's happening
         return self._async_form_for_suggestion(self.issue.suggestions[0])
 
-    async def async_step_fix_menu(self, _: None = None) -> FlowResult:
+    async def async_step_fix_menu(self, _: None = None) -> RepairsFlowResult:
         """Show the fix menu."""
         assert self.issue
 
@@ -120,7 +119,7 @@ class SupervisorIssueRepairFlow(RepairsFlow):
 
     async def _async_step_apply_suggestion(
         self, suggestion: Suggestion, confirmed: bool = False
-    ) -> FlowResult:
+    ) -> RepairsFlowResult:
         """Handle applying a suggestion as a flow step. Optionally request confirmation."""
         if not confirmed and suggestion.key in SUGGESTION_CONFIRMATION_REQUIRED:
             return self._async_form_for_suggestion(suggestion)
@@ -137,13 +136,13 @@ class SupervisorIssueRepairFlow(RepairsFlow):
         suggestion: Suggestion,
     ) -> Callable[
         [SupervisorIssueRepairFlow, dict[str, str] | None],
-        Coroutine[Any, Any, FlowResult],
+        Coroutine[Any, Any, RepairsFlowResult],
     ]:
         """Generate a step handler for a suggestion."""
 
         async def _async_step(
             self: SupervisorIssueRepairFlow, user_input: dict[str, str] | None = None
-        ) -> FlowResult:
+        ) -> RepairsFlowResult:
             """Handle a flow step for a suggestion."""
             return await self._async_step_apply_suggestion(
                 suggestion, confirmed=user_input is not None

--- a/homeassistant/components/homeassistant/repairs.py
+++ b/homeassistant/components/homeassistant/repairs.py
@@ -1,8 +1,11 @@
 """Repairs for Home Assistant."""
 
-from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
+from homeassistant.components.repairs import (
+    ConfirmRepairFlow,
+    RepairsFlow,
+    RepairsFlowResult,
+)
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import issue_registry as ir
 
 from .const import DOMAIN
@@ -18,7 +21,7 @@ class IntegrationNotFoundFlow(RepairsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
         return self.async_show_menu(
             step_id="init",
@@ -28,7 +31,7 @@ class IntegrationNotFoundFlow(RepairsFlow):
 
     async def async_step_confirm(
         self, user_input: dict[str, str] | None = None
-    ) -> FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the confirm step of a fix flow."""
         entries = self.hass.config_entries.async_entries(self.domain)
         for entry in entries:
@@ -37,7 +40,7 @@ class IntegrationNotFoundFlow(RepairsFlow):
 
     async def async_step_ignore(
         self, user_input: dict[str, str] | None = None
-    ) -> FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the ignore step of a fix flow."""
         ir.async_get(self.hass).async_ignore(
             DOMAIN, f"integration_not_found.{self.domain}", True
@@ -58,7 +61,7 @@ class OrphanedConfigEntryFlow(RepairsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
         return self.async_show_menu(
             step_id="init",
@@ -68,14 +71,14 @@ class OrphanedConfigEntryFlow(RepairsFlow):
 
     async def async_step_confirm(
         self, user_input: dict[str, str] | None = None
-    ) -> FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the confirm step of a fix flow."""
         await self.hass.config_entries.async_remove(self.entry_id)
         return self.async_create_entry(data={})
 
     async def async_step_ignore(
         self, user_input: dict[str, str] | None = None
-    ) -> FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the ignore step of a fix flow."""
         ir.async_get(self.hass).async_ignore(
             DOMAIN, f"orphaned_ignored_entry.{self.entry_id}", True

--- a/homeassistant/components/homewizard/repairs.py
+++ b/homeassistant/components/homewizard/repairs.py
@@ -1,11 +1,9 @@
 """Repairs for HomeWizard integration."""
 
-from homeassistant import data_entry_flow
-from homeassistant.components.repairs import RepairsFlow
+from homeassistant.components.repairs import RepairsFlow, RepairsFlowResult
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_IP_ADDRESS, CONF_TOKEN
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResult
 
 from .config_flow import async_request_token
 
@@ -19,14 +17,14 @@ class MigrateToV2ApiRepairFlow(RepairsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
 
         return await self.async_step_confirm()
 
     async def async_step_confirm(
         self, user_input: dict[str, str] | None = None
-    ) -> FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the confirm step of a fix flow."""
 
         if user_input is not None:
@@ -38,7 +36,7 @@ class MigrateToV2ApiRepairFlow(RepairsFlow):
 
     async def async_step_authorize(
         self, user_input: dict[str, str] | None = None
-    ) -> FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the authorize step of a fix flow."""
 
         ip_address = self.entry.data[CONF_IP_ADDRESS]

--- a/homeassistant/components/kitchen_sink/repairs.py
+++ b/homeassistant/components/kitchen_sink/repairs.py
@@ -2,8 +2,11 @@
 
 import voluptuous as vol
 
-from homeassistant import data_entry_flow
-from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
+from homeassistant.components.repairs import (
+    ConfirmRepairFlow,
+    RepairsFlow,
+    RepairsFlowResult,
+)
 from homeassistant.core import HomeAssistant
 
 
@@ -12,14 +15,14 @@ class DemoFixFlow(RepairsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
 
         return await self.async_step_confirm()
 
     async def async_step_confirm(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the confirm step of a fix flow."""
         if user_input is not None:
             return self.async_create_entry(data={})
@@ -32,7 +35,7 @@ class DemoColdTeaFixFlow(RepairsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
         return self.async_abort(reason="not_tea_time")
 

--- a/homeassistant/components/knx/repairs.py
+++ b/homeassistant/components/knx/repairs.py
@@ -8,8 +8,7 @@ import voluptuous as vol
 from xknx.exceptions.exception import InvalidSecureConfiguration
 from xknx.telegram import GroupAddress, IndividualAddress, Telegram
 
-from homeassistant import data_entry_flow
-from homeassistant.components.repairs import RepairsFlow
+from homeassistant.components.repairs import RepairsFlow, RepairsFlowResult
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import issue_registry as ir, selector
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -110,13 +109,13 @@ class DataSecureGroupIssueRepairFlow(RepairsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
         return await self.async_step_secure_knxkeys()
 
     async def async_step_secure_knxkeys(
         self, user_input: dict[str, Any] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Manage upload of new KNX Keyring file."""
         errors: dict[str, str] = {}
 
@@ -152,9 +151,7 @@ class DataSecureGroupIssueRepairFlow(RepairsFlow):
         )
 
     @callback
-    def finish_flow(
-        self, new_entry_data: KNXConfigEntryData
-    ) -> data_entry_flow.FlowResult:
+    def finish_flow(self, new_entry_data: KNXConfigEntryData) -> RepairsFlowResult:
         """Finish the repair flow. Reload the config entry."""
         knx_config_entries = self.hass.config_entries.async_entries(DOMAIN)
         if knx_config_entries:

--- a/homeassistant/components/lg_thinq/repairs.py
+++ b/homeassistant/components/lg_thinq/repairs.py
@@ -2,8 +2,11 @@
 
 import voluptuous as vol
 
-from homeassistant import data_entry_flow
-from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
+from homeassistant.components.repairs import (
+    ConfirmRepairFlow,
+    RepairsFlow,
+    RepairsFlowResult,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -18,13 +21,13 @@ class DeprecatedFanSpeedRepairFlow(RepairsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
         return await self.async_step_confirm()
 
     async def async_step_confirm(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the confirm step of a fix flow."""
         if user_input is not None:
             entity_registry = er.async_get(self.hass)

--- a/homeassistant/components/mqtt/repairs.py
+++ b/homeassistant/components/mqtt/repairs.py
@@ -4,8 +4,7 @@ from typing import TYPE_CHECKING
 
 import voluptuous as vol
 
-from homeassistant import data_entry_flow
-from homeassistant.components.repairs import RepairsFlow
+from homeassistant.components.repairs import RepairsFlow, RepairsFlowResult
 from homeassistant.const import CONF_PORT, CONF_PROTOCOL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -29,13 +28,13 @@ class MQTTDeviceEntryMigration(RepairsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
         return await self.async_step_confirm()
 
     async def async_step_confirm(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the confirm step of a fix flow."""
         if user_input is not None:
             device_registry = dr.async_get(self.hass)
@@ -67,13 +66,13 @@ class MQTTProtocolV5Migration(RepairsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
         return await self.async_step_confirm()
 
     async def async_step_confirm(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the confirm step of a fix flow."""
         if user_input is not None:
             entry = self.hass.config_entries.async_get_entry(self.entry_id)

--- a/homeassistant/components/ntfy/repairs.py
+++ b/homeassistant/components/ntfy/repairs.py
@@ -2,8 +2,11 @@
 
 import voluptuous as vol
 
-from homeassistant import data_entry_flow
-from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
+from homeassistant.components.repairs import (
+    ConfirmRepairFlow,
+    RepairsFlow,
+    RepairsFlowResult,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -20,14 +23,14 @@ class TopicProtectedRepairFlow(RepairsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Init repair flow."""
 
         return await self.async_step_confirm()
 
     async def async_step_confirm(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Confirm repair flow."""
         if user_input is not None:
             er.async_get(self.hass).async_update_entity(

--- a/homeassistant/components/openweathermap/repairs.py
+++ b/homeassistant/components/openweathermap/repairs.py
@@ -2,8 +2,7 @@
 
 from typing import TYPE_CHECKING, cast
 
-from homeassistant import data_entry_flow
-from homeassistant.components.repairs import RepairsFlow
+from homeassistant.components.repairs import RepairsFlow, RepairsFlowResult
 from homeassistant.const import CONF_API_KEY, CONF_MODE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import issue_registry as ir
@@ -25,13 +24,13 @@ class DeprecatedV25RepairFlow(RepairsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
         return self.async_show_form(step_id="migrate")
 
     async def async_step_migrate(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the migrate step of a fix flow."""
         errors, description_placeholders = {}, {}
         new_options = {**self.entry.options, CONF_MODE: OWM_MODE_V30}

--- a/homeassistant/components/opower/repairs.py
+++ b/homeassistant/components/opower/repairs.py
@@ -1,8 +1,7 @@
 """Repairs for Opower."""
 
-from homeassistant.components.repairs import RepairsFlow
+from homeassistant.components.repairs import RepairsFlow, RepairsFlowResult
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResult
 
 
 class UnsupportedUtilityFixFlow(RepairsFlow):
@@ -16,13 +15,13 @@ class UnsupportedUtilityFixFlow(RepairsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
         return await self.async_step_confirm()
 
     async def async_step_confirm(
         self, user_input: dict[str, str] | None = None
-    ) -> FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the confirm step of a fix flow."""
         if user_input is not None:
             await self.hass.config_entries.async_remove(self._entry_id)

--- a/homeassistant/components/repairs/__init__.py
+++ b/homeassistant/components/repairs/__init__.py
@@ -7,13 +7,14 @@ from homeassistant.helpers.typing import ConfigType
 from . import issue_handler, websocket_api
 from .const import DOMAIN
 from .issue_handler import ConfirmRepairFlow, RepairsFlowManager
-from .models import RepairsFlow
+from .models import RepairsFlow, RepairsFlowResult
 
 __all__ = [
     "DOMAIN",
     "ConfirmRepairFlow",
     "RepairsFlow",
     "RepairsFlowManager",
+    "RepairsFlowResult",
     "repairs_flow_manager",
 ]
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)

--- a/homeassistant/components/repairs/issue_handler.py
+++ b/homeassistant/components/repairs/issue_handler.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.integration_platform import (
 )
 
 from .const import DOMAIN
-from .models import RepairsFlow, RepairsProtocol
+from .models import RepairsFlow, RepairsFlowResult, RepairsProtocol
 
 
 class ConfirmRepairFlow(RepairsFlow):
@@ -21,13 +21,13 @@ class ConfirmRepairFlow(RepairsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
         return await self.async_step_confirm()
 
     async def async_step_confirm(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the confirm step of a fix flow."""
         if user_input is not None:
             return self.async_create_entry(data={})
@@ -44,7 +44,9 @@ class ConfirmRepairFlow(RepairsFlow):
         )
 
 
-class RepairsFlowManager(data_entry_flow.FlowManager):
+class RepairsFlowManager(
+    data_entry_flow.FlowManager[data_entry_flow.FlowContext, RepairsFlowResult, str]
+):
     """Manage repairs flows."""
 
     async def async_create_flow(
@@ -78,8 +80,12 @@ class RepairsFlowManager(data_entry_flow.FlowManager):
         return flow
 
     async def async_finish_flow(
-        self, flow: data_entry_flow.FlowHandler, result: data_entry_flow.FlowResult
-    ) -> data_entry_flow.FlowResult:
+        self,
+        flow: data_entry_flow.FlowHandler[
+            data_entry_flow.FlowContext, RepairsFlowResult, str
+        ],
+        result: RepairsFlowResult,
+    ) -> RepairsFlowResult:
         """Complete a fix flow.
 
         This method is called when a flow step returns FlowResultType.ABORT or

--- a/homeassistant/components/repairs/models.py
+++ b/homeassistant/components/repairs/models.py
@@ -5,8 +5,13 @@ from typing import Protocol
 from homeassistant import data_entry_flow
 from homeassistant.core import HomeAssistant
 
+# Placeholder TypeAlias for future TypedDict to handle next_flow.
+RepairsFlowResult = data_entry_flow.FlowResult[data_entry_flow.FlowContext, str]
 
-class RepairsFlow(data_entry_flow.FlowHandler):
+
+class RepairsFlow(
+    data_entry_flow.FlowHandler[data_entry_flow.FlowContext, RepairsFlowResult, str]
+):
     """Handle a flow for fixing an issue."""
 
     issue_id: str

--- a/homeassistant/components/shelly/repairs.py
+++ b/homeassistant/components/shelly/repairs.py
@@ -9,8 +9,11 @@ from aioshelly.rpc_device import RpcDevice
 from awesomeversion import AwesomeVersion
 import voluptuous as vol
 
-from homeassistant import data_entry_flow
-from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
+from homeassistant.components.repairs import (
+    ConfirmRepairFlow,
+    RepairsFlow,
+    RepairsFlowResult,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import issue_registry as ir
 
@@ -206,7 +209,7 @@ class CoiotConfigureFlow(ShellyBlockRepairsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
         issue_registry = ir.async_get(self.hass)
         description_placeholders = None
@@ -220,7 +223,7 @@ class CoiotConfigureFlow(ShellyBlockRepairsFlow):
 
     async def async_step_confirm(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the confirm step of a fix flow."""
         coiot_addr = await get_coiot_address(self.hass)
         coiot_port = get_coiot_port(self.hass)
@@ -236,7 +239,7 @@ class CoiotConfigureFlow(ShellyBlockRepairsFlow):
 
     async def async_step_ignore(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the ignore step of a fix flow."""
         ir.async_ignore_issue(self.hass, DOMAIN, self.issue_id, True)
         return self.async_abort(reason="issue_ignored")
@@ -251,13 +254,13 @@ class ShellyRpcRepairsFlow(RepairsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
         return await self.async_step_confirm()
 
     async def async_step_confirm(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the confirm step of a fix flow."""
         if user_input is not None:
             return await self._async_step_confirm()
@@ -273,7 +276,7 @@ class ShellyRpcRepairsFlow(RepairsFlow):
             description_placeholders=description_placeholders,
         )
 
-    async def _async_step_confirm(self) -> data_entry_flow.FlowResult:
+    async def _async_step_confirm(self) -> RepairsFlowResult:
         """Handle the confirm step of a fix flow."""
         raise NotImplementedError
 
@@ -281,13 +284,13 @@ class ShellyRpcRepairsFlow(RepairsFlow):
 class FirmwareUpdateFlow(ShellyRpcRepairsFlow):
     """Handler for Firmware Update flow."""
 
-    async def _async_step_confirm(self) -> data_entry_flow.FlowResult:
+    async def _async_step_confirm(self) -> RepairsFlowResult:
         """Handle the confirm step of a fix flow."""
         return await self.async_step_update_firmware()
 
     async def async_step_update_firmware(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the confirm step of a fix flow."""
         if not self._device.status["sys"]["available_updates"]:
             return self.async_abort(reason="update_not_available")
@@ -302,13 +305,13 @@ class FirmwareUpdateFlow(ShellyRpcRepairsFlow):
 class DisableOutboundWebSocketFlow(ShellyRpcRepairsFlow):
     """Handler for Disable Outbound WebSocket flow."""
 
-    async def _async_step_confirm(self) -> data_entry_flow.FlowResult:
+    async def _async_step_confirm(self) -> RepairsFlowResult:
         """Handle the confirm step of a fix flow."""
         return await self.async_step_disable_outbound_websocket()
 
     async def async_step_disable_outbound_websocket(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the confirm step of a fix flow."""
         try:
             result = await self._device.ws_setconfig(
@@ -332,7 +335,7 @@ class DisableOpenWiFiApFlow(RepairsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
         issue_registry = ir.async_get(self.hass)
         description_placeholders = None
@@ -346,7 +349,7 @@ class DisableOpenWiFiApFlow(RepairsFlow):
 
     async def async_step_confirm(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the confirm step of a fix flow."""
         try:
             result = await self._device.wifi_setconfig(ap_enable=False)
@@ -359,7 +362,7 @@ class DisableOpenWiFiApFlow(RepairsFlow):
 
     async def async_step_ignore(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the ignore step of a fix flow."""
         ir.async_ignore_issue(self.hass, DOMAIN, self.issue_id, True)
         return self.async_abort(reason="issue_ignored")

--- a/homeassistant/components/synology_dsm/repairs.py
+++ b/homeassistant/components/synology_dsm/repairs.py
@@ -7,8 +7,11 @@ from typing import cast
 from synology_dsm.api.file_station.models import SynoFileSharedFolder
 import voluptuous as vol
 
-from homeassistant import data_entry_flow
-from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
+from homeassistant.components.repairs import (
+    ConfirmRepairFlow,
+    RepairsFlow,
+    RepairsFlowResult,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.selector import (
@@ -41,7 +44,7 @@ class MissingBackupSetupRepairFlow(RepairsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
 
         return self.async_show_menu(
@@ -53,7 +56,7 @@ class MissingBackupSetupRepairFlow(RepairsFlow):
 
     async def async_step_confirm(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the confirm step of a fix flow."""
 
         syno_data = self.entry.runtime_data
@@ -99,7 +102,7 @@ class MissingBackupSetupRepairFlow(RepairsFlow):
 
     async def async_step_ignore(
         self, _: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the confirm step of a fix flow."""
         ir.async_ignore_issue(self.hass, DOMAIN, self.issue_id, True)
         return self.async_abort(reason="ignored")

--- a/homeassistant/components/unifiprotect/repairs.py
+++ b/homeassistant/components/unifiprotect/repairs.py
@@ -6,8 +6,11 @@ from uiprotect import ProtectApiClient
 from uiprotect.data import Bootstrap, Camera
 import voluptuous as vol
 
-from homeassistant import data_entry_flow
-from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
+from homeassistant.components.repairs import (
+    ConfirmRepairFlow,
+    RepairsFlow,
+    RepairsFlowResult,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import issue_registry as ir
 
@@ -45,14 +48,14 @@ class CloudAccountRepair(ProtectRepair):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
 
         return await self.async_step_confirm()
 
     async def async_step_confirm(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
 
         if user_input is None:
@@ -115,14 +118,14 @@ class RTSPRepair(ProtectRepair):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
 
         return await self.async_step_start()
 
     async def async_step_start(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
 
         if user_input is None:
@@ -147,7 +150,7 @@ class RTSPRepair(ProtectRepair):
 
     async def async_step_confirm(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the confirm step of a fix flow."""
         if user_input is not None:
             return self.async_create_entry(data={})

--- a/homeassistant/components/workday/repairs.py
+++ b/homeassistant/components/workday/repairs.py
@@ -5,8 +5,11 @@ from typing import Any, cast
 from holidays import list_supported_countries
 import voluptuous as vol
 
-from homeassistant import data_entry_flow
-from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
+from homeassistant.components.repairs import (
+    ConfirmRepairFlow,
+    RepairsFlow,
+    RepairsFlowResult,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_COUNTRY
 from homeassistant.core import HomeAssistant
@@ -31,7 +34,7 @@ class CountryFixFlow(RepairsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
         if self.country:
             return await self.async_step_province()
@@ -39,7 +42,7 @@ class CountryFixFlow(RepairsFlow):
 
     async def async_step_country(
         self, user_input: dict[str, Any] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the country step of a fix flow."""
         if user_input is not None:
             all_countries = list_supported_countries(include_aliases=False)
@@ -73,7 +76,7 @@ class CountryFixFlow(RepairsFlow):
 
     async def async_step_province(
         self, user_input: dict[str, Any] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the province step of a fix flow."""
         if user_input is not None:
             user_input.setdefault(CONF_PROVINCE, None)
@@ -121,13 +124,13 @@ class HolidayFixFlow(RepairsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
         return await self.async_step_fix_remove_holiday()
 
     async def async_step_fix_remove_holiday(
         self, user_input: dict[str, Any] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the options step of a fix flow."""
         errors: dict[str, str] = {}
         if user_input:

--- a/homeassistant/components/zeroconf/repairs.py
+++ b/homeassistant/components/zeroconf/repairs.py
@@ -1,11 +1,10 @@
 """Repairs for the zeroconf integration."""
 
-from homeassistant import data_entry_flow
 from homeassistant.components.homeassistant import (
     DOMAIN as HOMEASSISTANT_DOMAIN,
     SERVICE_HOMEASSISTANT_RESTART,
 )
-from homeassistant.components.repairs import RepairsFlow
+from homeassistant.components.repairs import RepairsFlow, RepairsFlowResult
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import instance_id, issue_registry as ir
 
@@ -22,13 +21,13 @@ class DuplicateInstanceIDRepairFlow(RepairsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the initial step."""
         return await self.async_step_confirm_recreate()
 
     async def async_step_confirm_recreate(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the confirm step."""
         if user_input is not None:
             await instance_id.async_recreate(self.hass)

--- a/homeassistant/components/zha/repairs/network_settings_inconsistent.py
+++ b/homeassistant/components/zha/repairs/network_settings_inconsistent.py
@@ -5,10 +5,9 @@ from typing import Any
 
 from zigpy.backups import NetworkBackup
 
-from homeassistant.components.repairs import RepairsFlow
+from homeassistant.components.repairs import RepairsFlow, RepairsFlowResult
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.json import json_dumps
 from homeassistant.util.json import json_loads_object
@@ -122,7 +121,7 @@ class NetworkSettingsInconsistentFlow(RepairsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
         return self.async_show_menu(
             step_id="init",
@@ -134,7 +133,7 @@ class NetworkSettingsInconsistentFlow(RepairsFlow):
 
     async def async_step_use_new_settings(
         self, user_input: dict[str, str] | None = None
-    ) -> FlowResult:
+    ) -> RepairsFlowResult:
         """Step to use the new settings found on the radio."""
         async with self._radio_mgr.create_zigpy_app(connect=False) as app:
             app.backups.add_backup(self._new_state)
@@ -144,7 +143,7 @@ class NetworkSettingsInconsistentFlow(RepairsFlow):
 
     async def async_step_restore_old_settings(
         self, user_input: dict[str, str] | None = None
-    ) -> FlowResult:
+    ) -> RepairsFlowResult:
         """Step to restore the most recent backup."""
         await self._radio_mgr.restore_backup(self._old_state)
 

--- a/homeassistant/components/zwave_js/repairs.py
+++ b/homeassistant/components/zwave_js/repairs.py
@@ -1,7 +1,10 @@
 """Repairs for Z-Wave JS."""
 
-from homeassistant import data_entry_flow
-from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
+from homeassistant.components.repairs import (
+    ConfirmRepairFlow,
+    RepairsFlow,
+    RepairsFlowResult,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 
@@ -21,7 +24,7 @@ class DeviceConfigFileChangedFlow(RepairsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
         return self.async_show_menu(
             menu_options=["confirm", "ignore"],
@@ -30,7 +33,7 @@ class DeviceConfigFileChangedFlow(RepairsFlow):
 
     async def async_step_confirm(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the confirm step of a fix flow."""
         try:
             node = async_get_node_from_device_id(self.hass, self.device_id)
@@ -44,7 +47,7 @@ class DeviceConfigFileChangedFlow(RepairsFlow):
 
     async def async_step_ignore(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the ignore step of a fix flow."""
         ir.async_get(self.hass).async_ignore(
             DOMAIN, f"device_config_file_changed.{self.device_id}", True
@@ -83,13 +86,13 @@ class MigrateUniqueIDFlow(RepairsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the first step of a fix flow."""
         return await self.async_step_confirm()
 
     async def async_step_confirm(
         self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    ) -> RepairsFlowResult:
         """Handle the confirm step of a fix flow."""
         if user_input is not None:
             config_entry = self.hass.config_entries.async_get_entry(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `RepairsFlowResult` TypeAlias to the `repairs` platform and update all core integrations implementing repairs flow to use this type alias in anticipation of changing `RepairsFlowResult` to a TypedDict to avoid mypy errors per https://github.com/home-assistant/core/pull/165091

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to PR: https://github.com/home-assistant/core/pull/165091 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.