### PR TITLE
Fix hassio.backup_partial AttributeError when folders are specified

### DIFF
--- a/homeassistant/components/hassio/services.py
+++ b/homeassistant/components/hassio/services.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from aiohasupervisor import SupervisorClient, SupervisorError
 from aiohasupervisor.models import (
+    Folder,
     FullBackupOptions,
     FullRestoreOptions,
     PartialBackupOptions,
@@ -70,6 +71,38 @@ SERVICE_MOUNT_RELOAD = "mount_reload"
 
 VALID_ADDON_SLUG = vol.Match(re.compile(r"^[-_.A-Za-z0-9]+$"))
 
+# Legacy alias used by the Supervisor API for the homeassistant flag, kept
+# for backwards compatibility with existing automations.
+LEGACY_FOLDER_HOMEASSISTANT = "homeassistant"
+
+
+def _valid_folder(value: Any) -> str:
+    """Validate value is a known folder name (including legacy homeassistant)."""
+    value = cv.string(value)
+    if value == LEGACY_FOLDER_HOMEASSISTANT:
+        return value
+    try:
+        Folder(value)
+    except ValueError as err:
+        raise vol.Invalid(f"Not a valid folder: {value}") from err
+    return value
+
+
+def _normalize_partial_backup_data(data: dict[str, Any]) -> dict[str, Any]:
+    """Translate folders to Folder enum and handle legacy homeassistant folder."""
+    if ATTR_APPS in data:
+        data[ATTR_ADDONS] = data.pop(ATTR_APPS)
+    if ATTR_FOLDERS in data:
+        folders = set(data[ATTR_FOLDERS])
+        if LEGACY_FOLDER_HOMEASSISTANT in folders:
+            folders.discard(LEGACY_FOLDER_HOMEASSISTANT)
+            data[ATTR_HOMEASSISTANT] = True
+        if folders:
+            data[ATTR_FOLDERS] = {Folder(folder) for folder in folders}
+        else:
+            data.pop(ATTR_FOLDERS)
+    return data
+
 
 def valid_addon(value: Any) -> str:
     """Validate value is a valid addon slug."""
@@ -113,7 +146,7 @@ SCHEMA_BACKUP_PARTIAL = SCHEMA_BACKUP_FULL.extend(
     {
         vol.Optional(ATTR_HOMEASSISTANT): cv.boolean,
         vol.Optional(ATTR_FOLDERS): vol.All(
-            cv.ensure_list, [cv.string], vol.Unique(), vol.Coerce(set)
+            cv.ensure_list, [_valid_folder], vol.Unique(), vol.Coerce(set)
         ),
         vol.Exclusive(ATTR_APPS, "apps_or_addons"): vol.All(
             cv.ensure_list, [VALID_ADDON_SLUG], vol.Unique(), vol.Coerce(set)
@@ -136,7 +169,7 @@ SCHEMA_RESTORE_PARTIAL = SCHEMA_RESTORE_FULL.extend(
     {
         vol.Optional(ATTR_HOMEASSISTANT): cv.boolean,
         vol.Optional(ATTR_FOLDERS): vol.All(
-            cv.ensure_list, [cv.string], vol.Unique(), vol.Coerce(set)
+            cv.ensure_list, [_valid_folder], vol.Unique(), vol.Coerce(set)
         ),
         vol.Exclusive(ATTR_APPS, "apps_or_addons"): vol.All(
             cv.ensure_list, [VALID_ADDON_SLUG], vol.Unique(), vol.Coerce(set)
@@ -343,9 +376,7 @@ def async_register_backup_restore_services(
         service: ServiceCall,
     ) -> ServiceResponse:
         """Handler for create partial backup service. Returns the new backup's ID."""
-        data = service.data.copy()
-        if ATTR_APPS in data:
-            data[ATTR_ADDONS] = data.pop(ATTR_APPS)
+        data = _normalize_partial_backup_data(service.data.copy())
         options = PartialBackupOptions(**data)
 
         try:
@@ -392,8 +423,7 @@ def async_register_backup_restore_services(
         """Handler for partial restore service."""
         data = service.data.copy()
         backup_slug = data.pop(ATTR_SLUG)
-        if ATTR_APPS in data:
-            data[ATTR_ADDONS] = data.pop(ATTR_APPS)
+        data = _normalize_partial_backup_data(data)
         options = PartialRestoreOptions(**data)
 
         try:

--- a/homeassistant/components/hassio/services.py
+++ b/homeassistant/components/hassio/services.py
@@ -76,27 +76,12 @@ VALID_ADDON_SLUG = vol.Match(re.compile(r"^[-_.A-Za-z0-9]+$"))
 LEGACY_FOLDER_HOMEASSISTANT = "homeassistant"
 
 
-def _valid_folder(value: Any) -> str:
-    """Validate value is a known folder name (including legacy homeassistant)."""
-    value = cv.string(value)
-    if value == LEGACY_FOLDER_HOMEASSISTANT:
-        return value
-    try:
-        Folder(value)
-    except ValueError as err:
-        raise vol.Invalid(f"Not a valid folder: {value}") from err
-    return value
-
-
 def _normalize_partial_options_data(data: dict[str, Any]) -> dict[str, Any]:
-    """Translate folders to Folder enum and handle legacy homeassistant folder.
-
-    Shared by both partial backup and partial restore service handlers.
-    """
+    """Map legacy aliases used by both partial backup and partial restore handlers."""
     if ATTR_APPS in data:
         data[ATTR_ADDONS] = data.pop(ATTR_APPS)
     if ATTR_FOLDERS in data:
-        folders = set(data[ATTR_FOLDERS])
+        folders: set[Any] = set(data[ATTR_FOLDERS])
         if LEGACY_FOLDER_HOMEASSISTANT in folders:
             folders.discard(LEGACY_FOLDER_HOMEASSISTANT)
             if data.get(ATTR_HOMEASSISTANT) is False:
@@ -106,7 +91,7 @@ def _normalize_partial_options_data(data: dict[str, Any]) -> dict[str, Any]:
                 )
             data[ATTR_HOMEASSISTANT] = True
         if folders:
-            data[ATTR_FOLDERS] = {Folder(folder) for folder in folders}
+            data[ATTR_FOLDERS] = folders
         else:
             data.pop(ATTR_FOLDERS)
     return data
@@ -154,7 +139,10 @@ SCHEMA_BACKUP_PARTIAL = SCHEMA_BACKUP_FULL.extend(
     {
         vol.Optional(ATTR_HOMEASSISTANT): cv.boolean,
         vol.Optional(ATTR_FOLDERS): vol.All(
-            cv.ensure_list, [_valid_folder], vol.Unique(), vol.Coerce(set)
+            cv.ensure_list,
+            [vol.Any(LEGACY_FOLDER_HOMEASSISTANT, vol.Coerce(Folder))],
+            vol.Unique(),
+            vol.Coerce(set),
         ),
         vol.Exclusive(ATTR_APPS, "apps_or_addons"): vol.All(
             cv.ensure_list, [VALID_ADDON_SLUG], vol.Unique(), vol.Coerce(set)
@@ -177,7 +165,10 @@ SCHEMA_RESTORE_PARTIAL = SCHEMA_RESTORE_FULL.extend(
     {
         vol.Optional(ATTR_HOMEASSISTANT): cv.boolean,
         vol.Optional(ATTR_FOLDERS): vol.All(
-            cv.ensure_list, [_valid_folder], vol.Unique(), vol.Coerce(set)
+            cv.ensure_list,
+            [vol.Any(LEGACY_FOLDER_HOMEASSISTANT, vol.Coerce(Folder))],
+            vol.Unique(),
+            vol.Coerce(set),
         ),
         vol.Exclusive(ATTR_APPS, "apps_or_addons"): vol.All(
             cv.ensure_list, [VALID_ADDON_SLUG], vol.Unique(), vol.Coerce(set)

--- a/homeassistant/components/hassio/services.py
+++ b/homeassistant/components/hassio/services.py
@@ -99,6 +99,11 @@ def _normalize_partial_options_data(data: dict[str, Any]) -> dict[str, Any]:
         folders = set(data[ATTR_FOLDERS])
         if LEGACY_FOLDER_HOMEASSISTANT in folders:
             folders.discard(LEGACY_FOLDER_HOMEASSISTANT)
+            if data.get(ATTR_HOMEASSISTANT) is False:
+                raise ServiceValidationError(
+                    f"{ATTR_HOMEASSISTANT}=False conflicts with the legacy "
+                    f"{LEGACY_FOLDER_HOMEASSISTANT!r} entry in {ATTR_FOLDERS}"
+                )
             data[ATTR_HOMEASSISTANT] = True
         if folders:
             data[ATTR_FOLDERS] = {Folder(folder) for folder in folders}

--- a/homeassistant/components/hassio/services.py
+++ b/homeassistant/components/hassio/services.py
@@ -88,8 +88,11 @@ def _valid_folder(value: Any) -> str:
     return value
 
 
-def _normalize_partial_backup_data(data: dict[str, Any]) -> dict[str, Any]:
-    """Translate folders to Folder enum and handle legacy homeassistant folder."""
+def _normalize_partial_options_data(data: dict[str, Any]) -> dict[str, Any]:
+    """Translate folders to Folder enum and handle legacy homeassistant folder.
+
+    Shared by both partial backup and partial restore service handlers.
+    """
     if ATTR_APPS in data:
         data[ATTR_ADDONS] = data.pop(ATTR_APPS)
     if ATTR_FOLDERS in data:
@@ -376,7 +379,7 @@ def async_register_backup_restore_services(
         service: ServiceCall,
     ) -> ServiceResponse:
         """Handler for create partial backup service. Returns the new backup's ID."""
-        data = _normalize_partial_backup_data(service.data.copy())
+        data = _normalize_partial_options_data(service.data.copy())
         options = PartialBackupOptions(**data)
 
         try:
@@ -423,7 +426,7 @@ def async_register_backup_restore_services(
         """Handler for partial restore service."""
         data = service.data.copy()
         backup_slug = data.pop(ATTR_SLUG)
-        data = _normalize_partial_backup_data(data)
+        data = _normalize_partial_options_data(data)
         options = PartialRestoreOptions(**data)
 
         try:

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -14,6 +14,7 @@ from aiohasupervisor.models import (
     AddonStage,
     AddonState,
     CIFSMountResponse,
+    Folder,
     FullBackupOptions,
     HomeAssistantOptions,
     InstalledAddon,
@@ -528,7 +529,7 @@ async def test_service_calls(
             name="2021-11-13 03:48:00",
             homeassistant=True,
             addons={"test"},
-            folders={"ssl"},
+            folders={Folder.SSL},
             password="123456",
         )
     )
@@ -552,7 +553,10 @@ async def test_service_calls(
     supervisor_client.backups.partial_restore.assert_called_once_with(
         "test",
         PartialRestoreOptions(
-            homeassistant=False, addons={"test"}, folders={"ssl"}, password="123456"
+            homeassistant=False,
+            addons={"test"},
+            folders={Folder.SSL},
+            password="123456",
         ),
     )
 
@@ -767,6 +771,42 @@ async def test_invalid_service_calls_folder_duplicates(hass: HomeAssistant) -> N
     with pytest.raises(Invalid, match="contains duplicate items"):
         await hass.services.async_call(
             "hassio", "restore_partial", {"folders": ["ssl", "ssl"]}
+        )
+
+
+@pytest.mark.usefixtures("hassio_env")
+async def test_partial_backup_legacy_homeassistant_folder(
+    hass: HomeAssistant, supervisor_client: AsyncMock
+) -> None:
+    """Test that the legacy "homeassistant" folder is translated to homeassistant=True."""
+    assert await async_setup_component(hass, "hassio", {})
+    supervisor_client.backups.partial_backup.return_value = NewBackup(
+        job_id=uuid4(), slug="partial"
+    )
+
+    await hass.services.async_call(
+        "hassio",
+        "backup_partial",
+        {"folders": ["homeassistant", "ssl"], "name": "test"},
+        blocking=True,
+    )
+    supervisor_client.backups.partial_backup.assert_called_once_with(
+        PartialBackupOptions(
+            name="test",
+            homeassistant=True,
+            folders={Folder.SSL},
+        )
+    )
+
+
+@pytest.mark.usefixtures("hassio_env", "supervisor_client")
+async def test_partial_backup_invalid_folder(hass: HomeAssistant) -> None:
+    """Test that an unknown folder name is rejected."""
+    assert await async_setup_component(hass, "hassio", {})
+
+    with pytest.raises(Invalid, match="Not a valid folder"):
+        await hass.services.async_call(
+            "hassio", "backup_partial", {"folders": ["bogus"]}
         )
 
 

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -810,6 +810,22 @@ async def test_partial_backup_invalid_folder(hass: HomeAssistant) -> None:
         )
 
 
+@pytest.mark.usefixtures("hassio_env", "supervisor_client")
+async def test_partial_backup_legacy_homeassistant_folder_conflict(
+    hass: HomeAssistant,
+) -> None:
+    """Reject combining homeassistant=False with the legacy "homeassistant" folder."""
+    assert await async_setup_component(hass, "hassio", {})
+
+    with pytest.raises(ServiceValidationError, match="conflicts"):
+        await hass.services.async_call(
+            "hassio",
+            "backup_partial",
+            {"homeassistant": False, "folders": ["homeassistant"]},
+            blocking=True,
+        )
+
+
 @pytest.mark.usefixtures("addon_installed")
 async def test_entry_load_and_unload(hass: HomeAssistant) -> None:
     """Test loading and unloading config entry."""

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -826,7 +826,7 @@ async def test_partial_backup_invalid_folder(hass: HomeAssistant) -> None:
     """Test that an unknown folder name is rejected."""
     assert await async_setup_component(hass, "hassio", {})
 
-    with pytest.raises(Invalid, match="Not a valid folder"):
+    with pytest.raises(Invalid, match="not a valid value"):
         await hass.services.async_call(
             "hassio", "backup_partial", {"folders": ["bogus"]}
         )

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -799,6 +799,28 @@ async def test_partial_backup_legacy_homeassistant_folder(
     )
 
 
+@pytest.mark.usefixtures("hassio_env")
+async def test_partial_restore_legacy_homeassistant_folder(
+    hass: HomeAssistant, supervisor_client: AsyncMock
+) -> None:
+    """Test that the legacy "homeassistant" folder is translated for restore too."""
+    assert await async_setup_component(hass, "hassio", {})
+
+    await hass.services.async_call(
+        "hassio",
+        "restore_partial",
+        {"slug": "test", "folders": ["homeassistant", "ssl"]},
+        blocking=True,
+    )
+    supervisor_client.backups.partial_restore.assert_called_once_with(
+        "test",
+        PartialRestoreOptions(
+            homeassistant=True,
+            folders={Folder.SSL},
+        ),
+    )
+
+
 @pytest.mark.usefixtures("hassio_env", "supervisor_client")
 async def test_partial_backup_invalid_folder(hass: HomeAssistant) -> None:
     """Test that an unknown folder name is rejected."""


### PR DESCRIPTION
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

After #166558 switched `hassio.backup_partial` / `hassio.restore_partial` to `aiohasupervisor`, the service schema still produced a `set[str]` for `folders`, but `PartialBackupOptions.folders` is typed `set[Folder]`. mashumaro's `to_dict()` then fails with:

```
AttributeError: 'str' object has no attribute 'value'
```

Additionally, the legacy `"homeassistant"` folder value (still accepted by Supervisor via `v1_folderlist`) is no longer part of the `Folder` enum, so any existing automation passing it would silently break.

This change:

- Validates folder names against the `Folder` enum at schema time and converts them before constructing the options.
- Translates the legacy `"homeassistant"` folder value to `homeassistant=True` to preserve backwards compatibility with existing automations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170175
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
