### PR TITLE
Bump Novy Cooker Hood quality scale to Gold

### DIFF
--- a/homeassistant/components/novy_cooker_hood/manifest.json
+++ b/homeassistant/components/novy_cooker_hood/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://www.home-assistant.io/integrations/novy_cooker_hood",
   "integration_type": "device",
   "iot_class": "assumed_state",
-  "quality_scale": "bronze",
+  "quality_scale": "gold",
   "requirements": ["rf-protocols==3.0.0"]
 }

--- a/homeassistant/components/novy_cooker_hood/quality_scale.yaml
+++ b/homeassistant/components/novy_cooker_hood/quality_scale.yaml
@@ -36,8 +36,8 @@ rules:
   # Silver
   action-exceptions: done
   config-entry-unloading: done
-  docs-configuration-parameters: todo
-  docs-installation-parameters: todo
+  docs-configuration-parameters: done
+  docs-installation-parameters: done
   entity-unavailable: done
   integration-owner: done
   log-when-unavailable: done
@@ -62,12 +62,12 @@ rules:
     status: exempt
     comment: |
       RF transmission is one-way; there is no data update.
-  docs-examples: todo
-  docs-known-limitations: todo
-  docs-supported-devices: todo
-  docs-supported-functions: todo
-  docs-troubleshooting: todo
-  docs-use-cases: todo
+  docs-examples: done
+  docs-known-limitations: done
+  docs-supported-devices: done
+  docs-supported-functions: done
+  docs-troubleshooting: done
+  docs-use-cases: done
   dynamic-devices:
     status: exempt
     comment: |
@@ -85,7 +85,12 @@ rules:
     comment: |
       The light entity represents the primary device function.
   entity-translations: done
-  exception-translations: done
+  exception-translations:
+    status: exempt
+    comment: |
+      The integration does not raise its own exceptions. Underlying transmit
+      errors already surface as translated `HomeAssistantError`s from the
+      `radio_frequency` integration.
   icon-translations:
     status: exempt
     comment: |


### PR DESCRIPTION
## Proposed change

Marks the remaining docs rules as `done` (the documentation pages are live on home-assistant.io) and exempts `exception-translations` since the integration only re-raises translated errors from `radio_frequency`. With `diagnostics` and `reconfiguration-flow` already merged, all Gold rules are now satisfied, so the manifest tier moves from `bronze` to `gold`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
