### PR TITLE
Guard async_migrate_entry() from downgraded from a future version (A-H)

### DIFF
--- a/homeassistant/components/adax/__init__.py
+++ b/homeassistant/components/adax/__init__.py
@@ -33,6 +33,11 @@ async def async_migrate_entry(
     hass: HomeAssistant, config_entry: AdaxConfigEntry
 ) -> bool:
     """Migrate old entry."""
+
+    if config_entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+
     # convert title and unique_id to string
     if config_entry.version == 1:
         if isinstance(config_entry.unique_id, int):

--- a/homeassistant/components/airnow/__init__.py
+++ b/homeassistant/components/airnow/__init__.py
@@ -68,6 +68,10 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate old entry."""
     _LOGGER.debug("Migrating from version %s", entry.version)
 
+    if entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+
     if entry.version == 1:
         new_options = {CONF_RADIUS: entry.data[CONF_RADIUS]}
         new_data = entry.data.copy()

--- a/homeassistant/components/airos/__init__.py
+++ b/homeassistant/components/airos/__init__.py
@@ -114,8 +114,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: AirOSConfigEntry) -> boo
 async def async_migrate_entry(hass: HomeAssistant, entry: AirOSConfigEntry) -> bool:
     """Migrate old config entry."""
 
-    # This means the user has downgraded from a future version
     if entry.version > 2:
+        # This means the user has downgraded from a future version
         return False
 
     # 1.1 Migrate config_entry to add advanced ssl settings

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -193,6 +193,10 @@ async def async_migrate_entry(hass: HomeAssistant, entry: AirVisualConfigEntry) 
     """Migrate an old config entry."""
     version = entry.version
 
+    if version > 3:
+        # This means the user has downgraded from a future version
+        return False
+
     LOGGER.debug("Migrating from version %s", version)
 
     # 1 -> 2: One geography per config entry

--- a/homeassistant/components/airzone/__init__.py
+++ b/homeassistant/components/airzone/__init__.py
@@ -119,6 +119,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: AirzoneConfigEntry) -> 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: AirzoneConfigEntry) -> bool:
     """Migrate an old entry."""
+
+    if entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+
     if entry.version == 1 and entry.minor_version < 2:
         # Add missing CONF_ID
         system_id = entry.data.get(CONF_ID, DEFAULT_SYSTEM_ID)

--- a/homeassistant/components/aladdin_connect/__init__.py
+++ b/homeassistant/components/aladdin_connect/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
 )
 
 from . import api
-from .const import CONFIG_FLOW_MINOR_VERSION, CONFIG_FLOW_VERSION, DOMAIN
+from .const import CONFIG_FLOW_MINOR_VERSION, DOMAIN
 from .coordinator import AladdinConnectConfigEntry, AladdinConnectCoordinator
 
 PLATFORMS: list[Platform] = [Platform.COVER, Platform.SENSOR]
@@ -76,13 +76,18 @@ async def async_migrate_entry(
     hass: HomeAssistant, config_entry: AladdinConnectConfigEntry
 ) -> bool:
     """Migrate old config."""
-    if config_entry.version < CONFIG_FLOW_VERSION:
+
+    if config_entry.version > 2:
+        # This means the user has downgraded from a future version
+        return False
+
+    if config_entry.version < 2:
         config_entry.async_start_reauth(hass)
         new_data = {**config_entry.data}
         hass.config_entries.async_update_entry(
             config_entry,
             data=new_data,
-            version=CONFIG_FLOW_VERSION,
+            version=2,
             minor_version=CONFIG_FLOW_MINOR_VERSION,
         )
 

--- a/homeassistant/components/alexa_devices/__init__.py
+++ b/homeassistant/components/alexa_devices/__init__.py
@@ -44,6 +44,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: AmazonConfigEntry) -> bo
 async def async_migrate_entry(hass: HomeAssistant, entry: AmazonConfigEntry) -> bool:
     """Migrate old entry."""
 
+    if entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+
     if entry.version == 1 and entry.minor_version < 3:
         if CONF_SITE in entry.data:
             # Site in data (wrong place), just move to login data

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -101,6 +101,10 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate old entry."""
     version = entry.version
 
+    if entry.version > 2:
+        # This means the user has downgraded from a future version
+        return False
+
     LOGGER.debug("Migrating from version %s", version)
 
     # 1 -> 2: Unique ID format changed, so delete and re-import:

--- a/homeassistant/components/analytics_insights/__init__.py
+++ b/homeassistant/components/analytics_insights/__init__.py
@@ -63,6 +63,11 @@ async def async_migrate_entry(
     hass: HomeAssistant, entry: AnalyticsInsightsConfigEntry
 ) -> bool:
     """Migrate to a new version."""
+
+    if entry.version > 2:
+        # This means the user has downgraded from a future version
+        return False
+
     # Migration for switching add-ons to apps
     if entry.version < 2:
         ent_reg = er.async_get(hass)

--- a/homeassistant/components/androidtv/__init__.py
+++ b/homeassistant/components/androidtv/__init__.py
@@ -168,6 +168,11 @@ async def async_connect_androidtv(
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate old entry."""
+
+    if entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+
     _LOGGER.debug(
         "Migrating configuration from version %s.%s", entry.version, entry.minor_version
     )

--- a/homeassistant/components/arve/__init__.py
+++ b/homeassistant/components/arve/__init__.py
@@ -14,6 +14,11 @@ PLATFORMS: list[Platform] = [Platform.SENSOR]
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ArveConfigEntry) -> bool:
     """Migrate entry."""
+
+    if entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+
     _LOGGER.debug("Migrating from version %s.%s", entry.version, entry.minor_version)
 
     if entry.version == 1:

--- a/homeassistant/components/aseko_pool_live/__init__.py
+++ b/homeassistant/components/aseko_pool_live/__init__.py
@@ -40,6 +40,11 @@ async def async_migrate_entry(
     hass: HomeAssistant, config_entry: AsekoConfigEntry
 ) -> bool:
     """Migrate old entry."""
+
+    if config_entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+
     _LOGGER.debug("Migrating from version %s", config_entry.version)
 
     if config_entry.version == 1:

--- a/homeassistant/components/axis/__init__.py
+++ b/homeassistant/components/axis/__init__.py
@@ -48,6 +48,11 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Migrate old entry."""
+
+    if config_entry.version > 3:
+        # This means the user has downgraded from a future version
+        return False
+
     _LOGGER.debug("Migrating from version %s", config_entry.version)
 
     if config_entry.version != 3:

--- a/homeassistant/components/blink/__init__.py
+++ b/homeassistant/components/blink/__init__.py
@@ -41,6 +41,11 @@ async def _reauth_flow_wrapper(
 
 async def async_migrate_entry(hass: HomeAssistant, entry: BlinkConfigEntry) -> bool:
     """Handle migration of a previous version config entry."""
+
+    if entry.version > 3:
+        # This means the user has downgraded from a future version
+        return False
+
     _LOGGER.debug("Migrating from version %s", entry.version)
     data = {**entry.data}
     if entry.version == 1:

--- a/homeassistant/components/brother/__init__.py
+++ b/homeassistant/components/brother/__init__.py
@@ -71,6 +71,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: BrotherConfigEntry) -> 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: BrotherConfigEntry) -> bool:
     """Migrate an old entry."""
+
+    if entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+
     if entry.version == 1 and entry.minor_version < 2:
         new_data = entry.data.copy()
         new_data[SECTION_ADVANCED_SETTINGS] = {

--- a/homeassistant/components/bsblan/__init__.py
+++ b/homeassistant/components/bsblan/__init__.py
@@ -224,15 +224,16 @@ async def async_unload_entry(hass: HomeAssistant, entry: BSBLanConfigEntry) -> b
 
 async def async_migrate_entry(hass: HomeAssistant, entry: BSBLanConfigEntry) -> bool:
     """Migrate old config entries to the latest schema."""
+
+    if entry.version > 1:
+        # Downgraded from a future version; cannot migrate.
+        return False
+
     LOGGER.debug(
         "Migrating BSB-LAN entry from version %s.%s",
         entry.version,
         entry.minor_version,
     )
-
-    if entry.version > 1:
-        # Downgraded from a future version; cannot migrate.
-        return False
 
     # 1.1 -> 1.2: Add CONF_HEATING_CIRCUITS. Attempt to discover available
     # heating circuits from the device; fall back to [1] (pre-multi-circuit

--- a/homeassistant/components/cookidoo/__init__.py
+++ b/homeassistant/components/cookidoo/__init__.py
@@ -46,6 +46,11 @@ async def async_migrate_entry(
     hass: HomeAssistant, config_entry: CookidooConfigEntry
 ) -> bool:
     """Migrate config entry."""
+
+    if config_entry.version > 1:
+        # Downgraded from a future version; cannot migrate.
+        return False
+
     _LOGGER.debug("Migrating from version %s", config_entry.version)
 
     if config_entry.version == 1 and config_entry.minor_version == 1:

--- a/homeassistant/components/derivative/__init__.py
+++ b/homeassistant/components/derivative/__init__.py
@@ -48,15 +48,15 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Migrate old entry."""
 
+    if config_entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+
     _LOGGER.debug(
         "Migrating configuration from version %s.%s",
         config_entry.version,
         config_entry.minor_version,
     )
-
-    if config_entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
 
     if config_entry.version == 1:
         if config_entry.minor_version < 2:

--- a/homeassistant/components/electric_kiwi/__init__.py
+++ b/homeassistant/components/electric_kiwi/__init__.py
@@ -82,6 +82,11 @@ async def async_migrate_entry(
     hass: HomeAssistant, config_entry: ElectricKiwiConfigEntry
 ) -> bool:
     """Migrate old entry."""
+
+    if config_entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+
     if config_entry.version == 1 and config_entry.minor_version == 1:
         implementation = (
             await config_entry_oauth2_flow.async_get_config_entry_implementation(

--- a/homeassistant/components/elevenlabs/__init__.py
+++ b/homeassistant/components/elevenlabs/__init__.py
@@ -92,15 +92,15 @@ async def async_migrate_entry(
 ) -> bool:
     """Migrate old config entry to new format."""
 
+    if config_entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+
     _LOGGER.debug(
         "Migrating configuration from version %s.%s",
         config_entry.version,
         config_entry.minor_version,
     )
-
-    if config_entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
 
     if config_entry.version == 1:
         new_options = {**config_entry.options}

--- a/homeassistant/components/epson/__init__.py
+++ b/homeassistant/components/epson/__init__.py
@@ -82,15 +82,16 @@ async def async_migrate_entry(
     hass: HomeAssistant, config_entry: EpsonConfigEntry
 ) -> bool:
     """Migrate old entry."""
+
+    if config_entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+
     _LOGGER.debug(
         "Migrating configuration from version %s.%s",
         config_entry.version,
         config_entry.minor_version,
     )
-
-    if config_entry.version > 1 or config_entry.minor_version > 1:
-        # This means the user has downgraded from a future version
-        return False
 
     if config_entry.version == 1 and config_entry.minor_version == 1:
         new_data = {**config_entry.data}

--- a/homeassistant/components/file/__init__.py
+++ b/homeassistant/components/file/__init__.py
@@ -54,7 +54,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Migrate config entry."""
     if config_entry.version > 2:
-        # Downgraded from future
+        # This means the user has downgraded from a future version
         return False
 
     if config_entry.version < 2:

--- a/homeassistant/components/forecast_solar/__init__.py
+++ b/homeassistant/components/forecast_solar/__init__.py
@@ -31,6 +31,10 @@ async def async_migrate_entry(
 ) -> bool:
     """Migrate old config entry."""
 
+    if entry.version > 2:
+        # This means the user has downgraded from a future version
+        return False
+
     if entry.version == 1:
         new_options = entry.options.copy()
         new_options |= {

--- a/homeassistant/components/foscam/__init__.py
+++ b/homeassistant/components/foscam/__init__.py
@@ -50,6 +50,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: FoscamConfigEntry) -> b
 
 async def async_migrate_entry(hass: HomeAssistant, entry: FoscamConfigEntry) -> bool:
     """Migrate old entry."""
+
+    if entry.version > 2:
+        # This means the user has downgraded from a future version
+        return False
+
     LOGGER.debug("Migrating from version %s", entry.version)
 
     if entry.version == 1:

--- a/homeassistant/components/fujitsu_fglair/__init__.py
+++ b/homeassistant/components/fujitsu_fglair/__init__.py
@@ -49,6 +49,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: FGLairConfigEntry) -> b
 async def async_migrate_entry(hass: HomeAssistant, entry: FGLairConfigEntry) -> bool:
     """Migrate old entry."""
     if entry.version > 1:
+        # This means the user has downgraded from a future version
         return False
 
     if entry.version == 1:

--- a/homeassistant/components/fyta/__init__.py
+++ b/homeassistant/components/fyta/__init__.py
@@ -63,11 +63,12 @@ async def async_migrate_entry(
     hass: HomeAssistant, config_entry: FytaConfigEntry
 ) -> bool:
     """Migrate old entry."""
-    _LOGGER.debug("Migrating from version %s", config_entry.version)
 
     if config_entry.version > 1:
         # This means the user has downgraded from a future version
         return False
+
+    _LOGGER.debug("Migrating from version %s", config_entry.version)
 
     if config_entry.version == 1:
         if config_entry.minor_version < 2:

--- a/homeassistant/components/generic/__init__.py
+++ b/homeassistant/components/generic/__init__.py
@@ -57,11 +57,12 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate entry."""
-    _LOGGER.debug("Migrating from version %s:%s", entry.version, entry.minor_version)
 
     if entry.version > 2:
         # This means the user has downgraded from a future version
         return False
+
+    _LOGGER.debug("Migrating from version %s:%s", entry.version, entry.minor_version)
 
     if entry.version == 1:
         # Migrate to advanced section

--- a/homeassistant/components/generic_hygrostat/__init__.py
+++ b/homeassistant/components/generic_hygrostat/__init__.py
@@ -145,13 +145,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Migrate old entry."""
-    _LOGGER.debug(
-        "Migrating from version %s.%s", config_entry.version, config_entry.minor_version
-    )
 
     if config_entry.version > 1:
         # This means the user has downgraded from a future version
         return False
+
+    _LOGGER.debug(
+        "Migrating from version %s.%s", config_entry.version, config_entry.minor_version
+    )
+
     if config_entry.version == 1:
         options = {**config_entry.options}
         if config_entry.minor_version < 2:

--- a/homeassistant/components/generic_thermostat/__init__.py
+++ b/homeassistant/components/generic_thermostat/__init__.py
@@ -72,13 +72,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Migrate old entry."""
-    _LOGGER.debug(
-        "Migrating from version %s.%s", config_entry.version, config_entry.minor_version
-    )
 
     if config_entry.version > 1:
         # This means the user has downgraded from a future version
         return False
+
+    _LOGGER.debug(
+        "Migrating from version %s.%s", config_entry.version, config_entry.minor_version
+    )
+
     if config_entry.version == 1:
         options = {**config_entry.options}
         if config_entry.minor_version < 2:

--- a/homeassistant/components/github/__init__.py
+++ b/homeassistant/components/github/__init__.py
@@ -66,6 +66,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: GithubConfigEntry) -> b
 
 async def async_migrate_entry(hass: HomeAssistant, entry: GithubConfigEntry) -> bool:
     """Migrate old entry."""
+
+    if entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+
     if entry.minor_version == 1:
         dev_reg = dr.async_get(hass)
         # In minor version 2 we migrated repositories from entry options to
@@ -87,4 +92,5 @@ async def async_migrate_entry(hass: HomeAssistant, entry: GithubConfigEntry) -> 
                     add_config_entry_id=entry.entry_id,
                 )
         hass.config_entries.async_update_entry(entry, minor_version=2)
+
     return True

--- a/homeassistant/components/google_generative_ai_conversation/__init__.py
+++ b/homeassistant/components/google_generative_ai_conversation/__init__.py
@@ -224,11 +224,12 @@ async def async_migrate_entry(
     hass: HomeAssistant, entry: GoogleGenerativeAIConfigEntry
 ) -> bool:
     """Migrate entry."""
-    LOGGER.debug("Migrating from version %s:%s", entry.version, entry.minor_version)
 
     if entry.version > 2:
         # This means the user has downgraded from a future version
         return False
+
+    LOGGER.debug("Migrating from version %s:%s", entry.version, entry.minor_version)
 
     if entry.version == 2 and entry.minor_version == 1:
         # Add TTS subentry which was missing in 2025.7.0b0

--- a/homeassistant/components/google_travel_time/__init__.py
+++ b/homeassistant/components/google_travel_time/__init__.py
@@ -39,6 +39,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Migrate an old config entry."""
 
+    if config_entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+
     if config_entry.version == 1:
         _LOGGER.debug(
             "Migrating from version %s.%s",
@@ -67,4 +71,5 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             config_entry.version,
             config_entry.minor_version,
         )
+
     return True

--- a/homeassistant/components/growatt_server/__init__.py
+++ b/homeassistant/components/growatt_server/__init__.py
@@ -90,6 +90,10 @@ async def async_migrate_entry(
         Setup:     [reuse cached API] → device_list()
     This reduces to just 1 login() call during the migration+setup cycle and prevent account lockout.
     """
+    if config_entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+
     _LOGGER.debug(
         "Migrating config entry from version %s.%s",
         config_entry.version,

--- a/homeassistant/components/here_travel_time/__init__.py
+++ b/homeassistant/components/here_travel_time/__init__.py
@@ -82,6 +82,10 @@ async def async_migrate_entry(
 ) -> bool:
     """Migrate an old config entry."""
 
+    if config_entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+
     if config_entry.version == 1 and config_entry.minor_version == 1:
         _LOGGER.debug(
             "Migrating from version %s.%s",

--- a/homeassistant/components/history_stats/__init__.py
+++ b/homeassistant/components/history_stats/__init__.py
@@ -96,13 +96,15 @@ async def async_setup_entry(
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Migrate old entry."""
-    _LOGGER.debug(
-        "Migrating from version %s.%s", config_entry.version, config_entry.minor_version
-    )
 
     if config_entry.version > 1:
         # This means the user has downgraded from a future version
         return False
+
+    _LOGGER.debug(
+        "Migrating from version %s.%s", config_entry.version, config_entry.minor_version
+    )
+
     if config_entry.version == 1:
         options = {**config_entry.options}
         if config_entry.minor_version < 2:

--- a/homeassistant/components/home_connect/__init__.py
+++ b/homeassistant/components/home_connect/__init__.py
@@ -146,6 +146,11 @@ async def async_migrate_entry(
     hass: HomeAssistant, entry: HomeConnectConfigEntry
 ) -> bool:
     """Migrate old entry."""
+
+    if entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+
     _LOGGER.debug("Migrating from version %s.%s", entry.version, entry.minor_version)
 
     if entry.version == 1:

--- a/homeassistant/components/homeassistant_sky_connect/__init__.py
+++ b/homeassistant/components/homeassistant_sky_connect/__init__.py
@@ -119,6 +119,10 @@ async def async_migrate_entry(
 ) -> bool:
     """Migrate old entry."""
 
+    if config_entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+
     _LOGGER.debug(
         "Migrating from version %s.%s", config_entry.version, config_entry.minor_version
     )

--- a/homeassistant/components/homeassistant_yellow/__init__.py
+++ b/homeassistant/components/homeassistant_yellow/__init__.py
@@ -125,6 +125,10 @@ async def async_migrate_entry(
 ) -> bool:
     """Migrate old entry."""
 
+    if config_entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+
     _LOGGER.debug(
         "Migrating from version %s.%s", config_entry.version, config_entry.minor_version
     )
@@ -165,7 +169,4 @@ async def async_migrate_entry(
             config_entry.minor_version,
         )
 
-        return True
-
-    # This means the user has downgraded from a future version
-    return False
+    return True

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -127,6 +127,7 @@ async def async_migrate_entry(
 ) -> bool:
     """Migrate the config entry from version 1 to version 2."""
     if config_entry.version > 2:
+        # This means the user has downgraded from a future version
         return False
 
     if config_entry.version == 1:

--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -508,6 +508,10 @@ async def async_migrate_entry(
     hass: HomeAssistant, config_entry: HuaweiLteConfigEntry
 ) -> bool:
     """Migrate config entry to new version."""
+    if config_entry.version > 3:
+        # This means the user has downgraded from a future version
+        return False
+
     if config_entry.version == 1:
         options = dict(config_entry.options)
         recipient = options.get(CONF_RECIPIENT)

--- a/homeassistant/components/hunterdouglas_powerview/__init__.py
+++ b/homeassistant/components/hunterdouglas_powerview/__init__.py
@@ -131,6 +131,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: PowerviewConfigEntry) -
 async def async_migrate_entry(hass: HomeAssistant, entry: PowerviewConfigEntry) -> bool:
     """Migrate entry."""
 
+    if entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+
     _LOGGER.debug("Migrating from version %s.%s", entry.version, entry.minor_version)
 
     if entry.version == 1:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Guard async_migrate_entry() from downgraded from a future version

/cc @MartinHjelmare 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
