### PR TITLE
Move infrared entity classes to entity module

### DIFF
--- a/homeassistant/components/infrared/__init__.py
+++ b/homeassistant/components/infrared/__init__.py
@@ -1,31 +1,31 @@
 """Provides functionality to interact with infrared devices."""
 
-from abc import abstractmethod
 from collections.abc import Callable
-from dataclasses import dataclass
 from datetime import timedelta
-from enum import StrEnum
 import logging
-from typing import final
 
 from infrared_protocols.commands import Command as InfraredCommand
-from propcache.api import cached_property
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import CALLBACK_TYPE, Context, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, entity_registry as er
-from homeassistant.helpers.deprecation import deprecated_class
-from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.util import dt as dt_util
 from homeassistant.util.hass_dict import HassKey
 
 from .const import DOMAIN
+from .entity import (  # noqa: F401
+    InfraredDeviceClass,
+    InfraredEmitterEntity,
+    InfraredEmitterEntityDescription,
+    InfraredEntity,
+    InfraredEntityDescription,
+    InfraredReceivedSignal,
+    InfraredReceiverEntity,
+    InfraredReceiverEntityDescription,
+)
 
 __all__ = [
     "DOMAIN",
@@ -41,13 +41,6 @@ __all__ = [
     "async_send_command",
     "async_subscribe_receiver",
 ]
-
-
-class InfraredDeviceClass(StrEnum):
-    """Device class for infrared entities."""
-
-    EMITTER = "emitter"
-    RECEIVER = "receiver"
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -180,150 +173,3 @@ def async_subscribe_receiver(
         )
 
     return entity.async_subscribe_received_signal(signal_callback)
-
-
-@dataclass(frozen=True, slots=True)
-class InfraredReceivedSignal:
-    """Represents a received IR signal."""
-
-    timings: list[int]
-    modulation: int | None = None
-
-
-class InfraredEmitterEntityDescription(EntityDescription, frozen_or_thawed=True):
-    """Describes infrared emitter entities."""
-
-
-class InfraredEmitterEntity(RestoreEntity):
-    """Base class for infrared emitter entities."""
-
-    entity_description: InfraredEmitterEntityDescription
-    _attr_device_class: InfraredDeviceClass = InfraredDeviceClass.EMITTER
-    _attr_should_poll = False
-    _attr_state: None = None
-
-    __last_command_sent: str | None = None
-
-    @property
-    @final
-    def state(self) -> str | None:
-        """Return the entity state."""
-        return self.__last_command_sent
-
-    @final
-    async def async_send_command_internal(self, command: InfraredCommand) -> None:
-        """Send an IR command and update state.
-
-        Should not be overridden, handles setting last sent timestamp.
-        """
-        await self.async_send_command(command)
-        self.__last_command_sent = dt_util.utcnow().isoformat(timespec="milliseconds")
-        self.async_write_ha_state()
-
-    @final
-    async def async_internal_added_to_hass(self) -> None:
-        """Call when the infrared entity is added to hass."""
-        await super().async_internal_added_to_hass()
-        state = await self.async_get_last_state()
-        if state is not None and state.state not in (STATE_UNAVAILABLE, None):
-            self.__last_command_sent = state.state
-
-    @abstractmethod
-    async def async_send_command(self, command: InfraredCommand) -> None:
-        """Send an IR command.
-
-        Args:
-            command: The IR command to send.
-
-        Raises:
-            HomeAssistantError: If transmission fails.
-        """
-
-
-class InfraredReceiverEntityDescription(EntityDescription, frozen_or_thawed=True):
-    """Describes infrared receiver entities."""
-
-
-class InfraredReceiverEntity(RestoreEntity):
-    """Base class for infrared receiver entities."""
-
-    entity_description: InfraredReceiverEntityDescription
-    _attr_device_class: InfraredDeviceClass = InfraredDeviceClass.RECEIVER
-    _attr_should_poll = False
-    _attr_state: None = None
-
-    __last_signal_received: str | None = None
-
-    @cached_property
-    def __signal_callbacks(self) -> set[Callable[[InfraredReceivedSignal], None]]:
-        """Subscriber callback set, lazily initialized on first access."""
-        return set()
-
-    @property
-    @final
-    def state(self) -> str | None:
-        """Return the entity state."""
-        return self.__last_signal_received
-
-    @final
-    async def async_internal_added_to_hass(self) -> None:
-        """Call when the infrared entity is added to hass."""
-        await super().async_internal_added_to_hass()
-        state = await self.async_get_last_state()
-        if state is not None and state.state not in (
-            STATE_UNAVAILABLE,
-            STATE_UNKNOWN,
-            None,
-        ):
-            self.__last_signal_received = state.state
-
-    @final
-    def _handle_received_signal(self, signal: InfraredReceivedSignal) -> None:
-        """Handle a received IR signal.
-
-        Should not be overridden. To be called by platform implementations when a
-        signal is received.
-        """
-        self.__last_signal_received = dt_util.utcnow().isoformat(
-            timespec="milliseconds"
-        )
-        self.async_write_ha_state()
-        for signal_callback in tuple(self.__signal_callbacks):
-            try:
-                signal_callback(signal)
-            except Exception:
-                _LOGGER.exception("Error in signal callback for %s", self.entity_id)
-
-    @callback
-    def async_subscribe_received_signal(
-        self,
-        signal_callback: Callable[[InfraredReceivedSignal], None],
-    ) -> CALLBACK_TYPE:
-        """Subscribe to received IR signals.
-
-        Returns a callable to unsubscribe.
-        """
-        callbacks = self.__signal_callbacks
-        callbacks.add(signal_callback)
-
-        @callback
-        def remove_callback() -> None:
-            callbacks.discard(signal_callback)
-
-        return remove_callback
-
-
-@deprecated_class(
-    "homeassistant.components.infrared.InfraredEmitterEntityDescription",
-    breaks_in_ha_version="2027.6",
-)
-class InfraredEntityDescription(InfraredEmitterEntityDescription):
-    """Deprecated alias for InfraredEmitterEntityDescription."""
-
-
-@deprecated_class(
-    "homeassistant.components.infrared.InfraredEmitterEntity",
-    breaks_in_ha_version="2027.6",
-)
-class InfraredEntity(InfraredEmitterEntity):
-    """Deprecated alias for InfraredEmitterEntity."""

--- a/homeassistant/components/infrared/entity.py
+++ b/homeassistant/components/infrared/entity.py
@@ -1,0 +1,174 @@
+"""Entity classes for the infrared integration."""
+
+from abc import abstractmethod
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+import logging
+from typing import final
+
+from infrared_protocols.commands import Command as InfraredCommand
+from propcache.api import cached_property
+
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.core import CALLBACK_TYPE, callback
+from homeassistant.helpers.deprecation import deprecated_class
+from homeassistant.helpers.entity import EntityDescription
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.util import dt as dt_util
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class InfraredDeviceClass(StrEnum):
+    """Device class for infrared entities."""
+
+    EMITTER = "emitter"
+    RECEIVER = "receiver"
+
+
+@dataclass(frozen=True, slots=True)
+class InfraredReceivedSignal:
+    """Represents a received IR signal."""
+
+    timings: list[int]
+    modulation: int | None = None
+
+
+class InfraredEmitterEntityDescription(EntityDescription, frozen_or_thawed=True):
+    """Describes infrared emitter entities."""
+
+
+class InfraredEmitterEntity(RestoreEntity):
+    """Base class for infrared emitter entities."""
+
+    entity_description: InfraredEmitterEntityDescription
+    _attr_device_class: InfraredDeviceClass = InfraredDeviceClass.EMITTER
+    _attr_should_poll = False
+    _attr_state: None = None
+
+    __last_command_sent: str | None = None
+
+    @property
+    @final
+    def state(self) -> str | None:
+        """Return the entity state."""
+        return self.__last_command_sent
+
+    @final
+    async def async_send_command_internal(self, command: InfraredCommand) -> None:
+        """Send an IR command and update state.
+
+        Should not be overridden, handles setting last sent timestamp.
+        """
+        await self.async_send_command(command)
+        self.__last_command_sent = dt_util.utcnow().isoformat(timespec="milliseconds")
+        self.async_write_ha_state()
+
+    @final
+    async def async_internal_added_to_hass(self) -> None:
+        """Call when the infrared entity is added to hass."""
+        await super().async_internal_added_to_hass()
+        state = await self.async_get_last_state()
+        if state is not None and state.state not in (STATE_UNAVAILABLE, None):
+            self.__last_command_sent = state.state
+
+    @abstractmethod
+    async def async_send_command(self, command: InfraredCommand) -> None:
+        """Send an IR command.
+
+        Args:
+            command: The IR command to send.
+
+        Raises:
+            HomeAssistantError: If transmission fails.
+        """
+
+
+class InfraredReceiverEntityDescription(EntityDescription, frozen_or_thawed=True):
+    """Describes infrared receiver entities."""
+
+
+class InfraredReceiverEntity(RestoreEntity):
+    """Base class for infrared receiver entities."""
+
+    entity_description: InfraredReceiverEntityDescription
+    _attr_device_class: InfraredDeviceClass = InfraredDeviceClass.RECEIVER
+    _attr_should_poll = False
+    _attr_state: None = None
+
+    __last_signal_received: str | None = None
+
+    @cached_property
+    def __signal_callbacks(self) -> set[Callable[[InfraredReceivedSignal], None]]:
+        """Subscriber callback set, lazily initialized on first access."""
+        return set()
+
+    @property
+    @final
+    def state(self) -> str | None:
+        """Return the entity state."""
+        return self.__last_signal_received
+
+    @final
+    async def async_internal_added_to_hass(self) -> None:
+        """Call when the infrared entity is added to hass."""
+        await super().async_internal_added_to_hass()
+        state = await self.async_get_last_state()
+        if state is not None and state.state not in (
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
+            None,
+        ):
+            self.__last_signal_received = state.state
+
+    @final
+    def _handle_received_signal(self, signal: InfraredReceivedSignal) -> None:
+        """Handle a received IR signal.
+
+        Should not be overridden. To be called by platform implementations when a
+        signal is received.
+        """
+        self.__last_signal_received = dt_util.utcnow().isoformat(
+            timespec="milliseconds"
+        )
+        self.async_write_ha_state()
+        for signal_callback in tuple(self.__signal_callbacks):
+            try:
+                signal_callback(signal)
+            except Exception:
+                _LOGGER.exception("Error in signal callback for %s", self.entity_id)
+
+    @callback
+    def async_subscribe_received_signal(
+        self,
+        signal_callback: Callable[[InfraredReceivedSignal], None],
+    ) -> CALLBACK_TYPE:
+        """Subscribe to received IR signals.
+
+        Returns a callable to unsubscribe.
+        """
+        callbacks = self.__signal_callbacks
+        callbacks.add(signal_callback)
+
+        @callback
+        def remove_callback() -> None:
+            callbacks.discard(signal_callback)
+
+        return remove_callback
+
+
+@deprecated_class(
+    "homeassistant.components.infrared.InfraredEmitterEntityDescription",
+    breaks_in_ha_version="2027.6",
+)
+class InfraredEntityDescription(InfraredEmitterEntityDescription):
+    """Deprecated alias for InfraredEmitterEntityDescription."""
+
+
+@deprecated_class(
+    "homeassistant.components.infrared.InfraredEmitterEntity",
+    breaks_in_ha_version="2027.6",
+)
+class InfraredEntity(InfraredEmitterEntity):
+    """Deprecated alias for InfraredEmitterEntity."""


### PR DESCRIPTION
## Breaking change

n/a

## Proposed change

Move `InfraredEmitterEntity`, `InfraredEmitterEntityDescription`, `InfraredReceiverEntity`, `InfraredReceiverEntityDescription`, and related classes from `__init__.py` to a dedicated `entity.py` module to satisfy the `hass-enforce-class-module` lint rule.

Also moves `InfraredDeviceClass`, `InfraredReceivedSignal`, and the deprecated aliases (`InfraredEntity`, `InfraredEntityDescription`) to the new module.

All symbols are re-exported from `__init__.py` for backward compatibility — no changes needed in downstream integrations.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr