### PR TITLE
Update rf-protocols to 3.0.0

### DIFF
--- a/homeassistant/components/honeywell_string_lights/config_flow.py
+++ b/homeassistant/components/honeywell_string_lights/config_flow.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from rf_protocols import RadioFrequencyCommand
+from rf_protocols.codes.honeywell.string_lights import CODES
 import voluptuous as vol
 
 from homeassistant.components.radio_frequency import async_get_transmitters
@@ -11,7 +12,6 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er, selector
 
 from .const import CONF_TRANSMITTER, DOMAIN
-from .light import COMMANDS
 
 
 class HoneywellStringLightsConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -24,7 +24,7 @@ class HoneywellStringLightsConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle the initial step."""
         sample_command: RadioFrequencyCommand = await self.hass.async_add_executor_job(
-            COMMANDS.load_command, "turn_on"
+            CODES.load_command, "turn_on"
         )
         try:
             transmitters = async_get_transmitters(

--- a/homeassistant/components/honeywell_string_lights/light.py
+++ b/homeassistant/components/honeywell_string_lights/light.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from rf_protocols import get_codes
+from rf_protocols.codes.honeywell.string_lights import CODES
 
 from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.components.radio_frequency import async_send_command
@@ -15,8 +15,6 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from .entity import HoneywellStringLightsEntity
 
 PARALLEL_UPDATES = 1
-
-COMMANDS = get_codes("honeywell/string_lights")
 
 
 async def async_setup_entry(
@@ -57,7 +55,7 @@ class HoneywellStringLight(HoneywellStringLightsEntity, LightEntity, RestoreEnti
 
     async def _async_send_command(self, name: str) -> None:
         """Load the named command and send it via the configured transmitter."""
-        command = await COMMANDS.async_load_command(name)
+        command = await CODES.async_load_command(name)
         await async_send_command(
             self.hass, self._transmitter, command, context=self._context
         )

--- a/homeassistant/components/honeywell_string_lights/manifest.json
+++ b/homeassistant/components/honeywell_string_lights/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "device",
   "iot_class": "assumed_state",
   "quality_scale": "bronze",
-  "requirements": ["rf-protocols==2.2.0"]
+  "requirements": ["rf-protocols==3.0.0"]
 }

--- a/homeassistant/components/novy_cooker_hood/commands.py
+++ b/homeassistant/components/novy_cooker_hood/commands.py
@@ -1,14 +1,7 @@
-"""Helpers for loading Novy cooker-hood RF commands."""
+"""Command names for the Novy Cooker Hood RF codes."""
 
 from typing import Final
-
-from rf_protocols import CodeCollection, get_codes
 
 COMMAND_LIGHT: Final = "light"
 COMMAND_PLUS: Final = "plus"
 COMMAND_MINUS: Final = "minus"
-
-
-def get_codes_for_code(code: int) -> CodeCollection:
-    """Return the bundled `rf-protocols` collection for a Novy cooker-hood code."""
-    return get_codes(f"novy/cooker_hood/code_{code}")

--- a/homeassistant/components/novy_cooker_hood/config_flow.py
+++ b/homeassistant/components/novy_cooker_hood/config_flow.py
@@ -3,6 +3,7 @@
 import asyncio
 from typing import Any
 
+from rf_protocols.codes.novy.cooker_hood import get_codes_for_code
 import voluptuous as vol
 
 from homeassistant.components.radio_frequency import (
@@ -17,7 +18,7 @@ from homeassistant.config_entries import (
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er, selector
 
-from .commands import COMMAND_LIGHT, get_codes_for_code
+from .commands import COMMAND_LIGHT
 from .const import (
     CODE_MAX,
     CODE_MIN,

--- a/homeassistant/components/novy_cooker_hood/fan.py
+++ b/homeassistant/components/novy_cooker_hood/fan.py
@@ -3,6 +3,8 @@
 import math
 from typing import Any
 
+from rf_protocols.codes.novy.cooker_hood import get_codes_for_code
+
 from homeassistant.components.fan import ATTR_PERCENTAGE, FanEntity, FanEntityFeature
 from homeassistant.components.radio_frequency import async_send_command
 from homeassistant.config_entries import ConfigEntry
@@ -14,7 +16,7 @@ from homeassistant.util.percentage import (
     ranged_value_to_percentage,
 )
 
-from .commands import COMMAND_MINUS, COMMAND_PLUS, get_codes_for_code
+from .commands import COMMAND_MINUS, COMMAND_PLUS
 from .const import CONF_CODE, SPEED_COUNT
 from .entity import NovyCookerHoodEntity
 

--- a/homeassistant/components/novy_cooker_hood/light.py
+++ b/homeassistant/components/novy_cooker_hood/light.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from rf_protocols.codes.novy.cooker_hood import get_codes_for_code
+
 from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.components.radio_frequency import async_send_command
 from homeassistant.config_entries import ConfigEntry
@@ -10,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .commands import COMMAND_LIGHT, get_codes_for_code
+from .commands import COMMAND_LIGHT
 from .const import CONF_CODE
 from .entity import NovyCookerHoodEntity
 

--- a/homeassistant/components/novy_cooker_hood/manifest.json
+++ b/homeassistant/components/novy_cooker_hood/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "device",
   "iot_class": "assumed_state",
   "quality_scale": "bronze",
-  "requirements": ["rf-protocols==2.2.0"]
+  "requirements": ["rf-protocols==3.0.0"]
 }

--- a/homeassistant/components/radio_frequency/manifest.json
+++ b/homeassistant/components/radio_frequency/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/radio_frequency",
   "integration_type": "entity",
   "quality_scale": "internal",
-  "requirements": ["rf-protocols==2.2.0"]
+  "requirements": ["rf-protocols==3.0.0"]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ python-slugify==8.0.4
 PyTurboJPEG==1.8.3
 PyYAML==6.0.3
 requests==2.33.1
-rf-protocols==2.2.0
+rf-protocols==3.0.0
 securetar==2026.4.1
 SQLAlchemy==2.0.49
 standard-aifc==3.13.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2861,7 +2861,7 @@ reolink-aio==0.19.1
 # homeassistant.components.honeywell_string_lights
 # homeassistant.components.novy_cooker_hood
 # homeassistant.components.radio_frequency
-rf-protocols==2.2.0
+rf-protocols==3.0.0
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2445,7 +2445,7 @@ reolink-aio==0.19.1
 # homeassistant.components.honeywell_string_lights
 # homeassistant.components.novy_cooker_hood
 # homeassistant.components.radio_frequency
-rf-protocols==2.2.0
+rf-protocols==3.0.0
 
 # homeassistant.components.rflink
 rflink==0.0.67

--- a/tests/components/broadlink/test_radio_frequency.py
+++ b/tests/components/broadlink/test_radio_frequency.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, call
 
 from broadlink.exceptions import BroadlinkException
 import pytest
-from rf_protocols import OOKCommand
+from rf_protocols.commands.ook import OOKCommand
 
 from homeassistant.components import radio_frequency
 from homeassistant.components.broadlink.const import DOMAIN

--- a/tests/components/esphome/test_radio_frequency.py
+++ b/tests/components/esphome/test_radio_frequency.py
@@ -8,7 +8,8 @@ from aioesphomeapi import (
     RadioFrequencyModulation,
 )
 import pytest
-from rf_protocols import ModulationType, OOKCommand
+from rf_protocols import ModulationType
+from rf_protocols.commands.ook import OOKCommand
 
 from homeassistant.components import radio_frequency
 from homeassistant.const import STATE_UNAVAILABLE

--- a/tests/components/honeywell_string_lights/test_light.py
+++ b/tests/components/honeywell_string_lights/test_light.py
@@ -1,6 +1,7 @@
 """Tests for the Honeywell String Lights light platform."""
 
-from homeassistant.components.honeywell_string_lights.light import COMMANDS
+from rf_protocols.codes.honeywell.string_lights import CODES
+
 from homeassistant.components.light import (
     DOMAIN as LIGHT_DOMAIN,
     SERVICE_TURN_OFF,
@@ -49,7 +50,7 @@ async def test_turn_on_off_sends_commands(
     assert state.context is context
     assert len(mock_rf_entity.send_command_calls) == 1
     command = mock_rf_entity.send_command_calls[0]
-    assert command.command is COMMANDS.load_command("turn_on")
+    assert command.command is CODES.load_command("turn_on")
     assert command.context is context
 
     await hass.services.async_call(
@@ -66,7 +67,7 @@ async def test_turn_on_off_sends_commands(
     assert state.context is context
     assert len(mock_rf_entity.send_command_calls) == 2
     command = mock_rf_entity.send_command_calls[1]
-    assert command.command is COMMANDS.load_command("turn_off")
+    assert command.command is CODES.load_command("turn_off")
     assert command.context is context
 
 

--- a/tests/components/kitchen_sink/test_radio_frequency.py
+++ b/tests/components/kitchen_sink/test_radio_frequency.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
-from rf_protocols import OOKCommand
+from rf_protocols.commands.ook import OOKCommand
 
 from homeassistant.components.kitchen_sink import DOMAIN
 from homeassistant.components.radio_frequency import async_send_command

--- a/tests/components/novy_cooker_hood/conftest.py
+++ b/tests/components/novy_cooker_hood/conftest.py
@@ -4,7 +4,7 @@ from collections.abc import Iterator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from rf_protocols import CodeCollection
+from rf_protocols.loader import CodeCollection
 
 from homeassistant.components.novy_cooker_hood.const import (
     CONF_CODE,
@@ -30,9 +30,19 @@ def mock_get_codes() -> Iterator[MagicMock]:
     fake_collection.async_load_command = AsyncMock(
         side_effect=lambda name: MockRadioFrequencyCommand()
     )
-    with patch(
-        "homeassistant.components.novy_cooker_hood.commands.get_codes",
-        return_value=fake_collection,
+    with (
+        patch(
+            "homeassistant.components.novy_cooker_hood.light.get_codes_for_code",
+            return_value=fake_collection,
+        ),
+        patch(
+            "homeassistant.components.novy_cooker_hood.fan.get_codes_for_code",
+            return_value=fake_collection,
+        ),
+        patch(
+            "homeassistant.components.novy_cooker_hood.config_flow.get_codes_for_code",
+            return_value=fake_collection,
+        ),
     ):
         yield fake_collection
 


### PR DESCRIPTION
## Proposed change

Bump `rf-protocols` from 2.2.0 to 3.0.0.

- Release notes: https://github.com/home-assistant-libs/rf-protocols/releases/tag/3.0.0
- Diff: https://github.com/home-assistant-libs/rf-protocols/compare/2.2.0...3.0.0

3.0.0 reshapes the public API to mirror the `infrared-protocols` package layout:

- The top-level `rf_protocols` module now only exposes `ModulationType` and `RadioFrequencyCommand`. `get_codes`, `CodeCollection`, `OOKCommand`, and `parse_sub_content` moved into submodules (`rf_protocols.loader`, `rf_protocols.commands.ook`, `rf_protocols.parser`).
- Each bundled device gets its own helper module — e.g. `rf_protocols.codes.honeywell.string_lights` exports a `CODES` collection, and `rf_protocols.codes.novy.cooker_hood` exports `get_codes_for_code()`. Integrations can import these directly instead of constructing path strings.

Updated imports in the `broadlink`, `esphome`, `honeywell_string_lights`, `kitchen_sink`, `novy_cooker_hood`, and `radio_frequency` integrations (and matching tests) to match the new layout. Took the opportunity to simplify `honeywell_string_lights` and `novy_cooker_hood`: both now import directly from the per-device helper modules. The local `get_codes_for_code` helper in `novy_cooker_hood/commands.py` is gone — that module now only holds the command-name constants.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: \`python3 -m script.hassfest\`.
- [x] New or updated dependencies have been added to \`requirements_all.txt\`.  
      Updated by running \`python3 -m script.gen_requirements_all\`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr