### PR TITLE
Add exception translations to FRITZ!SmartHome

### DIFF
--- a/homeassistant/components/fritzbox/coordinator.py
+++ b/homeassistant/components/fritzbox/coordinator.py
@@ -67,7 +67,10 @@ class FritzboxDataUpdateCoordinator(DataUpdateCoordinator[FritzboxCoordinatorDat
         try:
             await self.hass.async_add_executor_job(self.fritz.login)
         except RequestConnectionError as err:
-            raise ConfigEntryNotReady from err
+            raise ConfigEntryNotReady(
+                translation_domain=DOMAIN,
+                translation_key="connect_error",
+            ) from err
         except LoginError as err:
             raise ConfigEntryAuthFailed from err
 
@@ -188,7 +191,10 @@ class FritzboxDataUpdateCoordinator(DataUpdateCoordinator[FritzboxCoordinatorDat
                 ex,
             )
             self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
-            raise UpdateFailed from ex
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="connect_error_reload",
+            ) from ex
 
         for device in new_data.devices.values():
             # create device registry entry for new main devices

--- a/homeassistant/components/fritzbox/coordinator.py
+++ b/homeassistant/components/fritzbox/coordinator.py
@@ -72,7 +72,10 @@ class FritzboxDataUpdateCoordinator(DataUpdateCoordinator[FritzboxCoordinatorDat
                 translation_key="connect_error",
             ) from err
         except LoginError as err:
-            raise ConfigEntryAuthFailed from err
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="login_failed",
+            ) from err
 
         self.has_templates = await self.hass.async_add_executor_job(
             self.fritz.has_templates

--- a/homeassistant/components/fritzbox/strings.json
+++ b/homeassistant/components/fritzbox/strings.json
@@ -97,6 +97,9 @@
     "connect_error_reload": {
       "message": "A connection error occurred while updating the data from the FRITZ!Box. The integration is going to be reloaded to ensure a proper re-login."
     },
+    "login_failed": {
+      "message": "Login failed, please check your username and password and try again."
+    },
     "manual_switching_disabled": {
       "message": "Can't toggle switch while manual switching is disabled for the device."
     }

--- a/homeassistant/components/fritzbox/strings.json
+++ b/homeassistant/components/fritzbox/strings.json
@@ -92,10 +92,10 @@
       "message": "Can't change settings while manual access for telephone, app, or user interface is disabled on the device"
     },
     "connect_error": {
-      "message": "A connection error occured while setting up the integration, the setup will be retried."
+      "message": "A connection error occurred while setting up the integration, the setup will be retried."
     },
     "connect_error_reload": {
-      "message": "A connection error occured while updating the data from the FRITZ!Box, the integration is going to be reloaded to ensure a proper re-login."
+      "message": "A connection error occurred while updating the data from the FRITZ!Box, the integration is going to be reloaded to ensure a proper re-login."
     },
     "manual_switching_disabled": {
       "message": "Can't toggle switch while manual switching is disabled for the device."

--- a/homeassistant/components/fritzbox/strings.json
+++ b/homeassistant/components/fritzbox/strings.json
@@ -92,10 +92,10 @@
       "message": "Can't change settings while manual access for telephone, app, or user interface is disabled on the device"
     },
     "connect_error": {
-      "message": "A connection error occurred while setting up the integration, the setup will be retried."
+      "message": "A connection error occurred while setting up the integration. The setup will be retried."
     },
     "connect_error_reload": {
-      "message": "A connection error occurred while updating the data from the FRITZ!Box, the integration is going to be reloaded to ensure a proper re-login."
+      "message": "A connection error occurred while updating the data from the FRITZ!Box. The integration is going to be reloaded to ensure a proper re-login."
     },
     "manual_switching_disabled": {
       "message": "Can't toggle switch while manual switching is disabled for the device."

--- a/homeassistant/components/fritzbox/strings.json
+++ b/homeassistant/components/fritzbox/strings.json
@@ -91,6 +91,12 @@
     "change_settings_while_lock_enabled": {
       "message": "Can't change settings while manual access for telephone, app, or user interface is disabled on the device"
     },
+    "connect_error": {
+      "message": "A connection error occured while setting up the integration, the setup will be retried."
+    },
+    "connect_error_reload": {
+      "message": "A connection error occured while updating the data from the FRITZ!Box, the integration is going to be reloaded to ensure a proper re-login."
+    },
     "manual_switching_disabled": {
       "message": "Can't toggle switch while manual switching is disabled for the device."
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds the missing exception translations to full-fill IQS rule [`exception-translations`](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/exception-translations/)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
