### PR TITLE
Pin aiofile to 3.9.0 to fix test collection crash

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -225,6 +225,10 @@ pytest-rerunfailures==16.0.1
 # Fixes detected blocking call to load_default_certs https://github.com/home-assistant/core/issues/157475
 aiomqtt>=2.5.0
 
+# aiofile 3.10.0 crashes on import due to KeyError on package metadata
+# https://github.com/mosquito/aiofile/pull/106
+aiofile!=3.10.0
+
 # auth0-python v5.0 is a major rewrite with breaking changes
 # used by sharkiq==1.5.0
 # https://github.com/auth0/auth0-python/releases/tag/5.0.0

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -227,7 +227,7 @@ aiomqtt>=2.5.0
 
 # aiofile 3.10.0 crashes on import due to KeyError on package metadata
 # https://github.com/mosquito/aiofile/pull/106
-aiofile!=3.10.0
+aiofile==3.9.0
 
 # auth0-python v5.0 is a major rewrite with breaking changes
 # used by sharkiq==1.5.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -208,6 +208,10 @@ pytest-rerunfailures==16.0.1
 # Fixes detected blocking call to load_default_certs https://github.com/home-assistant/core/issues/157475
 aiomqtt>=2.5.0
 
+# aiofile 3.10.0 crashes on import due to KeyError on package metadata
+# https://github.com/mosquito/aiofile/pull/106
+aiofile!=3.10.0
+
 # auth0-python v5.0 is a major rewrite with breaking changes
 # used by sharkiq==1.5.0
 # https://github.com/auth0/auth0-python/releases/tag/5.0.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -210,7 +210,7 @@ aiomqtt>=2.5.0
 
 # aiofile 3.10.0 crashes on import due to KeyError on package metadata
 # https://github.com/mosquito/aiofile/pull/106
-aiofile!=3.10.0
+aiofile==3.9.0
 
 # auth0-python v5.0 is a major rewrite with breaking changes
 # used by sharkiq==1.5.0


### PR DESCRIPTION
## Breaking change

N/A

## Proposed change

Pin `aiofile==3.9.0` to work around a crash during test collection on Python 3.14.

`aiofile` 3.10.0 migrated to hatchling and PEP 621, which changed the package metadata format. The `version.py` module tries to read `package_metadata["Author"]`, but PEP 621's `authors` table only generates `Author-email` — no standalone `Author` field. This causes a `KeyError` on import, breaking any test that transitively imports `aiofile` (via `velbus-aio`).

Upstream fix PR: https://github.com/mosquito/aiofile/pull/106

CI failure example: https://github.com/home-assistant/core/actions/runs/25948577399/job/76281944514?pr=170851

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr