### PR TITLE
Add nest.set_fan_timer service action

### DIFF
--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -71,6 +71,7 @@ from .media_source import (
     async_get_media_source_devices,
     async_get_transcoder,
 )
+from .services import async_setup_services
 from .types import DevicesAddedListener, NestConfigEntry, NestData
 
 _LOGGER = logging.getLogger(__name__)
@@ -115,6 +116,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up Nest components with dispatch between old/new flows."""
     hass.http.register_view(NestEventMediaView(hass))
     hass.http.register_view(NestEventMediaThumbnailView(hass))
+    async_setup_services(hass)
     return True
 
 

--- a/homeassistant/components/nest/climate.py
+++ b/homeassistant/components/nest/climate.py
@@ -68,7 +68,7 @@ FAN_MODE_MAP = {
 FAN_INV_MODE_MAP = {v: k for k, v in FAN_MODE_MAP.items()}
 FAN_INV_MODES = list(FAN_INV_MODE_MAP)
 
-MAX_FAN_DURATION = 43200  # 15 hours is the max in the SDM API
+MAX_FAN_DURATION = 43200  # 12 hours is the max in the SDM API
 MIN_TEMP = 10
 MAX_TEMP = 32
 MIN_TEMP_RANGE = 1.66667
@@ -348,7 +348,7 @@ class ThermostatEntity(ClimateEntity):
 
     async def async_set_fan_timer(self, duration: timedelta) -> None:
         """Set a short term fan timer."""
-        if FanTrait.NAME not in self._device.traits:
+        if not self.supported_features & ClimateEntityFeature.FAN_MODE:
             raise HomeAssistantError(f"Entity {self.entity_id} does not support fan")
 
         if self.hvac_mode == HVACMode.OFF:

--- a/homeassistant/components/nest/climate.py
+++ b/homeassistant/components/nest/climate.py
@@ -1,5 +1,6 @@
 """Support for Google Nest SDM climate devices."""
 
+from datetime import timedelta
 from typing import Any, cast
 
 from google_nest_sdm.device import Device
@@ -343,4 +344,28 @@ class ThermostatEntity(ClimateEntity):
         except ApiException as err:
             raise HomeAssistantError(
                 f"Error setting {self.entity_id} fan mode to {fan_mode}: {err}"
+            ) from err
+
+    async def async_set_fan_timer(self, duration: timedelta) -> None:
+        """Set a short term fan timer."""
+        if FanTrait.NAME not in self._device.traits:
+            raise HomeAssistantError(f"Entity {self.entity_id} does not support fan")
+
+        if self.hvac_mode == HVACMode.OFF:
+            raise HomeAssistantError(
+                f"Cannot turn on fan for {self.entity_id}, please set an HVAC mode (e.g. heat/cool) first"
+            )
+
+        seconds = int(duration.total_seconds())
+        if seconds <= 0 or seconds > MAX_FAN_DURATION:
+            raise ValueError(
+                f"Duration {seconds} for {self.entity_id} must be between 1 and {MAX_FAN_DURATION} seconds"
+            )
+
+        trait = self._device.traits[FanTrait.NAME]
+        try:
+            await trait.set_timer(FAN_INV_MODE_MAP[FAN_ON], duration=seconds)
+        except ApiException as err:
+            raise HomeAssistantError(
+                f"Error setting {self.entity_id} fan timer: {err}"
             ) from err

--- a/homeassistant/components/nest/icons.json
+++ b/homeassistant/components/nest/icons.json
@@ -1,0 +1,7 @@
+{
+  "services": {
+    "set_fan_timer": {
+      "service": "mdi:fan-clock"
+    }
+  }
+}

--- a/homeassistant/components/nest/services.py
+++ b/homeassistant/components/nest/services.py
@@ -1,0 +1,26 @@
+"""Define services for the Nest integration."""
+
+import voluptuous as vol
+
+from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv, service
+
+from .const import DOMAIN
+
+SERVICE_SET_FAN_TIMER = "set_fan_timer"
+
+
+@callback
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Register services for the Nest integration."""
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVICE_SET_FAN_TIMER,
+        entity_domain=CLIMATE_DOMAIN,
+        schema={
+            vol.Required("duration"): cv.time_period,
+        },
+        func="async_set_fan_timer",
+    )

--- a/homeassistant/components/nest/services.py
+++ b/homeassistant/components/nest/services.py
@@ -2,7 +2,10 @@
 
 import voluptuous as vol
 
-from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.components.climate import (
+    DOMAIN as CLIMATE_DOMAIN,
+    ClimateEntityFeature,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, service
 
@@ -23,4 +26,5 @@ def async_setup_services(hass: HomeAssistant) -> None:
             vol.Required("duration"): cv.time_period,
         },
         func="async_set_fan_timer",
+        required_features=[ClimateEntityFeature.FAN_MODE],
     )

--- a/homeassistant/components/nest/services.yaml
+++ b/homeassistant/components/nest/services.yaml
@@ -3,6 +3,8 @@ set_fan_timer:
     entity:
       domain: climate
       integration: nest
+      supported_features:
+        - climate.ClimateEntityFeature.FAN_MODE
   fields:
     duration:
       required: true

--- a/homeassistant/components/nest/services.yaml
+++ b/homeassistant/components/nest/services.yaml
@@ -1,0 +1,10 @@
+set_fan_timer:
+  target:
+    entity:
+      domain: climate
+      integration: nest
+  fields:
+    duration:
+      required: true
+      selector:
+        duration:

--- a/homeassistant/components/nest/strings.json
+++ b/homeassistant/components/nest/strings.json
@@ -163,5 +163,17 @@
         "create_new_topic": "Create new topic"
       }
     }
+  },
+  "services": {
+    "set_fan_timer": {
+      "description": "Sets the fan to run for a specific duration.",
+      "fields": {
+        "duration": {
+          "description": "The duration the fan should run for.",
+          "name": "Duration"
+        }
+      },
+      "name": "Set fan timer"
+    }
   }
 }

--- a/tests/components/nest/test_climate.py
+++ b/tests/components/nest/test_climate.py
@@ -39,7 +39,11 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.exceptions import (
+    HomeAssistantError,
+    ServiceNotSupported,
+    ServiceValidationError,
+)
 
 from .common import (
     DEVICE_COMMAND,
@@ -1180,7 +1184,7 @@ async def test_set_fan_timer_no_fan(
     )
     await setup_platform()
 
-    with pytest.raises(HomeAssistantError, match="does not support fan"):
+    with pytest.raises(ServiceNotSupported, match="does not support action"):
         await hass.services.async_call(
             DOMAIN,
             "set_fan_timer",
@@ -1246,7 +1250,7 @@ async def test_set_fan_timer_invalid_duration(
     )
     await setup_platform()
 
-    # Duration too long (over 15 hours)
+    # Duration too long (over 12 hours)
     with pytest.raises(ValueError, match="must be between 1 and 43200 seconds"):
         await hass.services.async_call(
             DOMAIN,

--- a/tests/components/nest/test_climate.py
+++ b/tests/components/nest/test_climate.py
@@ -44,6 +44,7 @@ from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from .common import (
     DEVICE_COMMAND,
     DEVICE_ID,
+    DOMAIN,
     CreateDevice,
     PlatformSetup,
     create_nest_event,
@@ -1083,6 +1084,83 @@ async def test_thermostat_set_fan(
             "timerMode": "ON",
         },
     }
+
+
+async def test_set_fan_timer(
+    hass: HomeAssistant,
+    setup_platform: PlatformSetup,
+    auth: FakeAuth,
+    create_device: CreateDevice,
+) -> None:
+    """Test the set_fan_timer service."""
+    create_device.create(
+        {
+            "sdm.devices.traits.Fan": {
+                "timerMode": "OFF",
+            },
+            "sdm.devices.traits.ThermostatHvac": {"status": "HEATING"},
+            "sdm.devices.traits.ThermostatMode": {
+                "availableModes": ["HEAT", "OFF"],
+                "mode": "HEAT",
+            },
+            "sdm.devices.traits.TemperatureTrait": {"ambientTemperatureCelsius": 20.0},
+        }
+    )
+    await setup_platform()
+
+    # Call the set_fan_timer service
+    await hass.services.async_call(
+        DOMAIN,
+        "set_fan_timer",
+        {
+            "entity_id": "climate.my_thermostat",
+            "duration": {"minutes": 15},
+        },
+        blocking=True,
+    )
+
+    assert auth.method == "post"
+    assert auth.url == DEVICE_COMMAND
+    assert auth.json == {
+        "command": "sdm.devices.commands.Fan.SetTimer",
+        "params": {
+            "duration": "900s",
+            "timerMode": "ON",
+        },
+    }
+
+
+async def test_set_fan_timer_hvac_off(
+    hass: HomeAssistant,
+    setup_platform: PlatformSetup,
+    auth: FakeAuth,
+    create_device: CreateDevice,
+) -> None:
+    """Test the set_fan_timer service when HVAC is off."""
+    create_device.create(
+        {
+            "sdm.devices.traits.Fan": {
+                "timerMode": "OFF",
+            },
+            "sdm.devices.traits.ThermostatHvac": {"status": "OFF"},
+            "sdm.devices.traits.ThermostatMode": {
+                "availableModes": ["HEAT", "OFF"],
+                "mode": "OFF",
+            },
+        }
+    )
+    await setup_platform()
+
+    with pytest.raises(HomeAssistantError, match="Cannot turn on fan"):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_fan_timer",
+            {
+                "entity_id": "climate.my_thermostat",
+                "duration": {"minutes": 15},
+            },
+            blocking=True,
+        )
 
 
 async def test_thermostat_set_fan_when_off(

--- a/tests/components/nest/test_climate.py
+++ b/tests/components/nest/test_climate.py
@@ -1163,6 +1163,114 @@ async def test_set_fan_timer_hvac_off(
         )
 
 
+async def test_set_fan_timer_no_fan(
+    hass: HomeAssistant,
+    setup_platform: PlatformSetup,
+    create_device: CreateDevice,
+) -> None:
+    """Test the set_fan_timer service when device does not support fan."""
+    create_device.create(
+        {
+            "sdm.devices.traits.ThermostatHvac": {"status": "HEATING"},
+            "sdm.devices.traits.ThermostatMode": {
+                "availableModes": ["HEAT", "OFF"],
+                "mode": "HEAT",
+            },
+        }
+    )
+    await setup_platform()
+
+    with pytest.raises(HomeAssistantError, match="does not support fan"):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_fan_timer",
+            {
+                "entity_id": "climate.my_thermostat",
+                "duration": {"minutes": 15},
+            },
+            blocking=True,
+        )
+
+
+async def test_set_fan_timer_api_error(
+    hass: HomeAssistant,
+    setup_platform: PlatformSetup,
+    auth: FakeAuth,
+    create_device: CreateDevice,
+) -> None:
+    """Test the set_fan_timer service with an API error."""
+    create_device.create(
+        {
+            "sdm.devices.traits.Fan": {
+                "timerMode": "OFF",
+            },
+            "sdm.devices.traits.ThermostatHvac": {"status": "HEATING"},
+            "sdm.devices.traits.ThermostatMode": {
+                "availableModes": ["HEAT", "OFF"],
+                "mode": "HEAT",
+            },
+        }
+    )
+    await setup_platform()
+
+    auth.responses = [aiohttp.web.Response(status=HTTPStatus.INTERNAL_SERVER_ERROR)]
+    with pytest.raises(HomeAssistantError, match="Error setting .* fan timer"):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_fan_timer",
+            {
+                "entity_id": "climate.my_thermostat",
+                "duration": {"minutes": 15},
+            },
+            blocking=True,
+        )
+
+
+async def test_set_fan_timer_invalid_duration(
+    hass: HomeAssistant,
+    setup_platform: PlatformSetup,
+    create_device: CreateDevice,
+) -> None:
+    """Test the set_fan_timer service with invalid durations."""
+    create_device.create(
+        {
+            "sdm.devices.traits.Fan": {
+                "timerMode": "OFF",
+            },
+            "sdm.devices.traits.ThermostatHvac": {"status": "HEATING"},
+            "sdm.devices.traits.ThermostatMode": {
+                "availableModes": ["HEAT", "OFF"],
+                "mode": "HEAT",
+            },
+        }
+    )
+    await setup_platform()
+
+    # Duration too long (over 15 hours)
+    with pytest.raises(ValueError, match="must be between 1 and 43200 seconds"):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_fan_timer",
+            {
+                "entity_id": "climate.my_thermostat",
+                "duration": {"hours": 16},
+            },
+            blocking=True,
+        )
+
+    # Duration zero
+    with pytest.raises(ValueError, match="must be between 1 and 43200 seconds"):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_fan_timer",
+            {
+                "entity_id": "climate.my_thermostat",
+                "duration": {"seconds": 0},
+            },
+            blocking=True,
+        )
+
+
 async def test_thermostat_set_fan_when_off(
     hass: HomeAssistant,
     setup_platform: PlatformSetup,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `nest.set_fan_timer` action. It allows users to trigger the thermostat fan for a specific duration, mapping directly to the `sdm.devices.commands.Fan.SetTimer` command provided by the Nest SDM API.

The standard `climate.set_fan_mode` service in Home Assistant is limited to toggling the fan state (e.g., on or off) but does not support a duration parameter. Currently, the Nest integration hardcodes the "ON" mode to 12 hours (the API maximum), requiring users to create a second automation or timer to turn it off.

This implementation was motivated by a real-world failure: when a Nest thermostat went offline, a "turn fan off" automation failed to execute, causing the fan to run for several hours unnecessarily. By using the API-native timer, the "off" instruction is handled by the Nest hardware itself once the duration expires, making the fan control much more robust against temporary network or integration issues.

This "Custom Service" approach for entity-specific timers is consistent with several other Home Assistant integrations, including:
- Saunum: Uses `saunum.start_session` with a fan_duration.
- Modern Forms: Uses `modern_forms.set_fan_sleep_timer`.
- Snooz: Uses `snooz.transition_on` with a duration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45316
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
