### PR TITLE
fix: duplicated words in flux_led/tod/bond docstrings/comments

### DIFF
--- a/homeassistant/components/bond/button.py
+++ b/homeassistant/components/bond/button.py
@@ -14,7 +14,7 @@ from .models import BondData
 from .utils import BondDevice
 
 # The api requires a step size even though it does not
-# seem to matter what is is as the underlying device is likely
+# seem to matter what is as the underlying device is likely
 # getting an increase/decrease signal only
 STEP_SIZE = 10
 

--- a/homeassistant/components/flux_led/switch.py
+++ b/homeassistant/components/flux_led/switch.py
@@ -121,5 +121,5 @@ class FluxMusicSwitch(FluxEntity, SwitchEntity):
 
     @property
     def is_on(self) -> bool:
-        """Return true if microphone is is on."""
+        """Return true if microphone is on."""
         return self._device.is_on and self._device.effect == MODE_MUSIC

--- a/homeassistant/components/tod/binary_sensor.py
+++ b/homeassistant/components/tod/binary_sensor.py
@@ -237,7 +237,7 @@ class TodSensor(BinarySensorEntity):
         )
 
     def _turn_to_next_day(self) -> None:
-        """Turn to to the next day."""
+        """Turn to the next day."""
         if _is_sun_event(self._after):
             self._time_after = get_astral_event_next(
                 self.hass, self._after, self._time_after - self._after_offset


### PR DESCRIPTION
Three one-line typo fixes for duplicated words in component docstrings/comments:
- `homeassistant/components/flux_led/switch.py` — """Return true if microphone is is on.""" → """Return true if microphone is on."""
- `homeassistant/components/tod/binary_sensor.py` — """Turn to to the next day.""" → """Turn to the next day."""
- `homeassistant/components/bond/button.py` — "# seem to matter what is is as the underlying device is likely" → "# seem to matter what is as the underlying device is likely"

No code/behavior change.