### PR TITLE
Remove advanced mode dependency from risco options flow

### DIFF
--- a/homeassistant/components/risco/config_flow.py
+++ b/homeassistant/components/risco/config_flow.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.data_entry_flow import SectionConfig, section
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
@@ -27,6 +28,7 @@ from .const import (
     CONF_COMMUNICATION_DELAY,
     CONF_CONCURRENCY,
     CONF_HA_STATES_TO_RISCO,
+    CONF_MORE_OPTIONS,
     CONF_RISCO_STATES_TO_HA,
     DEFAULT_ADVANCED_OPTIONS,
     DEFAULT_OPTIONS,
@@ -217,7 +219,8 @@ class RiscoOptionsFlowHandler(OptionsFlow):
         self._data = {**DEFAULT_OPTIONS, **config_entry.options}
 
     def _options_schema(self) -> vol.Schema:
-        schema = vol.Schema(
+        self._data = {**DEFAULT_ADVANCED_OPTIONS, **self._data}
+        return vol.Schema(
             {
                 vol.Required(
                     CONF_CODE_ARM_REQUIRED, default=self._data[CONF_CODE_ARM_REQUIRED]
@@ -226,29 +229,33 @@ class RiscoOptionsFlowHandler(OptionsFlow):
                     CONF_CODE_DISARM_REQUIRED,
                     default=self._data[CONF_CODE_DISARM_REQUIRED],
                 ): bool,
+                vol.Required(CONF_MORE_OPTIONS): section(
+                    vol.Schema(
+                        {
+                            # Polling interval is user-configurable, which is no longer allowed
+                            # pylint: disable-next=hass-config-flow-polling-field
+                            vol.Required(
+                                CONF_SCAN_INTERVAL,
+                                default=self._data[CONF_SCAN_INTERVAL],
+                            ): int,
+                            vol.Required(
+                                CONF_CONCURRENCY,
+                                default=self._data[CONF_CONCURRENCY],
+                            ): int,
+                        }
+                    ),
+                    SectionConfig(collapsed=True),
+                ),
             }
         )
-        if self.show_advanced_options:
-            self._data = {**DEFAULT_ADVANCED_OPTIONS, **self._data}
-            schema = schema.extend(
-                {
-                    # Polling interval is user-configurable, which is no longer allowed
-                    # pylint: disable-next=hass-config-flow-polling-field
-                    vol.Required(
-                        CONF_SCAN_INTERVAL, default=self._data[CONF_SCAN_INTERVAL]
-                    ): int,
-                    vol.Required(
-                        CONF_CONCURRENCY, default=self._data[CONF_CONCURRENCY]
-                    ): int,
-                }
-            )
-        return schema
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Manage the options."""
         if user_input is not None:
+            more_options = user_input.pop(CONF_MORE_OPTIONS, {})
+            user_input.update(more_options)
             self._data = {**self._data, **user_input}
             return await self.async_step_risco_to_ha()
 

--- a/homeassistant/components/risco/const.py
+++ b/homeassistant/components/risco/const.py
@@ -24,6 +24,7 @@ CONF_RISCO_STATES_TO_HA = "risco_states_to_ha"
 CONF_HA_STATES_TO_RISCO = "ha_states_to_risco"
 CONF_COMMUNICATION_DELAY = "communication_delay"
 CONF_CONCURRENCY = "concurrency"
+CONF_MORE_OPTIONS = "more_options"
 
 RISCO_GROUPS = ["A", "B", "C", "D"]
 RISCO_ARM = "arm"

--- a/homeassistant/components/risco/strings.json
+++ b/homeassistant/components/risco/strings.json
@@ -91,9 +91,16 @@
       "init": {
         "data": {
           "code_arm_required": "Require PIN to arm",
-          "code_disarm_required": "Require PIN to disarm",
-          "concurrency": "Maximum concurrent requests in Risco local",
-          "scan_interval": "How often to poll Risco Cloud (in seconds)"
+          "code_disarm_required": "Require PIN to disarm"
+        },
+        "sections": {
+          "more_options": {
+            "data": {
+              "concurrency": "Maximum concurrent requests in Risco local",
+              "scan_interval": "How often to poll Risco Cloud (in seconds)"
+            },
+            "name": "More options"
+          }
         },
         "title": "Configure options"
       },

--- a/tests/components/risco/test_config_flow.py
+++ b/tests/components/risco/test_config_flow.py
@@ -10,7 +10,11 @@ from homeassistant.components.risco.config_flow import (
     CannotConnectError,
     UnauthorizedError,
 )
-from homeassistant.components.risco.const import CONF_COMMUNICATION_DELAY, DOMAIN
+from homeassistant.components.risco.const import (
+    CONF_COMMUNICATION_DELAY,
+    CONF_MORE_OPTIONS,
+    DOMAIN,
+)
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -358,7 +362,7 @@ async def test_options_flow(hass: HomeAssistant) -> None:
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input=TEST_OPTIONS,
+        user_input={**TEST_OPTIONS, CONF_MORE_OPTIONS: {}},
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "risco_to_ha"
@@ -380,13 +384,15 @@ async def test_options_flow(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert entry.options == {
         **TEST_OPTIONS,
+        "scan_interval": 30,
+        "concurrency": 4,
         "risco_states_to_ha": TEST_RISCO_TO_HA,
         "ha_states_to_risco": TEST_HA_TO_RISCO,
     }
 
 
 async def test_advanced_options_flow(hass: HomeAssistant) -> None:
-    """Test options flow."""
+    """Test options flow with more options."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id=TEST_CLOUD_DATA["username"],
@@ -395,16 +401,17 @@ async def test_advanced_options_flow(hass: HomeAssistant) -> None:
 
     entry.add_to_hass(hass)
 
-    result = await hass.config_entries.options.async_init(
-        entry.entry_id, context={"show_advanced_options": True}
-    )
+    result = await hass.config_entries.options.async_init(entry.entry_id)
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "init"
-    assert "concurrency" in result["data_schema"].schema
-    assert "scan_interval" in result["data_schema"].schema
+
     result = await hass.config_entries.options.async_configure(
-        result["flow_id"], user_input={**TEST_OPTIONS, **TEST_ADVANCED_OPTIONS}
+        result["flow_id"],
+        user_input={
+            **TEST_OPTIONS,
+            CONF_MORE_OPTIONS: TEST_ADVANCED_OPTIONS,
+        },
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "risco_to_ha"
@@ -446,7 +453,7 @@ async def test_ha_to_risco_schema(hass: HomeAssistant) -> None:
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input=TEST_OPTIONS,
+        user_input={**TEST_OPTIONS, CONF_MORE_OPTIONS: {}},
     )
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],

--- a/tests/components/risco/test_config_flow.py
+++ b/tests/components/risco/test_config_flow.py
@@ -391,7 +391,7 @@ async def test_options_flow(hass: HomeAssistant) -> None:
     }
 
 
-async def test_advanced_options_flow(hass: HomeAssistant) -> None:
+async def test_more_options_flow(hass: HomeAssistant) -> None:
     """Test options flow with more options."""
     entry = MockConfigEntry(
         domain=DOMAIN,


### PR DESCRIPTION
## Proposed change

Replace the `show_advanced_options` gate in the risco options flow with a collapsible "More options" section that is always visible to all users.

The polling interval and concurrency options are now shown in a collapsed section instead of being hidden behind the advanced mode toggle. The options entry data format is unchanged (flat), so no migration is needed.

Part of the effort to remove the advanced mode toggle and skill-gating terminology from Home Assistant.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/169821
- This PR is related to issue: https://github.com/home-assistant/epics/issues/26
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr