### PR TITLE
Move valve entity classes to entity module

### DIFF
--- a/homeassistant/components/valve/__init__.py
+++ b/homeassistant/components/valve/__init__.py
@@ -1,10 +1,7 @@
 """Support for Valve devices."""
 
-from dataclasses import dataclass
 from datetime import timedelta
-from enum import IntFlag, StrEnum
 import logging
-from typing import Any, final
 
 import voluptuous as vol
 
@@ -22,12 +19,22 @@ from homeassistant.const import (  # noqa: F401
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.hass_dict import HassKey
 
-from .const import DOMAIN, ValveState
+from .const import (  # noqa: F401
+    DOMAIN,
+    ValveDeviceClass,
+    ValveEntityFeature,
+    ValveState,
+)
+from .entity import (  # noqa: F401
+    ATTR_CURRENT_POSITION,
+    ATTR_IS_CLOSED,
+    ValveEntity,
+    ValveEntityDescription,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,29 +45,9 @@ PLATFORM_SCHEMA_BASE = cv.PLATFORM_SCHEMA_BASE
 SCAN_INTERVAL = timedelta(seconds=15)
 
 
-class ValveDeviceClass(StrEnum):
-    """Device class for valve."""
-
-    # Refer to the valve dev docs for device class descriptions
-    WATER = "water"
-    GAS = "gas"
-
-
 DEVICE_CLASSES_SCHEMA = vol.All(vol.Lower, vol.Coerce(ValveDeviceClass))
 
 
-# mypy: disallow-any-generics
-class ValveEntityFeature(IntFlag):
-    """Supported features of the valve entity."""
-
-    OPEN = 1
-    CLOSE = 2
-    SET_POSITION = 4
-    STOP = 8
-
-
-ATTR_CURRENT_POSITION = "current_position"
-ATTR_IS_CLOSED = "is_closed"
 ATTR_POSITION = "position"
 
 
@@ -116,169 +103,3 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.data[DATA_COMPONENT].async_unload_entry(entry)
-
-
-@dataclass(frozen=True, kw_only=True)
-class ValveEntityDescription(EntityDescription):
-    """A class that describes valve entities."""
-
-    device_class: ValveDeviceClass | None = None
-    reports_position: bool = False
-
-
-class ValveEntity(Entity):
-    """Base class for valve entities."""
-
-    entity_description: ValveEntityDescription
-    _attr_current_valve_position: int | None = None
-    _attr_device_class: ValveDeviceClass | None
-    _attr_is_closed: bool | None = None
-    _attr_is_closing: bool | None = None
-    _attr_is_opening: bool | None = None
-    _attr_reports_position: bool
-    _attr_supported_features: ValveEntityFeature = ValveEntityFeature(0)
-
-    __is_last_toggle_direction_open = True
-
-    @property
-    def reports_position(self) -> bool:
-        """Return True if entity reports position, False otherwise."""
-        if hasattr(self, "_attr_reports_position"):
-            return self._attr_reports_position
-        if hasattr(self, "entity_description"):
-            return self.entity_description.reports_position
-        raise ValueError(f"'reports_position' not set for {self.entity_id}.")
-
-    @property
-    def current_valve_position(self) -> int | None:
-        """Return current position of valve.
-
-        None is unknown, 0 is closed, 100 is fully open.
-        """
-        return self._attr_current_valve_position
-
-    @property
-    def device_class(self) -> ValveDeviceClass | None:
-        """Return the class of this entity."""
-        if hasattr(self, "_attr_device_class"):
-            return self._attr_device_class
-        if hasattr(self, "entity_description"):
-            return self.entity_description.device_class
-        return None
-
-    @property
-    @final
-    def state(self) -> str | None:
-        """Return the state of the valve."""
-        reports_position = self.reports_position
-        if self.is_opening:
-            self.__is_last_toggle_direction_open = True
-            return ValveState.OPENING
-        if self.is_closing:
-            self.__is_last_toggle_direction_open = False
-            return ValveState.CLOSING
-        if reports_position is True:
-            if (current_valve_position := self.current_valve_position) is None:
-                return None
-            position_zero = current_valve_position == 0
-            return ValveState.CLOSED if position_zero else ValveState.OPEN
-        if (closed := self.is_closed) is None:
-            return None
-        return ValveState.CLOSED if closed else ValveState.OPEN
-
-    @final
-    @property
-    def state_attributes(self) -> dict[str, Any]:
-        """Return the state attributes."""
-        data: dict[str, Any] = {}
-
-        if self.reports_position:
-            if (current_valve_position := self.current_valve_position) is None:
-                data[ATTR_IS_CLOSED] = None
-            else:
-                data[ATTR_IS_CLOSED] = current_valve_position == 0
-            data[ATTR_CURRENT_POSITION] = current_valve_position
-        else:
-            data[ATTR_IS_CLOSED] = self.is_closed
-
-        return data
-
-    @property
-    def supported_features(self) -> ValveEntityFeature:
-        """Flag supported features."""
-        return self._attr_supported_features
-
-    @property
-    def is_opening(self) -> bool | None:
-        """Return if the valve is opening or not."""
-        return self._attr_is_opening
-
-    @property
-    def is_closing(self) -> bool | None:
-        """Return if the valve is closing or not."""
-        return self._attr_is_closing
-
-    @property
-    def is_closed(self) -> bool | None:
-        """Return if the valve is closed or not."""
-        return self._attr_is_closed
-
-    def open_valve(self) -> None:
-        """Open the valve."""
-        raise NotImplementedError
-
-    async def async_open_valve(self) -> None:
-        """Open the valve."""
-        await self.hass.async_add_executor_job(self.open_valve)
-
-    @final
-    async def async_handle_open_valve(self) -> None:
-        """Open the valve."""
-        if self.supported_features & ValveEntityFeature.SET_POSITION:
-            await self.async_set_valve_position(100)
-            return
-        await self.async_open_valve()
-
-    def close_valve(self) -> None:
-        """Close valve."""
-        raise NotImplementedError
-
-    async def async_close_valve(self) -> None:
-        """Close valve."""
-        await self.hass.async_add_executor_job(self.close_valve)
-
-    @final
-    async def async_handle_close_valve(self) -> None:
-        """Close the valve."""
-        if self.supported_features & ValveEntityFeature.SET_POSITION:
-            await self.async_set_valve_position(0)
-            return
-        await self.async_close_valve()
-
-    async def async_toggle(self) -> None:
-        """Toggle the entity."""
-        if self.supported_features & ValveEntityFeature.STOP and (
-            self.is_closing or self.is_opening
-        ):
-            return await self.async_stop_valve()
-        if self.is_closed:
-            return await self.async_handle_open_valve()
-        if self.__is_last_toggle_direction_open:
-            return await self.async_handle_close_valve()
-        return await self.async_handle_open_valve()
-
-    def set_valve_position(self, position: int) -> None:
-        """Move the valve to a specific position."""
-        raise NotImplementedError
-
-    async def async_set_valve_position(self, position: int) -> None:
-        """Move the valve to a specific position."""
-        await self.hass.async_add_executor_job(self.set_valve_position, position)
-
-    def stop_valve(self) -> None:
-        """Stop the valve."""
-        raise NotImplementedError
-
-    async def async_stop_valve(self) -> None:
-        """Stop the valve."""
-        await self.hass.async_add_executor_job(self.stop_valve)

--- a/homeassistant/components/valve/const.py
+++ b/homeassistant/components/valve/const.py
@@ -1,8 +1,25 @@
 """Constants for the Valve entity platform."""
 
-from enum import StrEnum
+from enum import IntFlag, StrEnum
 
 DOMAIN = "valve"
+
+
+class ValveDeviceClass(StrEnum):
+    """Device class for valve."""
+
+    # Refer to the valve dev docs for device class descriptions
+    WATER = "water"
+    GAS = "gas"
+
+
+class ValveEntityFeature(IntFlag):
+    """Supported features of the valve entity."""
+
+    OPEN = 1
+    CLOSE = 2
+    SET_POSITION = 4
+    STOP = 8
 
 
 class ValveState(StrEnum):

--- a/homeassistant/components/valve/entity.py
+++ b/homeassistant/components/valve/entity.py
@@ -1,0 +1,177 @@
+"""Base entity for the Valve platform."""
+
+from dataclasses import dataclass
+from typing import Any, final
+
+from homeassistant.helpers.entity import Entity, EntityDescription
+
+from .const import ValveDeviceClass, ValveEntityFeature, ValveState
+
+ATTR_CURRENT_POSITION = "current_position"
+ATTR_IS_CLOSED = "is_closed"
+
+
+@dataclass(frozen=True, kw_only=True)
+class ValveEntityDescription(EntityDescription):
+    """A class that describes valve entities."""
+
+    device_class: ValveDeviceClass | None = None
+    reports_position: bool = False
+
+
+class ValveEntity(Entity):
+    """Base class for valve entities."""
+
+    entity_description: ValveEntityDescription
+    _attr_current_valve_position: int | None = None
+    _attr_device_class: ValveDeviceClass | None
+    _attr_is_closed: bool | None = None
+    _attr_is_closing: bool | None = None
+    _attr_is_opening: bool | None = None
+    _attr_reports_position: bool
+    _attr_supported_features: ValveEntityFeature = ValveEntityFeature(0)
+
+    __is_last_toggle_direction_open = True
+
+    @property
+    def reports_position(self) -> bool:
+        """Return True if entity reports position, False otherwise."""
+        if hasattr(self, "_attr_reports_position"):
+            return self._attr_reports_position
+        if hasattr(self, "entity_description"):
+            return self.entity_description.reports_position
+        raise ValueError(f"'reports_position' not set for {self.entity_id}.")
+
+    @property
+    def current_valve_position(self) -> int | None:
+        """Return current position of valve.
+
+        None is unknown, 0 is closed, 100 is fully open.
+        """
+        return self._attr_current_valve_position
+
+    @property
+    def device_class(self) -> ValveDeviceClass | None:
+        """Return the class of this entity."""
+        if hasattr(self, "_attr_device_class"):
+            return self._attr_device_class
+        if hasattr(self, "entity_description"):
+            return self.entity_description.device_class
+        return None
+
+    @property
+    @final
+    def state(self) -> str | None:
+        """Return the state of the valve."""
+        reports_position = self.reports_position
+        if self.is_opening:
+            self.__is_last_toggle_direction_open = True
+            return ValveState.OPENING
+        if self.is_closing:
+            self.__is_last_toggle_direction_open = False
+            return ValveState.CLOSING
+        if reports_position is True:
+            if (current_valve_position := self.current_valve_position) is None:
+                return None
+            position_zero = current_valve_position == 0
+            return ValveState.CLOSED if position_zero else ValveState.OPEN
+        if (closed := self.is_closed) is None:
+            return None
+        return ValveState.CLOSED if closed else ValveState.OPEN
+
+    @final
+    @property
+    def state_attributes(self) -> dict[str, Any]:
+        """Return the state attributes."""
+        data: dict[str, Any] = {}
+
+        if self.reports_position:
+            if (current_valve_position := self.current_valve_position) is None:
+                data[ATTR_IS_CLOSED] = None
+            else:
+                data[ATTR_IS_CLOSED] = current_valve_position == 0
+            data[ATTR_CURRENT_POSITION] = current_valve_position
+        else:
+            data[ATTR_IS_CLOSED] = self.is_closed
+
+        return data
+
+    @property
+    def supported_features(self) -> ValveEntityFeature:
+        """Flag supported features."""
+        return self._attr_supported_features
+
+    @property
+    def is_opening(self) -> bool | None:
+        """Return if the valve is opening or not."""
+        return self._attr_is_opening
+
+    @property
+    def is_closing(self) -> bool | None:
+        """Return if the valve is closing or not."""
+        return self._attr_is_closing
+
+    @property
+    def is_closed(self) -> bool | None:
+        """Return if the valve is closed or not."""
+        return self._attr_is_closed
+
+    def open_valve(self) -> None:
+        """Open the valve."""
+        raise NotImplementedError
+
+    async def async_open_valve(self) -> None:
+        """Open the valve."""
+        await self.hass.async_add_executor_job(self.open_valve)
+
+    @final
+    async def async_handle_open_valve(self) -> None:
+        """Open the valve."""
+        if self.supported_features & ValveEntityFeature.SET_POSITION:
+            await self.async_set_valve_position(100)
+            return
+        await self.async_open_valve()
+
+    def close_valve(self) -> None:
+        """Close valve."""
+        raise NotImplementedError
+
+    async def async_close_valve(self) -> None:
+        """Close valve."""
+        await self.hass.async_add_executor_job(self.close_valve)
+
+    @final
+    async def async_handle_close_valve(self) -> None:
+        """Close the valve."""
+        if self.supported_features & ValveEntityFeature.SET_POSITION:
+            await self.async_set_valve_position(0)
+            return
+        await self.async_close_valve()
+
+    async def async_toggle(self) -> None:
+        """Toggle the entity."""
+        if self.supported_features & ValveEntityFeature.STOP and (
+            self.is_closing or self.is_opening
+        ):
+            return await self.async_stop_valve()
+        if self.is_closed:
+            return await self.async_handle_open_valve()
+        if self.__is_last_toggle_direction_open:
+            return await self.async_handle_close_valve()
+        return await self.async_handle_open_valve()
+
+    def set_valve_position(self, position: int) -> None:
+        """Move the valve to a specific position."""
+        raise NotImplementedError
+
+    async def async_set_valve_position(self, position: int) -> None:
+        """Move the valve to a specific position."""
+        await self.hass.async_add_executor_job(self.set_valve_position, position)
+
+    def stop_valve(self) -> None:
+        """Stop the valve."""
+        raise NotImplementedError
+
+    async def async_stop_valve(self) -> None:
+        """Stop the valve."""
+        await self.hass.async_add_executor_job(self.stop_valve)


### PR DESCRIPTION
## Breaking change

n/a

## Proposed change

Move `ValveEntityDescription` and `ValveEntity` from `__init__.py` to a dedicated `entity.py` module to satisfy the `hass-enforce-class-module` lint rule. Also moves `ValveDeviceClass` and `ValveEntityFeature` to `const.py` to avoid circular imports between the new `entity.py` and `__init__.py`.

All symbols are re-exported from `__init__.py` for backward compatibility — no changes needed in downstream integrations.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr