### PR TITLE
Remove advanced mode dependency from onvif options flow

### DIFF
--- a/homeassistant/components/onvif/config_flow.py
+++ b/homeassistant/components/onvif/config_flow.py
@@ -35,7 +35,7 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.data_entry_flow import AbortFlow
+from homeassistant.data_entry_flow import AbortFlow, SectionConfig, section
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
@@ -43,6 +43,7 @@ from .const import (
     CONF_DEVICE_ID,
     CONF_ENABLE_WEBHOOKS,
     CONF_HARDWARE,
+    CONF_MORE_OPTIONS,
     DEFAULT_ARGUMENTS,
     DEFAULT_ENABLE_WEBHOOKS,
     DEFAULT_PORT,
@@ -409,30 +410,16 @@ class OnvifOptionsFlowHandler(OptionsFlow):
     ) -> ConfigFlowResult:
         """Manage the ONVIF devices options."""
         if user_input is not None:
+            more_options = user_input.pop(CONF_MORE_OPTIONS, {})
             self.options[CONF_EXTRA_ARGUMENTS] = user_input[CONF_EXTRA_ARGUMENTS]
             self.options[CONF_RTSP_TRANSPORT] = user_input[CONF_RTSP_TRANSPORT]
-            self.options[CONF_USE_WALLCLOCK_AS_TIMESTAMPS] = user_input.get(
+            self.options[CONF_ENABLE_WEBHOOKS] = user_input[CONF_ENABLE_WEBHOOKS]
+            self.options[CONF_USE_WALLCLOCK_AS_TIMESTAMPS] = more_options.get(
                 CONF_USE_WALLCLOCK_AS_TIMESTAMPS,
                 self.config_entry.options.get(CONF_USE_WALLCLOCK_AS_TIMESTAMPS, False),
             )
-            self.options[CONF_ENABLE_WEBHOOKS] = user_input.get(
-                CONF_ENABLE_WEBHOOKS,
-                self.config_entry.options.get(
-                    CONF_ENABLE_WEBHOOKS, DEFAULT_ENABLE_WEBHOOKS
-                ),
-            )
             return self.async_create_entry(title="", data=self.options)
 
-        advanced_options = {}
-        if self.show_advanced_options:
-            advanced_options[
-                vol.Optional(
-                    CONF_USE_WALLCLOCK_AS_TIMESTAMPS,
-                    default=self.config_entry.options.get(
-                        CONF_USE_WALLCLOCK_AS_TIMESTAMPS, False
-                    ),
-                )
-            ] = bool
         return self.async_show_form(
             step_id="onvif_devices",
             data_schema=vol.Schema(
@@ -455,7 +442,19 @@ class OnvifOptionsFlowHandler(OptionsFlow):
                             CONF_ENABLE_WEBHOOKS, DEFAULT_ENABLE_WEBHOOKS
                         ),
                     ): bool,
-                    **advanced_options,
+                    vol.Required(CONF_MORE_OPTIONS): section(
+                        vol.Schema(
+                            {
+                                vol.Optional(
+                                    CONF_USE_WALLCLOCK_AS_TIMESTAMPS,
+                                    default=self.config_entry.options.get(
+                                        CONF_USE_WALLCLOCK_AS_TIMESTAMPS, False
+                                    ),
+                                ): bool,
+                            }
+                        ),
+                        SectionConfig(collapsed=True),
+                    ),
                 }
             ),
         )

--- a/homeassistant/components/onvif/const.py
+++ b/homeassistant/components/onvif/const.py
@@ -18,6 +18,7 @@ CONF_DEVICE_ID = "deviceid"
 CONF_HARDWARE = "hardware"
 CONF_SNAPSHOT_AUTH = "snapshot_auth"
 CONF_ENABLE_WEBHOOKS = "enable_webhooks"
+CONF_MORE_OPTIONS = "more_options"
 DEFAULT_ENABLE_WEBHOOKS = True
 
 ATTR_PAN = "pan"

--- a/homeassistant/components/onvif/strings.json
+++ b/homeassistant/components/onvif/strings.json
@@ -77,8 +77,15 @@
         "data": {
           "enable_webhooks": "Enable webhooks",
           "extra_arguments": "Extra FFmpeg arguments",
-          "rtsp_transport": "RTSP transport mechanism",
-          "use_wallclock_as_timestamps": "Use wall clock as timestamps"
+          "rtsp_transport": "RTSP transport mechanism"
+        },
+        "sections": {
+          "more_options": {
+            "data": {
+              "use_wallclock_as_timestamps": "Use wall clock as timestamps"
+            },
+            "name": "More options"
+          }
         },
         "title": "ONVIF device options"
       }

--- a/tests/components/onvif/test_config_flow.py
+++ b/tests/components/onvif/test_config_flow.py
@@ -7,7 +7,7 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.onvif import config_flow
-from homeassistant.components.onvif.const import DOMAIN
+from homeassistant.components.onvif.const import CONF_MORE_OPTIONS, DOMAIN
 from homeassistant.config_entries import SOURCE_DHCP
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_USERNAME
 from homeassistant.core import HomeAssistant
@@ -648,9 +648,7 @@ async def test_option_flow(hass: HomeAssistant, option_value: bool) -> None:
     """Test config flow options."""
     entry, _, _ = await setup_onvif_integration(hass)
 
-    result = await hass.config_entries.options.async_init(
-        entry.entry_id, context={"show_advanced_options": True}
-    )
+    result = await hass.config_entries.options.async_init(entry.entry_id)
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "onvif_devices"
@@ -660,8 +658,10 @@ async def test_option_flow(hass: HomeAssistant, option_value: bool) -> None:
         user_input={
             config_flow.CONF_EXTRA_ARGUMENTS: "",
             config_flow.CONF_RTSP_TRANSPORT: list(config_flow.RTSP_TRANSPORTS)[1],
-            config_flow.CONF_USE_WALLCLOCK_AS_TIMESTAMPS: option_value,
             config_flow.CONF_ENABLE_WEBHOOKS: option_value,
+            CONF_MORE_OPTIONS: {
+                config_flow.CONF_USE_WALLCLOCK_AS_TIMESTAMPS: option_value,
+            },
         },
     )
 


### PR DESCRIPTION
## Proposed change

Replace the `show_advanced_options` gate in the onvif options flow with a collapsible "More options" section that is always visible to all users.

The "Use wall clock as timestamps" option is now shown in a collapsed section instead of being hidden behind the advanced mode toggle. The options entry data format is unchanged (flat), so no migration is needed.

Part of the effort to remove the advanced mode toggle and skill-gating terminology from Home Assistant.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/169819
- This PR is related to issue: https://github.com/home-assistant/epics/issues/26
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr