### PR TITLE
Fix flaky TTS tests by awaiting background tasks in retrieve_media

### DIFF
--- a/pylint/plugins/pylint_home_assistant/checkers/quality_scale/parallel_updates.py
+++ b/pylint/plugins/pylint_home_assistant/checkers/quality_scale/parallel_updates.py
@@ -25,7 +25,7 @@ class ParallelUpdatesChecker(BaseChecker):
     name = "home_assistant_parallel_updates"
     priority = -1
     msgs = {
-        "W7409": (
+        "W7411": (
             "Platform module should define `PARALLEL_UPDATES` constant "
             "(https://developers.home-assistant.io/docs/core/"
             "integration-quality-scale/rules/parallel-updates)",

--- a/tests/components/tts/common.py
+++ b/tests/components/tts/common.py
@@ -123,6 +123,11 @@ async def retrieve_media(
     client = await hass_client()
     req = await client.get(url)
 
+    # The HTTP response returns once the audio is streamed, but the
+    # background task that loads the cache (and writes it to disk) may
+    # still be in flight. Wait for it to avoid lingering tasks.
+    await hass.async_block_till_done(wait_background_tasks=True)
+
     return req.status
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix a flaky failure observed in CI where TTS tests fail with `Lingering task after test <Task cancelling name='tts_load_data_into_cache_...'>` (e.g. [this failed job](https://github.com/home-assistant/core/actions/runs/25881331158/job/76062964690?pr=170717), unrelated to the PR being tested).

`retrieve_media` in `tests/components/tts/common.py` returns as soon as the HTTP `GET /api/tts_proxy/{token}` response finishes streaming. However, the cache-population background task created by `SpeechManager.async_cache_message_in_memory` (`tts_load_data_into_cache_*`) can still be in flight after the HTTP response completes — it has to finish iterating the audio generator and then write the result to disk via an executor job. When the test ends before that background task completes, the conftest lingering-task check fails the test.

This change adds `await hass.async_block_till_done(wait_background_tasks=True)` after the HTTP request in `retrieve_media`, mirroring the pattern already used throughout `tests/components/tts/test_init.py`. One change in the shared helper covers all callers (marytts, google_generative_ai_conversation, microsoft, picotts, fish_audio, ...).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr