### PR TITLE
Enable the ruff  rule (unnecessary-empty-iterable-within-deque-call) and simplify 7  initializations

### DIFF
--- a/homeassistant/components/brands/__init__.py
+++ b/homeassistant/components/brands/__init__.py
@@ -41,7 +41,7 @@ CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Brands integration."""
-    access_tokens: deque[str] = deque([], 2)
+    access_tokens: deque[str] = deque(maxlen=2)
     access_tokens.append(hex(_RND.getrandbits(256))[2:])
     hass.data[DOMAIN] = access_tokens
 

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -445,7 +445,7 @@ class Camera(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         self.stream: Stream | None = None
         self.stream_options: dict[str, str | bool | float] = {}
         self.content_type: str = DEFAULT_CONTENT_TYPE
-        self.access_tokens: collections.deque = collections.deque([], 2)
+        self.access_tokens: collections.deque = collections.deque(maxlen=2)
         self._warned_old_signature = False
         self.async_update_token()
         self._create_stream_lock: asyncio.Lock | None = None

--- a/homeassistant/components/image/__init__.py
+++ b/homeassistant/components/image/__init__.py
@@ -207,7 +207,7 @@ class ImageEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     def __init__(self, hass: HomeAssistant, verify_ssl: bool = False) -> None:
         """Initialize an image entity."""
         self._client = get_async_client(hass, verify_ssl=verify_ssl)
-        self.access_tokens: collections.deque = collections.deque([], 2)
+        self.access_tokens: collections.deque = collections.deque(maxlen=2)
         self.async_update_token()
 
     @cached_property

--- a/homeassistant/components/mqtt/debug_info.py
+++ b/homeassistant/components/mqtt/debug_info.py
@@ -42,7 +42,7 @@ def log_message(
     )
     if topic not in entity_info["transmitted"]:
         entity_info["transmitted"][topic] = {
-            "messages": deque([], STORED_MESSAGES),
+            "messages": deque(maxlen=STORED_MESSAGES),
         }
     msg = TimestampedPublishMessage(
         topic, payload, qos, retain, timestamp=time.monotonic()
@@ -61,7 +61,7 @@ def add_subscription(
         if subscription not in entity_info["subscriptions"]:
             entity_info["subscriptions"][subscription] = {
                 "count": 1,
-                "messages": deque([], STORED_MESSAGES),
+                "messages": deque(maxlen=STORED_MESSAGES),
             }
         else:
             entity_info["subscriptions"][subscription]["count"] += 1

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -555,7 +555,7 @@ async def async_start(  # noqa: C901
                     MQTT_DISCOVERY_DONE.format(*discovery_hash),
                     discovery_done,
                 ),
-                "pending": deque([]),
+                "pending": deque(),
             }
 
         if component not in mqtt_data.platforms_loaded and payload:

--- a/homeassistant/components/push/camera.py
+++ b/homeassistant/components/push/camera.py
@@ -118,7 +118,7 @@ class PushCamera(Camera):
         self._filename = None
         self._expired_listener = None
         self._timeout = timeout
-        self.queue: deque[bytes] = deque([], buffer_size)
+        self.queue: deque[bytes] = deque(maxlen=buffer_size)
         self._current_image: bytes | None = None
         self._image_field = image_field
         self.webhook_id = webhook_id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -739,6 +739,7 @@ select = [
   "RUF032", # Decimal() called with float literal argument
   "RUF033", # __post_init__ method with argument defaults
   "RUF034", # Useless if-else condition
+  "RUF037", # Unnecessary empty iterable within deque call
   "RUF046", # Unnecessary cast to int
   "RUF051", # Use dict.pop(key, None) instead of if-key-in-dict-del
   "RUF059", # unused-unpacked-variable


### PR DESCRIPTION
## Proposed change

Enable the ruff `RUF037` rule (unnecessary-empty-iterable-within-deque-call) and simplify 7 `deque` initializations.

`deque([], maxlen)` is equivalent to `deque(maxlen=maxlen)` and `deque([])` is equivalent to `deque()`. The empty iterable argument is unnecessary and allocates a list for no reason.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr