### PR TITLE
Add hardware and software version to Zeversolar device info

### DIFF
--- a/homeassistant/components/zeversolar/entity.py
+++ b/homeassistant/components/zeversolar/entity.py
@@ -25,5 +25,7 @@ class ZeversolarEntity(
             identifiers={(DOMAIN, coordinator.data.serial_number)},
             name="Zeversolar Sensor",
             manufacturer="Zeversolar",
+            model=coordinator.data.hardware_version,
+            sw_version=coordinator.data.software_version,
             serial_number=coordinator.data.serial_number,
         )

--- a/homeassistant/components/zeversolar/entity.py
+++ b/homeassistant/components/zeversolar/entity.py
@@ -25,7 +25,7 @@ class ZeversolarEntity(
             identifiers={(DOMAIN, coordinator.data.serial_number)},
             name="Zeversolar Sensor",
             manufacturer="Zeversolar",
-            model=coordinator.data.hardware_version,
+            hw_version=coordinator.data.hardware_version,
             sw_version=coordinator.data.software_version,
             serial_number=coordinator.data.serial_number,
         )


### PR DESCRIPTION
## Proposed change

Adds `hw_version` and `sw_version` to the `DeviceInfo` in the Zeversolar base entity. Both values are already available from the existing `home.cgi` API response — this PR simply surfaces them in the HA device card.

- `hw_version` maps to `hardware_version` (e.g. `M10`, `M11`)
- `sw_version` maps to `software_version` (e.g. `19703-826R+17511-707R`)

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.