### PR TITLE
Drop Advanced mode dependency in generic camera config flow

### DIFF
--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -104,7 +104,6 @@ class InvalidStreamException(HomeAssistantError):
 
 def build_schema(
     is_options_flow: bool = False,
-    show_advanced_options: bool = False,
 ) -> vol.Schema:
     """Create schema for camera config setup."""
     rtsp_options = [
@@ -141,8 +140,7 @@ def build_schema(
     }
     if is_options_flow:
         advanced_section[vol.Optional(CONF_LIMIT_REFETCH_TO_URL_CHANGE)] = bool
-        if show_advanced_options:
-            advanced_section[vol.Optional(CONF_USE_WALLCLOCK_AS_TIMESTAMPS)] = bool
+        advanced_section[vol.Optional(CONF_USE_WALLCLOCK_AS_TIMESTAMPS)] = bool
 
     return vol.Schema(spec)
 
@@ -469,10 +467,7 @@ class GenericOptionsFlowHandler(OptionsFlow):
         return self.async_show_form(
             step_id="init",
             data_schema=self.add_suggested_values_to_schema(
-                build_schema(
-                    True,
-                    self.show_advanced_options,
-                ),
+                build_schema(True),
                 user_input or self.config_entry.options,
             ),
             errors=errors,

--- a/homeassistant/components/generic/strings.json
+++ b/homeassistant/components/generic/strings.json
@@ -40,8 +40,8 @@
               "rtsp_transport": "RTSP transport protocol",
               "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
             },
-            "description": "Advanced settings are only needed for special cases. Leave them unchanged unless you know what you are doing.",
-            "name": "Advanced settings"
+            "description": "These options are only needed for special cases.",
+            "name": "More options"
           }
         }
       },

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -949,9 +949,7 @@ async def test_options_use_wallclock_as_timestamps(
 ) -> None:
     """Test the use_wallclock_as_timestamps option flow."""
 
-    result = await hass.config_entries.options.async_init(
-        config_entry.entry_id, context={"show_advanced_options": True}
-    )
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "init"
 


### PR DESCRIPTION
## Proposed change

Removes the Advanced mode gate from the generic camera config flow so the `use_wallclock_as_timestamps` option is always visible in the options flow. Also renames the section's user-visible label from "Advanced settings" to "More options".


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #169811
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45327
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
