### PR TITLE
Add AES encryption support for Pushover messages

### DIFF
--- a/homeassistant/components/pushover/const.py
+++ b/homeassistant/components/pushover/const.py
@@ -17,6 +17,6 @@ ATTR_CALLBACK_URL: Final = "callback_url"
 ATTR_EXPIRE: Final = "expire"
 ATTR_TTL: Final = "ttl"
 ATTR_TIMESTAMP: Final = "timestamp"
-ATTR_ENCRYPTED_KEY: Final=""
+ATTR_ENCRYPTED_KEY: Final = "encrypted_key"
 
 CONF_USER_KEY: Final = "user_key"

--- a/homeassistant/components/pushover/const.py
+++ b/homeassistant/components/pushover/const.py
@@ -17,5 +17,6 @@ ATTR_CALLBACK_URL: Final = "callback_url"
 ATTR_EXPIRE: Final = "expire"
 ATTR_TTL: Final = "ttl"
 ATTR_TIMESTAMP: Final = "timestamp"
+ATTR_ENCRYPTED_KEY: Final=""
 
 CONF_USER_KEY: Final = "user_key"

--- a/homeassistant/components/pushover/notify.py
+++ b/homeassistant/components/pushover/notify.py
@@ -1,6 +1,14 @@
 """Pushover platform for notify component."""
 
 import logging
+import base64
+import hmac
+import hashlib
+import os
+import gzip
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives.padding import PKCS7
+from cryptography.hazmat.backends import default_backend
 from typing import Any
 
 from pushover_complete import BadAPIRequestError, PushoverAPI
@@ -28,6 +36,7 @@ from .const import (
     ATTR_TTL,
     ATTR_URL,
     ATTR_URL_TITLE,
+    ATTR_ENCRYPTED_KEY,
     CONF_USER_KEY,
     DOMAIN,
 )
@@ -62,6 +71,22 @@ class PushoverNotificationService(BaseNotificationService):
         self._user_key = user_key
         self.pushover = pushover
 
+
+    def encrypt(plaintext: str, key_hex: str) -> str:
+        """Encrypt the plaintext using AES-256-CBC with gzip compression and HMAC-SHA256."""
+        key = bytes.fromhex(key_hex)
+
+        iv = os.urandom(16)
+        compressed = gzip.compress(plaintext.encode(), compresslevel=9)
+        padder = PKCS7(128).padder()
+        padded = padder.update(compressed) + padder.finalize()
+        cipher = Cipher(algorithms.AES(key), modes.CBC(iv), backend=default_backend())
+        encryptor = cipher.encryptor()
+        ct = encryptor.update(padded) + encryptor.finalize()
+        h = hmac.new(key, iv + ct, hashlib.sha256).digest()
+        final = iv + ct + h
+        return base64.b64encode(final).decode()
+
     def send_message(self, message: str = "", **kwargs: Any) -> None:
         """Send a message to a user."""
 
@@ -78,6 +103,8 @@ class PushoverNotificationService(BaseNotificationService):
         timestamp = data.get(ATTR_TIMESTAMP)
         sound = data.get(ATTR_SOUND)
         html = 1 if data.get(ATTR_HTML, False) else 0
+        encrypted_key = data.get(ATTR_ENCRYPTED_KEY)
+        encrypted = 1 if encrypted_key else 0,
 
         # Check for attachment
         if (image := data.get(ATTR_ATTACHMENT)) is not None:
@@ -99,6 +126,11 @@ class PushoverNotificationService(BaseNotificationService):
                 # Remove attachment key to send without attachment.
                 image = None
 
+        # Encrypt message and title if encrypted_key is provided
+        if encrypted_key:
+            message = self.encrypt(message, encrypted_key)
+            title = self.encrypt(title, encrypted_key)
+
         try:
             self.pushover.send_message(
                 user=self._user_key,
@@ -116,6 +148,7 @@ class PushoverNotificationService(BaseNotificationService):
                 sound=sound,
                 html=html,
                 ttl=ttl,
+                encrypted=encrypted,
             )
         except BadAPIRequestError as err:
             raise HomeAssistantError(str(err)) from err

--- a/homeassistant/components/pushover/notify.py
+++ b/homeassistant/components/pushover/notify.py
@@ -104,7 +104,7 @@ class PushoverNotificationService(BaseNotificationService):
         sound = data.get(ATTR_SOUND)
         html = 1 if data.get(ATTR_HTML, False) else 0
         encrypted_key = data.get(ATTR_ENCRYPTED_KEY)
-        encrypted = 1 if encrypted_key else 0,
+        encrypted = 1 if encrypted_key else 0
 
         # Check for attachment
         if (image := data.get(ATTR_ATTACHMENT)) is not None:

--- a/homeassistant/components/pushover/notify.py
+++ b/homeassistant/components/pushover/notify.py
@@ -129,7 +129,8 @@ class PushoverNotificationService(BaseNotificationService):
         # Encrypt message and title if encrypted_key is provided
         if encrypted_key:
             message = self.encrypt(message, encrypted_key)
-            title = self.encrypt(title, encrypted_key)
+            if title is not None:
+                title = self.encrypt(title, encrypted_key)
 
         try:
             self.pushover.send_message(


### PR DESCRIPTION
Introduce ATTR_ENCRYPTED_KEY and add message encryption to the Pushover notify platform. Adds imports and an encrypt helper that compresses with gzip, pads with PKCS7, encrypts using AES-256-CBC, appends an HMAC-SHA256, and base64-encodes the result (key expected as hex). If ATTR_ENCRYPTED_KEY is provided, message and title are encrypted and the encrypted flag is set when calling the Pushover API.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
