### PR TITLE
Fix flaky test_history_stream_live_chained_events race condition

### DIFF
--- a/tests/components/history/test_websocket_api.py
+++ b/tests/components/history/test_websocket_api.py
@@ -2102,8 +2102,8 @@ async def test_history_stream_live_chained_events(
     now = dt_util.utcnow()
     await async_setup_component(hass, "history", {})
 
-    await async_wait_recording_done(hass)
     hass.states.async_set("binary_sensor.is_light", STATE_OFF)
+    await async_wait_recording_done(hass)
 
     client = await hass_ws_client()
     await client.send_json(


### PR DESCRIPTION
## Breaking change

_N/A_

## Proposed change

Fix a race condition in `test_history_stream_live_chained_events` that caused flaky failures on the PostgreSQL CI runner.

The test called `async_wait_recording_done` *before* setting the `binary_sensor.is_light` state, then immediately started a `history/stream` WebSocket subscription without waiting for the recorder to commit the state. On the PostgreSQL CI runner, database writes are slower than local SQLite, widening the race window and causing the initial history stream response to return empty `states` instead of the expected `binary_sensor.is_light` entry.

The fix moves `async_wait_recording_done` to *after* the `async_set` call, ensuring the state is committed to the database before the history stream queries for it.

Failed job: https://github.com/home-assistant/core/actions/runs/25775165504/job/75706338602?pr=170462

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #170462

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr