### PR TITLE
Avoid junk detection for fjaraskupan by looking for service

### DIFF
--- a/homeassistant/components/fjaraskupan/__init__.py
+++ b/homeassistant/components/fjaraskupan/__init__.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 import logging
 
-from fjaraskupan import Device
+from fjaraskupan import UUID_SERVICE, Device
 
 from homeassistant.components.bluetooth import (
     BluetoothCallbackMatcher,
@@ -37,6 +37,7 @@ PLATFORMS = [
 ]
 
 _LOGGER = logging.getLogger(__name__)
+_UUID = str(UUID_SERVICE).lower()
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: FjaraskupanConfigEntry) -> bool:
@@ -44,42 +45,60 @@ async def async_setup_entry(hass: HomeAssistant, entry: FjaraskupanConfigEntry) 
 
     entry.runtime_data = {}
 
-    def detection_callback(
-        service_info: BluetoothServiceInfoBleak, change: BluetoothChange
+    def data_callback(
+        service_info: BluetoothServiceInfoBleak, change_: BluetoothChange
     ) -> None:
-        if change != BluetoothChange.ADVERTISEMENT:
+        if (data := entry.runtime_data.get(service_info.address)) is None:
+            _LOGGER.debug("Ignoring: %s", service_info)
             return
-        if data := entry.runtime_data.get(service_info.address):
-            _LOGGER.debug("Update: %s", service_info)
-            data.detection_callback(service_info)
-        else:
-            _LOGGER.debug("Detected: %s", service_info)
 
-            device = Device(service_info.device.address)
-            device_info = DeviceInfo(
-                connections={(dr.CONNECTION_BLUETOOTH, service_info.address)},
-                identifiers={(DOMAIN, service_info.address)},
-                manufacturer="Fjäråskupan",
-                name="Fjäråskupan",
-            )
+        _LOGGER.debug("Update: %s", service_info)
+        data.detection_callback(service_info)
 
-            coordinator: FjaraskupanCoordinator = FjaraskupanCoordinator(
-                hass, entry, device, device_info
-            )
-            coordinator.detection_callback(service_info)
+    def detect_callback(
+        service_info: BluetoothServiceInfoBleak, change_: BluetoothChange
+    ) -> None:
+        if service_info.address in entry.runtime_data:
+            return
 
-            entry.runtime_data[service_info.address] = coordinator
-            async_dispatcher_send(
-                hass, f"{DISPATCH_DETECTION}.{entry.entry_id}", coordinator
-            )
+        _LOGGER.debug("Detected: %s", service_info)
+        device = Device(service_info.device.address)
+        device_info = DeviceInfo(
+            connections={(dr.CONNECTION_BLUETOOTH, service_info.address)},
+            identifiers={(DOMAIN, service_info.address)},
+            manufacturer="Fjäråskupan",
+            name="Fjäråskupan",
+        )
+
+        coordinator: FjaraskupanCoordinator = FjaraskupanCoordinator(
+            hass, entry, device, device_info
+        )
+        coordinator.detection_callback(service_info)
+
+        entry.runtime_data[service_info.address] = coordinator
+        async_dispatcher_send(
+            hass, f"{DISPATCH_DETECTION}.{entry.entry_id}", coordinator
+        )
 
     entry.async_on_unload(
         async_register_callback(
             hass,
-            detection_callback,
+            data_callback,
             BluetoothCallbackMatcher(
                 manufacturer_id=20296,
                 manufacturer_data_start=[79, 68, 70, 74, 65, 82],
+                connectable=False,
+            ),
+            BluetoothScanningMode.ACTIVE,
+        )
+    )
+
+    entry.async_on_unload(
+        async_register_callback(
+            hass,
+            detect_callback,
+            BluetoothCallbackMatcher(
+                service_uuid=_UUID,
                 connectable=False,
             ),
             BluetoothScanningMode.ACTIVE,

--- a/homeassistant/components/fjaraskupan/manifest.json
+++ b/homeassistant/components/fjaraskupan/manifest.json
@@ -4,8 +4,7 @@
   "bluetooth": [
     {
       "connectable": false,
-      "manufacturer_data_start": [79, 68, 70, 74, 65, 82],
-      "manufacturer_id": 20296
+      "service_uuid": "77a2bd49-1e5a-4961-bba1-21f34fa4bc7b"
     }
   ],
   "codeowners": ["@elupus"],

--- a/homeassistant/components/gardena_bluetooth/sensor.py
+++ b/homeassistant/components/gardena_bluetooth/sensor.py
@@ -73,7 +73,6 @@ DESCRIPTIONS = (
     GardenaBluetoothSensorEntityDescription(
         key=Valve.activation_reason.unique_id,
         translation_key="activation_reason",
-        state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         device_class=SensorDeviceClass.ENUM,

--- a/homeassistant/components/gardena_bluetooth/sensor.py
+++ b/homeassistant/components/gardena_bluetooth/sensor.py
@@ -76,7 +76,14 @@ DESCRIPTIONS = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
+        device_class=SensorDeviceClass.ENUM,
         char=Valve.activation_reason,
+        get=lambda x: (
+            x.name.lower()
+            if x and isinstance(x, Valve.activation_reason.enum)
+            else None
+        ),
+        options=[member.name.lower() for member in Valve.activation_reason.enum],
     ),
     GardenaBluetoothSensorEntityDescription(
         key=Battery.battery_level.unique_id,
@@ -188,10 +195,51 @@ DESCRIPTIONS = (
         char=EventHistory.error,
         get=lambda x: (
             x.error_code.name.lower()
-            if x and isinstance(x.error_code, EventHistory.error.enum)
+            if x is not None and isinstance(x.error_code, EventHistory.error.enum)
             else None
         ),
         options=[member.name.lower() for member in EventHistory.error.enum],
+    ),
+    GardenaBluetoothSensorEntityDescription(
+        key="valve_activation_reason",
+        translation_key="activation_reason",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.ENUM,
+        char=Valve.activation_reason,
+        get=lambda x: (
+            x.name.lower() if isinstance(x, Valve.activation_reason.enum) else None
+        ),
+        options=[member.name.lower() for member in Valve.activation_reason.enum],
+    ),
+    GardenaBluetoothSensorEntityDescription(
+        key="aqua_contour_activation_reason",
+        translation_key="activation_reason",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.ENUM,
+        char=AquaContourWatering.activation_reason,
+        get=lambda x: (
+            x.name.lower()
+            if isinstance(x, AquaContourWatering.activation_reason.enum)
+            else None
+        ),
+        options=[
+            member.name.lower() for member in AquaContourWatering.activation_reason.enum
+        ],
+    ),
+    GardenaBluetoothSensorEntityDescription(
+        key="aqua_contour_skipped_reason",
+        translation_key="skipped_reason",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.ENUM,
+        char=AquaContourWatering.skipped_reason,
+        get=lambda x: (
+            x.name.lower()
+            if isinstance(x, AquaContourWatering.skipped_reason.enum)
+            else None
+        ),
+        options=[
+            member.name.lower() for member in AquaContourWatering.skipped_reason.enum
+        ],
     ),
     GardenaBluetoothSensorEntityDescription(
         key="aqua_contour_error_timestamp",

--- a/homeassistant/components/gardena_bluetooth/strings.json
+++ b/homeassistant/components/gardena_bluetooth/strings.json
@@ -102,7 +102,13 @@
     },
     "sensor": {
       "activation_reason": {
-        "name": "Activation reason"
+        "name": "Activation reason",
+        "state": {
+          "external": "External",
+          "manual": "Manual",
+          "none": "-",
+          "setup": "Setup"
+        }
       },
       "aqua_contour_error": {
         "name": "Error",
@@ -145,6 +151,30 @@
       },
       "sensor_type": {
         "name": "Sensor type"
+      },
+      "skipped_reason": {
+        "name": "Skipped reason",
+        "state": {
+          "battery_empty": "Battery empty",
+          "charging_cable_plugged": "Charging cable plugged",
+          "contour_data_invalid": "Contour data invalid",
+          "contour_not_active": "Contour not active",
+          "contour_not_enabled_for_position": "Contour not enabled for position",
+          "humidity_sensor": "Humidity sensor",
+          "irrigation_control_changed": "Irrigation control changed",
+          "manual_mode": "Manual mode",
+          "no_water": "No water",
+          "none": "-",
+          "operational_mode_changed": "Operational mode changed",
+          "other_schedule_with_same_start_time": "Other schedule with same start time",
+          "position_changed": "Position changed",
+          "rain_pause": "Rain pause",
+          "rain_sensor": "Rain sensor",
+          "rotation_sensor_error": "Rotation sensor error",
+          "sprinkler_motor_error": "Sprinkler motor error",
+          "valve_motor_error": "Valve motor error",
+          "watering_already_active": "Watering already active"
+        }
       },
       "spray_current_distance": {
         "name": "Current distance"

--- a/homeassistant/components/gardena_bluetooth/strings.json
+++ b/homeassistant/components/gardena_bluetooth/strings.json
@@ -107,6 +107,7 @@
           "external": "External",
           "manual": "Manual",
           "none": "-",
+          "schedule": "Schedule",
           "setup": "Setup"
         }
       },

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -139,15 +139,7 @@ BLUETOOTH: Final[list[dict[str, bool | str | int | list[int]]]] = [
     {
         "connectable": False,
         "domain": "fjaraskupan",
-        "manufacturer_data_start": [
-            79,
-            68,
-            70,
-            74,
-            65,
-            82,
-        ],
-        "manufacturer_id": 20296,
+        "service_uuid": "77a2bd49-1e5a-4961-bba1-21f34fa4bc7b",
     },
     {
         "connectable": True,

--- a/tests/components/fjaraskupan/__init__.py
+++ b/tests/components/fjaraskupan/__init__.py
@@ -9,7 +9,7 @@ COOKER_SERVICE_INFO = BluetoothServiceInfoBleak(
     address="AA:BB:CC:DD:EE:FF",
     rssi=-60,
     manufacturer_data={},
-    service_uuids=[],
+    service_uuids=["77a2bd49-1e5a-4961-bba1-21f34fa4bc7b"],
     service_data={},
     source="local",
     device=generate_ble_device(address="AA:BB:CC:DD:EE:FF", name="COOKERHOOD_FJAR"),

--- a/tests/components/fjaraskupan/test_init.py
+++ b/tests/components/fjaraskupan/test_init.py
@@ -18,7 +18,7 @@ from tests.typing import WebSocketGenerator
 MOCK_SERVICE_INFO = BluetoothServiceInfo(
     address="11:11:11:11:11:11",
     name=DEVICE_NAME,
-    service_uuids=[],
+    service_uuids=["77a2bd49-1e5a-4961-bba1-21f34fa4bc7b"],
     rssi=-60,
     manufacturer_data={ANNOUNCE_MANUFACTURER: b"ODFJAR\x01\x02\x00\x00\x00\x30\x04"},
     service_data={},

--- a/tests/components/gardena_bluetooth/snapshots/test_sensor.ambr
+++ b/tests/components/gardena_bluetooth/snapshots/test_sensor.ambr
@@ -31,6 +31,72 @@
     'state': '45',
   })
 # ---
+# name: test_sensors[aqua_contour][sensor.mock_title_activation_reason-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'none',
+        'manual',
+        'schedule',
+        'external',
+        'setup',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mock_title_activation_reason',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Activation reason',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Activation reason',
+    'platform': 'gardena_bluetooth',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'activation_reason',
+    'unique_id': '00000000-0000-0000-0000-000000000003-aqua_contour_activation_reason',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[aqua_contour][sensor.mock_title_activation_reason-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Mock Title Activation reason',
+      'options': list([
+        'none',
+        'manual',
+        'schedule',
+        'external',
+        'setup',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_activation_reason',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'schedule',
+  })
+# ---
 # name: test_sensors[aqua_contour][sensor.mock_title_battery-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -433,6 +499,100 @@
     'state': '111',
   })
 # ---
+# name: test_sensors[aqua_contour][sensor.mock_title_skipped_reason-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'none',
+        'rain_pause',
+        'humidity_sensor',
+        'rain_sensor',
+        'watering_already_active',
+        'battery_empty',
+        'other_schedule_with_same_start_time',
+        'contour_not_active',
+        'contour_not_enabled_for_position',
+        'contour_data_invalid',
+        'position_changed',
+        'charging_cable_plugged',
+        'manual_mode',
+        'no_water',
+        'valve_motor_error',
+        'sprinkler_motor_error',
+        'rotation_sensor_error',
+        'operational_mode_changed',
+        'irrigation_control_changed',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mock_title_skipped_reason',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Skipped reason',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Skipped reason',
+    'platform': 'gardena_bluetooth',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'skipped_reason',
+    'unique_id': '00000000-0000-0000-0000-000000000003-aqua_contour_skipped_reason',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[aqua_contour][sensor.mock_title_skipped_reason-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Mock Title Skipped reason',
+      'options': list([
+        'none',
+        'rain_pause',
+        'humidity_sensor',
+        'rain_sensor',
+        'watering_already_active',
+        'battery_empty',
+        'other_schedule_with_same_start_time',
+        'contour_not_active',
+        'contour_not_enabled_for_position',
+        'contour_data_invalid',
+        'position_changed',
+        'charging_cable_plugged',
+        'manual_mode',
+        'no_water',
+        'valve_motor_error',
+        'sprinkler_motor_error',
+        'rotation_sensor_error',
+        'operational_mode_changed',
+        'irrigation_control_changed',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_skipped_reason',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'rain_sensor',
+  })
+# ---
 # name: test_sensors[aqua_contour][sensor.mock_title_watering_finished-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -482,6 +642,126 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2023-01-01T01:01:40+00:00',
+  })
+# ---
+# name: test_sensors[timer][sensor.mock_title_activation_reason-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mock_title_activation_reason',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Activation reason',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Activation reason',
+    'platform': 'gardena_bluetooth',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'activation_reason',
+    'unique_id': '00000000-0000-0000-0000-000000000001-98bd0f15-0b0e-421a-84e5-ddbf75dc6de4',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[timer][sensor.mock_title_activation_reason-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Mock Title Activation reason',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_activation_reason',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'schedule',
+  })
+# ---
+# name: test_sensors[timer][sensor.mock_title_activation_reason_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'none',
+        'manual',
+        'schedule',
+        'external',
+        'setup',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mock_title_activation_reason_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Activation reason',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Activation reason',
+    'platform': 'gardena_bluetooth',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'activation_reason',
+    'unique_id': '00000000-0000-0000-0000-000000000001-valve_activation_reason',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[timer][sensor.mock_title_activation_reason_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Mock Title Activation reason',
+      'options': list([
+        'none',
+        'manual',
+        'schedule',
+        'external',
+        'setup',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_activation_reason_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'schedule',
   })
 # ---
 # name: test_sensors[timer][sensor.mock_title_battery-entry]

--- a/tests/components/gardena_bluetooth/snapshots/test_sensor.ambr
+++ b/tests/components/gardena_bluetooth/snapshots/test_sensor.ambr
@@ -651,7 +651,13 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'options': list([
+        'none',
+        'manual',
+        'schedule',
+        'external',
+        'setup',
+      ]),
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -688,7 +694,13 @@
     'attributes': ReadOnlyDict({
       'device_class': 'enum',
       'friendly_name': 'Mock Title Activation reason',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'options': list([
+        'none',
+        'manual',
+        'schedule',
+        'external',
+        'setup',
+      ]),
     }),
     'context': <ANY>,
     'entity_id': 'sensor.mock_title_activation_reason',

--- a/tests/components/gardena_bluetooth/test_sensor.py
+++ b/tests/components/gardena_bluetooth/test_sensor.py
@@ -14,7 +14,7 @@ from gardena_bluetooth.const import (
     Spray,
     Valve,
 )
-from gardena_bluetooth.parse import ErrorData
+from gardena_bluetooth.parse import ActivationReason, ErrorData, SkipReason
 from habluetooth import BluetoothServiceInfo
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -80,6 +80,9 @@ async def test_setup(
             {
                 Battery.battery_level.uuid: Battery.battery_level.encode(100),
                 Valve.remaining_open_time.uuid: Valve.remaining_open_time.encode(10),
+                Valve.activation_reason.uuid: Valve.activation_reason.encode(
+                    ActivationReason.SCHEDULE
+                ),
             },
             id="timer",
         ),
@@ -100,6 +103,12 @@ async def test_setup(
                 ),
                 AquaContourWatering.remaining_watering_time.uuid: AquaContourWatering.remaining_watering_time.encode(
                     100
+                ),
+                AquaContourWatering.activation_reason.uuid: AquaContourWatering.activation_reason.encode(
+                    ActivationReason.SCHEDULE
+                ),
+                AquaContourWatering.skipped_reason.uuid: AquaContourWatering.skipped_reason.encode(
+                    SkipReason.RAIN_SENSOR
                 ),
             },
             id="aqua_contour",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Only add new fans when we see the advertisement service in the data.

Some interaction between these fans and multiple bluetooth proxies
causes random addresses with partial manufacture data to be seen.

To avoid these being added as devices, require a service id to be
seen before adding the device.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
