### PR TITLE
Move radio_frequency entity classes to entity module

### DIFF
--- a/homeassistant/components/radio_frequency/__init__.py
+++ b/homeassistant/components/radio_frequency/__init__.py
@@ -1,25 +1,23 @@
 """Provides functionality to interact with radio frequency devices."""
 
-from abc import abstractmethod
 from datetime import timedelta
 import logging
-from typing import final
 
 from rf_protocols import ModulationType, RadioFrequencyCommand
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import Context, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, entity_registry as er
-from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.util import dt as dt_util
 from homeassistant.util.hass_dict import HassKey
 
 from .const import DOMAIN
+from .entity import (
+    RadioFrequencyTransmitterEntity,
+    RadioFrequencyTransmitterEntityDescription,
+)
 
 __all__ = [
     "DOMAIN",
@@ -154,73 +152,3 @@ async def async_send_command(
         entity.async_set_context(context)
 
     await entity.async_send_command_internal(command)
-
-
-class RadioFrequencyTransmitterEntityDescription(
-    EntityDescription, frozen_or_thawed=True
-):
-    """Describes radio frequency transmitter entities."""
-
-
-class RadioFrequencyTransmitterEntity(RestoreEntity):
-    """Base class for radio frequency transmitter entities."""
-
-    entity_description: RadioFrequencyTransmitterEntityDescription
-    _attr_should_poll = False
-    _attr_state: None = None
-
-    __last_command_sent: str | None = None
-
-    @property
-    @abstractmethod
-    def supported_frequency_ranges(self) -> list[tuple[int, int]]:
-        """Return list of (min_hz, max_hz) tuples."""
-
-    @callback
-    @final
-    def supports_frequency(self, frequency: int) -> bool:
-        """Return whether the transmitter supports the given frequency."""
-        return any(
-            low <= frequency <= high for low, high in self.supported_frequency_ranges
-        )
-
-    @callback
-    @final
-    def supports_modulation(self, modulation: ModulationType) -> bool:
-        """Return whether the transmitter supports the given modulation."""
-        return modulation == ModulationType.OOK
-
-    @property
-    @final
-    def state(self) -> str | None:
-        """Return the entity state."""
-        return self.__last_command_sent
-
-    @final
-    async def async_send_command_internal(self, command: RadioFrequencyCommand) -> None:
-        """Send an RF command and update state.
-
-        Should not be overridden, handles setting last sent timestamp.
-        """
-        await self.async_send_command(command)
-        self.__last_command_sent = dt_util.utcnow().isoformat(timespec="milliseconds")
-        self.async_write_ha_state()
-
-    @final
-    async def async_internal_added_to_hass(self) -> None:
-        """Call when the radio frequency entity is added to hass."""
-        await super().async_internal_added_to_hass()
-        state = await self.async_get_last_state()
-        if state is not None and state.state not in (STATE_UNAVAILABLE, None):
-            self.__last_command_sent = state.state
-
-    @abstractmethod
-    async def async_send_command(self, command: RadioFrequencyCommand) -> None:
-        """Send an RF command.
-
-        Args:
-            command: The RF command to send.
-
-        Raises:
-            HomeAssistantError: If transmission fails.
-        """

--- a/homeassistant/components/radio_frequency/entity.py
+++ b/homeassistant/components/radio_frequency/entity.py
@@ -1,0 +1,82 @@
+"""Base entity for the radio frequency integration."""
+
+from abc import abstractmethod
+from typing import final
+
+from rf_protocols import ModulationType, RadioFrequencyCommand
+
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import callback
+from homeassistant.helpers.entity import EntityDescription
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.util import dt as dt_util
+
+
+class RadioFrequencyTransmitterEntityDescription(
+    EntityDescription, frozen_or_thawed=True
+):
+    """Describes radio frequency transmitter entities."""
+
+
+class RadioFrequencyTransmitterEntity(RestoreEntity):
+    """Base class for radio frequency transmitter entities."""
+
+    entity_description: RadioFrequencyTransmitterEntityDescription
+    _attr_should_poll = False
+    _attr_state: None = None
+
+    __last_command_sent: str | None = None
+
+    @property
+    @abstractmethod
+    def supported_frequency_ranges(self) -> list[tuple[int, int]]:
+        """Return list of (min_hz, max_hz) tuples."""
+
+    @callback
+    @final
+    def supports_frequency(self, frequency: int) -> bool:
+        """Return whether the transmitter supports the given frequency."""
+        return any(
+            low <= frequency <= high for low, high in self.supported_frequency_ranges
+        )
+
+    @callback
+    @final
+    def supports_modulation(self, modulation: ModulationType) -> bool:
+        """Return whether the transmitter supports the given modulation."""
+        return modulation == ModulationType.OOK
+
+    @property
+    @final
+    def state(self) -> str | None:
+        """Return the entity state."""
+        return self.__last_command_sent
+
+    @final
+    async def async_send_command_internal(self, command: RadioFrequencyCommand) -> None:
+        """Send an RF command and update state.
+
+        Should not be overridden, handles setting last sent timestamp.
+        """
+        await self.async_send_command(command)
+        self.__last_command_sent = dt_util.utcnow().isoformat(timespec="milliseconds")
+        self.async_write_ha_state()
+
+    @final
+    async def async_internal_added_to_hass(self) -> None:
+        """Call when the radio frequency entity is added to hass."""
+        await super().async_internal_added_to_hass()
+        state = await self.async_get_last_state()
+        if state is not None and state.state not in (STATE_UNAVAILABLE, None):
+            self.__last_command_sent = state.state
+
+    @abstractmethod
+    async def async_send_command(self, command: RadioFrequencyCommand) -> None:
+        """Send an RF command.
+
+        Args:
+            command: The RF command to send.
+
+        Raises:
+            HomeAssistantError: If transmission fails.
+        """


### PR DESCRIPTION
## Breaking change

n/a

## Proposed change

Move `RadioFrequencyTransmitterEntity` and `RadioFrequencyTransmitterEntityDescription` from `__init__.py` to a dedicated `entity.py` module to satisfy the `hass-enforce-class-module` lint rule.

All symbols are re-exported from `__init__.py` for backward compatibility — no changes needed in downstream integrations.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr