### PR TITLE
Fix coordinator data mutation in YouTube diagnostics

### DIFF
--- a/homeassistant/components/youtube/diagnostics.py
+++ b/homeassistant/components/youtube/diagnostics.py
@@ -14,7 +14,13 @@ async def async_get_config_entry_diagnostics(
     """Return diagnostics for a config entry."""
     coordinator = entry.runtime_data
     sensor_data: dict[str, Any] = {}
-    for channel_id, channel_data in dict(coordinator.data).items():
-        channel_data.get(ATTR_LATEST_VIDEO, {}).pop(ATTR_DESCRIPTION)
-        sensor_data[channel_id] = channel_data
+    for channel_id, channel_data in coordinator.data.items():
+        channel_copy = dict(channel_data)
+        if latest_video := channel_copy.get(ATTR_LATEST_VIDEO):
+            channel_copy[ATTR_LATEST_VIDEO] = {
+                key: value
+                for key, value in latest_video.items()
+                if key != ATTR_DESCRIPTION
+            }
+        sensor_data[channel_id] = channel_copy
     return sensor_data

--- a/homeassistant/components/youtube/diagnostics.py
+++ b/homeassistant/components/youtube/diagnostics.py
@@ -14,7 +14,7 @@ async def async_get_config_entry_diagnostics(
     """Return diagnostics for a config entry."""
     coordinator = entry.runtime_data
     sensor_data: dict[str, Any] = {}
-    for channel_id, channel_data in coordinator.data.items():
+    for channel_id, channel_data in dict(coordinator.data).items():
         channel_data.get(ATTR_LATEST_VIDEO, {}).pop(ATTR_DESCRIPTION)
         sensor_data[channel_id] = channel_data
     return sensor_data


### PR DESCRIPTION
## Proposed change

`async_get_config_entry_diagnostics` was iterating directly over
`coordinator.data`, meaning `channel_data` was a reference into the
live coordinator data. Calling `.pop(ATTR_DESCRIPTION)` on it
permanently mutated the coordinator's state on every diagnostics fetch.

This fix wraps the iteration in `dict(coordinator.data)` so we iterate
over a shallow copy, leaving the coordinator's live data untouched.

Thanks to @jbouwh for the suggested approach.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] The code change is tested and works locally
- [x] Local tests pass
- [x] There is no commented out code in this PR
- [x] I have followed the development checklist
- [x] I have followed the perfect PR recommendations
- [x] The code has been formatted using Ruff