### PR TITLE
Update pynobo to 1.9.0

### DIFF
--- a/homeassistant/components/nobo_hub/const.py
+++ b/homeassistant/components/nobo_hub/const.py
@@ -1,5 +1,7 @@
 """Constants for the Nobø Ecohub integration."""
 
+from typing import Final
+
 DOMAIN = "nobo_hub"
 
 CONF_SERIAL = "serial"
@@ -8,9 +10,9 @@ OVERRIDE_TYPE_CONSTANT = "constant"
 OVERRIDE_TYPE_NOW = "now"
 
 NOBO_MANUFACTURER = "Glen Dimplex Nordic AS"
-ATTR_HARDWARE_VERSION = "hardware_version"
-ATTR_SOFTWARE_VERSION = "software_version"
-ATTR_SERIAL = "serial"
-ATTR_TEMP_COMFORT_C = "temp_comfort_c"
-ATTR_TEMP_ECO_C = "temp_eco_c"
-ATTR_ZONE_ID = "zone_id"
+ATTR_HARDWARE_VERSION: Final = "hardware_version"
+ATTR_SOFTWARE_VERSION: Final = "software_version"
+ATTR_SERIAL: Final = "serial"
+ATTR_TEMP_COMFORT_C: Final = "temp_comfort_c"
+ATTR_TEMP_ECO_C: Final = "temp_eco_c"
+ATTR_ZONE_ID: Final = "zone_id"

--- a/homeassistant/components/nobo_hub/manifest.json
+++ b/homeassistant/components/nobo_hub/manifest.json
@@ -13,5 +13,5 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "quality_scale": "bronze",
-  "requirements": ["pynobo==1.8.1"]
+  "requirements": ["pynobo==1.9.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2360,7 +2360,7 @@ pynintendoauth==1.0.2
 pynintendoparental==2.3.4
 
 # homeassistant.components.nobo_hub
-pynobo==1.8.1
+pynobo==1.9.0
 
 # homeassistant.components.nordpool
 pynordpool==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2028,7 +2028,7 @@ pynintendoauth==1.0.2
 pynintendoparental==2.3.4
 
 # homeassistant.components.nobo_hub
-pynobo==1.8.1
+pynobo==1.9.0
 
 # homeassistant.components.nordpool
 pynordpool==0.4.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Update `pynobo` to 1.9.0. This is required to get the integration to silver on the quality scale.

### [1.9.0 release notes](https://github.com/echoromeo/pynobo/releases/tag/v1.9.0)

- Datetime fixes by @oyvindwe in https://github.com/echoromeo/pynobo/pull/37
- Convert to typed package with exception hierarchy by @oyvindwe in https://github.com/echoromeo/pynobo/pull/39
- Add connection-state API by @oyvindwe in https://github.com/echoromeo/pynobo/pull/40
- TypingTyping: add TypedDicts and pass mypy --strict by @oyvindwe in https://github.com/echoromeo/pynobo/pull/43
- Version 1.9.0 by @oyvindwe in https://github.com/echoromeo/pynobo/pull/41

Full Changelog: https://github.com/echoromeo/pynobo/compare/v1.8.1...v1.9.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
