### PR TITLE
Fix WeatherFlow Cloud empty observations

### DIFF
--- a/homeassistant/components/weatherflow_cloud/sensor.py
+++ b/homeassistant/components/weatherflow_cloud/sensor.py
@@ -486,8 +486,21 @@ class WeatherFlowCloudSensorREST(WeatherFlowSensorBase):
     coordinator: WeatherFlowCloudUpdateCoordinatorREST
 
     @property
+    def _observation(self) -> Observation | None:
+        """Return the current station observation."""
+        observations = self.coordinator.data[self.station_id].observation.obs
+        if not observations:
+            return None
+        return observations[0]
+
+    @property
+    def available(self) -> bool:
+        """Get if available."""
+        return super().available and self._observation is not None
+
+    @property
     def native_value(self) -> StateType | datetime:
         """Return the native value."""
-        return self.entity_description.value_fn(
-            self.coordinator.data[self.station_id].observation.obs[0]
-        )
+        if (observation := self._observation) is None:
+            return None
+        return self.entity_description.value_fn(observation)

--- a/tests/components/weatherflow_cloud/test_sensor.py
+++ b/tests/components/weatherflow_cloud/test_sensor.py
@@ -1,5 +1,6 @@
 """Tests for the WeatherFlow Cloud sensor platform."""
 
+from dataclasses import replace
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -17,7 +18,7 @@ from homeassistant.components.weatherflow_cloud.sensor import (
     WeatherFlowWebsocketSensorObservation,
     WeatherFlowWebsocketSensorWind,
 )
-from homeassistant.const import STATE_UNKNOWN, Platform
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -88,6 +89,34 @@ async def test_all_entities_with_lightning_error(
             hass.states.get("sensor.my_home_station_lightning_last_strike").state
             == STATE_UNKNOWN
         )
+
+
+async def test_rest_sensor_unavailable_with_empty_observation(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_rest_api: AsyncMock,
+    mock_websocket_api: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test REST sensors are unavailable when no current observation is returned."""
+    with patch(
+        "homeassistant.components.weatherflow_cloud.PLATFORMS", [Platform.SENSOR]
+    ):
+        await setup_integration(hass, mock_config_entry)
+
+    assert hass.states.get("sensor.my_home_station_temperature").state == "10.5"
+
+    all_data = await mock_rest_api.get_all_data()
+    all_data[24432].observation = replace(all_data[24432].observation, obs=[])
+    mock_rest_api.get_all_data.return_value = all_data
+
+    freezer.tick(timedelta(minutes=5))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get("sensor.my_home_station_temperature").state == STATE_UNAVAILABLE
+    )
 
 
 async def test_websocket_sensor_observation(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

WeatherFlow Cloud REST sensors now handle station observation responses with an empty `obs` list. When the API has no current observation, the affected REST sensors become unavailable instead of raising `IndexError` during coordinator listener updates.

A regression test covers updating from a normal observation to `obs: []`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170355
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
