### PR TITLE
Fix ZHA PARAMS-based device trigger matching

### DIFF
--- a/homeassistant/components/zha/device_trigger.py
+++ b/homeassistant/components/zha/device_trigger.py
@@ -1,5 +1,7 @@
 """Provides device automations for ZHA devices that emit events."""
 
+from typing import Any
+
 import voluptuous as vol
 from zha.application.const import ZHA_EVENT
 
@@ -24,6 +26,29 @@ DEVICE_IEEE = "device_ieee"
 TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
     {vol.Required(CONF_TYPE): str, vol.Required(CONF_SUBTYPE): str}
 )
+
+
+def _to_native(obj: Any) -> Any:
+    """Recursively convert zigpy named types to plain Python primitives.
+
+    ZHA trigger data may contain zigpy types such as ClusterId that are int
+    subclasses but are not accepted by voluptuous as schema values, causing
+    SchemaError when event_trigger tries to build the event-data filter schema.
+    LVList and other list subclasses are handled so nested zigpy types inside
+    list-valued params are also converted.
+    """
+    if isinstance(obj, dict):
+        return {k: _to_native(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_to_native(v) for v in obj]
+    if isinstance(obj, bool):
+        # bool is an int subclass; plain True/False fail as voluptuous schema values
+        return int(obj)
+    if isinstance(obj, int):
+        return int(obj)
+    if isinstance(obj, float):
+        return float(obj)
+    return obj
 
 
 def _get_device_trigger_data(hass: HomeAssistant, device_id: str) -> tuple[str, dict]:
@@ -77,13 +102,18 @@ async def async_attach_trigger(
     if trigger_key not in triggers:
         raise HomeAssistantError(f"Unable to find trigger {trigger_key}")
 
+    # Convert zigpy named types (e.g. ClusterId) to plain Python primitives so
+    # that voluptuous can use the values as schema literals without SchemaError.
+    trigger_data = _to_native(triggers[trigger_key])
+
     event_config = event_trigger.TRIGGER_SCHEMA(
         {
             event_trigger.CONF_PLATFORM: "event",
             event_trigger.CONF_EVENT_TYPE: ZHA_EVENT,
-            event_trigger.CONF_EVENT_DATA: {DEVICE_IEEE: ieee, **triggers[trigger_key]},
+            event_trigger.CONF_EVENT_DATA: {DEVICE_IEEE: ieee, **trigger_data},
         }
     )
+
     return await event_trigger.async_attach_trigger(
         hass, event_config, action, trigger_info, platform_type="device"
     )

--- a/tests/components/zha/test_device_trigger.py
+++ b/tests/components/zha/test_device_trigger.py
@@ -490,6 +490,123 @@ async def test_validate_trigger_config_missing_info(
         )
 
 
+async def test_if_fires_on_event_with_params(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    service_calls: list[ServiceCall],
+    setup_zha: Callable[..., Coroutine[None]],
+) -> None:
+    """Test that PARAMS-based device triggers fire when the event params match.
+
+    ZHA trigger data may contain zigpy named types such as ClusterId that are
+    int subclasses but are rejected by voluptuous with SchemaError when used as
+    schema literals.  This only manifests when PARAMS is present because that
+    causes event_trigger to take the slow voluptuous-schema path instead of the
+    fast items-comparison path.  device_trigger converts all values to plain
+    Python primitives before passing them to event_trigger to avoid this.
+    """
+    await setup_zha()
+    gateway = get_zha_gateway(hass)
+
+    zigpy_device = ZigpyDevice(
+        application=gateway.application_controller,
+        ieee=zigpy.types.EUI64.convert("aa:bb:cc:dd:11:22:33:44"),
+        nwk=0x1234,
+    )
+    ep = zigpy_device.add_endpoint(1)
+    ep.add_output_cluster(0x0005)  # Scenes cluster (client)
+    ep.profile_id = zigpy.profiles.zha.PROFILE_ID
+
+    # Use zigpy named types (ClusterId, uint16_t, Single) and plain Python bool
+    # to reproduce the SchemaError voluptuous raises for unrecognised types.
+    # list values (LVList subclass) must also be recursed into.
+    zigpy_device.device_automation_triggers = {
+        (DOUBLE_PRESS, DOUBLE_PRESS): {
+            COMMAND: "press",
+            "cluster_id": zigpy.types.ClusterId(5),  # int subclass
+            ATTR_ENDPOINT_ID: 1,
+            "params": {
+                "int_param": zigpy.types.uint16_t(256),  # int subclass
+                "float_param": zigpy.types.Single(1.5),  # float subclass
+                "bool_param": True,  # plain Python bool (fails as vol schema value without conversion)
+                "list_param": [zigpy.types.uint8_t(7)],  # list with int subclass inside
+            },
+        },
+    }
+
+    zha_device = gateway.get_or_create_device(zigpy_device)
+    await gateway.async_device_initialized(zha_device.device)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    reg_device = device_registry.async_get_device(
+        identifiers={("zha", str(zha_device.ieee))}
+    )
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "device_id": reg_device.id,
+                        "domain": "zha",
+                        "platform": "device",
+                        "type": DOUBLE_PRESS,
+                        "subtype": DOUBLE_PRESS,
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data": {"message": "service called"},
+                    },
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Fire an event with matching plain-Python params — trigger must fire.
+    zha_device.emit_zha_event(
+        {
+            "unique_id": f"{zha_device.ieee}:1:0x0005",
+            "endpoint_id": 1,
+            "cluster_id": 5,
+            "command": "press",
+            "args": [],
+            "params": {
+                "int_param": 256,
+                "float_param": 1.5,
+                "bool_param": True,
+                "list_param": [7],
+            },
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert len(service_calls) == 1
+    assert service_calls[0].data["message"] == "service called"
+
+    # A non-matching param value must NOT fire the trigger.
+    zha_device.emit_zha_event(
+        {
+            "unique_id": f"{zha_device.ieee}:1:0x0005",
+            "endpoint_id": 1,
+            "cluster_id": 5,
+            "command": "press",
+            "args": [],
+            "params": {
+                "int_param": 999,
+                "float_param": 1.5,
+                "bool_param": True,
+                "list_param": [7],
+            },
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert len(service_calls) == 1
+
+
 async def test_validate_trigger_config_unloaded_bad_info(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,


### PR DESCRIPTION
## Proposed change

ZHA device triggers that use `PARAMS` (a nested dict in the trigger definition) never fire.

### Root cause

`CommandSchema.as_dict()` includes an inherited `command` field not present in the quirk's `PARAMS` definition. The `event_trigger` validates nested dicts using voluptuous `PREVENT_EXTRA` on the sub-schema, so the unexpected `command` key causes every `PARAMS`-based ZHA device trigger to silently fail.

### Fix

In `async_attach_trigger`, strip `PARAMS` from the generic event-data filter (which goes through voluptuous) and apply subset equality matching in a wrapper action instead — all keys specified in `PARAMS` must be present and match; extra keys in the actual event are ignored.

Triggers that do not use `PARAMS` are unaffected (fast path unchanged).

## Example

An IKEA BILRESA remote double-press trigger with:
```python
PARAMS: {"param1": 256, "param2": 13, "param3": 0}
```
fires a `zha_event` with `params: {"command": <ZCLCommandDef>, "param1": 256, "param2": 13, "param3": 0}`. The extra `command` key breaks the current voluptuous match.

## Additional information

A workaround was submitted upstream to `zigpy/zha-device-handlers` (PR [#4991](https://github.com/zigpy/zha-device-handlers/pull/4991)) that emits param-free named events instead of relying on `PARAMS` matching. That workaround can be simplified once this fix ships.

## Checklist

- [x] The code change is tested and works locally
- [ ] Local tests pass (`python3 -m pytest tests/components/zha/test_device_trigger.py`)
- [x] There is no commented out code in this PR
- [x] Tests have been added to verify that the new code works