### PR TITLE
Fix assist pipeline `ResultStream` memory leak

### DIFF
--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -560,6 +560,7 @@ class PipelineRun:
     id: str = field(default_factory=ulid_util.ulid_now)
     stt_provider: stt.SpeechToTextEntity | stt.Provider = field(init=False, repr=False)
     tts_stream: tts.ResultStream | None = field(init=False, default=None)
+    tts_stream_started: bool = field(init=False, default=False)
     wake_word_entity_id: str | None = field(init=False, default=None, repr=False)
     wake_word_entity: wake_word.WakeWordDetectionEntity = field(init=False, repr=False)
 
@@ -681,6 +682,13 @@ class PipelineRun:
         # Stop the recording thread before emitting run-end.
         # This ensures that files are properly closed if the event handler reads them.
         await self._stop_debug_recording_thread()
+
+        # If the TTS stream was never used, we need to drop our reference to it.
+        # Otherwise, runs that abort before the TTS stream is used will leak forever.
+        if self.tts_stream is not None and not self.tts_stream_started:
+            self.hass.data[tts.DATA_TTS_MANAGER].token_to_stream.pop(
+                self.tts_stream.token, None
+            )
 
         self.process_event(
             PipelineEvent(
@@ -1449,6 +1457,7 @@ class PipelineRun:
     ) -> None:
         """Run text-to-speech portion of pipeline."""
         assert self.tts_stream is not None
+        self.tts_stream_started = True
 
         self.process_event(
             PipelineEvent(

--- a/homeassistant/components/wyoming/assist_satellite.py
+++ b/homeassistant/components/wyoming/assist_satellite.py
@@ -49,6 +49,8 @@ _RECONNECT_SECONDS: Final = 10
 _RESTART_SECONDS: Final = 3
 _PING_TIMEOUT: Final = 5
 _PING_SEND_DELAY: Final = 2
+_RESTART_INITIAL_BACKOFF: Final = 1.0
+_RESTART_MAX_BACKOFF: Final = 30.0
 _PIPELINE_FINISH_TIMEOUT: Final = 1
 _TTS_SAMPLE_RATE: Final = 22050
 _AUDIO_CHUNK_BYTES: Final = 2048  # 1024 samples
@@ -133,6 +135,11 @@ class WyomingAssistSatellite(WyomingSatelliteEntity, AssistSatelliteEntity):
         self._tts_stream_token: str | None = None
         self._is_tts_streaming: bool = False
 
+        # Set when the current pipeline run reaches `WAKE_WORD_START`. Used by the
+        # `restart_on_end` loop to detect runs that aborted before any audio was
+        # consumed.
+        self._wake_word_started: bool = False
+
     @property
     def pipeline_entity_id(self) -> str | None:
         """Return the entity ID of the pipeline to use for the next conversation."""
@@ -200,6 +207,7 @@ class WyomingAssistSatellite(WyomingSatelliteEntity, AssistSatelliteEntity):
                 self._tts_stream_token = tts_output["token"]
                 self._is_tts_streaming = False
         elif event.type == assist_pipeline.PipelineEventType.WAKE_WORD_START:
+            self._wake_word_started = True
             self.config_entry.async_create_background_task(
                 self.hass,
                 self._client.write_event(Detect().event()),
@@ -559,6 +567,7 @@ class WyomingAssistSatellite(WyomingSatelliteEntity, AssistSatelliteEntity):
         run_pipeline: RunPipeline | None = None
         send_ping = True
         self._run_loop_id = ulid_now()
+        next_restart_backoff = _RESTART_INITIAL_BACKOFF
 
         # Read events and check for pipeline end in parallel
         pipeline_ended_task = self.config_entry.async_create_background_task(
@@ -604,6 +613,17 @@ class WyomingAssistSatellite(WyomingSatelliteEntity, AssistSatelliteEntity):
                     if (run_pipeline is not None) and run_pipeline.restart_on_end:
                         # Automatically restart pipeline.
                         # Used with "always on" streaming satellites.
+                        if self._wake_word_started:
+                            next_restart_backoff = _RESTART_INITIAL_BACKOFF
+                        else:
+                            # Run aborted before any audio was consumed (e.g. no wake
+                            # engine). Back off exponentially so a broken satellite
+                            # doesn't enter a tight retry loop.
+                            await asyncio.sleep(next_restart_backoff)
+                            next_restart_backoff = min(
+                                next_restart_backoff * 2, _RESTART_MAX_BACKOFF
+                            )
+                        self._wake_word_started = False
                         self._run_pipeline_once(run_pipeline)
                         continue
 

--- a/tests/components/assist_pipeline/test_pipeline.py
+++ b/tests/components/assist_pipeline/test_pipeline.py
@@ -2273,3 +2273,44 @@ async def test_stt_vad_enabled_based_on_audio_processing(
 
         # VAD should NOT be created when requires_external_vad is False
         mock_vad.assert_not_called()
+
+
+async def test_pipeline_aborted_before_tts_does_not_leak_result_stream(
+    hass: HomeAssistant,
+    mock_wake_word_provider_entity: MockWakeWordEntity,
+    init_components,
+) -> None:
+    """Pipeline runs that abort before reaching TTS must not leak ResultStreams."""
+
+    async def audio_data() -> AsyncGenerator[bytes]:
+        yield make_10ms_chunk(b"not used")
+
+    with patch.object(
+        mock_wake_word_provider_entity,
+        "async_process_audio_stream",
+        side_effect=assist_pipeline.error.WakeWordTimeoutError(
+            code="timeout", message="timeout"
+        ),
+    ):
+        await assist_pipeline.async_pipeline_from_audio_stream(
+            hass,
+            context=Context(),
+            event_callback=lambda event: None,
+            stt_metadata=stt.SpeechMetadata(
+                language="",
+                format=stt.AudioFormats.WAV,
+                codec=stt.AudioCodecs.PCM,
+                bit_rate=stt.AudioBitRates.BITRATE_16,
+                sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
+                channel=stt.AudioChannels.CHANNEL_MONO,
+            ),
+            stt_stream=audio_data(),
+            start_stage=assist_pipeline.PipelineStage.WAKE_WORD,
+            end_stage=assist_pipeline.PipelineStage.TTS,
+            wake_word_settings=assist_pipeline.WakeWordSettings(
+                audio_seconds_to_buffer=1.5
+            ),
+            audio_settings=assist_pipeline.AudioSettings(is_vad_enabled=False),
+        )
+
+    assert len(hass.data[tts.DATA_TTS_MANAGER].token_to_stream) == 0

--- a/tests/components/wyoming/test_satellite.py
+++ b/tests/components/wyoming/test_satellite.py
@@ -1022,6 +1022,55 @@ async def test_satellite_error_during_pipeline(hass: HomeAssistant) -> None:
         assert mock_client.error.code == "test code"
 
 
+async def test_satellite_restart_on_end_backs_off_after_early_abort(
+    hass: HomeAssistant,
+) -> None:
+    """Always-on satellite must back off when restart_on_end aborts before audio."""
+    assert await async_setup_component(hass, assist_pipeline.DOMAIN, {})
+
+    events = [
+        RunPipeline(
+            start_stage=PipelineStage.WAKE,
+            end_stage=PipelineStage.TTS,
+            restart_on_end=True,
+        ).event(),
+    ]
+
+    pipeline_call_count = 0
+
+    async def _async_pipeline_from_audio_stream(
+        *args: Any, event_callback: Any, **kwargs: Any
+    ) -> None:
+        nonlocal pipeline_call_count
+        pipeline_call_count += 1
+
+        # Abort before `WAKE_WORD_START`
+        event_callback(
+            assist_pipeline.PipelineEvent(assist_pipeline.PipelineEventType.RUN_END)
+        )
+
+    with (
+        patch(
+            "homeassistant.components.wyoming.data.load_wyoming_info",
+            return_value=SATELLITE_INFO,
+        ),
+        patch(
+            "homeassistant.components.wyoming.assist_satellite.AsyncTcpClient",
+            SatelliteAsyncTcpClient(events),
+        ),
+        patch(
+            "homeassistant.components.assist_satellite.entity.async_pipeline_from_audio_stream",
+            _async_pipeline_from_audio_stream,
+        ),
+        patch("homeassistant.components.wyoming.assist_satellite._PING_SEND_DELAY", 0),
+    ):
+        await setup_config_entry(hass)
+
+        # Wait a bit, the tight retry loop would have triggered 300+ times
+        await asyncio.sleep(0.2)
+        assert pipeline_call_count == 1
+
+
 async def test_tts_not_wav(hass: HomeAssistant) -> None:
     """Test satellite receiving non-WAV audio from text-to-speech."""
     assert await async_setup_component(hass, assist_pipeline.DOMAIN, {})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes a memory leak in the assist pipeline. It has two causes, with a tiny memory leak turning into a larger one with a tight retry loop:
1. `ResultStream` objects are aged out after five minutes but if if something is registering them rapidly and never using them, they accumulate faster than they age out, consuming gigabytes of RAM in a few hours.
2. `run_pipeline.restart_on_end` will immediately call `self._run_pipeline_once(run_pipeline)`. If the pipeline itself is somehow broken (e.g. an addon is stopped), this turns into a very tight loop.

The tight retry loop alone still triggers ~200 `state_reported` events per second and will OOM Core on its own:
```python
2026-05-14 13:59:10.404 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event state_reported[L]: entity_id=assist_satellite.assist_microphone, last_reported=2026-05-14T13:59:10.404033-04:00, old_last_reported=2026-05-14T13:59:10.399479-04:00, new_state=<state assist_satellite.assist_microphone=idle; friendly_name=leak test voice assistant, supported_features=1 @ 2026-05-14T13:50:38.612495-04:00>>
2026-05-14 13:59:10.409 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event state_reported[L]: entity_id=assist_satellite.assist_microphone, last_reported=2026-05-14T13:59:10.409333-04:00, old_last_reported=2026-05-14T13:59:10.404033-04:00, new_state=<state assist_satellite.assist_microphone=idle; friendly_name=leak test voice assistant, supported_features=1 @ 2026-05-14T13:50:38.612495-04:00>>
2026-05-14 13:59:10.414 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event state_reported[L]: entity_id=assist_satellite.assist_microphone, last_reported=2026-05-14T13:59:10.414368-04:00, old_last_reported=2026-05-14T13:59:10.409333-04:00, new_state=<state assist_satellite.assist_microphone=idle; friendly_name=leak test voice assistant, supported_features=1 @ 2026-05-14T13:50:38.612495-04:00>>
2026-05-14 13:59:10.417 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event state_reported[L]: entity_id=assist_satellite.assist_microphone, last_reported=2026-05-14T13:59:10.417282-04:00, old_last_reported=2026-05-14T13:59:10.414368-04:00, new_state=<state assist_satellite.assist_microphone=idle; friendly_name=leak test voice assistant, supported_features=1 @ 2026-05-14T13:50:38.612495-04:00>>
2026-05-14 13:59:10.419 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event state_reported[L]: entity_id=assist_satellite.assist_microphone, last_reported=2026-05-14T13:59:10.419657-04:00, old_last_reported=2026-05-14T13:59:10.417282-04:00, new_state=<state assist_satellite.assist_microphone=idle; friendly_name=leak test voice assistant, supported_features=1 @ 2026-05-14T13:50:38.612495-04:00>>
```

This PR introduces two fixes:
1. Discard the `ResultStream` object if it was never used. These are already automatically collected but every 5 minutes.
2. Add exponential backoff to the retry attempts, capping at 30s, with initial retries starting at 1s.

I was able to reproduce the mentioned issue by starting a remote assist microphone and then disabling part of the assist pipeline. It would begin tightly spamming this. 

```python
WARNING:root:Event(type='error', data={'text': 'No wake-word-detection provider for: wake_word.openwakeword', 'code': 'wake-provider-missing'}, payload=None)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #168653, fixes #165953, fixes #167401
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
