### PR TITLE
Add quality scale for speedtestdotnet integration

### DIFF
--- a/homeassistant/components/speedtestdotnet/quality_scale.yaml
+++ b/homeassistant/components/speedtestdotnet/quality_scale.yaml
@@ -41,7 +41,7 @@ rules:
   reauthentication-flow:
     status: exempt
     comment: Integration has no authentication.
-  test-coverage: todo
+  test-coverage: done
 
   # Gold
   devices: done

--- a/homeassistant/components/speedtestdotnet/quality_scale.yaml
+++ b/homeassistant/components/speedtestdotnet/quality_scale.yaml
@@ -1,0 +1,82 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: Integration does not register custom service actions.
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: Integration has no custom service actions.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: todo
+  entity-event-setup:
+    status: exempt
+    comment: Integration has no manual event subscriptions.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: todo
+  test-before-setup: done
+  unique-config-entry: todo
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: Integration has no custom service actions.
+  config-entry-unloading: done
+  docs-configuration-parameters: todo
+  docs-installation-parameters:
+    status: exempt
+    comment: Integration has no installation parameters.
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: todo
+  reauthentication-flow:
+    status: exempt
+    comment: Integration has no authentication.
+  test-coverage: todo
+
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info:
+    status: exempt
+    comment: Integration is a cloud polling service and does not use discovery.
+  discovery:
+    status: exempt
+    comment: Integration is a cloud polling service and does not use discovery.
+  docs-data-update: done
+  docs-examples: done
+  docs-known-limitations: done
+  docs-supported-devices:
+    status: exempt
+    comment: Integration is a service, not a hardware device.
+  docs-supported-functions: done
+  docs-troubleshooting: todo
+  docs-use-cases: done
+  dynamic-devices:
+    status: exempt
+    comment: No devices added after integration setup.
+  entity-category: done
+  entity-device-class: done
+  entity-disabled-by-default: done
+  entity-translations: done
+  exception-translations: todo
+  icon-translations: done
+  reconfiguration-flow: todo
+  repair-issues: todo
+  stale-devices:
+    status: exempt
+    comment: Integration only creates a single device, and does not dynamically discover devices.
+
+  # Platinum
+  async-dependency: todo
+  inject-websession: todo
+  strict-typing: todo

--- a/homeassistant/components/speedtestdotnet/quality_scale.yaml
+++ b/homeassistant/components/speedtestdotnet/quality_scale.yaml
@@ -7,7 +7,7 @@ rules:
   brands: done
   common-modules: done
   config-flow-test-coverage: done
-  config-flow: done
+  config-flow: todo
   dependency-transparency: done
   docs-actions:
     status: exempt

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -868,7 +868,6 @@ INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE = [
     "sony_projector",
     "soundtouch",
     "spc",
-    "speedtestdotnet",
     "spider",
     "spotify",
     "sql",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds quality_scale.yaml to the speedtestdotnet integration and removes said integration from the hassfest exception list.

Checklist & reasonings:
## Bronze
- [X] `action-setup` - Service actions are registered in async_setup
    - Exempt: no custom service actions.
- [X] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval
    - Done: coordinator.py:39 sets update interval to DEFAULT_SCAN_INTERVAL = 60.
- [X] `brands` - Has branding assets available for the integration
    - Done: branding assets exist in brands repo.
- [X] `common-modules` - Place common patterns in common modules
    - Done: modules are separated appropriately.
- [X] `config-flow-test-coverage` - Full test coverage for the config flow
    - Done: tests/components/speedtestdotnet/test_config_flow.py, many different tests for the config flow.
- [ ] `config-flow` - Integration needs to be able to be set up via the UI
    - [ ] Uses `data_description` to give context to fields
    - [X] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
    - Done: no installation fields so I don't think data_description is needed.
- [X] `dependency-transparency` - Dependency transparency
    - Done: manifest.json:9 lists requirement.
- [X] `docs-actions` - The documentation describes the provided service actions that can be used
    - Exempt: no custom service actions.
- [X] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service
    - Done: link to speedtest.net web service in description.
- [X] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites
    - Done: proper manual configuration steps listed.
- [ ] `docs-removal-instructions` - The documentation provides removal instructions
    - Todo: currently no removal instructions in doc.
- [X] `entity-event-setup` - Entity events are subscribed in the correct lifecycle methods
    - Exempt: no manual event subscriptions.
- [X] `entity-unique-id` - Entities have a unique ID
    - Done: sensor.py:95 sets unique id to sensor.
- [X] `has-entity-name` - Entities use has_entity_name = True
    - Done: sensor.py:85 sets this.
- [X] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data
    - Done: __init__.py:30 properly stores runtime data.
- [ ] `test-before-configure` - Test a connection in the config flow
    - Todo: no testing done before configuration.
- [X] `test-before-setup` - Check during integration initialization if we are able to set it up correctly
    - Done: __init__.py:27 raises exception on failed setup.
- [ ] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice
    - todo: in config_flow.y:41 it looks like duplicate entries aren't allowed, but hassfest doesn't agree.

## Silver
- [X] `action-exceptions` - Service actions raise exceptions when encountering failures
    - Exempt: no custom service integrations.
- [X] `config-entry-unloading` - Support config entry unloading
    - Done: __init__.py:47 supports unloading.
- [ ] `docs-configuration-parameters` - The documentation describes all integra0tion configuration options
    - Todo: not all configuration options listed, for example selecting the speedtest server (config_flow.py:78)
- [X] `docs-installation-parameters` - The documentation describes all integr0ation installation parameters
    - Exempt: no installation parameters.
- [X] `entity-unavailable` - Mark entity unavailable if appropriate
    - Done: coordinator.py:82 raises an exception if the server is not found.
- [X] `integration-owner` - Has an integration owner
    - Done: listed in manifest.json
- [X] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected
    - Done: coordinator.py:82 raises  an exception when the service is unavailable.
- [ ] `parallel-updates` - Number of parallel updates is specified
    - Todo: no parallel updates specified.
- [X] `reauthentication-flow` - Reauthentication needs to be available via the UI
    - Exempt: no authentication requirements
- [X] `test-coverage` - Above 95% test coverage for all integration modules
    - done: total coverage is at 99% when using pytest.

## Gold
- [X] `devices` - The integration creates devices
    - Done: sensor.py:98 properly sets device type to sensor.
- [ ] `diagnostics` - Implements diagnostics
    - Todo: no diagnostics.py implemented.
- [X] `discovery-update-info` - Integration uses discovery info to update network information
    - Exempt: discovery is not relevant for the integration.
- [X] `discovery` - Devices can be discovered
    - Exempt: discovery is not relevant for the integration.
- [X] `docs-data-update` - The documentation describes how data is updated
    - Done: docs explain polling options.
- [X] `docs-examples` - The documentation provides automation examples the user can use.
    - Done: examples for automation included in docs.
- [X] `docs-known-limitations` - The documentation describes known limitations of the integration (not to be confused with bugs)
    - Done: known limitation for Raspberry Pi documented.
- [X] `docs-supported-devices` - The documentation describes known supported / unsupported devices
    - Exempt: integration is a service, not a hardware device.
- [X] `docs-supported-functions` - The documentation describes the supported functionality, including entities, and platforms
    - Done: various sensors listed in docs.
- [ ] `docs-troubleshooting` - The documentation provides troubleshooting information
    - Todo: no dedicated troubleshooting section.
- [X] `docs-use-cases` - The documentation describes use cases to illustrate how this integration can be used
    - Done: examples on how to apply integration in docs.
- [X] `dynamic-devices` - Devices added after integration setup
    - Exempt: no devices added after setup.
- [X] `entity-category` - Entities are assigned an appropriate EntityCategory
    - Done: okay for existing entities to remain as default.
- [X] `entity-device-class` - Entities use device classes where possible
    - Done: appropriate classes used. sensor.py:46/53/61 for examples.
- [X] `entity-disabled-by-default` - Integration disables less popular (or noisy) entities
    - Done: all enabled entities are pretty quiet.
- [X] `entity-translations` - Entities have translated names
    - Done: translations defined in strings.json.
- [ ] `exception-translations` - Exception messages are translatable
    - Todo: there are exceptions but no corresponding translations in strings.json.
- [X] `icon-translations` - Entities implement icon translations
    - Done: icons.json properly setup.
- [ ] `reconfiguration-flow` - Integrations should have a reconfigure flow
    - Todo: no async_step_reconfigure.
- [ ] `repair-issues` - Repair issues and repair flows are used when user intervention is needed
    - Todo: no repairs module or file.
- [X] `stale-devices` - Stale devices are removed
    - Exempt: no dynamically-created devices.

## Platinum
- [ ] `async-dependency` - Dependency is async
    - Todo: a couple instances where dependencies are not async (__init__.py:28, coordinator.py:80)
- [ ] `inject-websession` - The integration dependency supports passing in a websession
    - Todo: speedtest-cli is used directly instead of through a shared websession. Not 100% sure if this should be todo or exempt.
- [ ] `strict-typing` - Strict typing
    - Todo: .strict-typing includes this integration but there is no py.typed for PEP 561 compliance.

Tested with python -m script.hassfest

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
