### PR TITLE
Fix flaky diagnostics test for Novy Cooker Hood

### DIFF
--- a/homeassistant/components/novy_cooker_hood/diagnostics.py
+++ b/homeassistant/components/novy_cooker_hood/diagnostics.py
@@ -20,7 +20,10 @@ async def async_get_config_entry_diagnostics(
     transmitter_state = hass.states.get(transmitter.entity_id) if transmitter else None
     return {
         "config_entry": config_entry.as_dict(),
-        "entities": [entity.extended_dict for entity in entities],
+        "entities": [
+            entity.extended_dict
+            for entity in sorted(entities, key=lambda entity: entity.entity_id)
+        ],
         "transmitter": {
             "entity_id": transmitter.entity_id if transmitter else None,
             "state": transmitter_state.as_dict() if transmitter_state else None,


### PR DESCRIPTION
## Proposed change

The Novy Cooker Hood diagnostics output includes the list of entities returned by `er.async_get(...).entities.get_entries_for_config_entry_id(...)`. The registry does not guarantee a stable ordering across runs, which leads to occasional snapshot mismatches in `tests/components/novy_cooker_hood/test_diagnostics.py::test_diagnostics` — the `fan` and `light` entities show up in different orders.

Noticed on CI as a flaky failure:

```
FAILED tests/components/novy_cooker_hood/test_diagnostics.py::test_diagnostics - AssertionError: assert [+ received] == [- snapshot]
    dict({
     ...
      'entities': list([
  -     dict({
  -       ...
  -       'entity_id': 'fan.novy_cooker_hood',
  -       ...
  -     }),
        dict({
        ...
        }),
  +     dict({
  +       ...
  +       'entity_id': 'fan.novy_cooker_hood',
  +       ...
  +     }),
      ]),
     ...
    })
```

Sort the entities by `entity_id` before serializing them in the diagnostics payload so the output is deterministic.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


---
_Generated by [Claude Code](https://claude.ai/code/session_01WNErgp1XcFHvpc22gG2Mat)_