### PR TITLE
Fix swallowed exceptions in `synology_dsm` action handlers

### DIFF
--- a/homeassistant/components/synology_dsm/services.py
+++ b/homeassistant/components/synology_dsm/services.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, cast
 from synology_dsm.exceptions import SynologyDSMException
 
 from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.exceptions import HomeAssistantError
 
 from .const import CONF_SERIAL, DOMAIN, SERVICE_REBOOT, SERVICE_SHUTDOWN, SERVICES
 from .coordinator import SynologyDSMConfigEntry
@@ -32,20 +33,26 @@ async def _service_handler(call: ServiceCall) -> None:
         dsm_device = next(iter(dsm_devices.values()))
         serial = next(iter(dsm_devices))
     else:
-        LOGGER.error(
-            "More than one DSM configured, must specify one of serials %s",
-            sorted(dsm_devices),
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="missing_serial",
+            translation_placeholders={"serials": ", ".join(sorted(dsm_devices))},
         )
-        return
 
     if not dsm_device:
-        LOGGER.error("DSM with specified serial %s not found", serial)
-        return
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="serial_not_found",
+            translation_placeholders={"serial": serial},
+        )
 
     if call.service in [SERVICE_REBOOT, SERVICE_SHUTDOWN]:
         if serial not in dsm_devices:
-            LOGGER.error("DSM with specified serial %s not found", serial)
-            return
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="serial_not_found",
+                translation_placeholders={"serial": serial},
+            )
         LOGGER.debug("%s DSM with serial %s", call.service, serial)
         LOGGER.warning(
             (
@@ -58,15 +65,16 @@ async def _service_handler(call: ServiceCall) -> None:
         dsm_api = dsm_device.api
         try:
             await getattr(dsm_api, f"async_{call.service}")()
-        # pylint: disable-next=home-assistant-action-swallowed-exception
         except SynologyDSMException as ex:
-            LOGGER.error(
-                "%s of DSM with serial %s not possible, because of %s",
-                call.service,
-                serial,
-                ex,
-            )
-            return
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="execution_error",
+                translation_placeholders={
+                    "action": call.service,
+                    "serial": serial,
+                    "error": str(ex),
+                },
+            ) from ex
 
 
 @callback

--- a/homeassistant/components/synology_dsm/services.py
+++ b/homeassistant/components/synology_dsm/services.py
@@ -1,7 +1,7 @@
 """The Synology DSM component."""
 
 import logging
-from typing import TYPE_CHECKING, cast
+from typing import cast
 
 from synology_dsm.exceptions import SynologyDSMException
 
@@ -26,8 +26,12 @@ async def _service_handler(call: ServiceCall) -> None:
         entry: SynologyDSMConfigEntry | None = (
             call.hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, serial)
         )
-        if TYPE_CHECKING:
-            assert entry
+        if not entry:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="serial_not_found",
+                translation_placeholders={"serial": serial},
+            )
         dsm_device = entry.runtime_data
     elif len(dsm_devices) == 1:
         dsm_device = next(iter(dsm_devices.values()))

--- a/homeassistant/components/synology_dsm/strings.json
+++ b/homeassistant/components/synology_dsm/strings.json
@@ -187,6 +187,17 @@
       }
     }
   },
+  "exceptions": {
+    "execution_error": {
+      "message": "Execute {action} on DSM with serial {serial} not possible, because of {error}."
+    },
+    "missing_serial": {
+      "message": "More than one DSM configured, must specify one of serials: {serials}."
+    },
+    "serial_not_found": {
+      "message": "DSM with specified serial {serial} not found."
+    }
+  },
   "issues": {
     "missing_backup_setup": {
       "fix_flow": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With this we now raise a proper translatable `HomeAssistantError` instead of only log an error message and return silent. While testing it, a missing error handling was identified and also added (_back then it was assumed to always have a proper serial and those got covered by `if TYPE_CHECKING`, but it is possible to enter an invalid serial_)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170641
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
