### PR TITLE
Add MAC address to Indevolt device info

### DIFF
--- a/homeassistant/components/indevolt/coordinator.py
+++ b/homeassistant/components/indevolt/coordinator.py
@@ -17,6 +17,7 @@ from homeassistant.const import CONF_HOST, CONF_MODEL
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -85,7 +86,8 @@ class IndevoltCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         device_data = config_data.get("device", {})
 
         self.firmware_version = device_data.get("fw")
-        self.mac_address = device_data.get("mac")
+        raw_mac = device_data.get("mac")
+        self.mac_address = format_mac(raw_mac) if raw_mac else None
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch raw JSON data from the device."""

--- a/homeassistant/components/indevolt/coordinator.py
+++ b/homeassistant/components/indevolt/coordinator.py
@@ -47,6 +47,7 @@ class IndevoltCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     friendly_name: str
     config_entry: IndevoltConfigEntry
     firmware_version: str | None
+    mac_address: str | None
     serial_number: str
     device_model: str
     generation: int
@@ -84,6 +85,7 @@ class IndevoltCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         device_data = config_data.get("device", {})
 
         self.firmware_version = device_data.get("fw")
+        self.mac_address = device_data.get("mac")
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch raw JSON data from the device."""

--- a/homeassistant/components/indevolt/coordinator.py
+++ b/homeassistant/components/indevolt/coordinator.py
@@ -48,7 +48,7 @@ class IndevoltCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     friendly_name: str
     config_entry: IndevoltConfigEntry
     firmware_version: str | None
-    mac_address: str | None
+    mac_address: str
     serial_number: str
     device_model: str
     generation: int
@@ -84,10 +84,8 @@ class IndevoltCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         # Cache device information
         device_data = config_data.get("device", {})
-
         self.firmware_version = device_data.get("fw")
-        raw_mac = device_data.get("mac")
-        self.mac_address = format_mac(raw_mac) if raw_mac else None
+        self.mac_address = format_mac(device_data["mac"])
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch raw JSON data from the device."""

--- a/homeassistant/components/indevolt/coordinator.py
+++ b/homeassistant/components/indevolt/coordinator.py
@@ -48,7 +48,7 @@ class IndevoltCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     friendly_name: str
     config_entry: IndevoltConfigEntry
     firmware_version: str | None
-    mac_address: str
+    mac_address: str | None
     serial_number: str
     device_model: str
     generation: int
@@ -85,7 +85,8 @@ class IndevoltCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Cache device information
         device_data = config_data.get("device", {})
         self.firmware_version = device_data.get("fw")
-        self.mac_address = format_mac(device_data["mac"])
+        raw_mac = device_data.get("mac")
+        self.mac_address = format_mac(raw_mac) if raw_mac else None
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch raw JSON data from the device."""

--- a/homeassistant/components/indevolt/diagnostics.py
+++ b/homeassistant/components/indevolt/diagnostics.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from indevolt_api import IndevoltBattery, IndevoltSystem
 
-from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.components.diagnostics import REDACTED, async_redact_data
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 
@@ -25,6 +25,18 @@ TO_REDACT = {
 }
 
 
+def _redact_mac(mac_address: str | None) -> str | None:
+    """Redact the device-specific part of a MAC address (keep OUI, used for discovery)."""
+    if not mac_address:
+        return mac_address
+
+    parts = mac_address.split(":")
+    if len(parts) == 6:
+        return ":".join([*parts[:3], "XX", "XX", "XX"])
+
+    return REDACTED
+
+
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: IndevoltConfigEntry
 ) -> dict[str, Any]:
@@ -36,6 +48,7 @@ async def async_get_config_entry_diagnostics(
         "generation": coordinator.generation,
         "serial_number": coordinator.serial_number,
         "firmware_version": coordinator.firmware_version,
+        "mac_address": _redact_mac(coordinator.mac_address),
     }
 
     return {

--- a/homeassistant/components/indevolt/diagnostics.py
+++ b/homeassistant/components/indevolt/diagnostics.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from indevolt_api import IndevoltBattery, IndevoltSystem
 
-from homeassistant.components.diagnostics import REDACTED, async_redact_data
+from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 
@@ -25,18 +25,10 @@ TO_REDACT = {
 }
 
 
-def _redact_mac(mac_address: str | None) -> str | None:
+def _redact_mac(mac_address: str) -> str:
     """Redact the device-specific part of a MAC address (keep OUI, used for discovery)."""
-    if not mac_address:
-        return mac_address
-
-    # format_mac normalises to aa:bb:cc:dd:ee:ff; fall back to REDACTED for
-    # any unrecognised format that passed through unchanged.
     parts = mac_address.split(":")
-    if len(parts) == 6:
-        return ":".join([*parts[:3], "XX", "XX", "XX"])
-
-    return REDACTED
+    return ":".join([*parts[:3], "XX", "XX", "XX"])
 
 
 async def async_get_config_entry_diagnostics(

--- a/homeassistant/components/indevolt/diagnostics.py
+++ b/homeassistant/components/indevolt/diagnostics.py
@@ -42,7 +42,9 @@ async def async_get_config_entry_diagnostics(
         "generation": coordinator.generation,
         "serial_number": coordinator.serial_number,
         "firmware_version": coordinator.firmware_version,
-        "mac_address": _redact_mac(coordinator.mac_address),
+        "mac_address": _redact_mac(coordinator.mac_address)
+        if coordinator.mac_address
+        else None,
     }
 
     return {

--- a/homeassistant/components/indevolt/diagnostics.py
+++ b/homeassistant/components/indevolt/diagnostics.py
@@ -30,6 +30,8 @@ def _redact_mac(mac_address: str | None) -> str | None:
     if not mac_address:
         return mac_address
 
+    # format_mac normalises to aa:bb:cc:dd:ee:ff; fall back to REDACTED for
+    # any unrecognised format that passed through unchanged.
     parts = mac_address.split(":")
     if len(parts) == 6:
         return ":".join([*parts[:3], "XX", "XX", "XX"])

--- a/homeassistant/components/indevolt/entity.py
+++ b/homeassistant/components/indevolt/entity.py
@@ -1,6 +1,6 @@
 """Base entity for Indevolt integration."""
 
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
@@ -21,8 +21,12 @@ class IndevoltEntity(CoordinatorEntity[IndevoltCoordinator]):
     def device_info(self) -> DeviceInfo:
         """Return device information for registry."""
         coordinator = self.coordinator
+        connections: set[tuple[str, str]] = set()
+        if coordinator.mac_address:
+            connections.add((CONNECTION_NETWORK_MAC, coordinator.mac_address))
         return DeviceInfo(
             identifiers={(DOMAIN, coordinator.serial_number)},
+            connections=connections,
             manufacturer="INDEVOLT",
             serial_number=coordinator.serial_number,
             model=coordinator.device_model,

--- a/homeassistant/components/indevolt/entity.py
+++ b/homeassistant/components/indevolt/entity.py
@@ -21,12 +21,9 @@ class IndevoltEntity(CoordinatorEntity[IndevoltCoordinator]):
     def device_info(self) -> DeviceInfo:
         """Return device information for registry."""
         coordinator = self.coordinator
-        connections: set[tuple[str, str]] = set()
-        if coordinator.mac_address:
-            connections.add((CONNECTION_NETWORK_MAC, coordinator.mac_address))
         return DeviceInfo(
             identifiers={(DOMAIN, coordinator.serial_number)},
-            connections=connections,
+            connections={(CONNECTION_NETWORK_MAC, coordinator.mac_address)},
             manufacturer="INDEVOLT",
             serial_number=coordinator.serial_number,
             model=coordinator.device_model,

--- a/homeassistant/components/indevolt/entity.py
+++ b/homeassistant/components/indevolt/entity.py
@@ -21,9 +21,12 @@ class IndevoltEntity(CoordinatorEntity[IndevoltCoordinator]):
     def device_info(self) -> DeviceInfo:
         """Return device information for registry."""
         coordinator = self.coordinator
+        connections: set[tuple[str, str]] = set()
+        if coordinator.mac_address:
+            connections.add((CONNECTION_NETWORK_MAC, coordinator.mac_address))
         return DeviceInfo(
             identifiers={(DOMAIN, coordinator.serial_number)},
-            connections={(CONNECTION_NETWORK_MAC, coordinator.mac_address)},
+            connections=connections,
             manufacturer="INDEVOLT",
             serial_number=coordinator.serial_number,
             model=coordinator.device_model,

--- a/tests/components/indevolt/conftest.py
+++ b/tests/components/indevolt/conftest.py
@@ -20,6 +20,7 @@ TEST_PORT = 8080
 TEST_DEVICE_SN_GEN1 = "BK1600-12345678"
 TEST_DEVICE_SN_GEN2 = "SolidFlex2000-87654321"
 TEST_FW_VERSION = "1.2.3"
+TEST_MAC_ADDRESS = "AA:BB:CC:11:22:33"
 
 # Map device fixture names to generation and fixture files
 DEVICE_MAPPING = {
@@ -122,6 +123,7 @@ def mock_indevolt(generation: int) -> Generator[AsyncMock]:
                 "type": device_info["device"],
                 "generation": device_info["generation"],
                 "fw": TEST_FW_VERSION,
+                "mac": TEST_MAC_ADDRESS,
             }
         }
 

--- a/tests/components/indevolt/conftest.py
+++ b/tests/components/indevolt/conftest.py
@@ -19,22 +19,26 @@ ALT_TEST_HOST = "192.168.1.101"
 TEST_PORT = 8080
 TEST_DEVICE_SN_GEN1 = "BK1600-12345678"
 TEST_DEVICE_SN_GEN2 = "SolidFlex2000-87654321"
-TEST_FW_VERSION = "1.2.3"
-TEST_MAC_ADDRESS = "AA:BB:CC:11:22:33"
+TEST_MODEL_GEN1 = "BK1600"
+TEST_MODEL_GEN2 = "CMS-SF2000"
 
-# Map device fixture names to generation and fixture files
+# Create DeviceInfo per generation
 DEVICE_MAPPING = {
     1: {
-        "device": "BK1600",
+        "device": TEST_MODEL_GEN1,
         "generation": 1,
         "sn": TEST_DEVICE_SN_GEN1,
         "host": ALT_TEST_HOST,
+        "mac": "aa:bb:cc:11:22:33",
+        "fw": "1.2.3",
     },
     2: {
-        "device": "CMS-SF2000",
+        "device": TEST_MODEL_GEN2,
         "generation": 2,
         "sn": TEST_DEVICE_SN_GEN2,
         "host": TEST_HOST,
+        "mac": "aa:bb:cc:44:55:66",
+        "fw": "1.2.3",
     },
 }
 
@@ -122,8 +126,8 @@ def mock_indevolt(generation: int) -> Generator[AsyncMock]:
                 "sn": device_info["sn"],
                 "type": device_info["device"],
                 "generation": device_info["generation"],
-                "fw": TEST_FW_VERSION,
-                "mac": TEST_MAC_ADDRESS,
+                "fw": device_info["fw"],
+                "mac": device_info["mac"],
             }
         }
 

--- a/tests/components/indevolt/snapshots/test_diagnostics.ambr
+++ b/tests/components/indevolt/snapshots/test_diagnostics.ambr
@@ -39,6 +39,7 @@
     'device': dict({
       'firmware_version': '1.2.3',
       'generation': 1,
+      'mac_address': 'AA:BB:CC:XX:XX:XX',
       'model': 'BK1600',
       'serial_number': '**REDACTED**',
     }),
@@ -137,6 +138,7 @@
     'device': dict({
       'firmware_version': '1.2.3',
       'generation': 2,
+      'mac_address': 'AA:BB:CC:XX:XX:XX',
       'model': 'CMS-SF2000',
       'serial_number': '**REDACTED**',
     }),

--- a/tests/components/indevolt/snapshots/test_diagnostics.ambr
+++ b/tests/components/indevolt/snapshots/test_diagnostics.ambr
@@ -39,7 +39,7 @@
     'device': dict({
       'firmware_version': '1.2.3',
       'generation': 1,
-      'mac_address': 'AA:BB:CC:XX:XX:XX',
+      'mac_address': 'aa:bb:cc:XX:XX:XX',
       'model': 'BK1600',
       'serial_number': '**REDACTED**',
     }),
@@ -138,7 +138,7 @@
     'device': dict({
       'firmware_version': '1.2.3',
       'generation': 2,
-      'mac_address': 'AA:BB:CC:XX:XX:XX',
+      'mac_address': 'aa:bb:cc:XX:XX:XX',
       'model': 'CMS-SF2000',
       'serial_number': '**REDACTED**',
     }),

--- a/tests/components/indevolt/test_init.py
+++ b/tests/components/indevolt/test_init.py
@@ -39,12 +39,12 @@ async def test_device_info(
     mock_indevolt: AsyncMock,
     mock_config_entry: MockConfigEntry,
     generation: int,
+    device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test that device info is correctly registered in the device registry."""
     await setup_integration(hass, mock_config_entry)
 
     device_info = DEVICE_MAPPING[generation]
-    device_registry = dr.async_get(hass)
     device_entry = device_registry.async_get_device(
         connections={(CONNECTION_NETWORK_MAC, device_info["mac"])}
     )

--- a/tests/components/indevolt/test_init.py
+++ b/tests/components/indevolt/test_init.py
@@ -6,8 +6,11 @@ import pytest
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 
 from . import setup_integration
+from .conftest import DEVICE_MAPPING
 
 from tests.common import MockConfigEntry
 
@@ -28,6 +31,31 @@ async def test_load_unload(
 
     # Verify the config entry is properly unloaded
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+@pytest.mark.parametrize("generation", [1, 2], indirect=True)
+async def test_device_info(
+    hass: HomeAssistant,
+    mock_indevolt: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    generation: int,
+) -> None:
+    """Test that device info is correctly registered in the device registry."""
+    await setup_integration(hass, mock_config_entry)
+
+    device_info = DEVICE_MAPPING[generation]
+    device_registry = dr.async_get(hass)
+    device_entry = device_registry.async_get_device(
+        connections={(CONNECTION_NETWORK_MAC, device_info["mac"])}
+    )
+
+    assert device_entry is not None
+    assert device_entry.manufacturer == "INDEVOLT"
+    assert device_entry.model == device_info["device"]
+    assert device_entry.serial_number == device_info["sn"]
+    assert device_entry.sw_version == device_info["fw"]
+    assert device_entry.hw_version == str(device_info["generation"])
+    assert (CONNECTION_NETWORK_MAC, device_info["mac"]) in device_entry.connections
 
 
 @pytest.mark.parametrize("generation", [2], indirect=True)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds the MAC address to the device info (and redacts it for diagnostics). It is a "new feature" as it exposes new information, but with no impact on documentation (per my understanding). To complete the change, I added a new test to check the DeviceInfo (incl. MAC address).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
