### PR TITLE
Fix swallowed exception in unifi_access image thumbnail fetch

### DIFF
--- a/homeassistant/components/unifi_access/image.py
+++ b/homeassistant/components/unifi_access/image.py
@@ -1,19 +1,18 @@
 """Image platform for the UniFi Access integration."""
 
 from datetime import UTC, datetime
-import logging
 
 from unifi_access_api import Door, UnifiAccessError
 
 from homeassistant.components.image import ImageEntity
 from homeassistant.const import CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .const import DOMAIN
 from .coordinator import UnifiAccessConfigEntry, UnifiAccessCoordinator
 from .entity import UnifiAccessEntity
-
-_LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
 
@@ -76,11 +75,10 @@ class UnifiAccessDoorImageEntity(UnifiAccessEntity, ImageEntity):
             try:
                 return await self.coordinator.client.get_thumbnail(thumbnail.url)
             except UnifiAccessError as err:
-                _LOGGER.warning(
-                    "Failed to fetch thumbnail for door %s: %s",
-                    self._door_id,
-                    err,
-                )
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="fetch_thumbnail_failed",
+                ) from err
         return None
 
     def _handle_coordinator_update(self) -> None:

--- a/homeassistant/components/unifi_access/strings.json
+++ b/homeassistant/components/unifi_access/strings.json
@@ -136,6 +136,9 @@
     "emergency_failed": {
       "message": "Failed to set emergency status."
     },
+    "fetch_thumbnail_failed": {
+      "message": "Failed to fetch door thumbnail."
+    },
     "invalid_lock_rule_type": {
       "message": "The provided lock rule type is invalid."
     },

--- a/tests/components/unifi_access/test_image.py
+++ b/tests/components/unifi_access/test_image.py
@@ -155,9 +155,8 @@ async def test_async_image_get_thumbnail_api_error_returns_none(
     init_integration: MockConfigEntry,
     mock_client: MagicMock,
     hass_client: ClientSessionGenerator,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test async_image returns None (500) when get_thumbnail raises an API error."""
+    """Test async_image returns 500 when get_thumbnail raises an API error."""
     mock_client.get_thumbnail.side_effect = ApiNotFoundError(
         "Thumbnail fetch failed (404)"
     )
@@ -167,5 +166,3 @@ async def test_async_image_get_thumbnail_api_error_returns_none(
 
     assert resp.status == HTTPStatus.INTERNAL_SERVER_ERROR
     mock_client.get_thumbnail.assert_awaited_once_with("/preview/front_door.png")
-    assert "Failed to fetch thumbnail for door" in caplog.text
-    assert "Thumbnail fetch failed (404)" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix swallowed exception in unifi_access image thumbnail fetch

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170678
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
