### PR TITLE
Fix influxdb reconfigure for v1 configuration

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    }
+  }
+}

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,9 +1,0 @@
-{
-  "features": {
-    "ghcr.io/devcontainers/features/github-cli:1": {
-      "version": "1.1.0",
-      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
-      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
-    }
-  }
-}

--- a/homeassistant/components/influxdb/config_flow.py
+++ b/homeassistant/components/influxdb/config_flow.py
@@ -290,7 +290,9 @@ class InfluxDBConfigFlow(ConfigFlow, domain=DOMAIN):
                     scheme="https" if entry.data.get(CONF_SSL) else "http",
                     host=entry.data.get(CONF_HOST, ""),
                     port=entry.data.get(CONF_PORT),
-                    path=entry.data.get(CONF_PATH, ""),
+                    path=""
+                    if entry.data.get(CONF_PATH) is None
+                    else entry.data[CONF_PATH],
                 )
             )
 

--- a/tests/components/influxdb/test_config_flow.py
+++ b/tests/components/influxdb/test_config_flow.py
@@ -1188,3 +1188,29 @@ async def test_reconfigure_connection_error(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
+
+
+async def test_reconfigure_v1_none_path(
+    hass: HomeAssistant,
+) -> None:
+    """Test reconfigure flow starts correctly when CONF_PATH is None."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_API_VERSION: DEFAULT_API_VERSION,
+            CONF_HOST: "localhost",
+            CONF_PORT: 8086,
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "pass",
+            CONF_DB_NAME: "home_assistant",
+            CONF_SSL: False,
+            CONF_PATH: None,
+            CONF_VERIFY_SSL: False,
+        },
+    )
+    mock_entry.add_to_hass(hass)
+
+    result = await mock_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure_v1"

--- a/tests/components/influxdb/test_config_flow.py
+++ b/tests/components/influxdb/test_config_flow.py
@@ -783,6 +783,39 @@ async def test_single_instance_import(
             },
             "new_db (newhost)",
         ),
+        (
+            DEFAULT_API_VERSION,
+            {
+                CONF_API_VERSION: DEFAULT_API_VERSION,
+                CONF_HOST: "localhost",
+                CONF_PORT: 8086,
+                CONF_USERNAME: "user",
+                CONF_PASSWORD: "pass",
+                CONF_DB_NAME: "home_assistant",
+                CONF_SSL: False,
+                CONF_PATH: None,
+                CONF_VERIFY_SSL: False,
+            },
+            {
+                CONF_URL: "https://newhost:9999",
+                CONF_VERIFY_SSL: True,
+                CONF_DB_NAME: "new_db",
+                CONF_USERNAME: "new_user",
+                CONF_PASSWORD: "new_pass",
+            },
+            {
+                CONF_API_VERSION: DEFAULT_API_VERSION,
+                CONF_HOST: "newhost",
+                CONF_PORT: 9999,
+                CONF_USERNAME: "new_user",
+                CONF_PASSWORD: "new_pass",
+                CONF_DB_NAME: "new_db",
+                CONF_SSL: True,
+                CONF_PATH: "/",
+                CONF_VERIFY_SSL: True,
+            },
+            "new_db (newhost)",
+        ),
     ],
     indirect=["mock_client"],
 )
@@ -1188,29 +1221,3 @@ async def test_reconfigure_connection_error(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
-
-
-async def test_reconfigure_v1_none_path(
-    hass: HomeAssistant,
-) -> None:
-    """Test reconfigure flow starts correctly when CONF_PATH is None."""
-    mock_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_API_VERSION: DEFAULT_API_VERSION,
-            CONF_HOST: "localhost",
-            CONF_PORT: 8086,
-            CONF_USERNAME: "user",
-            CONF_PASSWORD: "pass",
-            CONF_DB_NAME: "home_assistant",
-            CONF_SSL: False,
-            CONF_PATH: None,
-            CONF_VERIFY_SSL: False,
-        },
-    )
-    mock_entry.add_to_hass(hass)
-
-    result = await mock_entry.start_reconfigure_flow(hass)
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_v1"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When influxdb v1 is imported, in `entry.data` key `path` is `None`. When reconfiguring, `URL.build` cannot deal with the `None`. Instead, an empty string should be passed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #165712
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
 
  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
