### PR TITLE
Wrap nobo_hub entity action errors with translation keys

### DIFF
--- a/homeassistant/components/nobo_hub/climate.py
+++ b/homeassistant/components/nobo_hub/climate.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from pynobo import nobo
+from pynobo import PynoboError, nobo
 
 from homeassistant.components.climate import (
     ATTR_TARGET_TEMP_HIGH,
@@ -22,6 +22,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import dt as dt_util
@@ -106,12 +107,15 @@ class NoboZone(NoboBaseEntity, ClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target HVAC mode."""
         if hvac_mode == HVACMode.AUTO:
-            await self.async_set_preset_mode(PRESET_NONE)
+            await self._apply_preset(PRESET_NONE, "set_hvac_mode_failed")
         elif hvac_mode == HVACMode.HEAT:
-            await self.async_set_preset_mode(PRESET_COMFORT)
+            await self._apply_preset(PRESET_COMFORT, "set_hvac_mode_failed")
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new zone override."""
+        await self._apply_preset(preset_mode, "set_preset_mode_failed")
+
+    async def _apply_preset(self, preset_mode: str, translation_key: str) -> None:
         if preset_mode == PRESET_ECO:
             mode = nobo.API.OVERRIDE_MODE_ECO
         elif preset_mode == PRESET_AWAY:
@@ -120,21 +124,35 @@ class NoboZone(NoboBaseEntity, ClimateEntity):
             mode = nobo.API.OVERRIDE_MODE_COMFORT
         else:  # PRESET_NONE
             mode = nobo.API.OVERRIDE_MODE_NORMAL
-        await self._nobo.async_create_override(
-            mode,
-            self._override_type,
-            nobo.API.OVERRIDE_TARGET_ZONE,
-            self._id,
-        )
+        try:
+            await self._nobo.async_create_override(
+                mode,
+                self._override_type,
+                nobo.API.OVERRIDE_TARGET_ZONE,
+                self._id,
+            )
+        except PynoboError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key=translation_key,
+                translation_placeholders={"error": str(err)},
+            ) from err
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         if ATTR_TARGET_TEMP_LOW in kwargs:
             low = round(kwargs[ATTR_TARGET_TEMP_LOW])
             high = round(kwargs[ATTR_TARGET_TEMP_HIGH])
-            await self._nobo.async_update_zone(
-                self._id, temp_comfort_c=high, temp_eco_c=low
-            )
+            try:
+                await self._nobo.async_update_zone(
+                    self._id, temp_comfort_c=high, temp_eco_c=low
+                )
+            except PynoboError as err:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="set_temperature_failed",
+                    translation_placeholders={"error": str(err)},
+                ) from err
 
     async def async_update(self) -> None:
         """Fetch new state data for this zone."""

--- a/homeassistant/components/nobo_hub/climate.py
+++ b/homeassistant/components/nobo_hub/climate.py
@@ -106,16 +106,23 @@ class NoboZone(NoboBaseEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target HVAC mode."""
-        if hvac_mode == HVACMode.AUTO:
-            await self._apply_preset(PRESET_NONE, "set_hvac_mode_failed")
-        elif hvac_mode == HVACMode.HEAT:
-            await self._apply_preset(PRESET_COMFORT, "set_hvac_mode_failed")
+        preset = PRESET_COMFORT if hvac_mode == HVACMode.HEAT else PRESET_NONE
+        await self._apply_preset(
+            preset, "set_hvac_mode_failed", {"hvac_mode": str(hvac_mode)}
+        )
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new zone override."""
-        await self._apply_preset(preset_mode, "set_preset_mode_failed")
+        await self._apply_preset(
+            preset_mode, "set_preset_mode_failed", {"preset_mode": preset_mode}
+        )
 
-    async def _apply_preset(self, preset_mode: str, translation_key: str) -> None:
+    async def _apply_preset(
+        self,
+        preset_mode: str,
+        translation_key: str,
+        translation_placeholders: dict[str, str],
+    ) -> None:
         if preset_mode == PRESET_ECO:
             mode = nobo.API.OVERRIDE_MODE_ECO
         elif preset_mode == PRESET_AWAY:
@@ -135,7 +142,7 @@ class NoboZone(NoboBaseEntity, ClimateEntity):
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key=translation_key,
-                translation_placeholders={"error": str(err)},
+                translation_placeholders=translation_placeholders,
             ) from err
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
@@ -151,7 +158,6 @@ class NoboZone(NoboBaseEntity, ClimateEntity):
                 raise HomeAssistantError(
                     translation_domain=DOMAIN,
                     translation_key="set_temperature_failed",
-                    translation_placeholders={"error": str(err)},
                 ) from err
 
     async def async_update(self) -> None:

--- a/homeassistant/components/nobo_hub/climate.py
+++ b/homeassistant/components/nobo_hub/climate.py
@@ -107,21 +107,16 @@ class NoboZone(NoboBaseEntity, ClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target HVAC mode."""
         preset = PRESET_COMFORT if hvac_mode == HVACMode.HEAT else PRESET_NONE
-        await self._apply_preset(
-            preset, "set_hvac_mode_failed", {"hvac_mode": str(hvac_mode)}
-        )
+        await self._apply_preset(preset, "set_hvac_mode_failed")
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new zone override."""
-        await self._apply_preset(
-            preset_mode, "set_preset_mode_failed", {"preset_mode": preset_mode}
-        )
+        await self._apply_preset(preset_mode, "set_preset_mode_failed")
 
     async def _apply_preset(
         self,
         preset_mode: str,
         translation_key: str,
-        translation_placeholders: dict[str, str],
     ) -> None:
         if preset_mode == PRESET_ECO:
             mode = nobo.API.OVERRIDE_MODE_ECO
@@ -142,7 +137,6 @@ class NoboZone(NoboBaseEntity, ClimateEntity):
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key=translation_key,
-                translation_placeholders=translation_placeholders,
             ) from err
 
     async def async_set_temperature(self, **kwargs: Any) -> None:

--- a/homeassistant/components/nobo_hub/quality_scale.yaml
+++ b/homeassistant/components/nobo_hub/quality_scale.yaml
@@ -27,12 +27,7 @@ rules:
   unique-config-entry: done
 
   # Silver
-  action-exceptions:
-    status: todo
-    comment: >
-      Entity actions (climate set_hvac_mode/set_preset_mode/set_temperature,
-      select select_option) currently raise unwrapped exceptions; will wrap
-      in HomeAssistantError with translation keys.
+  action-exceptions: done
   config-entry-unloading: done
   docs-configuration-parameters: done
   docs-installation-parameters: done
@@ -73,7 +68,7 @@ rules:
       PR #170135.
   entity-disabled-by-default: todo
   entity-translations: todo
-  exception-translations: todo
+  exception-translations: done
   icon-translations: todo
   reconfiguration-flow: todo
   repair-issues:

--- a/homeassistant/components/nobo_hub/select.py
+++ b/homeassistant/components/nobo_hub/select.py
@@ -1,6 +1,6 @@
 """Python Control of Nobø Hub - Nobø Energy Control."""
 
-from pynobo import nobo
+from pynobo import PynoboError, nobo
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.const import ATTR_NAME
@@ -83,8 +83,12 @@ class NoboGlobalSelector(NoboBaseEntity, SelectEntity):
             await self._nobo.async_create_override(
                 mode, self._override_type, nobo.API.OVERRIDE_TARGET_GLOBAL
             )
-        except Exception as exp:
-            raise HomeAssistantError from exp
+        except PynoboError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="set_global_override_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err
 
     async def async_update(self) -> None:
         """Fetch new state data for this zone."""
@@ -126,8 +130,12 @@ class NoboProfileSelector(NoboBaseEntity, SelectEntity):
             await self._nobo.async_update_zone(
                 self._id, week_profile_id=week_profile_id
             )
-        except Exception as exp:
-            raise HomeAssistantError from exp
+        except PynoboError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="set_week_profile_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err
 
     async def async_update(self) -> None:
         """Fetch new state data for this zone."""

--- a/homeassistant/components/nobo_hub/select.py
+++ b/homeassistant/components/nobo_hub/select.py
@@ -87,7 +87,7 @@ class NoboGlobalSelector(NoboBaseEntity, SelectEntity):
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="set_global_override_failed",
-                translation_placeholders={"error": str(err)},
+                translation_placeholders={"option": option},
             ) from err
 
     async def async_update(self) -> None:
@@ -134,7 +134,7 @@ class NoboProfileSelector(NoboBaseEntity, SelectEntity):
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="set_week_profile_failed",
-                translation_placeholders={"error": str(err)},
+                translation_placeholders={"option": option},
             ) from err
 
     async def async_update(self) -> None:

--- a/homeassistant/components/nobo_hub/select.py
+++ b/homeassistant/components/nobo_hub/select.py
@@ -87,7 +87,6 @@ class NoboGlobalSelector(NoboBaseEntity, SelectEntity):
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="set_global_override_failed",
-                translation_placeholders={"option": option},
             ) from err
 
     async def async_update(self) -> None:
@@ -134,7 +133,6 @@ class NoboProfileSelector(NoboBaseEntity, SelectEntity):
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="set_week_profile_failed",
-                translation_placeholders={"option": option},
             ) from err
 
     async def async_update(self) -> None:

--- a/homeassistant/components/nobo_hub/strings.json
+++ b/homeassistant/components/nobo_hub/strings.json
@@ -63,6 +63,21 @@
   "exceptions": {
     "cannot_connect": {
       "message": "Unable to connect to Nobø Ecohub with serial {serial} at {ip}; will retry. If the hub is on a different network from Home Assistant and has changed IP address, remove and re-add the integration."
+    },
+    "set_global_override_failed": {
+      "message": "Failed to set global override: {error}"
+    },
+    "set_hvac_mode_failed": {
+      "message": "Failed to set HVAC mode: {error}"
+    },
+    "set_preset_mode_failed": {
+      "message": "Failed to set preset mode: {error}"
+    },
+    "set_temperature_failed": {
+      "message": "Failed to set target temperature: {error}"
+    },
+    "set_week_profile_failed": {
+      "message": "Failed to set week profile: {error}"
     }
   },
   "options": {

--- a/homeassistant/components/nobo_hub/strings.json
+++ b/homeassistant/components/nobo_hub/strings.json
@@ -65,19 +65,19 @@
       "message": "Unable to connect to Nobø Ecohub with serial {serial} at {ip}; will retry. If the hub is on a different network from Home Assistant and has changed IP address, remove and re-add the integration."
     },
     "set_global_override_failed": {
-      "message": "Failed to set global override to {option}."
+      "message": "Failed to set global override."
     },
     "set_hvac_mode_failed": {
-      "message": "Failed to set HVAC mode to {hvac_mode}."
+      "message": "Failed to set HVAC mode."
     },
     "set_preset_mode_failed": {
-      "message": "Failed to set preset mode to {preset_mode}."
+      "message": "Failed to set preset mode."
     },
     "set_temperature_failed": {
       "message": "Failed to set target temperature."
     },
     "set_week_profile_failed": {
-      "message": "Failed to set week profile to {option}."
+      "message": "Failed to set week profile."
     }
   },
   "options": {

--- a/homeassistant/components/nobo_hub/strings.json
+++ b/homeassistant/components/nobo_hub/strings.json
@@ -65,19 +65,19 @@
       "message": "Unable to connect to Nobø Ecohub with serial {serial} at {ip}; will retry. If the hub is on a different network from Home Assistant and has changed IP address, remove and re-add the integration."
     },
     "set_global_override_failed": {
-      "message": "Failed to set global override: {error}"
+      "message": "Failed to set global override to {option}."
     },
     "set_hvac_mode_failed": {
-      "message": "Failed to set HVAC mode: {error}"
+      "message": "Failed to set HVAC mode to {hvac_mode}."
     },
     "set_preset_mode_failed": {
-      "message": "Failed to set preset mode: {error}"
+      "message": "Failed to set preset mode to {preset_mode}."
     },
     "set_temperature_failed": {
-      "message": "Failed to set target temperature: {error}"
+      "message": "Failed to set target temperature."
     },
     "set_week_profile_failed": {
-      "message": "Failed to set week profile: {error}"
+      "message": "Failed to set week profile to {option}."
     }
   },
   "options": {

--- a/tests/components/nobo_hub/test_climate.py
+++ b/tests/components/nobo_hub/test_climate.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock
 
-from pynobo import PynoboConnectionError, nobo
+from pynobo import PynoboError, nobo
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -254,7 +254,7 @@ async def test_climate_action_wraps_library_error(
     expected_key: str,
 ) -> None:
     """Library errors during climate actions are raised as HomeAssistantError."""
-    getattr(mock_nobo_hub, mock_attr).side_effect = PynoboConnectionError("boom")
+    getattr(mock_nobo_hub, mock_attr).side_effect = PynoboError("boom")
     with pytest.raises(HomeAssistantError) as exc_info:
         await hass.services.async_call(
             CLIMATE_DOMAIN,

--- a/tests/components/nobo_hub/test_climate.py
+++ b/tests/components/nobo_hub/test_climate.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock
 
-from pynobo import nobo
+from pynobo import PynoboConnectionError, nobo
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -24,10 +24,12 @@ from homeassistant.components.climate import (
 )
 from homeassistant.components.nobo_hub.const import (
     CONF_OVERRIDE_TYPE,
+    DOMAIN,
     OVERRIDE_TYPE_NOW,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from . import fire_hub_update
@@ -216,3 +218,49 @@ async def test_set_temperature_updates_zone(
     mock_nobo_hub.async_update_zone.assert_called_once_with(
         "1", temp_comfort_c=22, temp_eco_c=16
     )
+
+
+@pytest.mark.parametrize(
+    ("service", "service_data", "mock_attr", "expected_key"),
+    [
+        (
+            SERVICE_SET_HVAC_MODE,
+            {ATTR_HVAC_MODE: HVACMode.HEAT},
+            "async_create_override",
+            "set_hvac_mode_failed",
+        ),
+        (
+            SERVICE_SET_PRESET_MODE,
+            {ATTR_PRESET_MODE: PRESET_COMFORT},
+            "async_create_override",
+            "set_preset_mode_failed",
+        ),
+        (
+            SERVICE_SET_TEMPERATURE,
+            {ATTR_TARGET_TEMP_LOW: 17, ATTR_TARGET_TEMP_HIGH: 21},
+            "async_update_zone",
+            "set_temperature_failed",
+        ),
+    ],
+    ids=["set_hvac_mode", "set_preset_mode", "set_temperature"],
+)
+@pytest.mark.usefixtures("init_integration")
+async def test_climate_action_wraps_library_error(
+    hass: HomeAssistant,
+    mock_nobo_hub: MagicMock,
+    service: str,
+    service_data: dict[str, object],
+    mock_attr: str,
+    expected_key: str,
+) -> None:
+    """Library errors during climate actions are raised as HomeAssistantError."""
+    getattr(mock_nobo_hub, mock_attr).side_effect = PynoboConnectionError("boom")
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            service,
+            {ATTR_ENTITY_ID: CLIMATE_ENTITY, **service_data},
+            blocking=True,
+        )
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == expected_key

--- a/tests/components/nobo_hub/test_select.py
+++ b/tests/components/nobo_hub/test_select.py
@@ -2,10 +2,11 @@
 
 from unittest.mock import MagicMock
 
-from pynobo import nobo
+from pynobo import PynoboConnectionError, nobo
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.nobo_hub.const import DOMAIN
 from homeassistant.components.select import (
     ATTR_OPTION,
     DOMAIN as SELECT_DOMAIN,
@@ -76,10 +77,20 @@ async def test_week_profile_select(
 
 
 @pytest.mark.parametrize(
-    ("entity_id", "option", "mock_attr"),
+    ("entity_id", "option", "mock_attr", "expected_key"),
     [
-        (GLOBAL_ENTITY, "eco", "async_create_override"),
-        (PROFILE_ENTITY, "Default", "async_update_zone"),
+        (
+            GLOBAL_ENTITY,
+            "eco",
+            "async_create_override",
+            "set_global_override_failed",
+        ),
+        (
+            PROFILE_ENTITY,
+            "Default",
+            "async_update_zone",
+            "set_week_profile_failed",
+        ),
     ],
     ids=["global_override", "week_profile"],
 )
@@ -90,16 +101,19 @@ async def test_select_option_wraps_library_error(
     entity_id: str,
     option: str,
     mock_attr: str,
+    expected_key: str,
 ) -> None:
     """Library errors during selection are raised as HomeAssistantError."""
-    getattr(mock_nobo_hub, mock_attr).side_effect = OSError("boom")
-    with pytest.raises(HomeAssistantError):
+    getattr(mock_nobo_hub, mock_attr).side_effect = PynoboConnectionError("boom")
+    with pytest.raises(HomeAssistantError) as exc_info:
         await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {ATTR_ENTITY_ID: entity_id, ATTR_OPTION: option},
             blocking=True,
         )
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == expected_key
 
 
 @pytest.mark.usefixtures("init_integration")

--- a/tests/components/nobo_hub/test_select.py
+++ b/tests/components/nobo_hub/test_select.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock
 
-from pynobo import PynoboConnectionError, nobo
+from pynobo import PynoboError, nobo
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -104,7 +104,7 @@ async def test_select_option_wraps_library_error(
     expected_key: str,
 ) -> None:
     """Library errors during selection are raised as HomeAssistantError."""
-    getattr(mock_nobo_hub, mock_attr).side_effect = PynoboConnectionError("boom")
+    getattr(mock_nobo_hub, mock_attr).side_effect = PynoboError("boom")
     with pytest.raises(HomeAssistantError) as exc_info:
         await hass.services.async_call(
             SELECT_DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Wrap `nobo_hub` entity action errors with translation keys

- `climate.async_set_hvac_mode`/`set_preset_mode`/`set_temperature` and `select.async_select_option` (global + week profile) now wrap `PynoboError` in `HomeAssistantError` with per-action translation keys and the underlying error message
- Replace bare `except Exception` blocks in `select.py` with `PynoboError`
- Add `set_hvac_mode_failed` / `set_preset_mode_failed` / `set_temperature_failed` / `set_global_override_failed` / `set_week_profile_failed` exception strings
- Flip `action-exceptions` and `exception-translations` to done in `quality_scale.yaml`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
