### PR TITLE
Cancel previous Debouncer timer handle in _schedule_timer

### DIFF
--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -193,8 +193,9 @@ class Debouncer[_R_co]:
 
     @callback
     def _schedule_timer(self) -> None:
-        """Schedule a timer."""
-        if not self._shutdown_requested:
-            self._timer_task = self.hass.loop.call_later(
-                self.cooldown, self._on_debounce
-            )
+        """Schedule a timer, cancelling any previously-scheduled handle."""
+        if self._shutdown_requested:
+            return
+        if self._timer_task is not None:
+            self._timer_task.cancel()
+        self._timer_task = self.hass.loop.call_later(self.cooldown, self._on_debounce)

--- a/tests/helpers/test_debounce.py
+++ b/tests/helpers/test_debounce.py
@@ -578,3 +578,67 @@ async def test_shutdown_releases_parent_class(hass: HomeAssistant) -> None:
     # Debouncer shutdown releases the class
     debouncer.async_shutdown()
     assert my_class_weak_ref() is None
+
+
+async def test_schedule_timer_cancels_previous_handle(hass: HomeAssistant) -> None:
+    """Ensure _schedule_timer cancels any previously-scheduled handle."""
+    debouncer = debounce.Debouncer(
+        hass,
+        _LOGGER,
+        cooldown=0.01,
+        immediate=True,
+        function=AsyncMock(),
+    )
+
+    debouncer._schedule_timer()
+    first_handle = debouncer._timer_task
+    assert first_handle is not None
+    assert not first_handle.cancelled()
+
+    debouncer._schedule_timer()
+    second_handle = debouncer._timer_task
+    assert second_handle is not None
+    assert second_handle is not first_handle
+    assert first_handle.cancelled()
+
+    debouncer.async_shutdown()
+
+
+async def test_concurrent_async_call_does_not_orphan_timer(
+    hass: HomeAssistant,
+) -> None:
+    """Concurrent async_call during in-flight execution must not orphan a timer."""
+    started = asyncio.Event()
+    can_finish = asyncio.Event()
+
+    async def slow_function() -> None:
+        started.set()
+        await can_finish.wait()
+
+    debouncer = debounce.Debouncer(
+        hass,
+        _LOGGER,
+        cooldown=0.01,
+        immediate=True,
+        function=slow_function,
+    )
+
+    in_flight = hass.async_create_task(debouncer.async_call())
+    await started.wait()
+    assert debouncer._timer_task is None
+
+    # The concurrent call hits the locked-immediate branch and schedules T1.
+    await debouncer.async_call()
+    first_timer = debouncer._timer_task
+    assert first_timer is not None
+    assert not first_timer.cancelled()
+
+    # Letting the in-flight call complete schedules T2 in its finally clause.
+    can_finish.set()
+    await in_flight
+    second_timer = debouncer._timer_task
+    assert second_timer is not None
+    assert second_timer is not first_timer
+    assert first_timer.cancelled()
+
+    debouncer.async_shutdown()

--- a/tests/helpers/test_debounce.py
+++ b/tests/helpers/test_debounce.py
@@ -633,7 +633,7 @@ async def test_concurrent_async_call_does_not_orphan_timer(
     assert first_timer is not None
     assert not first_timer.cancelled()
 
-    # Letting the in-flight call complete schedules T2 in its finally clause.
+    # Letting the in-flight call complete schedules T2.
     can_finish.set()
     await in_flight
     second_timer = debouncer._timer_task

--- a/tests/helpers/test_debounce.py
+++ b/tests/helpers/test_debounce.py
@@ -587,7 +587,7 @@ async def test_schedule_timer_cancels_previous_handle(hass: HomeAssistant) -> No
     debouncer = debounce.Debouncer(
         hass,
         _LOGGER,
-        cooldown=1.0,
+        cooldown=3600.0,
         immediate=True,
         function=AsyncMock(),
     )
@@ -622,7 +622,7 @@ async def test_concurrent_async_call_does_not_orphan_timer(
     debouncer = debounce.Debouncer(
         hass,
         _LOGGER,
-        cooldown=1.0,
+        cooldown=3600.0,
         immediate=True,
         function=slow_function,
     )

--- a/tests/helpers/test_debounce.py
+++ b/tests/helpers/test_debounce.py
@@ -582,10 +582,12 @@ async def test_shutdown_releases_parent_class(hass: HomeAssistant) -> None:
 
 async def test_schedule_timer_cancels_previous_handle(hass: HomeAssistant) -> None:
     """Ensure _schedule_timer cancels any previously-scheduled handle."""
+    # Use a large cooldown so the scheduled timer can't fire mid-test on a slow
+    # event loop; the timer is only inspected and cancelled, never awaited.
     debouncer = debounce.Debouncer(
         hass,
         _LOGGER,
-        cooldown=0.01,
+        cooldown=1.0,
         immediate=True,
         function=AsyncMock(),
     )
@@ -615,10 +617,12 @@ async def test_concurrent_async_call_does_not_orphan_timer(
         started.set()
         await can_finish.wait()
 
+    # Use a large cooldown so the T1 timer scheduled below can't fire before
+    # the in-flight call completes; cancellation is verified deterministically.
     debouncer = debounce.Debouncer(
         hass,
         _LOGGER,
-        cooldown=0.01,
+        cooldown=1.0,
         immediate=True,
         function=slow_function,
     )


### PR DESCRIPTION
## Proposed change
Both async_call's finally clause and the locked-immediate branch in _async_schedule_or_call_now (added in #153596) can invoke _schedule_timer while a timer is already pending. Before this change _timer_task was overwritten unconditionally, orphaning the previous TimerHandle. async_cancel and async_shutdown only reach the currently-tracked handle, so the orphan persists until it fires on its own -- which surfaces as a "Lingering timer after test" failure under verify_cleanup for integrations that race async_request_refresh during setup.

Cancel _timer_task before replacing it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
