### PR TITLE
Add pylint checker for redundant @pytest.mark.usefixtures decorator

### DIFF
--- a/pylint/plugins/pylint_home_assistant/checkers/tests/__init__.py
+++ b/pylint/plugins/pylint_home_assistant/checkers/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test related checkers."""

--- a/pylint/plugins/pylint_home_assistant/checkers/tests/redundant_usefixtures.py
+++ b/pylint/plugins/pylint_home_assistant/checkers/tests/redundant_usefixtures.py
@@ -1,0 +1,117 @@
+"""Checker for redundant @pytest.mark.usefixtures decorators.
+
+When a module sets ``pytestmark = pytest.mark.usefixtures("fixture")``,
+every test in that module already uses the fixture. Adding
+``@pytest.mark.usefixtures("fixture")`` on individual tests is redundant.
+"""
+
+from astroid import nodes
+from pylint.checkers import BaseChecker
+from pylint.lint import PyLinter
+
+from pylint_home_assistant.helpers.module_info import is_test_module
+
+
+def _extract_usefixtures_names(node: nodes.NodeNG) -> set[str]:
+    """Extract fixture names from a pytest.mark.usefixtures(...) call."""
+    names: set[str] = set()
+    if not isinstance(node, nodes.Call):
+        return names
+    if not isinstance(node.func, nodes.Attribute):
+        return names
+    if node.func.attrname != "usefixtures":
+        return names
+    for arg in node.args:
+        if isinstance(arg, nodes.Const) and isinstance(arg.value, str):
+            names.add(arg.value)
+    return names
+
+
+def _collect_module_usefixtures(module: nodes.Module) -> set[str]:
+    """Collect fixture names from module-level pytestmark assignments."""
+    fixtures: set[str] = set()
+    for node in module.body:
+        if not isinstance(node, (nodes.Assign, nodes.AnnAssign)):
+            continue
+
+        # Get the target name
+        if isinstance(node, nodes.Assign):
+            targets = node.targets
+        else:
+            targets = [node.target]
+
+        for target in targets:
+            if not isinstance(target, nodes.AssignName):
+                continue
+            if target.name != "pytestmark":
+                continue
+
+            value = node.value
+            if value is None:
+                continue
+
+            # Reassignment replaces the previous value
+            fixtures.clear()
+
+            # pytestmark = pytest.mark.usefixtures("a", "b")
+            if isinstance(value, nodes.Call):
+                fixtures.update(_extract_usefixtures_names(value))
+
+            # pytestmark = [pytest.mark.usefixtures("a"), ...]
+            elif isinstance(value, (nodes.List, nodes.Tuple)):
+                for elt in value.elts:
+                    fixtures.update(_extract_usefixtures_names(elt))
+
+    return fixtures
+
+
+class RedundantUsefixtures(BaseChecker):
+    """Checker for redundant @pytest.mark.usefixtures on test functions."""
+
+    name = "home_assistant_tests_redundant_usefixtures"
+    priority = -1
+    msgs = {
+        "R7403": (
+            "'%s' is already applied by `pytestmark` at module level, "
+            "the `@pytest.mark.usefixtures` decorator is redundant",
+            "home-assistant-tests-redundant-usefixtures",
+            "Used when a test function has @pytest.mark.usefixtures for a "
+            "fixture that is already declared in the module's pytestmark.",
+        ),
+    }
+    options = ()
+
+    _module_fixtures: set[str]
+
+    def visit_module(self, node: nodes.Module) -> None:
+        """Collect module-level usefixtures."""
+        self._module_fixtures = set()
+        if is_test_module(node.name):
+            self._module_fixtures = _collect_module_usefixtures(node)
+
+    def visit_functiondef(self, node: nodes.FunctionDef) -> None:
+        """Check test functions for redundant usefixtures decorators."""
+        if not self._module_fixtures:
+            return
+
+        if not node.name.startswith("test_"):
+            return
+
+        if not node.decorators:
+            return
+
+        for decorator in node.decorators.nodes:
+            per_test = _extract_usefixtures_names(decorator)
+            for name in per_test & self._module_fixtures:
+                self.add_message(
+                    "home-assistant-tests-redundant-usefixtures",
+                    node=decorator,
+                    args=(name,),
+                )
+
+    visit_asyncfunctiondef = visit_functiondef
+
+
+def register(linter: PyLinter) -> None:
+    """Register the checker."""
+    linter.register_checker(RedundantUsefixtures(linter))

--- a/pylint/plugins/pylint_home_assistant/checkers/tests/redundant_usefixtures.py
+++ b/pylint/plugins/pylint_home_assistant/checkers/tests/redundant_usefixtures.py
@@ -1,10 +1,18 @@
 """Checker for redundant @pytest.mark.usefixtures decorators.
 
-When a module sets ``pytestmark = pytest.mark.usefixtures("fixture")``,
-every test in that module already uses the fixture. Adding
+When a module or its parent ``conftest.py`` files set
+``pytestmark = pytest.mark.usefixtures("fixture")``, every test in that
+module already uses the fixture. Adding
 ``@pytest.mark.usefixtures("fixture")`` on individual tests is redundant.
+
+Similarly, ``autouse=True`` fixtures in ``conftest.py`` files apply to all
+tests automatically, so explicit ``@pytest.mark.usefixtures`` for those
+is also redundant.
 """
 
+from pathlib import Path
+
+import astroid
 from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.lint import PyLinter
@@ -12,19 +20,29 @@ from pylint.lint import PyLinter
 from pylint_home_assistant.helpers.module_info import is_test_module
 
 
+def _is_pytest_mark_usefixtures(node: nodes.Call) -> bool:
+    """Check if a call node is ``pytest.mark.usefixtures(...)``."""
+    if not isinstance(node.func, nodes.Attribute):
+        return False
+    if node.func.attrname != "usefixtures":
+        return False
+    # Verify the chain is *.mark.usefixtures
+    if not isinstance(node.func.expr, nodes.Attribute):
+        return False
+    return bool(node.func.expr.attrname == "mark")
+
+
 def _extract_usefixtures_names(node: nodes.NodeNG) -> set[str]:
     """Extract fixture names from a pytest.mark.usefixtures(...) call."""
-    names: set[str] = set()
     if not isinstance(node, nodes.Call):
-        return names
-    if not isinstance(node.func, nodes.Attribute):
-        return names
-    if node.func.attrname != "usefixtures":
-        return names
-    for arg in node.args:
-        if isinstance(arg, nodes.Const) and isinstance(arg.value, str):
-            names.add(arg.value)
-    return names
+        return set()
+    if not _is_pytest_mark_usefixtures(node):
+        return set()
+    return {
+        arg.value
+        for arg in node.args
+        if isinstance(arg, nodes.Const) and isinstance(arg.value, str)
+    }
 
 
 def _collect_module_usefixtures(module: nodes.Module) -> set[str]:
@@ -65,6 +83,61 @@ def _collect_module_usefixtures(module: nodes.Module) -> set[str]:
     return fixtures
 
 
+def _collect_autouse_fixtures(module: nodes.Module) -> set[str]:
+    """Collect names of autouse=True fixtures from a module."""
+    fixtures: set[str] = set()
+    for node in module.body:
+        if not isinstance(node, nodes.FunctionDef):
+            continue
+        if not node.decorators:
+            continue
+        for decorator in node.decorators.nodes:
+            if not isinstance(decorator, nodes.Call):
+                continue
+            # Check for @pytest.fixture(autouse=True)
+            if not isinstance(decorator.func, nodes.Attribute):
+                continue
+            if decorator.func.attrname != "fixture":
+                continue
+            for kw in decorator.keywords:
+                if kw.arg == "autouse" and isinstance(kw.value, nodes.Const):
+                    if kw.value.value is True:
+                        fixtures.add(node.name)
+                        # Check for name= override
+                        for name_kw in decorator.keywords:
+                            if name_kw.arg == "name" and isinstance(
+                                name_kw.value, nodes.Const
+                            ):
+                                fixtures.discard(node.name)
+                                fixtures.add(name_kw.value.value)
+    return fixtures
+
+
+def _collect_conftest_fixtures(module: nodes.Module) -> set[str]:
+    """Collect usefixtures and autouse fixtures from conftest.py files."""
+    if not module.file:
+        return set()
+
+    fixtures: set[str] = set()
+    module_dir = Path(module.file).parent
+
+    # Walk up directories looking for conftest.py files
+    # Stop at the tests root (don't go above it)
+    current = module_dir
+    while current.name and current.name != "tests":
+        conftest_path = current / "conftest.py"
+        if conftest_path.exists():
+            try:
+                conftest_module = astroid.MANAGER.ast_from_file(str(conftest_path))
+                fixtures.update(_collect_module_usefixtures(conftest_module))
+                fixtures.update(_collect_autouse_fixtures(conftest_module))
+            except astroid.exceptions.AstroidSyntaxError:
+                pass
+        current = current.parent
+
+    return fixtures
+
+
 class RedundantUsefixtures(BaseChecker):
     """Checker for redundant @pytest.mark.usefixtures on test functions."""
 
@@ -76,7 +149,8 @@ class RedundantUsefixtures(BaseChecker):
             "the `@pytest.mark.usefixtures` decorator is redundant",
             "home-assistant-tests-redundant-usefixtures",
             "Used when a test function has @pytest.mark.usefixtures for a "
-            "fixture that is already declared in the module's pytestmark.",
+            "fixture that is already declared in the module's pytestmark "
+            "or in a parent conftest.py (via pytestmark or autouse=True).",
         ),
     }
     options = ()
@@ -88,6 +162,7 @@ class RedundantUsefixtures(BaseChecker):
         self._module_fixtures = set()
         if is_test_module(node.name):
             self._module_fixtures = _collect_module_usefixtures(node)
+            self._module_fixtures.update(_collect_conftest_fixtures(node))
 
     def visit_functiondef(self, node: nodes.FunctionDef) -> None:
         """Check test functions for redundant usefixtures decorators."""

--- a/tests/components/aladdin_connect/test_config_flow.py
+++ b/tests/components/aladdin_connect/test_config_flow.py
@@ -47,7 +47,6 @@ async def access_token(hass: HomeAssistant) -> str:
     "current_request_with_host",
     "use_cloud",
     "mock_setup_entry",
-    "mock_aladdin_connect_api",
 )
 async def test_full_flow(
     hass: HomeAssistant,
@@ -109,7 +108,6 @@ async def test_full_flow(
     "current_request_with_host",
     "use_cloud",
     "mock_setup_entry",
-    "mock_aladdin_connect_api",
 )
 async def test_full_dhcp_flow(
     hass: HomeAssistant,
@@ -180,9 +178,7 @@ async def test_full_dhcp_flow(
     assert result["result"].unique_id == USER_ID
 
 
-@pytest.mark.usefixtures(
-    "current_request_with_host", "use_cloud", "mock_aladdin_connect_api"
-)
+@pytest.mark.usefixtures("current_request_with_host", "use_cloud")
 async def test_duplicate_entry(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
@@ -256,7 +252,6 @@ async def test_duplicate_dhcp_entry(
     "current_request_with_host",
     "use_cloud",
     "mock_setup_entry",
-    "mock_aladdin_connect_api",
 )
 async def test_flow_reauth(
     hass: HomeAssistant,
@@ -317,9 +312,7 @@ async def test_flow_reauth(
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
-@pytest.mark.usefixtures(
-    "current_request_with_host", "use_cloud", "mock_aladdin_connect_api"
-)
+@pytest.mark.usefixtures("current_request_with_host", "use_cloud")
 async def test_flow_wrong_account_reauth(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,

--- a/tests/components/apple_tv/test_config_flow.py
+++ b/tests/components/apple_tv/test_config_flow.py
@@ -211,7 +211,7 @@ async def test_user_adds_dmap_device_failed(
     assert result2["reason"] == "device_did_not_pair"
 
 
-@pytest.mark.usefixtures("dmap_device_with_credentials", "mock_scan")
+@pytest.mark.usefixtures("dmap_device_with_credentials")
 async def test_user_adds_device_with_ip_filter(hass: HomeAssistant) -> None:
     """Test add device filtering by IP."""
     result = await hass.config_entries.flow.async_init(
@@ -837,7 +837,6 @@ async def test_zeroconf_add_existing_aborts(hass: HomeAssistant) -> None:
     assert result["reason"] == "already_in_progress"
 
 
-@pytest.mark.usefixtures("mock_scan")
 async def test_zeroconf_add_but_device_not_found(hass: HomeAssistant) -> None:
     """Test add device which is not found with another scan."""
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/august/test_config_flow.py
+++ b/tests/components/august/test_config_flow.py
@@ -32,7 +32,6 @@ def mock_setup_entry() -> Generator[Mock]:
         yield mock_setup_entry
 
 
-@pytest.mark.usefixtures("client_credentials")
 @pytest.mark.usefixtures("current_request_with_host")
 @pytest.mark.usefixtures("mock_setup_entry")
 async def test_full_flow(
@@ -98,7 +97,6 @@ async def test_full_flow(
     }
 
 
-@pytest.mark.usefixtures("client_credentials")
 @pytest.mark.usefixtures("current_request_with_host")
 @pytest.mark.usefixtures("mock_setup_entry")
 async def test_full_flow_already_exists(
@@ -152,7 +150,6 @@ async def test_full_flow_already_exists(
     assert result2["reason"] == "already_configured"
 
 
-@pytest.mark.usefixtures("client_credentials")
 @pytest.mark.usefixtures("current_request_with_host")
 @pytest.mark.usefixtures("mock_setup_entry")
 async def test_reauth(
@@ -212,7 +209,6 @@ async def test_reauth(
     assert mock_config_entry.data["token"]["access_token"] == reauth_jwt
 
 
-@pytest.mark.usefixtures("client_credentials")
 @pytest.mark.usefixtures("current_request_with_host")
 @pytest.mark.usefixtures("mock_setup_entry")
 async def test_reauth_wrong_account(
@@ -273,7 +269,6 @@ async def test_reauth_wrong_account(
     assert mock_config_entry.data["token"]["access_token"] == jwt
 
 
-@pytest.mark.usefixtures("client_credentials")
 @pytest.mark.usefixtures("current_request_with_host")
 @pytest.mark.usefixtures("mock_setup_entry")
 async def test_legacy_migration_with_email_match(
@@ -335,7 +330,6 @@ async def test_legacy_migration_with_email_match(
     assert mock_legacy_config_entry.data["token"]["access_token"] == migration_jwt
 
 
-@pytest.mark.usefixtures("client_credentials")
 @pytest.mark.usefixtures("current_request_with_host")
 @pytest.mark.usefixtures("mock_setup_entry")
 async def test_legacy_migration_wrong_email(
@@ -394,7 +388,6 @@ async def test_legacy_migration_wrong_email(
     assert "token" not in mock_legacy_config_entry.data  # Still legacy data
 
 
-@pytest.mark.usefixtures("client_credentials")
 @pytest.mark.usefixtures("current_request_with_host")
 @pytest.mark.usefixtures("mock_setup_entry")
 async def test_legacy_migration_no_email_in_jwt(

--- a/tests/components/bluetooth_le_tracker/test_device_tracker.py
+++ b/tests/components/bluetooth_le_tracker/test_device_tracker.py
@@ -67,7 +67,7 @@ class MockBleakClientBattery5(MockBleakClient):
         return b"\x05"
 
 
-@pytest.mark.usefixtures("mock_bluetooth", "mock_device_tracker_conf")
+@pytest.mark.usefixtures("mock_device_tracker_conf")
 async def test_do_not_see_device_if_time_not_updated(hass: HomeAssistant) -> None:
     """Test device going not_home after consider_home threshold from first scan if the subsequent scans have not incremented last seen time."""
 
@@ -132,7 +132,7 @@ async def test_do_not_see_device_if_time_not_updated(hass: HomeAssistant) -> Non
     assert state.state == "not_home"
 
 
-@pytest.mark.usefixtures("mock_bluetooth", "mock_device_tracker_conf")
+@pytest.mark.usefixtures("mock_device_tracker_conf")
 async def test_see_device_if_time_updated(hass: HomeAssistant) -> None:
     """Test device remaining home after consider_home threshold from first scan if the subsequent scans have incremented last seen time."""
 
@@ -213,7 +213,7 @@ async def test_see_device_if_time_updated(hass: HomeAssistant) -> None:
     assert state.state == "home"
 
 
-@pytest.mark.usefixtures("mock_bluetooth", "mock_device_tracker_conf")
+@pytest.mark.usefixtures("mock_device_tracker_conf")
 async def test_preserve_new_tracked_device_name(hass: HomeAssistant) -> None:
     """Test preserving tracked device name across new seens."""  # codespell:ignore seens
 
@@ -282,7 +282,7 @@ async def test_preserve_new_tracked_device_name(hass: HomeAssistant) -> None:
     assert state.name == name
 
 
-@pytest.mark.usefixtures("mock_bluetooth", "mock_device_tracker_conf")
+@pytest.mark.usefixtures("mock_device_tracker_conf")
 async def test_tracking_battery_times_out(hass: HomeAssistant) -> None:
     """Test tracking the battery times out."""
 
@@ -350,7 +350,7 @@ async def test_tracking_battery_times_out(hass: HomeAssistant) -> None:
     assert "battery" not in state.attributes
 
 
-@pytest.mark.usefixtures("mock_bluetooth", "mock_device_tracker_conf")
+@pytest.mark.usefixtures("mock_device_tracker_conf")
 async def test_tracking_battery_fails(hass: HomeAssistant) -> None:
     """Test tracking the battery fails."""
 
@@ -417,7 +417,7 @@ async def test_tracking_battery_fails(hass: HomeAssistant) -> None:
     assert "battery" not in state.attributes
 
 
-@pytest.mark.usefixtures("mock_bluetooth", "mock_device_tracker_conf")
+@pytest.mark.usefixtures("mock_device_tracker_conf")
 async def test_tracking_battery_successful(hass: HomeAssistant) -> None:
     """Test tracking the battery gets a value."""
 

--- a/tests/components/ecovacs/test_sensor.py
+++ b/tests/components/ecovacs/test_sensor.py
@@ -179,9 +179,7 @@ async def test_disabled_by_default_sensors(
         assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
-@pytest.mark.usefixtures(
-    "entity_registry_enabled_by_default", "mock_vacbot", "init_integration"
-)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "mock_vacbot")
 @pytest.mark.parametrize(("device_fixture"), ["123"])
 async def test_legacy_sensors(
     hass: HomeAssistant,

--- a/tests/components/electric_kiwi/test_config_flow.py
+++ b/tests/components/electric_kiwi/test_config_flow.py
@@ -24,7 +24,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 from tests.typing import ClientSessionGenerator
 
 
-@pytest.mark.usefixtures("current_request_with_host", "electrickiwi_api")
+@pytest.mark.usefixtures("current_request_with_host")
 async def test_full_flow(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,

--- a/tests/components/elgato/test_light.py
+++ b/tests/components/elgato/test_light.py
@@ -60,7 +60,7 @@ async def test_light_state_temperature(
 @pytest.mark.parametrize(
     ("device_fixtures", "state_variant"), [("light-strip", "state-color-temperature")]
 )
-@pytest.mark.usefixtures("state_variant", "device_fixtures", "init_integration")
+@pytest.mark.usefixtures("state_variant", "device_fixtures")
 async def test_light_change_state_temperature(
     hass: HomeAssistant,
     mock_elgato: MagicMock,
@@ -145,7 +145,6 @@ async def test_light_unavailable(
     assert state.state == STATE_UNAVAILABLE
 
 
-@pytest.mark.usefixtures("init_integration")
 async def test_light_identify(hass: HomeAssistant, mock_elgato: MagicMock) -> None:
     """Test identifying an Elgato Light."""
     await hass.services.async_call(

--- a/tests/components/google_photos/test_config_flow.py
+++ b/tests/components/google_photos/test_config_flow.py
@@ -132,7 +132,6 @@ async def test_full_flow(
 
 @pytest.mark.usefixtures(
     "current_request_with_host",
-    "setup_credentials",
     "mock_api",
 )
 @pytest.mark.parametrize(
@@ -179,7 +178,7 @@ async def test_api_not_enabled(
     assert result["description_placeholders"]["message"].endswith("some error")
 
 
-@pytest.mark.usefixtures("current_request_with_host", "setup_credentials")
+@pytest.mark.usefixtures("current_request_with_host")
 async def test_general_exception(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,

--- a/tests/components/heos/test_diagnostics.py
+++ b/tests/components/heos/test_diagnostics.py
@@ -1,7 +1,6 @@
 """Tests for the HEOS diagnostics module."""
 
 from pyheos import HeosError, HeosSystem
-import pytest
 from syrupy.assertion import SnapshotAssertion
 from syrupy.filters import props
 
@@ -41,7 +40,6 @@ async def test_config_entry_diagnostics(
     )
 
 
-@pytest.mark.usefixtures("controller")
 async def test_config_entry_diagnostics_error_getting_system(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -64,7 +62,6 @@ async def test_config_entry_diagnostics_error_getting_system(
     )
 
 
-@pytest.mark.usefixtures("controller")
 async def test_device_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,

--- a/tests/components/iron_os/test_update.py
+++ b/tests/components/iron_os/test_update.py
@@ -27,7 +27,7 @@ async def update_only() -> AsyncGenerator[None]:
         yield
 
 
-@pytest.mark.usefixtures("mock_pynecil", "ble_device", "mock_ironosupdate")
+@pytest.mark.usefixtures("mock_pynecil", "ble_device")
 async def test_update(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -1034,7 +1034,6 @@ async def test_reloadable(
     await help_test_reloadable(hass, mqtt_client_mock, domain, config)
 
 
-@pytest.mark.usefixtures("mock_temp_dir")
 @pytest.mark.parametrize(
     ("hass_config", "payload1", "state1", "payload2", "state2"),
     [

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -1708,7 +1708,6 @@ async def test_reloadable(
     await help_test_reloadable(hass, mqtt_client_mock, domain, config)
 
 
-@pytest.mark.usefixtures("mock_temp_dir")
 @pytest.mark.parametrize(
     "hass_config",
     [

--- a/tests/components/pooldose/test_sensor.py
+++ b/tests/components/pooldose/test_sensor.py
@@ -142,7 +142,6 @@ async def test_sensor_entity_unavailable_no_coordinator_data(
     assert temp_state.state == STATE_UNAVAILABLE
 
 
-@pytest.mark.usefixtures("mock_pooldose_client")
 async def test_sensor_unit_fallback_to_description(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -1332,7 +1332,7 @@ async def test_upnp_not_available(
     assert "Upnp services are not available" in caplog.text
 
 
-@pytest.mark.usefixtures("remote_websocket", "rest_api", "upnp_factory")
+@pytest.mark.usefixtures("remote_websocket", "rest_api")
 async def test_upnp_missing_service(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/components/watts/test_init.py
+++ b/tests/components/watts/test_init.py
@@ -57,7 +57,6 @@ async def test_setup_entry_success(
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
 
-@pytest.mark.usefixtures("setup_credentials")
 async def test_setup_entry_auth_failed(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
@@ -87,7 +86,6 @@ async def test_setup_entry_auth_failed(
     assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
-@pytest.mark.usefixtures("setup_credentials")
 async def test_setup_entry_not_ready(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
@@ -136,7 +134,6 @@ async def test_setup_entry_hub_coordinator_update_failed(
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-@pytest.mark.usefixtures("setup_credentials")
 async def test_setup_entry_server_error_5xx(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,

--- a/tests/components/weheat/test_init.py
+++ b/tests/components/weheat/test_init.py
@@ -19,7 +19,6 @@ from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import ClientResponseError
 
 
-@pytest.mark.usefixtures("setup_credentials")
 async def test_setup(
     hass: HomeAssistant,
     mock_weheat_discover: AsyncMock,
@@ -39,7 +38,6 @@ async def test_setup(
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
 
-@pytest.mark.usefixtures("setup_credentials")
 @pytest.mark.parametrize(
     ("setup_exception", "expected_setup_state"),
     [
@@ -72,7 +70,6 @@ async def test_setup_fail(
     assert mock_config_entry.state is expected_setup_state
 
 
-@pytest.mark.usefixtures("setup_credentials")
 async def test_setup_fail_discover(
     hass: HomeAssistant,
     mock_weheat_discover: AsyncMock,
@@ -88,7 +85,6 @@ async def test_setup_fail_discover(
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
-@pytest.mark.usefixtures("setup_credentials")
 async def test_oauth_implementation_not_available(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/whirlpool/test_config_flow.py
+++ b/tests/components/whirlpool/test_config_flow.py
@@ -67,7 +67,6 @@ def fixture_mock_whirlpool_setup_entry():
         yield mock_setup_entry
 
 
-@pytest.mark.usefixtures("mock_auth_api", "mock_appliances_manager_api")
 async def test_user_flow(
     hass: HomeAssistant,
     region: tuple[str, Region],
@@ -118,7 +117,6 @@ async def test_user_flow_invalid_auth(
     assert_successful_user_flow(mock_whirlpool_setup_entry, result, region[0], brand[0])
 
 
-@pytest.mark.usefixtures("mock_appliances_manager_api")
 @pytest.mark.parametrize(
     ("exception", "expected_error"),
     [
@@ -163,7 +161,6 @@ async def test_user_flow_auth_error(
     assert_successful_user_flow(mock_whirlpool_setup_entry, result, region[0], brand[0])
 
 
-@pytest.mark.usefixtures("mock_auth_api", "mock_appliances_manager_api")
 async def test_already_configured(
     hass: HomeAssistant, region: tuple[str, Region], brand: tuple[str, Brand]
 ) -> None:
@@ -193,7 +190,6 @@ async def test_already_configured(
 @pytest.mark.parametrize(
     "appliance_type", ["aircons", "washers", "dryers", "ovens", "refrigerators"]
 )
-@pytest.mark.usefixtures("mock_auth_api")
 async def test_no_appliances_flow(
     hass: HomeAssistant,
     region: tuple[str, Region],
@@ -236,9 +232,7 @@ async def test_no_appliances_flow(
     assert_successful_user_flow(mock_whirlpool_setup_entry, result, region[0], brand[0])
 
 
-@pytest.mark.usefixtures(
-    "mock_auth_api", "mock_appliances_manager_api", "mock_whirlpool_setup_entry"
-)
+@pytest.mark.usefixtures("mock_whirlpool_setup_entry")
 async def test_reauth_flow(
     hass: HomeAssistant, region: tuple[str, Region], brand: tuple[str, Brand]
 ) -> None:
@@ -263,7 +257,7 @@ async def test_reauth_flow(
     assert_successful_reauth_flow(mock_entry, result, region, brand)
 
 
-@pytest.mark.usefixtures("mock_appliances_manager_api", "mock_whirlpool_setup_entry")
+@pytest.mark.usefixtures("mock_whirlpool_setup_entry")
 async def test_reauth_flow_invalid_auth(
     hass: HomeAssistant,
     region: tuple[str, Region],
@@ -302,7 +296,7 @@ async def test_reauth_flow_invalid_auth(
     assert_successful_reauth_flow(mock_entry, result, region, brand)
 
 
-@pytest.mark.usefixtures("mock_appliances_manager_api", "mock_whirlpool_setup_entry")
+@pytest.mark.usefixtures("mock_whirlpool_setup_entry")
 @pytest.mark.parametrize(
     ("exception", "expected_error"),
     [

--- a/tests/components/wiim/test_config_flow.py
+++ b/tests/components/wiim/test_config_flow.py
@@ -38,7 +38,7 @@ async def setup_internal_url(hass: HomeAssistant) -> None:
     )
 
 
-@pytest.mark.usefixtures("mock_probe_player", "mock_setup_entry")
+@pytest.mark.usefixtures("mock_probe_player")
 async def test_user_flow_create_entry(hass: HomeAssistant) -> None:
     """Test the user flow."""
     result = await hass.config_entries.flow.async_init(
@@ -77,7 +77,6 @@ async def test_user_flow_abort_when_homeassistant_url_missing(
     mock_probe_player.assert_not_called()
 
 
-@pytest.mark.usefixtures("mock_setup_entry")
 async def test_user_flow_cannot_connect(
     hass: HomeAssistant, mock_probe_player: AsyncMock
 ) -> None:
@@ -105,7 +104,6 @@ async def test_user_flow_cannot_connect(
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
-@pytest.mark.usefixtures("mock_setup_entry")
 async def test_user_flow_no_probe(
     hass: HomeAssistant, mock_probe_player: AsyncMock
 ) -> None:
@@ -157,7 +155,7 @@ async def test_user_flow_already_configured(
     assert result["reason"] == "already_configured"
 
 
-@pytest.mark.usefixtures("mock_probe_player", "mock_setup_entry")
+@pytest.mark.usefixtures("mock_probe_player")
 async def test_zeroconf_flow(hass: HomeAssistant) -> None:
     """Test the zeroconf discovery flow."""
 
@@ -211,7 +209,6 @@ async def test_zeroconf_flow_no_probe(
     assert result["reason"] == "cannot_connect"
 
 
-@pytest.mark.usefixtures("mock_setup_entry")
 async def test_zeroconf_flow_already_configured(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:

--- a/tests/components/wled/test_button.py
+++ b/tests/components/wled/test_button.py
@@ -34,7 +34,6 @@ def override_platforms() -> Generator[None]:
         yield
 
 
-@pytest.mark.usefixtures("init_integration")
 async def test_snapshots(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
@@ -45,7 +44,6 @@ async def test_snapshots(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
-@pytest.mark.usefixtures("init_integration")
 async def test_device_snapshot(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,

--- a/tests/components/yale/test_config_flow.py
+++ b/tests/components/yale/test_config_flow.py
@@ -33,7 +33,6 @@ def mock_setup_entry() -> Generator[Mock]:
         yield mock_setup_entry
 
 
-@pytest.mark.usefixtures("client_credentials")
 @pytest.mark.usefixtures("current_request_with_host")
 async def test_full_flow(
     hass: HomeAssistant,
@@ -100,7 +99,6 @@ async def test_full_flow(
     }
 
 
-@pytest.mark.usefixtures("client_credentials")
 @pytest.mark.usefixtures("current_request_with_host")
 async def test_full_flow_already_exists(
     hass: HomeAssistant,
@@ -154,7 +152,6 @@ async def test_full_flow_already_exists(
     assert result2["reason"] == "already_configured"
 
 
-@pytest.mark.usefixtures("client_credentials")
 @pytest.mark.usefixtures("current_request_with_host")
 async def test_reauth(
     hass: HomeAssistant,
@@ -214,7 +211,6 @@ async def test_reauth(
     assert mock_config_entry.data["token"]["access_token"] == reauth_jwt
 
 
-@pytest.mark.usefixtures("client_credentials")
 @pytest.mark.usefixtures("current_request_with_host")
 async def test_reauth_wrong_account(
     hass: HomeAssistant,

--- a/tests/pylint/tests/__init__.py
+++ b/tests/pylint/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for test-related checkers."""

--- a/tests/pylint/tests/conftest.py
+++ b/tests/pylint/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Configuration for pylint tests checker tests."""
+
+from pylint.testutils.unittest_linter import UnittestLinter
+from pylint_home_assistant.checkers.tests.redundant_usefixtures import (
+    RedundantUsefixtures,
+)
+import pytest
+
+
+@pytest.fixture(name="usefixtures_checker")
+def usefixtures_checker_fixture(linter: UnittestLinter) -> RedundantUsefixtures:
+    """Fixture to provide a redundant usefixtures checker."""
+    return RedundantUsefixtures(linter)

--- a/tests/pylint/tests/test_redundant_usefixtures.py
+++ b/tests/pylint/tests/test_redundant_usefixtures.py
@@ -1,0 +1,205 @@
+"""Tests for the redundant usefixtures checker."""
+
+import astroid
+from pylint.testutils import UnittestLinter
+from pylint.utils.ast_walker import ASTWalker
+from pylint_home_assistant.checkers.tests.redundant_usefixtures import (
+    RedundantUsefixtures,
+)
+import pytest
+
+from tests.pylint import assert_no_messages
+
+
+@pytest.fixture(name="usefixtures_checker")
+def usefixtures_checker_fixture(linter: UnittestLinter) -> RedundantUsefixtures:
+    """Fixture to provide a redundant usefixtures checker."""
+    return RedundantUsefixtures(linter)
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        pytest.param(
+            """
+pytestmark = pytest.mark.usefixtures("init_integration")
+
+async def test_something(hass: HomeAssistant) -> None:
+    pass
+""",
+            id="no_per_test_decorator",
+        ),
+        pytest.param(
+            """
+pytestmark = pytest.mark.usefixtures("init_integration")
+
+@pytest.mark.usefixtures("other_fixture")
+async def test_something(hass: HomeAssistant) -> None:
+    pass
+""",
+            id="different_fixture",
+        ),
+        pytest.param(
+            """
+@pytest.mark.usefixtures("init_integration")
+async def test_something(hass: HomeAssistant) -> None:
+    pass
+""",
+            id="no_pytestmark",
+        ),
+        pytest.param(
+            """
+pytestmark = pytest.mark.parametrize("x", [1, 2])
+
+@pytest.mark.usefixtures("init_integration")
+async def test_something(hass: HomeAssistant) -> None:
+    pass
+""",
+            id="pytestmark_not_usefixtures",
+        ),
+        pytest.param(
+            """
+pytestmark = pytest.mark.usefixtures("fixture_a")
+pytestmark = pytest.mark.usefixtures("fixture_b")
+
+@pytest.mark.usefixtures("fixture_a")
+async def test_something(hass: HomeAssistant) -> None:
+    pass
+""",
+            id="reassigned_pytestmark_only_last_active",
+        ),
+    ],
+)
+def test_no_warning(
+    linter: UnittestLinter,
+    usefixtures_checker: RedundantUsefixtures,
+    code: str,
+) -> None:
+    """Test cases that should not trigger a warning."""
+    root_node = astroid.parse(code, "tests.components.test_integration.test_init")
+    walker = ASTWalker(linter)
+    walker.add_checker(usefixtures_checker)
+
+    with assert_no_messages(linter):
+        walker.walk(root_node)
+
+
+def test_single_fixture_redundant(
+    linter: UnittestLinter,
+    usefixtures_checker: RedundantUsefixtures,
+) -> None:
+    """Test that a redundant single-fixture decorator is flagged."""
+    root_node = astroid.parse(
+        """
+pytestmark = pytest.mark.usefixtures("init_integration")
+
+@pytest.mark.usefixtures("init_integration")
+async def test_something(hass: HomeAssistant) -> None:
+    pass
+""",
+        "tests.components.test_integration.test_init",
+    )
+    walker = ASTWalker(linter)
+    walker.add_checker(usefixtures_checker)
+    walker.walk(root_node)
+
+    messages = linter.release_messages()
+    assert len(messages) == 1
+    assert messages[0].msg_id == "home-assistant-tests-redundant-usefixtures"
+    assert messages[0].args == ("init_integration",)
+
+
+def test_multi_fixture_partial_redundant(
+    linter: UnittestLinter,
+    usefixtures_checker: RedundantUsefixtures,
+) -> None:
+    """Test that only the redundant fixture is flagged in a multi-fixture decorator."""
+    root_node = astroid.parse(
+        """
+pytestmark = pytest.mark.usefixtures("init_integration")
+
+@pytest.mark.usefixtures("init_integration", "other_fixture")
+async def test_something(hass: HomeAssistant) -> None:
+    pass
+""",
+        "tests.components.test_integration.test_init",
+    )
+    walker = ASTWalker(linter)
+    walker.add_checker(usefixtures_checker)
+    walker.walk(root_node)
+
+    messages = linter.release_messages()
+    assert len(messages) == 1
+    assert messages[0].args == ("init_integration",)
+
+
+def test_pytestmark_list(
+    linter: UnittestLinter,
+    usefixtures_checker: RedundantUsefixtures,
+) -> None:
+    """Test that pytestmark as a list is handled."""
+    root_node = astroid.parse(
+        """
+pytestmark = [pytest.mark.usefixtures("init_integration")]
+
+@pytest.mark.usefixtures("init_integration")
+async def test_something(hass: HomeAssistant) -> None:
+    pass
+""",
+        "tests.components.test_integration.test_init",
+    )
+    walker = ASTWalker(linter)
+    walker.add_checker(usefixtures_checker)
+    walker.walk(root_node)
+
+    messages = linter.release_messages()
+    assert len(messages) == 1
+
+
+def test_multiple_tests_flagged(
+    linter: UnittestLinter,
+    usefixtures_checker: RedundantUsefixtures,
+) -> None:
+    """Test that multiple tests with redundant decorators are each flagged."""
+    root_node = astroid.parse(
+        """
+pytestmark = pytest.mark.usefixtures("mock_setup_entry")
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_a(hass: HomeAssistant) -> None:
+    pass
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_b(hass: HomeAssistant) -> None:
+    pass
+""",
+        "tests.components.test_integration.test_init",
+    )
+    walker = ASTWalker(linter)
+    walker.add_checker(usefixtures_checker)
+    walker.walk(root_node)
+
+    messages = linter.release_messages()
+    assert len(messages) == 2
+
+
+def test_not_test_module_ignored(
+    linter: UnittestLinter,
+    usefixtures_checker: RedundantUsefixtures,
+) -> None:
+    """Test that non-test modules are ignored."""
+    root_node = astroid.parse(
+        """
+pytestmark = pytest.mark.usefixtures("init_integration")
+
+@pytest.mark.usefixtures("init_integration")
+async def test_something(hass: HomeAssistant) -> None:
+    pass
+""",
+        "homeassistant.components.test_integration",
+    )
+    walker = ASTWalker(linter)
+    walker.add_checker(usefixtures_checker)
+
+    with assert_no_messages(linter):
+        walker.walk(root_node)

--- a/tests/pylint/tests/test_redundant_usefixtures.py
+++ b/tests/pylint/tests/test_redundant_usefixtures.py
@@ -1,5 +1,7 @@
 """Tests for the redundant usefixtures checker."""
 
+from pathlib import Path
+
 import astroid
 from pylint.testutils import UnittestLinter
 from pylint.utils.ast_walker import ASTWalker
@@ -9,12 +11,6 @@ from pylint_home_assistant.checkers.tests.redundant_usefixtures import (
 import pytest
 
 from tests.pylint import assert_no_messages
-
-
-@pytest.fixture(name="usefixtures_checker")
-def usefixtures_checker_fixture(linter: UnittestLinter) -> RedundantUsefixtures:
-    """Fixture to provide a redundant usefixtures checker."""
-    return RedundantUsefixtures(linter)
 
 
 @pytest.mark.parametrize(
@@ -181,6 +177,104 @@ async def test_b(hass: HomeAssistant) -> None:
 
     messages = linter.release_messages()
     assert len(messages) == 2
+
+
+def test_conftest_pytestmark_redundant(
+    linter: UnittestLinter,
+    usefixtures_checker: RedundantUsefixtures,
+    tmp_path: Path,
+) -> None:
+    """Test that pytestmark from a parent conftest.py is detected."""
+    test_dir = tmp_path / "tests" / "components" / "test_int"
+    test_dir.mkdir(parents=True)
+
+    (test_dir / "conftest.py").write_text(
+        'import pytest\npytestmark = pytest.mark.usefixtures("init_integration")\n'
+    )
+
+    root_node = astroid.parse(
+        """
+@pytest.mark.usefixtures("init_integration")
+async def test_something(hass: HomeAssistant) -> None:
+    pass
+""",
+        "tests.components.test_int.test_init",
+    )
+    root_node.file = str(test_dir / "test_init.py")
+
+    walker = ASTWalker(linter)
+    walker.add_checker(usefixtures_checker)
+    walker.walk(root_node)
+
+    messages = linter.release_messages()
+    assert len(messages) == 1
+    assert messages[0].args == ("init_integration",)
+
+
+def test_conftest_autouse_fixture_redundant(
+    linter: UnittestLinter,
+    usefixtures_checker: RedundantUsefixtures,
+    tmp_path: Path,
+) -> None:
+    """Test that autouse fixtures from conftest.py are detected."""
+    test_dir = tmp_path / "tests" / "components" / "test_int"
+    test_dir.mkdir(parents=True)
+
+    (test_dir / "conftest.py").write_text(
+        "import pytest\n\n@pytest.fixture(autouse=True)\n"
+        "def mock_setup_entry():\n    yield\n"
+    )
+
+    root_node = astroid.parse(
+        """
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_something(hass: HomeAssistant) -> None:
+    pass
+""",
+        "tests.components.test_int.test_init",
+    )
+    root_node.file = str(test_dir / "test_init.py")
+
+    walker = ASTWalker(linter)
+    walker.add_checker(usefixtures_checker)
+    walker.walk(root_node)
+
+    messages = linter.release_messages()
+    assert len(messages) == 1
+    assert messages[0].args == ("mock_setup_entry",)
+
+
+def test_conftest_autouse_named_fixture_redundant(
+    linter: UnittestLinter,
+    usefixtures_checker: RedundantUsefixtures,
+    tmp_path: Path,
+) -> None:
+    """Test that autouse fixtures with name= override are detected by their public name."""
+    test_dir = tmp_path / "tests" / "components" / "test_int"
+    test_dir.mkdir(parents=True)
+
+    (test_dir / "conftest.py").write_text(
+        'import pytest\n\n@pytest.fixture(name="mock_setup_entry", autouse=True)\n'
+        "def mock_setup_entry_fixture():\n    yield\n"
+    )
+
+    root_node = astroid.parse(
+        """
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_something(hass: HomeAssistant) -> None:
+    pass
+""",
+        "tests.components.test_int.test_init",
+    )
+    root_node.file = str(test_dir / "test_init.py")
+
+    walker = ASTWalker(linter)
+    walker.add_checker(usefixtures_checker)
+    walker.walk(root_node)
+
+    messages = linter.release_messages()
+    assert len(messages) == 1
+    assert messages[0].args == ("mock_setup_entry",)
 
 
 def test_not_test_module_ignored(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a new pylint checker (`R7403` / `home-assistant-tests-redundant-usefixtures`) that flags `@pytest.mark.usefixtures` decorators on test functions when the same fixture is already applied module-wide via `pytestmark`.

```python
# pytestmark already applies mock_setup_entry to all tests in the module
pytestmark = pytest.mark.usefixtures("mock_setup_entry")

# Bad: redundant, already applied by pytestmark
@pytest.mark.usefixtures("mock_setup_entry")
async def test_something(hass: HomeAssistant) -> None:
    pass

# Good: no decorator needed
async def test_something(hass: HomeAssistant) -> None:
    pass
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
