### PR TITLE
Collapse advanced options on auswrt config flow

### DIFF
--- a/homeassistant/components/asuswrt/config_flow.py
+++ b/homeassistant/components/asuswrt/config_flow.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import callback
+from homeassistant.data_entry_flow import SectionConfig, section
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.schema_config_entry_flow import (
     SchemaCommonFlowHandler,
@@ -35,6 +36,7 @@ from .bridge import AsusWrtBridge
 from .const import (
     CONF_DNSMASQ,
     CONF_INTERFACE,
+    CONF_MORE_OPTIONS,
     CONF_REQUIRE_IP,
     CONF_SSH_KEY,
     CONF_TRACK_UNKNOWN,
@@ -145,8 +147,6 @@ class AsusWrtFlowHandler(ConfigFlow, domain=DOMAIN):
             vol.Required(CONF_HOST, default=user_input.get(CONF_HOST, "")): str,
             vol.Required(CONF_USERNAME, default=user_input.get(CONF_USERNAME, "")): str,
             vol.Exclusive(CONF_PASSWORD, PASS_KEY, PASS_KEY_MSG): str,
-            vol.Optional(CONF_PORT): cv.port,
-            vol.Exclusive(CONF_SSH_KEY, PASS_KEY, PASS_KEY_MSG): str,
             vol.Required(
                 CONF_PROTOCOL,
                 default=user_input.get(CONF_PROTOCOL, PROTOCOL_HTTPS),
@@ -154,6 +154,15 @@ class AsusWrtFlowHandler(ConfigFlow, domain=DOMAIN):
                 SelectSelectorConfig(
                     options=ALLOWED_PROTOCOL, translation_key="protocols"
                 )
+            ),
+            vol.Required(CONF_MORE_OPTIONS): section(
+                vol.Schema(
+                    {
+                        vol.Optional(CONF_PORT): cv.port,
+                        vol.Exclusive(CONF_SSH_KEY, PASS_KEY, PASS_KEY_MSG): str,
+                    }
+                ),
+                SectionConfig(collapsed=True),
             ),
         }
 
@@ -228,6 +237,10 @@ class AsusWrtFlowHandler(ConfigFlow, domain=DOMAIN):
 
         if user_input is None:
             return self._show_setup_form()
+
+        user_input = user_input.copy()
+        more_options = user_input.pop(CONF_MORE_OPTIONS, {})
+        user_input.update(more_options)
 
         self._config_data = user_input
         pwd: str | None = user_input.get(CONF_PASSWORD)

--- a/homeassistant/components/asuswrt/const.py
+++ b/homeassistant/components/asuswrt/const.py
@@ -4,6 +4,7 @@ DOMAIN = "asuswrt"
 
 CONF_DNSMASQ = "dnsmasq"
 CONF_INTERFACE = "interface"
+CONF_MORE_OPTIONS = "more_options"
 CONF_REQUIRE_IP = "require_ip"
 CONF_SSH_KEY = "ssh_key"
 CONF_TRACK_UNKNOWN = "track_unknown"

--- a/homeassistant/components/asuswrt/strings.json
+++ b/homeassistant/components/asuswrt/strings.json
@@ -23,15 +23,22 @@
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "password": "[%key:common::config_flow::data::password%]",
-          "port": "Port (leave empty for protocol default)",
           "protocol": "Communication protocol to use",
-          "ssh_key": "Path to your SSH key file (instead of password)",
           "username": "[%key:common::config_flow::data::username%]"
         },
         "data_description": {
           "host": "The hostname or IP address of your ASUSWRT router."
         },
-        "description": "Set required parameter to connect to your router"
+        "description": "Set required parameter to connect to your router",
+        "sections": {
+          "more_options": {
+            "data": {
+              "port": "Port (leave empty for protocol default)",
+              "ssh_key": "Path to your SSH key file (instead of password)"
+            },
+            "name": "More options"
+          }
+        }
       }
     }
   },

--- a/tests/components/asuswrt/test_config_flow.py
+++ b/tests/components/asuswrt/test_config_flow.py
@@ -10,6 +10,7 @@ import pytest
 from homeassistant.components.asuswrt.const import (
     CONF_DNSMASQ,
     CONF_INTERFACE,
+    CONF_MORE_OPTIONS,
     CONF_REQUIRE_IP,
     CONF_SSH_KEY,
     CONF_TRACK_UNKNOWN,
@@ -46,22 +47,34 @@ CONFIG_DATA = {
     CONF_PASSWORD: "pwd",
 }
 
+CONFIG_SCHEMA_HTTP = {
+    **CONFIG_DATA,
+    CONF_PROTOCOL: PROTOCOL_HTTPS,
+    CONF_MORE_OPTIONS: {CONF_PORT: 8443},
+}
+
 CONFIG_DATA_HTTP = {
     **CONFIG_DATA,
     CONF_PROTOCOL: PROTOCOL_HTTPS,
     CONF_PORT: 8443,
 }
 
-CONFIG_DATA_SSH = {
+CONFIG_SCHEMA_TELNET = {
     **CONFIG_DATA,
-    CONF_PROTOCOL: PROTOCOL_SSH,
-    CONF_PORT: 22,
+    CONF_PROTOCOL: PROTOCOL_TELNET,
+    CONF_MORE_OPTIONS: {CONF_PORT: 23},
 }
 
 CONFIG_DATA_TELNET = {
     **CONFIG_DATA,
     CONF_PROTOCOL: PROTOCOL_TELNET,
     CONF_PORT: 23,
+}
+
+CONFIG_SCHEMA_SSH = {
+    **CONFIG_DATA,
+    CONF_PROTOCOL: PROTOCOL_SSH,
+    CONF_MORE_OPTIONS: {CONF_PORT: 22},
 }
 
 
@@ -98,7 +111,7 @@ async def test_user_legacy(
 
     # test with all provided
     legacy_result = await hass.config_entries.flow.async_configure(
-        flow_result["flow_id"], user_input=CONFIG_DATA_TELNET
+        flow_result["flow_id"], user_input=CONFIG_SCHEMA_TELNET
     )
     await hass.async_block_till_done()
 
@@ -137,7 +150,7 @@ async def test_user_http(
 
     # test with all provided
     result = await hass.config_entries.flow.async_configure(
-        flow_result["flow_id"], user_input=CONFIG_DATA_HTTP
+        flow_result["flow_id"], user_input=CONFIG_SCHEMA_HTTP
     )
     await hass.async_block_till_done()
 
@@ -148,7 +161,7 @@ async def test_user_http(
     assert len(patch_setup_entry.mock_calls) == 1
 
 
-@pytest.mark.parametrize("config", [CONFIG_DATA_TELNET, CONFIG_DATA_HTTP])
+@pytest.mark.parametrize("config", [CONFIG_SCHEMA_TELNET, CONFIG_SCHEMA_HTTP])
 async def test_error_pwd_required(hass: HomeAssistant, config) -> None:
     """Test we abort for missing password."""
     config_data = {k: v for k, v in config.items() if k != CONF_PASSWORD}
@@ -164,7 +177,7 @@ async def test_error_pwd_required(hass: HomeAssistant, config) -> None:
 
 async def test_error_no_password_ssh(hass: HomeAssistant) -> None:
     """Test we abort for wrong password and ssh file combination."""
-    config_data = {k: v for k, v in CONFIG_DATA_SSH.items() if k != CONF_PASSWORD}
+    config_data = {k: v for k, v in CONFIG_SCHEMA_SSH.items() if k != CONF_PASSWORD}
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER},
@@ -177,8 +190,8 @@ async def test_error_no_password_ssh(hass: HomeAssistant) -> None:
 
 async def test_error_invalid_ssh(hass: HomeAssistant, patch_is_file) -> None:
     """Test we abort if invalid ssh file is provided."""
-    config_data = {k: v for k, v in CONFIG_DATA_SSH.items() if k != CONF_PASSWORD}
-    config_data[CONF_SSH_KEY] = SSH_KEY
+    config_data = {k: v for k, v in CONFIG_SCHEMA_SSH.items() if k != CONF_PASSWORD}
+    config_data[CONF_MORE_OPTIONS] = {CONF_SSH_KEY: SSH_KEY}
 
     def mock_is_file(file) -> bool:
         if str(file).endswith(SSH_KEY):
@@ -202,7 +215,7 @@ async def test_error_invalid_host(hass: HomeAssistant, patch_get_host) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER},
-        data=CONFIG_DATA_TELNET,
+        data=CONFIG_SCHEMA_TELNET,
     )
 
     assert result["type"] is FlowResultType.FORM
@@ -219,7 +232,7 @@ async def test_abort_if_not_unique_id_setup(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER},
-        data=CONFIG_DATA_TELNET,
+        data=CONFIG_SCHEMA_TELNET,
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "no_unique_id"
@@ -239,7 +252,7 @@ async def test_update_uniqueid_exist(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER},
-        data=CONFIG_DATA_HTTP,
+        data=CONFIG_SCHEMA_HTTP,
     )
     await hass.async_block_till_done()
 
@@ -263,7 +276,7 @@ async def test_abort_invalid_unique_id(hass: HomeAssistant, connect_legacy) -> N
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER},
-        data=CONFIG_DATA_TELNET,
+        data=CONFIG_SCHEMA_TELNET,
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "invalid_unique_id"
@@ -291,7 +304,7 @@ async def test_on_connect_legacy_failed(
 
     # go to legacy form
     result = await hass.config_entries.flow.async_configure(
-        flow_result["flow_id"], user_input=CONFIG_DATA_TELNET
+        flow_result["flow_id"], user_input=CONFIG_SCHEMA_TELNET
     )
     await hass.async_block_till_done()
 
@@ -320,7 +333,7 @@ async def test_on_connect_http_failed(
     connect_http.return_value.async_connect.side_effect = side_effect
 
     result = await hass.config_entries.flow.async_configure(
-        flow_result["flow_id"], user_input=CONFIG_DATA_HTTP
+        flow_result["flow_id"], user_input=CONFIG_SCHEMA_HTTP
     )
     await hass.async_block_till_done()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR is a follow up of PR #170029 

Move the config option that was available only in advanced mode in a collapsible "More options" section that is always visible to all users. The config entry data format is unchanged (flat), so no migration is needed.

<img width="572" height="764" alt="image" src="https://github.com/user-attachments/assets/e4a0aca4-450a-4f41-ad74-79c029c6d969" />


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #169806 
- This PR is related to issue: https://github.com/home-assistant/epics/issues/26
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
