### PR TITLE
Bump aioesphomeapi to 45.0.2

### DIFF
--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -17,7 +17,7 @@
   "mqtt": ["esphome/discover/#"],
   "quality_scale": "platinum",
   "requirements": [
-    "aioesphomeapi==45.0.1",
+    "aioesphomeapi==45.0.2",
     "esphome-dashboard-api==1.3.0",
     "bleak-esphome==3.7.3"
   ],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -254,7 +254,7 @@ aioelectricitymaps==1.1.1
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==45.0.1
+aioesphomeapi==45.0.2
 
 # homeassistant.components.matrix
 # homeassistant.components.slack

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -245,7 +245,7 @@ aioelectricitymaps==1.1.1
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==45.0.1
+aioesphomeapi==45.0.2
 
 # homeassistant.components.matrix
 # homeassistant.components.slack


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
changelog: https://github.com/esphome/aioesphomeapi/compare/v45.0.1...v45.0.2

This release adds two more defensive fixes around the unauthenticated portion of the Noise handshake. Both are low-severity hardening rather than exploitable RCE-style bugs, but worth upgrading for if you log to anything you'd rather not poison or leak.

- **Sanitize unauthenticated `server_name`, `mac_address`, and handshake-failure `explanation` before logging.** These three fields ride on the wire *before* the PSK-authenticated handshake completes, so an on-path attacker (ARP spoof, compromised VLAN device, MITM during plaintext-mode hello) can put anything in them. The previous code interpolated them unescaped into log/error messages and stashed them on `self` for reuse by every later error path — letting an attacker inject CRLF + ANSI escape sequences into operator-visible logs (HA UI, syslog, monitoring webhooks), forge fake log lines, hijack terminals via CSI sequences, or impersonate a different device's identity in alert messages. The fix decodes once with `errors="replace"`, strips non-printable characters, length-caps to the firmware's actual wire-format limits (32/16/64 bytes), and compares the *raw* decoded value (not the sanitized one) against `expected_name` / `expected_mac` so sanitization can't be used to bypass the identity check. Fixed in esphome/aioesphomeapi#1656.
- **Redact the PSK value from `Malformed PSK` error messages.** `_decode_noise_psk()` previously embedded the raw PSK string in `InvalidEncryptionKeyAPIError` on both failure paths (invalid base64, wrong byte length). The exception is logged at WARNING level by the connection layer, so the raw PSK landed in every sink (file logs, journald, log aggregators, Sentry, HA diagnostics bundles). Even a *malformed* PSK is highly sensitive — typos are nearly identical to the real key, clipboard pastes can carry stray characters, and the pasted value may simply be the real PSK of a sibling device. The fix replaces the value with its character length, which is enough to diagnose paste/encoding errors without exposing the secret. Fixed in esphome/aioesphomeapi#1657.

Threat model is "configuration-time / pre-handshake exposure," not a remote unauthenticated attack — same shape as v45.0.1's fixes.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
