### PR TITLE
Fix flaky input_datetime tests at date boundaries

### DIFF
--- a/tests/components/input_datetime/test_init.py
+++ b/tests/components/input_datetime/test_init.py
@@ -4,6 +4,7 @@ import datetime
 from typing import Any
 from unittest.mock import patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 import voluptuous as vol
 
@@ -347,7 +348,9 @@ async def test_set_datetime_date(hass: HomeAssistant) -> None:
     assert state.attributes["timestamp"] == date_dt_obj.timestamp()
 
 
-async def test_restore_state(hass: HomeAssistant) -> None:
+async def test_restore_state(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
     """Ensure states are restored on startup."""
     mock_restore_cache(
         hass,
@@ -405,7 +408,9 @@ async def test_restore_state(hass: HomeAssistant) -> None:
     assert state_was_date.state == default.strftime(FORMAT_TIME)
 
 
-async def test_default_value(hass: HomeAssistant) -> None:
+async def test_default_value(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
     """Test default value if none has been set via initial or restore state."""
     await async_setup_component(
         hass,
@@ -463,6 +468,7 @@ async def test_reload(
     entity_registry: er.EntityRegistry,
     hass_admin_user: MockUser,
     hass_read_only_user: MockUser,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test reload service."""
     count_start = len(hass.states.async_entity_ids())

--- a/tests/components/input_datetime/test_init.py
+++ b/tests/components/input_datetime/test_init.py
@@ -364,7 +364,7 @@ async def test_restore_state(hass: HomeAssistant) -> None:
     hass.set_state(CoreState.starting)
 
     initial = datetime.datetime(2017, 1, 1, 23, 42)
-    default = datetime.datetime.combine(datetime.date.today(), DEFAULT_TIME)
+    default = datetime.datetime.combine(dt_util.now().date(), DEFAULT_TIME)
 
     await async_setup_component(
         hass,
@@ -419,7 +419,7 @@ async def test_default_value(hass: HomeAssistant) -> None:
         },
     )
 
-    dt_obj = datetime.datetime.combine(datetime.date.today(), DEFAULT_TIME)
+    dt_obj = datetime.datetime.combine(dt_util.now().date(), DEFAULT_TIME)
     state_time = hass.states.get("input_datetime.test_time")
     assert state_time.state == dt_obj.strftime(FORMAT_TIME)
     assert state_time.attributes.get("timestamp") is not None
@@ -528,7 +528,7 @@ async def test_reload(
     assert state_3 is None
     assert state_1.state == DEFAULT_TIME.strftime(FORMAT_TIME)
     assert state_2.state == datetime.datetime.combine(
-        datetime.date.today(), DEFAULT_TIME
+        dt_util.now().date(), DEFAULT_TIME
     ).strftime(FORMAT_DATETIME)
 
     assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "dt1") == f"{DOMAIN}.dt1"


### PR DESCRIPTION
## Breaking change

_N/A_

## Proposed change

Fix three flaky tests in `input_datetime` (`test_restore_state`, `test_default_value`, `test_reload`) that fail when CI runs around midnight UTC.

The tests used `datetime.date.today()` (system local time) to build expected values, but the production code uses `dt_util.now().date()` (HA timezone-aware). Since the test `hass` fixture sets the timezone to US/Pacific, these dates diverge when UTC has crossed midnight but Pacific hasn't.

The fix replaces `datetime.date.today()` with `dt_util.now().date()` in the three test assertions to match production behavior.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr