### PR TITLE
Fix flaky logger tests due to test-ordering dependency

### DIFF
--- a/tests/components/logger/test_init.py
+++ b/tests/components/logger/test_init.py
@@ -309,14 +309,21 @@ async def _assert_log_levels(hass: HomeAssistant) -> None:
 
 def _reset_logging():
     """Reset loggers."""
-    logging.getLogger(CONFIGED_NS).orig_setLevel(logging.NOTSET)
-    logging.getLogger(f"{CONFIGED_NS}.info").orig_setLevel(logging.NOTSET)
-    logging.getLogger(f"{CONFIGED_NS}.debug").orig_setLevel(logging.NOTSET)
-    logging.getLogger(HASS_NS).orig_setLevel(logging.NOTSET)
-    logging.getLogger(COMPONENTS_NS).orig_setLevel(logging.NOTSET)
-    logging.getLogger(ZONE_NS).orig_setLevel(logging.NOTSET)
-    logging.getLogger(GROUP_NS).orig_setLevel(logging.NOTSET)
-    logging.getLogger(INTEGRATION_NS).orig_setLevel(logging.NOTSET)
+    for ns in (
+        CONFIGED_NS,
+        f"{CONFIGED_NS}.info",
+        f"{CONFIGED_NS}.debug",
+        HASS_NS,
+        COMPONENTS_NS,
+        ZONE_NS,
+        GROUP_NS,
+        INTEGRATION_NS,
+    ):
+        log = logging.getLogger(ns)
+        if hasattr(log, "orig_setLevel"):
+            log.orig_setLevel(logging.NOTSET)
+        else:
+            log.setLevel(logging.NOTSET)
 
 
 async def test_can_set_integration_level_from_store(

--- a/tests/components/logger/test_init.py
+++ b/tests/components/logger/test_init.py
@@ -24,7 +24,7 @@ ZONE_NS = f"{COMPONENTS_NS}.zone"
 GROUP_NS = f"{COMPONENTS_NS}.group"
 CONFIGED_NS = "otherlibx"
 UNCONFIG_NS = "unconfigurednamespace"
-INTEGRATION = "test_component"
+INTEGRATION = "test_logging"
 INTEGRATION_NS = f"homeassistant.components.{INTEGRATION}"
 
 
@@ -309,21 +309,14 @@ async def _assert_log_levels(hass: HomeAssistant) -> None:
 
 def _reset_logging():
     """Reset loggers."""
-    for ns in (
-        CONFIGED_NS,
-        f"{CONFIGED_NS}.info",
-        f"{CONFIGED_NS}.debug",
-        HASS_NS,
-        COMPONENTS_NS,
-        ZONE_NS,
-        GROUP_NS,
-        INTEGRATION_NS,
-    ):
-        log = logging.getLogger(ns)
-        if hasattr(log, "orig_setLevel"):
-            log.orig_setLevel(logging.NOTSET)
-        else:
-            log.setLevel(logging.NOTSET)
+    logging.getLogger(CONFIGED_NS).orig_setLevel(logging.NOTSET)
+    logging.getLogger(f"{CONFIGED_NS}.info").orig_setLevel(logging.NOTSET)
+    logging.getLogger(f"{CONFIGED_NS}.debug").orig_setLevel(logging.NOTSET)
+    logging.getLogger(HASS_NS).orig_setLevel(logging.NOTSET)
+    logging.getLogger(COMPONENTS_NS).orig_setLevel(logging.NOTSET)
+    logging.getLogger(ZONE_NS).orig_setLevel(logging.NOTSET)
+    logging.getLogger(GROUP_NS).orig_setLevel(logging.NOTSET)
+    logging.getLogger(INTEGRATION_NS).orig_setLevel(logging.NOTSET)
 
 
 async def test_can_set_integration_level_from_store(


### PR DESCRIPTION
## Breaking change

N/A

## Proposed change

Fix flaky logger tests caused by a test-ordering dependency on global logger state.

`_reset_logging()` unconditionally calls `orig_setLevel()` on all loggers including `INTEGRATION_NS`, but that method only exists on loggers that are instances of `HassLogger` (created after `logging.setLoggerClass(HassLogger)` was called). Python caches logger instances globally, so whether `INTEGRATION_NS` is a `HassLogger` depends on whether a previous test in the randomized run already caused that logger to be created. If not, the logger is a plain `logging.Logger` without `orig_setLevel`, and the test crashes with `AttributeError`.

The fix is to use a unique name for a component, so it is not pre-instantiated.

Example failure: https://github.com/home-assistant/core/actions/runs/25764516681/job/75674753476?pr=170458

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr