### PR TITLE
prusalink: tighten typing on job.filename and job.finish sensors

### DIFF
--- a/homeassistant/components/prusalink/config_flow.py
+++ b/homeassistant/components/prusalink/config_flow.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import Any
+from typing import Any, cast
 
 from awesomeversion import AwesomeVersion, AwesomeVersionException
 from httpx import HTTPError, InvalidURL
@@ -40,8 +40,11 @@ def ensure_printer_is_supported(version: VersionInfo) -> None:
             return
 
         # Workaround to allow PrusaLink 0.7.2 on MK3 and MK2.5 that supports
-        # the 2.0.0 API, but doesn't advertise it yet
-        if version.get("original", "").startswith(
+        # the 2.0.0 API, but doesn't advertise it yet. `original` is an
+        # undocumented field returned by older standalone PrusaLink builds;
+        # it is not part of VersionInfo, hence the cast.
+        original = cast(str, version.get("original", ""))
+        if original.startswith(
             ("PrusaLink I3MK3", "PrusaLink I3MK2")
         ) and AwesomeVersion("0.7.2") <= AwesomeVersion(version["server"]):
             return

--- a/homeassistant/components/prusalink/coordinator.py
+++ b/homeassistant/components/prusalink/coordinator.py
@@ -31,7 +31,12 @@ _LOGGER = logging.getLogger(__name__)
 # rapidly-changing metrics.
 _MINIMUM_REFRESH_INTERVAL = 1.0
 
-T = TypeVar("T", PrinterStatus, LegacyPrinterStatus, JobInfo, PrinterInfo, VersionInfo)
+# Job is the only coordinator whose payload can be None — pyprusalink's
+# get_job() returns None on HTTP 204 when no job is running. The other
+# endpoints always return data or raise on failure.
+T = TypeVar(
+    "T", PrinterStatus, LegacyPrinterStatus, JobInfo | None, PrinterInfo, VersionInfo
+)
 
 
 type PrusaLinkConfigEntry = ConfigEntry[dict[str, PrusaLinkUpdateCoordinator]]
@@ -85,8 +90,15 @@ class PrusaLinkUpdateCoordinator(DataUpdateCoordinator[T], ABC):
         """Expect a change."""
         self.expect_change_until = monotonic() + 30
 
-    def _get_update_interval(self, data: T) -> timedelta:
-        """Get new update interval."""
+    def _get_update_interval(self, data: T | None) -> timedelta:
+        """Get new update interval.
+
+        `data` is unused by the base implementation today, but kept on the
+        signature so subclasses can override based on payload state — e.g. a
+        future transfer coordinator that polls faster while a transfer is
+        active. The base class is called once from `__init__` with `None`
+        before the first fetch, hence `T | None`.
+        """
         if self.expect_change_until > monotonic():
             return timedelta(seconds=5)
 
@@ -109,10 +121,15 @@ class LegacyStatusCoordinator(PrusaLinkUpdateCoordinator[LegacyPrinterStatus]):
         return await self.api.get_legacy_printer()
 
 
-class JobUpdateCoordinator(PrusaLinkUpdateCoordinator[JobInfo]):
-    """Job update coordinator."""
+class JobUpdateCoordinator(PrusaLinkUpdateCoordinator[JobInfo | None]):
+    """Job update coordinator.
 
-    async def _fetch_data(self) -> JobInfo:
+    The job endpoint returns nothing (HTTP 204) when no job is running, so
+    `data` can legitimately be `None` here. Entity code that reads from this
+    coordinator's data must be `None`-aware.
+    """
+
+    async def _fetch_data(self) -> JobInfo | None:
         """Fetch the printer data."""
         return await self.api.get_job()
 

--- a/homeassistant/components/prusalink/entity.py
+++ b/homeassistant/components/prusalink/entity.py
@@ -29,8 +29,15 @@ class PrusaLinkEntity(CoordinatorEntity[PrusaLinkUpdateCoordinator]):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        return super().available and self.entity_description.available_fn(
-            self.coordinator.data
+        # `coordinator.data` can be None when the underlying endpoint
+        # returns no payload — e.g. the job coordinator yields None when
+        # no job is running on pyprusalink >= 3.0.0. Short-circuit to
+        # avoid passing None into `available_fn` lambdas that assume a
+        # dict (.get(), index, etc.).
+        return (
+            super().available
+            and self.coordinator.data is not None
+            and self.entity_description.available_fn(self.coordinator.data)
         )
 
     @property

--- a/homeassistant/components/prusalink/manifest.json
+++ b/homeassistant/components/prusalink/manifest.json
@@ -11,5 +11,5 @@
   "documentation": "https://www.home-assistant.io/integrations/prusalink",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "requirements": ["pyprusalink==2.2.0"]
+  "requirements": ["pyprusalink==3.0.0"]
 }

--- a/homeassistant/components/prusalink/sensor.py
+++ b/homeassistant/components/prusalink/sensor.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from typing import Generic, TypeVar, cast
 
 from pyprusalink.types import JobInfo, PrinterInfo, PrinterState, PrinterStatus
-from pyprusalink.types_legacy import LegacyPrinterStatus
+from pyprusalink.types_legacy import LegacyPrinterStatus, LegacyPrinterTelemetry
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -48,7 +48,7 @@ SENSORS: dict[str, tuple[PrusaLinkSensorEntityDescription, ...]] = {
         PrusaLinkSensorEntityDescription[PrinterStatus](
             key="printer.state",
             name=None,
-            value_fn=lambda data: cast(str, data["printer"]["state"].lower()),
+            value_fn=lambda data: cast(str, data["printer"]["state"]).lower(),
             device_class=SensorDeviceClass.ENUM,
             options=[state.value.lower() for state in PrinterState],
             translation_key="printer_state",
@@ -150,7 +150,12 @@ SENSORS: dict[str, tuple[PrusaLinkSensorEntityDescription, ...]] = {
         PrusaLinkSensorEntityDescription[LegacyPrinterStatus](
             key="printer.telemetry.material",
             translation_key="material",
-            value_fn=lambda data: cast(str, data["telemetry"]["material"]),
+            # `available_fn` guarantees `telemetry` is not None at this
+            # point; the inner cast narrows the Optional for the index.
+            value_fn=lambda data: cast(
+                str, cast(LegacyPrinterTelemetry, data["telemetry"])["material"]
+            ),
+            available_fn=lambda data: data.get("telemetry") is not None,
         ),
     ),
     "job": (
@@ -167,7 +172,10 @@ SENSORS: dict[str, tuple[PrusaLinkSensorEntityDescription, ...]] = {
         PrusaLinkSensorEntityDescription[JobInfo](
             key="job.filename",
             translation_key="filename",
-            value_fn=lambda data: cast(str, data["file"]["display_name"]),
+            # available_fn ensures `file` is not None; mypy doesn't follow
+            # that guarantee into the lambda. TODO: tighten in a followup
+            # PR (latent typing debt surfaced by pyprusalink 3.0.0 py.typed).
+            value_fn=lambda data: cast(str, data["file"]["display_name"]),  # type: ignore[index]
             available_fn=lambda data: (
                 data.get("file") is not None
                 and data.get("state") != PrinterState.IDLE.value
@@ -190,8 +198,11 @@ SENSORS: dict[str, tuple[PrusaLinkSensorEntityDescription, ...]] = {
             key="job.finish",
             translation_key="print_finish",
             device_class=SensorDeviceClass.TIMESTAMP,
+            # available_fn ensures `time_remaining` is not None; mypy doesn't
+            # follow the guarantee. TODO: tighten in a followup PR (latent
+            # typing debt surfaced by pyprusalink 3.0.0 py.typed).
             value_fn=ignore_variance(
-                lambda data: utcnow() + timedelta(seconds=data["time_remaining"]),
+                lambda data: utcnow() + timedelta(seconds=data["time_remaining"]),  # type: ignore[arg-type]
                 timedelta(minutes=2),
             ),
             available_fn=lambda data: (
@@ -214,7 +225,7 @@ SENSORS: dict[str, tuple[PrusaLinkSensorEntityDescription, ...]] = {
             translation_key="min_extrusion_temp",
             native_unit_of_measurement=UnitOfTemperature.CELSIUS,
             device_class=SensorDeviceClass.TEMPERATURE,
-            value_fn=lambda data: cast(int, data["min_extrusion_temp"]),
+            value_fn=lambda data: data["min_extrusion_temp"],
             supported_fn=lambda data: data.get("min_extrusion_temp") is not None,
             entity_registry_enabled_default=False,
         ),

--- a/homeassistant/components/prusalink/sensor.py
+++ b/homeassistant/components/prusalink/sensor.py
@@ -5,7 +5,13 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Generic, TypeVar, cast
 
-from pyprusalink.types import JobInfo, PrinterInfo, PrinterState, PrinterStatus
+from pyprusalink.types import (
+    JobFilePrint,
+    JobInfo,
+    PrinterInfo,
+    PrinterState,
+    PrinterStatus,
+)
 from pyprusalink.types_legacy import LegacyPrinterStatus, LegacyPrinterTelemetry
 
 from homeassistant.components.sensor import (
@@ -172,10 +178,11 @@ SENSORS: dict[str, tuple[PrusaLinkSensorEntityDescription, ...]] = {
         PrusaLinkSensorEntityDescription[JobInfo](
             key="job.filename",
             translation_key="filename",
-            # available_fn ensures `file` is not None; mypy doesn't follow
-            # that guarantee into the lambda. TODO: tighten in a followup
-            # PR (latent typing debt surfaced by pyprusalink 3.0.0 py.typed).
-            value_fn=lambda data: cast(str, data["file"]["display_name"]),  # type: ignore[index]
+            # `available_fn` guarantees `file` is not None at this point;
+            # the inner cast narrows the Optional for the index.
+            value_fn=lambda data: cast(
+                str, cast(JobFilePrint, data["file"])["display_name"]
+            ),
             available_fn=lambda data: (
                 data.get("file") is not None
                 and data.get("state") != PrinterState.IDLE.value
@@ -198,11 +205,12 @@ SENSORS: dict[str, tuple[PrusaLinkSensorEntityDescription, ...]] = {
             key="job.finish",
             translation_key="print_finish",
             device_class=SensorDeviceClass.TIMESTAMP,
-            # available_fn ensures `time_remaining` is not None; mypy doesn't
-            # follow the guarantee. TODO: tighten in a followup PR (latent
-            # typing debt surfaced by pyprusalink 3.0.0 py.typed).
+            # `available_fn` guarantees `time_remaining` is not None at this
+            # point; the cast narrows the Optional for `timedelta`.
             value_fn=ignore_variance(
-                lambda data: utcnow() + timedelta(seconds=data["time_remaining"]),  # type: ignore[arg-type]
+                lambda data: (
+                    utcnow() + timedelta(seconds=cast(int, data["time_remaining"]))
+                ),
                 timedelta(minutes=2),
             ),
             available_fn=lambda data: (

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2449,7 +2449,7 @@ pyprof2calltree==1.4.5
 pyprosegur==0.0.14
 
 # homeassistant.components.prusalink
-pyprusalink==2.2.0
+pyprusalink==3.0.0
 
 # homeassistant.components.ps4
 pyps4-2ndscreen==1.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2108,7 +2108,7 @@ pyprof2calltree==1.4.5
 pyprosegur==0.0.14
 
 # homeassistant.components.prusalink
-pyprusalink==2.2.0
+pyprusalink==3.0.0
 
 # homeassistant.components.ps4
 pyps4-2ndscreen==1.3.1

--- a/tests/components/prusalink/conftest.py
+++ b/tests/components/prusalink/conftest.py
@@ -119,11 +119,14 @@ def mock_get_status_printing() -> Generator[dict[str, Any]]:
 
 
 @pytest.fixture
-def mock_job_api_idle() -> Generator[dict[str, Any]]:
-    """Mock PrusaLink job API having no job."""
-    resp = {}
-    with patch("pyprusalink.PrusaLink.get_job", return_value=resp):
-        yield resp
+def mock_job_api_idle() -> Generator[None]:
+    """Mock PrusaLink job API having no job.
+
+    pyprusalink >= 3.0.0 returns `None` from `get_job()` on HTTP 204 when
+    no job is running, rather than an empty dict as in 2.x.
+    """
+    with patch("pyprusalink.PrusaLink.get_job", return_value=None):
+        yield None
 
 
 @pytest.fixture


### PR DESCRIPTION
## Proposed change

Follow-up to #170480 (depends on it merging first).

That PR added two `# type: ignore` comments on the `job.filename` and `job.finish` sensors with `TODO`s for a focused follow-up — this is the follow-up. Both lambdas are guarded at runtime by `available_fn`, but mypy doesn't follow the guarantee into `value_fn`. Switch to the inner-cast pattern that's already used on the `printer.telemetry.material` sensor in the same file.

- `job.filename` — `cast(JobFilePrint, data["file"])["display_name"]` narrows the `JobFilePrint | None` so `["display_name"]` type-checks.
- `job.finish` — `cast(int, data["time_remaining"])` narrows the `int | None` so it can be passed to `timedelta(seconds=...)`.

## Why now

Keeps the bump PR focused on what the 3.0.0 release actually requires (runtime fixes + typing surfaced by the new `py.typed` marker), and addresses the typing debt as its own reviewable change.

## No runtime impact

`cast()` is erased at runtime; existing tests already cover both lambdas in the happy path (file/time_remaining present) and the `available_fn` short-circuit when they're absent. No new tests needed.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (non-breaking change which fixes an issue)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] `pytest tests/components/prusalink/` — 34 passed
- [x] `prek run --files homeassistant/components/prusalink/sensor.py` — all hooks green (mypy, ruff, pylint, hassfest)