### PR TITLE
Apply unit_of_measurement to energy combined power sensor

### DIFF
--- a/homeassistant/components/energy/sensor.py
+++ b/homeassistant/components/energy/sensor.py
@@ -664,6 +664,12 @@ class EnergyPowerSensor(SensorEntity):
         self._is_inverted = "stat_rate_inverted" in config
         self._is_combined = "stat_rate_from" in config and "stat_rate_to" in config
 
+        # Combined mode always emits Watts because _update_state converts
+        # heterogeneous source units to W internally. Inverted mode copies
+        # the source unit in _update_state to track source changes.
+        if self._is_combined:
+            self._attr_native_unit_of_measurement = UnitOfPower.WATT
+
         # Determine source sensors
         if self._is_inverted:
             self._source_sensors = [config["stat_rate_inverted"]]
@@ -764,11 +770,6 @@ class EnergyPowerSensor(SensorEntity):
             # Check first sensor
             if source_entry := entity_reg.async_get(self._source_sensors[0]):
                 device_id = source_entry.device_id
-                # Combined mode always emits Watts because we convert
-                # heterogeneous source units internally. For inverted mode the
-                # unit is copied from the source state in _update_state.
-                if self._is_combined:
-                    self._attr_native_unit_of_measurement = UnitOfPower.WATT
                 # Get source name from registry
                 source_name = source_entry.name or source_entry.original_name
             # Assign power sensor to same device as source sensor(s)

--- a/tests/components/energy/test_sensor.py
+++ b/tests/components/energy/test_sensor.py
@@ -1615,6 +1615,7 @@ async def test_power_sensor_grid_combined(
     assert state is not None
     # 500 - 200 = 300 (net import)
     assert float(state.state) == 300.0
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfPower.WATT
 
 
 async def test_power_sensor_device_assignment(
@@ -1988,6 +1989,7 @@ async def test_power_sensor_combined_unit_conversion(
     assert state is not None
     # 1500 W - 500 W = 1000 W (units are converted to W internally)
     assert float(state.state) == 1000.0
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfPower.WATT
 
 
 async def test_power_sensor_inverted_negative_values(


### PR DESCRIPTION
## Proposed change

Mirrors #169427 for combined-mode `EnergyPowerSensor`. The `UnitOfPower.WATT` assignment was nested inside `if source_entry := entity_reg.async_get(source)` in `async_added_to_hass`, so when the first source sensor isn't in the entity registry the combined `sensor.energy_<type>_<from>_<to>_net_power` ended up with no `unit_of_measurement`. Moved the assignment to `__init__`. Combined mode always emits Watts always, so the unit doesn't depend on registry state.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: home-assistant/frontend#30318
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.