### PR TITLE
Fix flaky telegram_bot test timeout in CI

### DIFF
--- a/tests/components/telegram_bot/conftest.py
+++ b/tests/components/telegram_bot/conftest.py
@@ -1,6 +1,6 @@
 """Tests for the telegram_bot integration."""
 
-from collections.abc import AsyncGenerator, Generator
+from collections.abc import Generator
 from datetime import datetime
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -373,13 +373,11 @@ async def webhook_bot(
     mock_register_webhook: None,
     mock_external_calls: None,
     mock_generate_secret_token: str,
-) -> AsyncGenerator[None]:
+) -> None:
     """Fixture for setting up a webhook telegram bot."""
     mock_webhooks_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_webhooks_config_entry.entry_id)
     await hass.async_block_till_done()
-    yield
-    await hass.async_stop()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Breaking change

N/A

## Proposed change

Remove redundant `hass.async_stop()` from the `webhook_bot` test fixture teardown. The `hass` fixture already handles config entry unloading and `async_stop(force=True)` during its own teardown, making the explicit call in `webhook_bot` unnecessary.

The extra `async_stop()` call (without `force=True`) triggered the full HA shutdown sequence with long stage timeouts (20-100s per stage). Under CI load, this could exceed the 9s pytest-timeout, causing:
1. `test_send_message[send_location-input5]` to fail with `Timeout (>9.0s)`
2. `test_send_message_with_inline_keyboard[input0-expected0]` to fail with `RuntimeError: Failed to process thread exception` (cascading from the previous test's teardown)

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr