### PR TITLE
Fix duplicate doorbell events when entity becomes unavailable

### DIFF
--- a/homeassistant/components/alexa/state_report.py
+++ b/homeassistant/components/alexa/state_report.py
@@ -11,7 +11,12 @@ from uuid import uuid4
 import aiohttp
 
 from homeassistant.components import event
-from homeassistant.const import EVENT_STATE_CHANGED, STATE_ON
+from homeassistant.const import (
+    EVENT_STATE_CHANGED,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
 from homeassistant.core import (
     CALLBACK_TYPE,
     Event,
@@ -315,9 +320,16 @@ async def async_enable_proactive_mode(
 
         if should_doorbell:
             old_state = data["old_state"]
-            if new_state.domain == event.DOMAIN or (
+            if (
+                new_state.domain == event.DOMAIN
+                and new_state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN)
+                and (old_state is None or old_state.state != STATE_UNAVAILABLE)
+            ) or (
                 new_state.state == STATE_ON
-                and (old_state is None or old_state.state != STATE_ON)
+                and (
+                    old_state is None
+                    or old_state.state not in (STATE_ON, STATE_UNAVAILABLE)
+                )
             ):
                 await async_send_doorbell_event_message(
                     hass, smart_home_config, alexa_changed_entity

--- a/homeassistant/components/alexa/state_report.py
+++ b/homeassistant/components/alexa/state_report.py
@@ -301,12 +301,17 @@ async def async_enable_proactive_mode(
         if TYPE_CHECKING:
             assert new_state is not None
 
-        def valid_doorbell_timestamp(event_state: str) -> bool:
+        def valid_doorbell_timestamp(entity_id: str, event_state: str) -> bool:
             if event_state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
                 return False
             try:
                 timestamp = datetime.fromisoformat(event_state)
             except ValueError:
+                _LOGGER.debug(
+                    "Unable to parse ISO timestamp from state for %s. Got %s",
+                    entity_id,
+                    event_state,
+                )
                 return False
             else:
                 if (dt_util.utcnow() - timestamp) < timedelta(seconds=30):
@@ -335,7 +340,7 @@ async def async_enable_proactive_mode(
             old_state = data["old_state"]
             if (
                 new_state.domain == event.DOMAIN
-                and valid_doorbell_timestamp(new_state.state)
+                and valid_doorbell_timestamp(new_state.entity_id, new_state.state)
                 and (old_state is None or old_state.state != STATE_UNAVAILABLE)
             ) or (
                 new_state.state == STATE_ON

--- a/homeassistant/components/alexa/state_report.py
+++ b/homeassistant/components/alexa/state_report.py
@@ -2,6 +2,7 @@
 
 from asyncio import timeout
 from collections.abc import Mapping
+from datetime import datetime, timedelta
 from http import HTTPStatus
 import json
 import logging
@@ -300,6 +301,18 @@ async def async_enable_proactive_mode(
         if TYPE_CHECKING:
             assert new_state is not None
 
+        def valid_doorbell_timestamp(event_state: str) -> bool:
+            if event_state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+                return False
+            try:
+                timestamp = datetime.fromisoformat(event_state)
+            except ValueError:
+                return False
+            else:
+                if (dt_util.utcnow() - timestamp) < timedelta(seconds=30):
+                    return True
+                return False
+
         alexa_changed_entity: AlexaEntity = ENTITY_ADAPTERS[new_state.domain](
             hass, smart_home_config, new_state
         )
@@ -322,7 +335,7 @@ async def async_enable_proactive_mode(
             old_state = data["old_state"]
             if (
                 new_state.domain == event.DOMAIN
-                and new_state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN)
+                and valid_doorbell_timestamp(new_state.state)
                 and (old_state is None or old_state.state != STATE_UNAVAILABLE)
             ) or (
                 new_state.state == STATE_ON

--- a/homeassistant/components/alexa/state_report.py
+++ b/homeassistant/components/alexa/state_report.py
@@ -57,6 +57,25 @@ DEFAULT_TIMEOUT = 10
 TO_REDACT = {"correlationToken", "token"}
 
 
+def valid_doorbell_timestamp(entity_id: str, event_state: str) -> bool:
+    """Check if doorbell event timestamp is valid."""
+    if event_state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+        return False
+    try:
+        timestamp = datetime.fromisoformat(event_state)
+    except ValueError:
+        _LOGGER.debug(
+            "Unable to parse ISO timestamp from state for %s. Got %s",
+            entity_id,
+            event_state,
+        )
+        return False
+    else:
+        if (dt_util.utcnow() - timestamp) < timedelta(seconds=30):
+            return True
+        return False
+
+
 class AlexaDirective:
     """An incoming Alexa directive."""
 
@@ -301,23 +320,6 @@ async def async_enable_proactive_mode(
         if TYPE_CHECKING:
             assert new_state is not None
 
-        def valid_doorbell_timestamp(entity_id: str, event_state: str) -> bool:
-            if event_state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
-                return False
-            try:
-                timestamp = datetime.fromisoformat(event_state)
-            except ValueError:
-                _LOGGER.debug(
-                    "Unable to parse ISO timestamp from state for %s. Got %s",
-                    entity_id,
-                    event_state,
-                )
-                return False
-            else:
-                if (dt_util.utcnow() - timestamp) < timedelta(seconds=30):
-                    return True
-                return False
-
         alexa_changed_entity: AlexaEntity = ENTITY_ADAPTERS[new_state.domain](
             hass, smart_home_config, new_state
         )
@@ -342,6 +344,7 @@ async def async_enable_proactive_mode(
                 new_state.domain == event.DOMAIN
                 and valid_doorbell_timestamp(new_state.entity_id, new_state.state)
                 and (old_state is None or old_state.state != STATE_UNAVAILABLE)
+                and (old_state is None or old_state.state != new_state.state)
             ) or (
                 new_state.state == STATE_ON
                 and (

--- a/tests/components/alexa/test_state_report.py
+++ b/tests/components/alexa/test_state_report.py
@@ -9,7 +9,12 @@ import pytest
 from homeassistant import core
 from homeassistant.components.alexa import errors, state_report
 from homeassistant.components.alexa.resources import AlexaGlobalCatalog
-from homeassistant.const import PERCENTAGE, UnitOfLength, UnitOfTemperature
+from homeassistant.const import (
+    PERCENTAGE,
+    STATE_UNAVAILABLE,
+    UnitOfLength,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant
 
 from .test_common import TEST_URL, get_default_config
@@ -522,10 +527,10 @@ async def test_send_delete_message(
     )
 
 
-async def test_doorbell_event(
+async def test_doorbell_event_binary_sensor(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
-    """Test doorbell press reports."""
+    """Test doorbell press via bionary sensor reports."""
     aioclient_mock.post(TEST_URL, text="", status=202)
 
     hass.states.async_set(
@@ -547,6 +552,16 @@ async def test_doorbell_event(
             "friendly_name": "Test Doorbell Sensor",
             "device_class": "occupancy",
             "linkquality": 42,
+        },
+    )
+
+    hass.states.async_set(
+        "binary_sensor.test_doorbell",
+        STATE_UNAVAILABLE,
+        {
+            "friendly_name": "Test Doorbell Sensor",
+            "device_class": "occupancy",
+            "linkquality": 99,
         },
     )
 
@@ -582,6 +597,77 @@ async def test_doorbell_event(
         "binary_sensor.test_doorbell",
         "on",
         {"friendly_name": "Test Doorbell Sensor", "device_class": "occupancy"},
+    )
+
+    await hass.async_block_till_done()
+
+    assert len(aioclient_mock.mock_calls) == 2
+
+
+async def test_doorbell_event_for_event_entity(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test doorbell event reports."""
+    aioclient_mock.post(TEST_URL, text="", status=202)
+
+    hass.states.async_set(
+        "event.test_doorbell",
+        "unknown",
+        {
+            "friendly_name": "Test Doorbell Sensor",
+            "device_class": "doorbell",
+            "event_types": ["ring"],
+        },
+    )
+
+    await state_report.async_enable_proactive_mode(hass, get_default_config(hass))
+
+    hass.states.async_set(
+        "event.test_doorbell",
+        "2026-05-11T19:50:47.647427",
+        {
+            "friendly_name": "Test Doorbell Sensor",
+            "device_class": "doorbell",
+            "event_types": ["ring"],
+        },
+    )
+    hass.states.async_set(
+        "event.test_doorbell",
+        STATE_UNAVAILABLE,
+        {
+            "friendly_name": "Test Doorbell Sensor",
+            "device_class": "doorbell",
+            "event_types": ["ring"],
+        },
+    )
+    hass.states.async_set(
+        "event.test_doorbell",
+        "2026-05-11T19:50:47.647427",
+        {
+            "friendly_name": "Test Doorbell Sensor",
+            "device_class": "doorbell",
+            "event_types": ["ring"],
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert len(aioclient_mock.mock_calls) == 1
+    call = aioclient_mock.mock_calls
+
+    call_json = call[0][2]
+    assert call_json["event"]["header"]["namespace"] == "Alexa.DoorbellEventSource"
+    assert call_json["event"]["header"]["name"] == "DoorbellPress"
+    assert call_json["event"]["payload"]["cause"]["type"] == "PHYSICAL_INTERACTION"
+    assert call_json["event"]["endpoint"]["endpointId"] == "event#test_doorbell"
+
+    hass.states.async_set(
+        "event.test_doorbell",
+        "2026-05-11T20:10:30.369985",
+        {
+            "friendly_name": "Test Doorbell Sensor",
+            "device_class": "doorbell",
+            "event_types": ["ring"],
+        },
     )
 
     await hass.async_block_till_done()

--- a/tests/components/alexa/test_state_report.py
+++ b/tests/components/alexa/test_state_report.py
@@ -1,6 +1,7 @@
 """Test report state."""
 
 import json
+import logging
 from unittest.mock import AsyncMock, patch
 
 import aiohttp
@@ -609,6 +610,7 @@ async def test_doorbell_event_for_event_entity(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test doorbell event reports."""
     freezer.move_to("2026-05-11T19:50:47.647427+0000")
@@ -675,6 +677,23 @@ async def test_doorbell_event_for_event_entity(
     assert call_json["event"]["header"]["name"] == "DoorbellPress"
     assert call_json["event"]["payload"]["cause"]["type"] == "PHYSICAL_INTERACTION"
     assert call_json["event"]["endpoint"]["endpointId"] == "event#test_doorbell"
+
+    # Same event after being unavailable
+    with caplog.at_level(logging.DEBUG):
+        hass.states.async_set(
+            "event.test_doorbell",
+            "11 may 2026 19:50:30",
+            {
+                "friendly_name": "Test Doorbell Sensor",
+                "device_class": "doorbell",
+                "event_types": ["ring"],
+            },
+        )
+        await hass.async_block_till_done()
+        assert (
+            "Unable to parse ISO timestamp from state for "
+            "event.test_doorbell. Got 11 may 2026 19:50:30" in caplog.text
+        )
 
     # Later event
     freezer.tick(35000)

--- a/tests/components/alexa/test_state_report.py
+++ b/tests/components/alexa/test_state_report.py
@@ -530,7 +530,7 @@ async def test_send_delete_message(
 async def test_doorbell_event_binary_sensor(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
-    """Test doorbell press via bionary sensor reports."""
+    """Test doorbell press via binary sensor reports."""
     aioclient_mock.post(TEST_URL, text="", status=202)
 
     hass.states.async_set(

--- a/tests/components/alexa/test_state_report.py
+++ b/tests/components/alexa/test_state_report.py
@@ -4,6 +4,7 @@ import json
 from unittest.mock import AsyncMock, patch
 
 import aiohttp
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant import core
@@ -605,9 +606,12 @@ async def test_doorbell_event_binary_sensor(
 
 
 async def test_doorbell_event_for_event_entity(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test doorbell event reports."""
+    freezer.move_to("2026-05-11T19:50:47.647427+0000")
     aioclient_mock.post(TEST_URL, text="", status=202)
 
     hass.states.async_set(
@@ -622,9 +626,20 @@ async def test_doorbell_event_for_event_entity(
 
     await state_report.async_enable_proactive_mode(hass, get_default_config(hass))
 
+    # Stale event (does not trigger)
     hass.states.async_set(
         "event.test_doorbell",
-        "2026-05-11T19:50:47.647427",
+        "2026-05-11T19:40:48.1265799+00:00",
+        {
+            "friendly_name": "Test Doorbell Sensor",
+            "device_class": "doorbell",
+            "event_types": ["ring"],
+        },
+    )
+    # Event within 30 sec
+    hass.states.async_set(
+        "event.test_doorbell",
+        "2026-05-11T19:50:30.647427+00:00",
         {
             "friendly_name": "Test Doorbell Sensor",
             "device_class": "doorbell",
@@ -640,9 +655,10 @@ async def test_doorbell_event_for_event_entity(
             "event_types": ["ring"],
         },
     )
+    # Same event after being unavailable
     hass.states.async_set(
         "event.test_doorbell",
-        "2026-05-11T19:50:47.647427",
+        "2026-05-11T19:50:30.647427+00:00",
         {
             "friendly_name": "Test Doorbell Sensor",
             "device_class": "doorbell",
@@ -660,9 +676,12 @@ async def test_doorbell_event_for_event_entity(
     assert call_json["event"]["payload"]["cause"]["type"] == "PHYSICAL_INTERACTION"
     assert call_json["event"]["endpoint"]["endpointId"] == "event#test_doorbell"
 
+    # Later event
+    freezer.tick(35000)
+    await hass.async_block_till_done()
     hass.states.async_set(
         "event.test_doorbell",
-        "2026-05-11T20:10:30.369985",
+        f"{freezer.time_to_freeze.isoformat()}+00:00",
         {
             "friendly_name": "Test Doorbell Sensor",
             "device_class": "doorbell",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix duplicate doorbell events when entity becomes unavailable

The doorbell event should not trigger if the previous state was `unavailable`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170344
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
