### PR TITLE
Fix water_heater current temperature metric description in Prometheus exporter

### DIFF
--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -901,7 +901,7 @@ class PrometheusMetrics:
             state,
             WATER_HEATER_ATTR_CURRENT_TEMPERATURE,
             "water_heater_current_temperature_celsius",
-            "Target temperature in degrees Celsius",
+            "Current temperature in degrees Celsius",
         )
         self._temperature_metric(
             state,


### PR DESCRIPTION
## Summary

- Copy-paste error: the `water_heater_current_temperature_celsius` metric description said "Target temperature" instead of "Current temperature"

## Type of change

- Bug fix

## Test plan

- [x] Full prometheus test suite passes (50 tests)