### PR TITLE
Raise HomeAssistantError for Tractive action errors

### DIFF
--- a/homeassistant/components/tractive/strings.json
+++ b/homeassistant/components/tractive/strings.json
@@ -75,5 +75,13 @@
         "name": "Tracker LED"
       }
     }
+  },
+  "exceptions": {
+    "failed_to_turn_off": {
+      "message": "An error occurred while trying to turn off {entity}: {error}"
+    },
+    "failed_to_turn_on": {
+      "message": "An error occurred while trying to turn on {entity}: {error}"
+    }
   }
 }

--- a/homeassistant/components/tractive/strings.json
+++ b/homeassistant/components/tractive/strings.json
@@ -78,10 +78,10 @@
   },
   "exceptions": {
     "failed_to_turn_off": {
-      "message": "An error occurred while trying to turn off {entity}: {error}"
+      "message": "An error occurred while trying to turn off {entity}"
     },
     "failed_to_turn_on": {
-      "message": "An error occurred while trying to turn on {entity}: {error}"
+      "message": "An error occurred while trying to turn on {entity}"
     }
   }
 }

--- a/homeassistant/components/tractive/switch.py
+++ b/homeassistant/components/tractive/switch.py
@@ -9,6 +9,7 @@ from aiotractive.exceptions import TractiveError
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import Trackables, TractiveClient, TractiveConfigEntry
@@ -17,6 +18,7 @@ from .const import (
     ATTR_LED,
     ATTR_LIVE_TRACKING,
     ATTR_POWER_SAVING,
+    DOMAIN,
     TRACKER_SWITCH_STATUS_UPDATED,
 )
 from .entity import TractiveEntity
@@ -110,10 +112,15 @@ class TractiveSwitch(TractiveEntity, SwitchEntity):
         """Turn on a switch."""
         try:
             result = await self._method(True)
-        # pylint: disable-next=home-assistant-action-swallowed-exception
         except TractiveError as error:
-            _LOGGER.error(error)
-            return
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="failed_to_turn_on",
+                translation_placeholders={
+                    "entity": self.entity_id,
+                    "error": repr(error),
+                },
+            ) from error
         # Write state back to avoid switch flips with a slow response
         if result["pending"]:
             self._attr_is_on = True
@@ -123,10 +130,15 @@ class TractiveSwitch(TractiveEntity, SwitchEntity):
         """Turn off a switch."""
         try:
             result = await self._method(False)
-        # pylint: disable-next=home-assistant-action-swallowed-exception
         except TractiveError as error:
-            _LOGGER.error(error)
-            return
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="failed_to_turn_off",
+                translation_placeholders={
+                    "entity": self.entity_id,
+                    "error": repr(error),
+                },
+            ) from error
         # Write state back to avoid switch flips with a slow response
         if result["pending"]:
             self._attr_is_on = False

--- a/homeassistant/components/tractive/switch.py
+++ b/homeassistant/components/tractive/switch.py
@@ -116,10 +116,7 @@ class TractiveSwitch(TractiveEntity, SwitchEntity):
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="failed_to_turn_on",
-                translation_placeholders={
-                    "entity": self.entity_id,
-                    "error": repr(error),
-                },
+                translation_placeholders={"entity": self.entity_id},
             ) from error
         # Write state back to avoid switch flips with a slow response
         if result["pending"]:
@@ -134,10 +131,7 @@ class TractiveSwitch(TractiveEntity, SwitchEntity):
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="failed_to_turn_off",
-                translation_placeholders={
-                    "entity": self.entity_id,
-                    "error": repr(error),
-                },
+                translation_placeholders={"entity": self.entity_id},
             ) from error
         # Write state back to avoid switch flips with a slow response
         if result["pending"]:

--- a/tests/components/tractive/test_switch.py
+++ b/tests/components/tractive/test_switch.py
@@ -185,7 +185,7 @@ async def test_switch_on_with_exception(
 
     with pytest.raises(
         HomeAssistantError,
-        match=f"An error occurred while trying to turn on {entity_id}: TractiveError()",
+        match=f"An error occurred while trying to turn on {entity_id}",
     ):
         await hass.services.async_call(
             SWITCH_DOMAIN,
@@ -223,7 +223,7 @@ async def test_switch_off_with_exception(
 
     with pytest.raises(
         HomeAssistantError,
-        match=f"An error occurred while trying to turn off {entity_id}: TractiveError()",
+        match=f"An error occurred while trying to turn off {entity_id}",
     ):
         await hass.services.async_call(
             SWITCH_DOMAIN,

--- a/tests/components/tractive/test_switch.py
+++ b/tests/components/tractive/test_switch.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, patch
 
 from aiotractive.exceptions import TractiveError
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
@@ -15,7 +16,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     Platform,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from . import init_integration
@@ -182,12 +183,16 @@ async def test_switch_on_with_exception(
 
     mock_tractive_client.tracker.return_value.set_led_active.side_effect = TractiveError
 
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: entity_id},
-        blocking=True,
-    )
+    with pytest.raises(
+        HomeAssistantError,
+        match=f"An error occurred while trying to turn on {entity_id}: TractiveError()",
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
     await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
@@ -216,12 +221,16 @@ async def test_switch_off_with_exception(
         TractiveError
     )
 
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: entity_id},
-        blocking=True,
-    )
+    with pytest.raises(
+        HomeAssistantError,
+        match=f"An error occurred while trying to turn off {entity_id}: TractiveError()",
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
     await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
PR changes the way errors are handled during switch actions from logging the error to raising `HomeAssistantError`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170644
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
