### PR TITLE
Fix swallowed exception in opendisplay upload_image action handler

### DIFF
--- a/homeassistant/components/opendisplay/services.py
+++ b/homeassistant/components/opendisplay/services.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from collections.abc import Callable
+import contextlib
 from datetime import timedelta
 from enum import IntEnum
 import io
@@ -149,6 +150,13 @@ async def _async_download_image(hass: HomeAssistant, url: str) -> PILImage.Image
     return await hass.async_add_executor_job(_load_image_from_bytes, data)
 
 
+async def _cancel_upload_task(task: asyncio.Task) -> None:
+    """Cancel a running upload task and wait for it to finish."""
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+
 async def _async_upload_image(call: ServiceCall) -> None:
     """Handle the upload_image service call."""
     entry = _get_entry_for_device(call)
@@ -175,11 +183,7 @@ async def _async_upload_image(call: ServiceCall) -> None:
 
     current = asyncio.current_task()
     if (prev := entry.runtime_data.upload_task) is not None and not prev.done():
-        prev.cancel()
-        try:  # noqa: SIM105 - contextlib.suppress triggers E7405 in action handlers
-            await prev
-        except asyncio.CancelledError:
-            pass
+        await _cancel_upload_task(prev)
     entry.runtime_data.upload_task = current
 
     try:

--- a/homeassistant/components/opendisplay/services.py
+++ b/homeassistant/components/opendisplay/services.py
@@ -2,7 +2,6 @@
 
 import asyncio
 from collections.abc import Callable
-import contextlib
 from datetime import timedelta
 from enum import IntEnum
 import io
@@ -150,13 +149,6 @@ async def _async_download_image(hass: HomeAssistant, url: str) -> PILImage.Image
     return await hass.async_add_executor_job(_load_image_from_bytes, data)
 
 
-async def _cancel_upload_task(task: asyncio.Task) -> None:
-    """Cancel a running upload task and wait for it to finish."""
-    task.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await task
-
-
 async def _async_upload_image(call: ServiceCall) -> None:
     """Handle the upload_image service call."""
     entry = _get_entry_for_device(call)
@@ -183,7 +175,8 @@ async def _async_upload_image(call: ServiceCall) -> None:
 
     current = asyncio.current_task()
     if (prev := entry.runtime_data.upload_task) is not None and not prev.done():
-        await _cancel_upload_task(prev)
+        prev.cancel()
+        await asyncio.wait({prev})
     entry.runtime_data.upload_task = current
 
     try:

--- a/homeassistant/components/opendisplay/services.py
+++ b/homeassistant/components/opendisplay/services.py
@@ -2,7 +2,6 @@
 
 import asyncio
 from collections.abc import Callable
-import contextlib
 from datetime import timedelta
 from enum import IntEnum
 import io
@@ -177,9 +176,10 @@ async def _async_upload_image(call: ServiceCall) -> None:
     current = asyncio.current_task()
     if (prev := entry.runtime_data.upload_task) is not None and not prev.done():
         prev.cancel()
-        # pylint: disable-next=home-assistant-action-swallowed-exception
-        with contextlib.suppress(asyncio.CancelledError):
+        try:  # noqa: SIM105 - contextlib.suppress triggers E7405 in action handlers
             await prev
+        except asyncio.CancelledError:
+            pass
     entry.runtime_data.upload_task = current
 
     try:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replace `contextlib.suppress(asyncio.CancelledError)` with `asyncio.wait()` when awaiting a cancelled upload task. `asyncio.wait()` does not propagate task exceptions, so no exception suppression is needed, satisfying the `home-assistant-action-swallowed-exception` rule (E7405) without workarounds.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170630
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
