### PR TITLE
Fix flaky sensibo test_device snapshot ordering

### DIFF
--- a/tests/components/sensibo/snapshots/test_entity.ambr
+++ b/tests/components/sensibo/snapshots/test_entity.ambr
@@ -2,72 +2,6 @@
 # name: test_device
   list([
     DeviceRegistryEntrySnapshot({
-      'area_id': 'hallway',
-      'config_entries': <ANY>,
-      'config_entries_subentries': <ANY>,
-      'configuration_url': 'https://home.sensibo.com/',
-      'connections': set({
-        tuple(
-          'mac',
-          '00:02:00:b6:00:00',
-        ),
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': 'esp8266ex',
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'sensibo',
-          'ABC999111',
-        ),
-      }),
-      'labels': set({
-      }),
-      'manufacturer': 'Sensibo',
-      'model': 'skyv2',
-      'model_id': None,
-      'name': 'Hallway',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': '1234567890',
-      'sw_version': 'SKY30046',
-      'via_device_id': None,
-    }),
-    DeviceRegistryEntrySnapshot({
-      'area_id': 'kitchen',
-      'config_entries': <ANY>,
-      'config_entries_subentries': <ANY>,
-      'configuration_url': 'https://home.sensibo.com/',
-      'connections': set({
-        tuple(
-          'mac',
-          '00:01:00:01:00:01',
-        ),
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': 'pure-esp32',
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'sensibo',
-          'AAZZAAZZ',
-        ),
-      }),
-      'labels': set({
-      }),
-      'manufacturer': 'Sensibo',
-      'model': 'pure',
-      'model_id': None,
-      'name': 'Kitchen',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': '0987654321',
-      'sw_version': 'PUR00111',
-      'via_device_id': None,
-    }),
-    DeviceRegistryEntrySnapshot({
       'area_id': 'bedroom',
       'config_entries': <ANY>,
       'config_entries_subentries': <ANY>,
@@ -101,6 +35,39 @@
       'via_device_id': None,
     }),
     DeviceRegistryEntrySnapshot({
+      'area_id': 'hallway',
+      'config_entries': <ANY>,
+      'config_entries_subentries': <ANY>,
+      'configuration_url': 'https://home.sensibo.com/',
+      'connections': set({
+        tuple(
+          'mac',
+          '00:02:00:b6:00:00',
+        ),
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': 'esp8266ex',
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'sensibo',
+          'ABC999111',
+        ),
+      }),
+      'labels': set({
+      }),
+      'manufacturer': 'Sensibo',
+      'model': 'skyv2',
+      'model_id': None,
+      'name': 'Hallway',
+      'name_by_user': None,
+      'primary_config_entry': <ANY>,
+      'serial_number': '1234567890',
+      'sw_version': 'SKY30046',
+      'via_device_id': None,
+    }),
+    DeviceRegistryEntrySnapshot({
       'area_id': None,
       'config_entries': <ANY>,
       'config_entries_subentries': <ANY>,
@@ -128,6 +95,39 @@
       'serial_number': None,
       'sw_version': 'V17',
       'via_device_id': <ANY>,
+    }),
+    DeviceRegistryEntrySnapshot({
+      'area_id': 'kitchen',
+      'config_entries': <ANY>,
+      'config_entries_subentries': <ANY>,
+      'configuration_url': 'https://home.sensibo.com/',
+      'connections': set({
+        tuple(
+          'mac',
+          '00:01:00:01:00:01',
+        ),
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': 'pure-esp32',
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'sensibo',
+          'AAZZAAZZ',
+        ),
+      }),
+      'labels': set({
+      }),
+      'manufacturer': 'Sensibo',
+      'model': 'pure',
+      'model_id': None,
+      'name': 'Kitchen',
+      'name_by_user': None,
+      'primary_config_entry': <ANY>,
+      'serial_number': '0987654321',
+      'sw_version': 'PUR00111',
+      'via_device_id': None,
     }),
   ])
 # ---

--- a/tests/components/sensibo/test_entity.py
+++ b/tests/components/sensibo/test_entity.py
@@ -29,10 +29,11 @@ async def test_device(
     state1 = hass.states.get("climate.hallway")
     assert state1
 
-    assert (
-        dr.async_entries_for_config_entry(device_registry, load_int.entry_id)
-        == snapshot
+    device_entries = dr.async_entries_for_config_entry(
+        device_registry, load_int.entry_id
     )
+    device_entries.sort(key=lambda d: d.name)
+    assert device_entries == snapshot
 
 
 @pytest.mark.parametrize("p_error", SENSIBO_ERRORS)


### PR DESCRIPTION
## Proposed change

Fix flaky `test_device` in `tests/components/sensibo/test_entity.py`. The test compared device registry entries against a snapshot without deterministic ordering, causing intermittent CI failures when the device registry returned entries in a different order.

Sort device entries by name before comparing to the snapshot.

Failed job: https://github.com/home-assistant/core/actions/runs/25775165504/job/75706725554?pr=170462

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr