### PR TITLE
Fix spelling of RS-232 in Denon RS-232 integration

### DIFF
--- a/homeassistant/components/denon_rs232/__init__.py
+++ b/homeassistant/components/denon_rs232/__init__.py
@@ -1,4 +1,4 @@
-"""The Denon RS232 integration."""
+"""The Denon RS-232 integration."""
 
 from denon_rs232 import DenonReceiver, ReceiverState
 from denon_rs232.models import MODELS
@@ -14,7 +14,7 @@ PLATFORMS = [Platform.MEDIA_PLAYER]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: DenonRS232ConfigEntry) -> bool:
-    """Set up Denon RS232 from a config entry."""
+    """Set up Denon RS-232 from a config entry."""
     port = entry.data[CONF_DEVICE]
     model = MODELS[entry.data[CONF_MODEL]]
     receiver = DenonReceiver(port, model=model)

--- a/homeassistant/components/denon_rs232/config_flow.py
+++ b/homeassistant/components/denon_rs232/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for the Denon RS232 integration."""
+"""Config flow for the Denon RS-232 integration."""
 
 from typing import Any
 
@@ -63,7 +63,7 @@ async def _async_attempt_connect(port: str, model_key: str) -> str | None:
 
 
 class DenonRS232ConfigFlow(ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for Denon RS232."""
+    """Handle a config flow for Denon RS-232."""
 
     VERSION = 1
 

--- a/homeassistant/components/denon_rs232/const.py
+++ b/homeassistant/components/denon_rs232/const.py
@@ -1,4 +1,4 @@
-"""Constants for the Denon RS232 integration."""
+"""Constants for the Denon RS-232 integration."""
 
 import logging
 

--- a/homeassistant/components/denon_rs232/manifest.json
+++ b/homeassistant/components/denon_rs232/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "denon_rs232",
-  "name": "Denon RS232",
+  "name": "Denon RS-232",
   "codeowners": ["@balloob"],
   "config_flow": true,
   "dependencies": ["usb"],

--- a/homeassistant/components/denon_rs232/media_player.py
+++ b/homeassistant/components/denon_rs232/media_player.py
@@ -1,4 +1,4 @@
-"""Media player platform for the Denon RS232 integration."""
+"""Media player platform for the Denon RS-232 integration."""
 
 from typing import Literal, cast
 
@@ -77,7 +77,7 @@ async def async_setup_entry(
     config_entry: DenonRS232ConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up the Denon RS232 media player."""
+    """Set up the Denon RS-232 media player."""
     receiver = config_entry.runtime_data
     entities = [DenonRS232MediaPlayer(receiver, receiver.main, config_entry, "main")]
 
@@ -94,7 +94,7 @@ async def async_setup_entry(
 
 
 class DenonRS232MediaPlayer(MediaPlayerEntity):
-    """Representation of a Denon receiver controlled over RS232."""
+    """Representation of a Denon receiver controlled over RS-232."""
 
     _attr_device_class = MediaPlayerDeviceClass.RECEIVER
     _attr_has_entity_name = True

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -1339,7 +1339,7 @@
           "integration_type": "hub",
           "config_flow": true,
           "iot_class": "local_push",
-          "name": "Denon RS232"
+          "name": "Denon RS-232"
         },
         "heos": {
           "integration_type": "hub",

--- a/tests/components/denon_rs232/__init__.py
+++ b/tests/components/denon_rs232/__init__.py
@@ -1,4 +1,4 @@
-"""Tests for the Denon RS232 integration."""
+"""Tests for the Denon RS-232 integration."""
 
 MOCK_DEVICE = "/dev/ttyUSB0"
 MOCK_MODEL = "avr_3805"

--- a/tests/components/denon_rs232/conftest.py
+++ b/tests/components/denon_rs232/conftest.py
@@ -1,4 +1,4 @@
-"""Test fixtures for the Denon RS232 integration."""
+"""Test fixtures for the Denon RS-232 integration."""
 
 from typing import Literal
 from unittest.mock import AsyncMock, patch

--- a/tests/components/denon_rs232/test_config_flow.py
+++ b/tests/components/denon_rs232/test_config_flow.py
@@ -1,4 +1,4 @@
-"""Tests for the Denon RS232 config flow."""
+"""Tests for the Denon RS-232 config flow."""
 
 from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/components/denon_rs232/test_init.py
+++ b/tests/components/denon_rs232/test_init.py
@@ -1,4 +1,4 @@
-"""Tests for the Denon RS232 integration init."""
+"""Tests for the Denon RS-232 integration init."""
 
 from unittest.mock import AsyncMock
 

--- a/tests/components/denon_rs232/test_media_player.py
+++ b/tests/components/denon_rs232/test_media_player.py
@@ -1,4 +1,4 @@
-"""Tests for the Denon RS232 media player platform."""
+"""Tests for the Denon RS-232 media player platform."""
 
 from pathlib import Path
 from typing import Literal


### PR DESCRIPTION
## Proposed change

Updates the user-facing spelling of "RS232" to "RS-232" in the Denon RS-232 integration. "RS-232" is the correct spelling of the standard.

Changes are limited to user-facing strings and docstrings:
- Integration display name in `manifest.json` and the generated integrations index
- Module and class docstrings in the integration and its tests

The internal domain (`denon_rs232`), the external package import (`denon_rs232`), and Python class identifiers (e.g. `DenonRS232ConfigFlow`) are left unchanged — hyphens aren't valid in Python identifiers, and renaming the domain would be a breaking change for existing users.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---
_Generated by [Claude Code](https://claude.ai/code/session_01979HZaynpaVqzBRCNJ2s2D)_