### PR TITLE
Add support for SwitchBot Lock Vision (Pro) and Lock Pro Wifi

### DIFF
--- a/homeassistant/components/switchbot/__init__.py
+++ b/homeassistant/components/switchbot/__init__.py
@@ -164,6 +164,21 @@ PLATFORMS_BY_TYPE = {
         Platform.BINARY_SENSOR,
         Platform.EVENT,
     ],
+    SupportedModels.LOCK_VISION.value: [
+        Platform.BINARY_SENSOR,
+        Platform.LOCK,
+        Platform.SENSOR,
+    ],
+    SupportedModels.LOCK_VISION_PRO.value: [
+        Platform.BINARY_SENSOR,
+        Platform.LOCK,
+        Platform.SENSOR,
+    ],
+    SupportedModels.LOCK_PRO_WIFI.value: [
+        Platform.BINARY_SENSOR,
+        Platform.LOCK,
+        Platform.SENSOR,
+    ],
 }
 CLASS_BY_DEVICE = {
     SupportedModels.CEILING_LIGHT.value: switchbot.SwitchbotCeilingLight,
@@ -206,6 +221,9 @@ CLASS_BY_DEVICE = {
     SupportedModels.KEYPAD_VISION.value: switchbot.SwitchbotKeypadVision,
     SupportedModels.KEYPAD_VISION_PRO.value: switchbot.SwitchbotKeypadVision,
     SupportedModels.HYGROMETER_CO2.value: switchbot.SwitchbotMeterProCO2,
+    SupportedModels.LOCK_VISION_PRO.value: switchbot.SwitchbotLock,
+    SupportedModels.LOCK_VISION.value: switchbot.SwitchbotLock,
+    SupportedModels.LOCK_PRO_WIFI.value: switchbot.SwitchbotLock,
 }
 
 

--- a/homeassistant/components/switchbot/config_flow.py
+++ b/homeassistant/components/switchbot/config_flow.py
@@ -477,6 +477,9 @@ class SwitchbotOptionsFlowHandler(OptionsFlow):
             SupportedModels.LOCK,
             SupportedModels.LOCK_PRO,
             SupportedModels.LOCK_ULTRA,
+            SupportedModels.LOCK_PRO_WIFI,
+            SupportedModels.LOCK_VISION,
+            SupportedModels.LOCK_VISION_PRO,
         ):
             options.update(
                 {

--- a/homeassistant/components/switchbot/const.py
+++ b/homeassistant/components/switchbot/const.py
@@ -66,6 +66,9 @@ class SupportedModels(StrEnum):
     ART_FRAME = "art_frame"
     KEYPAD_VISION = "keypad_vision"
     KEYPAD_VISION_PRO = "keypad_vision_pro"
+    LOCK_VISION_PRO = "lock_vision_pro"
+    LOCK_VISION = "lock_vision"
+    LOCK_PRO_WIFI = "lock_pro_wifi"
 
 
 CONNECTABLE_SUPPORTED_MODEL_TYPES = {
@@ -111,6 +114,9 @@ CONNECTABLE_SUPPORTED_MODEL_TYPES = {
     SwitchbotModel.KEYPAD_VISION: SupportedModels.KEYPAD_VISION,
     SwitchbotModel.KEYPAD_VISION_PRO: SupportedModels.KEYPAD_VISION_PRO,
     SwitchbotModel.METER_PRO_C: SupportedModels.HYGROMETER_CO2,
+    SwitchbotModel.LOCK_VISION_PRO: SupportedModels.LOCK_VISION_PRO,
+    SwitchbotModel.LOCK_VISION: SupportedModels.LOCK_VISION,
+    SwitchbotModel.LOCK_PRO_WIFI: SupportedModels.LOCK_PRO_WIFI,
 }
 
 NON_CONNECTABLE_SUPPORTED_MODEL_TYPES = {
@@ -155,6 +161,9 @@ ENCRYPTED_MODELS = {
     SwitchbotModel.ART_FRAME,
     SwitchbotModel.KEYPAD_VISION,
     SwitchbotModel.KEYPAD_VISION_PRO,
+    SwitchbotModel.LOCK_VISION_PRO,
+    SwitchbotModel.LOCK_VISION,
+    SwitchbotModel.LOCK_PRO_WIFI,
 }
 
 ENCRYPTED_SWITCHBOT_MODEL_TO_CLASS: dict[
@@ -182,6 +191,9 @@ ENCRYPTED_SWITCHBOT_MODEL_TO_CLASS: dict[
     SwitchbotModel.ART_FRAME: switchbot.SwitchbotArtFrame,
     SwitchbotModel.KEYPAD_VISION: switchbot.SwitchbotKeypadVision,
     SwitchbotModel.KEYPAD_VISION_PRO: switchbot.SwitchbotKeypadVision,
+    SwitchbotModel.LOCK_VISION_PRO: switchbot.SwitchbotLock,
+    SwitchbotModel.LOCK_VISION: switchbot.SwitchbotLock,
+    SwitchbotModel.LOCK_PRO_WIFI: switchbot.SwitchbotLock,
 }
 
 HASS_SENSOR_TYPE_TO_SWITCHBOT_MODEL = {

--- a/tests/components/switchbot/__init__.py
+++ b/tests/components/switchbot/__init__.py
@@ -785,6 +785,81 @@ LOCK_ULTRA_SERVICE_INFO = BluetoothServiceInfoBleak(
 )
 
 
+LOCK_VISION_SERVICE_INFO = BluetoothServiceInfoBleak(
+    name="Lock Vision",
+    manufacturer_data={
+        2409: b"\xb0\xe9\xfe\x6f\xc9\xa6\x0a\x00\x00\x2e\x00\x0c\x00\x00\x00\x00"
+    },
+    service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": b"\x00\x80.\x00\x11i\x08"},
+    service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+    address="AA:BB:CC:DD:EE:FF",
+    rssi=-60,
+    source="local",
+    advertisement=generate_advertisement_data(
+        local_name="Lock Vision",
+        manufacturer_data={
+            2409: b"\xb0\xe9\xfe\x6f\xc9\xa6\x0a\x00\x00\x2e\x00\x0c\x00\x00\x00\x00"
+        },
+        service_data={
+            "0000fd3d-0000-1000-8000-00805f9b34fb": b"\x00\x80.\x00\x11i\x08"
+        },
+        service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+    ),
+    device=generate_ble_device("AA:BB:CC:DD:EE:FF", "Lock Vision"),
+    time=0,
+    connectable=True,
+    tx_power=-127,
+)
+
+
+LOCK_VISION_PRO_SERVICE_INFO = BluetoothServiceInfoBleak(
+    name="Lock Vision Pro",
+    manufacturer_data={
+        2409: b"\xb0\xe9\xfe\xe6\x1aq\x03\x00\x003\x00\x0c\x00\x00\x00\x00"
+    },
+    service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": b"\x00\x803\x00\x11i\t"},
+    service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+    address="AA:BB:CC:DD:EE:FF",
+    rssi=-60,
+    source="local",
+    advertisement=generate_advertisement_data(
+        local_name="Lock Vision Pro",
+        manufacturer_data={
+            2409: b"\xb0\xe9\xfe\xe6\x1aq\x03\x00\x003\x00\x0c\x00\x00\x00\x00"
+        },
+        service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": b"\x00\x803\x00\x11i\t"},
+        service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+    ),
+    device=generate_ble_device("AA:BB:CC:DD:EE:FF", "Lock Vision Pro"),
+    time=0,
+    connectable=True,
+    tx_power=-127,
+)
+
+
+LOCK_PRO_WIFI_SERVICE_INFO = BluetoothServiceInfoBleak(
+    name="Lock Pro Wifi",
+    manufacturer_data={2409: b"\xb0\xe9\xfe\xb0^\xfe\x0e\x02\x00=\x00\x08"},
+    service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": b"\x00\x80=\x00\x10\xff\x90"},
+    service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+    address="AA:BB:CC:DD:EE:FF",
+    rssi=-60,
+    source="local",
+    advertisement=generate_advertisement_data(
+        local_name="Lock Pro Wifi",
+        manufacturer_data={2409: b"\xb0\xe9\xfe\xb0^\xfe\x0e\x02\x00=\x00\x08"},
+        service_data={
+            "0000fd3d-0000-1000-8000-00805f9b34fb": b"\x00\x80=\x00\x10\xff\x90"
+        },
+        service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+    ),
+    device=generate_ble_device("AA:BB:CC:DD:EE:FF", "Lock Pro Wifi"),
+    time=0,
+    connectable=True,
+    tx_power=-127,
+)
+
+
 AIR_PURIFIER_TABLE_US_SERVICE_INFO = BluetoothServiceInfoBleak(
     name="Air Purifier Table US",
     manufacturer_data={

--- a/tests/components/switchbot/test_config_flow.py
+++ b/tests/components/switchbot/test_config_flow.py
@@ -1875,3 +1875,64 @@ async def test_user_show_menu_when_no_scanners(hass: HomeAssistant) -> None:
         CONF_SENSOR_TYPE: "bot",
     }
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_options_flow_lock_pro_wifi(hass: HomeAssistant) -> None:
+    """Test updating options for lock_pro_wifi."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_ADDRESS: "aa:bb:cc:dd:ee:ff",
+            CONF_NAME: "test-name",
+            CONF_PASSWORD: "test-password",
+            CONF_SENSOR_TYPE: "lock_pro_wifi",
+        },
+        options={CONF_RETRY_COUNT: 10},
+        unique_id="aabbccddeeff",
+    )
+    entry.add_to_hass(hass)
+
+    # Test night_latch should be disabled by default.
+    with patch_async_setup_entry() as mock_setup_entry:
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "init"
+        assert result["errors"] is None
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_RETRY_COUNT: 3,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_LOCK_NIGHTLATCH] is False
+
+    assert len(mock_setup_entry.mock_calls) == 1
+
+    # Test Set force night_latch to be enabled.
+    with patch_async_setup_entry() as mock_setup_entry:
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "init"
+        assert result["errors"] is None
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_LOCK_NIGHTLATCH: True,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_LOCK_NIGHTLATCH] is True
+
+    assert len(mock_setup_entry.mock_calls) == 0
+
+    assert entry.options[CONF_LOCK_NIGHTLATCH] is True

--- a/tests/components/switchbot/test_lock.py
+++ b/tests/components/switchbot/test_lock.py
@@ -19,8 +19,11 @@ from homeassistant.exceptions import HomeAssistantError
 
 from . import (
     LOCK_LITE_SERVICE_INFO,
+    LOCK_PRO_WIFI_SERVICE_INFO,
     LOCK_SERVICE_INFO,
     LOCK_ULTRA_SERVICE_INFO,
+    LOCK_VISION_PRO_SERVICE_INFO,
+    LOCK_VISION_SERVICE_INFO,
     WOLOCKPRO_SERVICE_INFO,
 )
 
@@ -35,6 +38,9 @@ from tests.components.bluetooth import inject_bluetooth_service_info
         ("lock", LOCK_SERVICE_INFO),
         ("lock_lite", LOCK_LITE_SERVICE_INFO),
         ("lock_ultra", LOCK_ULTRA_SERVICE_INFO),
+        ("lock_vision", LOCK_VISION_SERVICE_INFO),
+        ("lock_vision_pro", LOCK_VISION_PRO_SERVICE_INFO),
+        ("lock_pro_wifi", LOCK_PRO_WIFI_SERVICE_INFO),
     ],
 )
 @pytest.mark.parametrize(
@@ -83,6 +89,9 @@ async def test_lock_services(
         ("lock", LOCK_SERVICE_INFO),
         ("lock_lite", LOCK_LITE_SERVICE_INFO),
         ("lock_ultra", LOCK_ULTRA_SERVICE_INFO),
+        ("lock_vision", LOCK_VISION_SERVICE_INFO),
+        ("lock_vision_pro", LOCK_VISION_PRO_SERVICE_INFO),
+        ("lock_pro_wifi", LOCK_PRO_WIFI_SERVICE_INFO),
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for the SwitchBot Lock Vision, Lock Vision Pro, and Lock Pro Wifi to the SwitchBot integration.

This is a resubmission of #164725 from a writable fork. It also addresses the review feedback by extending the night-latch options handling to cover Lock Vision and Lock Vision Pro (not just Lock Pro Wifi). The dependency upgrade PR is https://github.com/home-assistant/core/pull/164298.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43854
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
