### PR TITLE
Add repair issue for unsupported Sunricher DALI firmware

### DIFF
--- a/homeassistant/components/sunricher_dali/__init__.py
+++ b/homeassistant/components/sunricher_dali/__init__.py
@@ -1,10 +1,12 @@
 """The Sunricher DALI integration."""
 
 import asyncio
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
+from contextlib import suppress
 import logging
 
-from PySrDaliGateway import DaliGateway, Device
+from packaging.version import InvalidVersion, Version
+from PySrDaliGateway import CallbackEventType, DaliGateway, Device
 from PySrDaliGateway.exceptions import DaliGatewayError
 
 from homeassistant.const import (
@@ -15,12 +17,18 @@ from homeassistant.const import (
     CONF_USERNAME,
     Platform,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, issue_registry as ir
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 
-from .const import CONF_SERIAL_NUMBER, DOMAIN, MANUFACTURER
+from .const import (
+    CONF_SERIAL_NUMBER,
+    DOMAIN,
+    MANUFACTURER,
+    MIN_SUPPORTED_FW_VERSION,
+    MIN_SUPPORTED_SW_VERSION,
+)
 from .types import DaliCenterConfigEntry, DaliCenterData
 
 _PLATFORMS: list[Platform] = [
@@ -31,6 +39,18 @@ _PLATFORMS: list[Platform] = [
     Platform.SENSOR,
 ]
 _LOGGER = logging.getLogger(__name__)
+
+_MIN_SUPPORTED_SW = Version(MIN_SUPPORTED_SW_VERSION)
+_MIN_SUPPORTED_FW = Version(MIN_SUPPORTED_FW_VERSION)
+
+
+async def _async_cleanup_failed_setup(
+    gateway: DaliGateway, unsub_version: Callable[[], None]
+) -> None:
+    """Clean up resources registered before config entry setup completed."""
+    unsub_version()
+    with suppress(DaliGatewayError):
+        await gateway.disconnect()
 
 
 def _remove_missing_devices(
@@ -78,21 +98,40 @@ async def async_setup_entry(hass: HomeAssistant, entry: DaliCenterConfigEntry) -
     )
     gw_sn = gateway.gw_sn
 
+    @callback
+    def _handle_version_update(versions: tuple[str, str]) -> None:
+        _async_check_firmware_version(hass, entry, gateway, versions)
+
+    unsub_version = gateway.register_listener(
+        CallbackEventType.VERSION_UPDATED,
+        _handle_version_update,
+        gateway.gw_sn,
+    )
+
     try:
         await gateway.connect()
     except DaliGatewayError as exc:
+        unsub_version()
         raise ConfigEntryNotReady(
             translation_domain=DOMAIN,
             translation_key="cannot_connect",
             translation_placeholders={"host": entry.data[CONF_HOST]},
         ) from exc
 
+    if gateway.software_version and gateway.firmware_version:
+        _async_check_firmware_version(hass, entry, gateway)
+
     try:
         devices, scenes = await asyncio.gather(
             gateway.discover_devices(),
             gateway.discover_scenes(),
         )
-    except DaliGatewayError as exc:
+    except Exception as exc:
+        # async_on_unload only fires after a successful load, so clean up
+        # the listener manually before bailing out.
+        await _async_cleanup_failed_setup(gateway, unsub_version)
+        if not isinstance(exc, DaliGatewayError):
+            raise
         raise ConfigEntryNotReady(
             translation_domain=DOMAIN,
             translation_key="cannot_discover_devices",
@@ -117,9 +156,64 @@ async def async_setup_entry(hass: HomeAssistant, entry: DaliCenterConfigEntry) -
         devices=devices,
         scenes=scenes,
     )
-    await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
+    try:
+        await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
+    except Exception:
+        await _async_cleanup_failed_setup(gateway, unsub_version)
+        raise
+    entry.async_on_unload(unsub_version)
 
     return True
+
+
+@callback
+def _async_check_firmware_version(
+    hass: HomeAssistant,
+    entry: DaliCenterConfigEntry,
+    gateway: DaliGateway,
+    versions: tuple[str, str] | None = None,
+) -> None:
+    """Raise a repair issue if the gateway firmware is below supported minimums."""
+    sw_version, fw_version = versions or (
+        gateway.software_version,
+        gateway.firmware_version,
+    )
+    issue_id = f"unsupported_firmware_{entry.entry_id}"
+
+    if not sw_version or not fw_version:
+        return
+
+    try:
+        sw_parsed = Version(sw_version)
+        fw_parsed = Version(fw_version)
+    except InvalidVersion:
+        _LOGGER.debug(
+            "Gateway %s reported unparsable firmware version (sw=%s, fw=%s)",
+            gateway.gw_sn,
+            sw_version,
+            fw_version,
+        )
+        return
+
+    if sw_parsed < _MIN_SUPPORTED_SW or fw_parsed < _MIN_SUPPORTED_FW:
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=False,
+            is_persistent=True,
+            issue_domain=DOMAIN,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key="unsupported_firmware",
+            translation_placeholders={
+                "sw_version": sw_version,
+                "fw_version": fw_version,
+                "min_sw_version": MIN_SUPPORTED_SW_VERSION,
+                "min_fw_version": MIN_SUPPORTED_FW_VERSION,
+            },
+        )
+    else:
+        ir.async_delete_issue(hass, DOMAIN, issue_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: DaliCenterConfigEntry) -> bool:
@@ -127,3 +221,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: DaliCenterConfigEntry) 
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, _PLATFORMS):
         await entry.runtime_data.gateway.disconnect()
     return unload_ok
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: DaliCenterConfigEntry) -> None:
+    """Clear persistent repair issues that belong to this entry."""
+    ir.async_delete_issue(hass, DOMAIN, f"unsupported_firmware_{entry.entry_id}")

--- a/homeassistant/components/sunricher_dali/const.py
+++ b/homeassistant/components/sunricher_dali/const.py
@@ -1,5 +1,10 @@
 """Constants for the Sunricher DALI integration."""
 
-DOMAIN = "sunricher_dali"
-MANUFACTURER = "Sunricher"
-CONF_SERIAL_NUMBER = "serial_number"
+from typing import Final
+
+DOMAIN: Final = "sunricher_dali"
+MANUFACTURER: Final = "Sunricher"
+CONF_SERIAL_NUMBER: Final = "serial_number"
+
+MIN_SUPPORTED_SW_VERSION: Final = "3.59"
+MIN_SUPPORTED_FW_VERSION: Final = "1.45"

--- a/homeassistant/components/sunricher_dali/quality_scale.yaml
+++ b/homeassistant/components/sunricher_dali/quality_scale.yaml
@@ -73,7 +73,7 @@ rules:
       by the entity platforms via their defaults and device classes where
       applicable.
   reconfiguration-flow: todo
-  repair-issues: todo
+  repair-issues: done
   stale-devices: todo
 
   # Platinum

--- a/homeassistant/components/sunricher_dali/strings.json
+++ b/homeassistant/components/sunricher_dali/strings.json
@@ -31,5 +31,11 @@
     "cannot_discover_devices": {
       "message": "Unable to discover devices and scenes from the gateway."
     }
+  },
+  "issues": {
+    "unsupported_firmware": {
+      "description": "The Sunricher DALI gateway is running unsupported firmware (software {sw_version}, firmware {fw_version}). Please upgrade through the DALI Center app to at least software {min_sw_version} and firmware {min_fw_version} to ensure full functionality.",
+      "title": "Unsupported gateway firmware"
+    }
   }
 }

--- a/tests/components/sunricher_dali/conftest.py
+++ b/tests/components/sunricher_dali/conftest.py
@@ -7,7 +7,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from PySrDaliGateway.helper import gen_device_unique_id, gen_group_unique_id
 import pytest
 
-from homeassistant.components.sunricher_dali.const import CONF_SERIAL_NUMBER, DOMAIN
+from homeassistant.components.sunricher_dali.const import (
+    CONF_SERIAL_NUMBER,
+    DOMAIN,
+    MIN_SUPPORTED_FW_VERSION,
+    MIN_SUPPORTED_SW_VERSION,
+)
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
@@ -314,6 +319,8 @@ def mock_gateway(
         mock_gateway.name = "Test Gateway"
         mock_gateway.username = "gateway_user"
         mock_gateway.passwd = "gateway_pass"
+        mock_gateway.software_version = MIN_SUPPORTED_SW_VERSION
+        mock_gateway.firmware_version = MIN_SUPPORTED_FW_VERSION
         mock_gateway.connect = AsyncMock()
         mock_gateway.disconnect = AsyncMock()
         mock_gateway.discover_devices = AsyncMock(return_value=mock_devices)

--- a/tests/components/sunricher_dali/test_init.py
+++ b/tests/components/sunricher_dali/test_init.py
@@ -1,16 +1,53 @@
 """Test the Sunricher DALI integration initialization."""
 
-from unittest.mock import MagicMock
+from collections.abc import Callable
+from unittest.mock import MagicMock, patch
 
+from PySrDaliGateway import CallbackEventType
 from PySrDaliGateway.exceptions import DaliGatewayError
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.sunricher_dali.const import DOMAIN
+from homeassistant.components.sunricher_dali.const import (
+    DOMAIN,
+    MIN_SUPPORTED_FW_VERSION,
+    MIN_SUPPORTED_SW_VERSION,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, issue_registry as ir
 
 from tests.common import MockConfigEntry
+
+
+def _register_stale_firmware_issue(hass: HomeAssistant, entry: MockConfigEntry) -> None:
+    """Pre-register an unsupported_firmware issue from a prior setup."""
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        f"unsupported_firmware_{entry.entry_id}",
+        is_fixable=False,
+        is_persistent=True,
+        issue_domain=DOMAIN,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key="unsupported_firmware",
+        translation_placeholders={
+            "sw_version": "3.50",
+            "fw_version": "1.30",
+            "min_sw_version": MIN_SUPPORTED_SW_VERSION,
+            "min_fw_version": MIN_SUPPORTED_FW_VERSION,
+        },
+    )
+
+
+def _get_version_listener(
+    mock_gateway: MagicMock,
+) -> Callable[[tuple[str, str]], None]:
+    """Find the VERSION_UPDATED listener registered on the gateway."""
+    for call in mock_gateway.register_listener.call_args_list:
+        if call.args[0] == CallbackEventType.VERSION_UPDATED:
+            return call.args[1]
+    raise AssertionError("VERSION_UPDATED listener was not registered")
 
 
 async def test_setup_entry_success(
@@ -79,6 +116,25 @@ async def test_setup_entry_discovery_error(
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
     mock_gateway.connect.assert_called_once()
     mock_gateway.discover_devices.assert_called_once()
+    mock_gateway.disconnect.assert_called_once()
+
+
+async def test_setup_entry_unexpected_discovery_error_cleans_up(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_gateway: MagicMock,
+) -> None:
+    """Test setup cleans up gateway resources after unexpected discovery errors."""
+    mock_config_entry.add_to_hass(hass)
+    mock_gateway.discover_devices.side_effect = RuntimeError("Unexpected failure")
+
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    mock_gateway.connect.assert_called_once()
+    mock_gateway.discover_devices.assert_called_once()
+    mock_gateway.disconnect.assert_called_once()
 
 
 async def test_unload_entry(
@@ -135,3 +191,163 @@ async def test_remove_stale_devices(
     )
     assert gateway_device is not None
     assert mock_config_entry.entry_id in gateway_device.config_entries
+
+
+@pytest.mark.parametrize(
+    ("sw_version", "fw_version", "preregister", "issue_exists"),
+    [
+        # versions below threshold create the issue
+        ("3.50", "1.45", False, True),
+        ("3.59", "1.30", False, True),
+        ("3.50", "1.30", False, True),
+        # versions at or above threshold clear any pre-existing issue
+        (MIN_SUPPORTED_SW_VERSION, MIN_SUPPORTED_FW_VERSION, True, False),
+        ("3.99", "1.99", True, False),
+        # supported versions without a pre-existing issue stay clean
+        ("3.99", "1.99", False, False),
+        # missing or unparsable versions skip the check, leaving any prior issue intact
+        ("", "1.45", True, True),
+        ("3.59", "", True, True),
+        ("not-a-version", "1.45", True, True),
+        ("3.59", "??", True, True),
+    ],
+)
+async def test_firmware_version_issue(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_gateway: MagicMock,
+    issue_registry: ir.IssueRegistry,
+    sw_version: str,
+    fw_version: str,
+    preregister: bool,
+    issue_exists: bool,
+) -> None:
+    """Make sure we get the issue for certain gateway firmware versions."""
+    mock_config_entry.add_to_hass(hass)
+    if preregister:
+        _register_stale_firmware_issue(hass, mock_config_entry)
+    mock_gateway.software_version = sw_version
+    mock_gateway.firmware_version = fw_version
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    issue_id = f"unsupported_firmware_{mock_config_entry.entry_id}"
+    issue = issue_registry.async_get_issue(DOMAIN, issue_id)
+    assert (issue is not None) == issue_exists
+
+
+async def test_firmware_listener_runtime_update(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_gateway: MagicMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """The VERSION_UPDATED listener re-evaluates the issue on runtime version changes."""
+    mock_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    issue_id = f"unsupported_firmware_{mock_config_entry.entry_id}"
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is None
+
+    listener = _get_version_listener(mock_gateway)
+
+    listener(("3.50", "1.30"))
+    await hass.async_block_till_done()
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is not None
+
+    listener(("3.99", "1.99"))
+    await hass.async_block_till_done()
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is None
+
+
+async def test_firmware_issue_raised_when_discover_fails(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_gateway: MagicMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Repair issue is raised from a delayed version event before discover fails."""
+    version_listener: Callable[[tuple[str, str]], None] | None = None
+    version_listener_subscribed = True
+
+    def _register_listener(
+        event_type: CallbackEventType,
+        listener: Callable[[tuple[str, str]], None],
+        _dev_id: str,
+    ) -> Callable[[], None]:
+        nonlocal version_listener, version_listener_subscribed
+        if event_type == CallbackEventType.VERSION_UPDATED:
+            version_listener = listener
+            version_listener_subscribed = True
+
+        def _unsubscribe() -> None:
+            nonlocal version_listener_subscribed
+            version_listener_subscribed = False
+
+        return _unsubscribe
+
+    def _emit_version_update() -> None:
+        if version_listener is None or not version_listener_subscribed:
+            return
+        version_listener(("3.50", "1.30"))
+
+    async def _discover_devices() -> None:
+        _emit_version_update()
+        raise DaliGatewayError("discover failed")
+
+    mock_gateway.register_listener.side_effect = _register_listener
+    mock_gateway.software_version = ""
+    mock_gateway.firmware_version = ""
+    mock_gateway.discover_devices.side_effect = _discover_devices
+    mock_config_entry.add_to_hass(hass)
+
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    issue_id = f"unsupported_firmware_{mock_config_entry.entry_id}"
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is not None
+    mock_gateway.disconnect.assert_called_once()
+
+
+async def test_firmware_listener_unsubscribed_when_forward_fails(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_gateway: MagicMock,
+) -> None:
+    """VERSION_UPDATED listener is removed if platform setup fails."""
+    unsubscribe = MagicMock()
+    mock_gateway.register_listener.return_value = unsubscribe
+    mock_config_entry.add_to_hass(hass)
+
+    with patch.object(
+        hass.config_entries,
+        "async_forward_entry_setups",
+        side_effect=RuntimeError("platform setup failed"),
+    ):
+        assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    unsubscribe.assert_called_once()
+    mock_gateway.disconnect.assert_called_once()
+
+
+async def test_remove_entry_clears_firmware_issue(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_gateway: MagicMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """async_remove_entry deletes the persistent unsupported_firmware issue."""
+    mock_config_entry.add_to_hass(hass)
+    _register_stale_firmware_issue(hass, mock_config_entry)
+    issue_id = f"unsupported_firmware_{mock_config_entry.entry_id}"
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is not None
+
+    assert await hass.config_entries.async_remove(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is None


### PR DESCRIPTION
Adds a per-config-entry repair issue when a Sunricher DALI gateway reports software or firmware below the supported minimum, and clears the issue again after an upgrade. The version listener is registered before connect so the issue can be raised even when discovery later fails, and setup failure paths clean up the listener and gateway connection.

Verify: ruff format/check, mypy, pylint, pytest tests/components/sunricher_dali/test_init.py, and pytest tests/components/sunricher_dali all pass locally. Field smoke on HA 192.168.2.149 confirmed the existing sunricher_dali entry is loaded with 67 devices and no active sunricher_dali repairs; this remains draft because the PR branch has not yet been deployed to that HA instance for hardware validation.