### PR TITLE
Add repair issue for unsupported gateway firmware to sunricher_dali

### DIFF
--- a/homeassistant/components/sunricher_dali/__init__.py
+++ b/homeassistant/components/sunricher_dali/__init__.py
@@ -1,10 +1,12 @@
 """The Sunricher DALI integration."""
 
 import asyncio
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
+from contextlib import suppress
 import logging
 
-from PySrDaliGateway import DaliGateway, Device
+from packaging.version import InvalidVersion, Version
+from PySrDaliGateway import CallbackEventType, DaliGateway, Device
 from PySrDaliGateway.exceptions import DaliGatewayError
 
 from homeassistant.const import (
@@ -15,12 +17,18 @@ from homeassistant.const import (
     CONF_USERNAME,
     Platform,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, issue_registry as ir
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 
-from .const import CONF_SERIAL_NUMBER, DOMAIN, MANUFACTURER
+from .const import (
+    CONF_SERIAL_NUMBER,
+    DOMAIN,
+    MANUFACTURER,
+    MIN_SUPPORTED_FW_VERSION,
+    MIN_SUPPORTED_SW_VERSION,
+)
 from .types import DaliCenterConfigEntry, DaliCenterData
 
 _PLATFORMS: list[Platform] = [
@@ -31,6 +39,18 @@ _PLATFORMS: list[Platform] = [
     Platform.SENSOR,
 ]
 _LOGGER = logging.getLogger(__name__)
+
+_MIN_SUPPORTED_SW = Version(MIN_SUPPORTED_SW_VERSION)
+_MIN_SUPPORTED_FW = Version(MIN_SUPPORTED_FW_VERSION)
+
+
+async def _async_cleanup_failed_setup(
+    gateway: DaliGateway, unsub_version: Callable[[], None]
+) -> None:
+    """Clean up resources registered before config entry setup completed."""
+    unsub_version()
+    with suppress(DaliGatewayError):
+        await gateway.disconnect()
 
 
 def _remove_missing_devices(
@@ -78,21 +98,40 @@ async def async_setup_entry(hass: HomeAssistant, entry: DaliCenterConfigEntry) -
     )
     gw_sn = gateway.gw_sn
 
+    @callback
+    def _handle_version_update(versions: tuple[str, str]) -> None:
+        _async_check_firmware_version(hass, entry, gateway, versions)
+
+    unsub_version = gateway.register_listener(
+        CallbackEventType.VERSION_UPDATED,
+        _handle_version_update,
+        gateway.gw_sn,
+    )
+
     try:
         await gateway.connect()
     except DaliGatewayError as exc:
+        unsub_version()
         raise ConfigEntryNotReady(
             translation_domain=DOMAIN,
             translation_key="cannot_connect",
             translation_placeholders={"host": entry.data[CONF_HOST]},
         ) from exc
 
+    if gateway.software_version and gateway.firmware_version:
+        _async_check_firmware_version(hass, entry, gateway)
+
     try:
         devices, scenes = await asyncio.gather(
             gateway.discover_devices(),
             gateway.discover_scenes(),
         )
-    except DaliGatewayError as exc:
+    except Exception as exc:
+        # async_on_unload only fires after a successful load, so clean up
+        # the listener manually before bailing out.
+        await _async_cleanup_failed_setup(gateway, unsub_version)
+        if not isinstance(exc, DaliGatewayError):
+            raise
         raise ConfigEntryNotReady(
             translation_domain=DOMAIN,
             translation_key="cannot_discover_devices",
@@ -117,9 +156,64 @@ async def async_setup_entry(hass: HomeAssistant, entry: DaliCenterConfigEntry) -
         devices=devices,
         scenes=scenes,
     )
-    await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
+    try:
+        await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
+    except Exception:
+        await _async_cleanup_failed_setup(gateway, unsub_version)
+        raise
+    entry.async_on_unload(unsub_version)
 
     return True
+
+
+@callback
+def _async_check_firmware_version(
+    hass: HomeAssistant,
+    entry: DaliCenterConfigEntry,
+    gateway: DaliGateway,
+    versions: tuple[str, str] | None = None,
+) -> None:
+    """Raise a repair issue if the gateway firmware is below supported minimums."""
+    sw_version, fw_version = versions or (
+        gateway.software_version,
+        gateway.firmware_version,
+    )
+    issue_id = f"unsupported_firmware_{entry.entry_id}"
+
+    if not sw_version or not fw_version:
+        return
+
+    try:
+        sw_parsed = Version(sw_version)
+        fw_parsed = Version(fw_version)
+    except InvalidVersion:
+        _LOGGER.debug(
+            "Gateway %s reported unparsable firmware version (sw=%s, fw=%s)",
+            gateway.gw_sn,
+            sw_version,
+            fw_version,
+        )
+        return
+
+    if sw_parsed < _MIN_SUPPORTED_SW or fw_parsed < _MIN_SUPPORTED_FW:
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=False,
+            is_persistent=True,
+            issue_domain=DOMAIN,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key="unsupported_firmware",
+            translation_placeholders={
+                "sw_version": sw_version,
+                "fw_version": fw_version,
+                "min_sw_version": MIN_SUPPORTED_SW_VERSION,
+                "min_fw_version": MIN_SUPPORTED_FW_VERSION,
+            },
+        )
+    else:
+        ir.async_delete_issue(hass, DOMAIN, issue_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: DaliCenterConfigEntry) -> bool:
@@ -127,3 +221,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: DaliCenterConfigEntry) 
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, _PLATFORMS):
         await entry.runtime_data.gateway.disconnect()
     return unload_ok
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: DaliCenterConfigEntry) -> None:
+    """Clear persistent repair issues that belong to this entry."""
+    ir.async_delete_issue(hass, DOMAIN, f"unsupported_firmware_{entry.entry_id}")

--- a/homeassistant/components/sunricher_dali/const.py
+++ b/homeassistant/components/sunricher_dali/const.py
@@ -1,5 +1,10 @@
 """Constants for the Sunricher DALI integration."""
 
-DOMAIN = "sunricher_dali"
-MANUFACTURER = "Sunricher"
-CONF_SERIAL_NUMBER = "serial_number"
+from typing import Final
+
+DOMAIN: Final = "sunricher_dali"
+MANUFACTURER: Final = "Sunricher"
+CONF_SERIAL_NUMBER: Final = "serial_number"
+
+MIN_SUPPORTED_SW_VERSION: Final = "3.59"
+MIN_SUPPORTED_FW_VERSION: Final = "1.45"

--- a/homeassistant/components/sunricher_dali/quality_scale.yaml
+++ b/homeassistant/components/sunricher_dali/quality_scale.yaml
@@ -73,7 +73,7 @@ rules:
       by the entity platforms via their defaults and device classes where
       applicable.
   reconfiguration-flow: todo
-  repair-issues: todo
+  repair-issues: done
   stale-devices: todo
 
   # Platinum

--- a/homeassistant/components/sunricher_dali/strings.json
+++ b/homeassistant/components/sunricher_dali/strings.json
@@ -31,5 +31,11 @@
     "cannot_discover_devices": {
       "message": "Unable to discover devices and scenes from the gateway."
     }
+  },
+  "issues": {
+    "unsupported_firmware": {
+      "description": "The Sunricher DALI gateway is running unsupported firmware (software {sw_version}, firmware {fw_version}). Please upgrade through the DALI Center app to at least software {min_sw_version} and firmware {min_fw_version} to ensure full functionality.",
+      "title": "Unsupported gateway firmware"
+    }
   }
 }

--- a/tests/components/sunricher_dali/conftest.py
+++ b/tests/components/sunricher_dali/conftest.py
@@ -7,7 +7,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from PySrDaliGateway.helper import gen_device_unique_id, gen_group_unique_id
 import pytest
 
-from homeassistant.components.sunricher_dali.const import CONF_SERIAL_NUMBER, DOMAIN
+from homeassistant.components.sunricher_dali.const import (
+    CONF_SERIAL_NUMBER,
+    DOMAIN,
+    MIN_SUPPORTED_FW_VERSION,
+    MIN_SUPPORTED_SW_VERSION,
+)
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
@@ -314,6 +319,8 @@ def mock_gateway(
         mock_gateway.name = "Test Gateway"
         mock_gateway.username = "gateway_user"
         mock_gateway.passwd = "gateway_pass"
+        mock_gateway.software_version = MIN_SUPPORTED_SW_VERSION
+        mock_gateway.firmware_version = MIN_SUPPORTED_FW_VERSION
         mock_gateway.connect = AsyncMock()
         mock_gateway.disconnect = AsyncMock()
         mock_gateway.discover_devices = AsyncMock(return_value=mock_devices)

--- a/tests/components/sunricher_dali/test_init.py
+++ b/tests/components/sunricher_dali/test_init.py
@@ -1,16 +1,53 @@
 """Test the Sunricher DALI integration initialization."""
 
-from unittest.mock import MagicMock
+from collections.abc import Callable
+from unittest.mock import MagicMock, patch
 
+from PySrDaliGateway import CallbackEventType
 from PySrDaliGateway.exceptions import DaliGatewayError
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.sunricher_dali.const import DOMAIN
+from homeassistant.components.sunricher_dali.const import (
+    DOMAIN,
+    MIN_SUPPORTED_FW_VERSION,
+    MIN_SUPPORTED_SW_VERSION,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, issue_registry as ir
 
 from tests.common import MockConfigEntry
+
+
+def _register_stale_firmware_issue(hass: HomeAssistant, entry: MockConfigEntry) -> None:
+    """Pre-register an unsupported_firmware issue from a prior setup."""
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        f"unsupported_firmware_{entry.entry_id}",
+        is_fixable=False,
+        is_persistent=True,
+        issue_domain=DOMAIN,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key="unsupported_firmware",
+        translation_placeholders={
+            "sw_version": "3.50",
+            "fw_version": "1.30",
+            "min_sw_version": MIN_SUPPORTED_SW_VERSION,
+            "min_fw_version": MIN_SUPPORTED_FW_VERSION,
+        },
+    )
+
+
+def _get_version_listener(
+    mock_gateway: MagicMock,
+) -> Callable[[tuple[str, str]], None]:
+    """Find the VERSION_UPDATED listener registered on the gateway."""
+    for call in mock_gateway.register_listener.call_args_list:
+        if call.args[0] == CallbackEventType.VERSION_UPDATED:
+            return call.args[1]
+    raise AssertionError("VERSION_UPDATED listener was not registered")
 
 
 async def test_setup_entry_success(
@@ -79,6 +116,25 @@ async def test_setup_entry_discovery_error(
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
     mock_gateway.connect.assert_called_once()
     mock_gateway.discover_devices.assert_called_once()
+    mock_gateway.disconnect.assert_called_once()
+
+
+async def test_setup_entry_unexpected_discovery_error_cleans_up(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_gateway: MagicMock,
+) -> None:
+    """Test setup cleans up gateway resources after unexpected discovery errors."""
+    mock_config_entry.add_to_hass(hass)
+    mock_gateway.discover_devices.side_effect = RuntimeError("Unexpected failure")
+
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    mock_gateway.connect.assert_called_once()
+    mock_gateway.discover_devices.assert_called_once()
+    mock_gateway.disconnect.assert_called_once()
 
 
 async def test_unload_entry(
@@ -135,3 +191,163 @@ async def test_remove_stale_devices(
     )
     assert gateway_device is not None
     assert mock_config_entry.entry_id in gateway_device.config_entries
+
+
+@pytest.mark.parametrize(
+    ("sw_version", "fw_version", "preregister", "issue_exists"),
+    [
+        # versions below threshold create the issue
+        ("3.50", "1.45", False, True),
+        ("3.59", "1.30", False, True),
+        ("3.50", "1.30", False, True),
+        # versions at or above threshold clear any pre-existing issue
+        (MIN_SUPPORTED_SW_VERSION, MIN_SUPPORTED_FW_VERSION, True, False),
+        ("3.99", "1.99", True, False),
+        # supported versions without a pre-existing issue stay clean
+        ("3.99", "1.99", False, False),
+        # missing or unparsable versions skip the check, leaving any prior issue intact
+        ("", "1.45", True, True),
+        ("3.59", "", True, True),
+        ("not-a-version", "1.45", True, True),
+        ("3.59", "??", True, True),
+    ],
+)
+async def test_firmware_version_issue(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_gateway: MagicMock,
+    issue_registry: ir.IssueRegistry,
+    sw_version: str,
+    fw_version: str,
+    preregister: bool,
+    issue_exists: bool,
+) -> None:
+    """Make sure we get the issue for certain gateway firmware versions."""
+    mock_config_entry.add_to_hass(hass)
+    if preregister:
+        _register_stale_firmware_issue(hass, mock_config_entry)
+    mock_gateway.software_version = sw_version
+    mock_gateway.firmware_version = fw_version
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    issue_id = f"unsupported_firmware_{mock_config_entry.entry_id}"
+    issue = issue_registry.async_get_issue(DOMAIN, issue_id)
+    assert (issue is not None) == issue_exists
+
+
+async def test_firmware_listener_runtime_update(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_gateway: MagicMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """The VERSION_UPDATED listener re-evaluates the issue on runtime version changes."""
+    mock_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    issue_id = f"unsupported_firmware_{mock_config_entry.entry_id}"
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is None
+
+    listener = _get_version_listener(mock_gateway)
+
+    listener(("3.50", "1.30"))
+    await hass.async_block_till_done()
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is not None
+
+    listener(("3.99", "1.99"))
+    await hass.async_block_till_done()
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is None
+
+
+async def test_firmware_issue_raised_when_discover_fails(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_gateway: MagicMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Repair issue is raised from a delayed version event before discover fails."""
+    version_listener: Callable[[tuple[str, str]], None] | None = None
+    version_listener_subscribed = True
+
+    def _register_listener(
+        event_type: CallbackEventType,
+        listener: Callable[[tuple[str, str]], None],
+        _dev_id: str,
+    ) -> Callable[[], None]:
+        nonlocal version_listener, version_listener_subscribed
+        if event_type == CallbackEventType.VERSION_UPDATED:
+            version_listener = listener
+            version_listener_subscribed = True
+
+        def _unsubscribe() -> None:
+            nonlocal version_listener_subscribed
+            version_listener_subscribed = False
+
+        return _unsubscribe
+
+    def _emit_version_update() -> None:
+        if version_listener is None or not version_listener_subscribed:
+            return
+        version_listener(("3.50", "1.30"))
+
+    async def _discover_devices() -> None:
+        _emit_version_update()
+        raise DaliGatewayError("discover failed")
+
+    mock_gateway.register_listener.side_effect = _register_listener
+    mock_gateway.software_version = ""
+    mock_gateway.firmware_version = ""
+    mock_gateway.discover_devices.side_effect = _discover_devices
+    mock_config_entry.add_to_hass(hass)
+
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    issue_id = f"unsupported_firmware_{mock_config_entry.entry_id}"
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is not None
+    mock_gateway.disconnect.assert_called_once()
+
+
+async def test_firmware_listener_unsubscribed_when_forward_fails(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_gateway: MagicMock,
+) -> None:
+    """VERSION_UPDATED listener is removed if platform setup fails."""
+    unsubscribe = MagicMock()
+    mock_gateway.register_listener.return_value = unsubscribe
+    mock_config_entry.add_to_hass(hass)
+
+    with patch.object(
+        hass.config_entries,
+        "async_forward_entry_setups",
+        side_effect=RuntimeError("platform setup failed"),
+    ):
+        assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    unsubscribe.assert_called_once()
+    mock_gateway.disconnect.assert_called_once()
+
+
+async def test_remove_entry_clears_firmware_issue(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_gateway: MagicMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """async_remove_entry deletes the persistent unsupported_firmware issue."""
+    mock_config_entry.add_to_hass(hass)
+    _register_stale_firmware_issue(hass, mock_config_entry)
+    issue_id = f"unsupported_firmware_{mock_config_entry.entry_id}"
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is not None
+
+    assert await hass.config_entries.async_remove(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Raises a repair issue when the gateway reports software or firmware versions below the minimums known to work, so users get an actionable nudge to upgrade through the DALI Center app instead of seeing setup retry indefinitely. Marks the `repair-issues` quality scale rule as done.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

