### PR TITLE
Fix flaky test_template_timeout race condition

### DIFF
--- a/homeassistant/helpers/template/__init__.py
+++ b/homeassistant/helpers/template/__init__.py
@@ -4,6 +4,7 @@ from ast import literal_eval
 import asyncio
 import collections.abc
 from collections.abc import Callable
+import contextlib
 from datetime import timedelta
 from functools import lru_cache, partial
 import logging
@@ -432,7 +433,7 @@ class Template:
             if self._exc_info:
                 raise TemplateError(self._exc_info[1].with_traceback(self._exc_info[2]))
         except TimeoutError:
-            if template_render_thread.is_alive():
+            with contextlib.suppress(ValueError):
                 template_render_thread.raise_exc(TimeoutError)
             return True
         finally:

--- a/homeassistant/util/executor.py
+++ b/homeassistant/util/executor.py
@@ -50,9 +50,9 @@ def join_or_interrupt_threads(
             _log_thread_running_at_shutdown(thread.name, thread.ident)
 
         with contextlib.suppress(SystemError, ValueError):
-            # SystemError at this stage is usually a race condition
-            # where the thread happens to die right before we force
-            # it to raise the exception
+            # SystemError or ValueError at this stage is usually a benign
+            # race condition where the thread dies right before we force
+            # it to raise the exception.
             async_raise(thread.ident, SystemExit)
 
     return joined

--- a/homeassistant/util/executor.py
+++ b/homeassistant/util/executor.py
@@ -49,7 +49,7 @@ def join_or_interrupt_threads(
         if log:
             _log_thread_running_at_shutdown(thread.name, thread.ident)
 
-        with contextlib.suppress(SystemError):
+        with contextlib.suppress(SystemError, ValueError):
             # SystemError at this stage is usually a race condition
             # where the thread happens to die right before we force
             # it to raise the exception

--- a/homeassistant/util/thread.py
+++ b/homeassistant/util/thread.py
@@ -46,6 +46,9 @@ def async_raise(tid: int, exctype: Any) -> None:
     if res == 1:
         return
 
+    if res == 0:
+        raise ValueError("Thread not found")
+
     # "if it returns a number greater than one, you're in trouble,
     # and you should call it again with exc=NULL to revert the effect"
     ctypes.pythonapi.PyThreadState_SetAsyncExc(c_tid, None)

--- a/tests/util/test_thread.py
+++ b/tests/util/test_thread.py
@@ -50,7 +50,7 @@ async def test_thread_fails_raise(hass: HomeAssistant) -> None:
     await asyncio.wait_for(finish_event.wait(), timeout=0.1)
     test_thread.join()
 
-    with pytest.raises(SystemError):
+    with pytest.raises(ValueError, match="Thread not found"):
         test_thread.raise_exc(ValueError)
 
 


### PR DESCRIPTION
## Proposed change

Fix a race condition in `async_raise` / `test_template_timeout` that causes flaky CI failures with `SystemError: PyThreadState_SetAsyncExc failed`.

The root cause: `PyThreadState_SetAsyncExc` returns 0 when the target thread has already exited, but `async_raise` treated both `res == 0` (thread gone) and `res > 1` (multiple threads affected) as the same `SystemError`. With the 1-microsecond timeout in `test_template_timeout`, the render thread can exit between the timeout firing and the `raise_exc` call.

Changes:
- `async_raise` now raises `ValueError("Thread not found")` for `res == 0`, keeping `SystemError` for the truly broken `res > 1` case
- `async_render_will_timeout` suppresses `ValueError` from `raise_exc` since the thread already finishing is a harmless race
- `executor.py` shutdown also suppresses `ValueError` for the same reason

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

Flaky test example: https://github.com/home-assistant/core/actions/runs/25922204459/job/76195010248?pr=170449

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr