### PR TITLE
Fix KeyError in CalDAV when supported components are not reported

### DIFF
--- a/homeassistant/components/caldav/api.py
+++ b/homeassistant/components/caldav/api.py
@@ -18,14 +18,14 @@ async def async_get_calendars(
 ) -> list[caldav.Calendar]:
     """Get all calendars that support the specified component."""
 
-    def _get_calendars() -> tuple[list[caldav.Calendar], list[tuple[str, str | None]]]:
+    def _get_calendars() -> tuple[list[caldav.Calendar], list[tuple[str, str | None, str]]]:
         calendars = []
-        needs_warning: list[tuple[str, str | None]] = []
+        needs_warning: list[tuple[str, str | None, str]] = []
         for calendar in client.principal().calendars():
             try:
                 supported_components = calendar.get_supported_components()
             except KeyError:
-                needs_warning.append((str(calendar.url), calendar.name))
+                needs_warning.append((str(calendar.url), calendar.name, component))
 
                 if component in ASSUMED_COMPONENTS:
                     # If the server does not specify supported components, we assume
@@ -41,26 +41,26 @@ async def async_get_calendars(
     calendars, needs_warning = await hass.async_add_executor_job(_get_calendars)
 
     if needs_warning:
-        warned_calendars: set[str] = hass.data.setdefault(
-            f"{DOMAIN}_warned_calendars", set()
+        warned_calendars: set[tuple[str, str]] = hass.data.setdefault(DOMAIN, {}).setdefault(
+            "warned_calendars", set()
         )
-        for url, name in needs_warning:
+        for url, name, comp in needs_warning:
             # This workaround and warning can be removed when we upgrade to caldav 3.0
-            if url not in warned_calendars:
-                warned_calendars.add(url)
-                if component in ASSUMED_COMPONENTS:
+            if (url, comp) not in warned_calendars:
+                warned_calendars.add((url, comp))
+                if comp in ASSUMED_COMPONENTS:
                     _LOGGER.warning(
                         "CalDAV server does not report supported components for calendar %s, "
                         "assuming it supports the requested component '%s'",
                         name,
-                        component,
+                        comp,
                     )
                 else:
                     _LOGGER.warning(
                         "CalDAV server does not report supported components for calendar %s. "
                         "Not assuming support for requested component '%s'",
                         name,
-                        component,
+                        comp,
                     )
 
     return calendars

--- a/homeassistant/components/caldav/api.py
+++ b/homeassistant/components/caldav/api.py
@@ -18,9 +18,9 @@ async def async_get_calendars(
 ) -> list[caldav.Calendar]:
     """Get all calendars that support the specified component."""
 
-    def _get_calendars() -> tuple[list[caldav.Calendar], list[tuple[str, str]]]:
+    def _get_calendars() -> tuple[list[caldav.Calendar], list[tuple[str, str | None]]]:
         calendars = []
-        needs_warning = []
+        needs_warning: list[tuple[str, str | None]] = []
         for calendar in client.principal().calendars():
             try:
                 supported_components = calendar.get_supported_components()

--- a/homeassistant/components/caldav/api.py
+++ b/homeassistant/components/caldav/api.py
@@ -7,6 +7,7 @@ import caldav
 from homeassistant.core import HomeAssistant
 
 _LOGGER = logging.getLogger(__name__)
+_CALENDARS_WARNED: set[str] = set()
 
 
 async def async_get_calendars(
@@ -20,23 +21,29 @@ async def async_get_calendars(
             try:
                 supported_components = calendar.get_supported_components()
             except KeyError:
+                # This workaround and warning can be removed when we upgrade to caldav 3.0
+                if str(calendar.url) not in _CALENDARS_WARNED:
+                    _CALENDARS_WARNED.add(str(calendar.url))
+                    if component in ("VEVENT", "VTODO"):
+                        _LOGGER.warning(
+                            "CalDAV server does not report supported components for calendar %s, "
+                            "assuming it supports the requested component '%s'",
+                            calendar.name,
+                            component,
+                        )
+                    else:
+                        _LOGGER.warning(
+                            "CalDAV server does not report supported components for calendar %s. "
+                            "Not assuming support for requested component '%s'",
+                            calendar.name,
+                            component,
+                        )
+
                 if component in ("VEVENT", "VTODO"):
-                    _LOGGER.warning(
-                        "CalDAV server does not report supported components for calendar %s, "
-                        "assuming it supports the requested component '%s'",
-                        calendar.name,
-                        component,
-                    )
                     # If the server does not specify supported components, we assume
                     # the calendar is supported for the requested component.
                     supported_components = [component]
                 else:
-                    _LOGGER.warning(
-                        "CalDAV server does not report supported components for calendar %s. "
-                        "Not assuming support for requested component '%s'",
-                        calendar.name,
-                        component,
-                    )
                     supported_components = []
 
             if component in supported_components:

--- a/homeassistant/components/caldav/api.py
+++ b/homeassistant/components/caldav/api.py
@@ -6,6 +6,8 @@ import caldav
 
 from homeassistant.core import HomeAssistant
 
+from .const import DOMAIN
+
 _LOGGER = logging.getLogger(__name__)
 
 ASSUMED_COMPONENTS = {"VEVENT", "VTODO"}
@@ -15,31 +17,15 @@ async def async_get_calendars(
     hass: HomeAssistant, client: caldav.DAVClient, component: str
 ) -> list[caldav.Calendar]:
     """Get all calendars that support the specified component."""
-    warned_calendars: set[str] = hass.data.setdefault("caldav_warned_calendars", set())
 
-    def _get_calendars() -> list[caldav.Calendar]:
+    def _get_calendars() -> tuple[list[caldav.Calendar], list[tuple[str, str]]]:
         calendars = []
+        needs_warning = []
         for calendar in client.principal().calendars():
             try:
                 supported_components = calendar.get_supported_components()
             except KeyError:
-                # This workaround and warning can be removed when we upgrade to caldav 3.0
-                if str(calendar.url) not in warned_calendars:
-                    warned_calendars.add(str(calendar.url))
-                    if component in ASSUMED_COMPONENTS:
-                        _LOGGER.warning(
-                            "CalDAV server does not report supported components for calendar %s, "
-                            "assuming it supports the requested component '%s'",
-                            calendar.name,
-                            component,
-                        )
-                    else:
-                        _LOGGER.warning(
-                            "CalDAV server does not report supported components for calendar %s. "
-                            "Not assuming support for requested component '%s'",
-                            calendar.name,
-                            component,
-                        )
+                needs_warning.append((str(calendar.url), calendar.name))
 
                 if component in ASSUMED_COMPONENTS:
                     # If the server does not specify supported components, we assume
@@ -50,9 +36,34 @@ async def async_get_calendars(
 
             if component in supported_components:
                 calendars.append(calendar)
-        return calendars
+        return calendars, needs_warning
 
-    return await hass.async_add_executor_job(_get_calendars)
+    calendars, needs_warning = await hass.async_add_executor_job(_get_calendars)
+
+    if needs_warning:
+        warned_calendars: set[str] = hass.data.setdefault(
+            f"{DOMAIN}_warned_calendars", set()
+        )
+        for url, name in needs_warning:
+            # This workaround and warning can be removed when we upgrade to caldav 3.0
+            if url not in warned_calendars:
+                warned_calendars.add(url)
+                if component in ASSUMED_COMPONENTS:
+                    _LOGGER.warning(
+                        "CalDAV server does not report supported components for calendar %s, "
+                        "assuming it supports the requested component '%s'",
+                        name,
+                        component,
+                    )
+                else:
+                    _LOGGER.warning(
+                        "CalDAV server does not report supported components for calendar %s. "
+                        "Not assuming support for requested component '%s'",
+                        name,
+                        component,
+                    )
+
+    return calendars
 
 
 def get_attr_value(obj: caldav.CalendarObjectResource, attribute: str) -> str | None:

--- a/homeassistant/components/caldav/api.py
+++ b/homeassistant/components/caldav/api.py
@@ -10,7 +10,7 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-ASSUMED_COMPONENTS = {"VEVENT", "VTODO"}
+ASSUMED_COMPONENTS = frozenset({"VEVENT", "VTODO"})
 
 
 async def async_get_calendars(

--- a/homeassistant/components/caldav/api.py
+++ b/homeassistant/components/caldav/api.py
@@ -54,14 +54,14 @@ async def async_get_calendars(
                     _LOGGER.warning(
                         "CalDAV server does not report supported components for calendar %s, "
                         "assuming it supports the requested component '%s'",
-                        name,
+                        name or url,
                         comp,
                     )
                 else:
                     _LOGGER.warning(
                         "CalDAV server does not report supported components for calendar %s. "
                         "Not assuming support for requested component '%s'",
-                        name,
+                        name or url,
                         comp,
                     )
 

--- a/homeassistant/components/caldav/api.py
+++ b/homeassistant/components/caldav/api.py
@@ -1,8 +1,12 @@
 """Library for working with CalDAV api."""
 
+import logging
+
 import caldav
 
 from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_get_calendars(
@@ -11,11 +15,33 @@ async def async_get_calendars(
     """Get all calendars that support the specified component."""
 
     def _get_calendars() -> list[caldav.Calendar]:
-        return [
-            calendar
-            for calendar in client.principal().calendars()
-            if component in calendar.get_supported_components()
-        ]
+        calendars = []
+        for calendar in client.principal().calendars():
+            try:
+                supported_components = calendar.get_supported_components()
+            except KeyError:
+                if component in ("VEVENT", "VTODO"):
+                    _LOGGER.warning(
+                        "CalDAV server does not report supported components for calendar %s, "
+                        "assuming it supports the requested component '%s'",
+                        calendar.name,
+                        component,
+                    )
+                    # If the server does not specify supported components, we assume
+                    # the calendar is supported for the requested component.
+                    supported_components = [component]
+                else:
+                    _LOGGER.warning(
+                        "CalDAV server does not report supported components for calendar %s. "
+                        "Not assuming support for requested component '%s'",
+                        calendar.name,
+                        component,
+                    )
+                    supported_components = []
+
+            if component in supported_components:
+                calendars.append(calendar)
+        return calendars
 
     return await hass.async_add_executor_job(_get_calendars)
 

--- a/homeassistant/components/caldav/api.py
+++ b/homeassistant/components/caldav/api.py
@@ -18,7 +18,9 @@ async def async_get_calendars(
 ) -> list[caldav.Calendar]:
     """Get all calendars that support the specified component."""
 
-    def _get_calendars() -> tuple[list[caldav.Calendar], list[tuple[str, str | None, str]]]:
+    def _get_calendars() -> tuple[
+        list[caldav.Calendar], list[tuple[str, str | None, str]]
+    ]:
         calendars = []
         needs_warning: list[tuple[str, str | None, str]] = []
         for calendar in client.principal().calendars():
@@ -41,9 +43,9 @@ async def async_get_calendars(
     calendars, needs_warning = await hass.async_add_executor_job(_get_calendars)
 
     if needs_warning:
-        warned_calendars: set[tuple[str, str]] = hass.data.setdefault(DOMAIN, {}).setdefault(
-            "warned_calendars", set()
-        )
+        warned_calendars: set[tuple[str, str]] = hass.data.setdefault(
+            DOMAIN, {}
+        ).setdefault("warned_calendars", set())
         for url, name, comp in needs_warning:
             # This workaround and warning can be removed when we upgrade to caldav 3.0
             if (url, comp) not in warned_calendars:

--- a/homeassistant/components/caldav/api.py
+++ b/homeassistant/components/caldav/api.py
@@ -7,13 +7,15 @@ import caldav
 from homeassistant.core import HomeAssistant
 
 _LOGGER = logging.getLogger(__name__)
-_CALENDARS_WARNED: set[str] = set()
+
+ASSUMED_COMPONENTS = {"VEVENT", "VTODO"}
 
 
 async def async_get_calendars(
     hass: HomeAssistant, client: caldav.DAVClient, component: str
 ) -> list[caldav.Calendar]:
     """Get all calendars that support the specified component."""
+    warned_calendars: set[str] = hass.data.setdefault("caldav_warned_calendars", set())
 
     def _get_calendars() -> list[caldav.Calendar]:
         calendars = []
@@ -22,9 +24,9 @@ async def async_get_calendars(
                 supported_components = calendar.get_supported_components()
             except KeyError:
                 # This workaround and warning can be removed when we upgrade to caldav 3.0
-                if str(calendar.url) not in _CALENDARS_WARNED:
-                    _CALENDARS_WARNED.add(str(calendar.url))
-                    if component in ("VEVENT", "VTODO"):
+                if str(calendar.url) not in warned_calendars:
+                    warned_calendars.add(str(calendar.url))
+                    if component in ASSUMED_COMPONENTS:
                         _LOGGER.warning(
                             "CalDAV server does not report supported components for calendar %s, "
                             "assuming it supports the requested component '%s'",
@@ -39,7 +41,7 @@ async def async_get_calendars(
                             component,
                         )
 
-                if component in ("VEVENT", "VTODO"):
+                if component in ASSUMED_COMPONENTS:
                     # If the server does not specify supported components, we assume
                     # the calendar is supported for the requested component.
                     supported_components = [component]

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -306,6 +306,8 @@ FORBIDDEN_PACKAGE_FILES_EXCEPTIONS = {
     },
     # https://github.com/basnijholt/aiokef
     "kef": {"homeassistant": {"aiokef"}},
+    # https://github.com/danifus/pyzipper
+    "knx": {"xknxproject": {"pyzipper"}},
     # https://github.com/hthiery/python-lacrosse
     "lacrosse": {"homeassistant": {"pylacrosse"}},
     # ???

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -306,8 +306,6 @@ FORBIDDEN_PACKAGE_FILES_EXCEPTIONS = {
     },
     # https://github.com/basnijholt/aiokef
     "kef": {"homeassistant": {"aiokef"}},
-    # https://github.com/danifus/pyzipper
-    "knx": {"xknxproject": {"pyzipper"}},
     # https://github.com/hthiery/python-lacrosse
     "lacrosse": {"homeassistant": {"pylacrosse"}},
     # ???

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -1275,7 +1275,5 @@ async def test_missing_supported_components(
     assert hass.states.get(TEST_ENTITY)
     assert (
         "CalDAV server does not report supported components for calendar Example, "
-        "assuming it supports the requested component 'VEVENT'"
-        in caplog.text
+        "assuming it supports the requested component 'VEVENT'" in caplog.text
     )
-

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -7,7 +7,7 @@ from typing import Any
 from unittest.mock import MagicMock, Mock
 import zoneinfo
 
-from caldav.objects import Event
+from caldav import Event
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
@@ -1269,6 +1269,7 @@ async def test_missing_supported_components(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test setup works when calendar raises KeyError on get_supported_components."""
+    caplog.set_level("WARNING")
     calendars[0].get_supported_components.side_effect = KeyError()
     await setup_platform_cb()
 

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -1291,6 +1291,15 @@ async def test_missing_supported_components(
     await async_get_calendars(hass, client, "VEVENT")
     assert warning_msg not in caplog.text
 
+    # Verify that querying a *different* component for the same calendar DOES log the warning again
+    # because de-duplication is keyed by (url, component).
+    vjournal_warning = (
+        "CalDAV server does not report supported components for calendar Example. "
+        "Not assuming support for requested component 'VJOURNAL'"
+    )
+    await async_get_calendars(hass, client, "VJOURNAL")
+    assert vjournal_warning in caplog.text
+
 
 async def test_missing_supported_components_not_assumed(
     hass: HomeAssistant,

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -1276,10 +1276,20 @@ async def test_missing_supported_components(
     await setup_platform_cb()
 
     assert hass.states.get(TEST_ENTITY)
-    assert (
+
+    warning_msg = (
         "CalDAV server does not report supported components for calendar Example, "
-        "assuming it supports the requested component 'VEVENT'" in caplog.text
+        "assuming it supports the requested component 'VEVENT'"
     )
+    assert warning_msg in caplog.text
+
+    # Clear caplog and call async_get_calendars again to verify warning is not logged again
+    caplog.clear()
+    client = MagicMock()
+    client.principal().calendars.return_value = calendars
+
+    await async_get_calendars(hass, client, "VEVENT")
+    assert warning_msg not in caplog.text
 
 
 async def test_missing_supported_components_not_assumed(
@@ -1296,7 +1306,13 @@ async def test_missing_supported_components_not_assumed(
     returned_calendars = await async_get_calendars(hass, client, "VJOURNAL")
 
     assert len(returned_calendars) == 0
-    assert (
+    warning_msg = (
         "CalDAV server does not report supported components for calendar Example. "
-        "Not assuming support for requested component 'VJOURNAL'" in caplog.text
+        "Not assuming support for requested component 'VJOURNAL'"
     )
+    assert warning_msg in caplog.text
+
+    # Clear caplog and call async_get_calendars again to verify warning is not logged again
+    caplog.clear()
+    await async_get_calendars(hass, client, "VJOURNAL")
+    assert warning_msg not in caplog.text

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -3,14 +3,16 @@
 from collections.abc import Awaitable, Callable
 import datetime
 from http import HTTPStatus
+import logging
 from typing import Any
 from unittest.mock import MagicMock, Mock
 import zoneinfo
 
-from caldav import Event
+from caldav.objects import Event
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
+from homeassistant.components.caldav.api import async_get_calendars
 from homeassistant.components.calendar import CalendarEntityFeature
 from homeassistant.const import STATE_OFF, STATE_ON, Platform
 from homeassistant.core import HomeAssistant
@@ -1269,7 +1271,7 @@ async def test_missing_supported_components(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test setup works when calendar raises KeyError on get_supported_components."""
-    caplog.set_level("WARNING")
+    caplog.set_level(logging.WARNING)
     calendars[0].get_supported_components.side_effect = KeyError()
     await setup_platform_cb()
 
@@ -1277,4 +1279,24 @@ async def test_missing_supported_components(
     assert (
         "CalDAV server does not report supported components for calendar Example, "
         "assuming it supports the requested component 'VEVENT'" in caplog.text
+    )
+
+
+async def test_missing_supported_components_not_assumed(
+    hass: HomeAssistant,
+    calendars: list[Mock],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test get_calendars excludes calendars when KeyError is raised for non-assumed components."""
+    caplog.set_level(logging.WARNING)
+    calendars[0].get_supported_components.side_effect = KeyError()
+    client = MagicMock()
+    client.principal().calendars.return_value = calendars
+
+    returned_calendars = await async_get_calendars(hass, client, "VJOURNAL")
+
+    assert len(returned_calendars) == 0
+    assert (
+        "CalDAV server does not report supported components for calendar Example. "
+        "Not assuming support for requested component 'VJOURNAL'" in caplog.text
     )

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -1260,3 +1260,22 @@ async def test_add_vevent(
     calendars[0].add_event.assert_called_once()
     assert calendars[0].add_event.call_args
     assert calendars[0].add_event.call_args[1] == expected_ics_fields
+
+
+async def test_missing_supported_components(
+    hass: HomeAssistant,
+    calendars: list[Mock],
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test setup works when calendar raises KeyError on get_supported_components."""
+    calendars[0].get_supported_components.side_effect = KeyError()
+    await setup_platform_cb()
+
+    assert hass.states.get(TEST_ENTITY)
+    assert (
+        "CalDAV server does not report supported components for calendar Example, "
+        "assuming it supports the requested component 'VEVENT'"
+        in caplog.text
+    )
+

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -1271,7 +1271,7 @@ async def test_missing_supported_components(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test setup works when calendar raises KeyError on get_supported_components."""
-    caplog.set_level(logging.WARNING)
+    caplog.set_level(logging.WARNING, logger="homeassistant.components.caldav.api")
     calendars[0].get_supported_components.side_effect = KeyError()
     await setup_platform_cb()
 
@@ -1307,7 +1307,7 @@ async def test_missing_supported_components_not_assumed(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test get_calendars excludes calendars when KeyError is raised for non-assumed components."""
-    caplog.set_level(logging.WARNING)
+    caplog.set_level(logging.WARNING, logger="homeassistant.components.caldav.api")
     calendars[0].get_supported_components.side_effect = KeyError()
     client = MagicMock()
     client.principal().calendars.return_value = calendars


### PR DESCRIPTION
## Proposed change

This PR fixes a bug in the CalDAV integration where setup fails with a `KeyError` if the server (such as Nextcloud or PurelyMail) omits the `supported-calendar-component-set` property for a calendar. 

Per [RFC 4791 Section 5.2.3](https://datatracker.ietf.org/doc/html/rfc4791#section-5.2.3), returning this property is optional. When absent, the server MUST accept all component types. The pinned `caldav==2.1.0` library blindly assumes the XML tag will be present, throwing a `KeyError` when it is missing.

This PR implements the same fallback logic recently merged into the upstream `caldav` library ([python-caldav/caldav@e288b7f](https://github.com/python-caldav/caldav/commit/e288b7f9fc55221a2e399b5c0d70fb670ef81a76)). The integration now catches the `KeyError`, logs a warning, and safely falls back to assuming the calendar supports `VEVENT` or `VTODO` if those were requested, avoiding setup crashes without requiring an upstream version bump.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #159543

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [x] I have followed the [perfect PR recommendations](https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr)
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.