### PR TITLE
Enable ruff S301 rule and remove pickle usage in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -754,6 +754,7 @@ select = [
   "S102",   # Use of exec detected
   "S103",   # bad-file-permissions
   "S108",   # hardcoded-temp-file
+  "S301",   # suspicious-pickle-usage
   "S306",   # suspicious-mktemp-usage
   "S307",   # suspicious-eval-usage
   "S313",   # suspicious-xmlc-element-tree-usage

--- a/tests/components/owntracks/test_device_tracker.py
+++ b/tests/components/owntracks/test_device_tracker.py
@@ -3,7 +3,6 @@
 import base64
 from collections.abc import Callable, Generator
 import json
-import pickle
 from typing import Any
 from unittest.mock import patch
 
@@ -1420,12 +1419,14 @@ def generate_ciphers(secret):
     ctxt = SecretBox(key).encrypt(msg, encoder=Base64Encoder).decode("utf-8")
 
     mctxt = base64.b64encode(
-        pickle.dumps(
-            (
-                secret.encode("utf-8"),
-                json.dumps(DEFAULT_LOCATION_MESSAGE).encode("utf-8"),
-            )
-        )
+        json.dumps(
+            [
+                base64.b64encode(secret.encode("utf-8")).decode("utf-8"),
+                base64.b64encode(
+                    json.dumps(DEFAULT_LOCATION_MESSAGE).encode("utf-8")
+                ).decode("utf-8"),
+            ]
+        ).encode("utf-8")
     ).decode("utf-8")
     return ctxt, mctxt
 
@@ -1441,18 +1442,20 @@ ENCRYPTED_LOCATION_MESSAGE = {
 }
 
 MOCK_ENCRYPTED_LOCATION_MESSAGE = {
-    # Mock-encrypted version of LOCATION_MESSAGE using pickle
+    # Mock-encrypted version of LOCATION_MESSAGE
     "_type": "encrypted",
     "data": MOCK_CIPHERTEXT,
 }
 
 
 def mock_cipher():
-    """Return a dummy pickle-based cipher."""
+    """Return a dummy mock cipher."""
 
     def mock_decrypt(ciphertext, key):
-        """Decrypt/unpickle."""
-        (mkey, plaintext) = pickle.loads(base64.b64decode(ciphertext))
+        """Decrypt mock-encrypted message."""
+        mkey, plaintext = json.loads(base64.b64decode(ciphertext))
+        mkey = base64.b64decode(mkey)
+        plaintext = base64.b64decode(plaintext)
         if key != mkey:
             raise ValueError
         return plaintext


### PR DESCRIPTION
## Proposed change

Enable the ruff `S301` rule (suspicious-pickle-usage) to prevent use of `pickle` for deserialization, which can lead to arbitrary code execution with untrusted data.

The only existing violation was in the owntracks test helper which used `pickle` as a quick way to bundle key+plaintext in a mock cipher. Replaced with `json` + base64 encoding — same behavior, no deserialization risk.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr