### PR TITLE
Fix fractional setpoints in Matter climate not rounded

### DIFF
--- a/homeassistant/components/matter/climate.py
+++ b/homeassistant/components/matter/climate.py
@@ -248,7 +248,7 @@ class MatterClimate(MatterEntity, ClimateEntity):
                         clusters.Thermostat.Attributes.OccupiedHeatingSetpoint
                     )
                 await self.write_attribute(
-                    value=int(target_temperature * TEMPERATURE_SCALING_FACTOR),
+                    value=round(target_temperature * TEMPERATURE_SCALING_FACTOR),
                     matter_attribute=matter_attribute,
                 )
             return
@@ -257,7 +257,7 @@ class MatterClimate(MatterEntity, ClimateEntity):
             # multi setpoint control - low setpoint (heat)
             if self.target_temperature_low != target_temperature_low:
                 await self.write_attribute(
-                    value=int(target_temperature_low * TEMPERATURE_SCALING_FACTOR),
+                    value=round(target_temperature_low * TEMPERATURE_SCALING_FACTOR),
                     matter_attribute=clusters.Thermostat.Attributes.OccupiedHeatingSetpoint,
                 )
 
@@ -265,7 +265,7 @@ class MatterClimate(MatterEntity, ClimateEntity):
             # multi setpoint control - high setpoint (cool)
             if self.target_temperature_high != target_temperature_high:
                 await self.write_attribute(
-                    value=int(target_temperature_high * TEMPERATURE_SCALING_FACTOR),
+                    value=round(target_temperature_high * TEMPERATURE_SCALING_FACTOR),
                     matter_attribute=clusters.Thermostat.Attributes.OccupiedCoolingSetpoint,
                 )
 

--- a/tests/components/matter/test_climate.py
+++ b/tests/components/matter/test_climate.py
@@ -402,6 +402,25 @@ async def test_thermostat_service_calls(
     )
     matter_client.write_attribute.reset_mock()
 
+    # fractional setpoints must round, not truncate: 10.2 * 100 is 1019.9999…
+    # in IEEE 754, so int() would produce 1019 instead of 1020.
+    await hass.services.async_call(
+        "climate",
+        "set_temperature",
+        {
+            "entity_id": "climate.longan_link_hvac",
+            "temperature": 10.2,
+            "hvac_mode": HVACMode.HEAT,
+        },
+        blocking=True,
+    )
+    assert matter_client.write_attribute.call_args_list[-1] == call(
+        node_id=matter_node.node_id,
+        attribute_path="1/513/18",
+        value=1020,
+    )
+    matter_client.write_attribute.reset_mock()
+
 
 @pytest.mark.parametrize("node_fixture", ["mock_room_airconditioner"])
 async def test_room_airconditioner(


### PR DESCRIPTION
## Proposed change

This fixes an issue with Matter where setting a thermostat target temperature with a fractional value (e.g. `10.2` °C) was sent to Matter as `1019` instead of `1020`.

As Matter encodes thermostat setpoints in hundredths of a degree, the integration multiplies the value by 100. The result was then converted with `int()`, which truncates toward zero. `10.2 * 100` evaluates to `1019.9999999999999`, so the encoded value came out one step low.

This is fixed by using `round()`, as it matches what the user requested and is consistent with how the Matter [`water_heater` platform](https://github.com/home-assistant/core/blob/944c0d7ed2e2d1270b8871a59eb19fedf6a59613/homeassistant/components/matter/water_heater.py#L116) and [`number` platform](https://github.com/home-assistant/core/blob/944c0d7ed2e2d1270b8871a59eb19fedf6a59613/homeassistant/components/matter/number.py#L556) already encode scaled values.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: (noticed here: https://github.com/matter-js/matterjs-server/issues/640#issuecomment-4433123486)
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
