### PR TITLE
Remove advanced mode dependency from nzbget config flow

### DIFF
--- a/homeassistant/components/nzbget/config_flow.py
+++ b/homeassistant/components/nzbget/config_flow.py
@@ -15,8 +15,16 @@ from homeassistant.const import (
     CONF_USERNAME,
     CONF_VERIFY_SSL,
 )
+from homeassistant.data_entry_flow import SectionConfig, section
 
-from .const import DEFAULT_NAME, DEFAULT_PORT, DEFAULT_SSL, DEFAULT_VERIFY_SSL, DOMAIN
+from .const import (
+    CONF_MORE_OPTIONS,
+    DEFAULT_NAME,
+    DEFAULT_PORT,
+    DEFAULT_SSL,
+    DEFAULT_VERIFY_SSL,
+    DOMAIN,
+)
 from .coordinator import NZBGetAPI, NZBGetAPIException
 
 _LOGGER = logging.getLogger(__name__)
@@ -51,8 +59,10 @@ class NZBGetConfigFlow(ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
-            if CONF_VERIFY_SSL not in user_input:
-                user_input[CONF_VERIFY_SSL] = DEFAULT_VERIFY_SSL
+            more_options = user_input.pop(CONF_MORE_OPTIONS, {})
+            user_input[CONF_VERIFY_SSL] = more_options.get(
+                CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL
+            )
 
             try:
                 await self.hass.async_add_executor_job(_validate_input, user_input)
@@ -67,24 +77,31 @@ class NZBGetConfigFlow(ConfigFlow, domain=DOMAIN):
                     data=user_input,
                 )
 
-        data_schema = {
-            vol.Required(CONF_HOST): str,
-            # Name field is no longer allowed in config flow schemas
-            # pylint: disable-next=hass-config-flow-name-field
-            vol.Optional(CONF_NAME, default=DEFAULT_NAME): str,
-            vol.Optional(CONF_USERNAME): str,
-            vol.Optional(CONF_PASSWORD): str,
-            vol.Optional(CONF_PORT, default=DEFAULT_PORT): int,
-            vol.Optional(CONF_SSL, default=DEFAULT_SSL): bool,
-        }
-
-        if self.show_advanced_options:
-            data_schema[vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL)] = (
-                bool
-            )
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_HOST): str,
+                # Name field is no longer allowed in config flow schemas
+                # pylint: disable-next=hass-config-flow-name-field
+                vol.Optional(CONF_NAME, default=DEFAULT_NAME): str,
+                vol.Optional(CONF_USERNAME): str,
+                vol.Optional(CONF_PASSWORD): str,
+                vol.Optional(CONF_PORT, default=DEFAULT_PORT): int,
+                vol.Optional(CONF_SSL, default=DEFAULT_SSL): bool,
+                vol.Required(CONF_MORE_OPTIONS): section(
+                    vol.Schema(
+                        {
+                            vol.Optional(
+                                CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL
+                            ): bool,
+                        }
+                    ),
+                    SectionConfig(collapsed=True),
+                ),
+            }
+        )
 
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(data_schema),
+            data_schema=data_schema,
             errors=errors or {},
         )

--- a/homeassistant/components/nzbget/const.py
+++ b/homeassistant/components/nzbget/const.py
@@ -6,6 +6,7 @@ DOMAIN = "nzbget"
 ATTR_SPEED = "speed"
 
 # Defaults
+CONF_MORE_OPTIONS = "more_options"
 DEFAULT_NAME = "NZBGet"
 DEFAULT_PORT = 6789
 DEFAULT_SPEED_LIMIT = 1000  # 1 Megabyte/Sec

--- a/homeassistant/components/nzbget/strings.json
+++ b/homeassistant/components/nzbget/strings.json
@@ -15,8 +15,15 @@
           "password": "[%key:common::config_flow::data::password%]",
           "port": "[%key:common::config_flow::data::port%]",
           "ssl": "[%key:common::config_flow::data::ssl%]",
-          "username": "[%key:common::config_flow::data::username%]",
-          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
+          "username": "[%key:common::config_flow::data::username%]"
+        },
+        "sections": {
+          "more_options": {
+            "data": {
+              "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
+            },
+            "name": "More options"
+          }
         },
         "title": "Connect to NZBGet"
       }

--- a/tests/components/nzbget/__init__.py
+++ b/tests/components/nzbget/__init__.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from homeassistant.components.nzbget.const import DOMAIN
+from homeassistant.components.nzbget.const import CONF_MORE_OPTIONS, DOMAIN
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
@@ -36,6 +36,7 @@ USER_INPUT = {
     CONF_PORT: 6789,
     CONF_SSL: False,
     CONF_USERNAME: "",
+    CONF_MORE_OPTIONS: {},
 }
 
 MOCK_VERSION = "21.0"

--- a/tests/components/nzbget/test_config_flow.py
+++ b/tests/components/nzbget/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from pynzbgetapi import NZBGetAPIException
 
-from homeassistant.components.nzbget.const import DOMAIN
+from homeassistant.components.nzbget.const import CONF_MORE_OPTIONS, DOMAIN
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
@@ -45,23 +45,23 @@ async def test_user_form(hass: HomeAssistant) -> None:
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "10.10.10.30"
-    assert result["data"] == {**USER_INPUT, CONF_VERIFY_SSL: False}
+    assert result["data"][CONF_VERIFY_SSL] is False
 
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_user_form_show_advanced_options(hass: HomeAssistant) -> None:
-    """Test we get the user initiated form with advanced options shown."""
+async def test_user_form_with_verify_ssl(hass: HomeAssistant) -> None:
+    """Test the user flow with verify SSL option."""
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER, "show_advanced_options": True}
+        DOMAIN, context={"source": SOURCE_USER}
     )
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
-    user_input_advanced = {
+    user_input = {
         **USER_INPUT,
-        CONF_VERIFY_SSL: True,
+        CONF_MORE_OPTIONS: {CONF_VERIFY_SSL: True},
     }
 
     with (
@@ -72,13 +72,13 @@ async def test_user_form_show_advanced_options(hass: HomeAssistant) -> None:
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input_advanced,
+            user_input,
         )
         await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "10.10.10.30"
-    assert result["data"] == {**USER_INPUT, CONF_VERIFY_SSL: True}
+    assert result["data"][CONF_VERIFY_SSL] is True
 
     assert len(mock_setup_entry.mock_calls) == 1
 


### PR DESCRIPTION
## Proposed change

Replace the `show_advanced_options` gate in the nzbget config flow with a collapsible "More options" section that is always visible to all users.

The "Verify SSL" option is now shown in a collapsed section instead of being hidden behind the advanced mode toggle. The config entry data format is unchanged (flat), so no migration is needed.

Part of the effort to remove the advanced mode toggle and skill-gating terminology from Home Assistant.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/169818
- This PR is related to issue: https://github.com/home-assistant/epics/issues/26
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr