### PR TITLE
Handle WiiM UPnP action errors as non-critical

### DIFF
--- a/homeassistant/components/wiim/media_player.py
+++ b/homeassistant/components/wiim/media_player.py
@@ -5,6 +5,7 @@ from functools import wraps
 from typing import Any, Concatenate
 
 from async_upnp_client.client import UpnpService, UpnpStateVariable
+from async_upnp_client.exceptions import UpnpActionResponseError
 from wiim.consts import PlayingStatus as SDKPlayingStatus
 from wiim.exceptions import WiimDeviceException, WiimException, WiimRequestException
 from wiim.models import (
@@ -46,6 +47,8 @@ MEDIA_CONTENT_ID_FAVORITES = (
 MEDIA_CONTENT_ID_PLAYLISTS = (
     f"{MEDIA_TYPE_WIIM_LIBRARY}/{MEDIA_CONTENT_ID_ROOT}/playlists"
 )
+# WiiM reports this AVTransport fault as "Transition not allowed".
+UPNP_AV_TRANSPORT_TRANSITION_NOT_AVAILABLE = 701
 
 SDK_TO_HA_STATE: dict[SDKPlayingStatus, MediaPlayerState] = {
     SDKPlayingStatus.PLAYING: MediaPlayerState.PLAYING,
@@ -68,6 +71,15 @@ SUPPORT_WIIM_BASE = (
 )
 
 
+def _upnp_action_response_error(err: BaseException) -> UpnpActionResponseError | None:
+    """Return the wrapped UPnP action response error, if present."""
+    cause = err.__cause__
+    if isinstance(cause, UpnpActionResponseError):
+        return cause
+
+    return None
+
+
 def media_player_exception_wrap[
     _WiimMediaPlayerEntityT: "WiimMediaPlayerEntity",
     **_P,
@@ -83,7 +95,22 @@ def media_player_exception_wrap[
     ) -> _R:
         try:
             result = await func(self, *args, **kwargs)
-        except (WiimDeviceException, WiimRequestException, WiimException) as err:
+        except WiimDeviceException as err:
+            if _upnp_action_response_error(err) is not None:
+                # A UPnP action response means the device answered the request and
+                # rejected that command, so the failure should not make HA mark the
+                # player unavailable.
+                raise HomeAssistantError(
+                    f"{func.__name__} failed for {self.entity_id}"
+                ) from err
+
+            # Preserve the previous behavior for WiiM device errors we do not
+            # understand yet: assume they are critical communication failures.
+            await self._async_handle_critical_error(err)
+            raise HomeAssistantError(
+                f"{func.__name__} failed for {self.entity_id}"
+            ) from err
+        except (WiimRequestException, WiimException) as err:
             await self._async_handle_critical_error(err)
             raise HomeAssistantError(
                 f"{func.__name__} failed for {self.entity_id}"
@@ -541,7 +568,34 @@ class WiimMediaPlayerEntity(WiimBaseEntity, MediaPlayerEntity):
     async def async_media_pause(self) -> None:
         """Send pause command."""
         target_device = self._get_command_target_device("media_pause")
-        await target_device.async_pause()
+        try:
+            await target_device.async_pause()
+        except WiimDeviceException as err:
+            upnp_error = _upnp_action_response_error(err)
+            if upnp_error is None or (
+                upnp_error.error_code != UPNP_AV_TRANSPORT_TRANSITION_NOT_AVAILABLE
+            ):
+                raise
+
+            if not target_device.supports_http_api:
+                raise
+
+            LOGGER.debug(
+                "Device %s rejected pause for the current transport state; "
+                "refreshing status instead",
+                target_device.udn,
+            )
+            # The cached state can still be playing if an earlier pause already
+            # reached the device. Refresh before treating 701 as idempotent.
+            await target_device.async_update_http_status()
+            if target_device.playing_status in {
+                SDKPlayingStatus.PAUSED,
+                SDKPlayingStatus.STOPPED,
+            }:
+                return
+
+            raise
+
         await target_device.sync_device_duration_and_position()
 
     @media_player_exception_wrap

--- a/tests/components/wiim/conftest.py
+++ b/tests/components/wiim/conftest.py
@@ -84,6 +84,7 @@ def mock_wiim_device() -> Generator[AsyncMock]:
         mock.av_transport_event_callback = None
         mock.rendering_control_event_callback = None
         mock.play_queue_event_callback = None
+        mock.set_available = MagicMock()
         mock.output_mode = "speaker"
         mock.supported_input_modes = (InputMode.LINE_IN.display_name,)  # type: ignore[attr-defined]
         mock.supported_output_modes = (

--- a/tests/components/wiim/test_media_player.py
+++ b/tests/components/wiim/test_media_player.py
@@ -2,8 +2,10 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from async_upnp_client.exceptions import UpnpActionResponseError
 import pytest
 from wiim.consts import PlayingStatus
+from wiim.exceptions import WiimDeviceException
 from wiim.models import (
     WiimGroupRole,
     WiimGroupSnapshot,
@@ -49,12 +51,26 @@ from homeassistant.components.media_player import (
 )
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 
 from . import fire_general_update, fire_transport_update, setup_integration
 
 from tests.common import MockConfigEntry
 
 MEDIA_PLAYER_ENTITY_ID = "media_player.test_wiim_device"
+
+
+def _wiim_device_upnp_action_error(
+    error_code: int, error_desc: str
+) -> WiimDeviceException:
+    """Return a WiimDeviceException wrapping a UPnP action response error."""
+    err = WiimDeviceException("UPnP action Pause failed")
+    err.__cause__ = UpnpActionResponseError(
+        status=500,
+        error_code=error_code,
+        error_desc=error_desc,
+    )
+    return err
 
 
 async def test_state_machine_updates_from_device_callbacks(
@@ -354,6 +370,166 @@ async def test_play_pause_and_seek_services_update_state_machine(
 
     state = hass.states.get(MEDIA_PLAYER_ENTITY_ID)
     assert state.attributes[ATTR_MEDIA_POSITION] == 60
+
+
+async def test_media_pause_transition_not_available_refreshes_state(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_wiim_device: MagicMock,
+    mock_wiim_controller: MagicMock,
+) -> None:
+    """Test pause is idempotent when the device rejects it for its current state."""
+    await setup_integration(hass, mock_config_entry)
+    mock_wiim_device.playing_status = PlayingStatus.PLAYING
+    await fire_general_update(hass, mock_wiim_device)
+
+    state = hass.states.get(MEDIA_PLAYER_ENTITY_ID)
+    assert state.state == MediaPlayerState.PLAYING
+
+    async def async_update_http_status() -> None:
+        mock_wiim_device.playing_status = PlayingStatus.PAUSED
+
+    mock_wiim_device.async_pause.side_effect = _wiim_device_upnp_action_error(
+        701,
+        "Transition not available",
+    )
+    mock_wiim_device.supports_http_api = True
+    mock_wiim_device.async_update_http_status = AsyncMock(
+        side_effect=async_update_http_status
+    )
+    mock_wiim_device.sync_device_duration_and_position.reset_mock()
+
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_MEDIA_PAUSE,
+        {ATTR_ENTITY_ID: MEDIA_PLAYER_ENTITY_ID},
+        blocking=True,
+    )
+
+    mock_wiim_device.async_pause.assert_awaited_once()
+    mock_wiim_device.async_update_http_status.assert_awaited_once()
+    mock_wiim_device.sync_device_duration_and_position.assert_not_awaited()
+    mock_wiim_device.set_available.assert_not_called()
+    mock_wiim_controller.async_update_all_multiroom_status.assert_not_awaited()
+
+    state = hass.states.get(MEDIA_PLAYER_ENTITY_ID)
+    assert state.state == MediaPlayerState.PAUSED
+
+
+async def test_media_pause_transition_not_available_raises_when_still_playing(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_wiim_device: MagicMock,
+    mock_wiim_controller: MagicMock,
+) -> None:
+    """Test pause 701 raises if refreshed device state is still playing."""
+    await setup_integration(hass, mock_config_entry)
+    mock_wiim_device.playing_status = PlayingStatus.PLAYING
+    await fire_general_update(hass, mock_wiim_device)
+
+    async def async_update_http_status() -> None:
+        mock_wiim_device.playing_status = PlayingStatus.PLAYING
+
+    mock_wiim_device.async_pause.side_effect = _wiim_device_upnp_action_error(
+        701,
+        "Transition not available",
+    )
+    mock_wiim_device.supports_http_api = True
+    mock_wiim_device.async_update_http_status = AsyncMock(
+        side_effect=async_update_http_status
+    )
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            MEDIA_PLAYER_DOMAIN,
+            SERVICE_MEDIA_PAUSE,
+            {ATTR_ENTITY_ID: MEDIA_PLAYER_ENTITY_ID},
+            blocking=True,
+        )
+
+    mock_wiim_device.async_pause.assert_awaited_once()
+    mock_wiim_device.async_update_http_status.assert_awaited_once()
+    mock_wiim_device.set_available.assert_not_called()
+    mock_wiim_controller.async_update_all_multiroom_status.assert_not_awaited()
+
+    state = hass.states.get(MEDIA_PLAYER_ENTITY_ID)
+    assert state.state == MediaPlayerState.PLAYING
+
+
+async def test_media_pause_transition_not_available_raises_without_http_api(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_wiim_device: MagicMock,
+    mock_wiim_controller: MagicMock,
+) -> None:
+    """Test pause 701 raises if the device state cannot be refreshed."""
+    await setup_integration(hass, mock_config_entry)
+    mock_wiim_device.async_pause.side_effect = _wiim_device_upnp_action_error(
+        701,
+        "Transition not available",
+    )
+    mock_wiim_device.supports_http_api = False
+    mock_wiim_device.async_update_http_status = AsyncMock()
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            MEDIA_PLAYER_DOMAIN,
+            SERVICE_MEDIA_PAUSE,
+            {ATTR_ENTITY_ID: MEDIA_PLAYER_ENTITY_ID},
+            blocking=True,
+        )
+
+    mock_wiim_device.async_pause.assert_awaited_once()
+    mock_wiim_device.async_update_http_status.assert_not_awaited()
+    mock_wiim_device.set_available.assert_not_called()
+    mock_wiim_controller.async_update_all_multiroom_status.assert_not_awaited()
+
+
+async def test_media_pause_upnp_action_error_does_not_mark_unavailable(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_wiim_device: MagicMock,
+    mock_wiim_controller: MagicMock,
+) -> None:
+    """Test UPnP action response errors do not mark the device unavailable."""
+    await setup_integration(hass, mock_config_entry)
+    mock_wiim_device.async_pause.side_effect = _wiim_device_upnp_action_error(
+        718,
+        "Conflict in function arguments",
+    )
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            MEDIA_PLAYER_DOMAIN,
+            SERVICE_MEDIA_PAUSE,
+            {ATTR_ENTITY_ID: MEDIA_PLAYER_ENTITY_ID},
+            blocking=True,
+        )
+
+    mock_wiim_device.set_available.assert_not_called()
+    mock_wiim_controller.async_update_all_multiroom_status.assert_not_awaited()
+
+
+async def test_media_pause_device_error_marks_unavailable(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_wiim_device: MagicMock,
+    mock_wiim_controller: MagicMock,
+) -> None:
+    """Test non-action WiiM device errors still mark the device unavailable."""
+    await setup_integration(hass, mock_config_entry)
+    mock_wiim_device.async_pause.side_effect = WiimDeviceException("Connection failed")
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            MEDIA_PLAYER_DOMAIN,
+            SERVICE_MEDIA_PAUSE,
+            {ATTR_ENTITY_ID: MEDIA_PLAYER_ENTITY_ID},
+            blocking=True,
+        )
+
+    mock_wiim_device.set_available.assert_called_once_with(False)
+    mock_wiim_controller.async_update_all_multiroom_status.assert_awaited_once()
 
 
 async def test_follower_routes_commands_and_reads_leader_metadata(


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

WiiM media player service calls currently treat all `WiimDeviceException` failures as critical by calling `_async_handle_critical_error`. This can mark the entity unavailable even when the device successfully responded to a UPnP action and rejected only the requested transport transition.

This PR treats `UpnpActionResponseError` wrapped by `WiimDeviceException` as a non-critical service failure. The media player service still raises `HomeAssistantError` so the failed service call is visible, but it no longer marks the device unavailable for a device-level action rejection.

It also handles AVTransport pause error `701` as an idempotent pause outcome. WiiM reports this as `Transition not allowed` when pause is requested in a transport state where pause is not valid, such as when playback is already paused. In that case the integration refreshes status instead of surfacing a service failure.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

Validation performed locally:

- `pytest -q tests/components/wiim/test_media_player.py`
- `ruff check homeassistant/components/wiim/media_player.py tests/components/wiim/test_media_player.py tests/components/wiim/conftest.py`
- `ruff format --check homeassistant/components/wiim/media_player.py tests/components/wiim/test_media_player.py tests/components/wiim/conftest.py`
- `git diff --check upstream/dev...HEAD`

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr