### PR TITLE
Make ConditionError a non dataclass

### DIFF
--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -1,7 +1,6 @@
 """The exceptions used by Home Assistant."""
 
 from collections.abc import Callable, Generator, Sequence
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from aiohttp import ClientResponse, ClientResponseError, RequestInfo
@@ -127,11 +126,13 @@ class TemplateError(HomeAssistantError):
             super().__init__(f"{exception.__class__.__name__}: {exception}")
 
 
-@dataclass(slots=True)
 class ConditionError(HomeAssistantError):
     """Error during condition evaluation."""
 
-    type: str
+    def __init__(self, type: str) -> None:
+        """Initialize condition error."""
+        super().__init__()
+        self.type = type
 
     @staticmethod
     def _indent(indent: int, message: str) -> str:
@@ -147,28 +148,45 @@ class ConditionError(HomeAssistantError):
         return "\n".join(list(self.output(indent=0)))
 
 
-@dataclass(slots=True)
 class ConditionErrorMessage(ConditionError):
     """Condition error message."""
 
-    # A message describing this error
-    message: str
+    def __init__(self, type: str, message: str) -> None:
+        """Initialize condition error with a message.
+
+        Args:
+            message: A message describing the error.
+        """
+        super().__init__(type)
+        self.message = message
 
     def output(self, indent: int) -> Generator[str]:
         """Yield an indented representation."""
         yield self._indent(indent, f"In '{self.type}' condition: {self.message}")
 
 
-@dataclass(slots=True)
 class ConditionErrorIndex(ConditionError):
     """Condition error with index."""
 
-    # The zero-based index of the failed condition, for conditions with multiple parts
-    index: int
-    # The total number of parts in this condition, including non-failed parts
-    total: int
-    # The error that this error wraps
-    error: ConditionError
+    def __init__(
+        self,
+        type: str,
+        *,
+        index: int,
+        total: int,
+        error: ConditionError,
+    ) -> None:
+        """Initialize condition error with index.
+
+        Args:
+            index: The zero-based index of the failed condition, for conditions with multiple parts.
+            total: The total number of parts in this condition, including non-failed parts.
+            error: The error that this error wraps.
+        """
+        super().__init__(type)
+        self.index = index
+        self.total = total
+        self.error = error
 
     def output(self, indent: int) -> Generator[str]:
         """Yield an indented representation."""
@@ -182,12 +200,17 @@ class ConditionErrorIndex(ConditionError):
         yield from self.error.output(indent + 1)
 
 
-@dataclass(slots=True)
 class ConditionErrorContainer(ConditionError):
     """Condition error with subconditions."""
 
-    # List of ConditionErrors that this error wraps
-    errors: Sequence[ConditionError]
+    def __init__(self, type: str, *, errors: Sequence[ConditionError]) -> None:
+        """Initialize condition error container.
+
+        Args:
+            errors: List of ConditionErrors that this error wraps.
+        """
+        super().__init__(type)
+        self.errors = errors
 
     def output(self, indent: int) -> Generator[str]:
         """Yield an indented representation."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make `ConditionError` a non dataclass and add `__init__` methods to replace the automatically generated ones.

Rationale: The automatically generated `__init__` does not call super, which is required for descendants of `HomeAssistantError`.

Side note: It's unfortunate this was not caught by pylint, which otherwise raises `super-init-not-called` if children don't call super.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
