### PR TITLE
Bump python-qube-heatpump to 1.10.0

### DIFF
--- a/homeassistant/components/hr_energy_qube/manifest.json
+++ b/homeassistant/components/hr_energy_qube/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "loggers": ["python_qube_heatpump"],
   "quality_scale": "bronze",
-  "requirements": ["python-qube-heatpump==1.8.0"]
+  "requirements": ["python-qube-heatpump==1.10.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2684,7 +2684,7 @@ python-picnic-api2==1.3.4
 python-pooldose==0.9.0
 
 # homeassistant.components.hr_energy_qube
-python-qube-heatpump==1.8.0
+python-qube-heatpump==1.10.0
 
 # homeassistant.components.rabbitair
 python-rabbitair==0.0.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2295,7 +2295,7 @@ python-picnic-api2==1.3.4
 python-pooldose==0.9.0
 
 # homeassistant.components.hr_energy_qube
-python-qube-heatpump==1.8.0
+python-qube-heatpump==1.10.0
 
 # homeassistant.components.rabbitair
 python-rabbitair==0.0.8


### PR DESCRIPTION
## Proposed change

Bump python-qube-heatpump library from 1.8.0 to 1.10.0.

### Library changelog

- **1.9.0**: Added `StatusCode.ANTI_LEGIONELLA` and `resolve_status()` helper for unified status reporting.
- **1.10.0**: Added `usr_pid_heatsetp`, `usr_pid_coolsetp`, and `modbus_roomtemp` typed fields to `QubeState`, read in `get_all_data()`. Enables climate entity support in a follow-up PR.

[Full diff: v1.8.0...v1.10.0](https://github.com/MattieGit/python-qube-heatpump/compare/v1.8.0...v1.10.0)

## Type of change

- [x] Dependency upgrade

## Additional information

- This PR is related to issue: 
- Link to documentation pull request: N/A (no user-facing changes)

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.
- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr