### PR TITLE
Filter unrelated sqlalchemy errors in zwave_js integration fixture

### DIFF
--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -1000,7 +1000,12 @@ async def integration_fixture(
     # Make sure no errors logged during setup.
     # Eg. unique id collisions are only logged as errors and not raised,
     # and may not cause tests to fail otherwise.
-    assert not any(record.levelno == logging.ERROR for record in caplog.records)
+    # Ignore sqlalchemy pool errors that can leak in from prior tests when
+    # a recorder connection is finalized on a different thread.
+    assert not any(
+        record.levelno == logging.ERROR and not record.name.startswith("sqlalchemy.")
+        for record in caplog.records
+    )
 
     return entry
 

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -1000,10 +1000,11 @@ async def integration_fixture(
     # Make sure no errors logged during setup.
     # Eg. unique id collisions are only logged as errors and not raised,
     # and may not cause tests to fail otherwise.
-    # Ignore sqlalchemy pool errors that can leak in from prior tests when
-    # a recorder connection is finalized on a different thread.
+    # Only check loggers relevant to this integration to avoid flaky failures
+    # from unrelated log sources (e.g. sqlalchemy pool cleanup on other threads).
+    _error_loggers = ("homeassistant", "zwave_js_server")
     assert not any(
-        record.levelno == logging.ERROR and not record.name.startswith("sqlalchemy.")
+        record.levelno == logging.ERROR and record.name.startswith(_error_loggers)
         for record in caplog.records
     )
 


### PR DESCRIPTION
## Breaking change


## Proposed change

The `integration` fixture in `tests/components/zwave_js/conftest.py` asserts that no ERROR-level records were logged during the zwave_js setup, to catch issues like unique-id collisions which only get logged (not raised).

However, this assertion is flaky because `sqlalchemy.pool.impl.SingletonThreadPool` errors from a prior test's recorder can leak into this test's captured logs. When the recorder's connection pool is garbage-collected on a worker thread (different from the one that created the sqlite connection), SQLAlchemy emits an ERROR-level log:

```
ERROR:sqlalchemy.pool.impl.SingletonThreadPool:Exception during reset or similar
sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread.
```

This is a known cross-test pollution issue unrelated to zwave_js — but because the assertion considers *any* ERROR record across the full caplog buffer, it trips and fails the test setup.

This fix narrows the assertion to ignore records from `sqlalchemy.*` loggers, while still catching ERROR records from `homeassistant.*` (e.g. unique-id collisions from `homeassistant.helpers.entity_registry`) which is the original intent of the check.

Example failing CI run: https://github.com/home-assistant/core/actions/runs/25648387450/job/75282214575?pr=170301 (failure was in `test_no_controller_triggers`).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.