### PR TITLE
Bump infrared-protocols to 5.3.0

### DIFF
--- a/homeassistant/components/infrared/manifest.json
+++ b/homeassistant/components/infrared/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/infrared",
   "integration_type": "entity",
   "quality_scale": "internal",
-  "requirements": ["infrared-protocols==5.2.0"]
+  "requirements": ["infrared-protocols==5.3.0"]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ home-assistant-bluetooth==2.0.0
 home-assistant-intents==2026.5.5
 httpx==0.28.1
 ifaddr==0.2.0
-infrared-protocols==5.2.0
+infrared-protocols==5.3.0
 Jinja2==3.1.6
 lru-dict==1.4.1
 mutagen==1.47.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1356,7 +1356,7 @@ influxdb-client==1.50.0
 influxdb==5.3.1
 
 # homeassistant.components.infrared
-infrared-protocols==5.2.0
+infrared-protocols==5.3.0
 
 # homeassistant.components.inkbird
 inkbird-ble==1.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1211,7 +1211,7 @@ influxdb-client==1.50.0
 influxdb==5.3.1
 
 # homeassistant.components.infrared
-infrared-protocols==5.2.0
+infrared-protocols==5.3.0
 
 # homeassistant.components.inkbird
 inkbird-ble==1.1.1


### PR DESCRIPTION
## Proposed change

Bump `infrared-protocols` from 5.2.0 to 5.3.0.

This release adds discrete power/mute and CBL/SAT/DVD/AUX source codes for Marantz devices.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Release notes: https://github.com/home-assistant-libs/infrared-protocols/releases/tag/5.3.0
Diff: https://github.com/home-assistant-libs/infrared-protocols/compare/5.2.0...5.3.0

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


---
_Generated by [Claude Code](https://claude.ai/code/session_01U7w1bVf6KabWbzNPMgZJt9)_