### PR TITLE
Add intent timer websocket API

### DIFF
--- a/homeassistant/components/intent/__init__.py
+++ b/homeassistant/components/intent/__init__.py
@@ -58,6 +58,7 @@ from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, TIMER_DATA
 from .timers import (
+    EVENT_TIMER_FINISHED,
     CancelAllTimersIntentHandler,
     CancelTimerIntentHandler,
     DecreaseTimerIntentHandler,
@@ -72,6 +73,7 @@ from .timers import (
     async_device_supports_timers,
     async_register_timer_handler,
 )
+from .timers_api import async_register_timers_api
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -79,6 +81,7 @@ CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
 __all__ = [
     "DOMAIN",
+    "EVENT_TIMER_FINISHED",
     "TimerEventType",
     "TimerInfo",
     "async_device_supports_timers",
@@ -156,6 +159,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     intent.async_register(hass, GetCurrentTimeIntentHandler())
     intent.async_register(hass, RespondIntentHandler())
     intent.async_register(hass, GetTemperatureIntent())
+
+    # Websocket API for voice timers
+    async_register_timers_api(hass)
 
     return True
 

--- a/homeassistant/components/intent/timers.py
+++ b/homeassistant/components/intent/timers.py
@@ -3,9 +3,9 @@
 import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
 from enum import StrEnum
 import logging
-import time
 from typing import Any
 
 from propcache.api import cached_property
@@ -19,9 +19,9 @@ from homeassistant.helpers import (
     device_registry as dr,
     intent,
 )
-from homeassistant.util import ulid as ulid_util
+from homeassistant.util import dt as dt_util, ulid as ulid_util
 
-from .const import TIMER_DATA
+from .const import DOMAIN, TIMER_DATA
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,6 +29,8 @@ TIMER_NOT_FOUND_RESPONSE = "timer_not_found"
 MULTIPLE_TIMERS_MATCHED_RESPONSE = "multiple_timers_matched"
 NO_TIMER_SUPPORT_RESPONSE = "no_timer_support"
 NO_TIMER_COMMAND_RESPONSE = "no_timer_command"
+
+EVENT_TIMER_FINISHED = f"{DOMAIN}_timer_finished"
 
 
 @dataclass
@@ -59,11 +61,11 @@ class TimerInfo:
     start_seconds: int | None
     """Number of seconds the timer should run as given by the user."""
 
-    created_at: int
-    """Timestamp when timer was created (time.monotonic_ns)"""
+    created_at: datetime
+    """Timestamp when timer was created (in UTC)"""
 
-    updated_at: int
-    """Timestamp when timer was last updated (time.monotonic_ns)"""
+    updated_at: datetime
+    """Timestamp when timer was last updated (in UTC)"""
 
     language: str
     """Language of command used to set the timer."""
@@ -92,6 +94,9 @@ class TimerInfo:
     This agent will be used to execute the conversation command.
     """
 
+    finished_event_data: dict[str, Any] | None = None
+    """Extra data to include in the timer finished event."""
+
     _created_seconds: int = 0
     """Number of seconds on the timer when it was created."""
 
@@ -105,8 +110,8 @@ class TimerInfo:
         if not self.is_active:
             return self.seconds
 
-        now = time.monotonic_ns()
-        seconds_running = int((now - self.updated_at) / 1e9)
+        now = dt_util.utcnow()
+        seconds_running = int((now - self.updated_at).total_seconds())
         return max(0, self.seconds - seconds_running)
 
     @property
@@ -126,18 +131,18 @@ class TimerInfo:
     def cancel(self) -> None:
         """Cancel the timer."""
         self.seconds = 0
-        self.updated_at = time.monotonic_ns()
+        self.updated_at = dt_util.utcnow()
         self.is_active = False
 
     def pause(self) -> None:
         """Pause the timer."""
         self.seconds = self.seconds_left
-        self.updated_at = time.monotonic_ns()
+        self.updated_at = dt_util.utcnow()
         self.is_active = False
 
     def unpause(self) -> None:
         """Unpause the timer."""
-        self.updated_at = time.monotonic_ns()
+        self.updated_at = dt_util.utcnow()
         self.is_active = True
 
     def add_time(self, seconds: int) -> None:
@@ -147,13 +152,27 @@ class TimerInfo:
         """
         self.seconds = max(0, self.seconds_left + seconds)
         self._created_seconds = max(self._created_seconds, self.seconds)
-        self.updated_at = time.monotonic_ns()
+        self.updated_at = dt_util.utcnow()
 
     def finish(self) -> None:
         """Finish the timer."""
         self.seconds = 0
-        self.updated_at = time.monotonic_ns()
+        self.updated_at = dt_util.utcnow()
         self.is_active = False
+
+    @property
+    def dict_repr(self) -> dict[str, Any]:
+        """Return a dictionary representation of the timer."""
+        return {
+            "id": self.id,
+            "name": self.name,
+            "seconds": self.seconds,
+            "device_id": self.device_id,
+            "created_at": self.created_at.timestamp(),
+            "updated_at": self.updated_at.timestamp(),
+            "is_active": self.is_active,
+            "has_conversation_command": self.conversation_command is not None,
+        }
 
 
 class TimerEventType(StrEnum):
@@ -227,6 +246,9 @@ class TimerManager:
         # device_id -> handler
         self.handlers: dict[str, TimerHandler] = {}
 
+        # websocket API
+        self.listeners: list[TimerHandler] = []
+
     def register_handler(
         self, device_id: str, handler: TimerHandler
     ) -> Callable[[], None]:
@@ -241,6 +263,18 @@ class TimerManager:
 
         return unregister
 
+    def register_listener(self, listener: TimerHandler) -> Callable[[], None]:
+        """Register a timer listener.
+
+        Returns a callable to unregister.
+        """
+        self.listeners.append(listener)
+
+        def unregister() -> None:
+            self.listeners.remove(listener)
+
+        return unregister
+
     def start_timer(
         self,
         device_id: str | None,
@@ -251,6 +285,7 @@ class TimerManager:
         name: str | None = None,
         conversation_command: str | None = None,
         conversation_agent_id: str | None = None,
+        finished_event_data: dict[str, Any] | None = None,
     ) -> str:
         """Start a timer."""
         if (not conversation_command) and (device_id is None):
@@ -272,7 +307,7 @@ class TimerManager:
             total_seconds += seconds
 
         timer_id = ulid_util.ulid_now()
-        created_at = time.monotonic_ns()
+        created_at = dt_util.utcnow()
         timer = TimerInfo(
             id=timer_id,
             name=name,
@@ -286,6 +321,7 @@ class TimerManager:
             updated_at=created_at,
             conversation_command=conversation_command,
             conversation_agent_id=conversation_agent_id,
+            finished_event_data=finished_event_data,
         )
 
         # Fill in area/floor info
@@ -307,6 +343,10 @@ class TimerManager:
 
         if (not timer.conversation_command) and (timer.device_id in self.handlers):
             self.handlers[timer.device_id](TimerEventType.STARTED, timer)
+
+        for listener in self.listeners:
+            listener(TimerEventType.STARTED, timer)
+
         _LOGGER.debug(
             "Timer started: id=%s, name=%s, hours=%s, minutes=%s, seconds=%s, device_id=%s",
             timer_id,
@@ -320,7 +360,7 @@ class TimerManager:
         return timer_id
 
     async def _wait_for_timer(
-        self, timer_id: str, seconds: int, updated_at: int
+        self, timer_id: str, seconds: int, updated_at: datetime
     ) -> None:
         """Sleep until timer is up. Timer is only finished if it hasn't been updated."""
         try:
@@ -346,6 +386,10 @@ class TimerManager:
 
         if (not timer.conversation_command) and (timer.device_id in self.handlers):
             self.handlers[timer.device_id](TimerEventType.CANCELLED, timer)
+
+        for listener in self.listeners:
+            listener(TimerEventType.CANCELLED, timer)
+
         _LOGGER.debug(
             "Timer cancelled: id=%s, name=%s, seconds_left=%s, device_id=%s",
             timer_id,
@@ -375,6 +419,9 @@ class TimerManager:
 
         if (not timer.conversation_command) and (timer.device_id in self.handlers):
             self.handlers[timer.device_id](TimerEventType.UPDATED, timer)
+
+        for listener in self.listeners:
+            listener(TimerEventType.UPDATED, timer)
 
         if seconds > 0:
             log_verb = "increased"
@@ -413,6 +460,10 @@ class TimerManager:
 
         if (not timer.conversation_command) and (timer.device_id in self.handlers):
             self.handlers[timer.device_id](TimerEventType.UPDATED, timer)
+
+        for listener in self.listeners:
+            listener(TimerEventType.UPDATED, timer)
+
         _LOGGER.debug(
             "Timer paused: id=%s, name=%s, seconds_left=%s, device_id=%s",
             timer_id,
@@ -439,6 +490,10 @@ class TimerManager:
 
         if (not timer.conversation_command) and (timer.device_id in self.handlers):
             self.handlers[timer.device_id](TimerEventType.UPDATED, timer)
+
+        for listener in self.listeners:
+            listener(TimerEventType.UPDATED, timer)
+
         _LOGGER.debug(
             "Timer unpaused: id=%s, name=%s, seconds_left=%s, device_id=%s",
             timer_id,
@@ -472,6 +527,16 @@ class TimerManager:
             )
         elif timer.device_id in self.handlers:
             self.handlers[timer.device_id](TimerEventType.FINISHED, timer)
+
+        for listener in self.listeners:
+            listener(TimerEventType.FINISHED, timer)
+
+        # Fire event
+        finished_event_data: dict[str, Any] = timer.dict_repr
+        if timer.finished_event_data:
+            finished_event_data.update(timer.finished_event_data)
+
+        self.hass.bus.async_fire(EVENT_TIMER_FINISHED, finished_event_data)
 
         _LOGGER.debug(
             "Timer finished: id=%s, name=%s, device_id=%s",

--- a/homeassistant/components/intent/timers_api.py
+++ b/homeassistant/components/intent/timers_api.py
@@ -1,0 +1,304 @@
+"""Timer websocket API."""
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components import websocket_api
+from homeassistant.const import ATTR_DEVICE_ID, ATTR_ID, ATTR_NAME
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv
+
+from .const import TIMER_DATA
+from .timers import (
+    TimerEventType,
+    TimerInfo,
+    TimerManager,
+    TimerNotFoundError,
+    TimersNotSupportedError,
+    _get_total_seconds,
+    _round_time,
+)
+
+_DURATION_FIELDS: dict[Any, Any] = {
+    vol.Optional("hours"): vol.All(vol.Coerce(int), vol.Range(min=0)),
+    vol.Optional("minutes"): vol.All(vol.Coerce(int), vol.Range(min=0)),
+    vol.Optional("seconds"): vol.All(vol.Coerce(int), vol.Range(min=0)),
+}
+_REQUIRE_DURATION = cv.has_at_least_one_key("hours", "minutes", "seconds")
+
+
+@callback
+def async_register_timers_api(hass: HomeAssistant) -> None:
+    """Register the timer websocket API."""
+    websocket_api.async_register_command(hass, websocket_start_timer)
+    websocket_api.async_register_command(hass, websocket_cancel_timer)
+    websocket_api.async_register_command(hass, websocket_pause_timer)
+    websocket_api.async_register_command(hass, websocket_unpause_timer)
+    websocket_api.async_register_command(hass, websocket_increase_timer)
+    websocket_api.async_register_command(hass, websocket_decrease_timer)
+    websocket_api.async_register_command(hass, websocket_timer_status)
+    websocket_api.async_register_command(hass, websocket_subscribe_timers)
+
+
+@websocket_api.websocket_command(
+    vol.All(
+        vol.Schema(
+            {
+                vol.Required("type"): "intent/timers/start",
+                vol.Required("device_id"): vol.Any(cv.string, None),
+                **_DURATION_FIELDS,
+                vol.Optional("name"): cv.string,
+                vol.Optional("finished_event_data"): dict[str, Any],
+            }
+        ),
+        _REQUIRE_DURATION,
+    )
+)
+@websocket_api.async_response
+async def websocket_start_timer(
+    hass: HomeAssistant,
+    connection: websocket_api.connection.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Start a timer with a duration and optional name."""
+    timer_manager: TimerManager = hass.data[TIMER_DATA]
+
+    try:
+        timer_id = timer_manager.start_timer(
+            device_id=msg["device_id"],
+            hours=msg.get("hours"),
+            minutes=msg.get("minutes"),
+            seconds=msg.get("seconds"),
+            language=hass.config.language,
+            name=msg.get("name"),
+            # Passed with EVENT_TIMER_FINISHED
+            finished_event_data=msg.get("finished_event_data"),
+        )
+        connection.send_result(msg["id"], {"timer_id": timer_id})
+    except (TimersNotSupportedError, ValueError) as err:
+        connection.send_error(msg["id"], websocket_api.ERR_NOT_SUPPORTED, str(err))
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "intent/timers/cancel",
+        vol.Required("timer_id"): cv.string,
+    }
+)
+@websocket_api.async_response
+async def websocket_cancel_timer(
+    hass: HomeAssistant,
+    connection: websocket_api.connection.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Cancel a timer."""
+    timer_manager: TimerManager = hass.data[TIMER_DATA]
+    timer_id = msg["timer_id"]
+
+    try:
+        timer_manager.cancel_timer(timer_id)
+        connection.send_result(msg["id"], {"timer_id": timer_id})
+    except TimerNotFoundError as err:
+        connection.send_error(msg["id"], websocket_api.ERR_NOT_FOUND, str(err))
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "intent/timers/pause",
+        vol.Required("timer_id"): cv.string,
+    }
+)
+@websocket_api.async_response
+async def websocket_pause_timer(
+    hass: HomeAssistant,
+    connection: websocket_api.connection.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Pause a timer."""
+    timer_manager: TimerManager = hass.data[TIMER_DATA]
+    timer_id = msg["timer_id"]
+
+    try:
+        timer_manager.pause_timer(timer_id)
+        connection.send_result(msg["id"], {"timer_id": timer_id})
+    except TimerNotFoundError as err:
+        connection.send_error(msg["id"], websocket_api.ERR_NOT_FOUND, str(err))
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "intent/timers/unpause",
+        vol.Required("timer_id"): cv.string,
+    }
+)
+@websocket_api.async_response
+async def websocket_unpause_timer(
+    hass: HomeAssistant,
+    connection: websocket_api.connection.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Unpause a timer."""
+    timer_manager: TimerManager = hass.data[TIMER_DATA]
+    timer_id = msg["timer_id"]
+
+    try:
+        timer_manager.unpause_timer(timer_id)
+        connection.send_result(msg["id"], {"timer_id": timer_id})
+    except TimerNotFoundError as err:
+        connection.send_error(msg["id"], websocket_api.ERR_NOT_FOUND, str(err))
+
+
+@websocket_api.websocket_command(
+    vol.All(
+        vol.Schema(
+            {
+                vol.Required("type"): "intent/timers/increase",
+                vol.Required("timer_id"): cv.string,
+                **_DURATION_FIELDS,
+            }
+        ),
+        _REQUIRE_DURATION,
+    )
+)
+@websocket_api.async_response
+async def websocket_increase_timer(
+    hass: HomeAssistant,
+    connection: websocket_api.connection.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Increase a timer's time."""
+    timer_manager: TimerManager = hass.data[TIMER_DATA]
+    timer_id = msg["timer_id"]
+
+    try:
+        total_seconds = _get_total_seconds(
+            {
+                key: {"value": msg[key]}
+                for key in ("hours", "minutes", "seconds")
+                if key in msg
+            }
+        )
+        timer_manager.add_time(timer_id, total_seconds)
+        connection.send_result(msg["id"], {"timer_id": timer_id})
+    except TimerNotFoundError as err:
+        connection.send_error(msg["id"], websocket_api.ERR_NOT_FOUND, str(err))
+
+
+@websocket_api.websocket_command(
+    vol.All(
+        vol.Schema(
+            {
+                vol.Required("type"): "intent/timers/decrease",
+                vol.Required("timer_id"): cv.string,
+                **_DURATION_FIELDS,
+            }
+        ),
+        _REQUIRE_DURATION,
+    )
+)
+@websocket_api.async_response
+async def websocket_decrease_timer(
+    hass: HomeAssistant,
+    connection: websocket_api.connection.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Decrease a timer's time."""
+    timer_manager: TimerManager = hass.data[TIMER_DATA]
+    timer_id = msg["timer_id"]
+
+    try:
+        total_seconds = _get_total_seconds(
+            {
+                key: {"value": msg[key]}
+                for key in ("hours", "minutes", "seconds")
+                if key in msg
+            }
+        )
+        timer_manager.remove_time(timer_id, total_seconds)
+        connection.send_result(msg["id"], {"timer_id": timer_id})
+    except TimerNotFoundError as err:
+        connection.send_error(msg["id"], websocket_api.ERR_NOT_FOUND, str(err))
+
+
+@websocket_api.websocket_command({vol.Required("type"): "intent/timers/status"})
+@websocket_api.async_response
+async def websocket_timer_status(
+    hass: HomeAssistant,
+    connection: websocket_api.connection.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Get the status of all timers."""
+    timer_manager: TimerManager = hass.data[TIMER_DATA]
+    statuses = _get_timer_statuses(timer_manager)
+    connection.send_result(msg["id"], {"timers": statuses})
+
+
+def _get_timer_statuses(timer_manager: TimerManager) -> list[dict[str, Any]]:
+    """Get timer statuses for a list of timers."""
+    statuses: list[dict[str, Any]] = []
+    for timer in timer_manager.timers.values():
+        total_seconds = timer.seconds_left
+
+        minutes, seconds = divmod(total_seconds, 60)
+        hours, minutes = divmod(minutes, 60)
+
+        # Get lower-precision time for feedback
+        rounded_hours, rounded_minutes, rounded_seconds = _round_time(
+            hours, minutes, seconds
+        )
+
+        statuses.append(
+            {
+                ATTR_ID: timer.id,
+                ATTR_NAME: timer.name or "",
+                ATTR_DEVICE_ID: timer.device_id or "",
+                "language": timer.language,
+                "start_hours": timer.start_hours or 0,
+                "start_minutes": timer.start_minutes or 0,
+                "start_seconds": timer.start_seconds or 0,
+                "is_active": timer.is_active,
+                "hours_left": hours,
+                "minutes_left": minutes,
+                "seconds_left": seconds,
+                "rounded_hours_left": rounded_hours,
+                "rounded_minutes_left": rounded_minutes,
+                "rounded_seconds_left": rounded_seconds,
+                "total_seconds_left": total_seconds,
+            }
+        )
+
+    return statuses
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "intent/timers/subscribe",
+    }
+)
+@websocket_api.async_response
+async def websocket_subscribe_timers(
+    hass: HomeAssistant,
+    connection: websocket_api.connection.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Subscribe to intent timers."""
+    msg_id = msg["id"]
+
+    timer_manager: TimerManager = hass.data[TIMER_DATA]
+
+    def send_event(event_type: TimerEventType, timer: TimerInfo) -> None:
+        """Send a timer event."""
+        connection.send_event(
+            msg_id,
+            {
+                "event_type": event_type,
+                "timer": timer.dict_repr,
+            },
+        )
+
+    connection.subscriptions[msg_id] = timer_manager.register_listener(send_event)
+
+    # Current timers
+    timers = [timer.dict_repr for timer in timer_manager.timers.values()]
+    connection.send_result(msg_id, {"timers": timers})

--- a/tests/components/intent/test_timers_api.py
+++ b/tests/components/intent/test_timers_api.py
@@ -1,0 +1,221 @@
+"""Tests for intent timers API."""
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from homeassistant.components.intent.timers import (
+    EVENT_TIMER_FINISHED,
+    TimerEventType,
+    TimerInfo,
+    async_register_timer_handler,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.setup import async_setup_component
+
+from tests.typing import WebSocketGenerator
+
+TIMESTAMP = 1735711690.0  # 2025-01-01 06:08:10
+
+
+@pytest.fixture
+async def init_components(hass: HomeAssistant) -> None:
+    """Initialize required components for tests."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, "conversation", {})
+    assert await async_setup_component(hass, "intent", {})
+
+
+@pytest.mark.freeze_time("2025-01-01 06:08:10")
+async def test_subscribe_timers_websocket(
+    hass: HomeAssistant, init_components, hass_ws_client: WebSocketGenerator
+) -> None:
+    """Test subscribing to timer updates via websocket."""
+    device_id = "test_device"
+
+    timer_id: str | None = None
+
+    def handle_timer(event_type: TimerEventType, timer: TimerInfo) -> None:
+        nonlocal timer_id
+        if event_type == TimerEventType.STARTED:
+            timer_id = timer.id
+
+    async_register_timer_handler(hass, device_id, handle_timer)
+
+    sub_client = await hass_ws_client(hass)
+    control_client = await hass_ws_client(hass)
+
+    await sub_client.send_json_auto_id({"type": "intent/timers/subscribe"})
+    msg = await sub_client.receive_json()
+    assert msg["success"]
+    assert msg["result"]["timers"] == []  # no timers yet
+
+    # Start a timer
+    await control_client.send_json_auto_id(
+        {
+            "type": "intent/timers/start",
+            "device_id": device_id,
+            "minutes": 30,
+            "name": "pizza",
+            "finished_event_data": {"test_key": "test_value"},
+        }
+    )
+    msg = await control_client.receive_json()
+    assert msg["success"]
+
+    # Verify started event
+    msg = await sub_client.receive_json()
+    assert msg["event"]["event_type"] == "started"
+    assert msg["event"]["timer"] == {
+        "id": timer_id,
+        "name": "pizza",
+        "seconds": 30 * 60,  # 30 minutes
+        "device_id": device_id,
+        "created_at": TIMESTAMP,
+        "updated_at": TIMESTAMP,
+        "is_active": True,
+        "has_conversation_command": False,
+    }
+
+    # Check status
+    await control_client.send_json_auto_id({"type": "intent/timers/status"})
+    msg = await control_client.receive_json()
+    assert msg["success"]
+    timers = msg["result"]["timers"]
+    assert len(timers) == 1
+    timer = timers[0]
+    assert timer["id"] == timer_id
+    assert timer["name"] == "pizza"
+    assert timer["is_active"]
+    assert timer["start_hours"] == 0
+    assert timer["start_minutes"] == 30
+    assert timer["start_seconds"] == 0
+    assert timer["total_seconds_left"] > 29 * 60  # 29 minutes
+    for key in (
+        "hours_left",
+        "minutes_left",
+        "seconds_left",
+        "rounded_hours_left",
+        "rounded_minutes_left",
+        "rounded_seconds_left",
+    ):
+        assert key in timer
+        assert isinstance(timer[key], int)
+
+    # -----
+    # Pause
+    # -----
+    await control_client.send_json_auto_id(
+        {"type": "intent/timers/pause", "timer_id": timer_id}
+    )
+    msg = await control_client.receive_json()
+    assert msg["success"]
+
+    # updated event
+    msg = await sub_client.receive_json()
+    assert msg["event"]["event_type"] == "updated"
+    assert msg["event"]["timer"]["id"] == timer_id
+    assert not msg["event"]["timer"]["is_active"]
+
+    # status
+    await control_client.send_json_auto_id({"type": "intent/timers/status"})
+    msg = await control_client.receive_json()
+    assert msg["success"]
+    assert msg["result"]["timers"][0]["id"] == timer_id
+    assert not msg["result"]["timers"][0]["is_active"]
+
+    # --------
+    # Increase
+    # --------
+    await control_client.send_json_auto_id(
+        {"type": "intent/timers/increase", "timer_id": timer_id, "hours": 1}
+    )
+    msg = await control_client.receive_json()
+    assert msg["success"]
+
+    # updated event
+    msg = await sub_client.receive_json()
+    assert msg["event"]["event_type"] == "updated"
+    assert msg["event"]["timer"]["id"] == timer_id
+    assert msg["event"]["timer"]["seconds"] == (30 + 60) * 60  # 1.5 hours
+
+    # status
+    await control_client.send_json_auto_id({"type": "intent/timers/status"})
+    msg = await control_client.receive_json()
+    assert msg["success"]
+    assert msg["result"]["timers"][0]["id"] == timer_id
+    assert msg["result"]["timers"][0]["hours_left"] == 1
+
+    # -------
+    # Unpause
+    # -------
+    await control_client.send_json_auto_id(
+        {"type": "intent/timers/unpause", "timer_id": timer_id}
+    )
+    msg = await control_client.receive_json()
+    assert msg["success"]
+
+    # updated event
+    msg = await sub_client.receive_json()
+    assert msg["event"]["event_type"] == "updated"
+    assert msg["event"]["timer"]["id"] == timer_id
+    assert msg["event"]["timer"]["is_active"]
+
+    # status
+    await control_client.send_json_auto_id({"type": "intent/timers/status"})
+    msg = await control_client.receive_json()
+    assert msg["success"]
+    assert msg["result"]["timers"][0]["id"] == timer_id
+    assert msg["result"]["timers"][0]["is_active"]
+
+    timer_finished: dict[str, Any] | None = None
+    timer_finished_ready = asyncio.Event()
+
+    # Subscribe to timer finished event before we remove all its time
+    @callback
+    def handle_finished(event):
+        nonlocal timer_finished
+        timer_finished = event
+        timer_finished_ready.set()
+
+    hass.bus.async_listen_once(EVENT_TIMER_FINISHED, handle_finished)
+
+    # --------
+    # Decrease
+    # --------
+    await control_client.send_json_auto_id(
+        {"type": "intent/timers/decrease", "timer_id": timer_id, "hours": 2}
+    )
+    msg = await control_client.receive_json()
+    assert msg["success"]
+
+    # updated event
+    msg = await sub_client.receive_json()
+    assert msg["event"]["event_type"] == "updated"
+    assert msg["event"]["timer"]["id"] == timer_id
+    assert msg["event"]["timer"]["seconds"] == 0
+
+    # status
+    await control_client.send_json_auto_id({"type": "intent/timers/status"})
+    msg = await control_client.receive_json()
+    assert msg["success"]
+    assert not msg["result"]["timers"]  # timer finished
+
+    # ------
+    # Finish
+    # ------
+    async with asyncio.timeout(1):
+        msg = await sub_client.receive_json()
+
+        # Wait for bus event
+        await timer_finished_ready.wait()
+
+    assert msg["event"]["event_type"] == "finished"
+    assert msg["event"]["timer"]["id"] == timer_id
+
+    assert timer_finished
+    assert timer_finished.data["id"] == timer_id
+
+    # Verify custom event data
+    assert timer_finished.data["test_key"] == "test_value"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a websocket API to control intent (voice) timers. This is a resurrection/extension of https://github.com/home-assistant/core/pull/153587

This PR adds 3 specific things:

- A websocket command for subscribing to timer events (from https://github.com/home-assistant/core/pull/153587)
- Websocket commands to start/pause/resume/cancel timers as well as add/remove time and get the status of all timers
- A bus event that's fired when a voice timer finishes (for advanced automations)

Some questions that may not be obvious:

- Why do we need a websocket API for voice timers?
    - Allow external conversation agents to use the existing voice timer infrastructure
    - Enable custom cards that display voice timers 
- Why not just use the intents (`HassStartTimer`, etc.)?
    - The intents do not have any subscription mechanism
    - The intents cannot target specific timers by id by design
- Why is there a new bus event?
    - To allow for voice timers to be automated on 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
