### PR TITLE
Fix Shelly media player availability

### DIFF
--- a/homeassistant/components/shelly/media_player.py
+++ b/homeassistant/components/shelly/media_player.py
@@ -192,6 +192,14 @@ class ShellyRpcMediaPlayer(ShellyRpcAttributeEntity, MediaPlayerEntity):
         return self._last_media_position_updated_at
 
     @property
+    def entity_picture(self) -> str | None:
+        """Return image of the media playing."""
+        if not self.available:
+            return None
+
+        return super().entity_picture
+
+    @property
     def media_image_url(self) -> str | None:
         """Return the image URL of current playing media."""
         if (thumb := self._media_meta.get("thumb")) and thumb.startswith("http"):

--- a/tests/components/shelly/test_media_player.py
+++ b/tests/components/shelly/test_media_player.py
@@ -36,6 +36,7 @@ from homeassistant.const import (
     STATE_BUFFERING,
     STATE_IDLE,
     STATE_PLAYING,
+    STATE_UNAVAILABLE,
     Platform,
 )
 from homeassistant.core import HomeAssistant
@@ -631,3 +632,27 @@ async def test_rpc_media_player_no_media_meta(
     assert state.attributes.get(ATTR_MEDIA_ALBUM_NAME) is None
     assert state.attributes.get(ATTR_MEDIA_DURATION) is None
     assert state.attributes.get(ATTR_MEDIA_POSITION) is None
+
+
+async def test_rpc_media_player_unavailable(
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test media player entity handles device going offline without raising."""
+    status = deepcopy(mock_rpc_device.status)
+    status["media"] = STATUS_AUDIO_FILE
+    monkeypatch.setattr(mock_rpc_device, "status", status)
+
+    await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
+
+    assert (state := hass.states.get(ENTITY_ID))
+    assert state.state == STATE_PLAYING
+
+    monkeypatch.setattr(mock_rpc_device, "connected", False)
+    monkeypatch.setattr(mock_rpc_device, "initialized", False)
+    mock_rpc_device.mock_disconnected()
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get(ENTITY_ID))
+    assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes:

```
2026-05-11 09:57:59.787 ERROR (MainThread) [homeassistant.components.shelly] Unexpected error updating listener 137947086113280 for Shelly Wall Display X1i [F78A6A]
Traceback (most recent call last):
  File "/workspaces/home-assistant-core/homeassistant/helpers/update_coordinator.py", line 201, in async_update_listeners
    update_callback()
    ~~~~~~~~~~~~~~~^^
  File "/workspaces/home-assistant-core/homeassistant/components/shelly/entity.py", line 439, in _update_callback
    self.async_write_ha_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/workspaces/home-assistant-core/homeassistant/helpers/entity.py", line 1054, in async_write_ha_state
    self._async_write_ha_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/workspaces/home-assistant-core/homeassistant/helpers/entity.py", line 1203, in _async_write_ha_state
    ) = self.__async_calculate_state()
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/workspaces/home-assistant-core/homeassistant/helpers/entity.py", line 1132, in __async_calculate_state
    if (entity_picture := self.entity_picture) is not None:
                          ^^^^^^^^^^^^^^^^^^^
  File "/workspaces/home-assistant-core/homeassistant/components/media_player/__init__.py", line 1082, in entity_picture
    if self.state == MediaPlayerState.OFF:
       ^^^^^^^^^^
  File "/workspaces/home-assistant-core/homeassistant/components/shelly/media_player.py", line 134, in state
    if self.status["playback"]["buffering"]:
       ^^^^^^^^^^^
  File "/workspaces/home-assistant-core/homeassistant/components/shelly/entity.py", line 429, in status
    return cast(dict, self.coordinator.device.status[self.key])
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/aioshelly/rpc_device/device.py", line 909, in status
    raise NotInitialized
aioshelly.exceptions.NotInitialized
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
