### PR TITLE
Remove advanced mode dependency from androidtv config flow

### DIFF
--- a/homeassistant/components/androidtv/config_flow.py
+++ b/homeassistant/components/androidtv/config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.config_entries import (
 )
 from homeassistant.const import CONF_DEVICE_CLASS, CONF_HOST, CONF_PORT
 from homeassistant.core import callback
+from homeassistant.data_entry_flow import SectionConfig, section
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.selector import (
     ObjectSelector,
@@ -32,6 +33,7 @@ from .const import (
     CONF_APPS,
     CONF_EXCLUDE_UNNAMED_APPS,
     CONF_GET_SOURCES,
+    CONF_MORE_OPTIONS,
     CONF_SCREENCAP_INTERVAL,
     CONF_STATE_DETECTION_RULES,
     CONF_TURN_OFF_COMMAND,
@@ -97,19 +99,21 @@ class AndroidTVFlowHandler(ConfigFlow, domain=DOMAIN):
                     )
                 ),
                 vol.Required(CONF_PORT, default=DEFAULT_PORT): cv.port,
+                vol.Required(CONF_MORE_OPTIONS): section(
+                    vol.Schema(
+                        {
+                            vol.Optional(CONF_ADBKEY): str,
+                            vol.Optional(CONF_ADB_SERVER_IP): str,
+                            vol.Optional(
+                                CONF_ADB_SERVER_PORT,
+                                default=DEFAULT_ADB_SERVER_PORT,
+                            ): cv.port,
+                        }
+                    ),
+                    SectionConfig(collapsed=True),
+                ),
             },
         )
-
-        if self.show_advanced_options:
-            data_schema = data_schema.extend(
-                {
-                    vol.Optional(CONF_ADBKEY): str,
-                    vol.Optional(CONF_ADB_SERVER_IP): str,
-                    vol.Required(
-                        CONF_ADB_SERVER_PORT, default=DEFAULT_ADB_SERVER_PORT
-                    ): cv.port,
-                }
-            )
 
         return self.async_show_form(
             step_id="user",
@@ -155,6 +159,10 @@ class AndroidTVFlowHandler(ConfigFlow, domain=DOMAIN):
         error = None
 
         if user_input is not None:
+            user_input = user_input.copy()
+            more_options = user_input.pop(CONF_MORE_OPTIONS, {})
+            user_input.update(more_options)
+
             host = user_input[CONF_HOST]
             adb_key = user_input.get(CONF_ADBKEY)
             if CONF_ADB_SERVER_IP in user_input:

--- a/homeassistant/components/androidtv/const.py
+++ b/homeassistant/components/androidtv/const.py
@@ -3,6 +3,7 @@
 DOMAIN = "androidtv"
 
 CONF_ADB_SERVER_IP = "adb_server_ip"
+CONF_MORE_OPTIONS = "more_options"
 CONF_ADB_SERVER_PORT = "adb_server_port"
 CONF_ADBKEY = "adbkey"
 CONF_APPS = "apps"

--- a/homeassistant/components/androidtv/strings.json
+++ b/homeassistant/components/androidtv/strings.json
@@ -14,12 +14,19 @@
     "step": {
       "user": {
         "data": {
-          "adb_server_ip": "IP address of the ADB server (leave empty to not use)",
-          "adb_server_port": "Port of the ADB server",
-          "adbkey": "Path to your ADB key file (leave empty to auto generate)",
           "device_class": "The type of device",
           "host": "[%key:common::config_flow::data::host%]",
           "port": "[%key:common::config_flow::data::port%]"
+        },
+        "sections": {
+          "more_options": {
+            "data": {
+              "adb_server_ip": "IP address of the ADB server (leave empty to not use)",
+              "adb_server_port": "Port of the ADB server",
+              "adbkey": "Path to your ADB key file (leave empty to auto generate)"
+            },
+            "name": "More options"
+          }
         }
       }
     }

--- a/tests/components/androidtv/test_config_flow.py
+++ b/tests/components/androidtv/test_config_flow.py
@@ -22,6 +22,7 @@ from homeassistant.components.androidtv.const import (
     CONF_APPS,
     CONF_EXCLUDE_UNNAMED_APPS,
     CONF_GET_SOURCES,
+    CONF_MORE_OPTIONS,
     CONF_SCREENCAP_INTERVAL,
     CONF_STATE_DETECTION_RULES,
     CONF_TURN_OFF_COMMAND,
@@ -65,6 +66,22 @@ CONFIG_ADB_SERVER = {
     CONF_ADB_SERVER_PORT: DEFAULT_ADB_SERVER_PORT,
 }
 
+# Flow input variants (with section nesting)
+FLOW_PYTHON_ADB = {
+    **CONFIG_PYTHON_ADB,
+    CONF_MORE_OPTIONS: {},
+}
+
+FLOW_ADB_SERVER = {
+    CONF_HOST: HOST,
+    CONF_PORT: DEFAULT_PORT,
+    CONF_DEVICE_CLASS: DEVICE_ANDROIDTV,
+    CONF_MORE_OPTIONS: {
+        CONF_ADB_SERVER_IP: "127.0.0.1",
+        CONF_ADB_SERVER_PORT: DEFAULT_ADB_SERVER_PORT,
+    },
+}
+
 CONNECT_METHOD = (
     "homeassistant.components.androidtv.config_flow.async_connect_androidtv"
 )
@@ -84,25 +101,26 @@ class MockConfigDevice:
 
 
 @pytest.mark.parametrize(
-    ("config", "eth_mac", "wifi_mac"),
+    ("flow_input", "expected_data", "eth_mac", "wifi_mac"),
     [
-        (CONFIG_PYTHON_ADB, ETH_MAC, None),
-        (CONFIG_ADB_SERVER, ETH_MAC, None),
-        (CONFIG_PYTHON_ADB, None, WIFI_MAC),
-        (CONFIG_ADB_SERVER, None, WIFI_MAC),
-        (CONFIG_PYTHON_ADB, ETH_MAC, WIFI_MAC),
-        (CONFIG_ADB_SERVER, ETH_MAC, WIFI_MAC),
+        (FLOW_PYTHON_ADB, CONFIG_PYTHON_ADB, ETH_MAC, None),
+        (FLOW_ADB_SERVER, CONFIG_ADB_SERVER, ETH_MAC, None),
+        (FLOW_PYTHON_ADB, CONFIG_PYTHON_ADB, None, WIFI_MAC),
+        (FLOW_ADB_SERVER, CONFIG_ADB_SERVER, None, WIFI_MAC),
+        (FLOW_PYTHON_ADB, CONFIG_PYTHON_ADB, ETH_MAC, WIFI_MAC),
+        (FLOW_ADB_SERVER, CONFIG_ADB_SERVER, ETH_MAC, WIFI_MAC),
     ],
 )
 async def test_user(
     hass: HomeAssistant,
-    config: dict[str, Any],
+    flow_input: dict[str, Any],
+    expected_data: dict[str, Any],
     eth_mac: str | None,
     wifi_mac: str | None,
 ) -> None:
     """Test user config."""
     flow_result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER, "show_advanced_options": True}
+        DOMAIN, context={"source": SOURCE_USER}
     )
     assert flow_result["type"] is FlowResultType.FORM
     assert flow_result["step_id"] == "user"
@@ -116,21 +134,24 @@ async def test_user(
         PATCH_SETUP_ENTRY as mock_setup_entry,
     ):
         result = await hass.config_entries.flow.async_configure(
-            flow_result["flow_id"], user_input=config
+            flow_result["flow_id"], user_input=flow_input
         )
         await hass.async_block_till_done()
 
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["title"] == HOST
-        assert result["data"] == config
+        assert result["data"] == expected_data
 
         assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_user_adbkey(hass: HomeAssistant) -> None:
     """Test user step with adbkey file."""
-    config_data = CONFIG_PYTHON_ADB.copy()
-    config_data[CONF_ADBKEY] = ADBKEY
+    flow_input = {
+        **CONFIG_PYTHON_ADB,
+        CONF_MORE_OPTIONS: {CONF_ADBKEY: ADBKEY},
+    }
+    expected_data = {**CONFIG_PYTHON_ADB, CONF_ADBKEY: ADBKEY}
 
     with (
         patch(
@@ -143,27 +164,34 @@ async def test_user_adbkey(hass: HomeAssistant) -> None:
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
-            context={"source": SOURCE_USER, "show_advanced_options": True},
-            data=config_data,
+            context={"source": SOURCE_USER},
+            data=flow_input,
         )
         await hass.async_block_till_done()
 
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["title"] == HOST
-        assert result["data"] == config_data
+        assert result["data"] == expected_data
 
         assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_error_both_key_server(hass: HomeAssistant) -> None:
     """Test we abort if both adb key and server are provided."""
-    config_data = CONFIG_ADB_SERVER.copy()
-
-    config_data[CONF_ADBKEY] = ADBKEY
+    flow_input = {
+        CONF_HOST: HOST,
+        CONF_PORT: DEFAULT_PORT,
+        CONF_DEVICE_CLASS: DEVICE_ANDROIDTV,
+        CONF_MORE_OPTIONS: {
+            CONF_ADB_SERVER_IP: "127.0.0.1",
+            CONF_ADB_SERVER_PORT: DEFAULT_ADB_SERVER_PORT,
+            CONF_ADBKEY: ADBKEY,
+        },
+    }
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        context={"source": SOURCE_USER, "show_advanced_options": True},
-        data=config_data,
+        context={"source": SOURCE_USER},
+        data=flow_input,
     )
 
     assert result["type"] is FlowResultType.FORM
@@ -177,7 +205,7 @@ async def test_error_both_key_server(hass: HomeAssistant) -> None:
         PATCH_SETUP_ENTRY,
     ):
         result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input=CONFIG_ADB_SERVER
+            result["flow_id"], user_input=FLOW_ADB_SERVER
         )
         await hass.async_block_till_done()
 
@@ -188,12 +216,14 @@ async def test_error_both_key_server(hass: HomeAssistant) -> None:
 
 async def test_error_invalid_key(hass: HomeAssistant) -> None:
     """Test we abort if component is already setup."""
-    config_data = CONFIG_PYTHON_ADB.copy()
-    config_data[CONF_ADBKEY] = ADBKEY
+    flow_input = {
+        **CONFIG_PYTHON_ADB,
+        CONF_MORE_OPTIONS: {CONF_ADBKEY: ADBKEY},
+    }
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        context={"source": SOURCE_USER, "show_advanced_options": True},
-        data=config_data,
+        context={"source": SOURCE_USER},
+        data=flow_input,
     )
 
     assert result["type"] is FlowResultType.FORM
@@ -207,7 +237,7 @@ async def test_error_invalid_key(hass: HomeAssistant) -> None:
         PATCH_SETUP_ENTRY,
     ):
         result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input=CONFIG_ADB_SERVER
+            result["flow_id"], user_input=FLOW_ADB_SERVER
         )
         await hass.async_block_till_done()
 
@@ -217,19 +247,19 @@ async def test_error_invalid_key(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    ("config", "eth_mac", "wifi_mac"),
+    ("flow_input", "eth_mac", "wifi_mac"),
     [
-        (CONFIG_ADB_SERVER, None, None),
-        (CONFIG_PYTHON_ADB, None, None),
-        (CONFIG_ADB_SERVER, INVALID_MAC, None),
-        (CONFIG_PYTHON_ADB, INVALID_MAC, None),
-        (CONFIG_ADB_SERVER, None, INVALID_MAC),
-        (CONFIG_PYTHON_ADB, None, INVALID_MAC),
+        (FLOW_ADB_SERVER, None, None),
+        (FLOW_PYTHON_ADB, None, None),
+        (FLOW_ADB_SERVER, INVALID_MAC, None),
+        (FLOW_PYTHON_ADB, INVALID_MAC, None),
+        (FLOW_ADB_SERVER, None, INVALID_MAC),
+        (FLOW_PYTHON_ADB, None, INVALID_MAC),
     ],
 )
 async def test_invalid_mac(
     hass: HomeAssistant,
-    config: dict[str, Any],
+    flow_input: dict[str, Any],
     eth_mac: str | None,
     wifi_mac: str | None,
 ) -> None:
@@ -241,7 +271,7 @@ async def test_invalid_mac(
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_USER},
-            data=config,
+            data=flow_input,
         )
 
         assert result["type"] is FlowResultType.ABORT
@@ -293,12 +323,12 @@ async def test_on_connect_failed(hass: HomeAssistant) -> None:
     """Test when we have errors connecting the router."""
     flow_result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        context={"source": SOURCE_USER, "show_advanced_options": True},
+        context={"source": SOURCE_USER},
     )
 
     with patch(CONNECT_METHOD, return_value=(None, "Error")):
         result = await hass.config_entries.flow.async_configure(
-            flow_result["flow_id"], user_input=CONFIG_ADB_SERVER
+            flow_result["flow_id"], user_input=FLOW_ADB_SERVER
         )
         assert result["type"] is FlowResultType.FORM
         assert result["errors"] == {"base": "cannot_connect"}
@@ -308,7 +338,7 @@ async def test_on_connect_failed(hass: HomeAssistant) -> None:
         side_effect=TypeError,
     ):
         result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input=CONFIG_ADB_SERVER
+            result["flow_id"], user_input=FLOW_ADB_SERVER
         )
         assert result2["type"] is FlowResultType.FORM
         assert result2["errors"] == {"base": "unknown"}
@@ -321,7 +351,7 @@ async def test_on_connect_failed(hass: HomeAssistant) -> None:
         PATCH_SETUP_ENTRY,
     ):
         result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"], user_input=CONFIG_ADB_SERVER
+            result2["flow_id"], user_input=FLOW_ADB_SERVER
         )
         await hass.async_block_till_done()
 


### PR DESCRIPTION
## Proposed change

Replace the `show_advanced_options` gate in the androidtv config flow with a collapsible "More options" section that is always visible to all users.

The ADB key, ADB server IP, and ADB server port fields are now shown in a collapsed section instead of being hidden behind the advanced mode toggle. The config entry data format is unchanged (flat), so no migration is needed.

Part of the effort to remove the advanced mode toggle and skill-gating terminology from Home Assistant.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/169805
- This PR is related to issue: https://github.com/home-assistant/epics/issues/26
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr