### PR TITLE
Add geo_location entity support to Prometheus exporter

### DIFF
--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -775,15 +775,11 @@ class PrometheusMetrics:
         self._numeric_metric(state, "person", "person")
 
     def _handle_geo_location(self, state: State) -> None:
-        labels = self._labels(
-            state, {"source": state.attributes.get("source", "")}
-        )
+        labels = self._labels(state, {"source": state.attributes.get("source", "")})
         if (value := self.state_as_number(state)) is not None:
             unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
             if unit is not None:
-                value = DistanceConverter.convert(
-                    value, unit, UnitOfLength.METERS
-                )
+                value = DistanceConverter.convert(value, unit, UnitOfLength.METERS)
             self._metric(
                 "geo_location_distance_meters",
                 prometheus_client.Gauge,

--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -771,6 +771,10 @@ class PrometheusMetrics:
     def _handle_person(self, state: State) -> None:
         self._numeric_metric(state, "person", "person")
 
+    def _handle_geo_location(self, state: State) -> None:
+        self._numeric_metric(state, "geo_location", "geo location")
+        self._handle_attributes(state)
+
     def _handle_lock(self, state: State) -> None:
         self._numeric_metric(state, "lock", "lock")
 

--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -58,6 +58,8 @@ from homeassistant.const import (
     ATTR_BATTERY_LEVEL,
     ATTR_DEVICE_CLASS,
     ATTR_FRIENDLY_NAME,
+    ATTR_LATITUDE,
+    ATTR_LONGITUDE,
     ATTR_MODE,
     ATTR_TEMPERATURE,
     ATTR_UNIT_OF_MEASUREMENT,
@@ -71,6 +73,7 @@ from homeassistant.const import (
     STATE_OPENING,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    UnitOfLength,
     UnitOfTemperature,
 )
 from homeassistant.core import Event, EventStateChangedData, HomeAssistant, State
@@ -104,7 +107,7 @@ from homeassistant.helpers.floor_registry import (
 )
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.dt import as_timestamp
-from homeassistant.util.unit_conversion import TemperatureConverter
+from homeassistant.util.unit_conversion import DistanceConverter, TemperatureConverter
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -772,8 +775,35 @@ class PrometheusMetrics:
         self._numeric_metric(state, "person", "person")
 
     def _handle_geo_location(self, state: State) -> None:
-        self._numeric_metric(state, "geo_location", "geo location")
-        self._handle_attributes(state)
+        labels = self._labels(
+            state, {"source": state.attributes.get("source", "")}
+        )
+        if (value := self.state_as_number(state)) is not None:
+            unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+            if unit is not None:
+                value = DistanceConverter.convert(
+                    value, unit, UnitOfLength.METERS
+                )
+            self._metric(
+                "geo_location_distance_meters",
+                prometheus_client.Gauge,
+                "Distance of the geo location event from home in meters",
+                labels,
+            ).set(value)
+        if (latitude := state.attributes.get(ATTR_LATITUDE)) is not None:
+            self._metric(
+                "geo_location_latitude_degrees",
+                prometheus_client.Gauge,
+                "Latitude of the geo location event in degrees",
+                labels,
+            ).set(latitude)
+        if (longitude := state.attributes.get(ATTR_LONGITUDE)) is not None:
+            self._metric(
+                "geo_location_longitude_degrees",
+                prometheus_client.Gauge,
+                "Longitude of the geo location event in degrees",
+                labels,
+            ).set(longitude)
 
     def _handle_lock(self, state: State) -> None:
         self._numeric_metric(state, "lock", "lock")

--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -19,6 +19,7 @@ from homeassistant.components import (
     cover,
     device_tracker,
     fan,
+    geo_location,
     humidifier,
     input_boolean,
     input_number,
@@ -1339,6 +1340,36 @@ async def test_person(
         friendly_name="Alice",
         entity="person.alice",
     ).withValue(0.0).assert_in_metrics(body)
+
+
+@pytest.mark.parametrize("namespace", [""])
+async def test_geo_location(
+    client: ClientSessionGenerator,
+    geo_location_entities: dict[str, er.RegistryEntry],
+) -> None:
+    """Test prometheus metrics for geo_location."""
+    body = await generate_latest_metrics(client)
+
+    EntityMetric(
+        metric_name="geo_location_state",
+        domain="geo_location",
+        friendly_name="Earthquake",
+        entity="geo_location.earthquake",
+    ).withValue(25.5).assert_in_metrics(body)
+
+    EntityMetric(
+        metric_name="geo_location_attr_latitude",
+        domain="geo_location",
+        friendly_name="Earthquake",
+        entity="geo_location.earthquake",
+    ).withValue(34.05).assert_in_metrics(body)
+
+    EntityMetric(
+        metric_name="geo_location_attr_longitude",
+        domain="geo_location",
+        friendly_name="Earthquake",
+        entity="geo_location.earthquake",
+    ).withValue(-118.25).assert_in_metrics(body)
 
 
 @pytest.mark.parametrize("namespace", [""])
@@ -2751,6 +2782,31 @@ async def device_tracker_fixture(
     )
     set_state_with_entry(hass, device_tracker_2, STATE_NOT_HOME)
     data["device_tracker_2"] = device_tracker_2
+
+    await hass.async_block_till_done()
+    return data
+
+
+@pytest.fixture(name="geo_location_entities")
+async def geo_location_fixture(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> dict[str, er.RegistryEntry]:
+    """Simulate geo_location entities."""
+    data = {}
+    geo_location_1 = entity_registry.async_get_or_create(
+        domain=geo_location.DOMAIN,
+        platform="test",
+        unique_id="geo_location_1",
+        suggested_object_id="earthquake",
+        original_name="Earthquake",
+    )
+    set_state_with_entry(
+        hass,
+        geo_location_1,
+        25.5,
+        {"source": "usgs_earthquakes", "latitude": 34.05, "longitude": -118.25},
+    )
+    data["geo_location_1"] = geo_location_1
 
     await hass.async_block_till_done()
     return data

--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -91,6 +91,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
     UnitOfEnergy,
+    UnitOfLength,
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
@@ -1351,24 +1352,27 @@ async def test_geo_location(
     body = await generate_latest_metrics(client)
 
     EntityMetric(
-        metric_name="geo_location_state",
+        metric_name="geo_location_distance_meters",
         domain="geo_location",
         friendly_name="Earthquake",
         entity="geo_location.earthquake",
-    ).withValue(25.5).assert_in_metrics(body)
+        source="usgs_earthquakes",
+    ).withValue(25500.0).assert_in_metrics(body)
 
     EntityMetric(
-        metric_name="geo_location_attr_latitude",
+        metric_name="geo_location_latitude_degrees",
         domain="geo_location",
         friendly_name="Earthquake",
         entity="geo_location.earthquake",
+        source="usgs_earthquakes",
     ).withValue(34.05).assert_in_metrics(body)
 
     EntityMetric(
-        metric_name="geo_location_attr_longitude",
+        metric_name="geo_location_longitude_degrees",
         domain="geo_location",
         friendly_name="Earthquake",
         entity="geo_location.earthquake",
+        source="usgs_earthquakes",
     ).withValue(-118.25).assert_in_metrics(body)
 
 
@@ -2804,7 +2808,12 @@ async def geo_location_fixture(
         hass,
         geo_location_1,
         25.5,
-        {"source": "usgs_earthquakes", "latitude": 34.05, "longitude": -118.25},
+        {
+            "source": "usgs_earthquakes",
+            "latitude": 34.05,
+            "longitude": -118.25,
+            "unit_of_measurement": UnitOfLength.KILOMETERS,
+        },
     )
     data["geo_location_1"] = geo_location_1
 


### PR DESCRIPTION
## Proposed change

Add support for `geo_location` entities to the Prometheus exporter. This exports three metrics per entity:

- `geo_location_distance_meters` — distance from home, converted to meters regardless of the user's unit system
- `geo_location_latitude_degrees` — latitude of the event
- `geo_location_longitude_degrees` — longitude of the event

All metrics include a `source` label (e.g. `usgs_earthquakes`, `nsw_rural_fire_service`) for filtering and grouping. Metric names follow [Prometheus naming best practices](https://prometheus.io/docs/practices/naming/).

## Type of change

- [x] New feature (which adds functionality to an existing integration)

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45413
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr