### PR TITLE
Fix coordinator exception handling, diagnostics, and pac sensor category

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2047,8 +2047,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/zeroconf/ @bdraco
 /homeassistant/components/zerproc/ @emlove
 /tests/components/zerproc/ @emlove
-/homeassistant/components/zeversolar/ @kvanzuijlen
-/tests/components/zeversolar/ @kvanzuijlen
+/homeassistant/components/zeversolar/ @kvanzuijlen @mhuiskes
+/tests/components/zeversolar/ @kvanzuijlen @mhuiskes
 /homeassistant/components/zha/ @dmulcahey @adminiuga @puddly @TheJulianJES
 /tests/components/zha/ @dmulcahey @adminiuga @puddly @TheJulianJES
 /homeassistant/components/zimi/ @markhannon

--- a/homeassistant/components/zeversolar/coordinator.py
+++ b/homeassistant/components/zeversolar/coordinator.py
@@ -8,7 +8,7 @@ import zeversolar
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN
 
@@ -24,6 +24,7 @@ class ZeversolarCoordinator(DataUpdateCoordinator[zeversolar.ZeverSolarData]):
 
     def __init__(self, hass: HomeAssistant, entry: ZeversolarConfigEntry) -> None:
         """Initialize the coordinator."""
+        self._client = zeversolar.ZeverSolarClient(host=entry.data[CONF_HOST])
         super().__init__(
             hass,
             _LOGGER,
@@ -31,8 +32,10 @@ class ZeversolarCoordinator(DataUpdateCoordinator[zeversolar.ZeverSolarData]):
             name=DOMAIN,
             update_interval=timedelta(minutes=1),
         )
-        self._client = zeversolar.ZeverSolarClient(host=entry.data[CONF_HOST])
 
     async def _async_update_data(self) -> zeversolar.ZeverSolarData:
         """Fetch the latest data from the source."""
-        return await self.hass.async_add_executor_job(self._client.get_data)
+        try:
+            return await self.hass.async_add_executor_job(self._client.get_data)
+        except Exception as err:
+            raise UpdateFailed(f"Cannot reach inverter: {err}") from err

--- a/homeassistant/components/zeversolar/diagnostics.py
+++ b/homeassistant/components/zeversolar/diagnostics.py
@@ -14,10 +14,9 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, config_entry: ZeversolarConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-
     data: ZeverSolarData = config_entry.runtime_data.data
 
-    payload: dict[str, Any] = {
+    return {
         "wifi_enabled": data.wifi_enabled,
         "serial_or_registry_id": data.serial_or_registry_id,
         "registry_key": data.registry_key,
@@ -33,8 +32,6 @@ async def async_get_config_entry_diagnostics(
         "meter_status": data.meter_status.value,
     }
 
-    return payload
-
 
 async def async_get_device_diagnostics(
     hass: HomeAssistant, entry: ZeversolarConfigEntry, device: DeviceEntry
@@ -42,7 +39,7 @@ async def async_get_device_diagnostics(
     """Return diagnostics for a device entry."""
     coordinator = entry.runtime_data
 
-    updateInterval = (
+    update_interval = (
         None
         if coordinator.update_interval is None
         else coordinator.update_interval.total_seconds()
@@ -52,5 +49,5 @@ async def async_get_device_diagnostics(
         "name": coordinator.name,
         "always_update": coordinator.always_update,
         "last_update_success": coordinator.last_update_success,
-        "update_interval": updateInterval,
+        "update_interval": update_interval,
     }

--- a/homeassistant/components/zeversolar/manifest.json
+++ b/homeassistant/components/zeversolar/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "zeversolar",
   "name": "Zeversolar",
-  "codeowners": ["@kvanzuijlen"],
+  "codeowners": ["@kvanzuijlen", "@mhuiskes"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/zeversolar",
   "integration_type": "device",

--- a/homeassistant/components/zeversolar/sensor.py
+++ b/homeassistant/components/zeversolar/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import EntityCategory, UnitOfEnergy, UnitOfPower
+from homeassistant.const import UnitOfEnergy, UnitOfPower
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -32,7 +32,6 @@ SENSOR_TYPES = (
         translation_key="pac",
         native_unit_of_measurement=UnitOfPower.WATT,
         state_class=SensorStateClass.MEASUREMENT,
-        entity_category=EntityCategory.DIAGNOSTIC,
         device_class=SensorDeviceClass.POWER,
         value_fn=lambda data: data.pac,
     ),

--- a/tests/components/zeversolar/__init__.py
+++ b/tests/components/zeversolar/__init__.py
@@ -5,48 +5,46 @@ from unittest.mock import patch
 from zeversolar import StatusEnum, ZeverSolarData
 
 from homeassistant.components.zeversolar.const import DOMAIN
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
-MOCK_HOST_ZEVERSOLAR = "zeversolar-fake-host"
-MOCK_PORT_ZEVERSOLAR = 10200
+MOCK_HOST = "192.168.1.1"
 MOCK_SERIAL_NUMBER = "123456778"
+
+MOCK_ZEVERSOLAR_DATA = ZeverSolarData(
+    wifi_enabled=False,
+    serial_or_registry_id="EAB9615C0001",
+    registry_key="WSMQKHTQ3JVYQWA9",
+    hardware_version="M10",
+    software_version="19703-826R+17511-707R",
+    reported_datetime="19900101 23:01:45",
+    communication_status=StatusEnum.OK,
+    num_inverters=1,
+    serial_number=MOCK_SERIAL_NUMBER,
+    pac=1234,
+    energy_today=123.4,
+    status=StatusEnum.OK,
+    meter_status=StatusEnum.OK,
+)
 
 
 async def init_integration(hass: HomeAssistant) -> MockConfigEntry:
-    """Mock integration setup."""
-
-    zeverData = ZeverSolarData(
-        wifi_enabled=False,
-        serial_or_registry_id="EAB9615C0001",
-        registry_key="WSMQKHTQ3JVYQWA9",
-        hardware_version="M10",
-        software_version="19703-826R+17511-707R",
-        reported_datetime="19900101 23:01:45",
-        communication_status=StatusEnum.OK,
-        num_inverters=1,
-        serial_number=MOCK_SERIAL_NUMBER,
-        pac=1234,
-        energy_today=123.4,
-        status=StatusEnum.OK,
-        meter_status=StatusEnum.OK,
+    """Set up the Zeversolar integration in the test environment."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: MOCK_HOST},
+        unique_id=MOCK_SERIAL_NUMBER,
+        entry_id="test_entry_id",
     )
+    entry.add_to_hass(hass)
 
-    with (
-        patch("zeversolar.ZeverSolarClient.get_data", return_value=zeverData),
+    with patch(
+        "zeversolar.ZeverSolarClient.get_data",
+        return_value=MOCK_ZEVERSOLAR_DATA,
     ):
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={
-                CONF_HOST: MOCK_HOST_ZEVERSOLAR,
-                CONF_PORT: MOCK_PORT_ZEVERSOLAR,
-            },
-            entry_id="my_id",
-        )
-
-        entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
-        return entry
+
+    return entry

--- a/tests/components/zeversolar/conftest.py
+++ b/tests/components/zeversolar/conftest.py
@@ -1,47 +1,42 @@
-"""Define mocks and test objects."""
+"""Define fixtures for Zeversolar tests."""
 
 import pytest
 from zeversolar import StatusEnum, ZeverSolarData
 
 from homeassistant.components.zeversolar.const import DOMAIN
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.const import CONF_HOST
 
 from tests.common import MockConfigEntry
 
-MOCK_HOST_ZEVERSOLAR = "zeversolar-fake-host"
-MOCK_PORT_ZEVERSOLAR = 10200
+MOCK_HOST = "192.168.1.1"
+MOCK_SERIAL_NUMBER = "123456778"
 
 
 @pytest.fixture
 def config_entry() -> MockConfigEntry:
     """Create a mock config entry."""
-
     return MockConfigEntry(
-        data={
-            CONF_HOST: MOCK_HOST_ZEVERSOLAR,
-            CONF_PORT: MOCK_PORT_ZEVERSOLAR,
-        },
         domain=DOMAIN,
-        unique_id="my_id_2",
+        data={CONF_HOST: MOCK_HOST},
+        unique_id=MOCK_SERIAL_NUMBER,
     )
 
 
 @pytest.fixture
 def zeversolar_data() -> ZeverSolarData:
     """Create a ZeverSolarData structure for tests."""
-
     return ZeverSolarData(
         wifi_enabled=False,
-        serial_or_registry_id="1223",
-        registry_key="A-2",
+        serial_or_registry_id="EAB9615C0001",
+        registry_key="WSMQKHTQ3JVYQWA9",
         hardware_version="M10",
-        software_version="123-23",
-        reported_datetime="19900101 23:00",
+        software_version="19703-826R+17511-707R",
+        reported_datetime="19900101 23:01:45",
         communication_status=StatusEnum.OK,
         num_inverters=1,
-        serial_number="123456778",
+        serial_number=MOCK_SERIAL_NUMBER,
         pac=1234,
-        energy_today=123,
+        energy_today=123.4,
         status=StatusEnum.OK,
         meter_status=StatusEnum.OK,
     )

--- a/tests/components/zeversolar/snapshots/test_sensor.ambr
+++ b/tests/components/zeversolar/snapshots/test_sensor.ambr
@@ -72,7 +72,7 @@
     'device_id': <ANY>,
     'disabled_by': None,
     'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_category': None,
     'entity_id': 'sensor.zeversolar_sensor_power',
     'has_entity_name': True,
     'hidden_by': None,

--- a/tests/components/zeversolar/test_config_flow.py
+++ b/tests/components/zeversolar/test_config_flow.py
@@ -32,28 +32,16 @@ async def test_form(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize(
     ("side_effect", "errors"),
     [
-        (
-            ZeverSolarHTTPNotFound,
-            {"base": "invalid_host"},
-        ),
-        (
-            ZeverSolarHTTPError,
-            {"base": "cannot_connect"},
-        ),
-        (
-            ZeverSolarTimeout,
-            {"base": "timeout_connect"},
-        ),
-        (
-            RuntimeError,
-            {"base": "unknown"},
-        ),
+        (ZeverSolarHTTPNotFound, {"base": "invalid_host"}),
+        (ZeverSolarHTTPError, {"base": "cannot_connect"}),
+        (ZeverSolarTimeout, {"base": "timeout_connect"}),
+        (RuntimeError, {"base": "unknown"}),
     ],
 )
 async def test_form_errors(
     hass: HomeAssistant,
-    side_effect: Exception,
-    errors: dict,
+    side_effect: type[Exception],
+    errors: dict[str, str],
 ) -> None:
     """Test we handle errors."""
     result = await hass.config_entries.flow.async_init(
@@ -66,9 +54,7 @@ async def test_form_errors(
     ):
         result2 = await hass.config_entries.flow.async_configure(
             flow_id=result["flow_id"],
-            user_input={
-                CONF_HOST: "test_ip",
-            },
+            user_input={CONF_HOST: "test_ip"},
         )
 
     assert result2["type"] is FlowResultType.FORM
@@ -104,9 +90,7 @@ async def test_abort_already_configured(hass: HomeAssistant) -> None:
     ):
         result2 = await hass.config_entries.flow.async_configure(
             flow_id=result["flow_id"],
-            user_input={
-                CONF_HOST: "test_ip",
-            },
+            user_input={CONF_HOST: "test_ip"},
         )
         await hass.async_block_till_done()
 
@@ -116,7 +100,7 @@ async def test_abort_already_configured(hass: HomeAssistant) -> None:
 
 
 async def _set_up_zeversolar(hass: HomeAssistant, flow_id: str) -> None:
-    """Reusable successful setup of Zeversolar sensor."""
+    """Reusable successful setup of Zeversolar."""
     mock_data = MagicMock()
     mock_data.serial_number = "test_serial"
     with (
@@ -128,15 +112,11 @@ async def _set_up_zeversolar(hass: HomeAssistant, flow_id: str) -> None:
     ):
         result2 = await hass.config_entries.flow.async_configure(
             flow_id=flow_id,
-            user_input={
-                CONF_HOST: "test_ip",
-            },
+            user_input={CONF_HOST: "test_ip"},
         )
         await hass.async_block_till_done()
 
     assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["title"] == "Zeversolar"
-    assert result2["data"] == {
-        CONF_HOST: "test_ip",
-    }
+    assert result2["data"] == {CONF_HOST: "test_ip"}
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/zeversolar/test_coordinator.py
+++ b/tests/components/zeversolar/test_coordinator.py
@@ -1,0 +1,31 @@
+"""Tests for the Zeversolar coordinator."""
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.zeversolar.const import DOMAIN
+from homeassistant.components.zeversolar.coordinator import ZeversolarCoordinator
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from tests.common import MockConfigEntry
+
+MOCK_HOST = "192.168.1.1"
+
+
+async def test_update_raises_update_failed_on_error(hass: HomeAssistant) -> None:
+    """_async_update_data wraps exceptions in UpdateFailed."""
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: MOCK_HOST})
+    entry.add_to_hass(hass)
+    coordinator = ZeversolarCoordinator(hass, entry)
+
+    with (
+        patch(
+            "zeversolar.ZeverSolarClient.get_data",
+            side_effect=Exception("network error"),
+        ),
+        pytest.raises(UpdateFailed, match="Cannot reach inverter"),
+    ):
+        await coordinator._async_update_data()

--- a/tests/components/zeversolar/test_init.py
+++ b/tests/components/zeversolar/test_init.py
@@ -1,39 +1,35 @@
-"""Test the init file code."""
+"""Test the Zeversolar integration setup."""
 
 from unittest.mock import patch
 
-from zeversolar import ZeverSolarData
 from zeversolar.exceptions import ZeverSolarTimeout
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
+from . import init_integration
+
 from tests.common import MockConfigEntry
 
 
-async def test_async_setup_entry_fails(
-    hass: HomeAssistant, config_entry: MockConfigEntry, zeversolar_data: ZeverSolarData
+async def test_setup_retries_when_inverter_unreachable(
+    hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
-    """Test to load/unload the integration."""
-
+    """Entry enters SETUP_RETRY when the inverter cannot be reached."""
     config_entry.add_to_hass(hass)
 
-    with (
-        patch("zeversolar.ZeverSolarClient.get_data", side_effect=ZeverSolarTimeout),
-    ):
+    with patch("zeversolar.ZeverSolarClient.get_data", side_effect=ZeverSolarTimeout):
         await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
-    with (
-        patch("homeassistant.components.zeversolar.PLATFORMS", []),
-        patch("zeversolar.ZeverSolarClient.get_data", return_value=zeversolar_data),
-    ):
-        hass.config_entries.async_schedule_reload(config_entry.entry_id)
-    assert config_entry.state is ConfigEntryState.LOADED
 
-    with (
-        patch("homeassistant.components.zeversolar.PLATFORMS", []),
-    ):
-        result = await hass.config_entries.async_unload(config_entry.entry_id)
+async def test_setup_and_unload(hass: HomeAssistant) -> None:
+    """Entry loads successfully and can be unloaded."""
+    entry = await init_integration(hass)
+    assert entry.state is ConfigEntryState.LOADED
+
+    result = await hass.config_entries.async_unload(entry.entry_id)
     assert result is True
-    assert config_entry.state is ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/zeversolar/test_sensor.py
+++ b/tests/components/zeversolar/test_sensor.py
@@ -1,10 +1,7 @@
-"""Test the sensor classes."""
-
-from unittest.mock import patch
+"""Test the Zeversolar sensor platform."""
 
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -14,14 +11,10 @@ from tests.common import snapshot_platform
 
 
 async def test_sensors(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, snapshot: SnapshotAssertion
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
 ) -> None:
-    """Test sensors."""
-
-    with patch(
-        "homeassistant.components.zeversolar.PLATFORMS",
-        [Platform.SENSOR],
-    ):
-        entry = await init_integration(hass)
-
-        await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
+    """Test sensors match snapshot."""
+    entry = await init_integration(hass)
+    await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)


### PR DESCRIPTION
## Proposed change

Bug fixes and cleanup to the existing `zeversolar` integration. No new platforms, no library version change.

- Wrap `_async_update_data` exceptions in `UpdateFailed` so network errors produce a clean `SETUP_RETRY` state instead of unhandled exceptions
- Move `_client` init before `super().__init__()` — parent constructor can trigger a refresh, so the client must exist first
- Fix diagnostics: `updateInterval` → `update_interval` (camelCase bug), remove unnecessary intermediate variable
- Remove `entity_category=DIAGNOSTIC` from `pac` — current AC power output is a primary measurement, not a diagnostic value
- Add `@mhuiskes` to `CODEOWNERS` and `manifest.json`
- Rewrite test helpers, clean up stale `CONF_PORT` references, add `test_coordinator.py` covering `UpdateFailed` wrapping

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:
- [ ] I have reviewed two other [open pull requests][prs] in this repository.