### PR TITLE
Fix line length violations in tests (non-components)

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -321,7 +321,8 @@ async def async_test_home_assistant(
                 StoreWithoutWriteLoad,
             ),
             patch(
-                "homeassistant.helpers.storage.Store",  # Floor & label registry are different
+                # Floor & label registry are different
+                "homeassistant.helpers.storage.Store",
                 StoreWithoutWriteLoad,
             ),
             patch(
@@ -1444,12 +1445,18 @@ class MockEntity(entity.Entity):
 
     @property
     def entity_registry_enabled_default(self) -> bool:
-        """Return if the entity should be enabled when first added to the entity registry."""
+        """Return if the entity should be enabled when first added.
+
+        When first added to the entity registry.
+        """
         return self._handle("entity_registry_enabled_default")
 
     @property
     def entity_registry_visible_default(self) -> bool:
-        """Return if the entity should be visible when first added to the entity registry."""
+        """Return if the entity should be visible when first added.
+
+        When first added to the entity registry.
+        """
         return self._handle("entity_registry_visible_default")
 
     @property
@@ -1625,7 +1632,8 @@ def mock_integration(
 
     def mock_import_platform(platform_name: str) -> NoReturn:
         raise ImportError(
-            f"Mocked unable to import platform '{integration.pkg_path}.{platform_name}'",
+            "Mocked unable to import platform"
+            f" '{integration.pkg_path}.{platform_name}'",
             name=f"{integration.pkg_path}.{platform_name}",
         )
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -1445,18 +1445,12 @@ class MockEntity(entity.Entity):
 
     @property
     def entity_registry_enabled_default(self) -> bool:
-        """Return if the entity should be enabled when first added.
-
-        When first added to the entity registry.
-        """
+        """Return if the entity should be enabled in the registry when first added."""
         return self._handle("entity_registry_enabled_default")
 
     @property
     def entity_registry_visible_default(self) -> bool:
-        """Return if the entity should be visible when first added.
-
-        When first added to the entity registry.
-        """
+        """Return if the entity should be visible in the registry when first added."""
         return self._handle("entity_registry_visible_default")
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -204,7 +204,9 @@ def pytest_runtest_setup() -> None:
       of times it was raised.
 
     freezegun:
-    - Modified to include https://github.com/spulec/freezegun/pull/424 and improve class str.
+    - Modified to include
+      https://github.com/spulec/freezegun/pull/424
+      and improve class str.
     """
     pytest_socket.socket_allow_hosts(["127.0.0.1"])
     pytest_socket.disable_socket(allow_unix_socket=True)
@@ -451,7 +453,8 @@ def verify_cleanup(
     try:
         # Verify respx.mock has been cleaned up
         assert not respx.mock.routes, (
-            "respx.mock routes not cleaned up, maybe the test needs to be decorated with @respx.mock"
+            "respx.mock routes not cleaned up, maybe the test"
+            " needs to be decorated with @respx.mock"
         )
     finally:
         # Clear mock routes not break subsequent tests
@@ -559,7 +562,9 @@ def aiohttp_client_cls() -> type[CoalescingClient]:
 
 @pytest.fixture
 def aiohttp_client() -> Generator[ClientSessionGenerator]:
-    """Override the default aiohttp_client since 3.x does not support aiohttp_client_cls.
+    """Override the default aiohttp_client since 3.x does not support it.
+
+    The aiohttp_client_cls is not supported in 3.x.
 
     Remove this when upgrading to 4.x as aiohttp_client_cls
     will do the same thing
@@ -691,7 +696,8 @@ async def hass(
 
         yield hass
 
-        # Config entries are not normally unloaded on HA shutdown. They are unloaded here
+        # Config entries are not normally unloaded on HA shutdown.
+        # They are unloaded here
         # to ensure that they could, and to help track lingering tasks and timers.
         loaded_entries = [
             entry
@@ -1011,7 +1017,11 @@ def hass_ws_client(
 def fail_on_log_exception(
     request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Fixture to fail if a callback wrapped by catch_log_exception or coroutine wrapped by async_create_catching_coro throws."""
+    """Fixture to fail if a callback or coroutine throws.
+
+    Catches callbacks wrapped by catch_log_exception or coroutines
+    wrapped by async_create_catching_coro.
+    """
     if "no_fail_on_log_exception" in request.keywords:
         return
 
@@ -1631,7 +1641,8 @@ def recorder_db_url(
             # to ensure that InnoDB does not deadlock.
             with engine.begin() as connection:
                 query = sa.text(
-                    "select id FROM information_schema.processlist WHERE db=:db and id != CONNECTION_ID()"
+                    "select id FROM information_schema.processlist"
+                    " WHERE db=:db and id != CONNECTION_ID()"
                 )
                 rows = connection.execute(query, parameters={"db": db}).fetchall()
                 if rows:
@@ -2223,7 +2234,8 @@ _real_dhcp_service_info_init = DhcpServiceInfo.__init__
 def _dhcp_service_info_init(self: DhcpServiceInfo, *args: Any, **kwargs: Any) -> None:
     """Override __init__ for DhcpServiceInfo.
 
-    Ensure that the macaddress is always in lowercase and without colons to match DHCP service.
+    Ensure that the macaddress is always in lowercase and
+    without colons to match DHCP service.
     """
     _real_dhcp_service_info_init(self, *args, **kwargs)
     if self.macaddress != self.macaddress.lower().replace(":", ""):

--- a/tests/hassfest/test_core_files.py
+++ b/tests/hassfest/test_core_files.py
@@ -94,5 +94,6 @@ def test_unexpected_entry(config: Config) -> None:
     assert len(config.errors) == 1
     assert (
         config.errors[0].error
-        == "'unknown_thing' in base_platforms in .core_files.yaml is not an entity platform or in EXTRA_BASE_PLATFORMS"
+        == "'unknown_thing' in base_platforms in .core_files.yaml"
+        " is not an entity platform or in EXTRA_BASE_PLATFORMS"
     )

--- a/tests/hassfest/test_integration_type.py
+++ b/tests/hassfest/test_integration_type.py
@@ -31,7 +31,10 @@ def test_integration_with_config_flow_and_integration_type(config: Config) -> No
 
 @pytest.mark.usefixtures("mock_core_integration")
 def test_integration_with_config_flow_missing_integration_type(config: Config) -> None:
-    """Integration with config_flow but no integration_type and not in allowlist should error."""
+    """Integration with config_flow but no integration_type.
+
+    Not in allowlist should error.
+    """
     integrations = {
         "test": _get_integration(
             "test",
@@ -46,7 +49,10 @@ def test_integration_with_config_flow_missing_integration_type(config: Config) -
 
 @pytest.mark.usefixtures("mock_core_integration")
 def test_integration_with_config_flow_in_allowlist(config: Config) -> None:
-    """Integration with config_flow but no integration_type and in allowlist should pass."""
+    """Integration with config_flow but no integration_type.
+
+    In allowlist should pass.
+    """
     domain = next(iter(integration_type.MISSING_INTEGRATION_TYPE))
     integrations = {
         domain: _get_integration(
@@ -80,7 +86,7 @@ def test_integration_with_integration_type_still_in_allowlist(config: Config) ->
 
 @pytest.mark.usefixtures("mock_core_integration")
 def test_integration_without_config_flow_skipped(config: Config) -> None:
-    """Integration without config_flow should be skipped regardless of integration_type."""
+    """Integration without config_flow should be skipped."""
     integrations = {
         "test": _get_integration(
             "test",

--- a/tests/hassfest/test_requirements.py
+++ b/tests/hassfest/test_requirements.py
@@ -171,7 +171,7 @@ def test_dependency_version_range_prepare_update(
 
 @pytest.mark.usefixtures("mock_forbidden_package_names")
 def test_check_dependency_package_names(integration: Integration) -> None:
-    """Test dependency package names check for forbidden package names is working correctly."""
+    """Test dependency package names check for forbidden names."""
     package = "homeassistant"
     pkg = "my_package"
 

--- a/tests/hassfest/test_translations.py
+++ b/tests/hassfest/test_translations.py
@@ -224,7 +224,9 @@ SAMPLE_STRINGS = {
         },
     },
     "application_credentials": {
-        "description": "To configure this integration, you need to create an application",
+        "description": (
+            "To configure this integration, you need to create an application"
+        ),
     },
     "issues": {
         "firmware_update_required": {

--- a/tests/hassfest/test_triggers.py
+++ b/tests/hassfest/test_triggers.py
@@ -41,7 +41,9 @@ TRIGGER_DESCRIPTIONS = {
             "triggers": {
                 "_": {
                     "name": "MQTT",
-                    "description": "When a specific message is received on a given MQTT topic.",
+                    "description": (
+                        "When a specific message is received on a given MQTT topic."
+                    ),
                     "fields": {
                         "event": {"name": "Event", "description": "The event."},
                         "offset": {"name": "Offset", "description": "The offset."},

--- a/tests/helpers/template/extensions/test_crypto.py
+++ b/tests/helpers/template/extensions/test_crypto.py
@@ -28,6 +28,10 @@ def test_sha256(hass: HomeAssistant) -> None:
 
 def test_sha512(hass: HomeAssistant) -> None:
     """Test the sha512 function and filter."""
-    ha_sha512 = "9e3c2cdd1fbab0037378d37e1baf8a3a4bf92c54b56ad1d459deee30ccbb2acbebd7a3614552ea08992ad27dedeb7b4c5473525ba90cb73dbe8b9ec5f69295bb"
+    ha_sha512 = (
+        "9e3c2cdd1fbab0037378d37e1baf8a3a4bf92c54b56ad1d459deee30"
+        "ccbb2acbebd7a3614552ea08992ad27dedeb7b4c5473525ba90cb73d"
+        "be8b9ec5f69295bb"
+    )
     assert render(hass, "{{ sha512('Home Assistant') }}") == ha_sha512
     assert render(hass, "{{ 'Home Assistant' | sha512 }}") == ha_sha512

--- a/tests/helpers/template/extensions/test_entities.py
+++ b/tests/helpers/template/extensions/test_entities.py
@@ -82,5 +82,6 @@ def test_is_hidden_entity(
 
     assert not render(
         hass,
-        f"{{{{ ['{visible_entity.entity_id}'] | select('is_hidden_entity') | first }}}}",
+        f"{{{{ ['{visible_entity.entity_id}']"
+        " | select('is_hidden_entity') | first }}}}",
     )

--- a/tests/helpers/template/extensions/test_entities.py
+++ b/tests/helpers/template/extensions/test_entities.py
@@ -83,5 +83,5 @@ def test_is_hidden_entity(
     assert not render(
         hass,
         f"{{{{ ['{visible_entity.entity_id}']"
-        " | select('is_hidden_entity') | first }}}}",
+        f" | select('is_hidden_entity') | first }}}}",
     )

--- a/tests/helpers/template/extensions/test_functional.py
+++ b/tests/helpers/template/extensions/test_functional.py
@@ -495,13 +495,15 @@ def test_combine(hass: HomeAssistant) -> None:
 
     assert render(
         hass,
-        "{{ combine({'a': 1, 'b': {'x': 1}}, {'b': {'y': 2}, 'c': 4}, recursive=True) }}",
+        "{{ combine({'a': 1, 'b': {'x': 1}},"
+        " {'b': {'y': 2}, 'c': 4}, recursive=True) }}",
     ) == {"a": 1, "b": {"x": 1, "y": 2}, "c": 4}
 
     # Test that recursive=False does not merge nested dictionaries
     assert render(
         hass,
-        "{{ combine({'a': 1, 'b': {'x': 1}}, {'b': {'y': 2}, 'c': 4}, recursive=False) }}",
+        "{{ combine({'a': 1, 'b': {'x': 1}},"
+        " {'b': {'y': 2}, 'c': 4}, recursive=False) }}",
     ) == {"a": 1, "b": {"y": 2}, "c": 4}
 
     # Test that None values are handled correctly in recursive merge

--- a/tests/helpers/template/extensions/test_math.py
+++ b/tests/helpers/template/extensions/test_math.py
@@ -314,28 +314,36 @@ def test_min_max_attribute(hass: HomeAssistant, attribute) -> None:
     assert (
         render(
             hass,
-            f"{{{{ (state_attr('test.object', 'objects') | min(attribute='{attribute}'))['{attribute}']}}}}",
+            "{{ (state_attr('test.object', 'objects')"
+            f" | min(attribute='{attribute}'))"
+            f"['{attribute}']}}}}",
         )
         == 1
     )
     assert (
         render(
             hass,
-            f"{{{{ (min(state_attr('test.object', 'objects'), attribute='{attribute}'))['{attribute}']}}}}",
+            "{{ (min(state_attr('test.object', 'objects'),"
+            f" attribute='{attribute}'))"
+            f"['{attribute}']}}}}",
         )
         == 1
     )
     assert (
         render(
             hass,
-            f"{{{{ (state_attr('test.object', 'objects') | max(attribute='{attribute}'))['{attribute}']}}}}",
+            "{{ (state_attr('test.object', 'objects')"
+            f" | max(attribute='{attribute}'))"
+            f"['{attribute}']}}}}",
         )
         == 3
     )
     assert (
         render(
             hass,
-            f"{{{{ (max(state_attr('test.object', 'objects'), attribute='{attribute}'))['{attribute}']}}}}",
+            "{{ (max(state_attr('test.object', 'objects'),"
+            f" attribute='{attribute}'))"
+            f"['{attribute}']}}}}",
         )
         == 3
     )

--- a/tests/helpers/template/extensions/test_regex.py
+++ b/tests/helpers/template/extensions/test_regex.py
@@ -166,7 +166,9 @@ def test_regex_groups_and_replacement_patterns(hass: HomeAssistant) -> None:
     # Test findall with groups
     result = render(
         hass,
-        r"""{{ 'Email: test@example.com, Phone: 123-456-7890' | regex_findall('(\\w+@\\w+\\.\\w+)|(\\d{3}-\\d{3}-\\d{4})') }}""",
+        r"{{ 'Email: test@example.com, Phone: 123-456-7890'"
+        r" | regex_findall('(\\w+@\\w+\\.\\w+)"
+        r"|(\\d{3}-\\d{3}-\\d{4})') }}",
     )
     # The result will contain tuples with empty strings for non-matching groups
     assert len(result) == 2

--- a/tests/helpers/template/extensions/test_serialization.py
+++ b/tests/helpers/template/extensions/test_serialization.py
@@ -119,7 +119,10 @@ def test_pack(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
     assert render(hass, "{{ pack(value, '>I') }}", variables) == b"\xde\xad\xbe\xef"
 
     # test with None value
-    # "Template warning: 'pack' unable to pack object with type '%s' and format_string '%s' see https://docs.python.org/3/library/struct.html for more information"
+    # "Template warning: 'pack' unable to pack object with
+    # type '%s' and format_string '%s' see
+    # https://docs.python.org/3/library/struct.html
+    # for more information"
     assert render(hass, "{{ pack(value, '>I') }}", {"value": None}) is None
     assert (
         "Template warning: 'pack' unable to pack object 'None' with type 'NoneType' and"
@@ -128,7 +131,10 @@ def test_pack(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
     )
 
     # test with invalid filter
-    # "Template warning: 'pack' unable to pack object with type '%s' and format_string '%s' see https://docs.python.org/3/library/struct.html for more information"
+    # "Template warning: 'pack' unable to pack object with
+    # type '%s' and format_string '%s' see
+    # https://docs.python.org/3/library/struct.html
+    # for more information"
     assert render(hass, "{{ pack(value, 'invalid filter') }}", variables) is None
     assert (
         "Template warning: 'pack' unable to pack object '3735928559' with type 'int'"

--- a/tests/helpers/template/extensions/test_state.py
+++ b/tests/helpers/template/extensions/test_state.py
@@ -60,7 +60,10 @@ def test_referring_states_by_entity_id(hass: HomeAssistant) -> None:
 
 def test_iterating_all_states(hass: HomeAssistant) -> None:
     """Test iterating all states."""
-    tmpl_str = "{% for state in states | sort(attribute='entity_id') %}{{ state.state }}{% endfor %}"
+    tmpl_str = (
+        "{% for state in states | sort(attribute='entity_id') %}"
+        "{{ state.state }}{% endfor %}"
+    )
 
     info = render_to_info(hass, tmpl_str)
     assert_result_info(info, "", all_states=True)
@@ -163,7 +166,7 @@ def test_is_state_attr(hass: HomeAssistant) -> None:
 
     result = render(
         hass,
-        """{% if is_state_attr("test.object", "mode", "on") %}yes{% else %}no{% endif %}""",
+        '{% if is_state_attr("test.object", "mode", "on") %}yes{% else %}no{% endif %}',
     )
     assert result == "yes"
 
@@ -172,25 +175,30 @@ def test_is_state_attr(hass: HomeAssistant) -> None:
 
     result = render(
         hass,
-        """{% if "test.object" is is_state_attr("mode", "on") %}yes{% else %}no{% endif %}""",
+        '{% if "test.object" is is_state_attr("mode", "on") %}'
+        "yes{% else %}no{% endif %}",
     )
     assert result == "yes"
 
     result = render(
         hass,
-        """{{ ['test.object'] | select("is_state_attr", "mode", "on") | first | default }}""",
+        "{{ ['test.object']"
+        ' | select("is_state_attr", "mode", "on")'
+        " | first | default }}",
     )
     assert result == "test.object"
 
     result = render(
         hass,
-        """{% if is_state_attr("test.object", "exists", None) %}yes{% else %}no{% endif %}""",
+        '{% if is_state_attr("test.object", "exists", None) %}'
+        "yes{% else %}no{% endif %}",
     )
     assert result == "yes"
 
     result = render(
         hass,
-        """{% if is_state_attr("test.object", "noexist", None) %}yes{% else %}no{% endif %}""",
+        '{% if is_state_attr("test.object", "noexist", None) %}'
+        "yes{% else %}no{% endif %}",
     )
     assert result == "no"
 
@@ -203,7 +211,7 @@ def test_state_attr(hass: HomeAssistant) -> None:
 
     result = render(
         hass,
-        """{% if state_attr("test.object", "mode") == "on" %}yes{% else %}no{% endif %}""",
+        '{% if state_attr("test.object", "mode") == "on" %}yes{% else %}no{% endif %}',
     )
     assert result == "yes"
 
@@ -212,7 +220,7 @@ def test_state_attr(hass: HomeAssistant) -> None:
 
     result = render(
         hass,
-        """{% if "test.object" | state_attr("mode") == "on" %}yes{% else %}no{% endif %}""",
+        '{% if "test.object" | state_attr("mode") == "on" %}yes{% else %}no{% endif %}',
     )
     assert result == "yes"
 
@@ -411,7 +419,9 @@ async def test_state_attr_translated(
             "climate.test_platform_5678",
             "fan_mode",
             {
-                "component.test_platform.entity.climate.my_climate.state_attributes.fan_mode.state.auto": "Platform Automatic",
+                "component.test_platform.entity.climate"
+                ".my_climate.state_attributes"
+                ".fan_mode.state.auto": "Platform Automatic",
             },
             "Platform Automatic",
         ),
@@ -419,7 +429,9 @@ async def test_state_attr_translated(
             "climate.living_room",
             "fan_mode",
             {
-                "component.climate.entity_component._.state_attributes.fan_mode.state.auto": "Automatic",
+                "component.climate.entity_component"
+                "._.state_attributes"
+                ".fan_mode.state.auto": "Automatic",
             },
             "Automatic",
         ),
@@ -427,7 +439,9 @@ async def test_state_attr_translated(
             "climate.living_room",
             "hvac_action",
             {
-                "component.climate.entity_component._.state_attributes.hvac_action.state.heating": "Heating",
+                "component.climate.entity_component"
+                "._.state_attributes"
+                ".hvac_action.state.heating": "Heating",
             },
             "Heating",
         ),
@@ -536,7 +550,11 @@ def test_distance_function_with_1_coord(hass: HomeAssistant) -> None:
 def test_distance_function_with_2_coords(hass: HomeAssistant) -> None:
     """Test distance function with 2 coords."""
     _set_up_units(hass)
-    tpl = f'{{{{ distance("32.87336", "-117.22943", {hass.config.latitude}, {hass.config.longitude}) | round }}}}'
+    tpl = (
+        f'{{{{ distance("32.87336", "-117.22943",'
+        f" {hass.config.latitude}, {hass.config.longitude})"
+        f" | round }}}}"
+    )
     assert render(hass, tpl) == 187
 
 
@@ -680,21 +698,33 @@ async def test_expand(hass: HomeAssistant) -> None:
 
     info = render_to_info(
         hass,
-        "{{ expand('test.object') | sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}",
+        (
+            "{{ expand('test.object')"
+            " | sort(attribute='entity_id')"
+            " | map(attribute='entity_id') | join(', ') }}"
+        ),
     )
     assert_result_info(info, "test.object", ["test.object"])
     assert info.rate_limit is None
 
     info = render_to_info(
         hass,
-        "{{ expand('group.new_group') | sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}",
+        (
+            "{{ expand('group.new_group')"
+            " | sort(attribute='entity_id')"
+            " | map(attribute='entity_id') | join(', ') }}"
+        ),
     )
     assert_result_info(info, "", ["group.new_group"])
     assert info.rate_limit is None
 
     info = render_to_info(
         hass,
-        "{{ expand(states.group) | sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}",
+        (
+            "{{ expand(states.group)"
+            " | sort(attribute='entity_id')"
+            " | map(attribute='entity_id') | join(', ') }}"
+        ),
     )
     assert_result_info(info, "", [], ["group"])
     assert info.rate_limit == DOMAIN_STATES_RATE_LIMIT
@@ -714,14 +744,22 @@ async def test_expand(hass: HomeAssistant) -> None:
 
     info = render_to_info(
         hass,
-        "{{ expand('group.new_group') | sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}",
+        (
+            "{{ expand('group.new_group')"
+            " | sort(attribute='entity_id')"
+            " | map(attribute='entity_id') | join(', ') }}"
+        ),
     )
     assert_result_info(info, "test.object", {"group.new_group", "test.object"})
     assert info.rate_limit is None
 
     info = render_to_info(
         hass,
-        "{{ expand(states.group) | sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}",
+        (
+            "{{ expand(states.group)"
+            " | sort(attribute='entity_id')"
+            " | map(attribute='entity_id') | join(', ') }}"
+        ),
     )
     assert_result_info(info, "test.object", {"test.object"}, ["group"])
     assert info.rate_limit == DOMAIN_STATES_RATE_LIMIT
@@ -730,7 +768,8 @@ async def test_expand(hass: HomeAssistant) -> None:
         hass,
         (
             "{{ expand('group.new_group', 'test.object')"
-            " | sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}"
+            " | sort(attribute='entity_id')"
+            " | map(attribute='entity_id') | join(', ') }}"
         ),
     )
     assert_result_info(info, "test.object", {"test.object", "group.new_group"})
@@ -739,7 +778,8 @@ async def test_expand(hass: HomeAssistant) -> None:
         hass,
         (
             "{{ ['group.new_group', 'test.object'] | expand"
-            " | sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}"
+            " | sort(attribute='entity_id')"
+            " | map(attribute='entity_id') | join(', ') }}"
         ),
     )
     assert_result_info(info, "test.object", {"test.object", "group.new_group"})
@@ -765,8 +805,11 @@ async def test_expand(hass: HomeAssistant) -> None:
     info = render_to_info(
         hass,
         (
-            "{{ states.group.power_sensors.attributes.entity_id | expand "
-            "| sort(attribute='entity_id') | map(attribute='state')|map('float')|sum  }}"
+            "{{ states.group.power_sensors.attributes"
+            ".entity_id | expand"
+            " | sort(attribute='entity_id')"
+            " | map(attribute='state')"
+            "|map('float')|sum  }}"
         ),
     )
     assert_result_info(
@@ -795,7 +838,11 @@ async def test_expand(hass: HomeAssistant) -> None:
 
     info = render_to_info(
         hass,
-        "{{ expand('light.grouped') | sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}",
+        (
+            "{{ expand('light.grouped')"
+            " | sort(attribute='entity_id')"
+            " | map(attribute='entity_id') | join(', ') }}"
+        ),
     )
     assert_result_info(
         info,
@@ -818,7 +865,11 @@ async def test_expand(hass: HomeAssistant) -> None:
     )
     info = render_to_info(
         hass,
-        "{{ expand('zone.test') | sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}",
+        (
+            "{{ expand('zone.test')"
+            " | sort(attribute='entity_id')"
+            " | map(attribute='entity_id') | join(', ') }}"
+        ),
     )
     assert_result_info(
         info,
@@ -834,7 +885,11 @@ async def test_expand(hass: HomeAssistant) -> None:
 
     info = render_to_info(
         hass,
-        "{{ expand('zone.test') | sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}",
+        (
+            "{{ expand('zone.test')"
+            " | sort(attribute='entity_id')"
+            " | map(attribute='entity_id') | join(', ') }}"
+        ),
     )
     assert_result_info(
         info,
@@ -850,7 +905,11 @@ async def test_expand(hass: HomeAssistant) -> None:
 
     info = render_to_info(
         hass,
-        "{{ expand('zone.test') | sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}",
+        (
+            "{{ expand('zone.test')"
+            " | sort(attribute='entity_id')"
+            " | map(attribute='entity_id') | join(', ') }}"
+        ),
     )
     assert_result_info(
         info,
@@ -890,13 +949,16 @@ def test_closest_function_to_coord(hass: HomeAssistant) -> None:
 
     result = render(
         hass,
-        f'{{{{ closest("{hass.config.latitude + 0.3}", {hass.config.longitude + 0.3}, states.test_domain).entity_id }}}}',
+        f'{{{{ closest("{hass.config.latitude + 0.3}",'
+        f" {hass.config.longitude + 0.3},"
+        f" states.test_domain).entity_id }}}}",
     )
     assert result == "test_domain.closest_zone"
 
     result = render(
         hass,
-        f'{{{{ (states.test_domain | closest("{hass.config.latitude + 0.3}", {hass.config.longitude + 0.3})).entity_id }}}}',
+        f'{{{{ (states.test_domain | closest("{hass.config.latitude + 0.3}",'
+        f" {hass.config.longitude + 0.3})).entity_id }}}}",
     )
     assert result == "test_domain.closest_zone"
 

--- a/tests/helpers/template/extensions/test_string.py
+++ b/tests/helpers/template/extensions/test_string.py
@@ -116,7 +116,8 @@ def test_urlencode_various_types(hass: HomeAssistant) -> None:
     # Test with nested dictionary values
     result = render(
         hass,
-        "{% set data = {'key': 'value with spaces', 'num': 123} %}{{ data | urlencode }}",
+        "{% set data = {'key': 'value with spaces', 'num': 123} %}"
+        "{{ data | urlencode }}",
     )
     # URL encoding can have different order, so check both parts are present
     # Note: urllib.parse.urlencode uses + for spaces in form data

--- a/tests/helpers/template/test_helpers.py
+++ b/tests/helpers/template/test_helpers.py
@@ -17,7 +17,11 @@ def test_raise_no_default() -> None:
     """Test raise_no_default raises ValueError with correct message."""
     with pytest.raises(
         ValueError,
-        match="Template error: test got invalid input 'invalid' when rendering or compiling template '' but no default was specified",
+        match=(
+            "Template error: test got invalid input 'invalid'"
+            " when rendering or compiling template ''"
+            " but no default was specified"
+        ),
     ):
         raise_no_default("test", "invalid")
 

--- a/tests/helpers/template/test_init.py
+++ b/tests/helpers/template/test_init.py
@@ -354,7 +354,8 @@ def test_async_render_to_info_with_complex_branching(hass: HomeAssistant) -> Non
 {%     elif     states.light.a == "on" %}
   {{ states[domain] | list }}
 {%         elif     states('light.b') == "on" %}
-  {{ states[otherdomain] | sort(attribute='entity_id') | map(attribute='entity_id') | list }}
+  {{ states[otherdomain] | sort(attribute='entity_id')
+     | map(attribute='entity_id') | list }}
 {% elif states.light.a == "on" %}
   {{ states["nonexist"] | list }}
 {% else %}
@@ -665,7 +666,9 @@ The temperature is {{ my_test_json.temperature }} {{ my_test_json.unit }}.
 {% if is_state("sun.sun", "above_horizon") -%}
   The sun rose {{ relative_time(states.sun.sun.last_changed) }} ago.
 {%- else -%}
-  The sun will rise at {{ as_timestamp(state_attr("sun.sun", "next_rising")) | timestamp_local }}.
+  The sun will rise at {{
+    as_timestamp(state_attr("sun.sun", "next_rising"))
+    | timestamp_local }}.
 {%- endif %}
 
 For loop example getting 3 entity values:
@@ -754,7 +757,10 @@ async def test_lights(hass: HomeAssistant) -> None:
     """Test we can sort lights."""
 
     tmpl = """
-          {% set lights_on = states.light|selectattr('state','eq','on')|sort(attribute='entity_id')|map(attribute='name')|list %}
+          {% set lights_on = states.light
+            |selectattr('state','eq','on')
+            |sort(attribute='entity_id')
+            |map(attribute='name')|list %}
           {% if lights_on|length == 0 %}
             No lights on. Sleep well..
           {% elif lights_on|length == 1 %}
@@ -882,8 +888,8 @@ async def test_undefined_symbol_warnings(
 
     assert render(hass, template_string) == ""
     assert (
-        f"Template variable warning: 'no_such_variable' is undefined when rendering '{template_string}'"
-        in caplog.text
+        f"Template variable warning: 'no_such_variable' is"
+        f" undefined when rendering '{template_string}'" in caplog.text
     )
 
 

--- a/tests/helpers/template/test_states.py
+++ b/tests/helpers/template/test_states.py
@@ -159,7 +159,9 @@ async def test_unavailable_states(hass: HomeAssistant) -> None:
         hass,
         (
             "{{ states | selectattr('state', 'in', ['unavailable','unknown','none']) "
-            "| sort(attribute='entity_id') | map(attribute='entity_id') | list | join(', ') }}"
+            "| sort(attribute='entity_id')"
+            " | map(attribute='entity_id')"
+            " | list | join(', ') }}"
         ),
     )
     assert result == "light.none, light.unavailable, light.unknown"

--- a/tests/helpers/test_category_registry.py
+++ b/tests/helpers/test_category_registry.py
@@ -246,7 +246,7 @@ async def test_update_category_with_same_data(
 async def test_update_category_with_same_name_change_case(
     category_registry: cr.CategoryRegistry,
 ) -> None:
-    """Make sure that we can reapply the same name with a different case to a category."""
+    """Make sure that we can reapply the same name with a different case."""
     category = category_registry.async_create(
         scope="automation",
         name="Energy saving",

--- a/tests/helpers/test_check_config.py
+++ b/tests/helpers/test_check_config.py
@@ -426,8 +426,10 @@ async def test_package_definition_invalid_slug_keys(hass: HomeAssistant) -> None
 
         warning = CheckConfigError(
             (
-                "Setup of package 'not a slug' failed: Invalid package definition 'not a slug': invalid slug not a "
-                "slug (try not_a_slug). Package will not be initialized"
+                "Setup of package 'not a slug' failed: Invalid"
+                " package definition 'not a slug': invalid slug"
+                " not a slug (try not_a_slug). Package will not"
+                " be initialized"
             ),
             "homeassistant.packages.not a slug",
             {"group": ["a"]},
@@ -449,8 +451,9 @@ async def test_package_definition_invalid_dict(hass: HomeAssistant) -> None:
 
         warning = CheckConfigError(
             (
-                "Setup of package 'not_a_dict' failed: Invalid package definition 'not_a_dict': expected a "
-                "dictionary. Package will not be initialized"
+                "Setup of package 'not_a_dict' failed: Invalid"
+                " package definition 'not_a_dict': expected a"
+                " dictionary. Package will not be initialized"
             ),
             "homeassistant.packages.not_a_dict",
             [{"group": ["a"]}],
@@ -461,7 +464,11 @@ async def test_package_definition_invalid_dict(hass: HomeAssistant) -> None:
 async def test_package_schema_invalid(hass: HomeAssistant) -> None:
     """Test an invalid platform config because of severely broken packages section."""
     files = {
-        YAML_CONFIG_FILE: "homeassistant:\n  packages:\n    - must\n    - not\n    - be\n    - a\n    - list"
+        YAML_CONFIG_FILE: (
+            "homeassistant:\n  packages:\n"
+            "    - must\n    - not\n    - be\n"
+            "    - a\n    - list"
+        )
     }
     with patch("os.path.isfile", return_value=True), patch_yaml_files(files):
         res = await async_check_ha_config_file(hass)
@@ -470,7 +477,9 @@ async def test_package_schema_invalid(hass: HomeAssistant) -> None:
         error = CheckConfigError(
             (
                 f"Invalid config for 'homeassistant' at {YAML_CONFIG_FILE}, line 2:"
-                " expected a dictionary for dictionary value 'packages', got ['must', 'not', 'be', 'a', 'list']"
+                " expected a dictionary for dictionary value"
+                " 'packages', got"
+                " ['must', 'not', 'be', 'a', 'list']"
             ),
             "homeassistant",
             {"packages": ["must", "not", "be", "a", "list"]},
@@ -584,7 +593,7 @@ bla:
 
 
 async def test_removed_yaml_support(hass: HomeAssistant) -> None:
-    """Test config validation check with removed CONFIG_SCHEMA without raise if present."""
+    """Test config check with removed CONFIG_SCHEMA without raise if present."""
     mock_integration(
         hass,
         MockModule(

--- a/tests/helpers/test_collection.py
+++ b/tests/helpers/test_collection.py
@@ -260,7 +260,7 @@ async def test_storage_collection_update_modifiet_at(
     entity_registry: er.EntityRegistry,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test that updating a storage collection will update the modified_at datetime in the entity registry."""
+    """Test updating a storage collection updates modified_at in the entity registry."""
 
     entities: dict[str, TestEntity] = {}
 

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -2390,7 +2390,7 @@ async def test_platform_backwards_compatibility_for_new_style_configs(
 async def test_get_condition_platform_registers_conditions(
     hass: HomeAssistant,
 ) -> None:
-    """Test _async_get_condition_platform registers conditions and notifies subscribers."""
+    """Test _async_get_condition_platform registers and notifies."""
 
     class MockCondition(Condition):
         """Mock condition."""
@@ -2834,7 +2834,8 @@ async def test_async_get_all_descriptions(
     ):
         new_descriptions = await condition.async_get_all_descriptions(hass)
     assert new_descriptions is not descriptions
-    # No light conditions added, they are gated by the automation.new_triggers_conditions
+    # No light conditions added, they are gated by the
+    # automation.new_triggers_conditions
     # labs flag
     assert new_descriptions == expected_descriptions
 
@@ -3098,7 +3099,7 @@ async def test_subscribe_conditions_experimental_conditions(
     new_triggers_conditions_enabled: bool,
     expected_events: list[set[str]],
 ) -> None:
-    """Test condition.async_subscribe_platform_events doesn't send events for disabled conditions."""
+    """Test async_subscribe_platform_events skips disabled conditions."""
     # Return empty conditions.yaml for light integration, the actual condition
     # descriptions are irrelevant for this test
     light_condition_descriptions = ""
@@ -3155,7 +3156,7 @@ async def test_subscribe_conditions_no_conditions(
     hass_ws_client: WebSocketGenerator,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test condition.async_subscribe_platform_events doesn't send events for platforms without conditions."""
+    """Test async_subscribe_platform_events skips platforms without conditions."""
     # Return empty conditions.yaml for light integration, the actual condition
     # descriptions are irrelevant for this test
     light_condition_descriptions = ""
@@ -3734,7 +3735,7 @@ async def test_numerical_condition_with_unit_entity_reference(
 async def test_numerical_condition_with_unit_entity_reference_incompatible_unit(
     hass: HomeAssistant,
 ) -> None:
-    """Test numerical condition returns false when entity reference has incompatible unit."""
+    """Test numerical condition returns false with incompatible unit."""
     test = await _setup_numerical_condition_with_unit(
         hass,
         condition_options={
@@ -5015,7 +5016,7 @@ async def test_state_condition_attr_duration_entity_added_to_target(
 async def test_state_condition_attr_duration_entity_removed_from_target(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:
-    """Test that _valid_since is evicted when an entity is removed from the tracked set."""
+    """Test _valid_since is evicted when entity is removed from tracked set."""
     label_reg = lr.async_get(hass)
     label = label_reg.async_create("Test Duration Remove")
 
@@ -5259,8 +5260,9 @@ async def test_state_condition_primary_entities_only(
     hass.states.async_set(primary_id, STATE_ON)
     hass.states.async_set(diagnostic_id, STATE_OFF)
     await hass.async_block_till_done()
-    # If diagnostic is included (primary_entities_only=False), behavior=all fails because
-    # the diagnostic entity is off. If excluded, only the primary is checked and it's on.
+    # If diagnostic is included (primary_entities_only=False),
+    # behavior=all fails because the diagnostic entity is off.
+    # If excluded, only the primary is checked and it's on.
     assert test.async_check() is primary_entities_only
 
     # Both on - true regardless of flag
@@ -5295,8 +5297,9 @@ async def test_numerical_condition_primary_entities_only(
     hass.states.async_set(primary_id, "75")
     hass.states.async_set(diagnostic_id, "25")
     await hass.async_block_till_done()
-    # If diagnostic is included (primary_entities_only=False), behavior=all fails because
-    # the diagnostic value is below the threshold. If excluded, only the primary is
+    # If diagnostic is included (primary_entities_only=False),
+    # behavior=all fails because the diagnostic value is below
+    # the threshold. If excluded, only the primary is
     # checked and it's above.
     assert test.async_check() is primary_entities_only
 
@@ -5358,7 +5361,7 @@ async def test_state_condition_primary_entities_only_with_duration(
 async def test_async_from_config_calls_async_setup_on_checker(
     hass: HomeAssistant,
 ) -> None:
-    """Test that async_from_config calls async_setup on ConditionChecker from factory path."""
+    """Test async_from_config calls async_setup on ConditionChecker."""
 
     class StubChecker(condition.ConditionChecker):
         """Stub checker to track async_setup calls."""

--- a/tests/helpers/test_config_entry_oauth2_flow.py
+++ b/tests/helpers/test_config_entry_oauth2_flow.py
@@ -486,7 +486,9 @@ async def test_abort_discovered_multiple(
             HTTPStatus.BAD_REQUEST,
             {
                 "error": "invalid_request",
-                "error_description": "Request was missing the 'redirect_uri' parameter.",
+                "error_description": (
+                    "Request was missing the 'redirect_uri' parameter."
+                ),
                 "error_uri": "Sensible URI: https://authorization-server.com/docs/access_token",
             },
             "oauth_unauthorized",
@@ -1199,11 +1201,11 @@ def test_compute_code_challenge_invalid_code_verifier(code_verifier: str) -> Non
         )
 
 
-async def test_async_get_config_entry_implementation_with_failing_provider_and_succeeding_provider(
+async def test_async_get_config_entry_impl_with_failing_and_succeeding_provider(
     hass: HomeAssistant,
     local_impl: config_entry_oauth2_flow.LocalOAuth2Implementation,
 ) -> None:
-    """Test async_get_config_entry_implementation when one provider fails but another succeeds."""
+    """Test async_get_config_entry_implementation with mixed providers."""
 
     async def failing_cloud_provider(
         _hass: HomeAssistant, _domain: str
@@ -1244,7 +1246,7 @@ async def test_async_get_config_entry_implementation_with_failing_provider_and_s
 async def test_async_get_config_entry_implementation_with_failing_provider(
     hass: HomeAssistant,
 ) -> None:
-    """Test async_get_config_entry_implementation when one provider fails and the other is empty."""
+    """Test async_get_config_entry_implementation with all failing providers."""
 
     async def failing_cloud_provider(
         _hass: HomeAssistant, _domain: str

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -933,10 +933,11 @@ def test_deprecated_with_no_optionals(caplog: pytest.LogCaptureFixture, schema) 
 def test_deprecated_or_removed_param_and_raise(
     caplog: pytest.LogCaptureFixture, schema
 ) -> None:
-    """Test removed or deprecation options and fail the config validation by raising an exception.
+    """Test removed or deprecation options and fail config validation.
 
     Expected behavior:
-        - Outputs the appropriate deprecation or removed from support error if key is detected
+        - Outputs the appropriate deprecation or removed
+          from support error if key is detected
     """
     removed_schema = vol.All(cv.deprecated("mars", raise_if_present=True), schema)
 
@@ -1119,14 +1120,17 @@ def test_deprecated_cant_find_module() -> None:
 def test_deprecated_or_removed_logger_with_config_attributes(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test if the logger outputs the correct message if the line and file attribute is available in config."""
+    """Test logger outputs correct message if line and file attr is available."""
     file: str = "configuration.yaml"
     line: int = 54
 
     # test as deprecated option
     replacement_key = "jupiter"
     option_status = "is deprecated"
-    replacement = f"'mars' option near {file}:{line} {option_status}, please replace it with '{replacement_key}'"
+    replacement = (
+        f"'mars' option near {file}:{line} {option_status},"
+        f" please replace it with '{replacement_key}'"
+    )
     config = OrderedDict([("mars", "blah")])
     config.__config_file__ = file
     config.__line__ = line
@@ -1144,7 +1148,10 @@ def test_deprecated_or_removed_logger_with_config_attributes(
 
     # test as removed option
     option_status = "has been removed"
-    replacement = f"'mars' option near {file}:{line} {option_status}, please remove it from your configuration"
+    replacement = (
+        f"'mars' option near {file}:{line} {option_status},"
+        " please remove it from your configuration"
+    )
     config = OrderedDict([("mars", "blah")])
     config.__config_file__ = file
     config.__line__ = line
@@ -1162,7 +1169,7 @@ def test_deprecated_or_removed_logger_with_config_attributes(
 def test_deprecated_logger_with_one_config_attribute(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test if the logger outputs the correct message if only one of line and file attribute is available in config."""
+    """Test logger message when only one of line/file attr is available."""
     file: str = "configuration.yaml"
     line: int = 54
     replacement = f"'mars' option near {file}:{line} is deprecated"
@@ -1198,7 +1205,7 @@ def test_deprecated_logger_with_one_config_attribute(
 def test_deprecated_logger_without_config_attributes(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test if the logger outputs the correct message if the line and file attribute is not available in config."""
+    """Test logger message when line and file attr is not available."""
     file: str = "configuration.yaml"
     line: int = 54
     replacement = f"'mars' option near {file}:{line} is deprecated"
@@ -1412,8 +1419,8 @@ def test_key_value_schemas_with_default() -> None:
         with pytest.raises(vol.Invalid) as excinfo:
             schema({"mode": mode})
         assert (
-            str(excinfo.value)
-            == f"Unexpected value for mode: '{mode}'. Expected number, string, a cool template"
+            str(excinfo.value) == f"Unexpected value for mode: '{mode}'."
+            " Expected number, string, a cool template"
         )
 
     with pytest.raises(vol.Invalid) as excinfo:
@@ -1945,7 +1952,9 @@ async def test_trigger_backwards_compatibility() -> None:
     assert cv._trigger_pre_validator({"trigger": "abc"}) == {"platform": "abc"}
     with pytest.raises(
         vol.Invalid,
-        match="Cannot specify both 'platform' and 'trigger'. Please use 'trigger' only.",
+        match=(
+            "Cannot specify both 'platform' and 'trigger'. Please use 'trigger' only."
+        ),
     ):
         cv._trigger_pre_validator({"trigger": "abc", "platform": "def"})
     with pytest.raises(

--- a/tests/helpers/test_deprecation.py
+++ b/tests/helpers/test_deprecation.py
@@ -335,7 +335,8 @@ def _get_value(
         ),
         (
             DeprecatedConstantEnum(TestDeprecatedConstantEnum.TEST, "2099.1"),
-            ". It will be removed in HA Core 2099.1. Use TestDeprecatedConstantEnum.TEST instead",
+            ". It will be removed in HA Core 2099.1."
+            " Use TestDeprecatedConstantEnum.TEST instead",
             "constant",
         ),
         (
@@ -414,7 +415,8 @@ def test_check_if_deprecated_constant(
     assert (
         module_name,
         logging.WARNING,
-        f"The deprecated {description} TEST_CONSTANT was used from hue{extra_msg}{extra_extra_msg}",
+        f"The deprecated {description} TEST_CONSTANT"
+        f" was used from hue{extra_msg}{extra_extra_msg}",
     ) in caplog.record_tuples
 
 
@@ -438,7 +440,8 @@ def test_check_if_deprecated_constant(
         ),
         (
             DeprecatedConstantEnum(TestDeprecatedConstantEnum.TEST, "2099.1"),
-            " which will be removed in HA Core 2099.1. Use TestDeprecatedConstantEnum.TEST instead",
+            " which will be removed in HA Core 2099.1."
+            " Use TestDeprecatedConstantEnum.TEST instead",
             "constant",
         ),
         (

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -5253,7 +5253,8 @@ async def test_device_name_translation_placeholders(
             "test_device",
             {
                 "en": {
-                    "component.test.device.test_device.name": "{placeholder} English dev {2ndplaceholder}"
+                    "component.test.device.test_device.name": "{placeholder} English dev"
+                    " {2ndplaceholder}"
                 },
             },
             {"placeholder": "special"},
@@ -5268,7 +5269,8 @@ async def test_device_name_translation_placeholders(
             "test_device",
             {
                 "en": {
-                    "component.test.device.test_device.name": "{placeholder} English ent {2ndplaceholder}"
+                    "component.test.device.test_device.name": "{placeholder} English ent"
+                    " {2ndplaceholder}"
                 },
             },
             {"placeholder": "special"},
@@ -5351,7 +5353,11 @@ async def test_async_get_or_create_thread_safety(
 
     with pytest.raises(
         RuntimeError,
-        match="Detected code that calls device_registry._async_update_device from a thread.",
+        match=(
+            "Detected code that calls"
+            " device_registry._async_update_device"
+            " from a thread."
+        ),
     ):
         await hass.async_add_executor_job(
             partial(
@@ -5381,7 +5387,11 @@ async def test_async_remove_device_thread_safety(
 
     with pytest.raises(
         RuntimeError,
-        match="Detected code that calls device_registry.async_remove_device from a thread.",
+        match=(
+            "Detected code that calls"
+            " device_registry.async_remove_device"
+            " from a thread."
+        ),
     ):
         await hass.async_add_executor_job(
             device_registry.async_remove_device, device.id

--- a/tests/helpers/test_discovery_flow.py
+++ b/tests/helpers/test_discovery_flow.py
@@ -107,7 +107,7 @@ async def test_async_create_flow_checks_existing_flows_after_startup(
 async def test_async_create_flow_checks_existing_flows_before_startup(
     hass: HomeAssistant, mock_flow_init: AsyncMock
 ) -> None:
-    """Test existing flows prevent an identical ones from being created before startup."""
+    """Test existing flows prevent identical ones from being created."""
     hass.set_state(CoreState.stopped)
     for _ in range(2):
         discovery_flow.async_create_flow(

--- a/tests/helpers/test_dispatcher.py
+++ b/tests/helpers/test_dispatcher.py
@@ -195,8 +195,8 @@ async def test_callback_exception_gets_logged(
     async_dispatcher_send(hass, "test", "bad")
 
     assert (
-        f"Exception in functools.partial({bad_handler}) when dispatching 'test': ('bad',)"
-        in caplog.text
+        f"Exception in functools.partial({bad_handler})"
+        " when dispatching 'test': ('bad',)" in caplog.text
     )
 
 

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1190,7 +1190,8 @@ async def test_friendly_name_description_device_class_name(
             "test_entity",
             {
                 "en": {
-                    "component.test.entity.test_domain.test_entity.name": "{placeholder} English ent"
+                    "component.test.entity.test_domain"
+                    ".test_entity.name": "{placeholder} English ent"
                 },
             },
             {"placeholder": "special"},
@@ -1201,7 +1202,8 @@ async def test_friendly_name_description_device_class_name(
             "test_entity",
             {
                 "en": {
-                    "component.test.entity.test_domain.test_entity.name": "English ent {placeholder}"
+                    "component.test.entity.test_domain"
+                    ".test_entity.name": "English ent {placeholder}"
                 },
             },
             {"placeholder": "special"},
@@ -1265,7 +1267,8 @@ async def test_entity_name_translation_placeholders(
             "test_entity",
             {
                 "en": {
-                    "component.test.entity.test_domain.test_entity.name": "{placeholder} English ent {2ndplaceholder}"
+                    "component.test.entity.test_domain"
+                    ".test_entity.name": "{placeholder} English ent {2ndplaceholder}"
                 },
             },
             {"placeholder": "special"},
@@ -1279,7 +1282,8 @@ async def test_entity_name_translation_placeholders(
             "test_entity",
             {
                 "en": {
-                    "component.test.entity.test_domain.test_entity.name": "{placeholder} English ent {2ndplaceholder}"
+                    "component.test.entity.test_domain"
+                    ".test_entity.name": "{placeholder} English ent {2ndplaceholder}"
                 },
             },
             {"placeholder": "special"},
@@ -1290,7 +1294,8 @@ async def test_entity_name_translation_placeholders(
             "test_entity",
             {
                 "en": {
-                    "component.test.entity.test_domain.test_entity.name": "{placeholder} English ent"
+                    "component.test.entity.test_domain"
+                    ".test_entity.name": "{placeholder} English ent"
                 },
             },
             None,

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -649,7 +649,7 @@ async def test_register_entity_service_response_data_multiple_matches(
 async def test_register_entity_service_response_data_multiple_matches_raises(
     hass: HomeAssistant,
 ) -> None:
-    """Test asking for service response data and matching many entities raises exceptions."""
+    """Test service response data with many entities raises exceptions."""
     entity1 = MockEntity(entity_id=f"{DOMAIN}.entity1")
     entity2 = MockEntity(entity_id=f"{DOMAIN}.entity2")
 

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -972,7 +972,7 @@ async def test_setup_entry_platform_not_ready_with_message(
 async def test_setup_entry_platform_not_ready_from_exception(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test when an entry is not ready yet that includes the causing exception string."""
+    """Test entry not ready yet includes the causing exception string."""
     original_exception = HomeAssistantError("The device dropped the connection")
     platform_exception = PlatformNotReady()
     platform_exception.__cause__ = original_exception
@@ -1019,7 +1019,7 @@ async def test_reset_cancels_retry_setup(hass: HomeAssistant) -> None:
 
 
 async def test_reset_cancels_retry_setup_when_not_started(hass: HomeAssistant) -> None:
-    """Test that resetting a platform will cancel scheduled a setup retry when not yet started."""
+    """Test resetting a platform cancels setup retry when not yet started."""
     hass.set_state(CoreState.starting)
     async_setup_entry = Mock(side_effect=PlatformNotReady)
     initial_listeners = hass.bus.async_listeners()[EVENT_HOMEASSISTANT_STARTED]
@@ -1611,8 +1611,8 @@ async def test_platform_with_no_setup(
     await entity_platform.async_setup(None)
 
     assert (
-        "The mock-platform platform for the mock-integration integration does not support platform setup."
-        in caplog.text
+        "The mock-platform platform for the mock-integration"
+        " integration does not support platform setup." in caplog.text
     )
     issue = issue_registry.async_get_issue(
         domain="homeassistant",
@@ -1635,7 +1635,7 @@ async def test_platform_with_no_setup_custom_component_hint(
     caplog: pytest.LogCaptureFixture,
     issue_registry: ir.IssueRegistry,
 ) -> None:
-    """Test setting up a custom integration platform without setup logs extra warning."""
+    """Test custom integration platform without setup logs extra warning."""
     platform_mod = types.ModuleType("custom_components.mock_integration.mock_platform")
     platform_mod.__file__ = (
         "/config/custom_components/mock_integration/mock_platform.py"
@@ -1747,7 +1747,7 @@ async def test_register_entity_service_response_data(hass: HomeAssistant) -> Non
 async def test_register_entity_service_response_data_multiple_matches(
     hass: HomeAssistant,
 ) -> None:
-    """Test an entity service that does supports response data and matching many entities."""
+    """Test entity service with response data matching many entities."""
 
     async def generate_response(
         target: MockEntity, call: ServiceCall

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -2617,7 +2617,7 @@ async def test_remove_config_entry_from_device_removes_entities_2(
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test that we don't remove entities with no config entry when device is modified."""
+    """Test we don't remove entities w/o config entry when device is modified."""
     config_entry_1 = MockConfigEntry(domain="hue")
     config_entry_1.add_to_hass(hass)
     config_entry_2 = MockConfigEntry(domain="device_tracker")
@@ -2821,7 +2821,7 @@ async def test_remove_config_subentry_from_device_removes_entities_2(
     subentries_in_device: list[str | None],
     subentry_in_entity: str | None,
 ) -> None:
-    """Test that we don't remove entities with no config entry when device is modified."""
+    """Test we don't remove entities w/o config entry when device is modified."""
     config_entry_1 = MockConfigEntry(
         domain="hue",
         subentries_data=[
@@ -3732,7 +3732,11 @@ def test_migrate_entity_to_new_platform_error_handling(
     # Test migrate entity without new config entry ID
     with pytest.raises(
         ValueError,
-        match="new_config_entry_id required because light.light is already linked to a config entry",
+        match=(
+            "new_config_entry_id required because"
+            " light.light is already linked"
+            " to a config entry"
+        ),
     ):
         entity_registry.async_update_entity_platform(
             "light.light",
@@ -3955,7 +3959,8 @@ async def test_restore_entity(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    # Re-add two entities, expect to get a new id after the purge for entity w/o config entry
+    # Re-add two entities, expect to get a new id after the purge
+    # for entity w/o config entry
     entry1_restored = entity_registry.async_get_or_create(
         "light", "hue", "1234", config_entry=config_entry
     )
@@ -4987,7 +4992,11 @@ async def test_get_or_create_thread_safety(
     """Test call async_get_or_create_from a thread."""
     with pytest.raises(
         RuntimeError,
-        match="Detected code that calls entity_registry.async_get_or_create from a thread.",
+        match=(
+            "Detected code that calls"
+            " entity_registry.async_get_or_create"
+            " from a thread."
+        ),
     ):
         await hass.async_add_executor_job(
             entity_registry.async_get_or_create, "light", "hue", "1234"
@@ -5001,7 +5010,11 @@ async def test_async_update_entity_thread_safety(
     entry = entity_registry.async_get_or_create("light", "hue", "1234")
     with pytest.raises(
         RuntimeError,
-        match="Detected code that calls entity_registry.async_update_entity from a thread.",
+        match=(
+            "Detected code that calls"
+            " entity_registry.async_update_entity"
+            " from a thread."
+        ),
     ):
         await hass.async_add_executor_job(
             partial(

--- a/tests/helpers/test_entityfilter.py
+++ b/tests/helpers/test_entityfilter.py
@@ -110,7 +110,7 @@ def test_with_include_domain_case4() -> None:
 
 
 def test_with_include_domain_exclude_glob_case4() -> None:
-    """Test case 4 - include and exclude specified, with included domain but excluded by glob."""
+    """Test case 4 - include and exclude, with included domain but excluded glob."""
     incl_dom = {"light", "sensor"}
     incl_ent = {"binary_sensor.working"}
     incl_glob = {}
@@ -175,7 +175,7 @@ def test_with_include_domain_glob_filtering_case4() -> None:
 
 
 def test_with_include_domain_glob_filtering_case4a_include_strong() -> None:
-    """Test case 4 - include and exclude specified, both have domains and globs, and a specifically included entity."""
+    """Test case 4 - include and exclude, domains, globs, and a specific entity."""
     incl_dom = {"light"}
     incl_glob = {"*working"}
     incl_ent = {"binary_sensor.specificly_included"}
@@ -198,7 +198,7 @@ def test_with_include_domain_glob_filtering_case4a_include_strong() -> None:
 
 
 def test_with_include_glob_filtering_case4a_include_strong() -> None:
-    """Test case 4 - include and exclude specified, both have globs, and a specifically included entity."""
+    """Test case 4 - include and exclude, globs, and a specific entity."""
     incl_dom = {}
     incl_glob = {"*working"}
     incl_ent = {"binary_sensor.specificly_included"}
@@ -260,7 +260,7 @@ def test_exclude_glob_case5() -> None:
 
 
 def test_exclude_glob_case5_include_strong() -> None:
-    """Test case 5 - include and exclude specified, with excluded glob, and a specifically included entity."""
+    """Test case 5 - include and exclude, excluded glob, specific entity."""
     incl_dom = {}
     incl_glob = {}
     incl_ent = {"binary_sensor.working"}

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -1457,13 +1457,30 @@ async def test_track_template_result_super_template_initially_false(
     "availability_template",
     [
         "{{ states('sensor.test2') != 'unavailable' }}",
-        "{% if states('sensor.test2') != 'unavailable' -%} true {%- else -%} false {%- endif %}",
-        "{% if states('sensor.test2') != 'unavailable' -%} 1 {%- else -%} 0 {%- endif %}",
-        "{% if states('sensor.test2') != 'unavailable' -%} yes {%- else -%} no {%- endif %}",
-        "{% if states('sensor.test2') != 'unavailable' -%} on {%- else -%} off {%- endif %}",
-        "{% if states('sensor.test2') != 'unavailable' -%} enable {%- else -%} disable {%- endif %}",
-        # This will throw when sensor.test2 is not "unavailable"
-        "{% if states('sensor.test2') != 'unavailable' -%} {{'a' + 5}} {%- else -%} false {%- endif %}",
+        (
+            "{% if states('sensor.test2') != 'unavailable' -%}"
+            " true {%- else -%} false {%- endif %}"
+        ),
+        (
+            "{% if states('sensor.test2') != 'unavailable' -%}"
+            " 1 {%- else -%} 0 {%- endif %}"
+        ),
+        (
+            "{% if states('sensor.test2') != 'unavailable' -%}"
+            " yes {%- else -%} no {%- endif %}"
+        ),
+        (
+            "{% if states('sensor.test2') != 'unavailable' -%}"
+            " on {%- else -%} off {%- endif %}"
+        ),
+        (
+            "{% if states('sensor.test2') != 'unavailable' -%}"
+            " enable {%- else -%} disable {%- endif %}"
+        ),
+        (
+            "{% if states('sensor.test2') != 'unavailable' -%}"
+            " {{'a' + 5}} {%- else -%} false {%- endif %}"
+        ),
     ],
 )
 async def test_track_template_result_super_template_2(
@@ -1609,13 +1626,30 @@ async def test_track_template_result_super_template_2(
     "availability_template",
     [
         "{{ states('sensor.test2') != 'unavailable' }}",
-        "{% if states('sensor.test2') != 'unavailable' -%} true {%- else -%} false {%- endif %}",
-        "{% if states('sensor.test2') != 'unavailable' -%} 1 {%- else -%} 0 {%- endif %}",
-        "{% if states('sensor.test2') != 'unavailable' -%} yes {%- else -%} no {%- endif %}",
-        "{% if states('sensor.test2') != 'unavailable' -%} on {%- else -%} off {%- endif %}",
-        "{% if states('sensor.test2') != 'unavailable' -%} enable {%- else -%} disable {%- endif %}",
-        # This will throw when sensor.test2 is not "unavailable"
-        "{% if states('sensor.test2') != 'unavailable' -%} {{'a' + 5}} {%- else -%} false {%- endif %}",
+        (
+            "{% if states('sensor.test2') != 'unavailable' -%}"
+            " true {%- else -%} false {%- endif %}"
+        ),
+        (
+            "{% if states('sensor.test2') != 'unavailable' -%}"
+            " 1 {%- else -%} 0 {%- endif %}"
+        ),
+        (
+            "{% if states('sensor.test2') != 'unavailable' -%}"
+            " yes {%- else -%} no {%- endif %}"
+        ),
+        (
+            "{% if states('sensor.test2') != 'unavailable' -%}"
+            " on {%- else -%} off {%- endif %}"
+        ),
+        (
+            "{% if states('sensor.test2') != 'unavailable' -%}"
+            " enable {%- else -%} disable {%- endif %}"
+        ),
+        (
+            "{% if states('sensor.test2') != 'unavailable' -%}"
+            " {{'a' + 5}} {%- else -%} false {%- endif %}"
+        ),
     ],
 )
 async def test_track_template_result_super_template_2_initially_false(
@@ -1980,7 +2014,8 @@ async def test_track_template_result_with_group(hass: HomeAssistant) -> None:
     specific_runs = []
     template_complex_str = r"""
 
-{{ states.group.power_sensors.attributes.entity_id | expand | map(attribute='state')|map('float')|sum  }}
+{{ states.group.power_sensors.attributes.entity_id
+   | expand | map(attribute='state')|map('float')|sum }}
 
 """
     template_complex = Template(template_complex_str, hass)
@@ -2024,7 +2059,9 @@ async def test_track_template_result_with_group(hass: HomeAssistant) -> None:
         "homeassistant.config.load_yaml_config_file",
         return_value={
             "group": {
-                "power_sensors": "sensor.power_1,sensor.power_2,sensor.power_3,sensor.power_4",
+                "power_sensors": (
+                    "sensor.power_1,sensor.power_2,sensor.power_3,sensor.power_4"
+                ),
             }
         },
     ):
@@ -2041,7 +2078,11 @@ async def test_track_template_result_and_conditional(hass: HomeAssistant) -> Non
     specific_runs = []
     hass.states.async_set("light.a", "off")
     hass.states.async_set("light.b", "off")
-    template_str = '{% if states.light.a.state == "on" and states.light.b.state == "on" %}on{% else %}off{% endif %}'
+    template_str = (
+        '{% if states.light.a.state == "on"'
+        ' and states.light.b.state == "on" %}'
+        "on{% else %}off{% endif %}"
+    )
 
     template = Template(template_str, hass)
 
@@ -2109,7 +2150,11 @@ async def test_track_template_result_and_conditional_upper_case(
     specific_runs = []
     hass.states.async_set("light.a", "off")
     hass.states.async_set("light.b", "off")
-    template_str = '{% if states.light.A.state == "on" and states.light.B.state == "on" %}on{% else %}off{% endif %}'
+    template_str = (
+        '{% if states.light.A.state == "on"'
+        ' and states.light.B.state == "on" %}'
+        "on{% else %}off{% endif %}"
+    )
 
     template = Template(template_str, hass)
 
@@ -2886,7 +2931,9 @@ async def test_track_template_unavailable_states_has_default_rate_limit(
     """Test template watching for unavailable states has a rate limit by default."""
     hass.states.async_set("sensor.zero", "unknown")
     template_refresh = Template(
-        "{{ states | selectattr('state', 'in', ['unavailable', 'unknown', 'none']) | list | count }}",
+        "{{ states | selectattr('state', 'in',"
+        " ['unavailable', 'unknown', 'none'])"
+        " | list | count }}",
         hass,
     )
 
@@ -3193,7 +3240,8 @@ async def test_async_track_template_result_multiple_templates_mixing_domain(
     template_2 = Template("{{ states.switch.test.state == 'on' }}", hass)
     template_3 = Template("{{ states.switch.test.state == 'off' }}", hass)
     template_4 = Template(
-        "{{ states.switch | sort(attribute='entity_id') | map(attribute='entity_id') | list }}",
+        "{{ states.switch | sort(attribute='entity_id')"
+        " | map(attribute='entity_id') | list }}",
         hass,
     )
 
@@ -4472,7 +4520,7 @@ async def test_async_call_later_cancel(hass: HomeAssistant) -> None:
 async def test_track_state_change_event_chain_multple_entity(
     hass: HomeAssistant,
 ) -> None:
-    """Test that adding a new state tracker inside a tracker does not fire right away."""
+    """Test adding a new state tracker inside a tracker doesn't fire right away."""
     tracker_called = []
     chained_tracker_called = []
 
@@ -4526,7 +4574,7 @@ async def test_track_state_change_event_chain_multple_entity(
 async def test_track_state_change_event_chain_single_entity(
     hass: HomeAssistant,
 ) -> None:
-    """Test that adding a new state tracker inside a tracker does not fire right away."""
+    """Test adding a new state tracker inside a tracker doesn't fire right away."""
     tracker_called = []
     chained_tracker_called = []
 
@@ -4742,7 +4790,7 @@ async def test_async_track_entity_registry_updated_event(hass: HomeAssistant) ->
 async def test_async_track_entity_registry_updated_event_with_a_callback_that_throws(
     hass: HomeAssistant,
 ) -> None:
-    """Test tracking entity registry updates for an entity_id when one callback throws."""
+    """Test tracking entity registry updates when one callback throws."""
 
     entity_id = "switch.puppy_feeder"
 
@@ -4775,7 +4823,7 @@ async def test_async_track_entity_registry_updated_event_with_a_callback_that_th
 async def test_async_track_entity_registry_updated_event_with_empty_list(
     hass: HomeAssistant,
 ) -> None:
-    """Test async_track_entity_registry_updated_event passing an empty list of entities."""
+    """Test async_track_entity_registry_updated_event with empty entity list."""
     unsub_single = async_track_entity_registry_updated_event(
         hass, [], ha.callback(lambda event: None)
     )
@@ -4847,7 +4895,7 @@ async def test_async_track_device_registry_updated_event(hass: HomeAssistant) ->
 async def test_async_track_device_registry_updated_event_with_empty_list(
     hass: HomeAssistant,
 ) -> None:
-    """Test async_track_device_registry_updated_event passing an empty list of devices."""
+    """Test async_track_device_registry_updated_event with empty device list."""
     unsub_single = async_track_device_registry_updated_event(
         hass, [], ha.callback(lambda event: None)
     )

--- a/tests/helpers/test_intent.py
+++ b/tests/helpers/test_intent.py
@@ -642,7 +642,7 @@ def test_async_register(hass: HomeAssistant) -> None:
 
 
 def test_async_register_overwrite(hass: HomeAssistant) -> None:
-    """Test registering multiple intents with the same type, ensuring the last one overwrites the previous one and a warning is emitted."""
+    """Test registering duplicate intent types overwrites and emits a warning."""
     handler1 = MagicMock()
     handler1.intent_type = "test_intent"
 
@@ -661,7 +661,7 @@ def test_async_register_overwrite(hass: HomeAssistant) -> None:
 
 
 def test_async_remove(hass: HomeAssistant) -> None:
-    """Test removing an intent and verifying it is no longer present in the Home Assistant data."""
+    """Test removing an intent and verifying it is no longer present."""
     handler = MagicMock()
     handler.intent_type = "test_intent"
 
@@ -916,7 +916,7 @@ async def test_service_handler_device_classes(
 async def test_service_handler_matched_states_uses_updated_state(
     hass: HomeAssistant,
 ) -> None:
-    """Test that matched_states reflects the post-service-call state, not the pre-call state."""
+    """Test matched_states reflects post-service-call state, not pre-call."""
     hass.states.async_set("light.kitchen", "off")
 
     async def mock_turn_on(call):

--- a/tests/helpers/test_issue_registry.py
+++ b/tests/helpers/test_issue_registry.py
@@ -367,7 +367,9 @@ async def test_get_or_create_thread_safety(
     """Test call async_get_or_create_from a thread."""
     with pytest.raises(
         RuntimeError,
-        match="Detected code that calls issue_registry.async_get_or_create from a thread.",
+        match=(
+            "Detected code that calls issue_registry.async_get_or_create from a thread."
+        ),
     ):
         await hass.async_add_executor_job(
             partial(

--- a/tests/helpers/test_label_registry.py
+++ b/tests/helpers/test_label_registry.py
@@ -217,7 +217,7 @@ async def test_update_label_with_same_data(
 async def test_update_label_with_same_name_change_case(
     label_registry: lr.LabelRegistry,
 ) -> None:
-    """Make sure that we can reapply the same name with a different case to the label."""
+    """Make sure we can reapply the same name with a different case."""
     label = label_registry.async_create("mock")
 
     updated_label = label_registry.async_update(label.label_id, name="Mock")

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -420,7 +420,8 @@ async def test_assist_api_prompt(
     )
     api = await llm.async_get_api(hass, "assist", llm_context)
     assert api.api_prompt == (
-        "Only if the user wants to control a device, tell them to expose entities to their "
+        "Only if the user wants to control a device, tell them to expose"
+        " entities to their "
         "voice assistant in Home Assistant."
     )
 
@@ -582,7 +583,8 @@ async def test_assist_api_prompt(
             suggested_area="Test Area 2",
         )
     )
-    exposed_entities_prompt = """Live Context: An overview of the areas and the devices in this smart home:
+    exposed_entities_prompt = """\
+Live Context: An overview of the areas and the devices in this smart home:
 - names: '1'
   domain: light
   state: unavailable
@@ -630,7 +632,8 @@ async def test_assist_api_prompt(
   state: unavailable
   areas: Test Area 2
 """
-    stateless_exposed_entities_prompt = """Static Context: An overview of the areas and the devices in this smart home:
+    stateless_exposed_entities_prompt = """\
+Static Context: An overview of the areas and the devices in this smart home:
 - names: '1'
   domain: light
   areas: Test Area 2
@@ -676,18 +679,32 @@ async def test_assist_api_prompt(
         "When a user asks to turn on all devices of a specific type, "
         "ask user to specify an area, unless there is only one device of that type."
     )
-    dynamic_context_prompt = """You ARE equipped to answer questions about the current state of
-the home using the `GetLiveContext` tool. This is a primary function. Do not state you lack the
-functionality if the question requires live data.
-If the user asks about device existence/type (e.g., "Do I have lights in the bedroom?"): Answer
-from the static context below.
-If the user asks about the CURRENT state, value, or mode (e.g., "Is the lock locked?",
-"Is the fan on?", "What mode is the thermostat in?", "What is the temperature outside?"):
-    1.  Recognize this requires live data.
-    2.  You MUST call `GetLiveContext`. This tool will provide the needed real-time information (like temperature from the local weather, lock status, etc.).
-    3.  Use the tool's response** to answer the user accurately (e.g., "The temperature outside is [value from tool].").
-For general knowledge questions not about the home: Answer truthfully from internal knowledge.
-"""
+    dynamic_context_prompt = (
+        "You ARE equipped to answer questions about the"
+        " current state of\nthe home using the"
+        " `GetLiveContext` tool. This is a primary"
+        " function. Do not state you lack the\n"
+        "functionality if the question requires live"
+        " data.\nIf the user asks about device"
+        ' existence/type (e.g., "Do I have lights in'
+        ' the bedroom?"): Answer\nfrom the static'
+        " context below.\nIf the user asks about the"
+        ' CURRENT state, value, or mode (e.g., "Is'
+        ' the lock locked?",\n"Is the fan on?",'
+        ' "What mode is the thermostat in?", "What'
+        ' is the temperature outside?"):\n'
+        "    1.  Recognize this requires live data.\n"
+        "    2.  You MUST call `GetLiveContext`. This"
+        " tool will provide the needed real-time"
+        " information (like temperature from the local"
+        " weather, lock status, etc.).\n"
+        "    3.  Use the tool's response** to answer"
+        ' the user accurately (e.g., "The temperature'
+        ' outside is [value from tool].").\n'
+        "For general knowledge questions not about the"
+        " home: Answer truthfully from internal"
+        " knowledge.\n"
+    )
     api = await llm.async_get_api(hass, "assist", llm_context)
     assert api.api_prompt == (
         f"""{first_part_prompt}
@@ -697,7 +714,8 @@ For general knowledge questions not about the home: Answer truthfully from inter
 {stateless_exposed_entities_prompt}"""
     )
 
-    # Verify that the GetLiveContext tool returns the same results as the exposed_entities_prompt
+    # Verify that the GetLiveContext tool returns the same results
+    # as the exposed_entities_prompt
     result = await api.async_call_tool(
         llm.ToolInput(tool_name="GetLiveContext", tool_args={})
     )
@@ -725,7 +743,8 @@ For general knowledge questions not about the home: Answer truthfully from inter
     floor = floor_registry.async_create("2")
     area_registry.async_update(area.id, floor_id=floor.floor_id)
     area_prompt = (
-        "You are in area Test Area (floor 2) and all generic commands like 'turn on the lights' "
+        "You are in area Test Area (floor 2) and all generic commands"
+        " like 'turn on the lights' "
         "should target this area."
     )
     api = await llm.async_get_api(hass, "assist", llm_context)

--- a/tests/helpers/test_network.py
+++ b/tests/helpers/test_network.py
@@ -620,7 +620,7 @@ async def test_get_request_host_without_port(hass: HomeAssistant) -> None:
 
 
 async def test_get_request_ipv6_address(hass: HomeAssistant) -> None:
-    """Test getting the ipv6 host of the current web request from the request context."""
+    """Test getting the ipv6 host of the current web request."""
     with pytest.raises(NoURLAvailableError):
         _get_request_host()
 
@@ -635,7 +635,7 @@ async def test_get_request_ipv6_address(hass: HomeAssistant) -> None:
 
 
 async def test_get_request_ipv6_address_without_port(hass: HomeAssistant) -> None:
-    """Test getting the ipv6 host of the current web request from the request context."""
+    """Test getting the ipv6 host of the current web request."""
     with pytest.raises(NoURLAvailableError):
         _get_request_host()
 

--- a/tests/helpers/test_reload.py
+++ b/tests/helpers/test_reload.py
@@ -163,7 +163,7 @@ async def test_setup_reload_service_when_async_process_component_config_fails(
 async def test_setup_reload_service_with_platform_that_provides_async_reset_platform(
     hass: HomeAssistant,
 ) -> None:
-    """Test setting up a reload service using a platform that has its own async_reset_platform."""
+    """Test reload service setup with platform's own async_reset_platform."""
     component_setup = AsyncMock(return_value=True)
 
     setup_called = []
@@ -217,7 +217,8 @@ async def test_async_integration_yaml_config(hass: HomeAssistant) -> None:
     with patch.object(config, "YAML_CONFIG_FILE", yaml_path):
         processed_config = await async_integration_yaml_config(hass, DOMAIN)
         assert processed_config == {DOMAIN: [{"name": "one"}, {"name": "two"}]}
-        # Test fetching yaml config does not raise when the raise_on_failure option is set
+        # Test fetching yaml config does not raise when
+        # the raise_on_failure option is set
         processed_config = await async_integration_yaml_config(
             hass, DOMAIN, raise_on_failure=True
         )
@@ -239,7 +240,8 @@ async def test_async_integration_failing_yaml_config(hass: HomeAssistant) -> Non
         # Test fetching yaml config does not raise without raise_on_failure option
         processed_config = await async_integration_yaml_config(hass, DOMAIN)
         assert processed_config is None
-        # Test fetching yaml config does not raise when the raise_on_failure option is set
+        # Test fetching yaml config does not raise when
+        # the raise_on_failure option is set
         with pytest.raises(ConfigValidationError):
             await async_integration_yaml_config(hass, DOMAIN, raise_on_failure=True)
 

--- a/tests/helpers/test_restore_state.py
+++ b/tests/helpers/test_restore_state.py
@@ -144,7 +144,7 @@ async def test_periodic_write(hass: HomeAssistant) -> None:
 
 
 async def test_save_persistent_states(hass: HomeAssistant) -> None:
-    """Test that we cancel the currently running job, save the data, and verify the perdiodic job continues."""
+    """Test we cancel the running job, save data, and verify periodic job continues."""
     data = async_get(hass)
     await hass.async_block_till_done()
     await data.store.async_save([])

--- a/tests/helpers/test_schema_config_entry_flow.py
+++ b/tests/helpers/test_schema_config_entry_flow.py
@@ -74,7 +74,7 @@ def manager_fixture():
 
 
 async def test_name(hass: HomeAssistant, entity_registry: er.EntityRegistry) -> None:
-    """Test the config flow name is copied from registry entry, with fallback to state."""
+    """Test config flow name is copied from registry, with state fallback."""
     entity_id = "switch.ceiling"
 
     # No entry or state, use Object ID

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -866,7 +866,9 @@ async def test_delay_template_invalid(
             "0": [{"result": {"event": "test_event", "event_data": {}}}],
             "1": [
                 {
-                    "error": "offset  should be format 'HH:MM', 'HH:MM:SS' or 'HH:MM:SS.F'"
+                    "error": (
+                        "offset  should be format 'HH:MM', 'HH:MM:SS' or 'HH:MM:SS.F'"
+                    )
                 }
             ],
         },
@@ -6447,7 +6449,10 @@ async def test_enabled_error_non_limited_template(hass: HomeAssistant) -> None:
     expected_trace = {
         "0": [
             {
-                "error": "TemplateError: Use of 'states' is not supported in limited templates"
+                "error": (
+                    "TemplateError: Use of 'states' is not"
+                    " supported in limited templates"
+                )
             }
         ],
     }

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -978,12 +978,34 @@ def test_choose_selector_serialize(snapshot: SnapshotAssertion) -> None:
     assert choose_selector.serialize() == snapshot
 
     # Test with Selector object instances
-    choose_selector_objects = selector.ChooseSelector(
+    nested_choose = selector.ChooseSelector(
         {
             "choices": {
                 "text_choice": {"selector": selector.TextSelector({"multiline": True})},
                 "number_choice": {
                     "selector": selector.NumberSelector({"min": 0, "max": 100})
+                },
+            }
+        }
+    )
+    nested_obj = selector.ObjectSelector(
+        {
+            "fields": {
+                "choose": {
+                    "required": True,
+                    "selector": nested_choose,
+                },
+            }
+        }
+    )
+    choose_selector_objects = selector.ChooseSelector(
+        {
+            "choices": {
+                "text_choice": {
+                    "selector": selector.TextSelector({"multiline": True}),
+                },
+                "number_choice": {
+                    "selector": selector.NumberSelector({"min": 0, "max": 100}),
                 },
                 "object_choice": {
                     "selector": selector.ObjectSelector(
@@ -997,36 +1019,7 @@ def test_choose_selector_serialize(snapshot: SnapshotAssertion) -> None:
                                     "selector": selector.NumberSelector({}),
                                 },
                                 "object": {
-                                    "selector": selector.ObjectSelector(
-                                        {
-                                            "fields": {
-                                                "choose": {
-                                                    "required": True,
-                                                    "selector": selector.ChooseSelector(
-                                                        {
-                                                            "choices": {
-                                                                "text_choice": {
-                                                                    "selector": selector.TextSelector(
-                                                                        {
-                                                                            "multiline": True
-                                                                        }
-                                                                    )
-                                                                },
-                                                                "number_choice": {
-                                                                    "selector": selector.NumberSelector(
-                                                                        {
-                                                                            "min": 0,
-                                                                            "max": 100,
-                                                                        }
-                                                                    )
-                                                                },
-                                                            }
-                                                        }
-                                                    ),
-                                                },
-                                            }
-                                        }
-                                    ),
+                                    "selector": nested_obj,
                                 },
                             },
                             "multiple": False,
@@ -1342,7 +1335,7 @@ def test_object_selector_schema(schema, valid_selections, invalid_selections) ->
 
 
 def test_object_selector_uses_selectors(snapshot: SnapshotAssertion) -> None:
-    """Test ObjectSelector custom serializer for using Selector in ObjectSelectorField."""
+    """Test ObjectSelector serializer with Selector in ObjectSelectorField."""
 
     selector_type = "object"
     schema = {

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -1210,7 +1210,7 @@ async def test_async_get_all_descriptions_filter(hass: HomeAssistant) -> None:
 async def test_async_get_all_descriptions_failing_integration(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test async_get_all_descriptions when async_get_integrations returns an exception."""
+    """Test async_get_all_descriptions when async_get_integrations fails."""
     group_config = {GROUP_DOMAIN: {}}
     await async_setup_component(hass, GROUP_DOMAIN, group_config)
 
@@ -1293,7 +1293,7 @@ async def test_async_get_all_descriptions_failing_integration(
 async def test_async_get_all_descriptions_dynamically_created_services(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test async_get_all_descriptions when async_get_integrations when services are dynamic."""
+    """Test async_get_all_descriptions when services are dynamic."""
     group_config = {GROUP_DOMAIN: {}}
     await async_setup_component(hass, GROUP_DOMAIN, group_config)
     descriptions = await service.async_get_all_descriptions(hass)
@@ -1317,7 +1317,7 @@ async def test_async_get_all_descriptions_dynamically_created_services(
 async def test_async_get_all_descriptions_new_service_added_while_loading(
     hass: HomeAssistant,
 ) -> None:
-    """Test async_get_all_descriptions when a new service is added while loading translations."""
+    """Test async_get_all_descriptions when a service is added while loading."""
     group_config = {GROUP_DOMAIN: {}}
     await async_setup_component(hass, GROUP_DOMAIN, group_config)
     descriptions = await service.async_get_all_descriptions(hass)
@@ -2543,7 +2543,8 @@ async def test_reload_service_helper(hass: HomeAssistant) -> None:
         reloader.execute_service(
             ServiceCall(hass, "test", "test", {"target": "target1"})
         ),
-        # These reload tasks will be deduplicated to (target2, target3, target4, target1)
+        # These reload tasks will be deduplicated to
+        # (target2, target3, target4, target1)
         # while the first task is reloaded, note that target1 can't be deduplicated
         # because it's already being reloaded.
         reloader.execute_service(
@@ -2601,7 +2602,8 @@ async def test_reload_service_helper(hass: HomeAssistant) -> None:
     tasks = [
         # This reload task will start executing first, (all)
         reloader.execute_service(ServiceCall(hass, "test", "test")),
-        # These reload tasks will be deduplicated to (target1, target2, target3, target4)
+        # These reload tasks will be deduplicated to
+        # (target1, target2, target3, target4)
         # while the first task is reloaded.
         reloader.execute_service(
             ServiceCall(hass, "test", "test", {"target": "target1"})
@@ -2626,7 +2628,8 @@ async def test_reload_service_helper(hass: HomeAssistant) -> None:
         reloader.execute_service(
             ServiceCall(hass, "test", "test", {"target": "target1"})
         ),
-        # These reload tasks will be deduplicated to (target2, target3, target4, target1)
+        # These reload tasks will be deduplicated to
+        # (target2, target3, target4, target1)
         # while the first task is reloaded, note that target1 can't be deduplicated
         # because it's already being reloaded.
         reloader.execute_service(
@@ -2697,7 +2700,8 @@ async def test_reload_service_helper(hass: HomeAssistant) -> None:
     tasks = [
         # This reload task will start executing first, (all)
         reloader.execute_service(ServiceCall(hass, "test", "test")),
-        # These reload tasks will be deduplicated to (target1, target2, target3, target4)
+        # These reload tasks will be deduplicated to
+        # (target1, target2, target3, target4)
         # while the first task is reloaded.
         reloader.execute_service(
             ServiceCall(hass, "test", "test", {"target": "target1"})
@@ -2733,7 +2737,8 @@ async def test_reload_service_helper(hass: HomeAssistant) -> None:
     tasks = [
         # This reload task will start executing first, (all)
         reloader.execute_service(ServiceCall(hass, "test", "test")),
-        # These reload tasks will be deduplicated to (target1, target2, target3, target4)
+        # These reload tasks will be deduplicated to
+        # (target1, target2, target3, target4)
         # while the first task is reloaded.
         reloader.execute_service(
             ServiceCall(hass, "test", "test", {"target": "target1"})
@@ -2759,7 +2764,8 @@ async def test_reload_service_helper(hass: HomeAssistant) -> None:
         ),
     ]
     await asyncio.gather(*tasks2)
-    # We don't try to reload the failed targets again, so only the new reload is executed
+    # We don't try to reload the failed targets again, so only the
+    # new reload is executed
     assert reloaded == unordered(["target1"])
 
 
@@ -2814,7 +2820,7 @@ async def test_deprecated_selected_entities_class(
 async def test_deprecated_async_extract_referenced_entity_ids(
     hass: HomeAssistant,
 ) -> None:
-    """Test that the deprecated async_extract_referenced_entity_ids function forwards correctly."""
+    """Test deprecated async_extract_referenced_entity_ids forwards correctly."""
     from homeassistant.helpers import target  # noqa: PLC0415
 
     mock_selected = target.SelectedEntities(

--- a/tests/helpers/test_significant_change.py
+++ b/tests/helpers/test_significant_change.py
@@ -82,7 +82,8 @@ async def test_significant_change_extra(
 
     checker.extra_significant_check = extra_significant_check
 
-    # This is normally a significant change (100 -> 200), but the extra arg check marks it
+    # This is normally a significant change (100 -> 200), but the
+    # extra arg check marks it
     # as insignificant.
     assert not checker.async_is_significant_change(
         State(ent_id, "200", attrs), extra_arg=1

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -435,7 +435,7 @@ async def test_not_delayed_saving_while_stopping(
 async def test_not_delayed_saving_after_stopping(
     hass: HomeAssistant, hass_storage: dict[str, Any]
 ) -> None:
-    """Test delayed saves don't write after stop if issued before stopping Home Assistant."""
+    """Test delayed saves don't write after stop if issued before stopping."""
     store = storage.Store(hass, MOCK_VERSION, MOCK_KEY)
     store.async_delay_save(lambda: MOCK_DATA, 10)
     assert store.key not in hass_storage
@@ -1363,7 +1363,7 @@ async def test_storage_concurrent_load(hass: HomeAssistant) -> None:
 async def test_load_empty_returns_none_and_read_only(
     hass: HomeAssistant, hass_storage: dict[str, Any]
 ) -> None:
-    """Test store with load_empty returns None, becomes read-only, and skips version checks."""
+    """Test store with load_empty returns None, becomes read-only."""
     # Use a future version to also verify no version error is raised
     hass_storage[MOCK_KEY] = {
         "version": 99,

--- a/tests/helpers/test_target.py
+++ b/tests/helpers/test_target.py
@@ -513,7 +513,7 @@ async def test_extract_referenced_entity_ids_primary_entities_only(
     selector_config: ConfigType,
     non_primary_entities: set[str],
 ) -> None:
-    """Test that primary_entities_only controls inclusion of config/diagnostic entities."""
+    """Test primary_entities_only controls config/diagnostic entity inclusion."""
     target_selection = target.TargetSelection(selector_config)
 
     selected_primary = target.async_extract_referenced_entity_ids(

--- a/tests/helpers/test_translation.py
+++ b/tests/helpers/test_translation.py
@@ -158,8 +158,9 @@ async def test_load_translations_files_invalid_localized_placeholders(
     )
     for expected_error in expected_errors:
         assert (
-            f"Validation of translation placeholders for localized ({language}) string {expected_error} failed"
-            in caplog.text
+            f"Validation of translation placeholders for"
+            f" localized ({language}) string"
+            f" {expected_error} failed" in caplog.text
         )
 
 
@@ -361,7 +362,7 @@ async def test_get_translation_categories(hass: HomeAssistant) -> None:
 async def test_translation_merging_loaded_together(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test we merge translations of two integrations when they are loaded at the same time."""
+    """Test we merge translations of two integrations loaded at the same time."""
     hass.config.components.add("hue")
     hass.config.components.add("homekit")
     hue_translations = await translation.async_get_translations(
@@ -620,7 +621,8 @@ async def test_translate_state(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.helpers.translation.async_get_cached_translations",
         return_value={
-            "component.platform.entity.binary_sensor.translation_key.state.on": "TRANSLATED"
+            "component.platform.entity.binary_sensor"
+            ".translation_key.state.on": "TRANSLATED"
         },
     ) as mock:
         result = translation.async_translate_state(
@@ -632,7 +634,8 @@ async def test_translate_state(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.helpers.translation.async_get_cached_translations",
         return_value={
-            "component.binary_sensor.entity_component.device_class.state.on": "TRANSLATED"
+            "component.binary_sensor.entity_component"
+            ".device_class.state.on": "TRANSLATED"
         },
     ) as mock:
         result = translation.async_translate_state(
@@ -688,7 +691,9 @@ async def test_translate_state_attr(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.helpers.translation.async_get_cached_translations",
         return_value={
-            "component.platform.entity.climate.translation_key.state_attributes.fan_mode.state.auto": "TRANSLATED"
+            "component.platform.entity.climate"
+            ".translation_key.state_attributes"
+            ".fan_mode.state.auto": "TRANSLATED"
         },
     ) as mock:
         result = translation.async_translate_state_attr(
@@ -706,7 +711,9 @@ async def test_translate_state_attr(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.helpers.translation.async_get_cached_translations",
         return_value={
-            "component.climate.entity_component.device_class.state_attributes.fan_mode.state.auto": "TRANSLATED"
+            "component.climate.entity_component"
+            ".device_class.state_attributes"
+            ".fan_mode.state.auto": "TRANSLATED"
         },
     ) as mock:
         result = translation.async_translate_state_attr(
@@ -724,7 +731,9 @@ async def test_translate_state_attr(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.helpers.translation.async_get_cached_translations",
         return_value={
-            "component.climate.entity_component._.state_attributes.fan_mode.state.auto": "TRANSLATED"
+            "component.climate.entity_component"
+            "._.state_attributes"
+            ".fan_mode.state.auto": "TRANSLATED"
         },
     ) as mock:
         result = translation.async_translate_state_attr(

--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -191,7 +191,8 @@ async def test_trigger_enabled_templates(
                         "event_type": "falsy_template_trigger_event",
                     },
                     {
-                        "enabled": False,  # eg. from a blueprints input defaulting to `false`
+                        # eg. from a blueprints input defaulting to `false`
+                        "enabled": False,
                         "platform": "event",
                         "event_type": "falsy_trigger_event",
                     },
@@ -302,7 +303,8 @@ async def test_trigger_enabled_template_limited(
             "automation": {
                 "trigger": [
                     {
-                        "enabled": "{{ states('sensor.limited') }}",  # only limited template supported
+                        # only limited template supported
+                        "enabled": "{{ states('sensor.limited') }}",
                         "platform": "event",
                         "event_type": "test_event",
                     },
@@ -1138,7 +1140,7 @@ async def test_subscribe_triggers_experimental_triggers(
     new_triggers_conditions_enabled: bool,
     expected_events: list[set[str]],
 ) -> None:
-    """Test trigger.async_subscribe_platform_events doesn't send events for disabled triggers."""
+    """Test async_subscribe_platform_events skips disabled triggers."""
     # Return empty triggers.yaml for light integration, the actual trigger descriptions
     # are irrelevant for this test
     light_trigger_descriptions = ""
@@ -1195,7 +1197,7 @@ async def test_subscribe_triggers_no_triggers(
     hass_ws_client: WebSocketGenerator,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test trigger.async_subscribe_platform_events doesn't send events for platforms without triggers."""
+    """Test async_subscribe_platform_events skips platforms without triggers."""
     # Return empty triggers.yaml for light integration, the actual trigger descriptions
     # are irrelevant for this test
     light_trigger_descriptions = ""
@@ -2093,7 +2095,8 @@ async def test_numerical_state_attribute_changed_with_unit_error_handling(
     ("trigger_options", "expected_result"),
     [
         # Valid configurations
-        # Don't use the enum in tests to allow testing validation of strings when the source is JSON or YAML
+        # Don't use the enum in tests to allow testing validation
+        # of strings when the source is JSON or YAML
         (
             {"threshold": {"type": "above", "value": {"number": 10}}},
             does_not_raise(),
@@ -2448,12 +2451,12 @@ def _make_with_unit_crossed_threshold_trigger_class() -> type[
         ),
     ],
 )
-async def test_numerical_state_attribute_crossed_threshold_with_unit_trigger_config_validation(
+async def test_numerical_state_attr_crossed_threshold_unit_trigger_config_validation(
     hass: HomeAssistant,
     trigger_options: dict[str, Any],
     expected_result: AbstractContextManager,
 ) -> None:
-    """Test numerical state attribute crossed threshold with unit trigger config validation."""
+    """Test numerical state attribute crossed threshold with unit trigger validation."""
     trigger_cls = _make_with_unit_crossed_threshold_trigger_class()
 
     async def async_get_triggers(hass: HomeAssistant) -> dict[str, type[Trigger]]:
@@ -2956,7 +2959,7 @@ async def test_make_entity_target_state_trigger(
     to_state: State,
     wrong_value_state: State,
 ) -> None:
-    """Test make_entity_target_state_trigger with state and attribute-based DomainSpec."""
+    """Test make_entity_target_state_trigger with state and attribute."""
     trigger_cls = make_entity_target_state_trigger(domain_specs, to_states=to_states)
 
     config = TriggerConfig(key="light.turned_on", target={"entity_id": "light.bed"})
@@ -3069,7 +3072,7 @@ async def test_make_entity_origin_state_trigger(
     to_state: State,
     wrong_from: State,
 ) -> None:
-    """Test make_entity_origin_state_trigger with state and attribute-based DomainSpec."""
+    """Test make_entity_origin_state_trigger with state and attribute."""
     trigger_cls = make_entity_origin_state_trigger(domain_specs, from_state=origin)
 
     config = TriggerConfig(
@@ -3247,7 +3250,7 @@ def _set_or_remove_state(
 async def test_entity_trigger_fires_on_valid_transition(
     hass: HomeAssistant, behavior: str
 ) -> None:
-    """Test EntityTriggerBase fires immediately on a valid off→on transition without duration."""
+    """Test EntityTriggerBase fires on a valid transition without duration."""
     entity_id = "test.entity_1"
     hass.states.async_set(entity_id, STATE_OFF)
     await hass.async_block_till_done()
@@ -3285,7 +3288,7 @@ async def test_entity_trigger_fires_on_valid_transition(
 async def test_entity_trigger_from_invalid_initial_state(
     hass: HomeAssistant, behavior: str, initial_state: str | None
 ) -> None:
-    """Test that the trigger does not fire when transitioning from unavailable, unknown, or no state."""
+    """Test trigger does not fire from unavailable, unknown, or no state."""
     entity_id = "test.entity_1"
     _set_or_remove_state(hass, entity_id, initial_state)
     await hass.async_block_till_done()
@@ -3376,7 +3379,7 @@ async def test_entity_trigger_first_requires_exactly_one(
 async def test_entity_trigger_last_ignores_unavailable_and_unknown_entity(
     hass: HomeAssistant, invalid_state: str
 ) -> None:
-    """Test behavior last: unavailable/unknown entities are excluded from the all-match check.
+    """Test behavior last: unavailable/unknown excluded from all-match.
 
     With three entities (A=off, B=unavailable, C=off), turning A on should
     not fire because C is still off, so the available entities do not all
@@ -3429,7 +3432,7 @@ async def test_entity_trigger_last_ignores_unavailable_and_unknown_entity(
 async def test_entity_trigger_first_ignores_unavailable_and_unknown_entity(
     hass: HomeAssistant, invalid_state: str
 ) -> None:
-    """Test behavior first: unavailable/unknown entities are excluded from check_one_match.
+    """Test behavior first: unavailable/unknown excluded from check_one_match.
 
     With three entities (A=off, B=unavailable, C=off), turning A on should
     fire because exactly one *available* entity matches. B is skipped.
@@ -3647,7 +3650,7 @@ async def test_entity_trigger_duration_last_requires_all(
 async def test_entity_trigger_duration_last_cancelled_when_all_entities_filtered(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:
-    """Test behavior last with for: timer is cancelled when every targeted entity is filtered out.
+    """Test behavior last with for: timer cancelled when all entities filtered.
 
     With behavior=last + `for:`, an "all match" check that becomes vacuously
     True (every targeted entity filtered by `_should_include` — here all
@@ -3965,7 +3968,7 @@ async def test_entity_trigger_duration_cancelled_on_invalid_state(
     expected_calls: int,
     invalid_state: str | None,
 ) -> None:
-    """Test if the duration timer is cancelled if entity becomes unavailable, unknown, or is removed.
+    """Test duration timer cancelled if entity becomes unavailable/unknown/removed.
 
     This is expected to happen in first and any modes, but not in last mode.
     """

--- a/tests/helpers/test_trigger_template_entity.py
+++ b/tests/helpers/test_trigger_template_entity.py
@@ -50,7 +50,11 @@ _PICTURE_TEMPLATE = '/local/picture_o{{ "n" if value=="on" else "ff" }}'
             "{{ x - 4 }}",
             template._SENTINEL,
             template._SENTINEL,
-            "Error parsing value for test.entity: 'x' is undefined (value: 1, template: {{ x - 4 }})",
+            (
+                "Error parsing value for test.entity:"
+                " 'x' is undefined"
+                " (value: 1, template: {{ x - 4 }})"
+            ),
         ),
     ],
 )
@@ -93,7 +97,8 @@ async def test_template_entity_requires_hass_set(hass: HomeAssistant) -> None:
             '{% if value=="on" %} mdi:on {% else %} mdi:off {% endif %}', hass
         ),
         "picture": template.Template(
-            '{% if value=="on" %} /local/picture_on {% else %} /local/picture_off {% endif %}',
+            '{% if value=="on" %} /local/picture_on'
+            " {% else %} /local/picture_off {% endif %}",
             hass,
         ),
     }
@@ -249,8 +254,8 @@ async def test_attribute_order(
     assert entity.extra_state_attributes == {"beer": 1, "more_beer": 2}
 
     assert (
-        "Error rendering attributes.no_beer template for test.entity: UndefinedError: 'sad' is undefined"
-        in caplog.text
+        "Error rendering attributes.no_beer template for"
+        " test.entity: UndefinedError: 'sad' is undefined" in caplog.text
     )
 
 
@@ -267,7 +272,8 @@ async def test_trigger_template_complex(hass: HomeAssistant) -> None:
             '{% if value=="on" %} mdi:on {% else %} mdi:off {% endif %}', hass
         ),
         CONF_PICTURE: template.Template(
-            '{% if value=="on" %} /local/picture_on {% else %} /local/picture_off {% endif %}',
+            '{% if value=="on" %} /local/picture_on'
+            " {% else %} /local/picture_off {% endif %}",
             hass,
         ),
         CONF_AVAILABILITY: template.Template('{{ has_value("test.entity") }}', hass),

--- a/tests/helpers/test_update_coordinator.py
+++ b/tests/helpers/test_update_coordinator.py
@@ -761,8 +761,7 @@ async def test_async_config_entry_first_refresh_failure_passed_through(
     method: str,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test async_config_entry_first_refresh passes through ConfigEntryError and
-    ConfigEntryAuthFailed.
+    """Test first refresh passes through ConfigEntryError and ConfigEntryAuthFailed.
 
     Verify we do not log the exception since it
     will be caught by config_entries.async_setup which will log it with

--- a/tests/helpers/test_update_coordinator.py
+++ b/tests/helpers/test_update_coordinator.py
@@ -761,7 +761,7 @@ async def test_async_config_entry_first_refresh_failure_passed_through(
     method: str,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test async_config_entry_first_refresh passes through ConfigEntryError & ConfigEntryAuthFailed.
+    """Test async_config_entry_first_refresh passes through ConfigEntryError.
 
     Verify we do not log the exception since it
     will be caught by config_entries.async_setup which will log it with
@@ -805,8 +805,13 @@ async def test_async_config_entry_first_refresh_invalid_state(
     crd.setup_method = AsyncMock()
     with pytest.raises(
         config_entries.ConfigEntryError,
-        match="`async_config_entry_first_refresh` called when config entry state is ConfigEntryState.NOT_LOADED, "
-        "but should only be called in state ConfigEntryState.SETUP_IN_PROGRESS",
+        match=(
+            "`async_config_entry_first_refresh` called when"
+            " config entry state is"
+            " ConfigEntryState.NOT_LOADED, but should only"
+            " be called in state"
+            " ConfigEntryState.SETUP_IN_PROGRESS"
+        ),
     ):
         await crd.async_config_entry_first_refresh()
 
@@ -827,8 +832,13 @@ async def test_async_config_entry_first_refresh_invalid_state_in_integration(
 
     with pytest.raises(
         config_entries.ConfigEntryError,
-        match="`async_config_entry_first_refresh` called when config entry state is ConfigEntryState.NOT_LOADED, "
-        "but should only be called in state ConfigEntryState.SETUP_IN_PROGRESS",
+        match=(
+            "`async_config_entry_first_refresh` called when"
+            " config entry state is"
+            " ConfigEntryState.NOT_LOADED, but should only"
+            " be called in state"
+            " ConfigEntryState.SETUP_IN_PROGRESS"
+        ),
     ):
         await crd.async_config_entry_first_refresh()
 
@@ -898,7 +908,7 @@ async def test_async_set_update_error(
 async def test_only_callback_on_change_when_always_update_is_false(
     crd: update_coordinator.DataUpdateCoordinator[int],
 ) -> None:
-    """Test we do not callback listeners unless something has actually changed when always_update is false."""
+    """Test no callback unless data actually changed (always_update=False)."""
     update_callback = Mock()
     crd.always_update = False
     remove_callbacks = crd.async_add_listener(update_callback)
@@ -968,7 +978,7 @@ async def test_only_callback_on_change_when_always_update_is_false(
 async def test_always_callback_when_always_update_is_true(
     crd: update_coordinator.DataUpdateCoordinator[int],
 ) -> None:
-    """Test we callback listeners even though the data is the same when always_update is True."""
+    """Test we callback listeners even with same data (always_update=True)."""
     update_callback = Mock()
     remove_callbacks = crd.async_add_listener(update_callback)
     mocked_data = None

--- a/tests/helpers/test_update_coordinator.py
+++ b/tests/helpers/test_update_coordinator.py
@@ -761,7 +761,8 @@ async def test_async_config_entry_first_refresh_failure_passed_through(
     method: str,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test async_config_entry_first_refresh passes through ConfigEntryError.
+    """Test async_config_entry_first_refresh passes through ConfigEntryError and
+    ConfigEntryAuthFailed.
 
     Verify we do not log the exception since it
     will be caught by config_entries.async_setup which will log it with

--- a/tests/pylint/actions/test_service_registration.py
+++ b/tests/pylint/actions/test_service_registration.py
@@ -182,7 +182,7 @@ def test_helper_function_flagged(
     linter: UnittestLinter,
     registration_checker: ServiceRegistrationChecker,
 ) -> None:
-    """Test that services registered in helper functions called from async_setup_entry are flagged."""
+    """Test services in helper functions called from setup are flagged."""
     root_node = astroid.parse(
         """
 def _register_services(hass):

--- a/tests/pylint/actions/test_swallowed_exceptions.py
+++ b/tests/pylint/actions/test_swallowed_exceptions.py
@@ -569,7 +569,7 @@ def test_standalone_service_handler_flagged(
     linter: UnittestLinter,
     error_propagation_checker: SwallowedActionExceptionsChecker,
 ) -> None:
-    """Test that standalone service handlers registered via hass.services are checked."""
+    """Test standalone service handlers via hass.services are checked."""
     root_node = astroid.parse(
         """
 async def async_setup(hass, config):

--- a/tests/pylint/test_greek_micro_char.py
+++ b/tests/pylint/test_greek_micro_char.py
@@ -20,7 +20,8 @@ from . import assert_no_messages
             id="good_const_with_annotation",
         ),
         pytest.param(
-            # Test using the correct μ-sign \u03bc with annotation using unicode encoding
+            # Test using the correct μ-sign \u03bc with annotation
+            # using unicode encoding
             """
         CONCENTRATION_MICROGRAMS_PER_CUBIC_METER: Final = "\u03bcg/m³"
         """,

--- a/tests/pylint/test_imports.py
+++ b/tests/pylint/test_imports.py
@@ -275,7 +275,10 @@ def test_bad_root_import(
             ),
         ),
         (
-            "from homeassistant.helpers.issue_registry import async_get as async_get_issue_registry",
+            (
+                "from homeassistant.helpers.issue_registry"
+                " import async_get as async_get_issue_registry"
+            ),
             "tests.components.pylint_test.climate",
             (
                 "async_get",

--- a/tests/pylint/test_sorted_platforms.py
+++ b/tests/pylint/test_sorted_platforms.py
@@ -34,7 +34,9 @@ from . import assert_adds_messages, assert_no_messages
         ),
         pytest.param(
             """
-        PLATFORMS: list[str] = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.SENSOR]
+        PLATFORMS: list[str] = [
+            Platform.BINARY_SENSOR, Platform.BUTTON, Platform.SENSOR
+        ]
         """,
             id="typed_multiple_platform",
         ),
@@ -58,7 +60,9 @@ from . import assert_adds_messages, assert_no_messages
         ),
         pytest.param(
             """
-        _PLATFORMS: list[str] = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.SENSOR]
+        _PLATFORMS: list[str] = [
+            Platform.BINARY_SENSOR, Platform.BUTTON, Platform.SENSOR
+        ]
         """,
             id="private_typed_multiple_platforms",
         ),

--- a/tests/pylint/test_unused_test_fixture_args.py
+++ b/tests/pylint/test_unused_test_fixture_args.py
@@ -108,7 +108,9 @@ def test_unused_multiple_args(
     """Test that multiple unused fixture args are all flagged."""
     root_node = astroid.parse(
         """
-def test_something(hass: HomeAssistant, enable_bluetooth: None, socket_enabled: None) -> None:
+def test_something(
+    hass: HomeAssistant, enable_bluetooth: None, socket_enabled: None
+) -> None:
     assert hass.state
 """,
         "tests.components.test_integration.test_init",

--- a/tests/syrupy.py
+++ b/tests/syrupy.py
@@ -242,8 +242,10 @@ class _IntFlagWrapper:
         self._flag = flag
 
     def __repr__(self) -> str:
-        # 3.10: <ClimateEntityFeature.SWING_MODE|PRESET_MODE|FAN_MODE|TARGET_TEMPERATURE: 57>
-        # 3.11: <ClimateEntityFeature.TARGET_TEMPERATURE|FAN_MODE|PRESET_MODE|SWING_MODE: 57>
+        # 3.10:
+        # <ClimateEntityFeature.SWING_MODE|PRESET_MODE|FAN_MODE|TARGET_TEMPERATURE: 57>
+        # 3.11:
+        # <ClimateEntityFeature.TARGET_TEMPERATURE|FAN_MODE|PRESET_MODE|SWING_MODE: 57>
         # Syrupy: <ClimateEntityFeature: 57>
         return f"<{self._flag.__class__.__name__}: {self._flag.value}>"
 

--- a/tests/test_backup_restore.py
+++ b/tests/test_backup_restore.py
@@ -182,7 +182,8 @@ def test_restoring_backup_that_is_not_a_file(
     restore_file_path.write_text(json.dumps(restore_config), encoding="utf-8")
     assert restore_file_path.exists()
 
-    # Create a directory at the backup file path to simulate the backup file not being a file
+    # Create a directory at the backup file path to simulate
+    # the backup file not being a file
     backup_file_path.mkdir(exist_ok=True)
 
     with (
@@ -227,7 +228,10 @@ def test_aborting_for_older_versions(restore_config: str, tmp_path: Path) -> Non
     with (
         pytest.raises(
             ValueError,
-            match="You need at least Home Assistant version 9999.99.99 to restore this backup",
+            match=(
+                "You need at least Home Assistant version"
+                " 9999.99.99 to restore this backup"
+            ),
         ),
     ):
         assert backup_restore.restore_backup(tmp_path.as_posix()) is True

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -141,7 +141,7 @@ async def test_async_enable_logging_supervisor(
     log_file_count: int,
     old_log_file_count: int,
 ) -> None:
-    """Test to ensure the default log file is not created on Supervisor installations."""
+    """Test the default log file is not created on Supervisor."""
 
     # Ensure we start with a clean slate
     cleanup_log_files()
@@ -183,7 +183,8 @@ async def test_async_enable_logging_supervisor(
             log_file="test.log",
         )
         mock_async_activate_log_queue_handler.assert_called_once()
-        # Even on Supervisor, the log file should be created if it is explicitly specified
+        # Even on Supervisor, the log file should be created
+        # if it is explicitly specified
         assert len(glob.glob(ARG_LOG_FILE)) > 0
 
     cleanup_log_files()
@@ -1598,8 +1599,8 @@ async def test_cancellation_does_not_leak_upward_from_async_setup_entry(
     await bootstrap._async_setup_multi_components(hass, {"test_package"}, {})
     await hass.async_block_till_done()
     assert (
-        "Error setting up entry Mock Title for test_package_raises_cancelled_error_config_entry"
-        in caplog.text
+        "Error setting up entry Mock Title"
+        " for test_package_raises_cancelled_error_config_entry" in caplog.text
     )
 
     assert "test_package" in hass.config.components
@@ -1750,7 +1751,8 @@ async def test_no_base_platforms_loaded_before_recorder(hass: HomeAssistant) -> 
         if domain_with_base_platforms_deps:
             problems[domain] = domain_with_base_platforms_deps
     assert not problems, (
-        f"Integrations that are setup before recorder have base platforms in their dependencies: {problems}"
+        "Integrations that are setup before recorder have"
+        f" base platforms in their dependencies: {problems}"
     )
 
     base_platform_py_files = {f"{base_platform}.py" for base_platform in base_platforms}
@@ -1764,7 +1766,8 @@ async def test_no_base_platforms_loaded_before_recorder(hass: HomeAssistant) -> 
         if integration_base_platforms_files:
             problems[domain] = integration_base_platforms_files
     assert not problems, (
-        f"Integrations that are setup before recorder implement base platforms: {problems}"
+        "Integrations that are setup before recorder"
+        f" implement base platforms: {problems}"
     )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -392,7 +392,7 @@ async def test_ensure_config_exists_uses_existing_config(hass: HomeAssistant) ->
 
 
 async def test_ensure_existing_files_is_not_overwritten(hass: HomeAssistant) -> None:
-    """Test that calling async_create_default_config does not overwrite existing files."""
+    """Test async_create_default_config does not overwrite files."""
     await hass.async_add_executor_job(create_file, SECRET_PATH)
 
     await config_util.async_create_default_config(hass)

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -250,7 +250,7 @@ async def test_call_setup_entry(hass: HomeAssistant) -> None:
 
 
 async def test_call_setup_entry_without_reload_support(hass: HomeAssistant) -> None:
-    """Test we call <component>.setup_entry and the <component> does not support unloading."""
+    """Test setup_entry when the component does not support unloading."""
     entry = MockConfigEntry(domain="comp")
     entry.add_to_hass(hass)
     assert not entry.supports_unload
@@ -3829,7 +3829,7 @@ async def test_unique_id_update_existing_entry_without_reload(
 async def test_unique_id_update_existing_entry_with_reload(
     hass: HomeAssistant, manager: config_entries.ConfigEntries
 ) -> None:
-    """Test that we update an entry if there already is an entry with unique ID and we reload on changes."""
+    """Test we update an entry with existing unique ID and reload."""
     hass.config.components.add("comp")
     entry = MockConfigEntry(
         domain="comp",
@@ -4119,7 +4119,7 @@ async def test_unique_id_in_progress(
 async def test_finish_flow_aborts_progress(
     hass: HomeAssistant, manager: config_entries.ConfigEntries
 ) -> None:
-    """Test that when finishing a flow, we abort other flows in progress with unique ID."""
+    """Test finishing a flow aborts other in-progress flows."""
     mock_integration(
         hass,
         MockModule("comp", async_setup_entry=AsyncMock(return_value=True)),
@@ -4565,7 +4565,7 @@ async def test_update_discovery_keys_2(
 async def test_async_current_entries_does_not_skip_ignore_non_user(
     hass: HomeAssistant, manager: config_entries.ConfigEntries
 ) -> None:
-    """Test that _async_current_entries does not skip ignore by default for non user step."""
+    """Test _async_current_entries does not skip ignore for non user."""
     hass.config.components.add("comp")
     entry = MockConfigEntry(
         domain="comp",
@@ -4680,18 +4680,20 @@ async def test_async_current_entries_explicit_include_ignore(
 async def test_partial_flows_hidden(
     hass: HomeAssistant, manager: config_entries.ConfigEntries
 ) -> None:
-    """Test that flows that don't have a cur_step and haven't finished initing are hidden."""
+    """Test flows without cur_step that haven't finished init."""
     async_setup_entry = AsyncMock(return_value=True)
     mock_integration(hass, MockModule("comp", async_setup_entry=async_setup_entry))
     mock_platform(hass, "comp.config_flow", None)
 
-    # A flag to test our assertion that `async_step_discovery` was called and is in its blocked state
+    # A flag to test our assertion that `async_step_discovery`
+    # was called and is in its blocked state
     # This simulates if the step was e.g. doing network i/o
     discovery_started = asyncio.Event()
 
-    # A flag to allow `async_step_discovery` to resume after we have verified the uninited flow is not
-    # visible and has not triggered a discovery alert. This lets us control when the mocked network
-    # i/o is complete.
+    # A flag to allow `async_step_discovery` to resume after we
+    # have verified the uninited flow is not visible and has not
+    # triggered a discovery alert. This lets us control when
+    # the mocked network i/o is complete.
     pause_discovery = asyncio.Event()
 
     class TestFlow(config_entries.ConfigFlow):
@@ -4725,7 +4727,8 @@ async def test_partial_flows_hidden(
         # Let the flow init complete
         pause_discovery.set()
 
-        # When it's complete it should now be visible in async_progress and have triggered
+        # When it's complete it should now be visible in
+        # async_progress and have triggered
         # discovery notifications
         result = await init_task
         assert result["type"] == data_entry_flow.FlowResultType.FORM
@@ -4781,7 +4784,7 @@ async def test_async_setup_init_entry(
 async def test_async_setup_init_entry_completes_before_loaded_event_fires(
     hass: HomeAssistant, manager: config_entries.ConfigEntries
 ) -> None:
-    """Test a config entry being initialized during integration setup before the loaded event fires."""
+    """Test config entry init during setup before loaded event."""
     load_events = async_capture_events(hass, EVENT_COMPONENT_LOADED)
 
     async def mock_async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -4913,7 +4916,7 @@ async def test_flow_with_default_discovery(
     manager: config_entries.ConfigEntries,
     discovery_source: tuple[str, dict | BaseServiceInfo],
 ) -> None:
-    """Test that finishing a default discovery flow removes the unique ID in the entry."""
+    """Test finishing a discovery flow removes the unique ID."""
     mock_integration(
         hass,
         MockModule("comp", async_setup_entry=AsyncMock(return_value=True)),
@@ -4963,7 +4966,7 @@ async def test_flow_with_default_discovery(
 async def test_flow_with_default_discovery_with_unique_id(
     hass: HomeAssistant, manager: config_entries.ConfigEntries
 ) -> None:
-    """Test discovery flow using the default discovery is ignored when unique ID is set."""
+    """Test discovery flow is ignored when unique ID is set."""
     mock_integration(hass, MockModule("comp"))
     mock_platform(hass, "comp.config_flow", None)
 
@@ -4996,7 +4999,7 @@ async def test_flow_with_default_discovery_with_unique_id(
 async def test_default_discovery_abort_existing_entries(
     hass: HomeAssistant, manager: config_entries.ConfigEntries
 ) -> None:
-    """Test that a flow without discovery implementation aborts when a config entry exists."""
+    """Test a flow without discovery aborts when entry exists."""
     hass.config.components.add("comp")
     entry = MockConfigEntry(domain="comp", data={}, unique_id="mock-unique-id")
     entry.add_to_hass(hass)
@@ -5060,7 +5063,7 @@ async def test_default_discovery_in_progress(
 async def test_default_discovery_abort_on_new_unique_flow(
     hass: HomeAssistant, manager: config_entries.ConfigEntries
 ) -> None:
-    """Test that a flow using default discovery is aborted when a second flow with unique ID is created."""
+    """Test default discovery flow aborted on second unique ID flow."""
     mock_integration(hass, MockModule("comp"))
     mock_platform(hass, "comp.config_flow", None)
 
@@ -5102,7 +5105,7 @@ async def test_default_discovery_abort_on_new_unique_flow(
 async def test_default_discovery_abort_on_user_flow_complete(
     hass: HomeAssistant, manager: config_entries.ConfigEntries
 ) -> None:
-    """Test that a flow using default discovery is aborted when a second flow completes."""
+    """Test default discovery flow aborted on second flow done."""
     mock_integration(hass, MockModule("comp"))
     mock_platform(hass, "comp.config_flow", None)
 
@@ -5468,7 +5471,7 @@ async def test_entry_state_change_error_does_not_block_transition(
     manager: config_entries.ConfigEntries,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test we transition states normally even if the callback throws in on_state_change."""
+    """Test state transitions when on_state_change callback throws."""
     entry = MockConfigEntry(
         title="test", domain="comp", state=config_entries.ConfigEntryState.NOT_LOADED
     )
@@ -6210,7 +6213,7 @@ async def test_entry_reload_concurrency_not_setup_setup(
 async def test_unique_id_update_while_setup_in_progress(
     hass: HomeAssistant, manager: config_entries.ConfigEntries
 ) -> None:
-    """Test we handle the case where the config entry is updated while setup is in progress."""
+    """Test config entry updated while setup is in progress."""
 
     async def mock_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Mock setting up entry."""
@@ -6419,7 +6422,9 @@ async def test_reauth_reconfigure_missing_entry_component(
         patch.object(frame, "_REPORTED_INTEGRATIONS", set()),
         pytest.raises(
             HomeAssistantError,
-            match=f"Cannot initialize a {source} flow without a link to the config entry",
+            match=(
+                f"Cannot initialize a {source} flow without a link to the config entry"
+            ),
         ),
     ):
         await manager.flow.async_init("test", context={"source": source})
@@ -6614,7 +6619,8 @@ async def test_async_wait_component_startup(hass: HomeAssistant) -> None:
     # Allow setup to proceed
     setup_stall.set()
 
-    # The component is scheduled to load, this will block until the config entry is loaded
+    # The component is scheduled to load, this will block
+    # until the config entry is loaded
     assert await hass.config_entries.async_wait_component(entry) is True
 
     # The component has been loaded
@@ -7033,7 +7039,7 @@ async def test_update_entry_and_reload(
 async def test_update_entry_and_reload_with_listener_logs(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test updating an entry and reloading with a config entry listener logs deprecation."""
+    """Test update and reload with config entry listener logs."""
     entry = MockConfigEntry(
         domain="comp",
         unique_id="1234",
@@ -8058,7 +8064,7 @@ async def test_in_progress_get_canceled_when_entry_is_created(
     flow_1_unique_id: str | None,
     flow_2_unique_id: str | None,
 ) -> None:
-    """Test that we abort all in progress flows when a new entry is created on a single instance only integration."""
+    """Test we abort in-progress flows on single instance integration."""
     integration = loader.Integration(
         hass,
         "components.comp",
@@ -9758,7 +9764,10 @@ async def test_options_flow_config_entry(
             1,
             pytest.raises(
                 ValueError,
-                match="Config entry update listeners should not be used with OptionsFlowWithReload",
+                match=(
+                    "Config entry update listeners should not"
+                    " be used with OptionsFlowWithReload"
+                ),
             ),
             0,
         ),
@@ -9898,7 +9907,7 @@ async def test_add_description_placeholder_automatically(
     hass: HomeAssistant,
     manager: config_entries.ConfigEntries,
 ) -> None:
-    """Test entry title is added automatically to reauth flows description placeholder."""
+    """Test entry title is added to reauth flow placeholders."""
 
     entry = MockConfigEntry(title="test_title", domain="test")
 
@@ -9922,7 +9931,7 @@ async def test_add_description_placeholder_automatically_not_overwrites(
     hass: HomeAssistant,
     manager: config_entries.ConfigEntries,
 ) -> None:
-    """Test entry title is not added automatically to reauth flows when custom name exist."""
+    """Test entry title not added to reauth when custom name exist."""
 
     entry = MockConfigEntry(title="test_title", domain="test2")
 
@@ -10385,7 +10394,7 @@ async def test_orphaned_ignored_entries(
     manager: config_entries.ConfigEntries,
     issue_registry: ir.IssueRegistry,
 ) -> None:
-    """Test orphaned ignored entries scanner creates a repair issue for missing (custom) integration."""
+    """Test orphaned ignored entries creates repair for missing integration."""
     await hass.config_entries.async_initialize()
     entry = MockConfigEntry(
         domain="ghost_orphan_domain", source=config_entries.SOURCE_IGNORE
@@ -10420,7 +10429,7 @@ async def test_orphaned_ignored_entries_existing_integration(
     manager: config_entries.ConfigEntries,
     issue_registry: ir.IssueRegistry,
 ) -> None:
-    """Just to be very thorough: test no repair issue is created for ignored entry with existing (custom) integration."""
+    """Test no repair issue for ignored entry with existing integration."""
     await hass.config_entries.async_initialize()
 
     # This time we mock we have an actual existing integration

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -654,7 +654,7 @@ async def test_stage_shutdown_timeouts(hass: HomeAssistant) -> None:
 async def test_stage_shutdown_generic_error(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Simulate a shutdown, test that a generic error at the final stage doesn't prevent it."""
+    """Simulate a shutdown, test generic error doesn't prevent it."""
 
     task = asyncio.Future()
     hass._tasks.add(task)
@@ -713,7 +713,7 @@ async def test_stage_shutdown_with_exit_code(hass: HomeAssistant) -> None:
 async def test_shutdown_calls_block_till_done_after_shutdown_run_callback_threadsafe(
     hass: HomeAssistant,
 ) -> None:
-    """Ensure shutdown_run_callback_threadsafe is called before the final async_block_till_done."""
+    """Ensure shutdown_run_callback_threadsafe is called first."""
     stop_calls = []
 
     async def _record_block_till_done(wait_background_tasks: bool = False):
@@ -932,7 +932,7 @@ async def test_add_job_partial_callback(hass: HomeAssistant) -> None:
 async def test_add_job_partial_coroutine_function(
     hass: HomeAssistant,
 ) -> None:
-    """Test add_job with a partial-wrapped coroutine function from an executor thread."""
+    """Test add_job with a partial-wrapped coroutine function."""
     result: list[tuple[str, int]] = []
 
     async def my_coro(name: str, value: int) -> None:
@@ -1222,7 +1222,10 @@ def test_state_as_compressed_state_json() -> None:
         last_changed=last_time,
         context=ha.Context(id="01H0D6H5K3SZJ3XGDHED1TJ79N"),
     )
-    expected = b'"happy.happy":{"s":"on","a":{"pig":"dog"},"c":"01H0D6H5K3SZJ3XGDHED1TJ79N","lc":471355200.0}'
+    expected = (
+        b'"happy.happy":{"s":"on","a":{"pig":"dog"}'
+        b',"c":"01H0D6H5K3SZJ3XGDHED1TJ79N","lc":471355200.0}'
+    )
     as_compressed_state = state.as_compressed_state_json
     # We are not too concerned about these being ReadOnlyDict
     # since we don't expect them to be called by external callers
@@ -1458,8 +1461,8 @@ async def test_eventbus_max_length_exceeded(hass: HomeAssistant) -> None:
         hass.bus.async_fire(long_evt_name)
 
     assert (
-        str(exc_info.value)
-        == f"Value {long_evt_name} for property event_type has a maximum length of 64 characters"
+        str(exc_info.value) == f"Value {long_evt_name} for property event_type"
+        " has a maximum length of 64 characters"
     )
     assert exc_info.value.translation_key == "max_length_exceeded"
     assert exc_info.value.property_name == "event_type"
@@ -2315,7 +2318,7 @@ async def test_log_blocking_events(
 async def test_chained_logging_hits_log_timeout(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Ensure we log which task is blocking startup when there is a task chain and debug logging is on."""
+    """Ensure we log which task is blocking startup on chain."""
     caplog.set_level(logging.DEBUG)
 
     created = 0
@@ -2344,7 +2347,7 @@ async def test_chained_logging_hits_log_timeout(
 async def test_chained_logging_misses_log_timeout(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Ensure we do not log which task is blocking startup if we do not hit the timeout."""
+    """Ensure we do not log blocking task if no timeout hit."""
     caplog.set_level(logging.DEBUG)
 
     created = 0
@@ -3174,7 +3177,8 @@ async def test_async_add_hass_job_deprecated(
 
     hass.async_add_hass_job(HassJob(_test))
     assert (
-        "Detected code that calls `async_add_hass_job`, which should be reviewed against "
+        "Detected code that calls `async_add_hass_job`,"
+        " which should be reviewed against "
         "https://developers.home-assistant.io/blog/2024/04/07/deprecate_add_hass_job"
         " for replacement options. This will stop working in Home Assistant 2025.5"
     ) in caplog.text

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -713,7 +713,7 @@ async def test_stage_shutdown_with_exit_code(hass: HomeAssistant) -> None:
 async def test_shutdown_calls_block_till_done_after_shutdown_run_callback_threadsafe(
     hass: HomeAssistant,
 ) -> None:
-    """Ensure shutdown_run_callback_threadsafe is called first."""
+    """Ensure shutdown_run_callback_threadsafe precedes final async_block_till_done."""
     stop_calls = []
 
     async def _record_block_till_done(wait_background_tasks: bool = False):

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -982,7 +982,7 @@ async def test_init_unknown_flow(manager: MockFlowManager) -> None:
 
 
 async def test_async_get_unknown_flow(manager: MockFlowManager) -> None:
-    """Test that UnknownFlow is raised when async_get is called with a flow_id that does not exist."""
+    """Test UnknownFlow raised when async_get gets unknown flow_id."""
 
     with pytest.raises(data_entry_flow.UnknownFlow):
         await manager.async_get("does_not_exist")
@@ -991,7 +991,7 @@ async def test_async_get_unknown_flow(manager: MockFlowManager) -> None:
 async def test_move_to_unknown_step_raises_and_removes_from_in_progress(
     manager: MockFlowManager,
 ) -> None:
-    """Test that moving to an unknown step raises and removes the flow from in progress."""
+    """Test unknown step raises and removes flow from in progress."""
 
     @manager.mock_reg_handler("test")
     class TestFlow(data_entry_flow.FlowHandler):
@@ -1017,7 +1017,7 @@ async def test_move_to_unknown_step_raises_and_removes_from_in_progress(
 async def test_next_step_unknown_step_raises_and_removes_from_in_progress(
     manager: MockFlowManager, result_type: str, params: dict[str, str]
 ) -> None:
-    """Test that moving to an unknown step raises and removes the flow from in progress."""
+    """Test unknown step raises and removes flow from in progress."""
 
     @manager.mock_reg_handler("test")
     class TestFlow(data_entry_flow.FlowHandler):

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -332,7 +332,7 @@ async def test_get_platform_caches_failures_when_component_loaded(
 async def test_get_platform_only_cached_module_not_found_when_component_loaded(
     hass: HomeAssistant,
 ) -> None:
-    """Test get_platform cache only cache module not found when the component is loaded."""
+    """Test get_platform caches module not found when loaded."""
     integration = await loader.async_get_integration(hass, "hue")
 
     with (
@@ -913,7 +913,7 @@ async def test_get_application_credentials(hass: HomeAssistant) -> None:
 
 
 async def test_get_zeroconf_back_compat(hass: HomeAssistant) -> None:
-    """Verify that custom components with zeroconf are found and legacy matchers are converted."""
+    """Verify custom components with zeroconf and legacy matchers."""
     test_1_integration = _get_test_integration(hass, "test_1", True)
     test_2_integration = _get_test_integration_with_legacy_zeroconf_matcher(
         hass, "test_2", True
@@ -1074,7 +1074,7 @@ async def test_get_custom_components_recovery_mode(hass: HomeAssistant) -> None:
 
 
 async def test_custom_integration_missing_version(hass: HomeAssistant) -> None:
-    """Test trying to load a custom integration without a version twice does not deadlock."""
+    """Test loading custom integration without version twice."""
     with pytest.raises(loader.IntegrationNotFound):
         await loader.async_get_integration(hass, "test_no_version")
 
@@ -1304,7 +1304,7 @@ async def test_config_folder_not_in_path() -> None:
 async def test_async_get_component_preloads_config_and_config_flow(
     hass: HomeAssistant,
 ) -> None:
-    """Verify async_get_component will try to preload the config and config_flow platform."""
+    """Verify async_get_component preloads config and config_flow."""
     executor_import_integration = _get_test_integration(
         hass, "executor_import", True, import_executor=True
     )
@@ -1350,7 +1350,7 @@ async def test_async_get_component_preloads_config_and_config_flow(
 async def test_async_get_component_loads_loop_if_already_in_sys_modules(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Verify async_get_component does not create an executor job if the module is already in sys.modules."""
+    """Verify async_get_component skips executor if already in sys.modules."""
     integration = await loader.async_get_integration(
         hass, "test_package_loaded_executor"
     )
@@ -1412,7 +1412,7 @@ async def test_async_get_component_loads_loop_if_already_in_sys_modules(
 
 @pytest.mark.usefixtures("enable_custom_integrations")
 async def test_async_get_component_concurrent_loads(hass: HomeAssistant) -> None:
-    """Verify async_get_component waits if the first load if called again when still in progress."""
+    """Verify async_get_component waits if load is in progress."""
     integration = await loader.async_get_integration(
         hass, "test_package_loaded_executor"
     )
@@ -1472,7 +1472,7 @@ async def test_async_get_component_concurrent_loads(hass: HomeAssistant) -> None
 async def test_async_get_component_deadlock_fallback(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Verify async_get_component fallback to importing in the event loop on deadlock."""
+    """Verify async_get_component falls back to event loop."""
     executor_import_integration = _get_test_integration(
         hass, "executor_import", True, import_executor=True
     )
@@ -1488,7 +1488,8 @@ async def test_async_get_component_deadlock_fallback(
         if import_attempts == 1:
             # _DeadlockError inherits from RuntimeError
             raise RuntimeError(
-                "Detected deadlock trying to import homeassistant.components.executor_import"
+                "Detected deadlock trying to import"
+                " homeassistant.components.executor_import"
             )
 
         return module_mock
@@ -1553,7 +1554,7 @@ async def test_async_get_component_deadlock_fallback_module_not_found(
 async def test_async_get_component_raises_after_import_failure(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Verify async_get_component raises if we fail to import in both the executor and loop."""
+    """Verify async_get_component raises on import failure."""
     executor_import_integration = _get_test_integration(
         hass, "executor_import", True, import_executor=True
     )
@@ -1569,7 +1570,8 @@ async def test_async_get_component_raises_after_import_failure(
         if import_attempts == 1:
             # _DeadlockError inherits from RuntimeError
             raise RuntimeError(
-                "Detected deadlock trying to import homeassistant.components.executor_import"
+                "Detected deadlock trying to import"
+                " homeassistant.components.executor_import"
             )
 
         if import_attempts == 2:
@@ -1610,7 +1612,8 @@ async def test_async_get_platform_deadlock_fallback(
         if import_attempts == 1:
             # _DeadlockError inherits from RuntimeError
             raise RuntimeError(
-                "Detected deadlock trying to import homeassistant.components.executor_import"
+                "Detected deadlock trying to import"
+                " homeassistant.components.executor_import"
             )
 
         return module_mock
@@ -1679,7 +1682,7 @@ async def test_async_get_platform_deadlock_fallback_module_not_found(
 async def test_async_get_platform_raises_after_import_failure(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Verify async_get_platform raises if we fail to import in both the executor and loop."""
+    """Verify async_get_platform raises on import failure."""
     executor_import_integration = _get_test_integration(
         hass, "executor_import", True, import_executor=True
     )
@@ -1695,7 +1698,8 @@ async def test_async_get_platform_raises_after_import_failure(
         if import_attempts == 1:
             # _DeadlockError inherits from RuntimeError
             raise RuntimeError(
-                "Detected deadlock trying to import homeassistant.components.executor_import"
+                "Detected deadlock trying to import"
+                " homeassistant.components.executor_import"
             )
 
         if import_attempts == 2:

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -317,7 +317,7 @@ async def test_get_integration_with_requirements_concurrency(
 async def test_get_integration_with_requirements_pip_install_fails_two_passes(
     hass: HomeAssistant,
 ) -> None:
-    """Check getting an integration with loaded requirements and the pip install fails two passes."""
+    """Check integration with requirements when pip install fails."""
     hass.config.skip_pip = False
     mock_integration(
         hass, MockModule("test_component_dep", requirements=["test-comp-dep==1.0.0"])
@@ -491,7 +491,7 @@ async def test_get_integration_with_missing_dependencies(hass: HomeAssistant) ->
 async def test_get_built_in_integration_with_missing_after_dependencies(
     hass: HomeAssistant,
 ) -> None:
-    """Check getting a built_in integration with missing after_dependencies results in exception."""
+    """Check built-in integration with missing after_dependencies."""
     hass.config.skip_pip = False
     mock_integration(
         hass,

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -27,7 +27,7 @@ TIMEOUT_SAFETY_MARGIN = 10
 
 
 async def test_cumulative_shutdown_timeout_less_than_supervisor() -> None:
-    """Verify the cumulative shutdown timeout is at least 10s less than the supervisor."""
+    """Verify cumulative shutdown timeout is 10s less than supervisor."""
     assert (
         core.STOPPING_STAGE_SHUTDOWN_TIMEOUT
         + core.STOP_STAGE_SHUTDOWN_TIMEOUT

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -27,7 +27,7 @@ TIMEOUT_SAFETY_MARGIN = 10
 
 
 async def test_cumulative_shutdown_timeout_less_than_supervisor() -> None:
-    """Verify cumulative shutdown timeout is 10s less than supervisor."""
+    """Verify cumulative shutdown timeout is at least 10s less than supervisor."""
     assert (
         core.STOPPING_STAGE_SHUTDOWN_TIMEOUT
         + core.STOP_STAGE_SHUTDOWN_TIMEOUT

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -260,7 +260,7 @@ async def test_component_not_found(
 async def test_yaml_component_not_found(
     hass: HomeAssistant, issue_registry: IssueRegistry
 ) -> None:
-    """setup_component should only raise an exception for missing config entry integrations."""
+    """setup_component should only raise for missing config entry."""
     assert await setup.async_setup_component(hass, "non_existing", {}) is False
     assert len(issue_registry.issues) == 0
     assert (
@@ -1114,7 +1114,7 @@ async def test_async_start_setup_config_entry_late_platform(
 async def test_async_start_setup_config_entry_platform_wait(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:
-    """Test setup started tracks wait time when a platform loads inside of config entry setup."""
+    """Test setup tracks wait time for platform in config entry."""
     hass.set_state(CoreState.not_running)
     setup_started = hass.data.setdefault(setup._DATA_SETUP_STARTED, {})
     setup_time = setup._setup_times(hass)
@@ -1145,7 +1145,8 @@ async def test_async_start_setup_config_entry_platform_wait(
             assert isinstance(setup_started[("august", "entry_id")], float)
 
     # CONFIG_ENTRY_PLATFORM_SETUP is run inside of CONFIG_ENTRY_SETUP, so it should not
-    # be tracked, but any wait time should still be tracked because its blocking the setup
+    # be tracked, but any wait time should still be tracked
+    # because its blocking the setup
     assert setup_time["august"] == {
         None: {setup.SetupPhases.SETUP: 10.0},
         "entry_id": {
@@ -1156,7 +1157,7 @@ async def test_async_start_setup_config_entry_platform_wait(
 
 
 async def test_async_start_setup_top_level_yaml(hass: HomeAssistant) -> None:
-    """Test setup started context manager keeps track of setup times with modern yaml."""
+    """Test setup started tracks setup times with modern yaml."""
     hass.set_state(CoreState.not_running)
     setup_started = hass.data.setdefault(setup._DATA_SETUP_STARTED, {})
     setup_time = setup._setup_times(hass)
@@ -1206,7 +1207,7 @@ async def test_async_start_setup_platform_integration(hass: HomeAssistant) -> No
 async def test_async_start_setup_legacy_platform_integration(
     hass: HomeAssistant,
 ) -> None:
-    """Test setup started keeps track of setup times for a legacy platform integration."""
+    """Test setup started tracks times for legacy platform."""
     hass.set_state(CoreState.not_running)
     setup_started = hass.data.setdefault(setup._DATA_SETUP_STARTED, {})
     setup_time = setup._setup_times(hass)
@@ -1438,7 +1439,8 @@ async def test_async_wait_component(hass: HomeAssistant) -> None:
     # Allow setup to proceed
     setup_stall.set()
 
-    # The component is scheduled to load, this will block until the config entry is loaded
+    # The component is scheduled to load, this will block
+    # until the config entry is loaded
     assert await setup.async_wait_component(hass, "test") is True
 
     # The component has been loaded

--- a/tests/test_test_fixtures.py
+++ b/tests/test_test_fixtures.py
@@ -148,6 +148,7 @@ async def test_evict_faked_translations(
     with pytest.raises(StopIteration):
         next(gen)
 
-    # The mock integration should be removed from the cache, the real domain should still be there
+    # The mock integration should be removed from the cache,
+    # the real domain should still be there
     assert fake_domain not in cache.loaded["en"]
     assert real_domain in cache.loaded["en"]

--- a/tests/util/test_async.py
+++ b/tests/util/test_async.py
@@ -89,7 +89,10 @@ async def test_run_callback_threadsafe(hass: HomeAssistant) -> None:
 
 
 async def test_callback_is_always_scheduled(hass: HomeAssistant) -> None:
-    """Test run_callback_threadsafe always calls call_soon_threadsafe before checking for shutdown."""
+    """Test run_callback_threadsafe always calls call_soon_threadsafe.
+
+    Checks that it is called before checking for shutdown.
+    """
     # We have to check the shutdown state AFTER the callback is scheduled otherwise
     # the function could continue on and the caller call `future.result()` after
     # the point in the main thread where callbacks are no longer run.
@@ -142,7 +145,8 @@ async def test_create_eager_task_from_thread(hass: HomeAssistant) -> None:
     with pytest.raises(
         RuntimeError,
         match=(
-            "Detected code that attempted to create an asyncio task from a thread. Please report this issue"
+            "Detected code that attempted to create an asyncio"
+            " task from a thread. Please report this issue"
         ),
     ):
         await hass.async_add_executor_job(create_task)

--- a/tests/util/test_collection.py
+++ b/tests/util/test_collection.py
@@ -4,7 +4,7 @@ from homeassistant.util.collection import chunked_or_all
 
 
 def test_chunked_or_all() -> None:
-    """Test chunked_or_all can iterate chunk sizes larger than the passed in collection."""
+    """Test chunked_or_all iterates chunk sizes larger than input."""
     all_items = []
     incoming = (1, 2, 3, 4)
     for chunk in chunked_or_all(incoming, 2):

--- a/tests/util/test_color.py
+++ b/tests/util/test_color.py
@@ -389,7 +389,8 @@ def test_color_rgb_to_rgbww() -> None:
         255,
         255,
     )
-    # Light with mid point at ~5500K (less warm white) -> output compensated by adding less blue
+    # Light with mid point at ~5500K (less warm white)
+    # -> output compensated by adding less blue
     assert color_util.color_rgb_to_rgbww(255, 255, 255, 1000, 10000) == (
         255,
         255,
@@ -397,7 +398,8 @@ def test_color_rgb_to_rgbww() -> None:
         0,
         0,
     )
-    # Light with mid point at ~1MK (unrealistically cold white) -> output compensated by adding red
+    # Light with mid point at ~1MK (unrealistically cold white)
+    # -> output compensated by adding red
     assert color_util.color_rgb_to_rgbww(255, 255, 255, 1000, 1000000) == (
         0,
         118,

--- a/tests/util/test_dt.py
+++ b/tests/util/test_dt.py
@@ -145,7 +145,7 @@ def test_parse_datetime_returns_none_for_incorrect_format() -> None:
 
 
 def test_parse_datetime_raises_for_incorrect_format() -> None:
-    """Test parse_datetime raises ValueError if raise_on_error is set with an incorrect format."""
+    """Test parse_datetime raises ValueError if raise_on_error is set."""
     with pytest.raises(ValueError):
         dt_util.parse_datetime("not a datetime string", raise_on_error=True)
 
@@ -390,7 +390,8 @@ def test_find_next_time_expression_time_dst() -> None:
     )
 
 
-# DST begins on 2021.03.28 2:00, clocks were turned forward 1h; 2:00-3:00 time does not exist
+# DST begins on 2021.03.28 2:00, clocks were turned forward 1h;
+# 2:00-3:00 time does not exist
 @pytest.mark.parametrize(
     ("now_dt", "expected_dt"),
     [
@@ -419,7 +420,8 @@ def test_find_next_time_expression_entering_dst(now_dt, expected_dt) -> None:
     assert dt_util.as_utc(res_dt) == dt_util.as_utc(expected_dt)
 
 
-# DST ends on 2021.10.31 2:00, clocks were turned backward 1h; 2:00-3:00 time is ambiguous
+# DST ends on 2021.10.31 2:00, clocks were turned backward 1h;
+# 2:00-3:00 time is ambiguous
 @pytest.mark.parametrize(
     ("now_dt", "expected_dt"),
     [
@@ -603,7 +605,7 @@ def test_find_next_time_expression_day_before_dst_change_the_same_time() -> None
 def test_find_next_time_expression_time_leave_dst_chicago_before_the_fold_30_s() -> (
     None
 ):
-    """Test leaving daylight saving time for find_next_time_expression_time 30s into the future."""
+    """Test leaving DST for find_next_time_expression_time 30s ahead."""
     tz = dt_util.get_time_zone("America/Chicago")
     dt_util.set_default_time_zone(tz)
 
@@ -625,10 +627,10 @@ def test_find_next_time_expression_time_leave_dst_chicago_before_the_fold_30_s()
     assert next_time.fold == 0
 
 
-def test_find_next_time_expression_time_leave_dst_chicago_before_the_fold_same_time() -> (
+def test_find_next_time_expression_time_leave_dst_chicago_before_fold_same_time() -> (
     None
 ):
-    """Test leaving daylight saving time for find_next_time_expression_time with the same time."""
+    """Test leaving DST for find_next_time_expression_time same time."""
     tz = dt_util.get_time_zone("America/Chicago")
     dt_util.set_default_time_zone(tz)
 
@@ -676,7 +678,7 @@ def test_find_next_time_expression_time_leave_dst_chicago_into_the_fold_same_tim
     )
 
 
-def test_find_next_time_expression_time_leave_dst_chicago_into_the_fold_ahead_1_hour_10_min() -> (
+def test_find_next_time_expression_time_leave_dst_chicago_into_fold_ahead_1h_10m() -> (
     None
 ):
     """Test leaving daylight saving time for find_next_time_expression_time."""
@@ -704,7 +706,7 @@ def test_find_next_time_expression_time_leave_dst_chicago_into_the_fold_ahead_1_
     )
 
 
-def test_find_next_time_expression_time_leave_dst_chicago_inside_the_fold_ahead_10_min() -> (
+def test_find_next_time_expression_time_leave_dst_chicago_inside_fold_ahead_10m() -> (
     None
 ):
     """Test leaving daylight saving time for find_next_time_expression_time."""
@@ -732,7 +734,7 @@ def test_find_next_time_expression_time_leave_dst_chicago_inside_the_fold_ahead_
     )
 
 
-def test_find_next_time_expression_time_leave_dst_chicago_past_the_fold_ahead_2_hour_10_min() -> (
+def test_find_next_time_expression_time_leave_dst_chicago_past_fold_ahead_2h_10m() -> (
     None
 ):
     """Test leaving daylight saving time for find_next_time_expression_time."""
@@ -783,10 +785,8 @@ def test_find_next_time_expression_microseconds() -> None:
     assert time_after == datetime(2022, 5, 13, 1, 5, 10, tzinfo=dt_util.UTC)
 
 
-def test_find_next_time_expression_tenth_second_pattern_does_not_drift_entering_dst() -> (
-    None
-):
-    """Test finding next time expression tenth second pattern does not drift entering dst."""
+def test_find_next_time_expression_tenth_second_no_drift_entering_dst() -> None:
+    """Test next time expression tenth second pattern no drift entering DST."""
     tz = dt_util.get_time_zone("America/Chicago")
     dt_util.set_default_time_zone(tz)
     tenth_second_pattern = (None, None, "10")

--- a/tests/util/test_language.py
+++ b/tests/util/test_language.py
@@ -207,7 +207,7 @@ def test_no_nb_same() -> None:
 
 
 def test_no_nb_prefer_exact() -> None:
-    """Test that the exact language is preferred even if an interchangeable language is available."""
+    """Test exact language preferred over interchangeable language."""
     assert language.matches(
         "no",
         ["en-US", "en-GB", "nb", "no"],
@@ -243,7 +243,7 @@ def test_he_iw_same() -> None:
 
 
 def test_he_iw_prefer_exact() -> None:
-    """Test that the exact language is preferred even if an interchangeable language is available."""
+    """Test exact language preferred over interchangeable language."""
     assert language.matches(
         "he",
         ["en-US", "en-GB", "iw", "he"],

--- a/tests/util/test_logging.py
+++ b/tests/util/test_logging.py
@@ -208,7 +208,8 @@ async def test_noisy_loggers(
     )
     assert (
         caplog.text.count(
-            "Module noisy2.module is logging too frequently. 5 messages since last count"
+            "Module noisy2.module is logging too frequently."
+            " 5 messages since last count"
         )
         == logger2_expected_notices
     )
@@ -226,7 +227,7 @@ async def test_noisy_loggers(
 async def test_noisy_loggers_ignores_self(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test that the noisy loggers warning does not trigger a warning for its own module."""
+    """Test noisy loggers warning doesn't trigger for its own module."""
 
     logging_util.async_activate_log_queue_handler(hass)
     logger1 = logging.getLogger("noisy_module1")
@@ -248,7 +249,7 @@ async def test_noisy_loggers_ignores_self(
 async def test_noisy_loggers_ignores_lower_than_info(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test that noisy loggers all logged as warnings, except for levels lower than INFO."""
+    """Test noisy loggers logged as warnings, except levels below INFO."""
 
     logging_util.async_activate_log_queue_handler(hass)
     logger = logging.getLogger("noisy_module")

--- a/tests/util/test_loop.py
+++ b/tests/util/test_loop.py
@@ -43,7 +43,7 @@ def patch_get_current_frame(stack: list[Mock]) -> Generator[None]:
 
 
 async def test_raise_for_blocking_call_async() -> None:
-    """Test raise_for_blocking_call detects when called from event loop without integration context."""
+    """Test raise_for_blocking_call detects without integration context."""
     with pytest.raises(RuntimeError):
         haloop.raise_for_blocking_call(banned_function)
 
@@ -51,7 +51,7 @@ async def test_raise_for_blocking_call_async() -> None:
 async def test_raise_for_blocking_call_async_non_strict_core(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test non_strict_core raise_for_blocking_call detects from event loop without integration context."""
+    """Test non_strict_core raise_for_blocking_call without integration."""
     stack = [
         Mock(
             filename="/home/paulus/homeassistant/core.py",
@@ -108,7 +108,7 @@ async def test_raise_for_blocking_call_async_non_strict_core(
 async def test_raise_for_blocking_call_async_integration(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test raise_for_blocking_call detects and raises when called from event loop from integration context."""
+    """Test raise_for_blocking_call detects and raises from integration context."""
     stack = [
         Mock(
             filename="/home/paulus/homeassistant/core.py",
@@ -148,7 +148,7 @@ async def test_raise_for_blocking_call_async_integration(
 async def test_raise_for_blocking_call_async_integration_non_strict(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test raise_for_blocking_call detects when called from event loop from integration context."""
+    """Test raise_for_blocking_call detects from integration context."""
     stack = [
         Mock(
             filename="/home/paulus/homeassistant/core.py",
@@ -215,7 +215,7 @@ async def test_raise_for_blocking_call_async_integration_non_strict(
 async def test_raise_for_blocking_call_async_custom(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test raise_for_blocking_call detects when called from event loop with custom component context."""
+    """Test raise_for_blocking_call detects from custom component context."""
     stack = [
         Mock(
             filename="/home/paulus/homeassistant/core.py",

--- a/tests/util/test_package.py
+++ b/tests/util/test_package.py
@@ -363,7 +363,10 @@ async def test_async_get_user_site(mock_env_copy) -> None:
 
 async def test_async_get_installed_packages() -> None:
     """Test async get installed packages."""
-    mock_output = b'[{"name": "package1", "version": "1.0.0"}, {"name": "package2", "version": "2.0.0"}]'
+    mock_output = (
+        b'[{"name": "package1", "version": "1.0.0"},'
+        b' {"name": "package2", "version": "2.0.0"}]'
+    )
 
     async_popen = MagicMock()
     async_popen.returncode = 0

--- a/tests/util/test_percentage.py
+++ b/tests/util/test_percentage.py
@@ -103,7 +103,7 @@ async def test_percentage_to_ordered_list_item() -> None:
 
 
 async def test_ranged_value_to_percentage_large() -> None:
-    """Test a large range of low and high values convert a single value to a percentage."""
+    """Test large range low/high values convert a value to a percentage."""
     value_range = (1, 255)
 
     assert ranged_value_to_percentage(value_range, 255) == 100
@@ -113,7 +113,7 @@ async def test_ranged_value_to_percentage_large() -> None:
 
 
 async def test_percentage_to_ranged_value_large() -> None:
-    """Test a large range of low and high values convert a percentage to a single value."""
+    """Test large range low/high values convert a percentage to a value."""
     value_range = (1, 255)
 
     assert percentage_to_ranged_value(value_range, 100) == 255
@@ -126,7 +126,7 @@ async def test_percentage_to_ranged_value_large() -> None:
 
 
 async def test_ranged_value_to_percentage_small() -> None:
-    """Test a small range of low and high values convert a single value to a percentage."""
+    """Test small range low/high values convert a value to a percentage."""
     value_range = (1, 6)
 
     assert ranged_value_to_percentage(value_range, 1) == 16
@@ -138,7 +138,7 @@ async def test_ranged_value_to_percentage_small() -> None:
 
 
 async def test_percentage_to_ranged_value_small() -> None:
-    """Test a small range of low and high values convert a percentage to a single value."""
+    """Test small range low/high values convert a percentage to a value."""
     value_range = (1, 6)
 
     assert math.ceil(percentage_to_ranged_value(value_range, 16)) == 1

--- a/tests/util/test_scaling.py
+++ b/tests/util/test_scaling.py
@@ -22,7 +22,7 @@ from homeassistant.util.percentage import (
 async def test_ranged_value_to_int_range_large(
     input_val: float, output_val: int
 ) -> None:
-    """Test a large range of low and high values convert a single value to a percentage."""
+    """Test large range low/high values convert a value to a percentage."""
     source_range = (1, 255)
     dest_range = (1, 100)
 
@@ -69,7 +69,7 @@ async def test_scale_to_ranged_value_large(
 async def test_scale_ranged_value_to_int_range_small(
     input_val: float, output_val: int
 ) -> None:
-    """Test a small range of low and high values convert a single value to a percentage."""
+    """Test small range low/high values convert a value to a percentage."""
     source_range = (1, 6)
     dest_range = (1, 100)
 

--- a/tests/util/test_timeout.py
+++ b/tests/util/test_timeout.py
@@ -99,7 +99,7 @@ async def test_mix_global_timeout_freeze_and_zone_freeze_inside_executor_job(
 async def test_mix_global_timeout_freeze_and_zone_freeze_different_order(
     hass: HomeAssistant,
 ) -> None:
-    """Test a simple global timeout freeze inside an executor job before timeout was set."""
+    """Test global timeout freeze in executor job before timeout set."""
     timeout = TimeoutManager()
 
     def _some_sync_work():
@@ -131,10 +131,10 @@ async def test_mix_global_timeout_freeze_and_zone_freeze_other_zone_inside_execu
                 await hass.async_add_executor_job(_some_sync_work)
 
 
-async def test_mix_global_timeout_freeze_and_zone_freeze_inside_executor_job_second_job_outside_zone_context(
+async def test_mix_global_timeout_freeze_and_zone_freeze_executor_2nd_outside_zone(
     hass: HomeAssistant,
 ) -> None:
-    """Test a simple global timeout freeze inside an executor job with second job outside of zone context."""
+    """Test global timeout freeze in executor with second job outside zone."""
     timeout = TimeoutManager()
 
     def _some_sync_work():


### PR DESCRIPTION
## Proposed change

Fix all 341 E501 (line too long) violations in test files outside of `tests/components/`: `tests/*.py`, `tests/helpers/`, `tests/util/`, `tests/hassfest/`, and `tests/pylint/`.

Part of a series to enforce the 88-character line length limit across the codebase. Changes are purely cosmetic — rewrapped comments, split long strings, shortened docstrings, and reformatted test data. No logic changes.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr