### PR TITLE
Add @mhuiskes as codeowner for zeversolar

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2060,8 +2060,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/zeroconf/ @bdraco
 /homeassistant/components/zerproc/ @emlove
 /tests/components/zerproc/ @emlove
-/homeassistant/components/zeversolar/ @kvanzuijlen
-/tests/components/zeversolar/ @kvanzuijlen
+/homeassistant/components/zeversolar/ @kvanzuijlen @mhuiskes
+/tests/components/zeversolar/ @kvanzuijlen @mhuiskes
 /homeassistant/components/zha/ @dmulcahey @adminiuga @puddly @TheJulianJES
 /tests/components/zha/ @dmulcahey @adminiuga @puddly @TheJulianJES
 /homeassistant/components/zimi/ @markhannon

--- a/homeassistant/components/zeversolar/manifest.json
+++ b/homeassistant/components/zeversolar/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "zeversolar",
   "name": "Zeversolar",
-  "codeowners": ["@kvanzuijlen"],
+  "codeowners": ["@kvanzuijlen", "@mhuiskes"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/zeversolar",
   "integration_type": "device",


### PR DESCRIPTION
## Proposed change
Add myself as co-maintainer alongside @kvanzuijlen for the zeversolar integration.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
I have been actively contributing improvements to the zeversolar integration and
the zeversolar library and would like to help maintain this integration.

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [translation requirements][translation-requirements]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.