### PR TITLE
Fix unused return value in Prometheus metric name sanitizer

### DIFF
--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -553,7 +553,7 @@ class PrometheusMetrics:
 
     @staticmethod
     def _sanitize_metric_name(metric: str) -> str:
-        metric.replace("\u03bc", "\u00b5")
+        metric = metric.replace("\u03bc", "\u00b5")
         return "".join(
             [c if c in ALLOWED_METRIC_CHARS else f"u{hex(ord(c))}" for c in metric]
         )


### PR DESCRIPTION
## Summary

- `_sanitize_metric_name` calls `metric.replace("μ", "µ")` but discards the return value
- Strings are immutable in Python, so the Greek mu → micro sign replacement was silently never applied
- Assigns the result back to `metric` so the sanitization actually takes effect

## Type of change

- Bug fix

## Test plan

- [x] Full prometheus test suite passes (50 tests)