### PR TITLE
Fix line length violations in components m

### DIFF
--- a/homeassistant/components/madvr/config_flow.py
+++ b/homeassistant/components/madvr/config_flow.py
@@ -104,7 +104,8 @@ async def test_connection(hass: HomeAssistant, host: str, port: int) -> str:
     # try to connect
     try:
         await asyncio.wait_for(madvr_client.open_connection(), timeout=15)
-    # connection can raise HeartBeatError if the device is not available or connection does not work
+    # connection can raise HeartBeatError if the device is not
+    # available or connection does not work
     except (TimeoutError, aiohttp.ClientError, OSError, HeartBeatError) as err:
         _LOGGER.error("Error connecting to madVR: %s", err)
         raise CannotConnect from err

--- a/homeassistant/components/manual/alarm_control_panel.py
+++ b/homeassistant/components/manual/alarm_control_panel.py
@@ -82,7 +82,9 @@ SUPPORTED_ARMING_STATE_TO_FEATURE = {
     AlarmControlPanelState.ARMED_HOME: AlarmControlPanelEntityFeature.ARM_HOME,
     AlarmControlPanelState.ARMED_NIGHT: AlarmControlPanelEntityFeature.ARM_NIGHT,
     AlarmControlPanelState.ARMED_VACATION: AlarmControlPanelEntityFeature.ARM_VACATION,
-    AlarmControlPanelState.ARMED_CUSTOM_BYPASS: AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS,
+    AlarmControlPanelState.ARMED_CUSTOM_BYPASS: (
+        AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS
+    ),
 }
 
 ATTR_PREVIOUS_STATE = "previous_state"

--- a/homeassistant/components/mastodon/entity.py
+++ b/homeassistant/components/mastodon/entity.py
@@ -26,7 +26,8 @@ class MastodonEntity(CoordinatorEntity[MastodonCoordinator]):
         assert unique_id is not None
         self._attr_unique_id = f"{unique_id}_{entity_description.key}"
 
-        # Legacy yaml config default title is Mastodon, don't make name Mastodon Mastodon
+        # Legacy yaml config default title is Mastodon,
+        # don't make name Mastodon Mastodon
         name = "Mastodon"
         if data.title != DEFAULT_NAME:
             name = f"Mastodon {data.title}"

--- a/homeassistant/components/matrix/__init__.py
+++ b/homeassistant/components/matrix/__init__.py
@@ -231,7 +231,8 @@ class MatrixBot:
             else:
                 command[CONF_ROOMS] = list(self._listening_rooms.values())
 
-            # COMMAND_SCHEMA guarantees that exactly one of CONF_WORD, CONF_EXPRESSION, or CONF_REACTION are set.
+            # COMMAND_SCHEMA guarantees that exactly one of
+            # CONF_WORD, CONF_EXPRESSION, or CONF_REACTION are set.
             if (word_command := command.get(CONF_WORD)) is not None:
                 for room_id in command[CONF_ROOMS]:
                     self._word_commands.setdefault(room_id, {})
@@ -247,7 +248,8 @@ class MatrixBot:
 
     async def _handle_room_message(self, room: MatrixRoom, message: Event) -> None:
         """Handle a message sent to a Matrix room."""
-        # Corresponds to message type 'm.text' and NOT other RoomMessage subtypes, like 'm.notice' and 'm.emote'.
+        # Corresponds to message type 'm.text' and NOT other
+        # RoomMessage subtypes, like 'm.notice' and 'm.emote'.
         if not isinstance(message, (RoomMessageText, ReactionEvent)):
             return
         # Don't respond to our own messages.
@@ -348,11 +350,12 @@ class MatrixBot:
                     resolve_response,
                 )
                 return {}
-        # The config schema guarantees it's a valid room alias or id, so room_id is always set.
+        # The config schema guarantees it's a valid room alias
+        # or id, so room_id is always set.
         return {room_alias_or_id: room_id}
 
     async def _resolve_room_aliases(self, listening_rooms: list[RoomAnyID]) -> None:
-        """Resolve any RoomAliases into RoomIDs for the purpose of client interactions."""
+        """Resolve RoomAliases into RoomIDs for client interactions."""
         resolved_rooms = [
             self.hass.async_create_task(
                 self._resolve_room_alias(room_alias_or_id), eager_start=False
@@ -438,7 +441,8 @@ class MatrixBot:
                 )
             elif isinstance(response, WhoamiResponse):
                 _LOGGER.debug(
-                    "Successfully restored login from access token: user_id '%s', device_id '%s'",
+                    "Successfully restored login from access token:"
+                    " user_id '%s', device_id '%s'",
                     response.user_id,
                     response.device_id,
                 )

--- a/homeassistant/components/matter/api.py
+++ b/homeassistant/components/matter/api.py
@@ -276,7 +276,7 @@ async def websocket_open_commissioning_window(
     matter: MatterAdapter,
     node: MatterNode,
 ) -> None:
-    """Open a commissioning window to commission a device present on this controller to another."""
+    """Open a commissioning window to commission a device to another."""
     result = await matter.matter_client.open_commissioning_window(node_id=node.node_id)
     connection.send_result(msg[ID], dataclass_to_dict(result))
 

--- a/homeassistant/components/matter/binary_sensor.py
+++ b/homeassistant/components/matter/binary_sensor.py
@@ -528,8 +528,7 @@ DISCOVERY_SCHEMAS = [
             entity_category=EntityCategory.DIAGNOSTIC,
             # LocalTemperature bit from RemoteSensing attribute
             device_to_ha=lambda x: bool(
-                x
-                & clusters.Thermostat.Bitmaps.RemoteSensingBitmap.kLocalTemperature  # Calculated Local Temperature is derived from a remote node
+                x & clusters.Thermostat.Bitmaps.RemoteSensingBitmap.kLocalTemperature
             ),
         ),
         entity_class=MatterBinarySensor,
@@ -544,8 +543,7 @@ DISCOVERY_SCHEMAS = [
             entity_category=EntityCategory.DIAGNOSTIC,
             # OutdoorTemperature bit from RemoteSensing attribute
             device_to_ha=lambda x: bool(
-                x
-                & clusters.Thermostat.Bitmaps.RemoteSensingBitmap.kOutdoorTemperature  # OutdoorTemperature is derived from a remote node
+                x & clusters.Thermostat.Bitmaps.RemoteSensingBitmap.kOutdoorTemperature
             ),
         ),
         entity_class=MatterBinarySensor,
@@ -563,8 +561,7 @@ DISCOVERY_SCHEMAS = [
             entity_category=EntityCategory.DIAGNOSTIC,
             # Occupancy bit from RemoteSensing attribute
             device_to_ha=lambda x: bool(
-                x
-                & clusters.Thermostat.Bitmaps.RemoteSensingBitmap.kOccupancy  # Occupancy is derived from a remote node
+                x & clusters.Thermostat.Bitmaps.RemoteSensingBitmap.kOccupancy
             ),
         ),
         entity_class=MatterBinarySensor,

--- a/homeassistant/components/matter/climate.py
+++ b/homeassistant/components/matter/climate.py
@@ -218,8 +218,10 @@ class MatterClimate(MatterEntity, ClimateEntity):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the climate entity."""
-        # Initialize preset handle mapping as instance attribute before calling super().__init__()
-        # because MatterEntity.__init__() calls _update_from_device() which needs this attribute
+        # Initialize preset handle mapping as instance attribute
+        # before calling super().__init__() because
+        # MatterEntity.__init__() calls _update_from_device()
+        # which needs this attribute
         self._matter_presets = []
         self._preset_handle_by_name: dict[str, bytes | None] = {}
         self._preset_name_by_handle: dict[bytes | None, str] = {}
@@ -362,7 +364,8 @@ class MatterClimate(MatterEntity, ClimateEntity):
             self.get_matter_attribute_value(clusters.Thermostat.Attributes.Presets)
             or []
         )
-        # Build preset mapping: use device-provided name if available, else generate unique name
+        # Build preset mapping: use device-provided name if
+        # available, else generate unique name
         self._preset_handle_by_name.clear()
         self._preset_name_by_handle.clear()
         if self._matter_presets:
@@ -412,8 +415,10 @@ class MatterClimate(MatterEntity, ClimateEntity):
     def _update_hvac_mode_and_action(self) -> None:
         """Update HVAC mode and action from device."""
         if self.get_matter_attribute_value(clusters.OnOff.Attributes.OnOff) is False:
-            # special case: the appliance has a dedicated Power switch on the OnOff cluster
-            # if the mains power is off - treat it as if the HVAC mode is off
+            # special case: the appliance has a dedicated Power
+            # switch on the OnOff cluster
+            # if the mains power is off - treat it as if the
+            # HVAC mode is off
             self._attr_hvac_mode = HVACMode.OFF
             self._attr_hvac_action = None
         else:

--- a/homeassistant/components/matter/cover.py
+++ b/homeassistant/components/matter/cover.py
@@ -32,7 +32,9 @@ TYPE_MAP = {
     clusters.WindowCovering.Enums.Type.kRollerShade: CoverDeviceClass.SHADE,
     clusters.WindowCovering.Enums.Type.kRollerShade2Motor: CoverDeviceClass.SHADE,
     clusters.WindowCovering.Enums.Type.kRollerShadeExterior: CoverDeviceClass.SHADE,
-    clusters.WindowCovering.Enums.Type.kRollerShadeExterior2Motor: CoverDeviceClass.SHADE,
+    clusters.WindowCovering.Enums.Type.kRollerShadeExterior2Motor: (
+        CoverDeviceClass.SHADE
+    ),
     clusters.WindowCovering.Enums.Type.kAwning: CoverDeviceClass.AWNING,
     clusters.WindowCovering.Enums.Type.kDrapery: CoverDeviceClass.CURTAIN,
     clusters.WindowCovering.Enums.Type.kTiltBlindTiltOnly: CoverDeviceClass.BLIND,
@@ -41,7 +43,7 @@ TYPE_MAP = {
 
 
 class OperationalStatus(IntEnum):
-    """Currently ongoing operations enumeration for coverings, as defined in the Matter spec."""
+    """Ongoing operations enumeration for coverings per Matter spec."""
 
     COVERING_IS_CURRENTLY_NOT_MOVING = 0b00
     COVERING_IS_CURRENTLY_OPENING = 0b01
@@ -71,7 +73,7 @@ class MatterCover(MatterEntity, CoverEntity):
 
     @property
     def is_closed(self) -> bool | None:
-        """Return true if cover is closed, if there is no position report, return None."""
+        """Return true if cover is closed, None if no position."""
         if not self._entity_info.endpoint.has_attribute(
             None, clusters.WindowCovering.Attributes.CurrentPositionLiftPercent100ths
         ):

--- a/homeassistant/components/matter/discovery.py
+++ b/homeassistant/components/matter/discovery.py
@@ -144,7 +144,8 @@ def async_discover_entities(
             continue
 
         # BEGIN checks on actual attribute values
-        # these are the least likely to be used and least efficient, so they are checked last
+        # these are the least likely to be used and least
+        # efficient, so they are checked last
 
         # check if PRIMARY value exists but is none/null
         if not schema.allow_none_value and any(

--- a/homeassistant/components/matter/entity.py
+++ b/homeassistant/components/matter/entity.py
@@ -126,7 +126,8 @@ class MatterEntity(Entity):
         self._attr_available = (
             self._endpoint.node.available and self._get_bridged_reachable()
         )
-        # mark endpoint postfix if the device has the primary attribute on multiple endpoints
+        # mark endpoint postfix if the device has the primary
+        # attribute on multiple endpoints
         if not self._endpoint.node.is_bridge_device and any(
             ep
             for ep in self._endpoint.node.endpoints.values()
@@ -212,8 +213,9 @@ class MatterEntity(Entity):
                 node_filter=self._endpoint.node.node_id,
             )
         )
-        # Subscribe to BridgedDeviceBasicInformation Reachable attribute (AttributeId: 17)
-        # for devices connected via a Matter bridge, to reflect real reachability status.
+        # Subscribe to BridgedDeviceBasicInformation Reachable
+        # attribute (AttributeId: 17) for devices connected via a
+        # Matter bridge, to reflect real reachability status.
         if self._endpoint.has_attribute(
             None, clusters.BridgedDeviceBasicInformation.Attributes.Reachable
         ):
@@ -342,7 +344,7 @@ class MatterEntity(Entity):
     ) -> Any:
         """Write an attribute(value) on the primary endpoint.
 
-        If matter_attribute is not provided, the primary attribute of the entity is used.
+        If matter_attribute is not provided, the primary attribute is used.
         """
         if matter_attribute is None:
             matter_attribute = self._entity_info.primary_attribute

--- a/homeassistant/components/matter/event.py
+++ b/homeassistant/components/matter/event.py
@@ -79,7 +79,8 @@ class MatterEventEntity(MatterEntity, EventEntity):
             # momentary switch without multi press support
             event_types.append("initial_press")
             if feature_map & SwitchFeature.kMomentarySwitchRelease:
-                # momentary switch without multi press support can optionally support release
+                # momentary switch without multi press support
+                # can optionally support release
                 event_types.append("short_release")
 
         # a momentary switch can optionally support long press

--- a/homeassistant/components/matter/fan.py
+++ b/homeassistant/components/matter/fan.py
@@ -170,8 +170,10 @@ class MatterFan(MatterEntity, FanEntity):
         self._calculate_features()
 
         if self.get_matter_attribute_value(clusters.OnOff.Attributes.OnOff) is False:
-            # special case: the appliance has a dedicated Power switch on the OnOff cluster
-            # if the mains power is off - treat it as if the fan mode is off
+            # special case: the appliance has a dedicated Power
+            # switch on the OnOff cluster
+            # if the mains power is off - treat it as if the
+            # fan mode is off
             self._attr_preset_mode = None
             self._attr_percentage = 0
             return

--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -45,7 +45,8 @@ COLOR_MODE_MAP = {
 }
 
 # Maximum Mireds value per the Matter spec is 65279
-# Conversion between Kelvin and Mireds is 1,000,000 / Kelvin, so this corresponds to a minimum color temperature of ~15.3K
+# Conversion between Kelvin and Mireds is 1,000,000 / Kelvin,
+# so this corresponds to a minimum color temperature of ~15.3K
 # Which is shown in UI as 15 Kelvin due to rounding.
 # But converting 15 Kelvin back to Mireds gives 66666 which is above the maximum,
 # and causes Invoke error, so cap values over maximum when sending
@@ -399,7 +400,8 @@ class MatterLight(MatterEntity, LightEntity):
             supported_color_modes = filter_supported_color_modes(supported_color_modes)
             self._attr_supported_color_modes = supported_color_modes
             self._check_transition_blocklist()
-            # flag support for transition as soon as we support setting brightness and/or color
+            # flag support for transition as soon as we support
+            # setting brightness and/or color
             if (
                 supported_color_modes != {ColorMode.ONOFF}
                 and not self._transitions_disabled
@@ -537,7 +539,8 @@ DISCOVERY_SCHEMAS = [
             clusters.ColorControl.Attributes.CurrentSaturation,
         ),
     ),
-    # Additional schema to match (color temperature) lights with incorrect/missing device type
+    # Additional schema to match (color temperature) lights
+    # with incorrect/missing device type
     MatterDiscoverySchema(
         platform=Platform.LIGHT,
         entity_description=MatterLightEntityDescription(

--- a/homeassistant/components/matter/number.py
+++ b/homeassistant/components/matter/number.py
@@ -64,7 +64,8 @@ class MatterRangeNumberEntityDescription(
 
     # command: a custom callback to create the command to send to the device
     # the callback's argument will be the converted device value from ha_to_device
-    # if omitted the command will just be a write_attribute command to the primary attribute
+    # if omitted the command will just be a write_attribute
+    # command to the primary attribute
     command: Callable[[int], ClusterCommand] | None = None
 
 
@@ -90,7 +91,7 @@ class MatterNumber(MatterEntity, NumberEntity):
 
 
 class MatterRangeNumber(MatterEntity, NumberEntity):
-    """Representation of a Matter Attribute as a Number entity with min and max values."""
+    """Matter Attribute as a Number entity with min and max."""
 
     entity_description: MatterRangeNumberEntityDescription
 
@@ -111,7 +112,8 @@ class MatterRangeNumber(MatterEntity, NumberEntity):
     @callback
     def _update_from_device(self) -> None:
         """Update from device."""
-        # get the value from the primary attribute and convert it to the HA value if needed
+        # get the value from the primary attribute and convert
+        # it to the HA value if needed
         value = self.get_matter_attribute_value(self._entity_info.primary_attribute)
         if value_convert := self.entity_description.device_to_ha:
             value = value_convert(value)
@@ -371,7 +373,8 @@ DISCOVERY_SCHEMAS = [
         entity_description=MatterNumberEntityDescription(
             key="PIROccupiedToUnoccupiedDelay",
             entity_category=EntityCategory.CONFIG,
-            translation_key="hold_time",  # pir_occupied_to_unoccupied_delay for old revisions
+            # pir_occupied_to_unoccupied_delay for old revisions
+            translation_key="hold_time",
             native_max_value=65534,
             native_min_value=0,
             native_unit_of_measurement=UnitOfTime.SECONDS,
@@ -414,7 +417,8 @@ DISCOVERY_SCHEMAS = [
         entity_class=MatterNumber,
         required_attributes=(
             clusters.OccupancySensing.Attributes.PIRUnoccupiedToOccupiedDelay,
-            # This attribute is mandatory when the PIRUnoccupiedToOccupiedDelay is present
+            # This attribute is mandatory when
+            # PIRUnoccupiedToOccupiedDelay is present
             clusters.OccupancySensing.Attributes.HoldTime,
         ),
         featuremap_contains=clusters.OccupancySensing.Bitmaps.Feature.kPassiveInfrared,

--- a/homeassistant/components/matter/select.py
+++ b/homeassistant/components/matter/select.py
@@ -21,7 +21,9 @@ DOOR_LOCK_OPERATING_MODE_MAP = {
     clusters.DoorLock.Enums.OperatingModeEnum.kNormal: "normal",
     clusters.DoorLock.Enums.OperatingModeEnum.kVacation: "vacation",
     clusters.DoorLock.Enums.OperatingModeEnum.kPrivacy: "privacy",
-    clusters.DoorLock.Enums.OperatingModeEnum.kNoRemoteLockUnlock: "no_remote_lock_unlock",
+    clusters.DoorLock.Enums.OperatingModeEnum.kNoRemoteLockUnlock: (
+        "no_remote_lock_unlock"
+    ),
     clusters.DoorLock.Enums.OperatingModeEnum.kPassage: "passage",
 }
 DOOR_LOCK_OPERATING_MODE_MAP_REVERSE = {
@@ -83,7 +85,8 @@ class MatterMapSelectEntityDescription(MatterSelectEntityDescription):
     device_to_ha: Callable[[int], str | None]
     ha_to_device: Callable[[str], int | None]
 
-    # list attribute: the attribute descriptor to get the list of values (= list of integers)
+    # list attribute: the attribute descriptor to get the list
+    # of values (= list of integers)
     list_attribute: type[ClusterAttributeDescriptor]
 
 
@@ -91,11 +94,15 @@ class MatterMapSelectEntityDescription(MatterSelectEntityDescription):
 class MatterListSelectEntityDescription(MatterSelectEntityDescription):
     """Describe Matter select entities for MatterListSelectEntity."""
 
-    # list attribute: the attribute descriptor to get the list of values (= list of strings)
+    # list attribute: the attribute descriptor to get the list
+    # of values (= list of strings)
     list_attribute: type[ClusterAttributeDescriptor]
-    # command: a custom callback to create the command to send to the device
-    # the callback's argument will be the index of the selected list value
-    # if omitted the command will just be a write_attribute command to the primary attribute
+    # command: a custom callback to create the command to send
+    # to the device
+    # the callback's argument will be the index of the selected
+    # list value
+    # if omitted the command will just be a write_attribute
+    # command to the primary attribute
     command: Callable[[int], ClusterCommand] | None = None
 
 
@@ -125,7 +132,7 @@ class MatterAttributeSelectEntity(MatterEntity, SelectEntity):
 
 
 class MatterMapSelectEntity(MatterAttributeSelectEntity):
-    """Representation of a Matter select entity where the options are defined in a State map."""
+    """Matter select entity where options are from a State map."""
 
     entity_description: MatterMapSelectEntityDescription
 
@@ -143,7 +150,8 @@ class MatterMapSelectEntity(MatterAttributeSelectEntity):
             for value in available_values
             if (mapped_value := self.entity_description.device_to_ha(value))
         ]
-        # use base implementation from MatterAttributeSelectEntity to set the current option
+        # use base implementation from
+        # MatterAttributeSelectEntity to set the current option
         super()._update_from_device()
 
 
@@ -185,7 +193,7 @@ class MatterDoorLockOperatingModeSelectEntity(MatterAttributeSelectEntity):
 
     This entity dynamically filters available operating modes based on the device's
     `SupportedOperatingModes` bitmap attribute. In this bitmap, bit=0 indicates a
-    supported mode and bit=1 indicates unsupported (inverted from typical bitmap conventions).
+    supported mode and bit=1 indicates unsupported (inverted from typical conventions).
     If the bitmap is unavailable, only mandatory modes are included. The mapping from
     bitmap bits to operating mode values is defined by the Matter specification.
     """
@@ -223,7 +231,7 @@ class MatterDoorLockOperatingModeSelectEntity(MatterAttributeSelectEntity):
 
 
 class MatterListSelectEntity(MatterEntity, SelectEntity):
-    """Representation of a select entity from Matter list and selected item Cluster attribute(s)."""
+    """Select entity from Matter list and selected item attributes."""
 
     entity_description: MatterListSelectEntityDescription
 
@@ -569,9 +577,12 @@ DISCOVERY_SCHEMAS = [
             translation_key="sensitivity_level",
             options=["10 mm", "20 mm", "30 mm"],
             device_to_ha={
-                0: "10 mm",  # 10 mm => CurrentSensitivityLevel=0 / highest sensitivity level
-                1: "20 mm",  # 20 mm => CurrentSensitivityLevel=1 / medium sensitivity level
-                2: "30 mm",  # 30 mm => CurrentSensitivityLevel=2 / lowest sensitivity level
+                # CurrentSensitivityLevel=0 / highest
+                0: "10 mm",
+                # CurrentSensitivityLevel=1 / medium
+                1: "20 mm",
+                # CurrentSensitivityLevel=2 / lowest
+                2: "30 mm",
             }.get,
             ha_to_device={
                 "10 mm": 0,

--- a/homeassistant/components/matter/sensor.py
+++ b/homeassistant/components/matter/sensor.py
@@ -68,14 +68,15 @@ CONTAMINATION_STATE_MAP = {
     clusters.SmokeCoAlarm.Enums.ContaminationStateEnum.kCritical: "critical",
 }
 
+_tvoc = clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement
 CONCENTRATION_LEVEL_MAP = {
     # enum with known Concentration Level values which we can translate
-    clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.Enums.LevelValueEnum.kUnknown: None,
-    clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.Enums.LevelValueEnum.kLow: "low",
-    clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.Enums.LevelValueEnum.kMedium: "medium",
-    clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.Enums.LevelValueEnum.kHigh: "high",
-    clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.Enums.LevelValueEnum.kCritical: "critical",
-    clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.Enums.LevelValueEnum.kUnknownEnumValue: None,
+    _tvoc.Enums.LevelValueEnum.kUnknown: None,
+    _tvoc.Enums.LevelValueEnum.kLow: "low",
+    _tvoc.Enums.LevelValueEnum.kMedium: "medium",
+    _tvoc.Enums.LevelValueEnum.kHigh: "high",
+    _tvoc.Enums.LevelValueEnum.kCritical: "critical",
+    _tvoc.Enums.LevelValueEnum.kUnknownEnumValue: None,
 }
 
 EVE_CLUSTER_WEATHER_MAP = {
@@ -94,43 +95,46 @@ OPERATIONAL_STATE_MAP = {
     clusters.OperationalState.Enums.OperationalStateEnum.kError: "error",
 }
 
+_op_err = clusters.OperationalState.Enums.ErrorStateEnum
 OPERATIONAL_STATE_ERROR_MAP = {
     # enum with known Error state values which we can translate
-    clusters.OperationalState.Enums.ErrorStateEnum.kNoError: "no_error",
-    clusters.OperationalState.Enums.ErrorStateEnum.kUnableToStartOrResume: "unable_to_start_or_resume",
-    clusters.OperationalState.Enums.ErrorStateEnum.kUnableToCompleteOperation: "unable_to_complete_operation",
-    clusters.OperationalState.Enums.ErrorStateEnum.kCommandInvalidInState: "command_invalid_in_state",
+    _op_err.kNoError: "no_error",
+    _op_err.kUnableToStartOrResume: "unable_to_start_or_resume",
+    _op_err.kUnableToCompleteOperation: ("unable_to_complete_operation"),
+    _op_err.kCommandInvalidInState: "command_invalid_in_state",
 }
 
+_rvc_op = clusters.RvcOperationalState.Enums.OperationalStateEnum
 RVC_OPERATIONAL_STATE_MAP = {
     # enum with known Operation state values which we can translate
     **OPERATIONAL_STATE_MAP,
-    clusters.RvcOperationalState.Enums.OperationalStateEnum.kSeekingCharger: "seeking_charger",
-    clusters.RvcOperationalState.Enums.OperationalStateEnum.kCharging: "charging",
-    clusters.RvcOperationalState.Enums.OperationalStateEnum.kDocked: "docked",
+    _rvc_op.kSeekingCharger: "seeking_charger",
+    _rvc_op.kCharging: "charging",
+    _rvc_op.kDocked: "docked",
 }
 
+_rvc_err = clusters.RvcOperationalState.Enums.ErrorStateEnum
 RVC_OPERATIONAL_STATE_ERROR_MAP = {
     # enum with known Error state values which we can translate
-    clusters.RvcOperationalState.Enums.ErrorStateEnum.kNoError: "no_error",
-    clusters.RvcOperationalState.Enums.ErrorStateEnum.kUnableToStartOrResume: "unable_to_start_or_resume",
-    clusters.RvcOperationalState.Enums.ErrorStateEnum.kUnableToCompleteOperation: "unable_to_complete_operation",
-    clusters.RvcOperationalState.Enums.ErrorStateEnum.kCommandInvalidInState: "command_invalid_in_state",
-    clusters.RvcOperationalState.Enums.ErrorStateEnum.kFailedToFindChargingDock: "failed_to_find_charging_dock",
-    clusters.RvcOperationalState.Enums.ErrorStateEnum.kStuck: "stuck",
-    clusters.RvcOperationalState.Enums.ErrorStateEnum.kDustBinMissing: "dust_bin_missing",
-    clusters.RvcOperationalState.Enums.ErrorStateEnum.kDustBinFull: "dust_bin_full",
-    clusters.RvcOperationalState.Enums.ErrorStateEnum.kWaterTankEmpty: "water_tank_empty",
-    clusters.RvcOperationalState.Enums.ErrorStateEnum.kWaterTankMissing: "water_tank_missing",
-    clusters.RvcOperationalState.Enums.ErrorStateEnum.kWaterTankLidOpen: "water_tank_lid_open",
-    clusters.RvcOperationalState.Enums.ErrorStateEnum.kMopCleaningPadMissing: "mop_cleaning_pad_missing",
-    clusters.RvcOperationalState.Enums.ErrorStateEnum.kLowBattery: "low_battery",
-    clusters.RvcOperationalState.Enums.ErrorStateEnum.kCannotReachTargetArea: "cannot_reach_target_area",
-    clusters.RvcOperationalState.Enums.ErrorStateEnum.kDirtyWaterTankFull: "dirty_water_tank_full",
-    clusters.RvcOperationalState.Enums.ErrorStateEnum.kDirtyWaterTankMissing: "dirty_water_tank_missing",
-    clusters.RvcOperationalState.Enums.ErrorStateEnum.kWheelsJammed: "wheels_jammed",
-    clusters.RvcOperationalState.Enums.ErrorStateEnum.kBrushJammed: "brush_jammed",
-    clusters.RvcOperationalState.Enums.ErrorStateEnum.kNavigationSensorObscured: "navigation_sensor_obscured",
+    _rvc_err.kNoError: "no_error",
+    _rvc_err.kUnableToStartOrResume: "unable_to_start_or_resume",
+    _rvc_err.kUnableToCompleteOperation: ("unable_to_complete_operation"),
+    _rvc_err.kCommandInvalidInState: "command_invalid_in_state",
+    _rvc_err.kFailedToFindChargingDock: ("failed_to_find_charging_dock"),
+    _rvc_err.kStuck: "stuck",
+    _rvc_err.kDustBinMissing: "dust_bin_missing",
+    _rvc_err.kDustBinFull: "dust_bin_full",
+    _rvc_err.kWaterTankEmpty: "water_tank_empty",
+    _rvc_err.kWaterTankMissing: "water_tank_missing",
+    _rvc_err.kWaterTankLidOpen: "water_tank_lid_open",
+    _rvc_err.kMopCleaningPadMissing: "mop_cleaning_pad_missing",
+    _rvc_err.kLowBattery: "low_battery",
+    _rvc_err.kCannotReachTargetArea: "cannot_reach_target_area",
+    _rvc_err.kDirtyWaterTankFull: "dirty_water_tank_full",
+    _rvc_err.kDirtyWaterTankMissing: "dirty_water_tank_missing",
+    _rvc_err.kWheelsJammed: "wheels_jammed",
+    _rvc_err.kBrushJammed: "brush_jammed",
+    _rvc_err.kNavigationSensorObscured: ("navigation_sensor_obscured"),
 }
 
 BOOST_STATE_MAP = {
@@ -181,14 +185,15 @@ EVSE_FAULT_STATE_MAP = {
     clusters.EnergyEvse.Enums.FaultStateEnum.kOther: "other",
 }
 
+_pump_ctrl = clusters.PumpConfigurationAndControl.Enums.ControlModeEnum
 PUMP_CONTROL_MODE_MAP = {
-    clusters.PumpConfigurationAndControl.Enums.ControlModeEnum.kConstantSpeed: "constant_speed",
-    clusters.PumpConfigurationAndControl.Enums.ControlModeEnum.kConstantPressure: "constant_pressure",
-    clusters.PumpConfigurationAndControl.Enums.ControlModeEnum.kProportionalPressure: "proportional_pressure",
-    clusters.PumpConfigurationAndControl.Enums.ControlModeEnum.kConstantFlow: "constant_flow",
-    clusters.PumpConfigurationAndControl.Enums.ControlModeEnum.kConstantTemperature: "constant_temperature",
-    clusters.PumpConfigurationAndControl.Enums.ControlModeEnum.kAutomatic: "automatic",
-    clusters.PumpConfigurationAndControl.Enums.ControlModeEnum.kUnknownEnumValue: None,
+    _pump_ctrl.kConstantSpeed: "constant_speed",
+    _pump_ctrl.kConstantPressure: "constant_pressure",
+    _pump_ctrl.kProportionalPressure: "proportional_pressure",
+    _pump_ctrl.kConstantFlow: "constant_flow",
+    _pump_ctrl.kConstantTemperature: "constant_temperature",
+    _pump_ctrl.kAutomatic: "automatic",
+    _pump_ctrl.kUnknownEnumValue: None,
 }
 
 MATTER_2000_TO_UNIX_EPOCH_OFFSET = (
@@ -239,7 +244,8 @@ class MatterSensorEntityDescription(SensorEntityDescription, MatterEntityDescrip
 class MatterListSensorEntityDescription(MatterSensorEntityDescription):
     """Describe Matter sensor entities from MatterListSensor."""
 
-    # list attribute: the attribute descriptor to get the list of values (= list of strings)
+    # list attribute: the attribute descriptor to get the list
+    # of values (= list of strings)
     list_attribute: type[ClusterAttributeDescriptor]
 
 
@@ -247,8 +253,10 @@ class MatterListSensorEntityDescription(MatterSensorEntityDescription):
 class MatterOperationalStateSensorEntityDescription(MatterSensorEntityDescription):
     """Describe Matter sensor entities from Matter OperationalState objects."""
 
-    # list attribute: the attribute descriptor to get the list of values (= list of structs)
-    # needs to be set for handling OperationalState not on the OperationalState cluster, but
+    # list attribute: the attribute descriptor to get the list
+    # of values (= list of structs)
+    # needs to be set for handling OperationalState not on the
+    # OperationalState cluster, but
     # on one of its derived clusters (e.g. RvcOperationalState)
     state_list_attribute: type[ClusterAttributeDescriptor] = (
         clusters.OperationalState.Attributes.OperationalStateList
@@ -277,7 +285,7 @@ class MatterSensor(MatterEntity, SensorEntity):
 
 
 class MatterDraftElectricalMeasurementSensor(MatterEntity, SensorEntity):
-    """Representation of a Matter sensor for Matter 1.0 draft ElectricalMeasurement cluster."""
+    """Matter sensor for 1.0 draft ElectricalMeasurement cluster."""
 
     entity_description: MatterSensorEntityDescription
 

--- a/homeassistant/components/matter/update.py
+++ b/homeassistant/components/matter/update.py
@@ -176,15 +176,22 @@ class MatterUpdate(MatterEntity, UpdateEntity):
         if self._software_update.update_source != UpdateSource.MAIN_NET_DCL:
             release_notes += (
                 "\n\n<ha-alert alert-type='warning'>"
-                f"Update provided by {self._software_update.update_source.value}. "
-                "Installing this update is at your own risk and you may run into unexpected "
-                "problems such as the need to re-add and factory reset your device.</ha-alert>\n\n"
+                "Update provided by "
+                f"{self._software_update.update_source.value}. "
+                "Installing this update is at your own risk "
+                "and you may run into unexpected "
+                "problems such as the need to re-add and "
+                "factory reset your device.</ha-alert>\n\n"
             )
         return release_notes + (
-            "\n\n<ha-alert alert-type='info'>The update process can take a while, "
-            "especially for battery powered devices. Please be patient and wait until the update "
-            "process is fully completed. Do not remove power from the device while it's updating. "
-            "The device may restart during the update process and be unavailable for several minutes."
+            "\n\n<ha-alert alert-type='info'>"
+            "The update process can take a while, "
+            "especially for battery powered devices. "
+            "Please be patient and wait until the update "
+            "process is fully completed. Do not remove power "
+            "from the device while it's updating. "
+            "The device may restart during the update process "
+            "and be unavailable for several minutes."
             "</ha-alert>\n\n"
         )
 

--- a/homeassistant/components/matter/vacuum.py
+++ b/homeassistant/components/matter/vacuum.py
@@ -211,7 +211,8 @@ class MatterVacuum(MatterEntity, StateVacuumEntity):
             != clusters.ServiceArea.Enums.SelectAreasStatus.kSuccess
         ):
             raise HomeAssistantError(
-                f"Failed to select areas: {response['statusText'] or response['status']}"
+                "Failed to select areas: "
+                f"{response['statusText'] or response['status']}"
             )
 
         await self.send_device_command(

--- a/homeassistant/components/matter/water_heater.py
+++ b/homeassistant/components/matter/water_heater.py
@@ -33,7 +33,8 @@ from .models import MatterDiscoverySchema
 
 TEMPERATURE_SCALING_FACTOR = 100
 
-# Map HA WH system mode to Matter ThermostatRunningMode attribute of the Thermostat cluster (Heat = 4)
+# Map HA WH system mode to Matter ThermostatRunningMode
+# attribute of the Thermostat cluster (Heat = 4)
 WATER_HEATER_SYSTEM_MODE_MAP = {
     STATE_ECO: 4,
     STATE_HIGH_DEMAND: 4,

--- a/homeassistant/components/maxcube/climate.py
+++ b/homeassistant/components/maxcube/climate.py
@@ -93,7 +93,8 @@ class MaxCubeClimate(ClimateEntity):
     def min_temp(self) -> float:
         """Return the minimum temperature."""
         temp = self._device.min_temperature or MIN_TEMPERATURE
-        # OFF_TEMPERATURE (always off) a is valid temperature to maxcube but not to Home Assistant.
+        # OFF_TEMPERATURE (always off) is valid to maxcube
+        # but not to Home Assistant.
         # We use HVACMode.OFF instead to represent a turned off thermostat.
         return max(temp, MIN_TEMPERATURE)
 

--- a/homeassistant/components/mcp/__init__.py
+++ b/homeassistant/components/mcp/__init__.py
@@ -40,7 +40,10 @@ async def async_get_config_entry_implementation(
 async def _create_token_manager(
     hass: HomeAssistant, entry: ModelContextProtocolConfigEntry
 ) -> TokenManager | None:
-    """Create a OAuth token manager for the config entry if the server requires authentication."""
+    """Create a OAuth token manager for the config entry.
+
+    Returns None if the server does not require authentication.
+    """
     try:
         implementation = await async_get_config_entry_implementation(hass, entry)
     except config_entry_oauth2_flow.ImplementationUnavailableError as err:

--- a/homeassistant/components/mcp/config_flow.py
+++ b/homeassistant/components/mcp/config_flow.py
@@ -244,13 +244,16 @@ class ModelContextProtocolConfigFlow(AbstractOAuth2FlowHandler, domain=DOMAIN):
                 _LOGGER.debug("Protected resource metadata: %s", resource_metadata)
                 oauth_config = await async_discover_authorization_server(
                     self.hass,
-                    # Use the first authorization server from the resource metadata as it
-                    # is the most common to have only one and there is not a defined strategy.
+                    # Use the first authorization server from the
+                    # resource metadata as it is the most common to
+                    # have only one and there is not a defined
+                    # strategy.
                     resource_metadata.authorization_servers[0],
                 )
             else:
                 _LOGGER.debug(
-                    "Discovering authorization server without protected resource metadata"
+                    "Discovering authorization server without"
+                    " protected resource metadata"
                 )
                 oauth_config = await async_discover_authorization_server(
                     self.hass,
@@ -268,7 +271,9 @@ class ModelContextProtocolConfigFlow(AbstractOAuth2FlowHandler, domain=DOMAIN):
             self.oauth_config = oauth_config
             self.data.update(
                 {
-                    CONF_AUTHORIZATION_URL: oauth_config.authorization_server.authorize_url,
+                    CONF_AUTHORIZATION_URL: (
+                        oauth_config.authorization_server.authorize_url
+                    ),
                     CONF_TOKEN_URL: oauth_config.authorization_server.token_url,
                     CONF_SCOPE: _select_scopes(
                         self.auth_header, oauth_config, resource_metadata
@@ -430,11 +435,12 @@ async def async_discover_protected_resource(
     auth_url: str,
     mcp_server_url: str,
 ) -> ResourceMetadata:
-    """Discover the OAuth configuration for a protected resource for MCP spec version 2025-11-25+.
+    """Discover the OAuth configuration for a protected resource.
 
-    This implements the functionality in the MCP spec for discovery. We use the information
-    from the WWW-Authenticate header to fetch the resource metadata implementing
-    RFC9728.
+    This is for MCP spec version 2025-11-25+. It implements the
+    functionality in the MCP spec for discovery. We use the information
+    from the WWW-Authenticate header to fetch the resource metadata
+    implementing RFC9728.
 
     For the url https://example.com/public/mcp we attempt these urls:
     - https://example.com/.well-known/oauth-protected-resource/public/mcp

--- a/homeassistant/components/mcp_server/const.py
+++ b/homeassistant/components/mcp_server/const.py
@@ -2,6 +2,6 @@
 
 DOMAIN = "mcp_server"
 TITLE = "Model Context Protocol Server"
-# The Stateless API is no longer registered explicitly, but this name may still exist in the
-# users config entry.
+# The Stateless API is no longer registered explicitly, but this
+# name may still exist in the users config entry.
 STATELESS_LLM_API = "stateless_assist"

--- a/homeassistant/components/meater/sensor.py
+++ b/homeassistant/components/meater/sensor.py
@@ -129,7 +129,8 @@ SENSOR_TYPES = (
         ),
     ),
     # Remaining time in seconds. When unknown/calculating default is used. Default: -1
-    # Exposed as a TIMESTAMP sensor where the timestamp is current time + remaining time.
+    # Exposed as a TIMESTAMP sensor where the timestamp is
+    # current time + remaining time.
     MeaterSensorEntityDescription(
         key="cook_time_remaining",
         translation_key="cook_time_remaining",

--- a/homeassistant/components/medcom_ble/config_flow.py
+++ b/homeassistant/components/medcom_ble/config_flow.py
@@ -67,7 +67,8 @@ class InspectorBLEConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Confirm discovery."""
-        # We always will have self._discovery_info be a BluetoothServiceInfo at this point
+        # We always will have self._discovery_info be a
+        # BluetoothServiceInfo at this point
         # and this helps mypy not complain
         assert self._discovery_info is not None
 
@@ -122,8 +123,9 @@ class InspectorBLEConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_check_connection(self) -> ConfigFlowResult:
-        """Check we can connect to the device before considering the configuration is successful."""
-        # We always will have self._discovery_info be a BluetoothServiceInfo at this point
+        """Check device connection before confirming configuration."""
+        # We always will have self._discovery_info be a
+        # BluetoothServiceInfo at this point
         # and this helps mypy not complain
         assert self._discovery_info is not None
 

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -168,7 +168,9 @@ def _promote_media_fields(data: dict[str, Any]) -> dict[str, Any]:
     if ATTR_MEDIA in data and isinstance(data[ATTR_MEDIA], dict):
         if ATTR_MEDIA_CONTENT_TYPE in data or ATTR_MEDIA_CONTENT_ID in data:
             raise vol.Invalid(
-                f"Play media cannot contain '{ATTR_MEDIA}' and '{ATTR_MEDIA_CONTENT_ID}' or '{ATTR_MEDIA_CONTENT_TYPE}'"
+                f"Play media cannot contain '{ATTR_MEDIA}' and "
+                f"'{ATTR_MEDIA_CONTENT_ID}' or "
+                f"'{ATTR_MEDIA_CONTENT_TYPE}'"
             )
         media_data = data[ATTR_MEDIA]
 

--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -160,7 +160,9 @@ class AtaDeviceClimate(MelCloudClimate):
             attr.update(
                 {
                     ATTR_VANE_HORIZONTAL: vane_horizontal,
-                    ATTR_VANE_HORIZONTAL_POSITIONS: self._device.vane_horizontal_positions,
+                    ATTR_VANE_HORIZONTAL_POSITIONS: (
+                        self._device.vane_horizontal_positions
+                    ),
                 }
             )
 

--- a/homeassistant/components/melnor/entity.py
+++ b/homeassistant/components/melnor/entity.py
@@ -87,7 +87,8 @@ def get_entities_for_valves[_T: EntityDescription](
     """Get descriptions for valves."""
     entities: list[CoordinatorEntity[MelnorDataUpdateCoordinator]] = []
 
-    # This device may not have 4 valves total, but the library will only expose the right number of valves
+    # This device may not have 4 valves total, but the library
+    # will only expose the right number of valves
     for i in range(1, 5):
         valve = coordinator.data[f"zone{i}"]
 

--- a/homeassistant/components/met/config_flow.py
+++ b/homeassistant/components/met/config_flow.py
@@ -53,7 +53,8 @@ def _get_data_schema(
     hass: HomeAssistant, config_entry: ConfigEntry | None = None
 ) -> vol.Schema:
     """Get a schema with default values."""
-    # If tracking home or no config entry is passed in, default value come from Home location
+    # If tracking home or no config entry is passed in,
+    # default value come from Home location
     if config_entry is None or config_entry.data.get(CONF_TRACK_HOME, False):
         return vol.Schema(
             {

--- a/homeassistant/components/met_eireann/weather.py
+++ b/homeassistant/components/met_eireann/weather.py
@@ -31,7 +31,7 @@ from .coordinator import MetEireannConfigEntry, MetEireannUpdateCoordinator
 
 
 def format_condition(condition: str | None) -> str | None:
-    """Map the conditions provided by the weather API to those supported by the frontend."""
+    """Map weather API conditions to those supported by the frontend."""
     if condition is not None:
         for key, value in CONDITION_MAP.items():
             if condition in value:

--- a/homeassistant/components/meteo_france/sensor.py
+++ b/homeassistant/components/meteo_france/sensor.py
@@ -237,7 +237,8 @@ class MeteoFranceSensor[_DataT: Rain | Forecast | CurrentPhenomenons](
         if hasattr(coordinator.data, "position"):
             city_name = coordinator.data.position["name"]
             self._attr_name = f"{city_name} {description.name}"
-            self._attr_unique_id = f"{coordinator.data.position['lat']},{coordinator.data.position['lon']}_{description.key}"
+            pos = coordinator.data.position
+            self._attr_unique_id = f"{pos['lat']},{pos['lon']}_{description.key}"
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -260,7 +261,9 @@ class MeteoFranceSensor[_DataT: Rain | Forecast | CurrentPhenomenons](
         # Specific case for probability forecast
         if path[0] == "probability_forecast":
             if len(path) == 3:
-                # This is a fix compared to other entitty as first index is always null in API result for unknown reason
+                # This is a fix compared to other entity as
+                # first index is always null in API result
+                # for unknown reason
                 value = _find_first_probability_forecast_not_null(data, path)
             else:
                 value = data[0][path[1]]

--- a/homeassistant/components/meteo_france/weather.py
+++ b/homeassistant/components/meteo_france/weather.py
@@ -50,7 +50,8 @@ def format_condition(condition: str, force_day: bool = False) -> str:
     """Return condition from dict CONDITION_MAP."""
     mapped_condition = CONDITION_MAP.get(condition, condition)
     if force_day and mapped_condition == ATTR_CONDITION_CLEAR_NIGHT:
-        # Meteo-France can return clear night condition instead of sunny for daily weather, so we map it to sunny
+        # Meteo-France can return clear night condition instead
+        # of sunny for daily weather, so we map it to sunny
         return ATTR_CONDITION_SUNNY
     return mapped_condition
 
@@ -100,7 +101,8 @@ class MeteoFranceWeather(
         super().__init__(coordinator)
         self._attr_name = self.coordinator.data.position["name"]
         self._mode = mode
-        self._attr_unique_id = f"{self.coordinator.data.position['lat']},{self.coordinator.data.position['lon']}"
+        pos = self.coordinator.data.position
+        self._attr_unique_id = f"{pos['lat']},{pos['lon']}"
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -195,7 +197,8 @@ class MeteoFranceWeather(
                 )
         else:
             for forecast in self.coordinator.data.daily_forecast:
-                # stop when we don't have a weather condition (can happen around last days of forecast, max 14)
+                # stop when we don't have a weather condition
+                # (can happen around last days of forecast, max 14)
                 if not forecast.get("weather12H"):
                     break
                 forecast_data.append(

--- a/homeassistant/components/meteo_lt/coordinator.py
+++ b/homeassistant/components/meteo_lt/coordinator.py
@@ -53,7 +53,8 @@ class MeteoLtUpdateCoordinator(DataUpdateCoordinator[MeteoLtForecast]):
         # Check if forecast data is available
         if not forecast.forecast_timestamps:
             raise UpdateFailed(
-                f"No forecast data available for {self.place_code} - API returned empty timestamps"
+                f"No forecast data available for {self.place_code}"
+                " - API returned empty timestamps"
             )
 
         return forecast

--- a/homeassistant/components/meteo_lt/weather.py
+++ b/homeassistant/components/meteo_lt/weather.py
@@ -127,7 +127,8 @@ class MeteoLtWeatherEntity(CoordinatorEntity[MeteoLtUpdateCoordinator], WeatherE
 
     async def async_forecast_daily(self) -> list[Forecast] | None:
         """Return the daily forecast."""
-        # Using hourly data to create daily summaries, since daily data is not provided directly
+        # Using hourly data to create daily summaries, since
+        # daily data is not provided directly
         if not self.coordinator.data:
             return None
 

--- a/homeassistant/components/miele/const.py
+++ b/homeassistant/components/miele/const.py
@@ -20,7 +20,8 @@ LIGHT_ON = 1
 LIGHT_OFF = 2
 
 # API "no reading" sentinels. Most temperatures use centidegrees (-32768 -> -327.68 °C).
-# Some devices report the int16 minimum already in degrees after scaling (-3276800 raw -> -32768 °C).
+# Some devices report the int16 minimum already in degrees
+# after scaling (-3276800 raw -> -32768 C).
 DISABLED_TEMP_ENTITIES = (
     -32768 / 100,
     -32766 / 100,

--- a/homeassistant/components/miele/diagnostics.py
+++ b/homeassistant/components/miele/diagnostics.py
@@ -36,19 +36,25 @@ async def async_get_config_entry_diagnostics(
         "devices": redact_identifiers(
             {
                 device_id: device_data.raw
-                for device_id, device_data in config_entry.runtime_data.coordinator.data.devices.items()
+                for device_id, device_data in (
+                    config_entry.runtime_data.coordinator.data.devices.items()
+                )
             }
         ),
         "filling_levels": redact_identifiers(
             {
                 device_id: filling_level_data.raw
-                for device_id, filling_level_data in config_entry.runtime_data.aux_coordinator.data.filling_levels.items()
+                for device_id, filling_level_data in (
+                    config_entry.runtime_data.aux_coordinator.data.filling_levels.items()
+                )
             }
         ),
         "actions": redact_identifiers(
             {
                 device_id: action_data.raw
-                for device_id, action_data in config_entry.runtime_data.coordinator.data.actions.items()
+                for device_id, action_data in (
+                    config_entry.runtime_data.coordinator.data.actions.items()
+                )
             }
         ),
     }

--- a/homeassistant/components/miele/sensor.py
+++ b/homeassistant/components/miele/sensor.py
@@ -847,8 +847,9 @@ async def async_setup_entry(
             and definition.description.value_fn(device) is None
             and definition.description.zone != 1
         ):
-            # Optional temperature datapoints (extra fridge zones, oven food probe): only
-            # create the entity after the API first reports a valid reading, then keep it
+            # Optional temperature datapoints (extra fridge
+            # zones, oven food probe): only create the entity
+            # after the API first reports a valid reading, keep it
             # so state can return to unknown when the datapoint is inactive.
             return _is_entity_registered(unique_id)
         if (
@@ -1163,7 +1164,8 @@ class MieleTimeSensor(MieleRestorableSensor):
         current_value = self.entity_description.value_fn(self.device)
         current_status = StateStatus(self.device.state_status).name
 
-        # report end-specific value when program ends (some devices are immediately reporting 0...)
+        # report end-specific value when program ends
+        # (some devices are immediately reporting 0...)
         if (
             current_status == StateStatus.program_ended.name
             and self.entity_description.end_value_fn is not None
@@ -1176,7 +1178,8 @@ class MieleTimeSensor(MieleRestorableSensor):
         elif current_status == StateStatus.program_ended.name:
             pass
 
-        # force unknown when appliance is not working (some devices are keeping last value until a new cycle starts)
+        # force unknown when appliance is not working (some
+        # devices keep last value until a new cycle starts)
         elif current_status in (
             StateStatus.off.name,
             StateStatus.on.name,
@@ -1213,7 +1216,8 @@ class MieleAbsoluteTimeSensor(MieleRestorableSensor):
         ) or current_status == StateStatus.program_ended.name:
             return
 
-        # force unknown when appliance is not working (some devices are keeping last value until a new cycle starts)
+        # force unknown when appliance is not working (some
+        # devices keep last value until a new cycle starts)
         if current_status in (
             StateStatus.off.name,
             StateStatus.on.name,
@@ -1260,9 +1264,11 @@ class MieleConsumptionSensor(MieleRestorableSensor):
             self._is_reporting = False
             self._attr_native_value = None
 
-        # appliance might report the last value for consumption of previous cycle and it will report 0
-        # only after a while, so it is necessary to force 0 until we see the 0 value coming from API, unless
-        # we already saw a valid value in this cycle from cache
+        # appliance might report the last value for consumption
+        # of previous cycle and it will report 0 only after a
+        # while, so it is necessary to force 0 until we see
+        # the 0 value coming from API, unless we already saw
+        # a valid value in this cycle from cache
         elif (
             current_status in (StateStatus.in_use.name, StateStatus.pause.name)
             and not self._is_reporting

--- a/homeassistant/components/miele/vacuum.py
+++ b/homeassistant/components/miele/vacuum.py
@@ -27,8 +27,9 @@ PARALLEL_UPDATES = 1
 _LOGGER = logging.getLogger(__name__)
 
 # The following const classes define program speeds and programs for the vacuum cleaner.
-# Miele have used the same and overlapping names for fan_speeds and programs even
-# if the contexts are different. This is an attempt to make it clearer in the integration.
+# Miele have used the same and overlapping names for
+# fan_speeds and programs even if the contexts are different.
+# This is an attempt to make it clearer in the integration.
 
 
 class FanSpeed(IntEnum):

--- a/homeassistant/components/minecraft_server/__init__.py
+++ b/homeassistant/components/minecraft_server/__init__.py
@@ -110,12 +110,14 @@ async def async_migrate_entry(
                 await api.async_initialize()
             except MinecraftServerAddressError:
                 _LOGGER.exception(
-                    "Can't migrate configuration entry due to error while parsing server address, try again later"
+                    "Can't migrate configuration entry due to error"
+                    " while parsing server address, try again later"
                 )
                 return False
 
         _LOGGER.debug(
-            "Migrating config entry, replacing host '%s' and port '%s' with address '%s'",
+            "Migrating config entry, replacing host '%s' and"
+            " port '%s' with address '%s'",
             config_data[CONF_HOST],
             config_data[CONF_PORT],
             address,

--- a/homeassistant/components/minecraft_server/api.py
+++ b/homeassistant/components/minecraft_server/api.py
@@ -101,7 +101,7 @@ class MinecraftServer:
         )
 
     async def async_is_online(self) -> bool:
-        """Check if the server is online, supporting both Java and Bedrock Edition servers."""
+        """Check if the server is online."""
         try:
             await self.async_get_data()
         except (
@@ -118,7 +118,7 @@ class MinecraftServer:
         return True
 
     async def async_get_data(self) -> MinecraftServerData:
-        """Get updated data from the server, supporting both Java and Bedrock Edition servers."""
+        """Get updated data from the server."""
         status_response: (
             BedrockStatusResponse | JavaStatusResponse | LegacyStatusResponse
         )
@@ -132,7 +132,8 @@ class MinecraftServer:
             status_response = await self._server.async_status(tries=DATA_UPDATE_RETRIES)
         except OSError as error:
             raise MinecraftServerConnectionError(
-                f"Status request to '{self._address}' failed: {self._get_error_message(error)}"
+                f"Status request to '{self._address}' failed: "
+                f"{self._get_error_message(error)}"
             ) from error
 
         if isinstance(status_response, JavaStatusResponse):

--- a/homeassistant/components/minecraft_server/config_flow.py
+++ b/homeassistant/components/minecraft_server/config_flow.py
@@ -38,7 +38,8 @@ class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_ADDRESS: address,
             }
 
-            # Some Bedrock Edition servers mimic a Java Edition server, therefore check for a Bedrock Edition server first.
+            # Some Bedrock Edition servers mimic a Java Edition
+            # server, therefore check for Bedrock Edition first.
             for server_type in MinecraftServerType:
                 api = MinecraftServer(self.hass, server_type, address)
 

--- a/homeassistant/components/minecraft_server/entity.py
+++ b/homeassistant/components/minecraft_server/entity.py
@@ -28,7 +28,12 @@ class MinecraftServerEntity(CoordinatorEntity[MinecraftServerCoordinator]):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, config_entry.entry_id)},
             manufacturer=MANUFACTURER,
-            model=f"Minecraft Server ({config_entry.data.get(CONF_TYPE, MinecraftServerType.JAVA_EDITION)})",
+            model=(
+                "Minecraft Server ("
+                f"{config_entry.data.get(CONF_TYPE, MinecraftServerType.JAVA_EDITION)})"
+            ),
             name=coordinator.name,
-            sw_version=f"{coordinator.data.version} ({coordinator.data.protocol_version})",
+            sw_version=(
+                f"{coordinator.data.version} ({coordinator.data.protocol_version})"
+            ),
         )

--- a/homeassistant/components/mobile_app/__init__.py
+++ b/homeassistant/components/mobile_app/__init__.py
@@ -174,7 +174,8 @@ async def _async_setup_cloudhook(
         ):
             await async_create_cloud_hook(hass, webhook_id, entry)
     elif CONF_CLOUDHOOK_URL in entry.data:
-        # If we have a cloudhook but no longer logged in to the cloud, remove it from the entry
+        # If we have a cloudhook but no longer logged in
+        # to the cloud, remove it from the entry
         clean_cloudhook()
 
     entry.async_on_unload(cloud.async_listen_connection_change(hass, manage_cloudhook))

--- a/homeassistant/components/mobile_app/const.py
+++ b/homeassistant/components/mobile_app/const.py
@@ -90,8 +90,9 @@ SCHEMA_APP_DATA = vol.Schema(
     {
         vol.Inclusive(ATTR_PUSH_TOKEN, "push_cloud"): cv.string,
         vol.Inclusive(ATTR_PUSH_URL, "push_cloud"): cv.url,
-        # Set to True to indicate that this registration will connect via websocket channel
-        # to receive push notifications.
+        # Set to True to indicate that this registration
+        # will connect via websocket channel to receive
+        # push notifications.
         vol.Optional(ATTR_PUSH_WEBSOCKET_CHANNEL): cv.boolean,
     },
     extra=vol.ALLOW_EXTRA,

--- a/homeassistant/components/mobile_app/entity.py
+++ b/homeassistant/components/mobile_app/entity.py
@@ -83,7 +83,8 @@ class MobileAppEntity(RestoreEntity):
         """Restore previous state."""
         config = self._config
 
-        # Only restore state if we don't have one already, since it can be set by a pending update
+        # Only restore state if we don't have one already,
+        # since it can be set by a pending update
         if config[ATTR_SENSOR_STATE] in (None, STATE_UNKNOWN):
             config[ATTR_SENSOR_STATE] = last_state.state
             config[ATTR_SENSOR_ATTRIBUTES] = {

--- a/homeassistant/components/mobile_app/notify.py
+++ b/homeassistant/components/mobile_app/notify.py
@@ -95,7 +95,8 @@ class MobileAppNotifyEntity(NotifyEntity):
         if title is not None:
             data[ATTR_TITLE] = title
 
-        # Sends notification via local push if available and fallback to cloud push if fails
+        # Sends notification via local push if available
+        # and fallback to cloud push if fails
         if (webhook_id := self._config_entry.data[ATTR_WEBHOOK_ID]) in self.hass.data[
             DOMAIN
         ][DATA_PUSH_CHANNEL]:
@@ -228,7 +229,9 @@ class MobileAppNotificationService(BaseNotificationService):
 
         if failed_targets:
             raise HomeAssistantError(
-                f"Device(s) with webhook id(s) {', '.join(failed_targets)} not connected to local push notifications"
+                "Device(s) with webhook id(s)"
+                f" {', '.join(failed_targets)}"
+                " not connected to local push notifications"
             )
 
     async def _async_send_remote_message_target(

--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -689,8 +689,9 @@ def _async_update_sensor_entity(
     # Replace existing pending update with the latest sensor data.
     hass.data[DOMAIN][DATA_PENDING_UPDATES][entity_type][unique_store_key] = data
 
-    # The signal might not be handled if the entity was just enabled, but the data is stored
-    # in pending updates and will be applied on entity initialization.
+    # The signal might not be handled if the entity was
+    # just enabled, but the data is stored in pending updates
+    # and will be applied on entity initialization.
     async_dispatcher_send(
         hass, f"{SIGNAL_SENSOR_UPDATE}-{entity_type}-{unique_store_key}"
     )

--- a/homeassistant/components/mobile_app/websocket_api.py
+++ b/homeassistant/components/mobile_app/websocket_api.py
@@ -26,7 +26,8 @@ def _ensure_webhook_access(func):
     @callback
     @wraps(func)
     def with_webhook_access(hass, connection, msg):
-        # Validate that the webhook ID is registered to the user of the websocket connection
+        # Validate that the webhook ID is registered to
+        # the user of the websocket connection
         config_entry = hass.data[DOMAIN][DATA_CONFIG_ENTRIES].get(msg["webhook_id"])
 
         if config_entry is None:

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -569,7 +569,10 @@ class ModbusThermostat(ModbusStructEntity, RestoreEntity, ClimateEntity):
                     break
 
             if self._attr_swing_mode is STATE_UNKNOWN:
-                _err = f"{self.name}: No answer received from Swing mode register. State is Unknown"
+                _err = (
+                    f"{self.name}: No answer received from"
+                    " Swing mode register. State is Unknown"
+                )
                 _LOGGER.error(_err)
 
         # Read the on/off register if defined. If the value in this

--- a/homeassistant/components/modbus/cover.py
+++ b/homeassistant/components/modbus/cover.py
@@ -62,8 +62,9 @@ class ModbusCover(ModbusBaseEntity, CoverEntity, RestoreEntity):
 
         self._attr_is_closed = False
 
-        # If we read cover status from coil, and not from optional status register,
-        # we interpret boolean value False as closed cover, and value True as open cover.
+        # If we read cover status from coil, and not from
+        # optional status register, we interpret boolean value
+        # False as closed cover, and value True as open cover.
         # Intermediate states are not supported in such a setup.
         if self._input_type == CALL_TYPE_COIL:
             self._write_type = CALL_TYPE_WRITE_COIL

--- a/homeassistant/components/modbus/light.py
+++ b/homeassistant/components/modbus/light.py
@@ -191,7 +191,7 @@ class ModbusLight(ModbusToggleEntity, LightEntity):
         )
 
     def _convert_modbus_percent_to_temperature(self, percent: int) -> int:
-        """Convert Modbus scale (0-100) to the color temperature in Kelvin (2000-7000 К)."""
+        """Convert Modbus scale (0-100) to color temp in Kelvin (2000-7000 K)."""
         return round(
             self._attr_min_color_temp_kelvin
             + (

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -316,10 +316,12 @@ class ModbusHub:
                     break
             except ModbusException as exception_error:
                 self._log_error(
-                    f"{self.name} connect failed, please check your configuration ({exception_error!s})"
+                    f"{self.name} connect failed, please check"
+                    f" your configuration ({exception_error!s})"
                 )
             _LOGGER.info(
-                f"modbus {self.name} connect NOT a success ! retrying in {PRIMARY_RECONNECT_DELAY} seconds"
+                f"modbus {self.name} connect NOT a success !"
+                f" retrying in {PRIMARY_RECONNECT_DELAY} seconds"
             )
             await asyncio.sleep(PRIMARY_RECONNECT_DELAY)
 
@@ -399,7 +401,10 @@ class ModbusHub:
             self._log_error(error)
             return None
         if result.isError():
-            error = f"Error: device: {slave} address: {address} -> pymodbus returned isError True"
+            error = (
+                f"Error: device: {slave} address: {address}"
+                " -> pymodbus returned isError True"
+            )
             self._log_error(error)
             return None
         return result

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -164,7 +164,10 @@ def struct_validator(config: dict[str, Any]) -> dict[str, Any]:
     ):
         if entry[0] is None:
             if entry[1] == DEMANDED:
-                error = f"{name}: `{entry[2]}` missing, demanded with `{CONF_DATA_TYPE}: {data_type}`"
+                error = (
+                    f"{name}: `{entry[2]}` missing,"
+                    f" demanded with `{CONF_DATA_TYPE}: {data_type}`"
+                )
                 raise vol.Invalid(error)
         elif entry[1] == ILLEGAL:
             error = f"{name}: `{entry[2]}` illegal with `{CONF_DATA_TYPE}: {data_type}`"
@@ -180,7 +183,8 @@ def struct_validator(config: dict[str, Any]) -> dict[str, Any]:
         bytecount = count * 2
         if bytecount != size:
             raise vol.Invalid(
-                f"{name}: Size of structure is {size} bytes but `{CONF_COUNT}: {count}` is {bytecount} bytes"
+                f"{name}: Size of structure is {size} bytes"
+                f" but `{CONF_COUNT}: {count}` is {bytecount} bytes"
             )
     else:
         if data_type != DataType.STRING:
@@ -199,7 +203,7 @@ def struct_validator(config: dict[str, Any]) -> dict[str, Any]:
 
 
 def hvac_fixedsize_reglist_validator(value: Any) -> list:
-    """Check the number of registers for target temp. and coerce it to a list, if valid."""
+    """Check the number of registers for target temp and coerce to a list."""
     if isinstance(value, int):
         value = [value] * len(HVACMode)
         return list(value)
@@ -214,7 +218,8 @@ def hvac_fixedsize_reglist_validator(value: Any) -> list:
             return list(value)
 
     raise vol.Invalid(
-        f"Invalid target temp register. Required type: integer, allowed 1 or list of {len(HVACMode)} registers"
+        "Invalid target temp register. Required type: integer,"
+        f" allowed 1 or list of {len(HVACMode)} registers"
     )
 
 
@@ -238,7 +243,10 @@ def duplicate_fan_mode_validator(config: dict[str, Any]) -> dict:
     errors = []
     for key, value in config[CONF_FAN_MODE_VALUES].items():
         if value in fan_modes:
-            warn = f"Modbus fan mode {key} has a duplicate value {value}, not loaded, values must be unique!"
+            warn = (
+                f"Modbus fan mode {key} has a duplicate value"
+                f" {value}, not loaded, values must be unique!"
+            )
             _LOGGER.warning(warn)
             errors.append(key)
         else:
@@ -257,7 +265,7 @@ def not_zero_value(val: float, errMsg: str) -> float:
 
 
 def ensure_and_check_conflicting_scales_and_offsets(config: dict[str, Any]) -> dict:
-    """Check for conflicts in scale/offset and ensure target/current temp scale/offset is set."""
+    """Check for conflicts in scale/offset and ensure target/current temp is set."""
     config_keys = [
         (CONF_SCALE, CONF_TARGET_TEMP_SCALE, CONF_CURRENT_TEMP_SCALE, DEFAULT_SCALE),
         (
@@ -271,10 +279,14 @@ def ensure_and_check_conflicting_scales_and_offsets(config: dict[str, Any]) -> d
     for generic_key, target_key, current_key, default_value in config_keys:
         if generic_key in config and (target_key in config or current_key in config):
             raise vol.Invalid(
-                f"Cannot use both '{generic_key}' and temperature-specific parameters "
-                f"('{target_key}' or '{current_key}') in the same configuration. "
-                f"Either the '{generic_key}' parameter (which applies to both temperatures) "
-                "or the new temperature-specific parameters, but not both."
+                f"Cannot use both '{generic_key}' and"
+                " temperature-specific parameters"
+                f" ('{target_key}' or '{current_key}')"
+                " in the same configuration."
+                f" Either the '{generic_key}' parameter"
+                " (which applies to both temperatures)"
+                " or the new temperature-specific"
+                " parameters, but not both."
             )
         if generic_key in config:
             value = config.pop(generic_key)
@@ -295,7 +307,11 @@ def duplicate_swing_mode_validator(config: dict[str, Any]) -> dict:
     errors = []
     for key, value in config[CONF_SWING_MODE_VALUES].items():
         if value in swing_modes:
-            warn = f"Modbus swing mode {key} has a duplicate value {value}, not loaded, values must be unique!"
+            warn = (
+                f"Modbus swing mode {key} has a duplicate"
+                f" value {value}, not loaded,"
+                " values must be unique!"
+            )
             _LOGGER.warning(warn)
             errors.append(key)
         else:
@@ -316,7 +332,9 @@ def register_int_list_validator(value: Any) -> Any:
             return value
 
     raise vol.Invalid(
-        f"Invalid {CONF_ADDRESS} register for fan/swing mode. Required type: positive integer, allowed 1 or list of 1 register."
+        f"Invalid {CONF_ADDRESS} register for fan/swing mode."
+        " Required type: positive integer,"
+        " allowed 1 or list of 1 register."
     )
 
 
@@ -447,7 +465,8 @@ def check_config(hass: HomeAssistant, config: dict) -> dict:
                     "",
                     "",
                 ],
-                f"Modbus {hub[CONF_NAME]} contain no entities, causing instability, entry not loaded",
+                f"Modbus {hub[CONF_NAME]} contain no entities,"
+                " causing instability, entry not loaded",
             )
             del config[hub_inx]
             continue

--- a/homeassistant/components/modem_callerid/config_flow.py
+++ b/homeassistant/components/modem_callerid/config_flow.py
@@ -32,7 +32,12 @@ class PhoneModemFlowHandler(ConfigFlow, domain=DOMAIN):
     async def async_step_usb(self, discovery_info: UsbServiceInfo) -> ConfigFlowResult:
         """Handle USB Discovery."""
         dev_path = discovery_info.device
-        unique_id = f"{discovery_info.vid}:{discovery_info.pid}_{discovery_info.serial_number}_{discovery_info.manufacturer}_{discovery_info.description}"
+        unique_id = (
+            f"{discovery_info.vid}:{discovery_info.pid}"
+            f"_{discovery_info.serial_number}"
+            f"_{discovery_info.manufacturer}"
+            f"_{discovery_info.description}"
+        )
         if (
             await self.validate_device_errors(dev_path=dev_path, unique_id=unique_id)
             is None

--- a/homeassistant/components/monarch_money/config_flow.py
+++ b/homeassistant/components/monarch_money/config_flow.py
@@ -54,7 +54,8 @@ async def validate_login(
 ) -> dict[str, Any]:
     """Validate the user input allows us to connect.
 
-    Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user. Upon success a session will be saved
+    Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
+    Upon success a session will be saved
     """
 
     if not email:
@@ -68,7 +69,8 @@ async def validate_login(
         try:
             await monarch_client.multi_factor_authenticate(email, password, mfa_code)
         except KeyError as err:
-            # A bug in the backing lib that I don't control throws a KeyError if the MFA code is wrong
+            # A bug in the backing lib that I don't control
+            # throws a KeyError if the MFA code is wrong
             LOGGER.debug("Bad MFA Code")
             raise BadMFA from err
     else:

--- a/homeassistant/components/monarch_money/entity.py
+++ b/homeassistant/components/monarch_money/entity.py
@@ -66,7 +66,11 @@ class MonarchMoneyAccountEntity(MonarchMoneyEntityBase):
             name=f"{account.institution_name} {account.name}",
             entry_type=DeviceEntryType.SERVICE,
             manufacturer=account.data_provider,
-            model=f"{account.institution_name} - {account.type_name} - {account.subtype_name}",
+            model=(
+                f"{account.institution_name}"
+                f" - {account.type_name}"
+                f" - {account.subtype_name}"
+            ),
             configuration_url=account.institution_url,
         )
 

--- a/homeassistant/components/monarch_money/sensor.py
+++ b/homeassistant/components/monarch_money/sensor.py
@@ -176,7 +176,7 @@ class MonarchMoneySensor(MonarchMoneyAccountEntity, SensorEntity):
 
     @property
     def entity_picture(self) -> str | None:
-        """Return the picture of the account as provided by monarch money if it exists."""
+        """Return the picture of the account if it exists."""
         if self.entity_description.picture_fn is not None:
             return self.entity_description.picture_fn(self.account_data)
         return None

--- a/homeassistant/components/monoprice/__init__.py
+++ b/homeassistant/components/monoprice/__init__.py
@@ -78,8 +78,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: MonopriceConfigEntry) -
     def _cleanup(monoprice) -> None:
         """Destroy the Monoprice object.
 
-        Destroying the Monoprice closes the serial connection, do it in an executor so the garbage
-        collection does not block.
+        Destroying the Monoprice closes the serial connection,
+        do it in an executor so the garbage collection
+        does not block.
         """
         del monoprice
 

--- a/homeassistant/components/monoprice/media_player.py
+++ b/homeassistant/components/monoprice/media_player.py
@@ -130,7 +130,7 @@ class MonopriceZone(MediaPlayerEntity):
 
     @property
     def entity_registry_enabled_default(self) -> bool:
-        """Return if the entity should be enabled when first added to the entity registry."""
+        """Return if the entity should be enabled when first added."""
         return self._zone_id < 20 or self._update_success
 
     @property

--- a/homeassistant/components/motion_blinds/entity.py
+++ b/homeassistant/components/motion_blinds/entity.py
@@ -133,7 +133,8 @@ class MotionCoordinatorEntity(CoordinatorEntity[DataUpdateCoordinatorMotionBlind
                 self._blind.angle == prev_angle for prev_angle in self._previous_angles
             )
         ):
-            # keep updating the position @self._update_interval_moving until the position does not change.
+            # keep updating the position @self._update_interval_moving
+            # until the position does not change.
             self._requesting_position = async_call_later(
                 self.hass,
                 self._update_interval_moving,
@@ -145,7 +146,7 @@ class MotionCoordinatorEntity(CoordinatorEntity[DataUpdateCoordinatorMotionBlind
             self._requesting_position = None
 
     async def async_request_position_till_stop(self, delay: int | None = None) -> None:
-        """Request the position of the blind every self._update_interval_moving seconds until it stops moving."""
+        """Request the position of the blind at intervals until it stops moving."""
         if delay is None:
             delay = self._update_interval_moving
 

--- a/homeassistant/components/motionblinds_ble/entity.py
+++ b/homeassistant/components/motionblinds_ble/entity.py
@@ -44,6 +44,6 @@ class MotionblindsBLEEntity(Entity):
         )
 
     async def async_update(self) -> None:
-        """Update state, called by HA if there is a poll interval and by the service homeassistant.update_entity."""
+        """Update state, called by HA on poll or homeassistant.update_entity."""
         _LOGGER.debug("(%s) Updating entity", self.entry.data[CONF_MAC_CODE])
         await self.device.status_query()

--- a/homeassistant/components/motionmount/__init__.py
+++ b/homeassistant/components/motionmount/__init__.py
@@ -45,7 +45,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: MotionMountConfigEntry) 
         # and update the config entry so we do not mix up devices.
         await mm.disconnect()
         raise ConfigEntryNotReady(
-            f"Unexpected device found at {host}; expected {entry.unique_id}, found {found_mac}"
+            f"Unexpected device found at {host};"
+            f" expected {entry.unique_id}, found {found_mac}"
         )
 
     # Check we're properly authenticated or be able to become so

--- a/homeassistant/components/motionmount/config_flow.py
+++ b/homeassistant/components/motionmount/config_flow.py
@@ -25,11 +25,20 @@ _LOGGER = logging.getLogger(__name__)
 
 
 # A MotionMount can be in four states:
-# 1. Old CE and old Pro FW -> It doesn't supply any kind of mac
-# 2. Old CE but new Pro FW -> It supplies its mac using DNS-SD, but a read of the mac fails
-# 3. New CE but old Pro FW -> It doesn't supply the mac using DNS-SD but we can read it (returning the EMPTY_MAC)
-# 4. New CE and new Pro FW -> Both DNS-SD and a read gives us the mac
-# If we can't get the mac, we use DEFAULT_DISCOVERY_UNIQUE_ID as an ID, so we can always configure a single MotionMount. Most households will only have a single MotionMount
+# 1. Old CE and old Pro FW ->
+#    It doesn't supply any kind of mac
+# 2. Old CE but new Pro FW ->
+#    It supplies its mac using DNS-SD,
+#    but a read of the mac fails
+# 3. New CE but old Pro FW ->
+#    It doesn't supply the mac using DNS-SD
+#    but we can read it (returning the EMPTY_MAC)
+# 4. New CE and new Pro FW ->
+#    Both DNS-SD and a read gives us the mac
+# If we can't get the mac, we use
+# DEFAULT_DISCOVERY_UNIQUE_ID as an ID, so we can
+# always configure a single MotionMount. Most
+# households will only have a single MotionMount
 class MotionMountFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a Vogel's MotionMount config flow."""
 

--- a/homeassistant/components/motionmount/select.py
+++ b/homeassistant/components/motionmount/select.py
@@ -111,7 +111,8 @@ class MotionMountPresets(MotionMountEntity, SelectEntity):
         if self.mm.is_moving:
             return self._attr_current_option
 
-        # When the mount isn't moving we select the option that matches the current position
+        # When the mount isn't moving we select the option
+        # that matches the current position
         self._attr_current_option = None
         if self.mm.extension == 0 and self.mm.turn == 0:
             self._attr_current_option = self._attr_options[0]  # Select Wall preset

--- a/homeassistant/components/mpd/media_player.py
+++ b/homeassistant/components/mpd/media_player.py
@@ -292,8 +292,9 @@ class MpdDevice(MediaPlayerEntity):
                 bytes(response["binary"])
             ).hexdigest()[:16]
         else:
-            # If there is no image, this hash has to be None, else the media player component
-            # assumes there is an image and returns an error trying to load it and the
+            # If there is no image, this hash has to be None,
+            # else the media player component assumes there is an
+            # image and returns an error trying to load it and the
             # frontend media control card breaks.
             self._media_image_hash = None
 
@@ -322,7 +323,8 @@ class MpdDevice(MediaPlayerEntity):
                         error,
                     )
 
-        # read artwork contained in the media directory (cover.{jpg,png,tiff,bmp}) if none is embedded
+        # read artwork contained in the media directory
+        # (cover.{jpg,png,tiff,bmp}) if none is embedded
         if can_albumart and not response:
             try:
                 with suppress(mpd.ConnectionError):

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -313,10 +313,11 @@ def subscribe(
 
     def remove() -> None:
         """Remove listener convert."""
-        # MQTT messages tend to be high volume,
-        # and since they come in via a thread and need to be processed in the event loop,
-        # we want to avoid hass.add_job since most of the time is spent calling
-        # inspect to figure out how to run the callback.
+        # MQTT messages tend to be high volume, and since they
+        # come in via a thread and need to be processed in the
+        # event loop, we want to avoid hass.add_job since most
+        # of the time is spent calling inspect to figure out
+        # how to run the callback.
         hass.loop.call_soon_threadsafe(async_remove)
 
     return remove

--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -4621,7 +4621,7 @@ class MQTTSubentryFlowHandler(ConfigSubentryFlow):
         if reconfig := (self._component_id is not None):
             component_data = self._subentry_data["components"][self._component_id]
             name: str | None = component_data.get(CONF_NAME)
-            platform_label = f"{self._subentry_data['components'][self._component_id][CONF_PLATFORM]} "
+            platform_label = f"{component_data[CONF_PLATFORM]} "
             entity_name_label = f" ({name})" if name is not None else ""
         data_schema = data_schema_from_fields(data_schema_fields, reconfig=reconfig)
         if user_input is not None:

--- a/homeassistant/components/mqtt/datetime.py
+++ b/homeassistant/components/mqtt/datetime.py
@@ -146,7 +146,8 @@ class MqttDateTime(MqttEntity, DateTimeEntity):
             value = parse(payload)
         except ParserError:
             _LOGGER.warning(
-                "Invalid received date/time expression on topic %s for entity %s, got %s",
+                "Invalid received date/time expression on topic"
+                " %s for entity %s, got %s",
                 msg.topic,
                 self.entity_id,
                 msg.payload,

--- a/homeassistant/components/mqtt/device_tracker.py
+++ b/homeassistant/components/mqtt/device_tracker.py
@@ -53,7 +53,9 @@ def valid_config(config: ConfigType) -> ConfigType:
     """Check if there is a state topic or json_attributes_topic."""
     if CONF_STATE_TOPIC not in config and CONF_JSON_ATTRS_TOPIC not in config:
         raise vol.Invalid(
-            f"Invalid device tracker config, missing {CONF_STATE_TOPIC} or {CONF_JSON_ATTRS_TOPIC}, got: {config}"
+            f"Invalid device tracker config, missing"
+            f" {CONF_STATE_TOPIC} or"
+            f" {CONF_JSON_ATTRS_TOPIC}, got: {config}"
         )
     return config
 

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -565,7 +565,10 @@ async def async_start(  # noqa: C901
             )
         elif already_discovered:
             # Dispatch update
-            message = f"Component has already been discovered: {component} {discovery_id}, sending update"
+            message = (
+                f"Component has already been discovered:"
+                f" {component} {discovery_id}, sending update"
+            )
             async_log_discovery_origin_info(message, payload)
             async_dispatcher_send(
                 hass, MQTT_DISCOVERY_UPDATED.format(*discovery_hash), payload

--- a/homeassistant/components/mqtt/event.py
+++ b/homeassistant/components/mqtt/event.py
@@ -111,7 +111,8 @@ class MqttEvent(MqttEntity, EventEntity):
         """Handle new MQTT messages."""
         if msg.retain:
             _LOGGER.debug(
-                "Ignoring event trigger from replayed retained payload '%s' on topic %s",
+                "Ignoring event trigger from replayed retained"
+                " payload '%s' on topic %s",
                 msg.payload,
                 msg.topic,
             )

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -157,8 +157,11 @@ class MqttCommandTemplateException(ServiceValidationError):
         }
         entity_id_log = "" if entity_id is None else f" for entity '{entity_id}'"
         self._message = (
-            f"{type(base_exception).__name__}: {base_exception} rendering template{entity_id_log}"
-            f", template: '{command_template}' and payload: {value_log}"
+            f"{type(base_exception).__name__}:"
+            f" {base_exception} rendering"
+            f" template{entity_id_log}"
+            f", template: '{command_template}'"
+            f" and payload: {value_log}"
         )
 
     def __str__(self) -> str:
@@ -243,8 +246,12 @@ class MqttValueTemplateException(TemplateError):
         )
         payload_log = str(payload)
         self._message = (
-            f"{type(base_exception).__name__}: {base_exception} rendering template{entity_id_log}"
-            f", template: '{value_template}'{default_payload_log} and payload: {payload_log}"
+            f"{type(base_exception).__name__}:"
+            f" {base_exception} rendering"
+            f" template{entity_id_log}"
+            f", template: '{value_template}'"
+            f"{default_payload_log}"
+            f" and payload: {payload_log}"
         )
 
     def __str__(self) -> str:

--- a/homeassistant/components/mqtt/notify.py
+++ b/homeassistant/components/mqtt/notify.py
@@ -52,7 +52,7 @@ async def async_setup_entry(
 
 
 class MqttNotify(MqttEntity, NotifyEntity):
-    """Representation of a notification entity service that can send messages using MQTT."""
+    """Notification entity that can send messages using MQTT."""
 
     _default_name = DEFAULT_NAME
     _entity_id_format = notify.ENTITY_ID_FORMAT

--- a/homeassistant/components/mqtt/vacuum.py
+++ b/homeassistant/components/mqtt/vacuum.py
@@ -145,7 +145,8 @@ def validate_clean_area_config(config: ConfigType) -> ConfigType:
         return config
     if not config.get(CONF_UNIQUE_ID):
         raise vol.Invalid(
-            f"Option `{CONF_CLEAN_SEGMENTS_COMMAND_TOPIC}` requires `{CONF_UNIQUE_ID}` to be configured"
+            f"Option `{CONF_CLEAN_SEGMENTS_COMMAND_TOPIC}`"
+            f" requires `{CONF_UNIQUE_ID}` to be configured"
         )
 
     return config

--- a/homeassistant/components/music_assistant/__init__.py
+++ b/homeassistant/components/music_assistant/__init__.py
@@ -218,7 +218,8 @@ async def async_setup_entry(  # noqa: C901
         mass.subscribe(handle_player_removed, EventType.PLAYER_REMOVED)
     )
 
-    # register listener for player configs (to handle toggling of the 'expose_to_ha' setting)
+    # register listener for player configs
+    # (to handle toggling of the 'expose_to_ha' setting)
     def handle_player_config_updated(event: MassEvent) -> None:
         """Handle Mass Player Config Updated event."""
         if event.object_id is None or not event.data:

--- a/homeassistant/components/music_assistant/button.py
+++ b/homeassistant/components/music_assistant/button.py
@@ -32,7 +32,7 @@ async def async_setup_entry(
 
 
 class MusicAssistantFavoriteButton(MusicAssistantEntity, ButtonEntity):
-    """Representation of a Button entity to favorite the currently playing item on a player."""
+    """Representation of a Button entity to favorite the current item."""
 
     entity_description = ButtonEntityDescription(
         key="favorite_now_playing",

--- a/homeassistant/components/music_assistant/config_flow.py
+++ b/homeassistant/components/music_assistant/config_flow.py
@@ -145,9 +145,11 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
         This flow is triggered by the Music Assistant app.
         """
         # Build URL from app discovery info
-        # The app exposes the API on port 8095, but also hosts an internal-only
-        # webserver (default at port 8094) for the Home Assistant integration to connect to.
-        # The info where the internal API is exposed is passed via discovery_info
+        # The app exposes the API on port 8095, but also
+        # hosts an internal-only webserver (default at port
+        # 8094) for the HA integration to connect to.
+        # The info where the internal API is exposed is
+        # passed via discovery_info
         host = discovery_info.config["host"]
         port = discovery_info.config["port"]
         self.url = f"http://{host}:{port}"
@@ -288,7 +290,8 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
         state = _encode_jwt(
             self.hass, {"flow_id": self.flow_id, "redirect_uri": redirect_uri}
         )
-        # Music Assistant server will redirect to: {redirect_uri}?state={state}&code={token}
+        # Music Assistant server will redirect to:
+        # {redirect_uri}?state={state}&code={token}
         params = urlencode(
             {
                 "return_url": f"{redirect_uri}?state={state}",

--- a/homeassistant/components/music_assistant/media_browser.py
+++ b/homeassistant/components/music_assistant/media_browser.py
@@ -547,7 +547,8 @@ def _process_search_results(
                 continue
 
             # Create browse item
-            # Convert to string to get the original value since we're using MASSMediaType enum
+            # Convert to string to get the original value
+            # since we're using MASSMediaType enum
             str_media_type = media_type.value.lower()
             can_expand = _should_expand_media_type(str_media_type)
             media_class = _get_media_class_for_type(str_media_type)

--- a/homeassistant/components/music_assistant/number.py
+++ b/homeassistant/components/music_assistant/number.py
@@ -77,7 +77,7 @@ async def async_setup_entry(
 
 
 class MusicAssistantPlayerConfigNumber(MusicAssistantPlayerOptionEntity, NumberEntity):
-    """Representation of a Number entity to control player provider dependent settings."""
+    """Representation of a Number entity to control player settings."""
 
     def __init__(
         self,

--- a/homeassistant/components/music_assistant/select.py
+++ b/homeassistant/components/music_assistant/select.py
@@ -48,10 +48,16 @@ async def async_setup_entry(
                 != PlayerOptionType.BOOLEAN  # these always go to switch
                 and player_option.options
             ):
-                # We ignore entities with unknown translation key for the base name.
-                # However, we accept a non-available translation_key in strings.json for the entity's state,
-                # as these are oftentimes dynamically created, dependent on a specific player and might not be known to the provider
-                # developer. In that case, the frontend falls back to showing the state's bare translation key.
+                # We ignore entities with unknown
+                # translation key for the base name.
+                # However, we accept a non-available
+                # translation_key in strings.json for the
+                # entity's state, as these are oftentimes
+                # dynamically created, dependent on a
+                # specific player and might not be known to
+                # the provider developer. In that case, the
+                # frontend falls back to showing the state's
+                # bare translation key.
                 if player_option.translation_key not in PLAYER_OPTIONS_SELECT:
                     continue
 
@@ -76,7 +82,7 @@ async def async_setup_entry(
 
 
 class MusicAssistantPlayerConfigSelect(MusicAssistantPlayerOptionEntity, SelectEntity):
-    """Representation of a select entity to control player provider dependent settings."""
+    """Representation of a select entity to control player settings."""
 
     def __init__(
         self,

--- a/homeassistant/components/music_assistant/switch.py
+++ b/homeassistant/components/music_assistant/switch.py
@@ -73,7 +73,7 @@ async def async_setup_entry(
 
 
 class MusicAssistantPlayerConfigSwitch(MusicAssistantPlayerOptionEntity, SwitchEntity):
-    """Representation of a Switch entity to control player provider dependent settings."""
+    """Representation of a Switch entity to control player settings."""
 
     def __init__(
         self,

--- a/homeassistant/components/mvglive/sensor.py
+++ b/homeassistant/components/mvglive/sensor.py
@@ -163,7 +163,7 @@ class MVGLiveSensor(SensorEntity):
 
 
 def _get_minutes_until_departure(departure_time: int) -> int:
-    """Calculate the time difference in minutes between the current time and a given departure time.
+    """Calculate the time difference in minutes between now and a departure time.
 
     Args:
         departure_time: Unix timestamp of the departure time, in seconds.

--- a/homeassistant/components/myneomitis/climate.py
+++ b/homeassistant/components/myneomitis/climate.py
@@ -295,7 +295,8 @@ class MyNeoClimate(ClimateEntity):
             ok = await self._set_device_mode(preset_to_restore)
             if not ok:
                 raise HomeAssistantError(
-                    f"Failed to restore preset '{preset_to_restore}' for {self.entity_id}"
+                    f"Failed to restore preset '{preset_to_restore}'"
+                    f" for {self.entity_id}"
                 )
             self._attr_preset_mode = preset_to_restore
 
@@ -338,7 +339,8 @@ class MyNeoClimate(ClimateEntity):
                 rfid = self._device.get("rfid")
                 if not gateway or not rfid:
                     _LOGGER.error(
-                        "Missing gateway or rfid for sub-device %s, cannot set temperature",
+                        "Missing gateway or rfid for sub-device"
+                        " %s, cannot set temperature",
                         self._attr_unique_id,
                     )
                     return False

--- a/homeassistant/components/mysensors/config_flow.py
+++ b/homeassistant/components/mysensors/config_flow.py
@@ -96,7 +96,8 @@ def _is_same_device(
 ) -> bool:
     """Check if another ConfigDevice is actually the same as user_input.
 
-    This function only compares addresses and tcp ports, so it is possible to fool it with tricks like port forwarding.
+    This function only compares addresses and tcp ports, so it is possible
+    to fool it with tricks like port forwarding.
     """
     if entry.data[CONF_DEVICE] != user_input[CONF_DEVICE]:
         return False

--- a/homeassistant/components/mysensors/helpers.py
+++ b/homeassistant/components/mysensors/helpers.py
@@ -157,7 +157,10 @@ def invalid_msg(
     """Return a message for an invalid child during schema validation."""
     presentation = gateway.const.Presentation
     set_req = gateway.const.SetReq
-    return f"{presentation(child.type).name} requires value_type {set_req[value_type_name].name}"
+    return (
+        f"{presentation(child.type).name} requires"
+        f" value_type {set_req[value_type_name].name}"
+    )
 
 
 def validate_set_msg(

--- a/homeassistant/components/myuplink/sensor.py
+++ b/homeassistant/components/myuplink/sensor.py
@@ -332,7 +332,7 @@ class MyUplinkEnumSensor(MyUplinkDevicePointSensor):
 
 
 class MyUplinkEnumRawSensor(MyUplinkDevicePointSensor):
-    """Representation of a myUplink device point sensor for raw value from ENUM device_class."""
+    """Representation of a myUplink device point sensor for raw ENUM value."""
 
     _attr_entity_registry_enabled_default = False
     _attr_device_class = None


### PR DESCRIPTION
## Proposed change

Fix all 209 E501 (line too long) violations in Home Assistant components starting with m.

Part of a series to enforce the 88-character line length limit across the codebase. Changes are purely cosmetic — rewrapped comments, split long strings, and reformatted docstrings. No logic changes.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr