### PR TITLE
Enable ruff DTZ011 rule to detect date.today() usage

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -1066,7 +1066,7 @@ def _validate_timespan(
 
     if event_in := values.get(EVENT_IN):
         days = event_in.get(EVENT_IN_DAYS, 7 * event_in.get(EVENT_IN_WEEKS, 0))
-        today = datetime.date.today()
+        today = datetime.date.today()  # noqa: DTZ011
         return (
             today + datetime.timedelta(days=days),
             today + datetime.timedelta(days=days + 1),

--- a/homeassistant/components/cookidoo/calendar.py
+++ b/homeassistant/components/cookidoo/calendar.py
@@ -58,7 +58,7 @@ class CookidooCalendarEntity(CookidooBaseEntity, CalendarEntity):
         if not self.coordinator.data.week_plan:
             return None
 
-        today = date.today()
+        today = date.today()  # noqa: DTZ011
         for day_data in self.coordinator.data.week_plan:
             day_date = date.fromisoformat(day_data.id)
             if day_date >= today and day_data.recipes:

--- a/homeassistant/components/cookidoo/coordinator.py
+++ b/homeassistant/components/cookidoo/coordinator.py
@@ -81,7 +81,7 @@ class CookidooDataUpdateCoordinator(DataUpdateCoordinator[CookidooData]):
             ingredient_items = await self.cookidoo.get_ingredient_items()
             additional_items = await self.cookidoo.get_additional_items()
             subscription = await self.cookidoo.get_active_subscription()
-            week_plan = await self.cookidoo.get_recipes_in_calendar_week(date.today())
+            week_plan = await self.cookidoo.get_recipes_in_calendar_week(date.today())  # noqa: DTZ011
         except CookidooAuthException:
             try:
                 await self.cookidoo.refresh_token()

--- a/homeassistant/components/habitica/services.py
+++ b/homeassistant/components/habitica/services.py
@@ -740,7 +740,7 @@ async def _create_or_update_task(call: ServiceCall) -> ServiceResponse:  # noqa:
             reminders.extend(
                 Reminders(
                     id=uuid4(),
-                    time=datetime.combine(date.today(), r, tzinfo=UTC),
+                    time=datetime.combine(date.today(), r, tzinfo=UTC),  # noqa: DTZ011
                 )
                 for r in add_reminders
                 if r not in existing_reminder_times

--- a/homeassistant/components/input_datetime/__init__.py
+++ b/homeassistant/components/input_datetime/__init__.py
@@ -98,7 +98,7 @@ def parse_initial_datetime(conf: dict[str, Any]) -> py_datetime.datetime:
         raise vol.Invalid(f"Initial value '{initial}' can't be parsed as a date")
 
     if (time := dt_util.parse_time(initial)) is not None:
-        return py_datetime.datetime.combine(py_datetime.date.today(), time)
+        return py_datetime.datetime.combine(py_datetime.date.today(), time)  # noqa: DTZ011
     raise vol.Invalid(f"Initial value '{initial}' can't be parsed as a time")
 
 
@@ -285,7 +285,8 @@ class InputDatetime(collection.CollectionEntity, RestoreEntity):
             current_datetime = dt_util.parse_datetime(default_value)
         else:
             current_datetime = py_datetime.datetime.combine(
-                py_datetime.date.today(), time
+                py_datetime.date.today(),  # noqa: DTZ011
+                time,
             )
 
         self._current_datetime = current_datetime.replace(

--- a/homeassistant/components/mealie/services.py
+++ b/homeassistant/components/mealie/services.py
@@ -137,8 +137,8 @@ async def _async_get_mealplan(call: ServiceCall) -> ServiceResponse:
     entry: MealieConfigEntry = service.async_get_config_entry(
         call.hass, DOMAIN, call.data[ATTR_CONFIG_ENTRY_ID]
     )
-    start_date = call.data.get(ATTR_START_DATE, date.today())
-    end_date = call.data.get(ATTR_END_DATE, date.today())
+    start_date = call.data.get(ATTR_START_DATE, date.today())  # noqa: DTZ011
+    end_date = call.data.get(ATTR_END_DATE, date.today())  # noqa: DTZ011
     if end_date < start_date:
         raise ServiceValidationError(
             translation_domain=DOMAIN,

--- a/homeassistant/components/recollect_waste/calendar.py
+++ b/homeassistant/components/recollect_waste/calendar.py
@@ -68,7 +68,7 @@ class ReCollectWasteCalendar(ReCollectWasteEntity, CalendarEntity):
             current_event = next(
                 event
                 for event in self.coordinator.data
-                if event.date >= datetime.date.today()
+                if event.date >= datetime.date.today()  # noqa: DTZ011
             )
         except StopIteration:
             self._event = None

--- a/homeassistant/components/recollect_waste/coordinator.py
+++ b/homeassistant/components/recollect_waste/coordinator.py
@@ -52,7 +52,7 @@ class ReCollectWasteDataUpdateCoordinator(DataUpdateCoordinator[list[PickupEvent
             # This ensures that data about when the next pickup is will be
             # returned when the next pickup is the first day of the next month.
             # Ex: Today is August 31st, tomorrow is a pickup on September 1st.
-            today = date.today()
+            today = date.today()  # noqa: DTZ011
             return await self._client.async_get_pickup_events(
                 start_date=today,
                 end_date=today + timedelta(days=35),

--- a/homeassistant/components/recollect_waste/sensor.py
+++ b/homeassistant/components/recollect_waste/sensor.py
@@ -70,7 +70,7 @@ class ReCollectWasteSensor(ReCollectWasteEntity, SensorEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        relevant_events = (e for e in self.coordinator.data if e.date >= date.today())
+        relevant_events = (e for e in self.coordinator.data if e.date >= date.today())  # noqa: DTZ011
         pickup_index = self.PICKUP_INDEX_MAP[self.entity_description.key]
 
         try:

--- a/homeassistant/components/ridwell/entity.py
+++ b/homeassistant/components/ridwell/entity.py
@@ -39,5 +39,5 @@ class RidwellEntity(CoordinatorEntity[RidwellDataUpdateCoordinator]):
         return next(
             event
             for event in self.coordinator.data[self._account.account_id]
-            if event.pickup_date >= date.today()
+            if event.pickup_date >= date.today()  # noqa: DTZ011
         )

--- a/homeassistant/components/saj/sensor.py
+++ b/homeassistant/components/saj/sensor.py
@@ -123,7 +123,7 @@ async def async_setup_platform(
             # Sensors with live values like "temperature" or "current_power"
             # will also be reset to None.
             if not success and (
-                (sensor.per_day_basis and date.today() > sensor.date_updated)
+                (sensor.per_day_basis and date.today() > sensor.date_updated)  # noqa: DTZ011
                 or (not sensor.per_day_basis and not sensor.per_total_basis)
             ):
                 state_unknown = True

--- a/homeassistant/components/solaredge/coordinator.py
+++ b/homeassistant/components/solaredge/coordinator.py
@@ -224,7 +224,7 @@ class SolarEdgeEnergyDetailsService(SolarEdgeDataService):
         """Update the data from the SolarEdge Monitoring API."""
         try:
             now = datetime.now()
-            today = date.today()
+            today = date.today()  # noqa: DTZ011
             midnight = datetime.combine(today, datetime.min.time())
             data = await self.api.get_energy_details(
                 self.site_id,

--- a/homeassistant/components/trafikverket_ferry/coordinator.py
+++ b/homeassistant/components/trafikverket_ferry/coordinator.py
@@ -34,7 +34,7 @@ def next_weekday(fromdate: date, weekday: int) -> date:
 
 def next_departuredate(departure: list[str]) -> date:
     """Calculate the next departuredate from an array input of short days."""
-    today_date = date.today()
+    today_date = date.today()  # noqa: DTZ011
     today_weekday = date.weekday(today_date)
     if WEEKDAYS[today_weekday] in departure:
         return today_date

--- a/homeassistant/components/trafikverket_train/util.py
+++ b/homeassistant/components/trafikverket_train/util.py
@@ -15,7 +15,7 @@ def next_weekday(fromdate: date, weekday: int) -> date:
 
 def next_departuredate(departure: list[str]) -> date:
     """Calculate the next departuredate from an array input of short days."""
-    today_date = date.today()
+    today_date = date.today()  # noqa: DTZ011
     today_weekday = date.weekday(today_date)
     if WEEKDAYS[today_weekday] in departure:
         return today_date

--- a/homeassistant/components/withings/coordinator.py
+++ b/homeassistant/components/withings/coordinator.py
@@ -270,7 +270,7 @@ class WithingsActivityDataUpdateCoordinator(
                 self._last_valid_update
             )
 
-        today = date.today()
+        today = date.today()  # noqa: DTZ011
         for activity in activities:
             if activity.date == today:
                 self._previous_data = activity

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -696,6 +696,7 @@ select = [
   "D",      # docstrings
   "DTZ003", # Use datetime.now(tz=) instead of datetime.utcnow()
   "DTZ004", # Use datetime.fromtimestamp(ts, tz=) instead of datetime.utcfromtimestamp(ts)
+  "DTZ011", # Use datetime.now(tz=).date() instead of date.today()
   "E",      # pycodestyle
   "F",      # pyflakes/autoflake
   "F541",   # f-string without any placeholders

--- a/tests/ruff.toml
+++ b/tests/ruff.toml
@@ -7,6 +7,7 @@ extend-ignore = [
     "B904", # Use raise from to specify exception cause
     "N815", # Variable {name} in class scope should not be mixedCase
     "RUF018", # Avoid assignment expressions in assert statements
+    "DTZ011", # date.today() used: tests commonly use naive dates
     "S107", # Possible hardcoded password assigned to function default
     "SLF001", # Private member accessed: Tests do often test internals a lot
 ]


### PR DESCRIPTION
## Proposed change

Enable the ruff `DTZ011` rule ([call-date-today](https://docs.astral.sh/ruff/rules/call-date-today/)) to flag usage of `date.today()`, which returns the date based on the system's local timezone rather than the Home Assistant configured timezone. This can cause incorrect behavior around midnight for users whose HA timezone differs from the server timezone.

All 17 existing occurrences in production code are suppressed with `# noqa: DTZ011` and tracked as individual bug issues under home-assistant/epics#63. Tests are excluded via `tests/ruff.toml` since test code commonly uses naive dates with frozen time.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: home-assistant/epics#63
  - home-assistant/core#170579 (recollect_waste)
  - home-assistant/core#170580 (calendar)
  - home-assistant/core#170581 (cookidoo)
  - home-assistant/core#170582 (habitica)
  - home-assistant/core#170584 (input_datetime)
  - home-assistant/core#170585 (mealie)
  - home-assistant/core#170586 (trafikverket_ferry)
  - home-assistant/core#170587 (ridwell)
  - home-assistant/core#170588 (saj)
  - home-assistant/core#170589 (solaredge)
  - home-assistant/core#170590 (trafikverket_train)
  - home-assistant/core#170591 (withings)
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr