### PR TITLE
Add diagnostics support for cert_expiry integration

### DIFF
--- a/homeassistant/components/cert_expiry/diagnostics.py
+++ b/homeassistant/components/cert_expiry/diagnostics.py
@@ -1,12 +1,12 @@
 """Diagnostics for the cert_expiry integration."""
 
-from typing import Any
+from typing import Any, cast
 
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 
-from .coordinator import CertExpiryConfigEntry
+from .coordinator import CertExpiryConfigEntry, CertExpiryDataUpdateCoordinator
 
 TO_REDACT = {CONF_HOST, "name", "title", "unique_id"}
 
@@ -16,7 +16,18 @@ async def async_get_config_entry_diagnostics(
     entry: CertExpiryConfigEntry,
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator = entry.runtime_data
+    entry_diagnostics = entry.as_dict()
+
+    coordinator = cast(
+        CertExpiryDataUpdateCoordinator | None,
+        getattr(entry, "runtime_data", None),
+    )
+
+    if coordinator is None:
+        return {
+            "entry": async_redact_data(entry_diagnostics, TO_REDACT),
+            "coordinator": None,
+        }
 
     expiry = coordinator.data.isoformat() if coordinator.data else None
     cert_error = (
@@ -27,9 +38,6 @@ async def async_get_config_entry_diagnostics(
         if coordinator.cert_error
         else None
     )
-
-    # Build entry and coordinator diagnostics.
-    entry_diagnostics = entry.as_dict()
 
     coordinator_diagnostics = {
         "host": coordinator.host,

--- a/homeassistant/components/cert_expiry/diagnostics.py
+++ b/homeassistant/components/cert_expiry/diagnostics.py
@@ -34,7 +34,6 @@ async def async_get_config_entry_diagnostics(
         "is_cert_valid": coordinator.is_cert_valid,
         "cert_error": cert_error,
         "last_update_success": coordinator.last_update_success,
-        "update_interval": str(coordinator.update_interval),
     }
 
     return {

--- a/homeassistant/components/cert_expiry/diagnostics.py
+++ b/homeassistant/components/cert_expiry/diagnostics.py
@@ -1,0 +1,45 @@
+"""Diagnostics for the cert_expiry integration."""
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+
+from .coordinator import CertExpiryConfigEntry
+
+REDACT_LIST = {CONF_HOST, "host", "name", "title", "unique_id"}
+
+
+async def async_get_config_entry_diagnostics(
+    _hass: HomeAssistant,
+    entry: CertExpiryConfigEntry,
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator = entry.runtime_data
+
+    expiry = coordinator.data.isoformat() if coordinator.data else None
+    cert_error = str(coordinator.cert_error) if coordinator.cert_error else None
+
+    # Build entry and coordinator diagnostics.
+    entry_diagnostics = {
+        "data": entry.data,
+        "options": entry.options,
+        "title": entry.title,
+        "unique_id": entry.unique_id,
+    }
+    coordinator_diagnostics = {
+        "host": coordinator.host,
+        "port": coordinator.port,
+        "name": coordinator.name,
+        "data": expiry,
+        "is_cert_valid": coordinator.is_cert_valid,
+        "cert_error": cert_error,
+        "last_update_success": coordinator.last_update_success,
+        "update_interval": str(coordinator.update_interval),
+    }
+
+    return {
+        "entry": async_redact_data(entry_diagnostics, REDACT_LIST),
+        "coordinator": async_redact_data(coordinator_diagnostics, REDACT_LIST),
+    }

--- a/homeassistant/components/cert_expiry/diagnostics.py
+++ b/homeassistant/components/cert_expiry/diagnostics.py
@@ -20,7 +20,12 @@ async def async_get_config_entry_diagnostics(
 
     expiry = coordinator.data.isoformat() if coordinator.data else None
     cert_error = (
-        type(coordinator.cert_error).__name__ if coordinator.cert_error else None
+        (
+            f"{type(coordinator.cert_error).__module__}."
+            f"{type(coordinator.cert_error).__qualname__}"
+        )
+        if coordinator.cert_error
+        else None
     )
 
     # Build entry and coordinator diagnostics.

--- a/homeassistant/components/cert_expiry/diagnostics.py
+++ b/homeassistant/components/cert_expiry/diagnostics.py
@@ -23,31 +23,36 @@ async def async_get_config_entry_diagnostics(
         getattr(entry, "runtime_data", None),
     )
 
-    if coordinator is None:
-        return {
-            "entry": async_redact_data(entry_diagnostics, TO_REDACT),
-            "coordinator": None,
-        }
-
-    expiry = coordinator.data.isoformat() if coordinator.data else None
-    cert_error = (
-        (
-            f"{type(coordinator.cert_error).__module__}."
-            f"{type(coordinator.cert_error).__qualname__}"
-        )
-        if coordinator.cert_error
-        else None
-    )
-
-    coordinator_diagnostics = {
-        "host": coordinator.host,
-        "port": coordinator.port,
-        "name": coordinator.name,
-        "expiry_datetime": expiry,
-        "is_cert_valid": coordinator.is_cert_valid,
-        "cert_error": cert_error,
-        "last_update_success": coordinator.last_update_success,
+    coordinator_diagnostics: dict[str, Any] = {
+        "host": None,
+        "port": None,
+        "name": None,
+        "expiry_datetime": None,
+        "is_cert_valid": None,
+        "cert_error": None,
+        "last_update_success": None,
     }
+
+    if coordinator is not None:
+        expiry = coordinator.data.isoformat() if coordinator.data else None
+        cert_error = (
+            (
+                f"{type(coordinator.cert_error).__module__}."
+                f"{type(coordinator.cert_error).__qualname__}"
+            )
+            if coordinator.cert_error
+            else None
+        )
+
+        coordinator_diagnostics = {
+            "host": coordinator.host,
+            "port": coordinator.port,
+            "name": coordinator.name,
+            "expiry_datetime": expiry,
+            "is_cert_valid": coordinator.is_cert_valid,
+            "cert_error": cert_error,
+            "last_update_success": coordinator.last_update_success,
+        }
 
     return {
         "entry": async_redact_data(entry_diagnostics, TO_REDACT),

--- a/homeassistant/components/cert_expiry/diagnostics.py
+++ b/homeassistant/components/cert_expiry/diagnostics.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 
 from .coordinator import CertExpiryConfigEntry
 
-REDACT_LIST = {CONF_HOST, "host", "name", "title", "unique_id"}
+TO_REDACT = {CONF_HOST, "name", "title", "unique_id"}
 
 
 async def async_get_config_entry_diagnostics(
@@ -24,17 +24,13 @@ async def async_get_config_entry_diagnostics(
     )
 
     # Build entry and coordinator diagnostics.
-    entry_diagnostics = {
-        "data": entry.data,
-        "options": entry.options,
-        "title": entry.title,
-        "unique_id": entry.unique_id,
-    }
+    entry_diagnostics = entry.as_dict()
+
     coordinator_diagnostics = {
         "host": coordinator.host,
         "port": coordinator.port,
         "name": coordinator.name,
-        "data": expiry,
+        "expiry_datetime": expiry,
         "is_cert_valid": coordinator.is_cert_valid,
         "cert_error": cert_error,
         "last_update_success": coordinator.last_update_success,
@@ -42,6 +38,6 @@ async def async_get_config_entry_diagnostics(
     }
 
     return {
-        "entry": async_redact_data(entry_diagnostics, REDACT_LIST),
-        "coordinator": async_redact_data(coordinator_diagnostics, REDACT_LIST),
+        "entry": async_redact_data(entry_diagnostics, TO_REDACT),
+        "coordinator": async_redact_data(coordinator_diagnostics, TO_REDACT),
     }

--- a/homeassistant/components/cert_expiry/diagnostics.py
+++ b/homeassistant/components/cert_expiry/diagnostics.py
@@ -19,7 +19,9 @@ async def async_get_config_entry_diagnostics(
     coordinator = entry.runtime_data
 
     expiry = coordinator.data.isoformat() if coordinator.data else None
-    cert_error = str(coordinator.cert_error) if coordinator.cert_error else None
+    cert_error = (
+        type(coordinator.cert_error).__name__ if coordinator.cert_error else None
+    )
 
     # Build entry and coordinator diagnostics.
     entry_diagnostics = {

--- a/homeassistant/components/cert_expiry/diagnostics.py
+++ b/homeassistant/components/cert_expiry/diagnostics.py
@@ -1,12 +1,12 @@
 """Diagnostics for the cert_expiry integration."""
 
-from typing import Any, cast
+from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 
-from .coordinator import CertExpiryConfigEntry, CertExpiryDataUpdateCoordinator
+from .coordinator import CertExpiryConfigEntry
 
 TO_REDACT = {CONF_HOST, "name", "title", "unique_id"}
 
@@ -18,10 +18,7 @@ async def async_get_config_entry_diagnostics(
     """Return diagnostics for a config entry."""
     entry_diagnostics = entry.as_dict()
 
-    coordinator = cast(
-        CertExpiryDataUpdateCoordinator | None,
-        getattr(entry, "runtime_data", None),
-    )
+    coordinator = getattr(entry, "runtime_data", None)
 
     coordinator_diagnostics: dict[str, Any] = {
         "host": None,

--- a/tests/components/cert_expiry/snapshots/test_diagnostics.ambr
+++ b/tests/components/cert_expiry/snapshots/test_diagnostics.ambr
@@ -9,7 +9,6 @@
       'last_update_success': True,
       'name': '**REDACTED**',
       'port': 443,
-      'update_interval': '12:00:00',
     }),
     'entry': dict({
       'created_at': '2020-06-12T08:00:00+00:00',

--- a/tests/components/cert_expiry/snapshots/test_diagnostics.ambr
+++ b/tests/components/cert_expiry/snapshots/test_diagnostics.ambr
@@ -3,7 +3,7 @@
   dict({
     'coordinator': dict({
       'cert_error': None,
-      'data': '2020-09-20T15:01:00+00:00',
+      'expiry_datetime': '2020-09-20T15:01:00+00:00',
       'host': '**REDACTED**',
       'is_cert_valid': True,
       'last_update_success': True,
@@ -12,14 +12,28 @@
       'update_interval': '12:00:00',
     }),
     'entry': dict({
+      'created_at': '2020-06-12T08:00:00+00:00',
       'data': dict({
         'host': '**REDACTED**',
         'port': 443,
       }),
+      'disabled_by': None,
+      'discovery_keys': dict({
+      }),
+      'domain': 'cert_expiry',
+      'entry_id': 'test-entry',
+      'minor_version': 1,
+      'modified_at': '2020-06-12T08:00:00+00:00',
       'options': dict({
       }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'user',
+      'subentries': list([
+      ]),
       'title': '**REDACTED**',
       'unique_id': '**REDACTED**',
+      'version': 1,
     }),
   })
 # ---

--- a/tests/components/cert_expiry/snapshots/test_diagnostics.ambr
+++ b/tests/components/cert_expiry/snapshots/test_diagnostics.ambr
@@ -1,0 +1,25 @@
+# serializer version: 1
+# name: test_config_entry_diagnostics
+  dict({
+    'coordinator': dict({
+      'cert_error': None,
+      'data': '2020-09-20T15:01:00+00:00',
+      'host': '**REDACTED**',
+      'is_cert_valid': True,
+      'last_update_success': True,
+      'name': '**REDACTED**',
+      'port': 443,
+      'update_interval': '12:00:00',
+    }),
+    'entry': dict({
+      'data': dict({
+        'host': '**REDACTED**',
+        'port': 443,
+      }),
+      'options': dict({
+      }),
+      'title': '**REDACTED**',
+      'unique_id': '**REDACTED**',
+    }),
+  })
+# ---

--- a/tests/components/cert_expiry/snapshots/test_diagnostics.ambr
+++ b/tests/components/cert_expiry/snapshots/test_diagnostics.ambr
@@ -36,3 +36,40 @@
     }),
   })
 # ---
+# name: test_config_entry_diagnostics_with_cert_error
+  dict({
+    'coordinator': dict({
+      'cert_error': 'homeassistant.components.cert_expiry.errors.ValidationFailure',
+      'expiry_datetime': None,
+      'host': '**REDACTED**',
+      'is_cert_valid': False,
+      'last_update_success': True,
+      'name': '**REDACTED**',
+      'port': 443,
+    }),
+    'entry': dict({
+      'created_at': '2020-06-12T08:00:00+00:00',
+      'data': dict({
+        'host': '**REDACTED**',
+        'port': 443,
+      }),
+      'disabled_by': None,
+      'discovery_keys': dict({
+      }),
+      'domain': 'cert_expiry',
+      'entry_id': 'test-entry-error',
+      'minor_version': 1,
+      'modified_at': '2020-06-12T08:00:00+00:00',
+      'options': dict({
+      }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'user',
+      'subentries': list([
+      ]),
+      'title': '**REDACTED**',
+      'unique_id': '**REDACTED**',
+      'version': 1,
+    }),
+  })
+# ---

--- a/tests/components/cert_expiry/test_diagnostics.py
+++ b/tests/components/cert_expiry/test_diagnostics.py
@@ -1,0 +1,45 @@
+"""Tests for the Cert Expiry diagnostics."""
+
+from unittest.mock import patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.cert_expiry.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
+
+from .const import HOST, PORT
+from .helpers import future_timestamp, static_datetime
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+
+@pytest.mark.freeze_time(static_datetime())
+async def test_config_entry_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test config entry diagnostics."""
+    # Create fake config entry: simulate "host = example.com, port = 443".
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: HOST, CONF_PORT: PORT},
+        unique_id=f"{HOST}:{PORT}",
+    )
+
+    timestamp = future_timestamp(100)
+
+    # patch network call and setup integration.
+    with patch(
+        "homeassistant.components.cert_expiry.coordinator.get_cert_expiry_timestamp",
+        return_value=timestamp,
+    ):
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert await get_diagnostics_for_config_entry(hass, hass_client, entry) == snapshot

--- a/tests/components/cert_expiry/test_diagnostics.py
+++ b/tests/components/cert_expiry/test_diagnostics.py
@@ -8,7 +8,6 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant.components.cert_expiry.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 
 from .const import HOST, PORT
 from .helpers import future_timestamp, static_datetime
@@ -42,7 +41,7 @@ async def test_config_entry_diagnostics(
         return_value=timestamp,
     ):
         entry.add_to_hass(hass)
-        assert await async_setup_component(hass, DOMAIN, {}) is True
+        assert await hass.config_entries.async_setup(entry.entry_id)
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 

--- a/tests/components/cert_expiry/test_diagnostics.py
+++ b/tests/components/cert_expiry/test_diagnostics.py
@@ -6,8 +6,9 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.cert_expiry.const import DOMAIN
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
 
 from .const import HOST, PORT
 from .helpers import future_timestamp, static_datetime
@@ -28,6 +29,8 @@ async def test_config_entry_diagnostics(
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_HOST: HOST, CONF_PORT: PORT},
+        entry_id="test-entry",
+        title=HOST,
         unique_id=f"{HOST}:{PORT}",
     )
 
@@ -39,7 +42,8 @@ async def test_config_entry_diagnostics(
         return_value=timestamp,
     ):
         entry.add_to_hass(hass)
-        assert await hass.config_entries.async_setup(entry.entry_id)
+        assert await async_setup_component(hass, DOMAIN, {}) is True
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
     assert await get_diagnostics_for_config_entry(hass, hass_client, entry) == snapshot

--- a/tests/components/cert_expiry/test_diagnostics.py
+++ b/tests/components/cert_expiry/test_diagnostics.py
@@ -45,4 +45,6 @@ async def test_config_entry_diagnostics(
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
-    assert await get_diagnostics_for_config_entry(hass, hass_client, entry) == snapshot
+        assert (
+            await get_diagnostics_for_config_entry(hass, hass_client, entry) == snapshot
+        )

--- a/tests/components/cert_expiry/test_diagnostics.py
+++ b/tests/components/cert_expiry/test_diagnostics.py
@@ -6,6 +6,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.cert_expiry.const import DOMAIN
+from homeassistant.components.cert_expiry.errors import ValidationFailure
 from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import HomeAssistant
 
@@ -39,6 +40,35 @@ async def test_config_entry_diagnostics(
     with patch(
         "homeassistant.components.cert_expiry.coordinator.get_cert_expiry_timestamp",
         return_value=timestamp,
+    ):
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+        assert (
+            await get_diagnostics_for_config_entry(hass, hass_client, entry) == snapshot
+        )
+
+
+@pytest.mark.freeze_time(static_datetime())
+async def test_config_entry_diagnostics_with_cert_error(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test config entry diagnostics with a certificate validation error."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: HOST, CONF_PORT: PORT},
+        entry_id="test-entry-error",
+        title=HOST,
+        unique_id=f"{HOST}:{PORT}",
+    )
+
+    with patch(
+        "homeassistant.components.cert_expiry.coordinator.get_cert_expiry_timestamp",
+        side_effect=ValidationFailure("certificate error for sensitive.example.com"),
     ):
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This adds config entry diagnostics for the cert_expiry integration, to help troubleshoot certificate expiry issues.
Displayed states:
- entry.data: Config data for entry (host and port). Host is redacted.
- entry.options: Any saved user settings.
- entry.title: Title shown in UI for entry. Usually hostname so redacted.
- entry.unique_id: Identifier for config entry. Contains hostname so redacted.
- coordinator.host: The configured hostname/domain. This could expose private information and is therefore redacted.
- coordinator.port: The TLS port being checked. By default is set to 443.
- coordinator.name: Display name given to the endpoint by Home Assistant. Derived from host so also redacted just in case.
- expiry: Latest certificate expiry timestamp collected.
- coordinator.is_cert_valid: Was the certificate valid on last check?
- cert_error: Stored validation error, or None if no error.
- coordinator.last_update_sucess: Did the most recent update successfully complete?
- coordinator.update_interval: How often the coordinator will check (should be 12 hours).

If any of these fields should be redacted/unredacted let me know and i'll quickly address it.

Also added a diagnostics test for the config entry, which mocks a connection and generates a snapshot containing the relevant states.

Local tests run:
- pytest tests/components/cert_expiry/test_diagnostics.py
- pytest tests/components/cert_expiry
- ruff format homeassistant/components/cert_expiry tests/components/cert_expiry
- ruff check homeassistant/components/cert_expiry tests/components/cert_expiry
- python -m mypy homeassistant/components/cert_expiry

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
