### PR TITLE
Bump serialx to 1.7.2

### DIFF
--- a/homeassistant/components/acer_projector/manifest.json
+++ b/homeassistant/components/acer_projector/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/acer_projector",
   "iot_class": "local_polling",
   "quality_scale": "legacy",
-  "requirements": ["serialx==1.7.1"]
+  "requirements": ["serialx==1.7.2"]
 }

--- a/homeassistant/components/serial/manifest.json
+++ b/homeassistant/components/serial/manifest.json
@@ -4,5 +4,5 @@
   "codeowners": ["@fabaff"],
   "documentation": "https://www.home-assistant.io/integrations/serial",
   "iot_class": "local_polling",
-  "requirements": ["serialx==1.7.1"]
+  "requirements": ["serialx==1.7.2"]
 }

--- a/homeassistant/components/usb/manifest.json
+++ b/homeassistant/components/usb/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "system",
   "iot_class": "local_push",
   "quality_scale": "internal",
-  "requirements": ["aiousbwatcher==1.1.2", "serialx==1.7.1"]
+  "requirements": ["aiousbwatcher==1.1.2", "serialx==1.7.2"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -63,7 +63,7 @@ PyTurboJPEG==1.8.3
 PyYAML==6.0.3
 requests==2.33.1
 securetar==2026.4.1
-serialx==1.7.1
+serialx==1.7.2
 SQLAlchemy==2.0.49
 standard-aifc==3.13.0
 standard-telnetlib==3.13.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2960,7 +2960,7 @@ sentry-sdk==2.48.0
 # homeassistant.components.acer_projector
 # homeassistant.components.serial
 # homeassistant.components.usb
-serialx==1.7.1
+serialx==1.7.2
 
 # homeassistant.components.sfr_box
 sfrbox-api==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2526,7 +2526,7 @@ sentry-sdk==2.48.0
 # homeassistant.components.acer_projector
 # homeassistant.components.serial
 # homeassistant.components.usb
-serialx==1.7.1
+serialx==1.7.2
 
 # homeassistant.components.sfr_box
 sfrbox-api==0.1.1


### PR DESCRIPTION
## Proposed change

Bump serialx from 1.7.1 to 1.7.2. This incorporates the following releases:
- https://github.com/puddly/serialx/releases/tag/v1.7.2

This fixes a crash when USB-to-serial adapters report an actual hardware baud rate (e.g. 115384 computed from clock divisors) instead of the exact requested rate. The sentinel-based search for termios2 speed field offsets failed in that case with `"Could not determine offset of termios2 speed fields"`. The fix replaces it with hardcoded struct offsets matching the known termios2 layout (same approach as pyserial).

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes https://github.com/puddly/serialx/issues/83
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr