### PR TITLE
Add chat log and response rendering to Wyoming conversation

### DIFF
--- a/homeassistant/components/wyoming/conversation.py
+++ b/homeassistant/components/wyoming/conversation.py
@@ -105,6 +105,8 @@ class WyomingConversationEntity(
         intent_response = intent.IntentResponse(language=user_input.language)
 
         context = {"conversation_id": conversation_id}
+        if user_input.device_id:
+            context["device_id"] = user_input.device_id
         if user_input.satellite_id:
             context["satellite_id"] = user_input.satellite_id
 

--- a/homeassistant/components/wyoming/conversation.py
+++ b/homeassistant/components/wyoming/conversation.py
@@ -1,7 +1,7 @@
 """Support for Wyoming intent recognition services."""
 
 import logging
-from typing import Literal
+from typing import Any, Literal
 
 from wyoming.asr import Transcript
 from wyoming.client import AsyncTcpClient
@@ -216,7 +216,7 @@ class WyomingConversationEntity(
                     if template.is_template_string(response_text):
                         # Render text as a template
                         response_text = self._render_speech_template(
-                            response_text, intent_response
+                            response_text, intent_response, intent_slots
                         )
 
                     intent_response.async_set_speech(response_text)
@@ -253,6 +253,7 @@ class WyomingConversationEntity(
         self,
         response_text: str,
         intent_response: intent.IntentResponse,
+        intent_slots: dict[str, Any],
     ) -> str:
         """Render speech template with similar behavior to the default agent."""
         state1: State | None = None
@@ -262,12 +263,15 @@ class WyomingConversationEntity(
             state1 = intent_response.unmatched_states[0]
 
         # Render response template
+        speech_slots = {name: value["value"] for name, value in intent_slots.items()}
+        speech_slots.update(intent_response.speech_slots)
+
         response_template = template.Template(response_text, self.hass)
         try:
             speech = response_template.async_render(
                 {
                     # Slots from intent recognizer and response
-                    "slots": intent_response.speech_slots,
+                    "slots": speech_slots,
                     # First matched or unmatched state
                     "state": (
                         template.TemplateState(self.hass, state1)

--- a/homeassistant/components/wyoming/conversation.py
+++ b/homeassistant/components/wyoming/conversation.py
@@ -11,8 +11,9 @@ from wyoming.intent import Intent, NotRecognized
 
 from homeassistant.components import conversation
 from homeassistant.const import MATCH_ALL
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import intent
+from homeassistant.core import HomeAssistant, State
+from homeassistant.exceptions import TemplateError
+from homeassistant.helpers import chat_session, intent, llm, template
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import ulid as ulid_util
 
@@ -119,68 +120,17 @@ class WyomingConversationEntity(
                         language=user_input.language,
                     ).event()
                 )
-
-                while True:
-                    event = await client.read_event()
-                    if event is None:
-                        _LOGGER.debug("Connection lost")
-                        intent_response.async_set_error(
-                            intent.IntentResponseErrorCode.UNKNOWN,
-                            "Connection to service was lost",
-                        )
-                        return conversation.ConversationResult(
-                            response=intent_response,
-                            conversation_id=user_input.conversation_id,
-                        )
-
-                    if Intent.is_type(event.type):
-                        # Success
-                        recognized_intent = Intent.from_event(event)
-                        _LOGGER.debug("Recognized intent: %s", recognized_intent)
-
-                        intent_type = recognized_intent.name
-                        intent_slots = {
-                            e.name: {"value": e.value}
-                            for e in recognized_intent.entities
-                        }
-                        intent_response = await intent.async_handle(
-                            self.hass,
-                            DOMAIN,
-                            intent_type,
-                            intent_slots,
-                            text_input=user_input.text,
-                            language=user_input.language,
-                            satellite_id=user_input.satellite_id,
-                            device_id=user_input.device_id,
-                        )
-
-                        if (not intent_response.speech) and recognized_intent.text:
-                            intent_response.async_set_speech(recognized_intent.text)
-
-                        break
-
-                    if NotRecognized.is_type(event.type):
-                        not_recognized = NotRecognized.from_event(event)
-                        intent_response.async_set_error(
-                            intent.IntentResponseErrorCode.NO_INTENT_MATCH,
-                            not_recognized.text or "",
-                        )
-                        break
-
-                    if Handled.is_type(event.type):
-                        # Success
-                        handled = Handled.from_event(event)
-                        intent_response.async_set_speech(handled.text or "")
-                        break
-
-                    if NotHandled.is_type(event.type):
-                        not_handled = NotHandled.from_event(event)
-                        intent_response.async_set_error(
-                            intent.IntentResponseErrorCode.FAILED_TO_HANDLE,
-                            not_handled.text or "",
-                        )
-                        break
-
+                with (
+                    chat_session.async_get_chat_session(
+                        self.hass, user_input.conversation_id
+                    ) as session,
+                    conversation.async_get_chat_log(
+                        self.hass, session, user_input
+                    ) as chat_log,
+                ):
+                    intent_response = await self._async_process(
+                        user_input, client, chat_log, intent_response
+                    )
         except (OSError, WyomingError) as err:
             _LOGGER.exception("Unexpected error while communicating with service")
             intent_response.async_set_error(
@@ -206,3 +156,145 @@ class WyomingConversationEntity(
         return conversation.ConversationResult(
             response=intent_response, conversation_id=conversation_id
         )
+
+    async def _async_process(
+        self,
+        user_input: conversation.ConversationInput,
+        client: AsyncTcpClient,
+        chat_log: conversation.ChatLog,
+        intent_response: intent.IntentResponse,
+    ) -> intent.IntentResponse:
+        """Process a sentence into an intent response."""
+        while True:
+            event = await client.read_event()
+            if event is None:
+                raise WyomingError("Connection lost")
+
+            if Intent.is_type(event.type):
+                # Success
+                recognized_intent = Intent.from_event(event)
+                _LOGGER.debug("Recognized intent: %s", recognized_intent)
+
+                intent_type = recognized_intent.name
+                intent_slots = {
+                    e.name: {"value": e.value} for e in recognized_intent.entities
+                }
+
+                # Add to trace and chat log
+                conversation.async_conversation_trace_append(
+                    conversation.ConversationTraceEventType.TOOL_CALL,
+                    {
+                        "intent_name": intent_type,
+                        "slots": intent_slots,
+                    },
+                )
+                tool_input = llm.ToolInput(
+                    tool_name=intent_type,
+                    tool_args=intent_slots,
+                    external=True,
+                )
+                chat_log.async_add_assistant_content_without_tools(
+                    conversation.AssistantContent(
+                        agent_id=user_input.agent_id,
+                        content=None,
+                        tool_calls=[tool_input],
+                    )
+                )
+                intent_response = await intent.async_handle(
+                    self.hass,
+                    DOMAIN,
+                    intent_type,
+                    intent_slots,
+                    text_input=user_input.text,
+                    language=user_input.language,
+                    satellite_id=user_input.satellite_id,
+                    device_id=user_input.device_id,
+                )
+
+                if (not intent_response.speech) and recognized_intent.text:
+                    response_text = recognized_intent.text
+                    if template.is_template_string(response_text):
+                        # Render text as a template
+                        response_text = self._render_speech_template(
+                            response_text, intent_response
+                        )
+
+                    intent_response.async_set_speech(response_text)
+
+                break
+
+            if NotRecognized.is_type(event.type):
+                # Intent was not recognized
+                not_recognized = NotRecognized.from_event(event)
+                intent_response.async_set_error(
+                    intent.IntentResponseErrorCode.NO_INTENT_MATCH,
+                    not_recognized.text or "",
+                )
+                break
+
+            if Handled.is_type(event.type):
+                # Success
+                handled = Handled.from_event(event)
+                intent_response.async_set_speech(handled.text or "")
+                break
+
+            if NotHandled.is_type(event.type):
+                # Command was not handled
+                not_handled = NotHandled.from_event(event)
+                intent_response.async_set_error(
+                    intent.IntentResponseErrorCode.FAILED_TO_HANDLE,
+                    not_handled.text or "",
+                )
+                break
+
+        return intent_response
+
+    def _render_speech_template(
+        self,
+        response_text: str,
+        intent_response: intent.IntentResponse,
+    ) -> str:
+        """Render speech template with similar behavior to the default agent."""
+        state1: State | None = None
+        if intent_response.matched_states:
+            state1 = intent_response.matched_states[0]
+        elif intent_response.unmatched_states:
+            state1 = intent_response.unmatched_states[0]
+
+        # Render response template
+        response_template = template.Template(response_text, self.hass)
+        try:
+            speech = response_template.async_render(
+                {
+                    # Slots from intent recognizer and response
+                    "slots": intent_response.speech_slots,
+                    # First matched or unmatched state
+                    "state": (
+                        template.TemplateState(self.hass, state1)
+                        if state1 is not None
+                        else None
+                    ),
+                    "query": {
+                        # Entity states that matched the query (e.g, "on")
+                        "matched": [
+                            template.TemplateState(self.hass, state)
+                            for state in intent_response.matched_states
+                        ],
+                        # Entity states that did not match the query
+                        "unmatched": [
+                            template.TemplateState(self.hass, state)
+                            for state in intent_response.unmatched_states
+                        ],
+                    },
+                }
+            )
+        except TemplateError:
+            _LOGGER.exception("Unexpected error while rendering response")
+            raise
+
+        # Normalize whitespace
+        if speech is not None:
+            speech = str(speech)
+            speech = " ".join(speech.strip().split())
+
+        return speech

--- a/tests/components/wyoming/snapshots/test_conversation.ambr
+++ b/tests/components/wyoming/snapshots/test_conversation.ambr
@@ -1,6 +1,6 @@
 # serializer version: 1
 # name: test_connection_lost
-  'Connection to service was lost'
+  'Error communicating with service: Connection lost'
 # ---
 # name: test_oserror
   'Error communicating with service: Boom!'

--- a/tests/components/wyoming/test_conversation.py
+++ b/tests/components/wyoming/test_conversation.py
@@ -18,11 +18,13 @@ from homeassistant.helpers import intent
 
 from . import HANDLE_INFO, INTENT_INFO, MockAsyncTcpClient
 
-from tests.components.conversation import MockChatLog
+from tests.components.conversation import MockChatLog, mock_chat_log  # noqa: F401
 
 
 async def test_intent(
-    hass: HomeAssistant, init_wyoming_intent: ConfigEntry, mock_chat_log: MockChatLog
+    hass: HomeAssistant,
+    init_wyoming_intent: ConfigEntry,
+    mock_chat_log: MockChatLog,  # noqa: F811
 ) -> None:
     """Test when an intent is recognized."""
     agent_id = "conversation.test_intent"

--- a/tests/components/wyoming/test_conversation.py
+++ b/tests/components/wyoming/test_conversation.py
@@ -67,6 +67,7 @@ async def test_intent(hass: HomeAssistant, init_wyoming_intent: ConfigEntry) -> 
     assert client.transcript.context == {
         "conversation_id": conversation_id,
         "satellite_id": satellite_id,
+        "device_id": device_id,
     }
 
     assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
@@ -141,6 +142,7 @@ async def test_handle(hass: HomeAssistant, init_wyoming_handle: ConfigEntry) -> 
     agent_id = "conversation.test_handle"
     conversation_id = "conversation-1234"
     satellite_id = "satellite-1234"
+    device_id = "device-1234"
 
     client = MockAsyncTcpClient([Handled(text="success").event()])
     with patch(
@@ -155,6 +157,7 @@ async def test_handle(hass: HomeAssistant, init_wyoming_handle: ConfigEntry) -> 
             language=hass.config.language,
             agent_id=agent_id,
             satellite_id=satellite_id,
+            device_id=device_id,
         )
 
     # Ensure language and context are sent
@@ -163,6 +166,7 @@ async def test_handle(hass: HomeAssistant, init_wyoming_handle: ConfigEntry) -> 
     assert client.transcript.context == {
         "conversation_id": conversation_id,
         "satellite_id": satellite_id,
+        "device_id": device_id,
     }
 
     assert result.response.response_type == intent.IntentResponseType.ACTION_DONE

--- a/tests/components/wyoming/test_conversation.py
+++ b/tests/components/wyoming/test_conversation.py
@@ -37,12 +37,14 @@ async def test_intent(
         entities=[Entity(name="entity", value="value")],
         text="""
         {# Verify template variables are present #}
+        {% if slots.entity == 'value' %}
         {% if slots.slot_name == 'slot_value' %}
         {% if state.entity_id == 'test.matched1' %}
         {% if query.matched[0].entity_id == 'test.matched1' %}
         {% if query.unmatched[0].entity_id == 'test.unmatched1' %}
         {% if query.unmatched[1].entity_id == 'test.unmatched2' %}
         success
+        {% endif %}
         {% endif %}
         {% endif %}
         {% endif %}

--- a/tests/components/wyoming/test_conversation.py
+++ b/tests/components/wyoming/test_conversation.py
@@ -10,25 +10,43 @@ from wyoming.info import Info
 from wyoming.intent import Entity, Intent, NotRecognized
 
 from homeassistant.components import conversation
+from homeassistant.components.conversation import chat_log
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import MATCH_ALL
-from homeassistant.core import Context, HomeAssistant
+from homeassistant.core import Context, HomeAssistant, State
 from homeassistant.helpers import intent
 
 from . import HANDLE_INFO, INTENT_INFO, MockAsyncTcpClient
 
+from tests.components.conversation import MockChatLog
 
-async def test_intent(hass: HomeAssistant, init_wyoming_intent: ConfigEntry) -> None:
+
+async def test_intent(
+    hass: HomeAssistant, init_wyoming_intent: ConfigEntry, mock_chat_log: MockChatLog
+) -> None:
     """Test when an intent is recognized."""
     agent_id = "conversation.test_intent"
-    conversation_id = "conversation-1234"
+    conversation_id = mock_chat_log.conversation_id
     satellite_id = "satellite-1234"
     device_id = "device-1234"
 
     test_intent = Intent(
         name="TestIntent",
         entities=[Entity(name="entity", value="value")],
-        text="success",
+        text="""
+        {# Verify template variables are present #}
+        {% if slots.slot_name == 'slot_value' %}
+        {% if state.entity_id == 'test.matched1' %}
+        {% if query.matched[0].entity_id == 'test.matched1' %}
+        {% if query.unmatched[0].entity_id == 'test.unmatched1' %}
+        {% if query.unmatched[1].entity_id == 'test.unmatched2' %}
+        success
+        {% endif %}
+        {% endif %}
+        {% endif %}
+        {% endif %}
+        {% endif %}
+        """,
     )
 
     class TestIntentHandler(intent.IntentHandler):
@@ -41,7 +59,19 @@ async def test_intent(hass: HomeAssistant, init_wyoming_intent: ConfigEntry) -> 
             assert intent_obj.slots.get("entity", {}).get("value") == "value"
             assert intent_obj.satellite_id == satellite_id
             assert intent_obj.device_id == device_id
-            return intent_obj.create_response()
+            response = intent_obj.create_response()
+
+            # Add parts to test response rendering
+            response.async_set_speech_slots({"slot_name": "slot_value"})
+            response.async_set_states(
+                matched_states=[State("test.matched1", "on")],
+                unmatched_states=[
+                    State("test.unmatched1", "off"),
+                    State("test.unmatched2", "off"),
+                ],
+            )
+
+            return response
 
     intent.async_register(hass, TestIntentHandler())
 
@@ -74,6 +104,21 @@ async def test_intent(hass: HomeAssistant, init_wyoming_intent: ConfigEntry) -> 
     assert result.response.speech, "No speech"
     assert result.response.speech.get("plain", {}).get("speech") == "success"
     assert result.conversation_id == conversation_id
+
+    # Verify that chat log recorded intent as tool call
+    content: chat_log.AssistantContent | None = next(
+        filter(
+            lambda c: isinstance(c, chat_log.AssistantContent), mock_chat_log.content
+        ),
+        None,
+    )
+    assert content is not None, "Missing assistant content"
+    assert content.tool_calls and len(content.tool_calls) == 1
+    tool_call = content.tool_calls[0]
+    assert tool_call.tool_name == test_intent.name
+    assert tool_call.tool_args == {
+        e.name: {"value": e.value} for e in test_intent.entities
+    }
 
 
 async def test_intent_handle_error(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds some improvements to the Wyoming `conversation` entity, specifically:

- Add missing `device_id` passed alongside `satellite_id`
- Register intents as tool calls in the chat log so they show up correctly in the debug view
- Render intent responses like the default agent if they're templates so external agents can reuse the responses from the [intents repo](https://github.com/OHF-Voice/intents)

The `async_process` method of the conversation entity was slightly refactored to avoid too much nesting with the chat log addition. This also makes the error handling cleaner :)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
