### PR TITLE
Clean up template engine after extension modularization

### DIFF
--- a/homeassistant/helpers/template/extensions/state.py
+++ b/homeassistant/helpers/template/extensions/state.py
@@ -1,6 +1,5 @@
 """State functions for Home Assistant templates."""
 
-import collections.abc
 from collections.abc import Iterable
 import logging
 from typing import TYPE_CHECKING, Any
@@ -162,7 +161,7 @@ class StateExtension(BaseTemplateExtension):
                     continue
             elif isinstance(entity, State):
                 entity_id = entity.entity_id
-            elif isinstance(entity, collections.abc.Iterable):
+            elif isinstance(entity, Iterable):
                 search += entity
                 continue
             else:

--- a/tests/helpers/template/test_init.py
+++ b/tests/helpers/template/test_init.py
@@ -84,16 +84,6 @@ def test_invalid_template(hass: HomeAssistant) -> None:
         tmpl.async_render()
 
 
-def test_invalid_entity_id(hass: HomeAssistant) -> None:
-    """Test referring states by entity id."""
-    with pytest.raises(TemplateError):
-        render(hass, '{{ states["big.fat..."] }}')
-    with pytest.raises(TemplateError):
-        render(hass, '{{ states.test["big.fat..."] }}')
-    with pytest.raises(TemplateError):
-        render(hass, '{{ states["invalid/domain"] }}')
-
-
 def test_raise_exception_on_error(hass: HomeAssistant) -> None:
     """Test raising an exception on error."""
     with pytest.raises(TemplateError):
@@ -599,19 +589,6 @@ def test_state_with_unit_and_rounding_options(
     assert tpl2.async_render() == output2_2
 
 
-def test_length_of_states(hass: HomeAssistant) -> None:
-    """Test fetching the length of states."""
-    hass.states.async_set("sensor.test", "23")
-    hass.states.async_set("sensor.test2", "wow")
-    hass.states.async_set("climate.test2", "cooling")
-
-    result = render(hass, "{{ states | length }}")
-    assert result == 3
-
-    result = render(hass, "{{ states.sensor | length }}")
-    assert result == 2
-
-
 def test_render_complex_handling_non_template_values(hass: HomeAssistant) -> None:
     """Test that we can render non-template fields."""
     assert template.render_complex(
@@ -705,21 +682,6 @@ For loop example getting 3 entity values:
     assert "sensor0" in result
     assert "sensor1" in result
     assert "sun" in result
-
-
-async def test_slice_states(hass: HomeAssistant) -> None:
-    """Test iterating states with a slice."""
-    hass.states.async_set("sensor.test", "23")
-
-    result = render(
-        hass,
-        (
-            "{% for states in states | slice(1) -%}{% set state = states | first %}"
-            "{{ state.entity_id }}"
-            "{%- endfor %}"
-        ),
-    )
-    assert result == "sensor.test"
 
 
 async def test_lifecycle(hass: HomeAssistant) -> None:
@@ -831,63 +793,6 @@ async def test_template_errors(hass: HomeAssistant) -> None:
 
     with pytest.raises(TemplateError):
         render(hass, "{{ utcnow() | random }}")
-
-
-async def test_state_attributes(hass: HomeAssistant) -> None:
-    """Test state attributes."""
-    hass.states.async_set("sensor.test", "23")
-
-    result = render(hass, "{{ states.sensor.test.last_changed }}")
-    assert result == str(hass.states.get("sensor.test").last_changed)
-
-    result = render(hass, "{{ states.sensor.test.object_id }}")
-    assert result == hass.states.get("sensor.test").object_id
-
-    result = render(hass, "{{ states.sensor.test.domain }}")
-    assert result == hass.states.get("sensor.test").domain
-
-    result = render(hass, "{{ states.sensor.test.context.id }}")
-    assert result == hass.states.get("sensor.test").context.id
-
-    result = render(hass, "{{ states.sensor.test.state_with_unit }}")
-    assert result == 23
-
-    result = render(hass, "{{ states.sensor.test.invalid_prop }}")
-    assert result == ""
-
-    with pytest.raises(TemplateError):
-        render(hass, "{{ states.sensor.test.invalid_prop.xx }}")
-
-
-async def test_unavailable_states(hass: HomeAssistant) -> None:
-    """Test watching unavailable states."""
-
-    for i in range(10):
-        hass.states.async_set(f"light.sensor{i}", "on")
-
-    hass.states.async_set("light.unavailable", "unavailable")
-    hass.states.async_set("light.unknown", "unknown")
-    hass.states.async_set("light.none", "none")
-
-    result = render(
-        hass,
-        (
-            "{{ states | selectattr('state', 'in', ['unavailable','unknown','none']) "
-            "| sort(attribute='entity_id') | map(attribute='entity_id') | list | join(', ') }}"
-        ),
-    )
-    assert result == "light.none, light.unavailable, light.unknown"
-
-    result = render(
-        hass,
-        (
-            "{{ states.light "
-            "| selectattr('state', 'in', ['unavailable','unknown','none']) "
-            "| sort(attribute='entity_id') | map(attribute='entity_id') | list "
-            "| join(', ') }}"
-        ),
-    )
-    assert result == "light.none, light.unavailable, light.unknown"
 
 
 async def test_no_result_parsing(hass: HomeAssistant) -> None:

--- a/tests/helpers/template/test_states.py
+++ b/tests/helpers/template/test_states.py
@@ -6,10 +6,13 @@ import pytest
 
 from homeassistant.const import STATE_ON
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import template
 from homeassistant.helpers.json import json_dumps
 from homeassistant.helpers.template import states as template_states
 from homeassistant.util import dt as dt_util
+
+from .helpers import render
 
 from tests.common import async_fire_time_changed
 
@@ -76,3 +79,98 @@ async def test_lru_increases_with_many_entities(hass: HomeAssistant) -> None:
     assert template_states.CACHED_TEMPLATE_NO_COLLECT_LRU.get_size() == int(
         round(mock_entity_count * template_states.ENTITY_COUNT_GROWTH_FACTOR)
     )
+
+
+def test_invalid_entity_id(hass: HomeAssistant) -> None:
+    """Test referring states by entity id."""
+    with pytest.raises(TemplateError):
+        render(hass, '{{ states["big.fat..."] }}')
+    with pytest.raises(TemplateError):
+        render(hass, '{{ states.test["big.fat..."] }}')
+    with pytest.raises(TemplateError):
+        render(hass, '{{ states["invalid/domain"] }}')
+
+
+def test_length_of_states(hass: HomeAssistant) -> None:
+    """Test fetching the length of states."""
+    hass.states.async_set("sensor.test", "23")
+    hass.states.async_set("sensor.test2", "wow")
+    hass.states.async_set("climate.test2", "cooling")
+
+    result = render(hass, "{{ states | length }}")
+    assert result == 3
+
+    result = render(hass, "{{ states.sensor | length }}")
+    assert result == 2
+
+
+async def test_slice_states(hass: HomeAssistant) -> None:
+    """Test iterating states with a slice."""
+    hass.states.async_set("sensor.test", "23")
+
+    result = render(
+        hass,
+        (
+            "{% for states in states | slice(1) -%}{% set state = states | first %}"
+            "{{ state.entity_id }}"
+            "{%- endfor %}"
+        ),
+    )
+    assert result == "sensor.test"
+
+
+async def test_state_attributes(hass: HomeAssistant) -> None:
+    """Test state attributes."""
+    hass.states.async_set("sensor.test", "23")
+
+    result = render(hass, "{{ states.sensor.test.last_changed }}")
+    assert result == str(hass.states.get("sensor.test").last_changed)
+
+    result = render(hass, "{{ states.sensor.test.object_id }}")
+    assert result == hass.states.get("sensor.test").object_id
+
+    result = render(hass, "{{ states.sensor.test.domain }}")
+    assert result == hass.states.get("sensor.test").domain
+
+    result = render(hass, "{{ states.sensor.test.context.id }}")
+    assert result == hass.states.get("sensor.test").context.id
+
+    result = render(hass, "{{ states.sensor.test.state_with_unit }}")
+    assert result == 23
+
+    result = render(hass, "{{ states.sensor.test.invalid_prop }}")
+    assert result == ""
+
+    with pytest.raises(TemplateError):
+        render(hass, "{{ states.sensor.test.invalid_prop.xx }}")
+
+
+async def test_unavailable_states(hass: HomeAssistant) -> None:
+    """Test watching unavailable states."""
+
+    for i in range(10):
+        hass.states.async_set(f"light.sensor{i}", "on")
+
+    hass.states.async_set("light.unavailable", "unavailable")
+    hass.states.async_set("light.unknown", "unknown")
+    hass.states.async_set("light.none", "none")
+
+    result = render(
+        hass,
+        (
+            "{{ states | selectattr('state', 'in', ['unavailable','unknown','none']) "
+            "| sort(attribute='entity_id') | map(attribute='entity_id') | list | join(', ') }}"
+        ),
+    )
+    assert result == "light.none, light.unavailable, light.unknown"
+
+    result = render(
+        hass,
+        (
+            "{{ states.light "
+            "| selectattr('state', 'in', ['unavailable','unknown','none']) "
+            "| sort(attribute='entity_id') | map(attribute='entity_id') | list "
+            "| join(', ') }}"
+        ),
+    )
+    assert result == "light.none, light.unavailable, light.unknown"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Small cleanup after the template engine modularization effort:

- Remove redundant `import collections.abc` from the state extension (already importing `Iterable` from `collections.abc` directly)
- Move remaining state infrastructure tests (`test_invalid_entity_id`, `test_length_of_states`, `test_slice_states`, `test_state_attributes`, `test_unavailable_states`) from `test_init.py` to `test_states.py` where they belong

There is no functional change in this PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr