### PR TITLE
Bump victron-mqtt to 2026.5.2

### DIFF
--- a/homeassistant/components/victron_gx/manifest.json
+++ b/homeassistant/components/victron_gx/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "quality_scale": "platinum",
-  "requirements": ["victron-mqtt==2026.4.17"],
+  "requirements": ["victron-mqtt==2026.5.2"],
   "ssdp": [
     {
       "X_MqttOnLan": "1",

--- a/homeassistant/components/victron_gx/strings.json
+++ b/homeassistant/components/victron_gx/strings.json
@@ -9,6 +9,7 @@
     "bms_connection_lost": "BMS connection lost",
     "bulk": "Bulk",
     "bulk_time_limit_exceeded": "Bulk time limit exceeded",
+    "charge_current_limit": "Charge current limit",
     "charger_current_reversed": "Charger current reversed",
     "charger_only": "Charger only",
     "charger_over_current": "Charger over current",
@@ -55,6 +56,7 @@
     "no_error": "No error",
     "not_available": "Not available",
     "not_connected": "Not connected",
+    "not_used": "Not used",
     "ok": "Ok",
     "output_apparent_power_phase": "Output apparent power {phase}",
     "output_current_phase": "Output current {phase}",
@@ -76,6 +78,7 @@
     "scheduled_recharging": "Scheduled recharging",
     "self_consumption": "Self-consumption",
     "sensor_battery_voltage": "Sensor battery voltage",
+    "shore": "Shore",
     "shore_power": "Shore power",
     "starting_up": "Starting up",
     "state": "State",
@@ -211,6 +214,9 @@
       "solarcharger_load_state": {
         "name": "Load state"
       },
+      "switch_output_state": {
+        "name": "[%key:component::victron_gx::common::state%]"
+      },
       "system_dynamicess_active": {
         "name": "Dynamic ESS active"
       },
@@ -236,7 +242,7 @@
     },
     "number": {
       "alternator_charge_current_limit": {
-        "name": "Charge current limit"
+        "name": "[%key:component::victron_gx::common::charge_current_limit%]"
       },
       "evcharger_set_current": {
         "name": "Charge current setpoint"
@@ -310,8 +316,14 @@
       "multiplus_assist_current_boost_factor": {
         "name": "Assist current boost factor"
       },
+      "solarcharger_charge_current_limit": {
+        "name": "[%key:component::victron_gx::common::charge_current_limit%]"
+      },
       "switch_output_dimming": {
         "name": "Dimming"
+      },
+      "switch_output_state": {
+        "name": "[%key:component::victron_gx::common::state%]"
       },
       "system_ac_export_limit": {
         "name": "AC export limit"
@@ -387,21 +399,29 @@
           "off": "[%key:common::state::off%]"
         }
       },
-      "system_ess_batterylife_state": {
-        "name": "ESS BatteryLife state",
+      "switch_output_state": {
+        "name": "[%key:component::victron_gx::common::state%]",
         "state": {
-          "keep_batteries_charged": "'Keep batteries charged' mode enabled",
-          "recharge": "Recharge, SoC dropped 5% or more below minimum SoC",
-          "recharge_no_battery_life": "Recharge, SoC dropped 5% or more below minimum SoC (No BatteryLife)",
-          "self_consumption": "[%key:component::victron_gx::common::self_consumption%]",
-          "self_consumption_soc_above_min": "Self-consumption, SoC at or above minimum SoC",
-          "self_consumption_soc_at_100": "Self-consumption, SoC at 100%",
-          "self_consumption_soc_below_min": "Self-consumption, SoC is below minimum SoC",
-          "self_consumption_soc_exceeds_85": "Self-consumption, SoC exceeds 85%",
-          "soc_below_battery_life_dynamic_soc_limit": "SoC below BatteryLife dynamic SoC limit",
-          "soc_below_soc_limit_24_hours": "SoC has been below SoC limit for more than 24 hours. Charging battery with 5 amps",
-          "sustain": "Multi/Quattro is in sustain",
-          "with_battery_life": "Optimized mode with BatteryLife"
+          "off": "[%key:common::state::off%]",
+          "on": "[%key:common::state::on%]"
+        }
+      },
+      "system_ac_input_1_type": {
+        "name": "AC input 1 source type",
+        "state": {
+          "generator": "[%key:component::victron_gx::common::generator%]",
+          "grid": "[%key:component::victron_gx::common::grid%]",
+          "not_used": "[%key:component::victron_gx::common::not_used%]",
+          "shore": "[%key:component::victron_gx::common::shore%]"
+        }
+      },
+      "system_ac_input_2_type": {
+        "name": "AC input 2 source type",
+        "state": {
+          "generator": "[%key:component::victron_gx::common::generator%]",
+          "grid": "[%key:component::victron_gx::common::grid%]",
+          "not_used": "[%key:component::victron_gx::common::not_used%]",
+          "shore": "[%key:component::victron_gx::common::shore%]"
         }
       },
       "system_ess_mode": {
@@ -435,6 +455,15 @@
           "wednesday": "[%key:common::time::wednesday%]",
           "weekdays": "Weekdays",
           "weekends": "Weekends"
+        }
+      },
+      "system_ess_user_mode": {
+        "name": "[%key:component::victron_gx::common::ess_mode%]",
+        "state": {
+          "external_control": "[%key:component::victron_gx::common::external_control%]",
+          "keep_batteries_charged": "Keep batteries charged",
+          "optimized_battery_life": "Optimized (with BatteryLife)",
+          "optimized_no_battery_life": "Optimized (without BatteryLife)"
         }
       },
       "system_settings_dess_mode": {
@@ -706,8 +735,7 @@
         "name": "[%key:component::victron_gx::common::temperature%]"
       },
       "battery_time_since_last_full_charge": {
-        "name": "Time since last full charge",
-        "unit_of_measurement": "seconds"
+        "name": "Time since last full charge"
       },
       "battery_time_to_go": {
         "name": "Time to go"
@@ -1436,6 +1464,13 @@
       "solarcharger_yield_yesterday": {
         "name": "[%key:component::victron_gx::common::yield_yesterday%]"
       },
+      "switch_output_state": {
+        "name": "[%key:component::victron_gx::common::state%]",
+        "state": {
+          "off": "[%key:common::state::off%]",
+          "on": "[%key:common::state::on%]"
+        }
+      },
       "system_ac_active_input_source": {
         "name": "AC active input source",
         "state": {
@@ -1592,6 +1627,23 @@
       },
       "system_dynamicess_target_soc": {
         "name": "Dynamic ESS target SoC"
+      },
+      "system_ess_batterylife_state_sensor": {
+        "name": "ESS BatteryLife state (detailed)",
+        "state": {
+          "keep_batteries_charged": "'Keep batteries charged' mode enabled",
+          "recharge": "Recharge, SoC dropped 5% or more below minimum SoC",
+          "recharge_no_battery_life": "Recharge, SoC dropped 5% or more below minimum SoC (No BatteryLife)",
+          "self_consumption": "[%key:component::victron_gx::common::self_consumption%]",
+          "self_consumption_soc_above_min": "Self-consumption, SoC at or above minimum SoC",
+          "self_consumption_soc_at_100": "Self-consumption, SoC at 100%",
+          "self_consumption_soc_below_min": "Self-consumption, SoC is below minimum SoC",
+          "self_consumption_soc_exceeds_85": "Self-consumption, SoC exceeds 85%",
+          "soc_below_battery_life_dynamic_soc_limit": "SoC below BatteryLife dynamic SoC limit",
+          "soc_below_soc_limit_24_hours": "SoC has been below SoC limit for more than 24 hours. Charging battery with 5 amps",
+          "sustain": "Multi/Quattro is in sustain",
+          "with_battery_life": "Optimized mode with BatteryLife"
+        }
       },
       "system_generator_load_phase": {
         "name": "Genset load {phase}"
@@ -1984,6 +2036,9 @@
       },
       "system_settings_overvoltage_feedin": {
         "name": "PV DC overvoltage feed-in"
+      },
+      "system_settings_prevent_ac_feedin": {
+        "name": "ESS prevent AC feed-in"
       },
       "vebus_device_device_number_power_assist_enabled": {
         "name": "{device_number} PowerAssist enabled"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3279,7 +3279,7 @@ viaggiatreno_ha==0.2.4
 victron-ble-ha-parser==0.7.0
 
 # homeassistant.components.victron_gx
-victron-mqtt==2026.4.17
+victron-mqtt==2026.5.2
 
 # homeassistant.components.victron_remote_monitoring
 victron-vrm==0.1.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2794,7 +2794,7 @@ venstarcolortouch==0.21
 victron-ble-ha-parser==0.7.0
 
 # homeassistant.components.victron_gx
-victron-mqtt==2026.4.17
+victron-mqtt==2026.5.2
 
 # homeassistant.components.victron_remote_monitoring
 victron-vrm==0.1.8


### PR DESCRIPTION
## Proposed change

Bump `victron-mqtt` library from `2026.4.17` to `2026.5.2` for the `victron_gx` integration.

Changes include:
- Update `victron-mqtt` dependency version in `manifest.json`, `requirements_all.txt`, and `requirements_test_all.txt`
- Update entity translations (`strings.json`) from latest topic definitions

Changelog: https://github.com/tomer-w/victron_mqtt/compare/v2026.4.17...v2026.5.2

## Type of change

- [x] Dependency upgrade

## Additional information

- This PR is related to issue:
- Link to documentation pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40m+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr