### PR TITLE
Enable ruff RUF057 rule and remove unnecessary round() calls

### DIFF
--- a/homeassistant/components/philips_js/light.py
+++ b/homeassistant/components/philips_js/light.py
@@ -289,7 +289,7 @@ class PhilipsTVLightEntity(PhilipsJsEntity, LightEntity):
             "color": {
                 "hue": round(hs_color[0] * 255.0 / 360.0),
                 "saturation": round(hs_color[1] * 255.0 / 100.0),
-                "brightness": round(brightness),
+                "brightness": brightness,
             },
             "colorDelta": {
                 "hue": 0,

--- a/homeassistant/components/philips_js/light.py
+++ b/homeassistant/components/philips_js/light.py
@@ -245,7 +245,7 @@ class PhilipsTVLightEntity(PhilipsJsEntity, LightEntity):
                 *_average_pixels(self._tv.ambilight_cached)
             )
             self._attr_hs_color = hsv_h, hsv_s
-            self._attr_brightness = hsv_v * 255.0 / 100.0
+            self._attr_brightness = round(hsv_v * 255.0 / 100.0)
         else:
             self._attr_hs_color = None
             self._attr_brightness = None

--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -488,7 +488,7 @@ def color_rgbww_to_rgb(
 
 
 def color_rgb_to_hex(r: int, g: int, b: int) -> str:
-    """Return a RGB color from a hex color string."""
+    """Return a hex color string from RGB integer values."""
     return f"{r:02x}{g:02x}{b:02x}"
 
 

--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -489,7 +489,7 @@ def color_rgbww_to_rgb(
 
 def color_rgb_to_hex(r: int, g: int, b: int) -> str:
     """Return a RGB color from a hex color string."""
-    return f"{round(r):02x}{round(g):02x}{round(b):02x}"
+    return f"{r:02x}{g:02x}{b:02x}"
 
 
 def rgb_hex_to_rgb_list(hex_string: str) -> list[int]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -743,6 +743,7 @@ select = [
   "RUF037", # Unnecessary empty iterable within deque call
   "RUF046", # Unnecessary cast to int
   "RUF051", # Use dict.pop(key, None) instead of if-key-in-dict-del
+  "RUF057", # Unnecessary round call
   "RUF059", # unused-unpacked-variable
   "RUF100", # Unused `noqa` directive
   "RUF101", # noqa directives that use redirected rule codes

--- a/tests/util/test_color.py
+++ b/tests/util/test_color.py
@@ -288,7 +288,7 @@ def test_color_rgb_to_hex() -> None:
     assert color_util.color_rgb_to_hex(255, 255, 255) == "ffffff"
     assert color_util.color_rgb_to_hex(0, 0, 0) == "000000"
     assert color_util.color_rgb_to_hex(51, 153, 255) == "3399ff"
-    assert color_util.color_rgb_to_hex(255, 67.9204190, 0) == "ff4400"
+    assert color_util.color_rgb_to_hex(255, 68, 0) == "ff4400"
 
 
 def test_match_max_scale() -> None:


### PR DESCRIPTION
## Proposed change

Enable the ruff `RUF057` rule (unnecessary-round) and remove 4 redundant `round()` calls on values that are already integers.

- `color_rgb_to_hex(r: int, g: int, b: int)` — `round()` on int parameters is a no-op
- `_set_ambilight_expert_config(brightness: int)` — same

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr