### PR TITLE
Fix availability of IMGW-PIB sensors

### DIFF
--- a/homeassistant/components/imgw_pib/entity.py
+++ b/homeassistant/components/imgw_pib/entity.py
@@ -20,3 +20,11 @@ class ImgwPibEntity(CoordinatorEntity[ImgwPibDataUpdateCoordinator]):
         super().__init__(coordinator)
 
         self._attr_device_info = coordinator.device_info
+
+    @property
+    def available(self) -> bool:
+        """Return the value reported by the sensor."""
+        if self.state is not None:
+            return super().available
+
+        return False

--- a/homeassistant/components/imgw_pib/entity.py
+++ b/homeassistant/components/imgw_pib/entity.py
@@ -20,11 +20,3 @@ class ImgwPibEntity(CoordinatorEntity[ImgwPibDataUpdateCoordinator]):
         super().__init__(coordinator)
 
         self._attr_device_info = coordinator.device_info
-
-    @property
-    def available(self) -> bool:
-        """Return the value reported by the sensor."""
-        if self.state is not None:
-            return super().available
-
-        return False

--- a/homeassistant/components/imgw_pib/sensor.py
+++ b/homeassistant/components/imgw_pib/sensor.py
@@ -118,9 +118,7 @@ async def async_setup_entry(
             entity_reg.async_remove(entity_id)
 
     async_add_entities(
-        ImgwPibSensorEntity(coordinator, description)
-        for description in SENSOR_TYPES
-        if getattr(coordinator.data, description.key).value is not None
+        ImgwPibSensorEntity(coordinator, description) for description in SENSOR_TYPES
     )
 
 

--- a/tests/components/imgw_pib/test_sensor.py
+++ b/tests/components/imgw_pib/test_sensor.py
@@ -9,7 +9,7 @@ from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.imgw_pib.const import DOMAIN, UPDATE_INTERVAL
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.const import STATE_UNAVAILABLE, Platform
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -66,6 +66,34 @@ async def test_availability(
     assert state
     assert state.state != STATE_UNAVAILABLE
     assert state.state == "526.0"
+
+
+async def test_unknown_state(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_imgw_pib_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Ensure the entity is created when temporarily there is no value."""
+    entity_id = "sensor.river_name_station_name_ice_phenomena"
+    mock_imgw_pib_client.get_hydrological_data.return_value.ice_phenomena.value = None
+
+    await init_integration(hass, mock_config_entry)
+
+    # Initially, the state should be unknown since the value is None
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_UNKNOWN
+
+    mock_imgw_pib_client.get_hydrological_data.return_value.ice_phenomena.value = 22
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state != STATE_UNAVAILABLE
+    assert state.state == "22"
 
 
 async def test_remove_entity(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, the integration does not create an entity if the value is None. This is a remnant of the backend library using two API endpoints (not all measurement stations were available in the data from both endpoints). The additional endpoint has been blocked for HA users by IMGW-PIB https://github.com/home-assistant/core/pull/134668

Currently, some values ​​(e.g., Ice phenomena) are temporarily unavailable in the API data. Thanks to this change, the entity will be created, but its status will be `Unknown` while the data is missing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
