### PR TITLE
Fix flaky test_add_event_date_in_x in Google Calendar

### DIFF
--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -538,18 +538,18 @@ async def async_create_event(entity: GoogleCalendarEntity, call: ServiceCall) ->
 
     if EVENT_IN in call.data:
         if EVENT_IN_DAYS in call.data[EVENT_IN]:
-            now = datetime.now().date()
+            today = dt_util.now().date()
 
-            start_in = now + timedelta(days=call.data[EVENT_IN][EVENT_IN_DAYS])
+            start_in = today + timedelta(days=call.data[EVENT_IN][EVENT_IN_DAYS])
             end_in = start_in + timedelta(days=1)
 
             start = DateOrDatetime(date=start_in)
             end = DateOrDatetime(date=end_in)
 
         elif EVENT_IN_WEEKS in call.data[EVENT_IN]:
-            now = datetime.now().date()
+            today = dt_util.now().date()
 
-            start_in = now + timedelta(weeks=call.data[EVENT_IN][EVENT_IN_WEEKS])
+            start_in = today + timedelta(weeks=call.data[EVENT_IN][EVENT_IN_WEEKS])
             end_in = start_in + timedelta(days=1)
 
             start = DateOrDatetime(date=start_in)

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, patch
 import zoneinfo
 
 from aiohttp.client_exceptions import ClientError
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 import voluptuous as vol
 
@@ -449,6 +450,7 @@ async def test_add_event_date_in_x(
     end_timedelta: datetime.timedelta,
     aioclient_mock: AiohttpClientMocker,
     add_event_call_service: Callable[[dict[str, Any]], Awaitable[None]],
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test service call that adds an event with various time ranges."""
 
@@ -456,9 +458,10 @@ async def test_add_event_date_in_x(
     mock_events_list({})
     assert await component_setup()
 
-    now = datetime.datetime.now()
-    start_date = now + start_timedelta
-    end_date = now + end_timedelta
+    freezer.move_to("2025-06-15 08:00:00")
+    today = datetime.date(2025, 6, 15)
+    start_date = today + start_timedelta
+    end_date = today + end_timedelta
 
     aioclient_mock.clear_requests()
     mock_insert_event(
@@ -470,8 +473,8 @@ async def test_add_event_date_in_x(
     assert aioclient_mock.mock_calls[0][2] == {
         "summary": TEST_EVENT_SUMMARY,
         "description": TEST_EVENT_DESCRIPTION,
-        "start": {"date": start_date.date().isoformat()},
-        "end": {"date": end_date.date().isoformat()},
+        "start": {"date": start_date.isoformat()},
+        "end": {"date": end_date.isoformat()},
     }
 
 

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -458,8 +458,11 @@ async def test_add_event_date_in_x(
     mock_events_list({})
     assert await component_setup()
 
-    freezer.move_to("2025-06-15 08:00:00")
-    today = datetime.date(2025, 6, 15)
+    # Freeze at 2025-06-15 03:00 UTC which is 2025-06-14 21:00 in America/Regina
+    # (the test timezone). This ensures dt_util.now().date() returns June 14
+    # while a naive datetime.now().date() would return June 15 in UTC.
+    freezer.move_to("2025-06-15 03:00:00+00:00")
+    today = datetime.date(2025, 6, 14)
     start_date = today + start_timedelta
     end_date = today + end_timedelta
 


### PR DESCRIPTION
## Breaking change

N/A

## Proposed change

Fix flaky `test_add_event_date_in_x` test that fails near date boundaries due to timezone differences between CI and local environments.

The production code in `async_create_event` used bare `datetime.now().date()` (system local time) instead of `dt_util.now().date()` (HA timezone-aware). The test also used `datetime.datetime.now()` without freezing time, so when CI runs in a different timezone than expected, the computed dates differ by one day.

Changes:
- Use `dt_util.now().date()` instead of `datetime.now().date()` in the create event handler so date calculations respect the HA-configured timezone
- Freeze time in the test to a deterministic value, eliminating timezone-dependent flakiness

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Dependency upgrade
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)