### PR TITLE
Require service on fjaraskupan to detect it

### DIFF
--- a/homeassistant/components/fjaraskupan/__init__.py
+++ b/homeassistant/components/fjaraskupan/__init__.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 import logging
 
-from fjaraskupan import Device
+from fjaraskupan import UUID_SERVICE, Device
 
 from homeassistant.components.bluetooth import (
     BluetoothCallbackMatcher,
@@ -37,6 +37,7 @@ PLATFORMS = [
 ]
 
 _LOGGER = logging.getLogger(__name__)
+_UUID = str(UUID_SERVICE).lower()
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: FjaraskupanConfigEntry) -> bool:
@@ -44,42 +45,60 @@ async def async_setup_entry(hass: HomeAssistant, entry: FjaraskupanConfigEntry) 
 
     entry.runtime_data = {}
 
-    def detection_callback(
-        service_info: BluetoothServiceInfoBleak, change: BluetoothChange
+    def data_callback(
+        service_info: BluetoothServiceInfoBleak, change_: BluetoothChange
     ) -> None:
-        if change != BluetoothChange.ADVERTISEMENT:
+        if (data := entry.runtime_data.get(service_info.address)) is None:
+            _LOGGER.debug("Ignoring: %s", service_info)
             return
-        if data := entry.runtime_data.get(service_info.address):
-            _LOGGER.debug("Update: %s", service_info)
-            data.detection_callback(service_info)
-        else:
-            _LOGGER.debug("Detected: %s", service_info)
 
-            device = Device(service_info.device.address)
-            device_info = DeviceInfo(
-                connections={(dr.CONNECTION_BLUETOOTH, service_info.address)},
-                identifiers={(DOMAIN, service_info.address)},
-                manufacturer="Fjäråskupan",
-                name="Fjäråskupan",
-            )
+        _LOGGER.debug("Update: %s", service_info)
+        data.detection_callback(service_info)
 
-            coordinator: FjaraskupanCoordinator = FjaraskupanCoordinator(
-                hass, entry, device, device_info
-            )
-            coordinator.detection_callback(service_info)
+    def detect_callback(
+        service_info: BluetoothServiceInfoBleak, change_: BluetoothChange
+    ) -> None:
+        if service_info.address in entry.runtime_data:
+            return
 
-            entry.runtime_data[service_info.address] = coordinator
-            async_dispatcher_send(
-                hass, f"{DISPATCH_DETECTION}.{entry.entry_id}", coordinator
-            )
+        _LOGGER.debug("Detected: %s", service_info)
+        device = Device(service_info.device.address)
+        device_info = DeviceInfo(
+            connections={(dr.CONNECTION_BLUETOOTH, service_info.address)},
+            identifiers={(DOMAIN, service_info.address)},
+            manufacturer="Fjäråskupan",
+            name="Fjäråskupan",
+        )
+
+        coordinator: FjaraskupanCoordinator = FjaraskupanCoordinator(
+            hass, entry, device, device_info
+        )
+        coordinator.detection_callback(service_info)
+
+        entry.runtime_data[service_info.address] = coordinator
+        async_dispatcher_send(
+            hass, f"{DISPATCH_DETECTION}.{entry.entry_id}", coordinator
+        )
 
     entry.async_on_unload(
         async_register_callback(
             hass,
-            detection_callback,
+            data_callback,
             BluetoothCallbackMatcher(
                 manufacturer_id=20296,
                 manufacturer_data_start=[79, 68, 70, 74, 65, 82],
+                connectable=False,
+            ),
+            BluetoothScanningMode.ACTIVE,
+        )
+    )
+
+    entry.async_on_unload(
+        async_register_callback(
+            hass,
+            detect_callback,
+            BluetoothCallbackMatcher(
+                service_uuid=_UUID,
                 connectable=False,
             ),
             BluetoothScanningMode.ACTIVE,

--- a/homeassistant/components/fjaraskupan/config_flow.py
+++ b/homeassistant/components/fjaraskupan/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for Fjäråskupan integration."""
 
-from fjaraskupan import device_filter
+from fjaraskupan import UUID_SERVICE
 
 from homeassistant.components.bluetooth import async_discovered_service_info
 from homeassistant.core import HomeAssistant
@@ -15,7 +15,8 @@ async def _async_has_devices(hass: HomeAssistant) -> bool:
     service_infos = async_discovered_service_info(hass)
 
     for service_info in service_infos:
-        if device_filter(service_info.device, service_info.advertisement):
+        uuids = service_info.service_uuids
+        if str(UUID_SERVICE) in uuids:
             return True
 
     return False

--- a/homeassistant/components/fjaraskupan/manifest.json
+++ b/homeassistant/components/fjaraskupan/manifest.json
@@ -4,8 +4,7 @@
   "bluetooth": [
     {
       "connectable": false,
-      "manufacturer_data_start": [79, 68, 70, 74, 65, 82],
-      "manufacturer_id": 20296
+      "service_uuid": "77a2bd49-1e5a-4961-bba1-21f34fa4bc7b"
     }
   ],
   "codeowners": ["@elupus"],

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -139,15 +139,7 @@ BLUETOOTH: Final[list[dict[str, bool | str | int | list[int]]]] = [
     {
         "connectable": False,
         "domain": "fjaraskupan",
-        "manufacturer_data_start": [
-            79,
-            68,
-            70,
-            74,
-            65,
-            82,
-        ],
-        "manufacturer_id": 20296,
+        "service_uuid": "77a2bd49-1e5a-4961-bba1-21f34fa4bc7b",
     },
     {
         "connectable": True,

--- a/tests/components/fjaraskupan/__init__.py
+++ b/tests/components/fjaraskupan/__init__.py
@@ -9,7 +9,7 @@ COOKER_SERVICE_INFO = BluetoothServiceInfoBleak(
     address="AA:BB:CC:DD:EE:FF",
     rssi=-60,
     manufacturer_data={},
-    service_uuids=[],
+    service_uuids=["77a2bd49-1e5a-4961-bba1-21f34fa4bc7b"],
     service_data={},
     source="local",
     device=generate_ble_device(address="AA:BB:CC:DD:EE:FF", name="COOKERHOOD_FJAR"),

--- a/tests/components/fjaraskupan/__init__.py
+++ b/tests/components/fjaraskupan/__init__.py
@@ -1,11 +1,13 @@
 """Tests for the Fjäråskupan integration."""
 
+from fjaraskupan import ANNOUNCE_MANUFACTURER, DEVICE_NAME
+
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 
 from tests.components.bluetooth import generate_advertisement_data, generate_ble_device
 
 COOKER_SERVICE_INFO = BluetoothServiceInfoBleak(
-    name="COOKERHOOD_FJAR",
+    name=DEVICE_NAME,
     address="AA:BB:CC:DD:EE:FF",
     rssi=-60,
     manufacturer_data={},
@@ -13,6 +15,21 @@ COOKER_SERVICE_INFO = BluetoothServiceInfoBleak(
     service_data={},
     source="local",
     device=generate_ble_device(address="AA:BB:CC:DD:EE:FF", name="COOKERHOOD_FJAR"),
+    advertisement=generate_advertisement_data(),
+    time=0,
+    connectable=True,
+    tx_power=-127,
+)
+
+COOKER_SERVICE_INFO_DATA = BluetoothServiceInfoBleak(
+    name=DEVICE_NAME,
+    address="AA:BB:CC:DD:EE:FF",
+    rssi=-60,
+    manufacturer_data={ANNOUNCE_MANUFACTURER: b"ODFJAR\x01\x02\x00\x00\x00\x30\x04"},
+    service_uuids=[],
+    service_data={},
+    source="local",
+    device=generate_ble_device(address="AA:BB:CC:DD:EE:FF", name=DEVICE_NAME),
     advertisement=generate_advertisement_data(),
     time=0,
     connectable=True,

--- a/tests/components/fjaraskupan/test_config_flow.py
+++ b/tests/components/fjaraskupan/test_config_flow.py
@@ -10,7 +10,9 @@ from homeassistant.components.fjaraskupan.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from . import COOKER_SERVICE_INFO
+from . import COOKER_SERVICE_INFO, COOKER_SERVICE_INFO_DATA
+
+from tests.components.bluetooth import inject_bluetooth_service_info
 
 
 @pytest.fixture(name="mock_setup_entry", autouse=True)
@@ -60,3 +62,36 @@ async def test_scan_no_devices(hass: HomeAssistant) -> None:
 
         assert result["type"] is FlowResultType.ABORT
         assert result["reason"] == "no_devices_found"
+
+
+async def test_discovery(hass: HomeAssistant) -> None:
+    """Test we get the form."""
+
+    inject_bluetooth_service_info(
+        hass,
+        COOKER_SERVICE_INFO,
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    result = next(iter(hass.config_entries.flow.async_progress_by_handler(DOMAIN)))
+    assert result["step_id"] == "confirm"
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Fjäråskupan"
+    assert result["data"] == {}
+
+
+async def test_discovery_ignored_without_service(hass: HomeAssistant) -> None:
+    """Test we don't start discovery on only manufacturer data since that can be invalid."""
+
+    inject_bluetooth_service_info(
+        hass,
+        COOKER_SERVICE_INFO_DATA,
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    result = next(
+        iter(hass.config_entries.flow.async_progress_by_handler(DOMAIN)), None
+    )
+    assert result is None

--- a/tests/components/fjaraskupan/test_init.py
+++ b/tests/components/fjaraskupan/test_init.py
@@ -18,7 +18,7 @@ from tests.typing import WebSocketGenerator
 MOCK_SERVICE_INFO = BluetoothServiceInfo(
     address="11:11:11:11:11:11",
     name=DEVICE_NAME,
-    service_uuids=[],
+    service_uuids=["77a2bd49-1e5a-4961-bba1-21f34fa4bc7b"],
     rssi=-60,
     manufacturer_data={ANNOUNCE_MANUFACTURER: b"ODFJAR\x01\x02\x00\x00\x00\x30\x04"},
     service_data={},

--- a/tests/components/fjaraskupan/test_init.py
+++ b/tests/components/fjaraskupan/test_init.py
@@ -15,10 +15,21 @@ from tests.components.bluetooth import (
 )
 from tests.typing import WebSocketGenerator
 
-MOCK_SERVICE_INFO = BluetoothServiceInfo(
+MOCK_SERVICE_INFO_DISCOVERY = BluetoothServiceInfo(
     address="11:11:11:11:11:11",
     name=DEVICE_NAME,
     service_uuids=["77a2bd49-1e5a-4961-bba1-21f34fa4bc7b"],
+    rssi=-60,
+    manufacturer_data={},
+    service_data={},
+    source="local",
+)
+
+
+MOCK_SERVICE_INFO = BluetoothServiceInfo(
+    address="11:11:11:11:11:11",
+    name=DEVICE_NAME,
+    service_uuids=[],
     rssi=-60,
     manufacturer_data={ANNOUNCE_MANUFACTURER: b"ODFJAR\x01\x02\x00\x00\x00\x30\x04"},
     service_data={},
@@ -40,16 +51,30 @@ async def test_setup(
 
     inject_bluetooth_service_info(
         hass,
-        MOCK_SERVICE_INFO,
+        MOCK_SERVICE_INFO_DISCOVERY,
     )
 
     await hass.async_block_till_done()
     device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, MOCK_SERVICE_INFO.address)}
+        identifiers={(DOMAIN, MOCK_SERVICE_INFO_DISCOVERY.address)}
     )
     assert device_entry is not None
     assert device_entry.manufacturer == "Fjäråskupan"
     assert device_entry.name == "Fjäråskupan"
+
+    state = hass.states.get("fan.fjaraskupan")
+    assert state
+    assert state.state == "off"
+
+    inject_bluetooth_service_info(
+        hass,
+        MOCK_SERVICE_INFO,
+    )
+
+    await hass.async_block_till_done()
+    state = hass.states.get("fan.fjaraskupan")
+    assert state
+    assert state.state == "on"
 
 
 async def test_remove_device(
@@ -67,11 +92,11 @@ async def test_remove_device(
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id) is True
 
-    inject_bluetooth_service_info(hass, MOCK_SERVICE_INFO)
+    inject_bluetooth_service_info(hass, MOCK_SERVICE_INFO_DISCOVERY)
 
     await hass.async_block_till_done()
     device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, MOCK_SERVICE_INFO.address)}
+        identifiers={(DOMAIN, MOCK_SERVICE_INFO_DISCOVERY.address)}
     )
     assert device_entry
 

--- a/tests/components/fjaraskupan/test_init.py
+++ b/tests/components/fjaraskupan/test_init.py
@@ -77,6 +77,30 @@ async def test_setup(
     assert state.state == "on"
 
 
+async def test_setup_ignore_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test setup does not create a device before we see service."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id) is True
+
+    inject_bluetooth_service_info(
+        hass,
+        MOCK_SERVICE_INFO,
+    )
+
+    await hass.async_block_till_done()
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, MOCK_SERVICE_INFO_DISCOVERY.address)}
+    )
+    assert device_entry is None
+
+
 async def test_remove_device(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Only add new fans when we see the advertisement service in the data.

Some interaction between these fans and multiple bluetooth proxies
causes random addresses with partial manufacture data to be seen.

To avoid these being added as devices, require a service id to be
seen before adding the device.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
