### PR TITLE
Add pylint checker for branching in test functions

### DIFF
--- a/pylint/plugins/pylint_home_assistant/checkers/test_determinism.py
+++ b/pylint/plugins/pylint_home_assistant/checkers/test_determinism.py
@@ -1,0 +1,150 @@
+"""Checker for non-deterministic test execution paths.
+
+``if`` and ``match`` statements inside test functions create non-deterministic
+execution paths — some branches may never run, silently hiding failures.
+Tests should use ``@pytest.mark.parametrize`` to cover different cases
+explicitly, or split into separate test functions.
+
+This rule only applies to ``test_*`` functions in test modules.
+
+To reduce false positives, the checker skips:
+- Guard clauses (``return``, ``raise``, ``pytest.skip/fail/xfail``)
+- ``if`` statements where the condition references a function parameter
+  (conditional setup in an already-parametrized test)
+- ``if`` statements that don't contain any ``assert`` in their branches
+  (pure setup logic, not branching assertions)
+"""
+
+from astroid import nodes
+from pylint.checkers import BaseChecker
+from pylint.lint import PyLinter
+
+from pylint_home_assistant.helpers.module_info import is_test_module
+
+
+def _is_guard_clause(node: nodes.If) -> bool:
+    """Return True if the ``if`` is a guard clause.
+
+    Guards are allowed patterns:
+    - ``pytest.skip(...)`` / ``pytest.xfail(...)``
+    - Early ``return``
+    - ``raise`` (e.g., ``pytest.fail`` or assertion helpers)
+    """
+    for child in node.body:
+        if isinstance(child, (nodes.Return, nodes.Raise)):
+            return True
+        if isinstance(child, nodes.Expr) and isinstance(child.value, nodes.Call):
+            call = child.value
+            if isinstance(call.func, nodes.Attribute) and call.func.attrname in (
+                "skip",
+                "xfail",
+                "fail",
+            ):
+                return True
+    return False
+
+
+def _condition_references_parameter(node: nodes.If, param_names: set[str]) -> bool:
+    """Return True if the ``if`` condition references a function parameter.
+
+    This catches conditional setup in parametrized tests, e.g.::
+
+        @pytest.mark.parametrize("action_type", ["template", "trigger"])
+        def test_something(action_type):
+            if action_type == "template":
+                action = {...}
+            else:
+                action = {...}
+    """
+    for name_node in node.test.nodes_of_class(nodes.Name):
+        if name_node.name in param_names:
+            return True
+    return False
+
+
+def _contains_assert(node: nodes.NodeNG) -> bool:
+    """Return True if the node tree contains any ``assert`` statement."""
+    return any(node.nodes_of_class(nodes.Assert))
+
+
+def _branches_contain_assert(node: nodes.If) -> bool:
+    """Return True if any branch of the ``if`` contains an ``assert``."""
+    if _contains_assert(node):
+        return True
+    for handler in node.orelse:
+        if isinstance(handler, nodes.If):
+            if _branches_contain_assert(handler):
+                return True
+        elif _contains_assert(handler):
+            return True
+    return False
+
+
+class HassTestDeterminismChecker(BaseChecker):
+    """Checker for branching in test functions.
+
+    ``if`` and ``match`` statements in test functions create
+    non-deterministic execution paths. Use ``@pytest.mark.parametrize``
+    or split into separate tests instead.
+    """
+
+    name = "home_assistant_test_determinism"
+    priority = -1
+    msgs = {
+        "W7409": (
+            "Test function '%s' contains a %s statement, use "
+            "`@pytest.mark.parametrize` or split into separate tests instead",
+            "home-assistant-test-non-deterministic",
+            "Used when a test function contains an if or match statement "
+            "that creates non-deterministic execution paths. Use "
+            "pytest.mark.parametrize to explicitly cover each case.",
+        ),
+    }
+    options = ()
+
+    _in_test_module: bool
+
+    def visit_module(self, node: nodes.Module) -> None:
+        """Track whether we are in a test module."""
+        self._in_test_module = is_test_module(node.name)
+
+    def visit_functiondef(self, node: nodes.FunctionDef) -> None:
+        """Check test functions for branching statements."""
+        if not self._in_test_module:
+            return
+
+        if not node.name.startswith("test_"):
+            return
+
+        # Only check top-level test functions
+        if not isinstance(node.parent, nodes.Module):
+            return
+
+        param_names = {arg.name for arg in node.args.args}
+
+        for child in node.body:
+            if isinstance(child, nodes.If):
+                if _is_guard_clause(child):
+                    continue
+                if _condition_references_parameter(child, param_names):
+                    continue
+                if not _branches_contain_assert(child):
+                    continue
+                self.add_message(
+                    "home-assistant-test-non-deterministic",
+                    node=child,
+                    args=(node.name, "if"),
+                )
+            elif isinstance(child, nodes.Match):
+                self.add_message(
+                    "home-assistant-test-non-deterministic",
+                    node=child,
+                    args=(node.name, "match"),
+                )
+
+    visit_asyncfunctiondef = visit_functiondef
+
+
+def register(linter: PyLinter) -> None:
+    """Register the checker."""
+    linter.register_checker(HassTestDeterminismChecker(linter))

--- a/tests/components/backblaze_b2/test_backup.py
+++ b/tests/components/backblaze_b2/test_backup.py
@@ -109,6 +109,7 @@ async def test_agents_get_backup(
     )
     response = await client.receive_json()
     assert response["success"]
+    # pylint: disable-next=home-assistant-test-non-deterministic
     if response["result"]["backup"]:
         assert response["result"]["backup"]["backup_id"] == TEST_BACKUP.backup_id
 

--- a/tests/components/huawei_lte/test_config_flow.py
+++ b/tests/components/huawei_lte/test_config_flow.py
@@ -361,6 +361,7 @@ async def test_ssdp(
 
     for k, v in expected_result.items():
         assert result[k] == v  # type: ignore[literal-required] # expected is a subset
+    # pylint: disable-next=home-assistant-test-non-deterministic
     if result.get("data_schema"):
         assert result["data_schema"] is not None
         assert result["data_schema"]({})[CONF_URL] == url + "/"

--- a/tests/components/mysensors/test_config_flow.py
+++ b/tests/components/mysensors/test_config_flow.py
@@ -74,6 +74,7 @@ async def test_config_mqtt(hass: HomeAssistant, mqtt: None) -> None:
         )
         await hass.async_block_till_done()
 
+    # pylint: disable-next=home-assistant-test-non-deterministic
     if "errors" in result:
         assert not result["errors"]
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -135,6 +136,7 @@ async def test_config_serial(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
+    # pylint: disable-next=home-assistant-test-non-deterministic
     if "errors" in result:
         assert not result["errors"]
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -174,6 +176,7 @@ async def test_config_tcp(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
+    # pylint: disable-next=home-assistant-test-non-deterministic
     if "errors" in result:
         assert not result["errors"]
     assert result["type"] is FlowResultType.CREATE_ENTRY

--- a/tests/components/openai_conversation/test_init.py
+++ b/tests/components/openai_conversation/test_init.py
@@ -1176,6 +1176,7 @@ async def test_migration_from_v1_disabled(
         for subentry in entry.subentries.values()
         if subentry.subentry_type == "tts"
     ]
+    # pylint: disable-next=home-assistant-test-non-deterministic
     if entry.minor_version == 4:
         assert len(stt_subentries) == 0
         assert len(tts_subentries) == 0

--- a/tests/components/openrgb/test_init.py
+++ b/tests/components/openrgb/test_init.py
@@ -85,6 +85,7 @@ async def test_remove_config_entry_device_still_connected(
         None,
     )
 
+    # pylint: disable-next=home-assistant-test-non-deterministic
     if rgb_device:
         # Try to remove device that's still connected - should be blocked
         result = await async_remove_config_entry_device(

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -2395,6 +2395,7 @@ async def test_list_statistic_ids(
     )
     response = await client.receive_json()
     assert response["success"]
+    # pylint: disable-next=home-assistant-test-non-deterministic
     if has_mean:
         assert response["result"] == [
             {
@@ -2417,6 +2418,7 @@ async def test_list_statistic_ids(
     )
     response = await client.receive_json()
     assert response["success"]
+    # pylint: disable-next=home-assistant-test-non-deterministic
     if has_sum:
         assert response["result"] == [
             {

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -414,6 +414,7 @@ async def test_skip_out_of_order_packet(hass: HomeAssistant) -> None:
     # If skipped packet would have been the first packet of a segment, the previous
     # segment will be longer by a packet duration
     # We also may possibly lose a segment due to the shifting pts boundary
+    # pylint: disable-next=home-assistant-test-non-deterministic
     if out_of_order_index % PACKETS_PER_SEGMENT == 0:
         # Check duration of affected segment and remove it
         longer_segment_index = int((out_of_order_index - 1) * SEGMENTS_PER_PACKET)

--- a/tests/pylint/test_determinism.py
+++ b/tests/pylint/test_determinism.py
@@ -1,0 +1,250 @@
+"""Tests for the test determinism checker."""
+
+import astroid
+from pylint.testutils import UnittestLinter
+from pylint.utils.ast_walker import ASTWalker
+from pylint_home_assistant.checkers.test_determinism import HassTestDeterminismChecker
+import pytest
+
+from . import assert_no_messages
+
+
+@pytest.fixture(name="determinism_checker")
+def determinism_checker_fixture(linter: UnittestLinter) -> HassTestDeterminismChecker:
+    """Fixture to provide a test determinism checker."""
+    return HassTestDeterminismChecker(linter)
+
+
+@pytest.mark.parametrize(
+    ("code", "module_name"),
+    [
+        pytest.param(
+            """
+def test_something(hass: HomeAssistant) -> None:
+    assert hass.state == "ready"
+""",
+            "tests.components.test_integration.test_init",
+            id="no_branching",
+        ),
+        pytest.param(
+            """
+def test_something(hass: HomeAssistant) -> None:
+    if not hass:
+        return
+    assert hass.state == "ready"
+""",
+            "tests.components.test_integration.test_init",
+            id="guard_clause_return",
+        ),
+        pytest.param(
+            """
+def test_something(hass: HomeAssistant) -> None:
+    if sys.platform == "win32":
+        pytest.skip("Not supported on Windows")
+    assert hass.state == "ready"
+""",
+            "tests.components.test_integration.test_init",
+            id="guard_clause_pytest_skip",
+        ),
+        pytest.param(
+            """
+def test_something(hass: HomeAssistant) -> None:
+    if not hass:
+        pytest.fail("hass is required")
+    assert hass.state == "ready"
+""",
+            "tests.components.test_integration.test_init",
+            id="guard_clause_pytest_fail",
+        ),
+        pytest.param(
+            """
+def test_something(hass: HomeAssistant) -> None:
+    if not hass:
+        raise ValueError("hass is required")
+    assert hass.state == "ready"
+""",
+            "tests.components.test_integration.test_init",
+            id="guard_clause_raise",
+        ),
+        pytest.param(
+            """
+def test_something(hass: HomeAssistant) -> None:
+    if not hass:
+        pytest.xfail("expected to fail")
+    assert hass.state == "ready"
+""",
+            "tests.components.test_integration.test_init",
+            id="guard_clause_pytest_xfail",
+        ),
+        pytest.param(
+            """
+def test_something(action_type: str) -> None:
+    if action_type == "template":
+        action = {"wait_template": "{{ true }}"}
+    else:
+        action = {"wait_for_trigger": {"platform": "state"}}
+    run_action(action)
+""",
+            "tests.components.test_integration.test_init",
+            id="condition_references_parameter",
+        ),
+        pytest.param(
+            """
+def test_something(hass: HomeAssistant) -> None:
+    if hass.config.language == "en":
+        data = {"lang": "en"}
+    else:
+        data = {"lang": "other"}
+    do_something(data)
+""",
+            "tests.components.test_integration.test_init",
+            id="if_without_assert_setup_only",
+        ),
+        pytest.param(
+            """
+@pytest.fixture
+def my_fixture() -> None:
+    if something:
+        do_setup()
+    else:
+        do_other_setup()
+""",
+            "tests.components.test_integration.test_init",
+            id="fixture_function_ignored",
+        ),
+        pytest.param(
+            """
+def helper_function() -> None:
+    if something:
+        do_a()
+    else:
+        do_b()
+""",
+            "tests.components.test_integration.test_init",
+            id="non_test_function_ignored",
+        ),
+        pytest.param(
+            """
+def test_something(hass: HomeAssistant) -> None:
+    if something:
+        do_a()
+    else:
+        do_b()
+""",
+            "homeassistant.components.test_integration",
+            id="not_test_module_ignored",
+        ),
+    ],
+)
+def test_no_warning(
+    linter: UnittestLinter,
+    determinism_checker: HassTestDeterminismChecker,
+    code: str,
+    module_name: str,
+) -> None:
+    """Test cases that should not trigger a warning."""
+    root_node = astroid.parse(code, module_name)
+    walker = ASTWalker(linter)
+    walker.add_checker(determinism_checker)
+
+    with assert_no_messages(linter):
+        walker.walk(root_node)
+
+
+def test_if_statement_flagged(
+    linter: UnittestLinter,
+    determinism_checker: HassTestDeterminismChecker,
+) -> None:
+    """Test that if statement with branching assertions is flagged."""
+    root_node = astroid.parse(
+        """
+def test_sensor_value(hass) -> None:
+    state = hass.states.get("sensor.test")
+    if state.attributes.get("device_class") == "temperature":
+        assert state.attributes.get("unit") == "C"
+    else:
+        assert state.attributes.get("unit") == "ppm"
+""",
+        "tests.components.test_integration.test_sensor",
+    )
+    walker = ASTWalker(linter)
+    walker.add_checker(determinism_checker)
+    walker.walk(root_node)
+
+    messages = linter.release_messages()
+    assert len(messages) == 1
+    assert messages[0].msg_id == "home-assistant-test-non-deterministic"
+    assert messages[0].args == ("test_sensor_value", "if")
+
+
+def test_multiple_if_statements(
+    linter: UnittestLinter,
+    determinism_checker: HassTestDeterminismChecker,
+) -> None:
+    """Test that multiple if statements are each flagged."""
+    root_node = astroid.parse(
+        """
+def test_something(hass) -> None:
+    if condition_a:
+        assert do_a()
+
+    if condition_b:
+        assert do_b()
+""",
+        "tests.components.test_integration.test_init",
+    )
+    walker = ASTWalker(linter)
+    walker.add_checker(determinism_checker)
+    walker.walk(root_node)
+
+    messages = linter.release_messages()
+    assert len(messages) == 2
+
+
+def test_async_test_function(
+    linter: UnittestLinter,
+    determinism_checker: HassTestDeterminismChecker,
+) -> None:
+    """Test that async test functions are also checked."""
+    root_node = astroid.parse(
+        """
+async def test_something(hass) -> None:
+    if something:
+        assert do_a()
+    else:
+        assert do_b()
+""",
+        "tests.components.test_integration.test_init",
+    )
+    walker = ASTWalker(linter)
+    walker.add_checker(determinism_checker)
+    walker.walk(root_node)
+
+    messages = linter.release_messages()
+    assert len(messages) == 1
+    assert messages[0].args == ("test_something", "if")
+
+
+def test_match_statement_flagged(
+    linter: UnittestLinter,
+    determinism_checker: HassTestDeterminismChecker,
+) -> None:
+    """Test that match statements are also flagged."""
+    root_node = astroid.parse(
+        """
+def test_something(state) -> None:
+    match state:
+        case "on":
+            assert True
+        case "off":
+            assert False
+""",
+        "tests.components.test_integration.test_init",
+    )
+    walker = ASTWalker(linter)
+    walker.add_checker(determinism_checker)
+    walker.walk(root_node)
+
+    messages = linter.release_messages()
+    assert len(messages) == 1
+    assert messages[0].args == ("test_something", "match")

--- a/tests/test_test_fixtures.py
+++ b/tests/test_test_fixtures.py
@@ -122,6 +122,7 @@ async def test_evict_faked_translations(
     fake_domain = "test"
     real_domain = "homeassistant"
 
+    # pylint: disable-next=home-assistant-test-non-deterministic
     if "en" in cache.loaded:
         # Evict the real domain from the cache in case it's been loaded before
         cache.loaded["en"].discard(real_domain)


### PR DESCRIPTION
## Proposed change

Adds a new pylint checker that flags `if` and `match` statements inside test functions that create non-deterministic execution paths. This enforces the existing guideline: "Avoid using conditions/branching in tests. Instead, either split tests or adjust the test parametrization to cover all cases without branching."

The rule (`W7409` / `home-assistant-test-non-deterministic`) only applies to `test_*` functions in test modules.

To reduce false positives, the checker skips:
- **Guard clauses**: `if` with `return`, `raise`, `pytest.skip`, `pytest.fail`, or `pytest.xfail`
- **Parametrized setup**: `if` where the condition references a function parameter (conditional setup in an already-parametrized test)
- **Pure setup logic**: `if` branches that don't contain any `assert` statements

This brings the violation count from 339 (naive approach) down to 11 true positives, all suppressed with `# pylint: disable-next` comments for now.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr