### PR TITLE
Initiate translation attributes on class level of HomeAssistantError

### DIFF
--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -36,6 +36,9 @@ class HomeAssistantError(Exception):
 
     _message: str | None = None
     generate_message: bool = False
+    translation_domain: str | None = None
+    translation_key: str | None = None
+    translation_placeholders: dict[str, str] | None = None
 
     def __init__(
         self,

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -120,10 +120,17 @@ async def test_home_assistant_error(
 
 
 async def test_home_assistant_error_subclass(hass: HomeAssistant) -> None:
-    """Test __str__ method on an HomeAssistantError subclass."""
+    """Test __str__ method and translation attributes on HomeAssistantError subclass."""
 
     class _SubExceptionDefault(HomeAssistantError):
         """Sub class, default with generated message."""
+
+    class _SubExceptionNoSuper(HomeAssistantError):
+        """Sub class which doesn't call super().__init__()."""
+
+        # pylint: disable-next=super-init-not-called
+        def __init__(self) -> None:
+            pass
 
     class _SubExceptionConstructor(HomeAssistantError):
         """Sub class with constructor, no generated message."""
@@ -186,6 +193,18 @@ async def test_home_assistant_error_subclass(hass: HomeAssistant) -> None:
                 translation_placeholders={"bla": "Bla"},
             )
         assert str(exc.value) == "Bla from cache"
+        assert exc.value.translation_domain == "test"
+        assert exc.value.translation_key == "bla"
+        assert exc.value.translation_placeholders == {"bla": "Bla"}
+
+        # A subclass which doesn't call super should not raise an error when __str__
+        # is called and should have None for translation attributes.
+        with pytest.raises(HomeAssistantError) as exc:
+            raise _SubExceptionNoSuper()
+        assert str(exc.value) == ""
+        assert exc.value.translation_domain is None
+        assert exc.value.translation_key is None
+        assert exc.value.translation_placeholders is None
 
         # A subclass with a constructor that does not parse `args` to the super class
         with pytest.raises(HomeAssistantError) as exc:
@@ -196,11 +215,18 @@ async def test_home_assistant_error_subclass(hass: HomeAssistant) -> None:
                 translation_placeholders={"bla": "Bla"},
             )
         assert str(exc.value) == "Bla from cache"
+        assert exc.value.translation_domain == "test"
+        assert exc.value.translation_key == "bla"
+        assert exc.value.translation_placeholders == {"bla": "Bla"}
+
         with pytest.raises(HomeAssistantError) as exc:
             raise _SubExceptionConstructor(
                 "custom arg",
             )
         assert str(exc.value) == ""
+        assert exc.value.translation_domain is None
+        assert exc.value.translation_key is None
+        assert exc.value.translation_placeholders is None
 
         # A subclass with a constructor that generates the message
         with pytest.raises(HomeAssistantError) as exc:
@@ -211,6 +237,9 @@ async def test_home_assistant_error_subclass(hass: HomeAssistant) -> None:
                 translation_placeholders={"bla": "Bla"},
             )
         assert str(exc.value) == "Bla from cache"
+        assert exc.value.translation_domain == "test"
+        assert exc.value.translation_key == "bla"
+        assert exc.value.translation_placeholders == {"bla": "Bla"}
 
         # A subclass without overridden constructors and passed args
         # defaults to the passed args
@@ -222,6 +251,9 @@ async def test_home_assistant_error_subclass(hass: HomeAssistant) -> None:
                 translation_placeholders={"bla": "Bla"},
             )
         assert str(exc.value) == "wrong value"
+        assert exc.value.translation_domain == "test"
+        assert exc.value.translation_key == "bla"
+        assert exc.value.translation_placeholders == {"bla": "Bla"}
 
         # A subclass without overridden constructors and passed args
         # and generate_message = True,  generates a message
@@ -233,6 +265,9 @@ async def test_home_assistant_error_subclass(hass: HomeAssistant) -> None:
                 translation_placeholders={"bla": "Bla"},
             )
         assert str(exc.value) == "Bla from cache"
+        assert exc.value.translation_domain == "test"
+        assert exc.value.translation_key == "bla"
+        assert exc.value.translation_placeholders == {"bla": "Bla"}
 
         # A subclass with an ExceptionGroup subclass requires a message to be passed.
         # As we pass args, we will not generate the message.
@@ -246,12 +281,19 @@ async def test_home_assistant_error_subclass(hass: HomeAssistant) -> None:
                 translation_placeholders={"bla": "Bla"},
             )
         assert str(exc.value) == "group message (2 sub-exceptions)"
+        assert exc.value.translation_domain == "test"
+        assert exc.value.translation_key == "bla"
+        assert exc.value.translation_placeholders == {"bla": "Bla"}
+
         with pytest.raises(HomeAssistantError) as exc:
             raise _SubClassWithExceptionGroup(
                 "group message",
                 [ValueError("wrong value"), TypeError("wrong type")],
             )
         assert str(exc.value) == "group message (2 sub-exceptions)"
+        assert exc.value.translation_domain is None
+        assert exc.value.translation_key is None
+        assert exc.value.translation_placeholders is None
 
         # A subclass with an ExceptionGroup subclass requires a message to be passed.
         # The `generate_message` flag is set.`
@@ -265,3 +307,6 @@ async def test_home_assistant_error_subclass(hass: HomeAssistant) -> None:
                 translation_placeholders={"bla": "Bla"},
             )
         assert str(exc.value) == "Bla from cache"
+        assert exc.value.translation_domain == "test"
+        assert exc.value.translation_key == "bla"
+        assert exc.value.translation_placeholders == {"bla": "Bla"}

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -200,7 +200,7 @@ async def test_home_assistant_error_subclass(hass: HomeAssistant) -> None:
         # A subclass which doesn't call super should not raise an error when __str__
         # is called and should have None for translation attributes.
         with pytest.raises(HomeAssistantError) as exc:
-            raise _SubExceptionNoSuper()
+            raise _SubExceptionNoSuper
         assert str(exc.value) == ""
         assert exc.value.translation_domain is None
         assert exc.value.translation_key is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Initiate translation attributes on class level of `HomeAssistantError` to avoid child classes which lack calls so `super().__init__` interfering with error handling

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
