### PR TITLE
Improve plex config flow UX and remove advanced mode dependency

### DIFF
--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -39,7 +39,6 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from .const import (
     AUTH_CALLBACK_NAME,
     AUTH_CALLBACK_PATH,
-    AUTOMATIC_SETUP_STRING,
     CONF_IGNORE_NEW_SHARED_USERS,
     CONF_IGNORE_PLEX_WEB_CLIENTS,
     CONF_MONITORED_USERS,
@@ -50,7 +49,6 @@ from .const import (
     DEFAULT_SSL,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
-    MANUAL_SETUP_STRING,
     PLEX_SERVER_CONFIG,
     X_PLEX_DEVICE_NAME,
     X_PLEX_PLATFORM,
@@ -115,41 +113,22 @@ class PlexFlowHandler(ConfigFlow, domain=DOMAIN):
     async def async_step_user(
         self,
         user_input: dict[str, Any] | None = None,
-        errors: dict[str, str] | None = None,
     ) -> ConfigFlowResult:
         """Handle a flow initialized by the user."""
-        if user_input is not None:
-            return await self._async_step_plex_website_auth()
-        if self.show_advanced_options:
-            return await self.async_step_user_advanced(errors=errors)
-        return self.async_show_form(
+        return self.async_show_menu(
             step_id="user",
-            errors=errors,
-            description_placeholders={"plex_server_url": "[plex.tv](https://plex.tv)"},
+            menu_options=["website_auth", "manual_setup"],
         )
 
-    async def async_step_user_advanced(
+    async def async_step_website_auth(
         self,
-        user_input: dict[str, str] | None = None,
+        user_input: dict[str, Any] | None = None,
         errors: dict[str, str] | None = None,
     ) -> ConfigFlowResult:
-        """Handle an advanced mode flow initialized by the user."""
-        if user_input is not None:
-            if user_input.get("setup_method") == MANUAL_SETUP_STRING:
-                self._manual = True
-                return await self.async_step_manual_setup()
-            return await self._async_step_plex_website_auth()
-
-        data_schema = vol.Schema(
-            {
-                vol.Required("setup_method", default=AUTOMATIC_SETUP_STRING): vol.In(
-                    [AUTOMATIC_SETUP_STRING, MANUAL_SETUP_STRING]
-                )
-            }
-        )
-        return self.async_show_form(
-            step_id="user_advanced", data_schema=data_schema, errors=errors
-        )
+        """Handle website authentication."""
+        if errors:
+            return self.async_show_form(step_id="website_auth", errors=errors)
+        return await self._async_step_plex_website_auth()
 
     async def async_step_manual_setup(
         self,
@@ -157,6 +136,7 @@ class PlexFlowHandler(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] | None = None,
     ) -> ConfigFlowResult:
         """Begin manual configuration."""
+        self._manual = True
         if user_input is not None and errors is None:
             user_input.pop(CONF_URL, None)
             if host := user_input.get(CONF_HOST):
@@ -240,7 +220,7 @@ class PlexFlowHandler(ConfigFlow, domain=DOMAIN):
                 return await self.async_step_manual_setup(
                     user_input=server_config, errors=errors
                 )
-            return await self.async_step_user(errors=errors)
+            return await self.async_step_website_auth(errors=errors)
 
         server_id = plex_server.machine_identifier
         url = plex_server.url_in_use

--- a/homeassistant/components/plex/const.py
+++ b/homeassistant/components/plex/const.py
@@ -52,9 +52,6 @@ X_PLEX_PLATFORM = "Home Assistant"
 X_PLEX_PRODUCT = "Home Assistant"
 X_PLEX_VERSION = __version__
 
-AUTOMATIC_SETUP_STRING = "Obtain a new token from plex.tv"
-MANUAL_SETUP_STRING = "Configure Plex server manually"
-
 SERVICE_REFRESH_LIBRARY = "refresh_library"
 
 PLEX_URI_SCHEME = "plex://"

--- a/homeassistant/components/plex/strings.json
+++ b/homeassistant/components/plex/strings.json
@@ -29,18 +29,20 @@
       },
       "select_server": {
         "data": {
-          "server": "Server"
+          "server_id": "Server"
         },
         "description": "Multiple servers available, select one:",
         "title": "Select Plex server"
       },
       "user": {
-        "description": "Continue to {plex_server_url} to link a Plex server."
-      },
-      "user_advanced": {
-        "data": {
-          "setup_method": "Setup method"
+        "description": "A Plex server can be set up in Home Assistant in two different ways.\n\nYou can link your Plex account by logging in via plex.tv, which will automatically discover and connect your servers, or you can manually enter the server address and token.",
+        "menu_options": {
+          "manual_setup": "Enter manually",
+          "website_auth": "Link Plex account (recommended)"
         }
+      },
+      "website_auth": {
+        "description": "Something went wrong connecting to Plex. Please try again."
       }
     }
   },

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -12,7 +12,6 @@ import requests_mock
 
 from homeassistant.components.plex import config_flow
 from homeassistant.components.plex.const import (
-    AUTOMATIC_SETUP_STRING,
     CONF_IGNORE_NEW_SHARED_USERS,
     CONF_IGNORE_PLEX_WEB_CLIENTS,
     CONF_MONITORED_USERS,
@@ -20,7 +19,6 @@ from homeassistant.components.plex.const import (
     CONF_SERVER_IDENTIFIER,
     CONF_USE_EPISODE_ART,
     DOMAIN,
-    MANUAL_SETUP_STRING,
     PLEX_SERVER_CONFIG,
     SERVERS,
 )
@@ -54,7 +52,7 @@ async def test_bad_credentials(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] is FlowResultType.FORM
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "user"
 
     with (
@@ -65,7 +63,8 @@ async def test_bad_credentials(hass: HomeAssistant) -> None:
         patch("plexauth.PlexAuth.token", return_value="BAD TOKEN"),
     ):
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
+            result["flow_id"],
+            user_input={"next_step_id": "website_auth"},
         )
         assert result["type"] is FlowResultType.EXTERNAL_STEP
 
@@ -75,7 +74,7 @@ async def test_bad_credentials(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
         assert result["type"] is FlowResultType.FORM
-        assert result["step_id"] == "user"
+        assert result["step_id"] == "website_auth"
         assert result["errors"][CONF_TOKEN] == "faulty_credentials"
 
 
@@ -85,7 +84,7 @@ async def test_bad_hostname(hass: HomeAssistant, mock_plex_calls) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] is FlowResultType.FORM
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "user"
 
     with (
@@ -97,7 +96,8 @@ async def test_bad_hostname(hass: HomeAssistant, mock_plex_calls) -> None:
         patch("plexauth.PlexAuth.token", return_value=MOCK_TOKEN),
     ):
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
+            result["flow_id"],
+            user_input={"next_step_id": "website_auth"},
         )
         assert result["type"] is FlowResultType.EXTERNAL_STEP
 
@@ -107,7 +107,7 @@ async def test_bad_hostname(hass: HomeAssistant, mock_plex_calls) -> None:
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
         assert result["type"] is FlowResultType.FORM
-        assert result["step_id"] == "user"
+        assert result["step_id"] == "website_auth"
         assert result["errors"][CONF_HOST] == "not_found"
 
 
@@ -117,7 +117,7 @@ async def test_unknown_exception(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] is FlowResultType.FORM
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "user"
 
     with (
@@ -126,7 +126,8 @@ async def test_unknown_exception(hass: HomeAssistant) -> None:
         patch("plexauth.PlexAuth.token", return_value="MOCK_TOKEN"),
     ):
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
+            result["flow_id"],
+            user_input={"next_step_id": "website_auth"},
         )
         assert result["type"] is FlowResultType.EXTERNAL_STEP
 
@@ -151,7 +152,7 @@ async def test_no_servers_found(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] is FlowResultType.FORM
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "user"
 
     with (
@@ -159,7 +160,8 @@ async def test_no_servers_found(
         patch("plexauth.PlexAuth.token", return_value=MOCK_TOKEN),
     ):
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
+            result["flow_id"],
+            user_input={"next_step_id": "website_auth"},
         )
         assert result["type"] is FlowResultType.EXTERNAL_STEP
 
@@ -168,7 +170,7 @@ async def test_no_servers_found(
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
         assert result["type"] is FlowResultType.FORM
-        assert result["step_id"] == "user"
+        assert result["step_id"] == "website_auth"
         assert result["errors"]["base"] == "no_servers"
 
 
@@ -182,7 +184,7 @@ async def test_single_available_server(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] is FlowResultType.FORM
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "user"
 
     with (
@@ -190,7 +192,8 @@ async def test_single_available_server(
         patch("plexauth.PlexAuth.token", return_value=MOCK_TOKEN),
     ):
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
+            result["flow_id"],
+            user_input={"next_step_id": "website_auth"},
         )
         assert result["type"] is FlowResultType.EXTERNAL_STEP
 
@@ -226,7 +229,7 @@ async def test_multiple_servers_with_selection(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] is FlowResultType.FORM
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "user"
 
     requests_mock.get(
@@ -238,7 +241,8 @@ async def test_multiple_servers_with_selection(
         patch("plexauth.PlexAuth.token", return_value=MOCK_TOKEN),
     ):
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
+            result["flow_id"],
+            user_input={"next_step_id": "website_auth"},
         )
         assert result["type"] is FlowResultType.EXTERNAL_STEP
 
@@ -291,7 +295,7 @@ async def test_adding_last_unconfigured_server(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] is FlowResultType.FORM
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "user"
 
     requests_mock.get(
@@ -304,7 +308,8 @@ async def test_adding_last_unconfigured_server(
         patch("plexauth.PlexAuth.token", return_value=MOCK_TOKEN),
     ):
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
+            result["flow_id"],
+            user_input={"next_step_id": "website_auth"},
         )
         assert result["type"] is FlowResultType.EXTERNAL_STEP
 
@@ -350,7 +355,7 @@ async def test_all_available_servers_configured(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] is FlowResultType.FORM
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "user"
 
     requests_mock.get("https://plex.tv/api/v2/user", text=plextv_account)
@@ -364,7 +369,8 @@ async def test_all_available_servers_configured(
         patch("plexauth.PlexAuth.token", return_value=MOCK_TOKEN),
     ):
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
+            result["flow_id"],
+            user_input={"next_step_id": "website_auth"},
         )
         assert result["type"] is FlowResultType.EXTERNAL_STEP
 
@@ -481,7 +487,7 @@ async def test_external_timed_out(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] is FlowResultType.FORM
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "user"
 
     with (
@@ -489,7 +495,8 @@ async def test_external_timed_out(hass: HomeAssistant) -> None:
         patch("plexauth.PlexAuth.token", return_value=None),
     ):
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
+            result["flow_id"],
+            user_input={"next_step_id": "website_auth"},
         )
         assert result["type"] is FlowResultType.EXTERNAL_STEP
 
@@ -510,7 +517,7 @@ async def test_callback_view(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] is FlowResultType.FORM
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "user"
 
     with (
@@ -518,7 +525,8 @@ async def test_callback_view(
         patch("plexauth.PlexAuth.token", return_value=MOCK_TOKEN),
     ):
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
+            result["flow_id"],
+            user_input={"next_step_id": "website_auth"},
         )
         assert result["type"] is FlowResultType.EXTERNAL_STEP
 
@@ -541,46 +549,33 @@ async def test_manual_config(hass: HomeAssistant, mock_plex_calls) -> None:
                 "some random message that doesn't match"
             )
 
-    # Basic mode
+    # Automatic setup
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] is FlowResultType.FORM
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "user"
-    assert result["data_schema"] is None
-    hass.config_entries.flow.async_abort(result["flow_id"])
-
-    # Advanced automatic
-    result = await hass.config_entries.flow.async_init(
-        config_flow.DOMAIN,
-        context={"source": SOURCE_USER, "show_advanced_options": True},
-    )
-
-    assert result["data_schema"] is not None
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user_advanced"
 
     with patch("plexauth.PlexAuth.initiate_auth"):
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={"setup_method": AUTOMATIC_SETUP_STRING}
+            result["flow_id"],
+            user_input={"next_step_id": "website_auth"},
         )
 
     assert result["type"] is FlowResultType.EXTERNAL_STEP
     hass.config_entries.flow.async_abort(result["flow_id"])
 
-    # Advanced manual
+    # Manual setup
     result = await hass.config_entries.flow.async_init(
-        config_flow.DOMAIN,
-        context={"source": SOURCE_USER, "show_advanced_options": True},
+        config_flow.DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["data_schema"] is not None
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user_advanced"
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={"setup_method": MANUAL_SETUP_STRING}
+        result["flow_id"], user_input={"next_step_id": "manual_setup"}
     )
 
     assert result["type"] is FlowResultType.FORM
@@ -673,14 +668,14 @@ async def test_manual_config_with_token(
 
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
-        context={"source": SOURCE_USER, "show_advanced_options": True},
+        context={"source": SOURCE_USER},
     )
 
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user_advanced"
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={"setup_method": MANUAL_SETUP_STRING}
+        result["flow_id"], user_input={"next_step_id": "manual_setup"}
     )
 
     assert result["type"] is FlowResultType.FORM
@@ -746,11 +741,17 @@ async def test_reauth(
     result = await entry.start_reauth_flow(hass)
     flow_id = result["flow_id"]
 
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "user"
+
     with (
         patch("plexauth.PlexAuth.initiate_auth"),
         patch("plexauth.PlexAuth.token", return_value="BRAND_NEW_TOKEN"),
     ):
-        result = await hass.config_entries.flow.async_configure(flow_id, user_input={})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"next_step_id": "website_auth"},
+        )
         assert result["type"] is FlowResultType.EXTERNAL_STEP
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
@@ -794,11 +795,17 @@ async def test_reauth_multiple_servers_available(
 
     flow_id = result["flow_id"]
 
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "user"
+
     with (
         patch("plexauth.PlexAuth.initiate_auth"),
         patch("plexauth.PlexAuth.token", return_value="BRAND_NEW_TOKEN"),
     ):
-        result = await hass.config_entries.flow.async_configure(flow_id, user_input={})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"next_step_id": "website_auth"},
+        )
         assert result["type"] is FlowResultType.EXTERNAL_STEP
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
@@ -826,16 +833,12 @@ async def test_client_request_missing(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] is FlowResultType.FORM
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "user"
 
-    with (
-        patch("plexauth.PlexAuth.initiate_auth"),
-        patch("plexauth.PlexAuth.token", return_value=None),
-        pytest.raises(RuntimeError),
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
+    with pytest.raises(RuntimeError):
+        await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={"next_step_id": "website_auth"}
         )
 
 
@@ -849,20 +852,16 @@ async def test_client_header_issues(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] is FlowResultType.FORM
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "user"
 
     with (
-        patch("plexauth.PlexAuth.initiate_auth"),
-        patch("plexauth.PlexAuth.token", return_value=None),
         patch(
             "homeassistant.helpers.http.current_request.get",
             return_value=MockRequest(),
         ),
-        pytest.raises(
-            RuntimeError,
-        ),
+        pytest.raises(RuntimeError),
     ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
+        await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={"next_step_id": "website_auth"}
         )


### PR DESCRIPTION
## Proposed change

Improve the plex config flow by replacing the setup method selection with a menu, always presenting both options to all users: linking a Plex account via plex.tv (OAuth) or manual server configuration. This also removes the `show_advanced_options` dependency.

Previously, users without advanced mode enabled only saw an empty form that redirected to plex.tv. Users with advanced mode got a separate `user_advanced` step with a dropdown to choose between automatic and manual setup. This merges both paths into a single menu step, removes the `user_advanced` step entirely, and cleans up the now-unused `AUTOMATIC_SETUP_STRING` and `MANUAL_SETUP_STRING` constants.

Also fixes a pre-existing bug where the `select_server` step's data key in strings.json was `server` instead of `server_id`, causing the raw key to be shown instead of the "Server" label.

<img width="655" height="356" alt="CleanShot 2026-05-13 at 14 22 26" src="https://github.com/user-attachments/assets/446d235b-a5e9-4534-86af-4d4d90287058" />

<img width="634" height="364" alt="CleanShot 2026-05-13 at 14 23 04" src="https://github.com/user-attachments/assets/464fe080-283b-4447-94d7-b54c090e1399" />

<img width="645" height="636" alt="CleanShot 2026-05-13 at 14 23 14" src="https://github.com/user-attachments/assets/4c3ce530-cd68-455d-be8d-6a5196da6ab9" />


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/169820
- This PR is related to issue: https://github.com/home-assistant/epics/issues/26
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr