### PR TITLE
Add exposed_entities template extension function

### DIFF
--- a/homeassistant/components/homeassistant/exposed_entities.py
+++ b/homeassistant/components/homeassistant/exposed_entities.py
@@ -253,10 +253,9 @@ class ExposedEntities:
                 should_expose = registry_entry.options[assistant]["should_expose"]
                 return should_expose
 
-        if self.async_get_expose_new_entities(assistant):
-            should_expose = self._is_default_exposed(entity_id, registry_entry)
-        else:
-            should_expose = False
+        should_expose = self._async_compute_default_should_expose(
+            assistant, entity_id, registry_entry
+        )
 
         assistant_options: ReadOnlyDict[str, Any] | dict[str, Any]
         assistant_options = registry_entry.options.get(assistant, {})
@@ -266,6 +265,27 @@ class ExposedEntities:
         )
 
         return should_expose
+
+    @callback
+    def async_get_should_expose(self, assistant: str, entity_id: str) -> bool:
+        """Return True if an entity should be exposed, without persisting defaults."""
+        should_expose: bool
+
+        entity_registry = er.async_get(self._hass)
+        if registry_entry := entity_registry.async_get(entity_id):
+            options: Mapping[str, Any] = registry_entry.options.get(assistant, {})
+            if "should_expose" in options:
+                should_expose = options["should_expose"]
+                return should_expose
+            return self._async_compute_default_should_expose(
+                assistant, entity_id, registry_entry
+            )
+        if (
+            exposed_entity := self.entities.get(entity_id)
+        ) and "should_expose" in exposed_entity.assistants.get(assistant, {}):
+            should_expose = exposed_entity.assistants[assistant]["should_expose"]
+            return should_expose
+        return self._async_compute_default_should_expose(assistant, entity_id, None)
 
     def _async_should_expose_legacy_entity(
         self, assistant: str, entity_id: str
@@ -280,10 +300,9 @@ class ExposedEntities:
                 should_expose = exposed_entity.assistants[assistant]["should_expose"]
                 return should_expose
 
-        if self.async_get_expose_new_entities(assistant):
-            should_expose = self._is_default_exposed(entity_id, None)
-        else:
-            should_expose = False
+        should_expose = self._async_compute_default_should_expose(
+            assistant, entity_id, None
+        )
 
         if exposed_entity:
             new_exposed_entity = self._update_exposed_entity(
@@ -297,6 +316,15 @@ class ExposedEntities:
         self._async_schedule_save()
 
         return should_expose
+
+    @callback
+    def _async_compute_default_should_expose(
+        self, assistant: str, entity_id: str, registry_entry: er.RegistryEntry | None
+    ) -> bool:
+        """Compute default exposure for an entity without persisting it."""
+        if self.async_get_expose_new_entities(assistant):
+            return self._is_default_exposed(entity_id, registry_entry)
+        return False
 
     def _is_default_exposed(
         self, entity_id: str, registry_entry: er.RegistryEntry | None
@@ -516,6 +544,15 @@ def async_should_expose(hass: HomeAssistant, assistant: str, entity_id: str) -> 
     """Return True if an entity should be exposed to an assistant."""
     exposed_entities = hass.data[DATA_EXPOSED_ENTITIES]
     return exposed_entities.async_should_expose(assistant, entity_id)
+
+
+@callback
+def async_get_should_expose(
+    hass: HomeAssistant, assistant: str, entity_id: str
+) -> bool:
+    """Return True if an entity should be exposed, without persisting defaults."""
+    exposed_entities = hass.data[DATA_EXPOSED_ENTITIES]
+    return exposed_entities.async_get_should_expose(assistant, entity_id)
 
 
 @callback

--- a/homeassistant/helpers/template/__init__.py
+++ b/homeassistant/helpers/template/__init__.py
@@ -51,6 +51,7 @@ from .extensions import (
     DateTimeExtension,
     DeviceExtension,
     EntityExtension,
+    ExposedEntitiesExtension,
     FloorExtension,
     FunctionalExtension,
     IssuesExtension,
@@ -813,6 +814,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.add_extension(DateTimeExtension)
         self.add_extension(DeviceExtension)
         self.add_extension(EntityExtension)
+        self.add_extension(ExposedEntitiesExtension)
         self.add_extension(FloorExtension)
         self.add_extension(FunctionalExtension)
         self.add_extension(IssuesExtension)
@@ -824,6 +826,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.add_extension(StringExtension)
         self.add_extension(TypeCastExtension)
         self.add_extension(VersionExtension)
+
 
         if hass is not None:
             # This environment has access to hass, attach its loader

--- a/homeassistant/helpers/template/__init__.py
+++ b/homeassistant/helpers/template/__init__.py
@@ -827,7 +827,6 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.add_extension(TypeCastExtension)
         self.add_extension(VersionExtension)
 
-
         if hass is not None:
             # This environment has access to hass, attach its loader
             # to enable imports.

--- a/homeassistant/helpers/template/extensions/__init__.py
+++ b/homeassistant/helpers/template/extensions/__init__.py
@@ -8,6 +8,7 @@ from .crypto import CryptoExtension
 from .datetime import DateTimeExtension
 from .devices import DeviceExtension
 from .entities import EntityExtension
+from .exposed_entities import ExposedEntitiesExtension
 from .floors import FloorExtension
 from .functional import FunctionalExtension
 from .issues import IssuesExtension
@@ -29,6 +30,7 @@ __all__ = [
     "DateTimeExtension",
     "DeviceExtension",
     "EntityExtension",
+    "ExposedEntitiesExtension",
     "FloorExtension",
     "FunctionalExtension",
     "IssuesExtension",

--- a/homeassistant/helpers/template/extensions/exposed_entities.py
+++ b/homeassistant/helpers/template/extensions/exposed_entities.py
@@ -1,6 +1,7 @@
 """Template functions for exposed entities."""
 
 from collections.abc import Iterable
+from itertools import chain
 from typing import TYPE_CHECKING
 
 from homeassistant.helpers import entity_registry as er
@@ -29,16 +30,22 @@ class ExposedEntitiesExtension(BaseTemplateExtension):
         )
 
     def assist_exposed_entities(self) -> Iterable[str]:
-        """Return entity IDs for all entities exposed to the conversation integration."""
+        """Return entity IDs for all entities exposed to Assist."""
         # Imported here to avoid a circular import at module load time, as this
         # extension is imported very early during bootstrap.
-        from homeassistant.components import conversation  # noqa: PLC0415
         from homeassistant.components.homeassistant.exposed_entities import (  # noqa: PLC0415
+            DATA_EXPOSED_ENTITIES,
             async_should_expose,
         )
 
+        exposed_entities = self.hass.data[DATA_EXPOSED_ENTITIES]
+        entity_registry = er.async_get(self.hass)
+        # Entities tracked by the exposed entities helper may not be in the
+        # registry (e.g. legacy entities), so consider both sources.
         return [
-            entry.entity_id
-            for entry in er.async_get(self.hass).entities.values()
-            if async_should_expose(self.hass, conversation.DOMAIN, entry.entity_id)
+            entity_id
+            for entity_id in dict.fromkeys(
+                chain(exposed_entities.entities, entity_registry.entities)
+            )
+            if async_should_expose(self.hass, "conversation", entity_id)
         ]

--- a/homeassistant/helpers/template/extensions/exposed_entities.py
+++ b/homeassistant/helpers/template/extensions/exposed_entities.py
@@ -1,0 +1,39 @@
+"""Template functions for exposed entities."""
+
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+from homeassistant.components.homeassistant.exposed_entities import async_should_expose
+from homeassistant.helpers import entity_registry as er
+
+from .base import BaseTemplateExtension, TemplateFunction
+
+if TYPE_CHECKING:
+    from homeassistant.helpers.template import TemplateEnvironment
+
+
+class ExposedEntitiesExtension(BaseTemplateExtension):
+    """Extension for exposed entities template functions."""
+
+    def __init__(self, environment: TemplateEnvironment) -> None:
+        """Initialize the exposed entities extension."""
+        super().__init__(
+            environment,
+            functions=[
+                TemplateFunction(
+                    "exposed_entities",
+                    self.exposed_entities,
+                    as_global=True,
+                    as_filter=True,
+                    requires_hass=True,
+                ),
+            ],
+        )
+
+    def exposed_entities(self, assistant: str) -> Iterable[str]:
+        """Return entity IDs for all entities exposed to a particular assistant."""
+        return [
+            entry.entity_id
+            for entry in er.async_get(self.hass).entities.values()
+            if async_should_expose(self.hass, assistant, entry.entity_id)
+        ]

--- a/homeassistant/helpers/template/extensions/exposed_entities.py
+++ b/homeassistant/helpers/template/extensions/exposed_entities.py
@@ -3,7 +3,6 @@
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
-from homeassistant.components.homeassistant.exposed_entities import async_should_expose
 from homeassistant.helpers import entity_registry as er
 
 from .base import BaseTemplateExtension, TemplateFunction
@@ -21,19 +20,25 @@ class ExposedEntitiesExtension(BaseTemplateExtension):
             environment,
             functions=[
                 TemplateFunction(
-                    "exposed_entities",
-                    self.exposed_entities,
+                    "assist_exposed_entities",
+                    self.assist_exposed_entities,
                     as_global=True,
-                    as_filter=True,
                     requires_hass=True,
                 ),
             ],
         )
 
-    def exposed_entities(self, assistant: str) -> Iterable[str]:
-        """Return entity IDs for all entities exposed to a particular assistant."""
+    def assist_exposed_entities(self) -> Iterable[str]:
+        """Return entity IDs for all entities exposed to the conversation integration."""
+        # Imported here to avoid a circular import at module load time, as this
+        # extension is imported very early during bootstrap.
+        from homeassistant.components import conversation  # noqa: PLC0415
+        from homeassistant.components.homeassistant.exposed_entities import (  # noqa: PLC0415
+            async_should_expose,
+        )
+
         return [
             entry.entity_id
             for entry in er.async_get(self.hass).entities.values()
-            if async_should_expose(self.hass, assistant, entry.entity_id)
+            if async_should_expose(self.hass, conversation.DOMAIN, entry.entity_id)
         ]

--- a/homeassistant/helpers/template/extensions/exposed_entities.py
+++ b/homeassistant/helpers/template/extensions/exposed_entities.py
@@ -35,7 +35,7 @@ class ExposedEntitiesExtension(BaseTemplateExtension):
         # extension is imported very early during bootstrap.
         from homeassistant.components.homeassistant.exposed_entities import (  # noqa: PLC0415
             DATA_EXPOSED_ENTITIES,
-            async_should_expose,
+            async_get_should_expose,
         )
 
         exposed_entities = self.hass.data[DATA_EXPOSED_ENTITIES]
@@ -47,5 +47,5 @@ class ExposedEntitiesExtension(BaseTemplateExtension):
             for entity_id in dict.fromkeys(
                 chain(exposed_entities.entities, entity_registry.entities)
             )
-            if async_should_expose(self.hass, "conversation", entity_id)
+            if async_get_should_expose(self.hass, "conversation", entity_id)
         ]

--- a/tests/helpers/template/extensions/test_exposed_entities.py
+++ b/tests/helpers/template/extensions/test_exposed_entities.py
@@ -1,0 +1,80 @@
+"""Test exposed entities template functions."""
+
+from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from tests.helpers.template.helpers import assert_result_info, render_to_info
+
+
+async def test_exposed_entities(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test exposed_entities function."""
+    assert await async_setup_component(hass, "homeassistant", {})
+
+    # Test no exposed entities
+    info = render_to_info(hass, "{{ exposed_entities('conversation') }}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    # Create some entities
+    entry1 = entity_registry.async_get_or_create("light", "test", "entity1")
+    entry2 = entity_registry.async_get_or_create("switch", "test", "entity2")
+    entry3 = entity_registry.async_get_or_create("binary_sensor", "test", "entity3")
+
+    # Expose some entities to conversation assistant
+    async_expose_entity(hass, "conversation", entry1.entity_id, True)
+    async_expose_entity(hass, "conversation", entry2.entity_id, True)
+
+    async_expose_entity(hass, "conversation", entry3.entity_id, False)
+
+    info = render_to_info(hass, "{{ exposed_entities('conversation') }}")
+    assert_result_info(info, [entry1.entity_id, entry2.entity_id])
+    assert info.rate_limit is None
+
+
+async def test_exposed_entities_as_filter(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test exposed_entities as a filter."""
+    assert await async_setup_component(hass, "homeassistant", {})
+
+    entry1 = entity_registry.async_get_or_create("light", "test", "entity1")
+    entry2 = entity_registry.async_get_or_create("switch", "test", "entity2")
+
+    async_expose_entity(hass, "conversation", entry1.entity_id, True)
+    async_expose_entity(hass, "conversation", entry2.entity_id, True)
+
+    info = render_to_info(hass, '{{ "conversation" | exposed_entities }}')
+    assert_result_info(info, [entry1.entity_id, entry2.entity_id])
+    assert info.rate_limit is None
+
+
+async def test_exposed_entities_multiple_assistants(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test exposed_entities with multiple assistants."""
+    assert await async_setup_component(hass, "homeassistant", {})
+
+    entry1 = entity_registry.async_get_or_create("light", "test", "entity1")
+    entry2 = entity_registry.async_get_or_create("switch", "test", "entity2")
+    entry3 = entity_registry.async_get_or_create("binary_sensor", "test", "entity3")
+
+    # Expose different entities to different assistants
+    async_expose_entity(hass, "conversation", entry1.entity_id, True)
+    async_expose_entity(hass, "conversation", entry2.entity_id, True)
+
+    async_expose_entity(hass, "cloud.alexa", entry2.entity_id, True)
+    async_expose_entity(hass, "cloud.alexa", entry3.entity_id, True)
+
+    # Test conversation assistant
+    info = render_to_info(hass, '{{ exposed_entities("conversation") }}')
+    assert_result_info(info, [entry1.entity_id, entry2.entity_id])
+    assert info.rate_limit is None
+
+    # Test Alexa assistant
+    info = render_to_info(hass, '{{ exposed_entities("cloud.alexa") }}')
+    assert_result_info(info, [entry2.entity_id, entry3.entity_id])
+    assert info.rate_limit is None

--- a/tests/helpers/template/extensions/test_exposed_entities.py
+++ b/tests/helpers/template/extensions/test_exposed_entities.py
@@ -8,14 +8,14 @@ from homeassistant.setup import async_setup_component
 from tests.helpers.template.helpers import assert_result_info, render_to_info
 
 
-async def test_exposed_entities(
+async def test_assist_exposed_entities(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
-    """Test exposed_entities function."""
+    """Test assist_exposed_entities function."""
     assert await async_setup_component(hass, "homeassistant", {})
 
     # Test no exposed entities
-    info = render_to_info(hass, "{{ exposed_entities('conversation') }}")
+    info = render_to_info(hass, "{{ assist_exposed_entities() }}")
     assert_result_info(info, [])
     assert info.rate_limit is None
 
@@ -30,32 +30,15 @@ async def test_exposed_entities(
 
     async_expose_entity(hass, "conversation", entry3.entity_id, False)
 
-    info = render_to_info(hass, "{{ exposed_entities('conversation') }}")
+    info = render_to_info(hass, "{{ assist_exposed_entities() }}")
     assert_result_info(info, [entry1.entity_id, entry2.entity_id])
     assert info.rate_limit is None
 
 
-async def test_exposed_entities_as_filter(
+async def test_assist_exposed_entities_only_conversation(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
-    """Test exposed_entities as a filter."""
-    assert await async_setup_component(hass, "homeassistant", {})
-
-    entry1 = entity_registry.async_get_or_create("light", "test", "entity1")
-    entry2 = entity_registry.async_get_or_create("switch", "test", "entity2")
-
-    async_expose_entity(hass, "conversation", entry1.entity_id, True)
-    async_expose_entity(hass, "conversation", entry2.entity_id, True)
-
-    info = render_to_info(hass, '{{ "conversation" | exposed_entities }}')
-    assert_result_info(info, [entry1.entity_id, entry2.entity_id])
-    assert info.rate_limit is None
-
-
-async def test_exposed_entities_multiple_assistants(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry
-) -> None:
-    """Test exposed_entities with multiple assistants."""
+    """Test assist_exposed_entities only returns entities exposed to conversation."""
     assert await async_setup_component(hass, "homeassistant", {})
 
     entry1 = entity_registry.async_get_or_create("light", "test", "entity1")
@@ -69,12 +52,7 @@ async def test_exposed_entities_multiple_assistants(
     async_expose_entity(hass, "cloud.alexa", entry2.entity_id, True)
     async_expose_entity(hass, "cloud.alexa", entry3.entity_id, True)
 
-    # Test conversation assistant
-    info = render_to_info(hass, '{{ exposed_entities("conversation") }}')
+    # Only entities exposed to conversation are returned
+    info = render_to_info(hass, "{{ assist_exposed_entities() }}")
     assert_result_info(info, [entry1.entity_id, entry2.entity_id])
-    assert info.rate_limit is None
-
-    # Test Alexa assistant
-    info = render_to_info(hass, '{{ exposed_entities("cloud.alexa") }}')
-    assert_result_info(info, [entry2.entity_id, entry3.entity_id])
     assert info.rate_limit is None

--- a/tests/helpers/template/extensions/test_exposed_entities.py
+++ b/tests/helpers/template/extensions/test_exposed_entities.py
@@ -56,3 +56,15 @@ async def test_assist_exposed_entities_only_conversation(
     info = render_to_info(hass, "{{ assist_exposed_entities() }}")
     assert_result_info(info, [entry1.entity_id, entry2.entity_id])
     assert info.rate_limit is None
+
+
+async def test_assist_exposed_entities_not_in_registry(hass: HomeAssistant) -> None:
+    """Test assist_exposed_entities includes entities not in the registry."""
+    assert await async_setup_component(hass, "homeassistant", {})
+
+    # Expose an entity that is not in the entity registry
+    async_expose_entity(hass, "conversation", "light.legacy", True)
+
+    info = render_to_info(hass, "{{ assist_exposed_entities() }}")
+    assert_result_info(info, ["light.legacy"])
+    assert info.rate_limit is None

--- a/tests/helpers/template/extensions/test_exposed_entities.py
+++ b/tests/helpers/template/extensions/test_exposed_entities.py
@@ -58,6 +58,24 @@ async def test_assist_exposed_entities_only_conversation(
     assert info.rate_limit is None
 
 
+async def test_assist_exposed_entities_default_exposure_is_read_only(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test entities exposed only by default are returned without mutating state."""
+    assert await async_setup_component(hass, "homeassistant", {})
+
+    # conversation exposes new entities by default and "light" is a default
+    # exposed domain, so this entity is exposed without any explicit setting.
+    entry = entity_registry.async_get_or_create("light", "test", "entity1")
+
+    info = render_to_info(hass, "{{ assist_exposed_entities() }}")
+    assert_result_info(info, [entry.entity_id])
+    assert info.rate_limit is None
+
+    # Rendering must not persist the derived should_expose value.
+    assert "conversation" not in entity_registry.async_get(entry.entity_id).options
+
+
 async def test_assist_exposed_entities_not_in_registry(hass: HomeAssistant) -> None:
     """Test assist_exposed_entities includes entities not in the registry."""
     assert await async_setup_component(hass, "homeassistant", {})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a new template extension function called `assist_exposed_entities` that returns the entity ids that are [exposed to Assist](https://www.home-assistant.io/voice_control/voice_remote_expose_devices/).

Example:

```{{ assist_exposed_entities() }}```

There is currently no way to get the exposure status of an entity within a template. This information is needed when creating automations related to voice, where only exposed entities should be targeted. For example: turning on the exposed lights in an area, or only targeting the media player in an area that's been exposed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
