### PR TITLE
Add helper base classes for infrared consumers

### DIFF
--- a/homeassistant/components/infrared/__init__.py
+++ b/homeassistant/components/infrared/__init__.py
@@ -20,7 +20,12 @@ from .entity import (  # noqa: F401
     InfraredReceiverEntity,
     InfraredReceiverEntityDescription,
 )
-from .helpers import InfraredEmitterConsumerEntity, InfraredReceiverConsumerEntity
+from .helpers import (
+    InfraredEmitterConsumerEntity,
+    InfraredReceiverConsumerEntity,
+    async_send_command,
+    async_subscribe_receiver,
+)
 
 __all__ = [
     "DOMAIN",

--- a/homeassistant/components/infrared/__init__.py
+++ b/homeassistant/components/infrared/__init__.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import DATA_COMPONENT, DOMAIN
 from .entity import (  # noqa: F401
+    InfraredCommand,
     InfraredDeviceClass,
     InfraredEmitterEntity,
     InfraredEmitterEntityDescription,
@@ -29,6 +30,7 @@ from .helpers import (
 
 __all__ = [
     "DOMAIN",
+    "InfraredCommand",
     "InfraredEmitterConsumerEntity",
     "InfraredEmitterEntity",
     "InfraredEmitterEntityDescription",

--- a/homeassistant/components/infrared/__init__.py
+++ b/homeassistant/components/infrared/__init__.py
@@ -1,21 +1,15 @@
 """Provides functionality to interact with infrared devices."""
 
-from collections.abc import Callable
 from datetime import timedelta
 import logging
 
-from infrared_protocols.commands import Command as InfraredCommand
-import voluptuous as vol
-
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import CALLBACK_TYPE, Context, HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.util.hass_dict import HassKey
 
-from .const import DOMAIN
+from .const import DATA_COMPONENT, DOMAIN
 from .entity import (  # noqa: F401
     InfraredDeviceClass,
     InfraredEmitterEntity,
@@ -26,14 +20,17 @@ from .entity import (  # noqa: F401
     InfraredReceiverEntity,
     InfraredReceiverEntityDescription,
 )
+from .helpers import InfraredEmitterConsumerEntity, InfraredReceiverConsumerEntity
 
 __all__ = [
     "DOMAIN",
+    "InfraredEmitterConsumerEntity",
     "InfraredEmitterEntity",
     "InfraredEmitterEntityDescription",
     "InfraredEntity",
     "InfraredEntityDescription",
     "InfraredReceivedSignal",
+    "InfraredReceiverConsumerEntity",
     "InfraredReceiverEntity",
     "InfraredReceiverEntityDescription",
     "async_get_emitters",
@@ -45,9 +42,6 @@ __all__ = [
 
 _LOGGER = logging.getLogger(__name__)
 
-DATA_COMPONENT: HassKey[
-    EntityComponent[InfraredEmitterEntity | InfraredReceiverEntity]
-] = HassKey(DOMAIN)
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
 PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA
 PLATFORM_SCHEMA_BASE = cv.PLATFORM_SCHEMA_BASE
@@ -100,76 +94,3 @@ def async_get_receivers(hass: HomeAssistant) -> list[str]:
         for entity in component.entities
         if isinstance(entity, InfraredReceiverEntity)
     ]
-
-
-async def async_send_command(
-    hass: HomeAssistant,
-    entity_id_or_uuid: str,
-    command: InfraredCommand,
-    context: Context | None = None,
-) -> None:
-    """Send an IR command to the specified infrared entity.
-
-    Raises:
-        HomeAssistantError: If the infrared entity is not found.
-    """
-    component = hass.data.get(DATA_COMPONENT)
-    if component is None:
-        raise HomeAssistantError(
-            translation_domain=DOMAIN,
-            translation_key="component_not_loaded",
-        )
-
-    ent_reg = er.async_get(hass)
-    entity_id = er.async_validate_entity_id(ent_reg, entity_id_or_uuid)
-    entity = component.get_entity(entity_id)
-    if entity is None or not isinstance(entity, InfraredEmitterEntity):
-        raise HomeAssistantError(
-            translation_domain=DOMAIN,
-            translation_key="entity_not_found",
-            translation_placeholders={"entity_id": entity_id},
-        )
-
-    if context is not None:
-        entity.async_set_context(context)
-
-    await entity.async_send_command_internal(command)
-
-
-@callback
-def async_subscribe_receiver(
-    hass: HomeAssistant,
-    entity_id_or_uuid: str,
-    signal_callback: Callable[[InfraredReceivedSignal], None],
-) -> CALLBACK_TYPE:
-    """Subscribe to IR signals from a specific receiver entity.
-
-    Raises:
-        HomeAssistantError: If the receiver entity is not found.
-    """
-    component = hass.data.get(DATA_COMPONENT)
-    if component is None:
-        raise HomeAssistantError(
-            translation_domain=DOMAIN,
-            translation_key="component_not_loaded",
-        )
-
-    ent_reg = er.async_get(hass)
-    try:
-        entity_id = er.async_validate_entity_id(ent_reg, entity_id_or_uuid)
-    except vol.Invalid as err:
-        raise HomeAssistantError(
-            translation_domain=DOMAIN,
-            translation_key="receiver_not_found",
-            translation_placeholders={"entity_id": entity_id_or_uuid},
-        ) from err
-
-    entity = component.get_entity(entity_id)
-    if entity is None or not isinstance(entity, InfraredReceiverEntity):
-        raise HomeAssistantError(
-            translation_domain=DOMAIN,
-            translation_key="receiver_not_found",
-            translation_placeholders={"entity_id": entity_id},
-        )
-
-    return entity.async_subscribe_received_signal(signal_callback)

--- a/homeassistant/components/infrared/const.py
+++ b/homeassistant/components/infrared/const.py
@@ -2,4 +2,12 @@
 
 from typing import Final
 
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.util.hass_dict import HassKey
+
+from .entity import InfraredEmitterEntity, InfraredReceiverEntity
+
 DOMAIN: Final = "infrared"
+DATA_COMPONENT: HassKey[
+    EntityComponent[InfraredEmitterEntity | InfraredReceiverEntity]
+] = HassKey(DOMAIN)

--- a/homeassistant/components/infrared/helpers.py
+++ b/homeassistant/components/infrared/helpers.py
@@ -1,0 +1,232 @@
+"""Helper base entities for integrations that consume infrared emitters/receivers."""
+
+from abc import abstractmethod
+from collections.abc import Callable
+import logging
+
+from infrared_protocols.commands import Command as InfraredCommand
+import voluptuous as vol
+
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import (
+    CALLBACK_TYPE,
+    Context,
+    Event,
+    EventStateChangedData,
+    HomeAssistant,
+    callback,
+)
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.event import async_track_state_change_event
+
+from .const import DATA_COMPONENT, DOMAIN
+from .entity import (
+    InfraredEmitterEntity,
+    InfraredReceivedSignal,
+    InfraredReceiverEntity,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_send_command(
+    hass: HomeAssistant,
+    entity_id_or_uuid: str,
+    command: InfraredCommand,
+    context: Context | None = None,
+) -> None:
+    """Send an IR command to the specified infrared entity.
+
+    Raises:
+        HomeAssistantError: If the infrared entity is not found.
+    """
+    component = hass.data.get(DATA_COMPONENT)
+    if component is None:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="component_not_loaded",
+        )
+
+    ent_reg = er.async_get(hass)
+    entity_id = er.async_validate_entity_id(ent_reg, entity_id_or_uuid)
+    entity = component.get_entity(entity_id)
+    if entity is None or not isinstance(entity, InfraredEmitterEntity):
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="entity_not_found",
+            translation_placeholders={"entity_id": entity_id},
+        )
+
+    if context is not None:
+        entity.async_set_context(context)
+
+    await entity.async_send_command_internal(command)
+
+
+@callback
+def async_subscribe_receiver(
+    hass: HomeAssistant,
+    entity_id_or_uuid: str,
+    signal_callback: Callable[[InfraredReceivedSignal], None],
+) -> CALLBACK_TYPE:
+    """Subscribe to IR signals from a specific receiver entity.
+
+    Raises:
+        HomeAssistantError: If the receiver entity is not found.
+    """
+    component = hass.data.get(DATA_COMPONENT)
+    if component is None:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="component_not_loaded",
+        )
+
+    ent_reg = er.async_get(hass)
+    try:
+        entity_id = er.async_validate_entity_id(ent_reg, entity_id_or_uuid)
+    except vol.Invalid as err:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="receiver_not_found",
+            translation_placeholders={"entity_id": entity_id_or_uuid},
+        ) from err
+
+    entity = component.get_entity(entity_id)
+    if entity is None or not isinstance(entity, InfraredReceiverEntity):
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="receiver_not_found",
+            translation_placeholders={"entity_id": entity_id},
+        )
+
+    return entity.async_subscribe_received_signal(signal_callback)
+
+
+class InfraredEmitterConsumerEntity(Entity):
+    """Base entity for integrations that send commands via an infrared emitter.
+
+    Tracks the availability of the underlying infrared emitter entity.
+    """
+
+    _attr_should_poll = False
+    _infrared_emitter_entity_id: str
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to infrared entity state changes."""
+        await super().async_added_to_hass()
+
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass,
+                [self._infrared_emitter_entity_id],
+                self._async_ir_state_changed,
+            )
+        )
+
+        # Set initial availability based on current infrared entity state
+        ir_state = self.hass.states.get(self._infrared_emitter_entity_id)
+        self._attr_available = (
+            ir_state is not None and ir_state.state != STATE_UNAVAILABLE
+        )
+
+    async def _send_command(self, command: InfraredCommand) -> None:
+        """Send an IR command through the infrared emitter entity."""
+        await async_send_command(
+            self.hass, self._infrared_emitter_entity_id, command, context=self._context
+        )
+
+    @callback
+    def _async_ir_state_changed(self, event: Event[EventStateChangedData]) -> None:
+        """Handle infrared entity state changes."""
+        new_state = event.data["new_state"]
+        ir_available = new_state is not None and new_state.state != STATE_UNAVAILABLE
+        if ir_available != self.available:
+            _LOGGER.info(
+                "Infrared entity %s used by %s is %s",
+                self._infrared_emitter_entity_id,
+                self.entity_id,
+                "available" if ir_available else "unavailable",
+            )
+
+            self._attr_available = ir_available
+            self.async_write_ha_state()
+
+
+class InfraredReceiverConsumerEntity(Entity):
+    """Base entity for integrations that consume signals from an infrared receiver.
+
+    Tracks the availability of the underlying infrared receiver entity and
+    manages the subscription to received IR signals.
+    """
+
+    _attr_should_poll = False
+    _infrared_receiver_entity_id: str
+    _remove_signal_subscription: CALLBACK_TYPE | None = None
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to infrared entity state changes and receiver signals."""
+        await super().async_added_to_hass()
+
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass,
+                [self._infrared_receiver_entity_id],
+                self._async_ir_state_changed,
+            )
+        )
+
+        # Set initial availability based on current infrared entity state
+        ir_state = self.hass.states.get(self._infrared_receiver_entity_id)
+        self._attr_available = (
+            ir_state is not None and ir_state.state != STATE_UNAVAILABLE
+        )
+
+        self._async_update_receiver_subscription()
+        self.async_on_remove(self._async_unsubscribe_receiver)
+
+    @abstractmethod
+    @callback
+    def _handle_signal(self, signal: InfraredReceivedSignal) -> None:
+        """Handle a received IR signal."""
+
+    @callback
+    def _async_unsubscribe_receiver(self) -> None:
+        """Unsubscribe from the current IR receiver."""
+        if self._remove_signal_subscription is None:
+            return
+        self._remove_signal_subscription()
+        self._remove_signal_subscription = None
+
+    @callback
+    def _async_update_receiver_subscription(self) -> None:
+        """Update the IR receiver subscription when availability changes."""
+        if not self.available:
+            self._async_unsubscribe_receiver()
+        elif self._remove_signal_subscription is None:
+            _LOGGER.debug(
+                "Subscribing to infrared receiver entity %s for %s",
+                self._infrared_receiver_entity_id,
+                self.entity_id,
+            )
+            self._remove_signal_subscription = async_subscribe_receiver(
+                self.hass, self._infrared_receiver_entity_id, self._handle_signal
+            )
+
+    @callback
+    def _async_ir_state_changed(self, event: Event[EventStateChangedData]) -> None:
+        """Handle infrared entity state changes."""
+        new_state = event.data["new_state"]
+        ir_available = new_state is not None and new_state.state != STATE_UNAVAILABLE
+        if ir_available != self.available:
+            _LOGGER.info(
+                "Infrared entity %s used by %s is %s",
+                self._infrared_receiver_entity_id,
+                self.entity_id,
+                "available" if ir_available else "unavailable",
+            )
+            self._attr_available = ir_available
+            self.async_write_ha_state()
+
+        self._async_update_receiver_subscription()

--- a/homeassistant/components/infrared/helpers.py
+++ b/homeassistant/components/infrared/helpers.py
@@ -186,8 +186,8 @@ class InfraredReceiverConsumerEntity(Entity):
         self._async_update_receiver_subscription()
         self.async_on_remove(self._async_unsubscribe_receiver)
 
-    @abstractmethod
     @callback
+    @abstractmethod
     def _handle_signal(self, signal: InfraredReceivedSignal) -> None:
         """Handle a received IR signal."""
 

--- a/homeassistant/components/kitchen_sink/event.py
+++ b/homeassistant/components/kitchen_sink/event.py
@@ -5,20 +5,12 @@ from infrared_protocols.commands.nec import NECCommand
 from homeassistant.components.event import EventEntity
 from homeassistant.components.infrared import (
     InfraredReceivedSignal,
-    async_subscribe_receiver,
+    InfraredReceiverConsumerEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_UNAVAILABLE
-from homeassistant.core import (
-    CALLBACK_TYPE,
-    Event,
-    EventStateChangedData,
-    HomeAssistant,
-    callback,
-)
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.event import async_track_state_change_event
 
 from .const import (
     CONF_INFRARED_RECEIVER_ENTITY_ID,
@@ -67,85 +59,31 @@ async def async_setup_entry(
         )
 
 
-class DemoInfraredEvent(EventEntity):
+class DemoInfraredEvent(InfraredReceiverConsumerEntity, EventEntity):
     """Representation of a demo infrared event entity."""
 
     _attr_has_entity_name = True
     _attr_name = "Received IR Event"
-    _attr_should_poll = False
     _attr_event_types = list(COMMAND_EVENTS.values())
 
     def __init__(
         self, subentry_id: str, device_name: str, infrared_receiver_entity_id: str
     ) -> None:
         """Initialize the demo infrared event entity."""
-        self._receiver_entity_id = infrared_receiver_entity_id
+        self._infrared_receiver_entity_id = infrared_receiver_entity_id
         self._attr_unique_id = subentry_id
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, subentry_id)}, name=device_name
         )
 
-    async def async_added_to_hass(self) -> None:
-        """Subscribe to the IR receiver when added to hass."""
-        await super().async_added_to_hass()
-
-        @callback
-        def _handle_signal(signal: InfraredReceivedSignal) -> None:
-            """Handle a received IR signal."""
-            command = NECCommand.from_raw_timings(signal.timings)
-            if command is None or command.address != INFRARED_FAN_ADDRESS:
-                return
-            event_type = COMMAND_EVENTS.get(command.command)
-            if event_type is None:
-                return
-            self._trigger_event(event_type, {"raw_code": signal.timings})
-            self.async_write_ha_state()
-
-        remove_signal_subscription: CALLBACK_TYPE | None = None
-
-        @callback
-        def _async_unsubscribe_receiver() -> None:
-            """Unsubscribe from the current IR receiver."""
-            nonlocal remove_signal_subscription
-
-            if remove_signal_subscription is None:
-                return
-            remove_signal_subscription()
-            remove_signal_subscription = None
-
-        @callback
-        def _async_update_receiver_subscription(write_state: bool = True) -> None:
-            """Update the IR receiver subscription when availability changes."""
-            nonlocal remove_signal_subscription
-
-            ir_state = self.hass.states.get(self._receiver_entity_id)
-            receiver_available = (
-                ir_state is not None and ir_state.state != STATE_UNAVAILABLE
-            )
-
-            if not receiver_available:
-                _async_unsubscribe_receiver()
-            elif remove_signal_subscription is None:
-                remove_signal_subscription = async_subscribe_receiver(
-                    self.hass, self._receiver_entity_id, _handle_signal
-                )
-
-            if self._attr_available == receiver_available:
-                return
-
-            self._attr_available = receiver_available
-            if write_state:
-                self.async_write_ha_state()
-
-        @callback
-        def _async_ir_state_changed(event: Event[EventStateChangedData]) -> None:
-            """Handle infrared entity state changes."""
-            _async_update_receiver_subscription()
-
-        _async_update_receiver_subscription(write_state=False)
-        self.async_on_remove(_async_unsubscribe_receiver)
-        self.async_on_remove(
-            async_track_state_change_event(
-                self.hass, [self._receiver_entity_id], _async_ir_state_changed
-            )
-        )
+    @callback
+    def _handle_signal(self, signal: InfraredReceivedSignal) -> None:
+        """Handle a received IR signal."""
+        command = NECCommand.from_raw_timings(signal.timings)
+        if command is None or command.address != INFRARED_FAN_ADDRESS:
+            return
+        event_type = COMMAND_EVENTS.get(command.command)
+        if event_type is None:
+            return
+        self._trigger_event(event_type, {"raw_code": signal.timings})
+        self.async_write_ha_state()

--- a/homeassistant/components/kitchen_sink/fan.py
+++ b/homeassistant/components/kitchen_sink/fan.py
@@ -5,13 +5,11 @@ from typing import Any
 from infrared_protocols.commands.nec import NECCommand
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
-from homeassistant.components.infrared import async_send_command
+from homeassistant.components.infrared import InfraredEmitterConsumerEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_UNAVAILABLE
-from homeassistant.core import Event, EventStateChangedData, HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.event import async_track_state_change_event
 
 from .const import (
     CONF_INFRARED_ENTITY_ID,
@@ -50,12 +48,11 @@ async def async_setup_entry(
         )
 
 
-class DemoInfraredFan(FanEntity):
+class DemoInfraredFan(InfraredEmitterConsumerEntity, FanEntity):
     """Representation of a demo infrared fan entity."""
 
     _attr_has_entity_name = True
     _attr_name = None
-    _attr_should_poll = False
     _attr_assumed_state = True
     _attr_speed_count = 3
     _attr_supported_features = (
@@ -71,7 +68,7 @@ class DemoInfraredFan(FanEntity):
         infrared_entity_id: str,
     ) -> None:
         """Initialize the demo infrared fan entity."""
-        self._infrared_entity_id = infrared_entity_id
+        self._infrared_emitter_entity_id = infrared_entity_id
         self._attr_unique_id = subentry_id
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, subentry_id)},
@@ -79,40 +76,14 @@ class DemoInfraredFan(FanEntity):
         )
         self._attr_percentage = 0
 
-    async def async_added_to_hass(self) -> None:
-        """Subscribe to infrared entity state changes."""
-        await super().async_added_to_hass()
-
-        @callback
-        def _async_ir_state_changed(event: Event[EventStateChangedData]) -> None:
-            """Handle infrared entity state changes."""
-            new_state = event.data["new_state"]
-            self._attr_available = (
-                new_state is not None and new_state.state != STATE_UNAVAILABLE
-            )
-            self.async_write_ha_state()
-
-        self.async_on_remove(
-            async_track_state_change_event(
-                self.hass, [self._infrared_entity_id], _async_ir_state_changed
-            )
-        )
-
-        # Set initial availability based on current infrared entity state
-        ir_state = self.hass.states.get(self._infrared_entity_id)
-        self._attr_available = (
-            ir_state is not None and ir_state.state != STATE_UNAVAILABLE
-        )
-
-    async def _send_command(self, command_code: int) -> None:
+    async def _send_fan_command(self, command_code: int) -> None:
         """Send an IR command using the NEC protocol."""
-        command = NECCommand(
-            address=INFRARED_FAN_ADDRESS,
-            command=command_code,
-            modulation=38000,
-        )
-        await async_send_command(
-            self.hass, self._infrared_entity_id, command, context=self._context
+        await self._send_command(
+            NECCommand(
+                address=INFRARED_FAN_ADDRESS,
+                command=command_code,
+                modulation=38000,
+            )
         )
 
     async def async_turn_on(
@@ -125,13 +96,13 @@ class DemoInfraredFan(FanEntity):
         if percentage is not None:
             await self.async_set_percentage(percentage)
             return
-        await self._send_command(INFRARED_CMD_POWER_ON)
+        await self._send_fan_command(INFRARED_CMD_POWER_ON)
         self._attr_percentage = 33
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the fan."""
-        await self._send_command(INFRARED_CMD_POWER_OFF)
+        await self._send_fan_command(INFRARED_CMD_POWER_OFF)
         self._attr_percentage = 0
         self.async_write_ha_state()
 
@@ -142,10 +113,10 @@ class DemoInfraredFan(FanEntity):
             return
 
         if percentage <= 33:
-            await self._send_command(INFRARED_CMD_SPEED_LOW)
+            await self._send_fan_command(INFRARED_CMD_SPEED_LOW)
         elif percentage <= 66:
-            await self._send_command(INFRARED_CMD_SPEED_MEDIUM)
+            await self._send_fan_command(INFRARED_CMD_SPEED_MEDIUM)
         else:
-            await self._send_command(INFRARED_CMD_SPEED_HIGH)
+            await self._send_fan_command(INFRARED_CMD_SPEED_HIGH)
         self._attr_percentage = percentage
         self.async_write_ha_state()

--- a/homeassistant/components/kitchen_sink/fan.py
+++ b/homeassistant/components/kitchen_sink/fan.py
@@ -41,7 +41,7 @@ async def async_setup_entry(
                 DemoInfraredFan(
                     subentry_id=subentry_id,
                     device_name=subentry.title,
-                    infrared_entity_id=subentry.data[CONF_INFRARED_ENTITY_ID],
+                    infrared_emitter_entity_id=subentry.data[CONF_INFRARED_ENTITY_ID],
                 )
             ],
             config_subentry_id=subentry_id,
@@ -65,10 +65,10 @@ class DemoInfraredFan(InfraredEmitterConsumerEntity, FanEntity):
         self,
         subentry_id: str,
         device_name: str,
-        infrared_entity_id: str,
+        infrared_emitter_entity_id: str,
     ) -> None:
         """Initialize the demo infrared fan entity."""
-        self._infrared_emitter_entity_id = infrared_entity_id
+        self._infrared_emitter_entity_id = infrared_emitter_entity_id
         self._attr_unique_id = subentry_id
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, subentry_id)},

--- a/homeassistant/components/lg_infrared/button.py
+++ b/homeassistant/components/lg_infrared/button.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from infrared_protocols.codes.lg.tv import LGTVCode
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.components.infrared import InfraredEmitterConsumerEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -130,7 +131,7 @@ async def async_setup_entry(
         )
 
 
-class LgIrButton(LgIrEntity, ButtonEntity):
+class LgIrButton(LgIrEntity, InfraredEmitterConsumerEntity, ButtonEntity):
     """LG IR button entity."""
 
     entity_description: LgIrButtonEntityDescription
@@ -142,9 +143,10 @@ class LgIrButton(LgIrEntity, ButtonEntity):
         description: LgIrButtonEntityDescription,
     ) -> None:
         """Initialize LG IR button."""
-        super().__init__(entry, infrared_entity_id, unique_id_suffix=description.key)
+        super().__init__(entry, unique_id_suffix=description.key)
+        self._infrared_emitter_entity_id = infrared_entity_id
         self.entity_description = description
 
     async def async_press(self) -> None:
         """Press the button."""
-        await self._send_command(self.entity_description.command_code)
+        await self._send_command(self.entity_description.command_code.to_command())

--- a/homeassistant/components/lg_infrared/entity.py
+++ b/homeassistant/components/lg_infrared/entity.py
@@ -1,75 +1,20 @@
 """Common entity for LG IR integration."""
 
-import logging
-
-from infrared_protocols.codes.lg.tv import LGTVCode
-
-from homeassistant.components.infrared import async_send_command
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_UNAVAILABLE
-from homeassistant.core import Event, EventStateChangedData, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.event import async_track_state_change_event
 
 from .const import DOMAIN
 
-_LOGGER = logging.getLogger(__name__)
-
 
 class LgIrEntity(Entity):
-    """LG IR base entity."""
+    """LG IR base entity providing common device info."""
 
     _attr_has_entity_name = True
-    _attr_should_poll = False
 
-    def __init__(
-        self, entry: ConfigEntry, infrared_entity_id: str, unique_id_suffix: str
-    ) -> None:
+    def __init__(self, entry: ConfigEntry, unique_id_suffix: str) -> None:
         """Initialize LG IR entity."""
-        self._infrared_entity_id = infrared_entity_id
         self._attr_unique_id = f"{entry.entry_id}_{unique_id_suffix}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry.entry_id)}, name="LG TV", manufacturer="LG"
         )
-
-    async def async_added_to_hass(self) -> None:
-        """Subscribe to infrared entity state changes."""
-        await super().async_added_to_hass()
-
-        self.async_on_remove(
-            async_track_state_change_event(
-                self.hass, [self._infrared_entity_id], self._async_ir_state_changed
-            )
-        )
-
-        # Set initial availability based on current infrared entity state
-        ir_state = self.hass.states.get(self._infrared_entity_id)
-        self._attr_available = (
-            ir_state is not None and ir_state.state != STATE_UNAVAILABLE
-        )
-
-    async def _send_command(self, code: LGTVCode) -> None:
-        """Send an IR command using the LG protocol."""
-        await async_send_command(
-            self.hass,
-            self._infrared_entity_id,
-            code.to_command(),
-            context=self._context,
-        )
-
-    @callback
-    def _async_ir_state_changed(self, event: Event[EventStateChangedData]) -> None:
-        """Handle infrared entity state changes."""
-        new_state = event.data["new_state"]
-        ir_available = new_state is not None and new_state.state != STATE_UNAVAILABLE
-        if ir_available != self.available:
-            _LOGGER.info(
-                "Infrared entity %s used by %s is %s",
-                self._infrared_entity_id,
-                self.entity_id,
-                "available" if ir_available else "unavailable",
-            )
-
-            self._attr_available = ir_available
-            self.async_write_ha_state()

--- a/homeassistant/components/lg_infrared/event.py
+++ b/homeassistant/components/lg_infrared/event.py
@@ -1,7 +1,6 @@
 """Event platform for LG IR integration."""
 
 import logging
-from typing import override
 
 from infrared_protocols.codes.lg.tv import LG_ADDRESS, LGTVCode
 from infrared_protocols.commands.nec import NECCommand
@@ -9,16 +8,10 @@ from infrared_protocols.commands.nec import NECCommand
 from homeassistant.components.event import EventEntity
 from homeassistant.components.infrared import (
     InfraredReceivedSignal,
-    async_subscribe_receiver,
+    InfraredReceiverConsumerEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import (
-    CALLBACK_TYPE,
-    Event,
-    EventStateChangedData,
-    HomeAssistant,
-    callback,
-)
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import CONF_DEVICE_TYPE, CONF_INFRARED_RECEIVER_ENTITY_ID, LGDeviceType
@@ -98,27 +91,16 @@ async def async_setup_entry(
     async_add_entities([LgIrReceivedCommandEvent(entry, receiver_entity_id)])
 
 
-class LgIrReceivedCommandEvent(LgIrEntity, EventEntity):
+class LgIrReceivedCommandEvent(LgIrEntity, InfraredReceiverConsumerEntity, EventEntity):
     """Event entity that fires when an LG TV IR command is received."""
 
     _attr_translation_key = "received_command"
     _attr_event_types = _EVENT_TYPES
 
-    def __init__(
-        self,
-        entry: ConfigEntry,
-        receiver_entity_id: str,
-    ) -> None:
+    def __init__(self, entry: ConfigEntry, receiver_entity_id: str) -> None:
         """Initialize the event entity."""
-        super().__init__(entry, receiver_entity_id, unique_id_suffix="received_command")
-        self._remove_signal_subscription: CALLBACK_TYPE | None = None
-
-    async def async_added_to_hass(self) -> None:
-        """Subscribe to the IR receiver when added to hass."""
-        await super().async_added_to_hass()
-
-        self._async_update_receiver_subscription()
-        self.async_on_remove(self._async_unsubscribe_receiver)
+        super().__init__(entry, unique_id_suffix="received_command")
+        self._infrared_receiver_entity_id = receiver_entity_id
 
     @callback
     def _handle_signal(self, signal: InfraredReceivedSignal) -> None:
@@ -133,8 +115,6 @@ class LgIrReceivedCommandEvent(LgIrEntity, EventEntity):
         try:
             command_code = LGTVCode(nec_command.command)
         except ValueError:
-            # Ensure that a future change to the LGTVCode enum doesn't break this and
-            # shows as unknown
             event_type = _EVENT_TYPE_UNKNOWN
         else:
             event_type = _COMMAND_CODE_TO_EVENT_TYPE.get(
@@ -147,33 +127,3 @@ class LgIrReceivedCommandEvent(LgIrEntity, EventEntity):
 
         self._trigger_event(event_type)
         self.async_write_ha_state()
-
-    @callback
-    def _async_unsubscribe_receiver(self) -> None:
-        """Unsubscribe from the current IR receiver."""
-        if self._remove_signal_subscription is None:
-            return
-        self._remove_signal_subscription()
-        self._remove_signal_subscription = None
-
-    @callback
-    def _async_update_receiver_subscription(self) -> None:
-        """Update the IR receiver subscription when availability changes."""
-        if not self.available:
-            self._async_unsubscribe_receiver()
-        elif self._remove_signal_subscription is None:
-            _LOGGER.debug(
-                "Subscribing to infrared receiver entity %s for %s",
-                self._infrared_entity_id,
-                self.entity_id,
-            )
-            self._remove_signal_subscription = async_subscribe_receiver(
-                self.hass, self._infrared_entity_id, self._handle_signal
-            )
-
-    @override
-    @callback
-    def _async_ir_state_changed(self, event: Event[EventStateChangedData]) -> None:
-        """Handle infrared entity state changes."""
-        super()._async_ir_state_changed(event)
-        self._async_update_receiver_subscription()

--- a/homeassistant/components/lg_infrared/media_player.py
+++ b/homeassistant/components/lg_infrared/media_player.py
@@ -2,6 +2,7 @@
 
 from infrared_protocols.codes.lg.tv import LGTVCode
 
+from homeassistant.components.infrared import InfraredEmitterConsumerEntity
 from homeassistant.components.media_player import (
     MediaPlayerDeviceClass,
     MediaPlayerEntity,
@@ -32,7 +33,7 @@ async def async_setup_entry(
         async_add_entities([LgIrTvMediaPlayer(entry, infrared_entity_id)])
 
 
-class LgIrTvMediaPlayer(LgIrEntity, MediaPlayerEntity):
+class LgIrTvMediaPlayer(LgIrEntity, InfraredEmitterConsumerEntity, MediaPlayerEntity):
     """LG IR media player entity."""
 
     _attr_name = None
@@ -52,45 +53,46 @@ class LgIrTvMediaPlayer(LgIrEntity, MediaPlayerEntity):
 
     def __init__(self, entry: ConfigEntry, infrared_entity_id: str) -> None:
         """Initialize LG IR media player."""
-        super().__init__(entry, infrared_entity_id, unique_id_suffix="media_player")
+        super().__init__(entry, unique_id_suffix="media_player")
+        self._infrared_emitter_entity_id = infrared_entity_id
         self._attr_state = MediaPlayerState.ON
 
     async def async_turn_on(self) -> None:
         """Turn on the TV."""
-        await self._send_command(LGTVCode.POWER_ON)
+        await self._send_command(LGTVCode.POWER_ON.to_command())
 
     async def async_turn_off(self) -> None:
         """Turn off the TV."""
-        await self._send_command(LGTVCode.POWER_OFF)
+        await self._send_command(LGTVCode.POWER_OFF.to_command())
 
     async def async_volume_up(self) -> None:
         """Send volume up command."""
-        await self._send_command(LGTVCode.VOLUME_UP)
+        await self._send_command(LGTVCode.VOLUME_UP.to_command())
 
     async def async_volume_down(self) -> None:
         """Send volume down command."""
-        await self._send_command(LGTVCode.VOLUME_DOWN)
+        await self._send_command(LGTVCode.VOLUME_DOWN.to_command())
 
     async def async_mute_volume(self, mute: bool) -> None:
         """Send mute command."""
-        await self._send_command(LGTVCode.MUTE)
+        await self._send_command(LGTVCode.MUTE.to_command())
 
     async def async_media_next_track(self) -> None:
         """Send channel up command."""
-        await self._send_command(LGTVCode.CHANNEL_UP)
+        await self._send_command(LGTVCode.CHANNEL_UP.to_command())
 
     async def async_media_previous_track(self) -> None:
         """Send channel down command."""
-        await self._send_command(LGTVCode.CHANNEL_DOWN)
+        await self._send_command(LGTVCode.CHANNEL_DOWN.to_command())
 
     async def async_media_play(self) -> None:
         """Send play command."""
-        await self._send_command(LGTVCode.PLAY)
+        await self._send_command(LGTVCode.PLAY.to_command())
 
     async def async_media_pause(self) -> None:
         """Send pause command."""
-        await self._send_command(LGTVCode.PAUSE)
+        await self._send_command(LGTVCode.PAUSE.to_command())
 
     async def async_media_stop(self) -> None:
         """Send stop command."""
-        await self._send_command(LGTVCode.STOP)
+        await self._send_command(LGTVCode.STOP.to_command())

--- a/homeassistant/components/samsung_infrared/entity.py
+++ b/homeassistant/components/samsung_infrared/entity.py
@@ -1,79 +1,22 @@
 """Common entity for Samsung IR integration."""
 
-import logging
-
-from infrared_protocols.codes.samsung.tv import SamsungTVCode
-
-from homeassistant.components.infrared import async_send_command
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_UNAVAILABLE
-from homeassistant.core import Event, EventStateChangedData, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.event import async_track_state_change_event
 
 from .const import DOMAIN
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class SamsungIrEntity(Entity):
     """Samsung IR base entity."""
 
     _attr_has_entity_name = True
-    _attr_should_poll = False
 
-    def __init__(
-        self, entry: ConfigEntry, infrared_emitter_entity_id: str, unique_id_suffix: str
-    ) -> None:
+    def __init__(self, entry: ConfigEntry, unique_id_suffix: str) -> None:
         """Initialize Samsung IR entity."""
-        self._infrared_emitter_entity_id = infrared_emitter_entity_id
         self._attr_unique_id = f"{entry.entry_id}_{unique_id_suffix}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry.entry_id)},
             name="Samsung TV",
             manufacturer="Samsung",
-        )
-
-    async def async_added_to_hass(self) -> None:
-        """Subscribe to infrared entity state changes."""
-        await super().async_added_to_hass()
-
-        @callback
-        def _async_ir_state_changed(event: Event[EventStateChangedData]) -> None:
-            """Handle infrared entity state changes."""
-            new_state = event.data["new_state"]
-            ir_available = (
-                new_state is not None and new_state.state != STATE_UNAVAILABLE
-            )
-            if ir_available != self.available:
-                _LOGGER.info(
-                    "Infrared entity %s used by %s is %s",
-                    self._infrared_emitter_entity_id,
-                    self.entity_id,
-                    "available" if ir_available else "unavailable",
-                )
-
-                self._attr_available = ir_available
-                self.async_write_ha_state()
-
-        self.async_on_remove(
-            async_track_state_change_event(
-                self.hass, [self._infrared_emitter_entity_id], _async_ir_state_changed
-            )
-        )
-
-        # Set initial availability based on current infrared entity state
-        ir_state = self.hass.states.get(self._infrared_emitter_entity_id)
-        self._attr_available = (
-            ir_state is not None and ir_state.state != STATE_UNAVAILABLE
-        )
-
-    async def _send_command(self, code: SamsungTVCode) -> None:
-        """Send an IR command using the Samsung protocol."""
-        await async_send_command(
-            self.hass,
-            self._infrared_emitter_entity_id,
-            code.to_command(),
-            context=self._context,
         )

--- a/homeassistant/components/samsung_infrared/media_player.py
+++ b/homeassistant/components/samsung_infrared/media_player.py
@@ -2,6 +2,7 @@
 
 from infrared_protocols.codes.samsung.tv import SamsungTVCode
 
+from homeassistant.components.infrared import InfraredEmitterConsumerEntity
 from homeassistant.components.media_player import (
     MediaPlayerDeviceClass,
     MediaPlayerEntity,
@@ -30,7 +31,9 @@ async def async_setup_entry(
         async_add_entities([SamsungIrTvMediaPlayer(entry, infrared_emitter_entity_id)])
 
 
-class SamsungIrTvMediaPlayer(SamsungIrEntity, MediaPlayerEntity):
+class SamsungIrTvMediaPlayer(
+    SamsungIrEntity, InfraredEmitterConsumerEntity, MediaPlayerEntity
+):
     """Samsung IR media player entity."""
 
     _attr_name = None
@@ -50,47 +53,46 @@ class SamsungIrTvMediaPlayer(SamsungIrEntity, MediaPlayerEntity):
 
     def __init__(self, entry: ConfigEntry, infrared_emitter_entity_id: str) -> None:
         """Initialize Samsung IR media player."""
-        super().__init__(
-            entry, infrared_emitter_entity_id, unique_id_suffix="media_player"
-        )
+        super().__init__(entry, unique_id_suffix="media_player")
+        self._infrared_emitter_entity_id = infrared_emitter_entity_id
         self._attr_state = MediaPlayerState.ON
 
     async def async_turn_on(self) -> None:
         """Turn on the TV."""
-        await self._send_command(SamsungTVCode.POWER_ON)
+        await self._send_command(SamsungTVCode.POWER_ON.to_command())
 
     async def async_turn_off(self) -> None:
         """Turn off the TV."""
-        await self._send_command(SamsungTVCode.POWER_OFF)
+        await self._send_command(SamsungTVCode.POWER_OFF.to_command())
 
     async def async_volume_up(self) -> None:
         """Send volume up command."""
-        await self._send_command(SamsungTVCode.VOLUME_UP)
+        await self._send_command(SamsungTVCode.VOLUME_UP.to_command())
 
     async def async_volume_down(self) -> None:
         """Send volume down command."""
-        await self._send_command(SamsungTVCode.VOLUME_DOWN)
+        await self._send_command(SamsungTVCode.VOLUME_DOWN.to_command())
 
     async def async_mute_volume(self, mute: bool) -> None:
         """Send mute command."""
-        await self._send_command(SamsungTVCode.MUTE)
+        await self._send_command(SamsungTVCode.MUTE.to_command())
 
     async def async_media_next_track(self) -> None:
         """Send channel up command."""
-        await self._send_command(SamsungTVCode.CHANNEL_UP)
+        await self._send_command(SamsungTVCode.CHANNEL_UP.to_command())
 
     async def async_media_previous_track(self) -> None:
         """Send channel down command."""
-        await self._send_command(SamsungTVCode.CHANNEL_DOWN)
+        await self._send_command(SamsungTVCode.CHANNEL_DOWN.to_command())
 
     async def async_media_play(self) -> None:
         """Send play command."""
-        await self._send_command(SamsungTVCode.PLAY)
+        await self._send_command(SamsungTVCode.PLAY.to_command())
 
     async def async_media_pause(self) -> None:
         """Send pause command."""
-        await self._send_command(SamsungTVCode.PAUSE)
+        await self._send_command(SamsungTVCode.PAUSE.to_command())
 
     async def async_media_stop(self) -> None:
         """Send stop command."""
-        await self._send_command(SamsungTVCode.STOP)
+        await self._send_command(SamsungTVCode.STOP.to_command())

--- a/tests/components/infrared/test_init.py
+++ b/tests/components/infrared/test_init.py
@@ -109,7 +109,7 @@ async def test_async_send_command_entity_not_found(hass: HomeAssistant) -> None:
     """Test async_send_command raises error when entity not found."""
     with pytest.raises(
         HomeAssistantError,
-        match="entity_not_found",
+        match="Infrared entity .+ not found",
     ):
         await async_send_command(hass, "infrared.nonexistent_entity", TEST_COMMAND)
 
@@ -121,7 +121,7 @@ async def test_async_send_command_rejects_receiver(
     """Test async_send_command rejects a receiver entity."""
     with pytest.raises(
         HomeAssistantError,
-        match="entity_not_found",
+        match="Infrared entity .+ not found",
     ):
         await async_send_command(
             hass, mock_infrared_receiver_entity.entity_id, TEST_COMMAND
@@ -262,7 +262,7 @@ async def test_async_subscribe_receiver_not_found(
     """Test async_subscribe_receiver raises when the entity is missing or invalid."""
     with pytest.raises(
         HomeAssistantError,
-        match="receiver_not_found",
+        match="Infrared receiver entity .+ not found",
     ):
         async_subscribe_receiver(hass, entity_id_or_uuid, lambda _: None)
 
@@ -274,7 +274,7 @@ async def test_async_subscribe_receiver_rejects_emitter(
     """Test async_subscribe_receiver rejects an emitter entity."""
     with pytest.raises(
         HomeAssistantError,
-        match="receiver_not_found",
+        match="Infrared receiver entity .+ not found",
     ):
         async_subscribe_receiver(
             hass, mock_infrared_emitter_entity.entity_id, lambda _: None

--- a/tests/components/infrared/test_init.py
+++ b/tests/components/infrared/test_init.py
@@ -109,7 +109,7 @@ async def test_async_send_command_entity_not_found(hass: HomeAssistant) -> None:
     """Test async_send_command raises error when entity not found."""
     with pytest.raises(
         HomeAssistantError,
-        match="Infrared entity `infrared.nonexistent_entity` not found",
+        match="entity_not_found",
     ):
         await async_send_command(hass, "infrared.nonexistent_entity", TEST_COMMAND)
 
@@ -121,7 +121,7 @@ async def test_async_send_command_rejects_receiver(
     """Test async_send_command rejects a receiver entity."""
     with pytest.raises(
         HomeAssistantError,
-        match=f"Infrared entity `{mock_infrared_receiver_entity.entity_id}` not found",
+        match="entity_not_found",
     ):
         await async_send_command(
             hass, mock_infrared_receiver_entity.entity_id, TEST_COMMAND
@@ -262,7 +262,7 @@ async def test_async_subscribe_receiver_not_found(
     """Test async_subscribe_receiver raises when the entity is missing or invalid."""
     with pytest.raises(
         HomeAssistantError,
-        match=f"Infrared receiver entity `{entity_id_or_uuid}` not found",
+        match="receiver_not_found",
     ):
         async_subscribe_receiver(hass, entity_id_or_uuid, lambda _: None)
 
@@ -274,10 +274,7 @@ async def test_async_subscribe_receiver_rejects_emitter(
     """Test async_subscribe_receiver rejects an emitter entity."""
     with pytest.raises(
         HomeAssistantError,
-        match=(
-            f"Infrared receiver entity `{mock_infrared_emitter_entity.entity_id}`"
-            " not found"
-        ),
+        match="receiver_not_found",
     ):
         async_subscribe_receiver(
             hass, mock_infrared_emitter_entity.entity_id, lambda _: None

--- a/tests/components/lg_infrared/conftest.py
+++ b/tests/components/lg_infrared/conftest.py
@@ -57,7 +57,7 @@ def mock_lg_tv_code_to_command() -> Generator[None]:
     rather than the raw NEC timings.
     """
     with patch(
-        "homeassistant.components.lg_infrared.entity.LGTVCode.to_command",
+        "infrared_protocols.codes.lg.tv.LGTVCode.to_command",
         autospec=True,
         side_effect=lambda self, **kwargs: self,
     ):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a first step in making infrared consumer integrations simpler to write.
Moves the common entity code to two new classes in the infrared component, that handle entity availability and subscriptions (for receivers).

In a follow up PR I'll also move related common test code to a common place.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
