### PR TITLE
Fix binary_sensor metric description in Prometheus exporter

### DIFF
--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -750,7 +750,7 @@ class PrometheusMetrics:
         metric.set(value)
 
     def _handle_binary_sensor(self, state: State) -> None:
-        self._numeric_metric(state, "binary_sensor", "binary boolean")
+        self._numeric_metric(state, "binary_sensor", "binary sensor")
 
     def _handle_input_boolean(self, state: State) -> None:
         self._numeric_metric(state, "input_boolean", "input boolean")


### PR DESCRIPTION
## Summary

- The `binary_sensor` metric description incorrectly said "binary boolean" instead of "binary sensor"

## Type of change

- Bug fix

## Test plan

- [x] Full prometheus test suite passes (50 tests)