### PR TITLE
Add FlowSpeech integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -554,6 +554,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/firmata/ @DaAwesomeP
 /homeassistant/components/fish_audio/ @noambav
 /tests/components/fish_audio/ @noambav
+/homeassistant/components/flowspeech/ @hengyin1
+/tests/components/flowspeech/ @hengyin1
 /homeassistant/components/fitbit/ @allenporter
 /tests/components/fitbit/ @allenporter
 /homeassistant/components/fivem/ @Sander0542

--- a/homeassistant/components/flowspeech/__init__.py
+++ b/homeassistant/components/flowspeech/__init__.py
@@ -1,0 +1,52 @@
+"""The FlowSpeech integration."""
+
+from flowspeech_sdk import (
+    FlowSpeechAuthError,
+    FlowSpeechClient,
+    FlowSpeechConnectionError,
+    FlowSpeechError,
+)
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+
+from .const import CONF_API_KEY
+from .types import FlowSpeechConfigEntry
+
+PLATFORMS: list[Platform] = [Platform.TTS]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: FlowSpeechConfigEntry
+) -> bool:
+    """Set up FlowSpeech from a config entry."""
+    client = FlowSpeechClient(api_key=entry.data[CONF_API_KEY])
+
+    try:
+        await hass.async_add_executor_job(client.get_quota)
+    except FlowSpeechAuthError as exc:
+        raise ConfigEntryAuthFailed(f"Invalid FlowSpeech API key: {exc}") from exc
+    except FlowSpeechConnectionError as exc:
+        raise ConfigEntryNotReady(f"Cannot connect to FlowSpeech: {exc}") from exc
+    except FlowSpeechError as exc:
+        raise ConfigEntryNotReady(f"FlowSpeech setup failed: {exc}") from exc
+
+    entry.runtime_data = client
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
+    return True
+
+
+async def _async_update_listener(
+    hass: HomeAssistant, entry: FlowSpeechConfigEntry
+) -> None:
+    """Handle options update."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_unload_entry(
+    hass: HomeAssistant, entry: FlowSpeechConfigEntry
+) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/flowspeech/config_flow.py
+++ b/homeassistant/components/flowspeech/config_flow.py
@@ -1,0 +1,101 @@
+"""Config flow for the FlowSpeech integration."""
+
+from typing import Any
+
+from flowspeech_sdk import (
+    FlowSpeechAuthError,
+    FlowSpeechClient,
+    FlowSpeechConnectionError,
+    FlowSpeechError,
+)
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+
+from .const import (
+    API_KEYS_URL,
+    CONF_API_KEY,
+    CONF_VOICE,
+    DEFAULT_VOICE,
+    DOMAIN,
+    SIGNUP_URL,
+)
+
+
+def _schema(
+    api_key: str | None = None,
+    voice: str | None = None,
+) -> vol.Schema:
+    """Return config-flow schema."""
+    return vol.Schema(
+        {
+            vol.Required(CONF_API_KEY, default=api_key or vol.UNDEFINED): str,
+            vol.Optional(CONF_VOICE, default=voice or DEFAULT_VOICE): str,
+        }
+    )
+
+
+async def _validate_input(hass, user_input: dict[str, Any]) -> None:
+    """Validate FlowSpeech credentials."""
+    client = FlowSpeechClient(api_key=user_input[CONF_API_KEY])
+    try:
+        await hass.async_add_executor_job(client.get_quota)
+    except FlowSpeechAuthError as exc:
+        raise InvalidAuth from exc
+    except FlowSpeechConnectionError as exc:
+        raise CannotConnect from exc
+    except FlowSpeechError as exc:
+        raise CannotConnect from exc
+
+
+class FlowSpeechConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for FlowSpeech."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                await _validate_input(self.hass, user_input)
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except Exception:  # noqa: BLE001
+                errors["base"] = "unknown"
+            else:
+                await self.async_set_unique_id("flowspeech")
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(
+                    title="FlowSpeech",
+                    data={
+                        CONF_API_KEY: user_input[CONF_API_KEY],
+                        CONF_VOICE: user_input.get(CONF_VOICE) or DEFAULT_VOICE,
+                    },
+                )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=_schema(
+                user_input.get(CONF_API_KEY) if user_input else None,
+                user_input.get(CONF_VOICE) if user_input else None,
+            ),
+            errors=errors,
+            description_placeholders={
+                "signup_url": SIGNUP_URL,
+                "api_keys_url": API_KEYS_URL,
+            },
+        )
+
+
+class CannotConnect(Exception):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidAuth(Exception):
+    """Error to indicate invalid authentication."""

--- a/homeassistant/components/flowspeech/const.py
+++ b/homeassistant/components/flowspeech/const.py
@@ -1,0 +1,25 @@
+"""Constants for the FlowSpeech integration."""
+
+from typing import Final, Literal
+
+DOMAIN: Final = "flowspeech"
+MANUFACTURER: Final = "FlowSpeech"
+
+CONF_API_KEY: Literal["api_key"] = "api_key"
+CONF_VOICE: Literal["voice"] = "voice"
+
+DEFAULT_VOICE: Final = "Kore"
+SIGNUP_URL: Final = "https://flowspeech.io/"
+API_KEYS_URL: Final = "https://flowspeech.io/settings/apikeys"
+
+SUPPORTED_LANGUAGES: Final = [
+    "en",
+    "ar",
+    "de",
+    "es",
+    "fr",
+    "ja",
+    "ko",
+    "zh",
+]
+

--- a/homeassistant/components/flowspeech/error.py
+++ b/homeassistant/components/flowspeech/error.py
@@ -1,0 +1,18 @@
+"""Errors for the FlowSpeech integration."""
+
+
+class FlowSpeechIntegrationError(Exception):
+    """Base error for FlowSpeech integration setup."""
+
+
+class CannotConnectError(FlowSpeechIntegrationError):
+    """Raised when FlowSpeech cannot be reached."""
+
+
+class InvalidAuthError(FlowSpeechIntegrationError):
+    """Raised when FlowSpeech rejects credentials."""
+
+
+class UnexpectedError(FlowSpeechIntegrationError):
+    """Raised when an unexpected setup error occurs."""
+

--- a/homeassistant/components/flowspeech/icons.json
+++ b/homeassistant/components/flowspeech/icons.json
@@ -1,0 +1,7 @@
+{
+  "services": {
+    "say": {
+      "service": "mdi:account-voice"
+    }
+  }
+}

--- a/homeassistant/components/flowspeech/manifest.json
+++ b/homeassistant/components/flowspeech/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "flowspeech",
+  "name": "FlowSpeech",
+  "codeowners": ["@hengyin1"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/flowspeech",
+  "integration_type": "service",
+  "iot_class": "cloud_polling",
+  "quality_scale": "bronze",
+  "requirements": ["flowspeech-sdk==0.1.0"]
+}

--- a/homeassistant/components/flowspeech/quality_scale.yaml
+++ b/homeassistant/components/flowspeech/quality_scale.yaml
@@ -1,0 +1,80 @@
+rules:
+  # Bronze
+  action-setup: done
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow: done
+  config-flow-test-coverage: done
+  dependency-transparency: done
+  docs-actions: done
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  entity-event-setup:
+    status: exempt
+    comment: Entities in this integration do not subscribe to events.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions: done
+  config-entry-unloading: done
+  docs-configuration-parameters: todo
+  docs-installation-parameters: todo
+  entity-unavailable:
+    status: exempt
+    comment: TTS platform has no state to mark unavailable.
+  integration-owner: done
+  log-when-unavailable: todo
+  parallel-updates: done
+  reauthentication-flow: todo
+  test-coverage: todo
+
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info:
+    status: exempt
+    comment: This service integration has no discovery.
+  discovery:
+    status: exempt
+    comment: This service integration has no discovery.
+  docs-data-update:
+    status: exempt
+    comment: This service integration has no data polling endpoint.
+  docs-examples: done
+  docs-known-limitations: todo
+  docs-supported-devices:
+    status: exempt
+    comment: This service integration does not support devices.
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: done
+  dynamic-devices:
+    status: exempt
+    comment: This service integration has no devices.
+  entity-category:
+    status: exempt
+    comment: The TTS entity has no entity category.
+  entity-device-class:
+    status: exempt
+    comment: There is no device class for TTS entities.
+  entity-disabled-by-default: todo
+  entity-translations: todo
+  exception-translations: todo
+  icon-translations: done
+  reconfiguration-flow: todo
+  repair-issues: todo
+  stale-devices:
+    status: exempt
+    comment: This service integration has no devices.
+
+  # Platinum
+  async-dependency: todo
+  inject-websession: todo
+  strict-typing: todo

--- a/homeassistant/components/flowspeech/strings.json
+++ b/homeassistant/components/flowspeech/strings.json
@@ -1,0 +1,26 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Set up FlowSpeech",
+        "description": "Enter your FlowSpeech API key. You can create an account at {signup_url} and manage API keys at {api_keys_url}.",
+        "data": {
+          "api_key": "API key",
+          "voice": "Default voice"
+        },
+        "data_description": {
+          "api_key": "Your FlowSpeech API key.",
+          "voice": "The default FlowSpeech voice to use for text-to-speech."
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "FlowSpeech is already configured"
+    }
+  }
+}

--- a/homeassistant/components/flowspeech/tts.py
+++ b/homeassistant/components/flowspeech/tts.py
@@ -1,0 +1,79 @@
+"""TTS platform for the FlowSpeech integration."""
+
+from functools import partial
+from typing import Any
+
+from flowspeech_sdk import FlowSpeechError, FlowSpeechRateLimitError
+
+from homeassistant.components.tts import TextToSpeechEntity, TtsAudioType
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import CONF_VOICE, DEFAULT_VOICE, DOMAIN, MANUFACTURER, SUPPORTED_LANGUAGES
+from .types import FlowSpeechConfigEntry
+
+PARALLEL_UPDATES = 1
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: FlowSpeechConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up FlowSpeech TTS platform."""
+    async_add_entities([FlowSpeechTTSEntity(entry)])
+
+
+class FlowSpeechTTSEntity(TextToSpeechEntity):
+    """FlowSpeech TTS entity."""
+
+    _attr_has_entity_name = True
+    _attr_name = None
+    _attr_supported_options = [CONF_VOICE]
+
+    def __init__(self, entry: FlowSpeechConfigEntry) -> None:
+        """Initialize the TTS entity."""
+        self.entry = entry
+        self.client = entry.runtime_data
+        self._attr_unique_id = entry.entry_id
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.entry_id)},
+            manufacturer=MANUFACTURER,
+            model="Text To Speech",
+            name="FlowSpeech",
+            entry_type=DeviceEntryType.SERVICE,
+        )
+
+    @property
+    def default_language(self) -> str:
+        """Return the default language."""
+        return "en"
+
+    @property
+    def supported_languages(self) -> list[str]:
+        """Return supported languages."""
+        return SUPPORTED_LANGUAGES
+
+    async def async_get_tts_audio(
+        self,
+        message: str,
+        language: str,
+        options: dict[str, Any],
+    ) -> TtsAudioType:
+        """Load TTS audio from FlowSpeech."""
+        voice = options.get(CONF_VOICE) or self.entry.data.get(CONF_VOICE) or DEFAULT_VOICE
+        if not isinstance(voice, str) or not voice.strip():
+            raise ServiceValidationError("FlowSpeech voice is required")
+
+        try:
+            result = await self.hass.async_add_executor_job(
+                partial(self.client.synthesize, message, voice=voice)
+            )
+        except FlowSpeechRateLimitError as err:
+            raise HomeAssistantError(f"FlowSpeech rate limited the request: {err}") from err
+        except FlowSpeechError as err:
+            raise HomeAssistantError(f"FlowSpeech TTS request failed: {err}") from err
+
+        return result.audio_format, result.audio

--- a/homeassistant/components/flowspeech/types.py
+++ b/homeassistant/components/flowspeech/types.py
@@ -1,0 +1,7 @@
+"""Types for the FlowSpeech integration."""
+
+from flowspeech_sdk import FlowSpeechClient
+
+from homeassistant.config_entries import ConfigEntry
+
+type FlowSpeechConfigEntry = ConfigEntry[FlowSpeechClient]

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -227,6 +227,7 @@ FLOWS = {
         "firefly_iii",
         "fireservicerota",
         "fish_audio",
+        "flowspeech",
         "fitbit",
         "fivem",
         "fjaraskupan",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -2097,6 +2097,12 @@
       "config_flow": true,
       "iot_class": "cloud_polling"
     },
+    "flowspeech": {
+      "name": "FlowSpeech",
+      "integration_type": "service",
+      "config_flow": true,
+      "iot_class": "cloud_polling"
+    },
     "fitbit": {
       "name": "Fitbit",
       "integration_type": "service",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -996,6 +996,9 @@ fints==3.1.0
 # homeassistant.components.fish_audio
 fish-audio-sdk==1.1.0
 
+# homeassistant.components.flowspeech
+flowspeech-sdk==0.1.0
+
 # homeassistant.components.fitbit
 fitbit-web-api==2.13.5
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -890,6 +890,9 @@ fints==3.1.0
 # homeassistant.components.fish_audio
 fish-audio-sdk==1.1.0
 
+# homeassistant.components.flowspeech
+flowspeech-sdk==0.1.0
+
 # homeassistant.components.fitbit
 fitbit-web-api==2.13.5
 

--- a/tests/components/flowspeech/__init__.py
+++ b/tests/components/flowspeech/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the FlowSpeech integration."""

--- a/tests/components/flowspeech/conftest.py
+++ b/tests/components/flowspeech/conftest.py
@@ -1,0 +1,19 @@
+"""Common fixtures for the FlowSpeech tests."""
+
+import pytest
+
+from homeassistant.components.flowspeech.const import CONF_API_KEY, CONF_VOICE, DOMAIN
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Fixture for a FlowSpeech config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="FlowSpeech",
+        data={CONF_API_KEY: "fs_test", CONF_VOICE: "Kore"},
+        unique_id="flowspeech",
+        entry_id="test-entry-id",
+    )

--- a/tests/components/flowspeech/test_config_flow.py
+++ b/tests/components/flowspeech/test_config_flow.py
@@ -1,0 +1,34 @@
+"""Tests for the FlowSpeech config flow."""
+
+from unittest.mock import patch
+
+from homeassistant import config_entries
+from homeassistant.components.flowspeech.const import CONF_API_KEY, CONF_VOICE, DOMAIN
+from homeassistant.data_entry_flow import FlowResultType
+
+
+async def test_form(hass):
+    """Test that the form is served."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+
+async def test_create_entry(hass):
+    """Test creating a config entry."""
+    with (
+        patch("flowspeech_sdk.FlowSpeechClient.get_quota", return_value={"remaining": 100}),
+        patch("homeassistant.components.flowspeech.async_setup_entry", return_value=True),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={CONF_API_KEY: "fs_test", CONF_VOICE: "Kore"},
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "FlowSpeech"
+    assert result["data"] == {CONF_API_KEY: "fs_test", CONF_VOICE: "Kore"}

--- a/tests/components/flowspeech/test_tts.py
+++ b/tests/components/flowspeech/test_tts.py
@@ -1,0 +1,30 @@
+"""Tests for the FlowSpeech TTS platform."""
+
+from dataclasses import dataclass
+
+from homeassistant.components.flowspeech.tts import FlowSpeechTTSEntity
+
+
+@dataclass
+class _Result:
+    audio_format: str = "wav"
+    audio: bytes = b"audio"
+
+
+class _Client:
+    def synthesize(self, message, *, voice):
+        assert message == "hello"
+        assert voice == "Kore"
+        return _Result()
+
+
+async def test_tts_entity_uses_configured_voice(hass, mock_config_entry):
+    """Test TTS synthesis."""
+    mock_config_entry.runtime_data = _Client()
+    entity = FlowSpeechTTSEntity(mock_config_entry)
+    entity.hass = hass
+
+    audio_format, audio = await entity.async_get_tts_audio("hello", "en", {})
+
+    assert audio_format == "wav"
+    assert audio == b"audio"


### PR DESCRIPTION
## Breaking change
None.

## Proposed change
Adds a new FlowSpeech text-to-speech integration using `flowspeech-sdk`.

The integration includes a config flow, TTS platform, runtime setup, translations, quality scale metadata, generated integration metadata, tests, and documentation/brand companion PRs.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45318
- Link to developer documentation pull request: 
- Link to frontend pull request: 
- Link to brands pull request: https://github.com/home-assistant/brands/pull/10292
- Dependency: `flowspeech-sdk==0.1.0` (initial release)

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr