### PR TITLE
Fix Apple TV keyboard focus binary_sensor missing on cold start

### DIFF
--- a/homeassistant/components/apple_tv/binary_sensor.py
+++ b/homeassistant/components/apple_tv/binary_sensor.py
@@ -5,7 +5,7 @@ from pyatv.interface import AppleTV, KeyboardListener
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.const import CONF_NAME
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -21,27 +21,31 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Load Apple TV binary sensor based on a config entry."""
-    # apple_tv config entries always have a unique id
     manager = config_entry.runtime_data
-    cb: CALLBACK_TYPE
+    added = False
 
+    @callback
     def setup_entities(atv: AppleTV) -> None:
+        nonlocal added
+        if added:
+            return
         if atv.features.in_state(FeatureState.Available, FeatureName.TextFocusState):
             assert config_entry.unique_id is not None
             name: str = config_entry.data[CONF_NAME]
             async_add_entities(
                 [AppleTVKeyboardFocused(name, config_entry.unique_id, manager)]
             )
-            cb()
+            added = True
 
-    cb = async_dispatcher_connect(
-        hass, f"{SIGNAL_CONNECTED}_{config_entry.unique_id}", setup_entities
+    config_entry.async_on_unload(
+        async_dispatcher_connect(
+            hass, f"{SIGNAL_CONNECTED}_{config_entry.unique_id}", setup_entities
+        )
     )
-    config_entry.async_on_unload(cb)
 
     # The manager may have already connected (and dispatched SIGNAL_CONNECTED)
     # before this platform was forwarded, in which case the signal above was
-    # missed — handle that case directly.
+    # missed; handle that case directly.
     if manager.atv is not None:
         setup_entities(manager.atv)
 

--- a/homeassistant/components/apple_tv/binary_sensor.py
+++ b/homeassistant/components/apple_tv/binary_sensor.py
@@ -39,6 +39,12 @@ async def async_setup_entry(
     )
     config_entry.async_on_unload(cb)
 
+    # The manager may have already connected (and dispatched SIGNAL_CONNECTED)
+    # before this platform was forwarded, in which case the signal above was
+    # missed — handle that case directly.
+    if manager.atv is not None:
+        setup_entities(manager.atv)
+
 
 class AppleTVKeyboardFocused(AppleTVEntity, BinarySensorEntity, KeyboardListener):
     """Binary sensor for Text input focused."""

--- a/tests/components/apple_tv/test_binary_sensor.py
+++ b/tests/components/apple_tv/test_binary_sensor.py
@@ -1,0 +1,62 @@
+"""Tests for Apple TV binary sensor."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pyatv.const import DeviceModel, KeyboardFocusState, Protocol
+
+from homeassistant.components.apple_tv.const import DOMAIN
+from homeassistant.const import CONF_ADDRESS, CONF_NAME
+from homeassistant.core import HomeAssistant
+
+from .common import create_conf, mrp_service
+
+from tests.common import MockConfigEntry
+
+
+async def test_keyboard_focus_entity_created_on_setup(
+    hass: HomeAssistant,
+    mock_async_zeroconf: MagicMock,
+) -> None:
+    """Test the keyboard focus binary sensor is created when the device supports it.
+
+    Regression test for https://github.com/home-assistant/core/issues/170075 — the
+    initial SIGNAL_CONNECTED dispatch happens in async_first_connect (before platform
+    forwarding), so the binary_sensor platform must also handle the already-connected
+    case rather than relying solely on the dispatcher signal.
+    """
+    atv = AsyncMock()
+    atv.close = MagicMock()
+    atv.features = MagicMock()
+    atv.features.in_state = MagicMock(return_value=True)
+    atv.keyboard = AsyncMock()
+    atv.keyboard.text_focus_state = KeyboardFocusState.Unfocused
+    atv.push_updater = MagicMock()
+    atv.device_info.model = DeviceModel.Gen4K
+    atv.device_info.raw_model = "AppleTV6,2"
+    atv.device_info.version = "15.0"
+    atv.device_info.mac = "AA:BB:CC:DD:EE:FF"
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Living Room",
+        unique_id="mrpid",
+        data={
+            CONF_ADDRESS: "127.0.0.1",
+            CONF_NAME: "Living Room",
+            "credentials": {str(Protocol.MRP.value): "mrp_creds"},
+            "identifiers": ["mrpid"],
+        },
+    )
+    entry.add_to_hass(hass)
+
+    scan_result = create_conf("127.0.0.1", "Living Room", mrp_service())
+
+    with (
+        patch("homeassistant.components.apple_tv.scan", return_value=[scan_result]),
+        patch("homeassistant.components.apple_tv.connect", return_value=atv),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.living_room_keyboard_focus")
+    assert state is not None


### PR DESCRIPTION
## Proposed change

The Apple TV keyboard focus `binary_sensor` subscribes to `SIGNAL_CONNECTED`,
but `async_first_connect` already awaits the connection (and dispatches the
signal) before platforms are forwarded, so the initial signal is always missed
on cold start. This matches the symptoms in #170075: most users never see the
entity; one user observed it appearing only after reconnect events.

Verified end-to-end on Apple TV 4K (gen 3), tvOS 26.4: entity appears after
fresh pairing and persists across HA restart.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #170075

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.