### PR TITLE
Bump aioesphomeapi to 45.0.1

### DIFF
--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -17,7 +17,7 @@
   "mqtt": ["esphome/discover/#"],
   "quality_scale": "platinum",
   "requirements": [
-    "aioesphomeapi==45.0.0",
+    "aioesphomeapi==45.0.1",
     "esphome-dashboard-api==1.3.0",
     "bleak-esphome==3.7.3"
   ],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -254,7 +254,7 @@ aioelectricitymaps==1.1.1
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==45.0.0
+aioesphomeapi==45.0.1
 
 # homeassistant.components.matrix
 # homeassistant.components.slack

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -245,7 +245,7 @@ aioelectricitymaps==1.1.1
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==45.0.0
+aioesphomeapi==45.0.1
 
 # homeassistant.components.matrix
 # homeassistant.components.slack


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
changelog: https://github.com/esphome/aioesphomeapi/compare/v45.0.0...v45.0.1

This release adds bounds checks for several DoS vectors that a misbehaving or compromised ESPHome device could use to OOM the client process (typically Home Assistant). All three require an established API session — i.e. a device the user has already adopted — but a malicious or buggy peer in that session was previously able to:

- **Stream `CameraImageResponse` chunks indefinitely** or rotate `cam_msg.key` across ~4 billion values to grow the per-subscription reassembly buffer without bound. Affects every install that has an ESPHome camera. Fixed in esphome/aioesphomeapi#1648.
- **Send a `length` varuint of arbitrary size** in plaintext mode (no `noise_psk`), causing the client to buffer up to that many bytes — easy multi-GiB allocation — or stream `\x80\x80…` indefinitely with no terminator, growing the receive buffer and forcing repeated O(N²) bigint shifts on every `data_received`. The noise path was incidentally protected by its fixed 16-bit length header; plaintext had no equivalent cap. Fixed in esphome/aioesphomeapi#1651.
- **Send `msg_type=0`**, which silently routed the payload to the last registered protobuf class instead of dropping it as an unknown message type. Low impact in practice (the connection drops anyway when the parse fails) but a footgun for future code. Fixed in esphome/aioesphomeapi#1645.

Threat model is "adopted device misbehaves," not a remote unauthenticated attack. Plaintext-mode users should upgrade preferentially since esphome/aioesphomeapi#1651 lowers the bar to "anyone who can reach the device on the LAN" (no `noise_psk` means no auth on the wire and a network attacker can MITM).



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
