### PR TITLE
cert_expiry: Fix error attribute returning string "None" for valid certificates

### DIFF
--- a/homeassistant/components/cert_expiry/entity.py
+++ b/homeassistant/components/cert_expiry/entity.py
@@ -17,5 +17,7 @@ class CertExpiryEntity(CoordinatorEntity[CertExpiryDataUpdateCoordinator]):
         """Return additional sensor state attributes."""
         return {
             "is_valid": self.coordinator.is_cert_valid,
-            "error": str(self.coordinator.cert_error),
+            "error": str(self.coordinator.cert_error)
+            if self.coordinator.cert_error
+            else None,
         }

--- a/tests/components/cert_expiry/test_init.py
+++ b/tests/components/cert_expiry/test_init.py
@@ -72,7 +72,7 @@ async def test_unload_config_entry(hass: HomeAssistant) -> None:
     assert entry.state is ConfigEntryState.LOADED
     state = hass.states.get("sensor.example_com_cert_expiry")
     assert state.state == timestamp.isoformat()
-    assert state.attributes.get("error") == "None"
+    assert state.attributes.get("error") is None
     assert state.attributes.get("is_valid")
 
     await hass.config_entries.async_unload(entry.entry_id)
@@ -115,5 +115,5 @@ async def test_delay_load_during_startup(hass: HomeAssistant) -> None:
 
     state = hass.states.get("sensor.example_com_cert_expiry")
     assert state.state == timestamp.isoformat()
-    assert state.attributes.get("error") == "None"
+    assert state.attributes.get("error") is None
     assert state.attributes.get("is_valid")

--- a/tests/components/cert_expiry/test_sensor.py
+++ b/tests/components/cert_expiry/test_sensor.py
@@ -44,7 +44,7 @@ async def test_async_setup_entry(hass: HomeAssistant) -> None:
     assert state is not None
     assert state.state != STATE_UNAVAILABLE
     assert state.state == timestamp.isoformat()
-    assert state.attributes.get("error") == "None"
+    assert state.attributes.get("error") is None
     assert state.attributes.get("is_valid")
 
 
@@ -101,7 +101,7 @@ async def test_update_sensor(hass: HomeAssistant) -> None:
     assert state is not None
     assert state.state != STATE_UNAVAILABLE
     assert state.state == timestamp.isoformat()
-    assert state.attributes.get("error") == "None"
+    assert state.attributes.get("error") is None
     assert state.attributes.get("is_valid")
 
     next_update = starting_time + timedelta(hours=24)
@@ -119,7 +119,7 @@ async def test_update_sensor(hass: HomeAssistant) -> None:
     assert state is not None
     assert state.state != STATE_UNAVAILABLE
     assert state.state == timestamp.isoformat()
-    assert state.attributes.get("error") == "None"
+    assert state.attributes.get("error") is None
     assert state.attributes.get("is_valid")
 
 
@@ -151,7 +151,7 @@ async def test_update_sensor_network_errors(hass: HomeAssistant) -> None:
     assert state is not None
     assert state.state != STATE_UNAVAILABLE
     assert state.state == timestamp.isoformat()
-    assert state.attributes.get("error") == "None"
+    assert state.attributes.get("error") is None
     assert state.attributes.get("is_valid")
 
     next_update = starting_time + timedelta(hours=24)
@@ -185,7 +185,7 @@ async def test_update_sensor_network_errors(hass: HomeAssistant) -> None:
         assert state is not None
         assert state.state != STATE_UNAVAILABLE
         assert state.state == timestamp.isoformat()
-        assert state.attributes.get("error") == "None"
+        assert state.attributes.get("error") is None
         assert state.attributes.get("is_valid")
 
     next_update = starting_time + timedelta(hours=72)
@@ -220,3 +220,69 @@ async def test_update_sensor_network_errors(hass: HomeAssistant) -> None:
 
     state = hass.states.get("sensor.example_com_cert_expiry")
     assert state.state == STATE_UNAVAILABLE
+
+
+async def test_error_attribute_is_none_when_cert_valid(hass: HomeAssistant) -> None:
+    """Test that the error attribute is None (not the string 'None') for a valid cert.
+
+    Regression test: previously str(None) produced the misleading string "None"
+    even when no error had occurred.
+    """
+    assert hass.state is CoreState.running
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: HOST, CONF_PORT: PORT},
+        unique_id=f"{HOST}:{PORT}",
+    )
+
+    starting_time = static_datetime()
+    timestamp = future_timestamp(100)
+
+    # Start with a valid cert — error should be None, not "None"
+    with (
+        freeze_time(starting_time),
+        patch(
+            "homeassistant.components.cert_expiry.coordinator.get_cert_expiry_timestamp",
+            return_value=timestamp,
+        ),
+    ):
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.example_com_cert_expiry")
+    assert state.attributes.get("error") is None
+    assert state.attributes.get("is_valid") is True
+
+    # Simulate a cert error on next poll
+    next_update = starting_time + timedelta(hours=12)
+    with (
+        freeze_time(next_update),
+        patch(
+            "homeassistant.components.cert_expiry.helper.async_get_cert",
+            side_effect=ssl.SSLError("certificate has expired"),
+        ),
+    ):
+        async_fire_time_changed(hass, utcnow() + timedelta(hours=12))
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.example_com_cert_expiry")
+    assert state.attributes.get("error") == "certificate has expired"
+    assert state.attributes.get("is_valid") is False
+
+    # Cert becomes valid again — error must return to None, not "None"
+    next_update = starting_time + timedelta(hours=24)
+    with (
+        freeze_time(next_update),
+        patch(
+            "homeassistant.components.cert_expiry.coordinator.get_cert_expiry_timestamp",
+            return_value=timestamp,
+        ),
+    ):
+        async_fire_time_changed(hass, utcnow() + timedelta(hours=24))
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.example_com_cert_expiry")
+    assert state.attributes.get("error") is None
+    assert state.attributes.get("is_valid") is True


### PR DESCRIPTION
## Breaking change

The error state attribute on the Certificate Expiry sensor previously returned the string `None`. When no error has
occurred, `cert_error` is `None`, so this produced the string `"None"` rather than a proper null value. It now returns null.

Note: this is a minor breaking change for any automation or template that checks `error == "None"` on a healthy sensor. The correct check going forward is `error == None` or `error is None` in templates.

Before:

```
{{ state_attr('sensor.example_com_cert_expiry', 'error') == "None" }}
```

After:

```
{{ state_attr('sensor.example_com_cert_expiry', 'error') is None }}
```

## Proposed change

The error state attribute was populated using str(self.coordinator.cert_error) unconditionally. When no error has occurred, cert_error is None, so this produced the string "None" rather than a proper null value.

This is semantically incorrect — a healthy sensor should not carry an attribute that reads like an active error. The fix returns None when no error is present, which is consistent with how optional error attributes are handled elsewhere in HA.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Breaking change (fix/feature causing existing functionality to break)

## Additional information

- Updated all affected test assertions from `== "None"` to `is None`
- Added `test_error_attribute_is_none_when_cert_valid` regression test
  covering the full valid → error → valid cycle

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally
- [x] Local tests pass
- [x] There is no commented out code in this PR
- [x] I have followed the development checklist
- [x] I have followed the perfect PR recommendations
- [x] The code has been formatted using Ruff
- [x] Tests have been added to verify that the new code works
- [x] I have reviewed two other [open pull requests][prs] in this repository.