### PR TITLE
Remove advanced mode dependency from coolmaster config flow

### DIFF
--- a/homeassistant/components/coolmaster/config_flow.py
+++ b/homeassistant/components/coolmaster/config_flow.py
@@ -9,8 +9,10 @@ from homeassistant.components.climate import HVACMode
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import callback
+from homeassistant.data_entry_flow import SectionConfig, section
 
 from .const import (
+    CONF_MORE_OPTIONS,
     CONF_SEND_WAKEUP_PROMPT,
     CONF_SUPPORTED_MODES,
     CONF_SWING_SUPPORT,
@@ -29,11 +31,21 @@ AVAILABLE_MODES = [
 
 MODES_SCHEMA = {vol.Required(mode, default=True): bool for mode in AVAILABLE_MODES}
 
-DATA_SCHEMA = {
-    vol.Required(CONF_HOST): str,
-    **MODES_SCHEMA,
-    vol.Required(CONF_SWING_SUPPORT, default=False): bool,
-}
+DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        **MODES_SCHEMA,
+        vol.Required(CONF_SWING_SUPPORT, default=False): bool,
+        vol.Required(CONF_MORE_OPTIONS): section(
+            vol.Schema(
+                {
+                    vol.Required(CONF_SEND_WAKEUP_PROMPT, default=False): bool,
+                }
+            ),
+            SectionConfig(collapsed=True),
+        ),
+    }
+)
 
 
 async def _validate_connection(host: str, send_wakeup_prompt: bool) -> bool:
@@ -47,16 +59,9 @@ class CoolmasterConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    def _get_data_schema(self) -> vol.Schema:
-        schema_dict = DATA_SCHEMA.copy()
-
-        if self.show_advanced_options:
-            schema_dict[vol.Required(CONF_SEND_WAKEUP_PROMPT, default=False)] = bool
-
-        return vol.Schema(schema_dict)
-
     @callback
     def _async_get_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
+        more_options = data.get(CONF_MORE_OPTIONS, {})
         supported_modes = [
             key for (key, value) in data.items() if key in AVAILABLE_MODES and value
         ]
@@ -67,7 +72,9 @@ class CoolmasterConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_PORT: DEFAULT_PORT,
                 CONF_SUPPORTED_MODES: supported_modes,
                 CONF_SWING_SUPPORT: data[CONF_SWING_SUPPORT],
-                CONF_SEND_WAKEUP_PROMPT: data.get(CONF_SEND_WAKEUP_PROMPT, False),
+                CONF_SEND_WAKEUP_PROMPT: more_options.get(
+                    CONF_SEND_WAKEUP_PROMPT, False
+                ),
             },
         )
 
@@ -75,18 +82,17 @@ class CoolmasterConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a flow initialized by the user."""
-        data_schema = self._get_data_schema()
-
         if user_input is None:
-            return self.async_show_form(step_id="user", data_schema=data_schema)
+            return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA)
 
         errors = {}
 
         host = user_input[CONF_HOST]
+        more_options = user_input.get(CONF_MORE_OPTIONS, {})
 
         try:
             result = await _validate_connection(
-                host, user_input.get(CONF_SEND_WAKEUP_PROMPT, False)
+                host, more_options.get(CONF_SEND_WAKEUP_PROMPT, False)
             )
             if not result:
                 errors["base"] = "no_units"
@@ -95,7 +101,7 @@ class CoolmasterConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if errors:
             return self.async_show_form(
-                step_id="user", data_schema=data_schema, errors=errors
+                step_id="user", data_schema=DATA_SCHEMA, errors=errors
             )
 
         return self._async_get_entry(user_input)

--- a/homeassistant/components/coolmaster/const.py
+++ b/homeassistant/components/coolmaster/const.py
@@ -6,6 +6,7 @@ DEFAULT_PORT = 10102
 
 CONF_SUPPORTED_MODES = "supported_modes"
 CONF_SWING_SUPPORT = "swing_support"
+CONF_MORE_OPTIONS = "more_options"
 CONF_SEND_WAKEUP_PROMPT = "send_wakeup_prompt"
 MAX_RETRIES = 3
 BACKOFF_BASE_DELAY = 2

--- a/homeassistant/components/coolmaster/strings.json
+++ b/homeassistant/components/coolmaster/strings.json
@@ -14,14 +14,23 @@
           "heat_cool": "Support automatic heat/cool mode",
           "host": "[%key:common::config_flow::data::host%]",
           "off": "Can be turned off",
-          "send_wakeup_prompt": "Send wakeup prompt",
           "swing_support": "Control swing mode"
         },
         "data_description": {
-          "host": "The hostname or IP address of your CoolMasterNet device.",
-          "send_wakeup_prompt": "Send the coolmaster unit an empty commaand before issuing any actual command. This is required for serial models."
+          "host": "The hostname or IP address of your CoolMasterNet device."
         },
-        "description": "Set up your CoolMasterNet connection details."
+        "description": "Set up your CoolMasterNet connection details.",
+        "sections": {
+          "more_options": {
+            "data": {
+              "send_wakeup_prompt": "Send wakeup prompt"
+            },
+            "data_description": {
+              "send_wakeup_prompt": "Send the coolmaster unit an empty command before issuing any actual command. This is required for serial models."
+            },
+            "name": "More options"
+          }
+        }
       }
     }
   },

--- a/tests/components/coolmaster/test_config_flow.py
+++ b/tests/components/coolmaster/test_config_flow.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant import config_entries
 from homeassistant.components.coolmaster.config_flow import AVAILABLE_MODES
 from homeassistant.components.coolmaster.const import DOMAIN
@@ -9,34 +11,21 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 
-def _flow_data(advanced=False):
-    options = {"host": "1.1.1.1"}
+def _flow_data(send_wakeup_prompt: bool = False) -> dict:
+    options: dict = {"host": "1.1.1.1"}
     for mode in AVAILABLE_MODES:
         options[mode] = True
     options["swing_support"] = False
-    if advanced:
-        options["send_wakeup_prompt"] = True
+    options["more_options"] = {"send_wakeup_prompt": send_wakeup_prompt}
     return options
 
 
-async def test_form_non_advanced(hass: HomeAssistant) -> None:
-    """Test we get the form in non-advanced mode."""
-    await form_base(hass, advanced=False)
-
-
-async def test_form_advanced(hass: HomeAssistant) -> None:
-    """Test we get the form in advanced mode."""
-    await form_base(hass, advanced=True)
-
-
-async def form_base(hass: HomeAssistant, advanced: bool) -> None:
+@pytest.mark.parametrize("send_wakeup_prompt", [True, False])
+async def test_form(hass: HomeAssistant, send_wakeup_prompt: bool) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        context={
-            "source": config_entries.SOURCE_USER,
-            "show_advanced_options": advanced,
-        },
+        context={"source": config_entries.SOURCE_USER},
     )
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] is None
@@ -52,22 +41,19 @@ async def form_base(hass: HomeAssistant, advanced: bool) -> None:
         ) as mock_setup_entry,
     ):
         result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"], _flow_data(advanced)
+            result["flow_id"], _flow_data(send_wakeup_prompt)
         )
         await hass.async_block_till_done()
 
     assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["title"] == "1.1.1.1"
-    _expected_data = {
+    assert result2["data"] == {
         "host": "1.1.1.1",
         "port": 10102,
         "supported_modes": AVAILABLE_MODES,
         "swing_support": False,
-        "send_wakeup_prompt": False,
+        "send_wakeup_prompt": send_wakeup_prompt,
     }
-    if advanced:
-        _expected_data["send_wakeup_prompt"] = True
-    assert result2["data"] == _expected_data
     assert len(mock_setup_entry.mock_calls) == 1
 
 


### PR DESCRIPTION
## Proposed change

Replace the `show_advanced_options` gate in the coolmaster config flow with a collapsible "More options" section that is always visible to all users.

The "Send wakeup prompt" option is now shown in a collapsed section instead of being hidden behind the advanced mode toggle. The config entry data format is unchanged (flat), so no migration is needed.

Part of the effort to remove the advanced mode toggle and skill-gating terminology from Home Assistant.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/169808
- This PR is related to issue: https://github.com/home-assistant/epics/issues/26
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr