### PR TITLE
Add explicit pac sensor translation for Zeversolar

### DIFF
--- a/homeassistant/components/zeversolar/strings.json
+++ b/homeassistant/components/zeversolar/strings.json
@@ -24,6 +24,9 @@
     "sensor": {
       "energy_today": {
         "name": "Energy today"
+      },
+      "pac": {
+        "name": "Power"
       }
     }
   }


### PR DESCRIPTION
## Proposed change

Adds an explicit translation string for the `pac` (current AC power) sensor. The upstream `strings.json` had no entry for `pac`, relying on the `SensorDeviceClass.POWER` fallback name. Making it explicit is the correct HA practice. Functionally equivalent — the displayed name stays "Power".

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)

To help with the load of incoming pull requests:
- [ ] I have reviewed two other [open pull requests][prs] in this repository.