### PR TITLE
Fix line length violations in tests/components d-f

### DIFF
--- a/tests/components/data_grand_lyon/test_sensor.py
+++ b/tests/components/data_grand_lyon/test_sensor.py
@@ -59,7 +59,7 @@ async def test_stop_sensor_secondary_departure_disabled_by_default(
     mock_config_entry: MockConfigEntry,
     mock_tcl_client: AsyncMock,
 ) -> None:
-    """Test that direction/type sensors past the first departure are disabled by default."""
+    """Test direction/type sensors past the first departure are disabled by default."""
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/deako/test_init.py
+++ b/tests/components/deako/test_init.py
@@ -44,7 +44,7 @@ async def test_deako_async_setup_entry_devices_error(
     pydeako_deako_mock: MagicMock,
     pydeako_discoverer_mock: MagicMock,
 ) -> None:
-    """Test async_setup_entry raises ConfigEntryNotReady when pydeako raises DeviceListTimeout."""
+    """Test async_setup_entry raises ConfigEntryNotReady on DeviceListTimeout."""
 
     mock_config_entry.add_to_hass(hass)
 

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -142,7 +142,7 @@ async def test_flow_manual_configuration_decision(
 async def test_flow_manual_configuration(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
-    """Test that config flow works with manual configuration after no discovered bridges."""
+    """Test config flow works with manual config after no discovered bridges."""
     logging.getLogger("homeassistant.components.deconz").setLevel(logging.DEBUG)
     aioclient_mock.get(
         pydeconz.utils.URL_DISCOVER,

--- a/tests/components/deconz/test_light.py
+++ b/tests/components/deconz/test_light.py
@@ -562,7 +562,7 @@ async def test_ikea_default_transition_time(
     hass: HomeAssistant,
     mock_put_request: Callable[[str, str], AiohttpClientMocker],
 ) -> None:
-    """Verify that service calls to IKEA lights always extend with transition tinme 0 if absent."""
+    """Verify IKEA light calls always extend with transition time 0 if absent."""
     aioclient_mock = mock_put_request("/lights/0/state")
 
     await hass.services.async_call(

--- a/tests/components/decora_wifi/test_config_flow.py
+++ b/tests/components/decora_wifi/test_config_flow.py
@@ -51,7 +51,7 @@ async def test_user_flow_error_and_recovery(
     login_side_effect: Exception | None,
     expected_error: str,
 ) -> None:
-    """Test user flow shows the correct error and that the user can retry successfully."""
+    """Test user flow shows the correct error and the user can retry."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )

--- a/tests/components/derivative/test_sensor.py
+++ b/tests/components/derivative/test_sensor.py
@@ -405,9 +405,11 @@ async def test_data_moving_average_for_irregular_times(hass: HomeAssistant) -> N
     """Test derivative sensor state."""
     # We simulate the following situation:
     # The temperature rises 1 °C per minute for 30 minutes long.
-    # There is 60 random datapoints (and the start and end) and the signal is normally distributed
-    # around the expected value with ±0.1°C
-    # We use a time window of 1 minute and expect an error of less than the standard deviation. (0.01)
+    # There is 60 random datapoints (and the start and end) and
+    # the signal is normally distributed around the expected
+    # value with ±0.1°C
+    # We use a time window of 1 minute and expect an error of
+    # less than the standard deviation. (0.01)
 
     time_window = 60
     random.seed(0)
@@ -447,12 +449,15 @@ async def test_data_moving_average_for_irregular_times(hass: HomeAssistant) -> N
 
 async def test_double_signal_after_delay(hass: HomeAssistant) -> None:
     """Test derivative sensor state."""
-    # The old algorithm would produce extreme values if, after a delay longer than the time window
-    # there would be two signals, a large spike would be produced. Check explicitly for this situation
+    # The old algorithm would produce extreme values if, after
+    # a delay longer than the time window there would be two
+    # signals, a large spike would be produced. Check
+    # explicitly for this situation
     time_window = 60
     times = [*range(time_window * 10), time_window * 20, time_window * 20 + 0.01]
 
-    # just apply sine as some sort of temperature change and make sure the change after the delay is very small
+    # just apply sine as some sort of temperature change and
+    # make sure the change after the delay is very small
     temperature_values = [sin(x) for x in times]
     temperature_values[-2] = temperature_values[-3] + 0.01
     temperature_values[-1] = temperature_values[-2] + 0.01
@@ -856,7 +861,7 @@ async def test_suffix(hass: HomeAssistant) -> None:
 
 
 async def test_total_increasing_reset(hass: HomeAssistant) -> None:
-    """Test derivative sensor state with total_increasing sensor input where it should ignore the reset value."""
+    """Test derivative with total_increasing input where it should ignore the reset."""
     times = [0, 20, 30, 35, 40, 50, 60]
     values = [0, 10, 30, 40, 0, 10, 40]
     expected_times = [0, 20, 30, 35, 50, 60]
@@ -1084,7 +1089,8 @@ async def test_unavailable_boot(
 
         state = hass.states.get("sensor.power")
         assert state is not None
-        # Now that the source sensor has two valid datapoints, we can calculate derivative
+        # Now that the source sensor has two valid datapoints,
+        # we can calculate derivative
         assert state.state == "5.00"
         assert state.attributes.get("unit_of_measurement") == "kW"
 

--- a/tests/components/devialet/test_init.py
+++ b/tests/components/devialet/test_init.py
@@ -30,7 +30,7 @@ async def test_load_unload_config_entry(
 async def test_load_unload_config_entry_when_device_unavailable(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
-    """Test the Devialet configuration entry loading and unloading when the device is unavailable."""
+    """Test the Devialet config entry loading/unloading when device is unavailable."""
     entry = await setup_integration(hass, aioclient_mock, state="unavailable")
 
     assert entry.state is ConfigEntryState.LOADED

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -701,7 +701,7 @@ async def test_async_get_device_automations_all_devices_action_exception_throw(
     entity_registry: er.EntityRegistry,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test we get can fetch all the actions when no device id is passed and can handle one throwing an exception."""
+    """Test we can fetch all actions with no device id and handle exceptions."""
     await async_setup_component(hass, "device_automation", {})
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -1118,7 +1118,7 @@ async def test_automation_with_dynamically_validated_condition(
 async def test_automation_with_integration_without_device_condition(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test device automation condition with integration without device condition support."""
+    """Test device condition with integration without device condition support."""
     mock_integration(hass, MockModule(domain="test"))
     assert await async_setup_component(
         hass,
@@ -1235,7 +1235,7 @@ async def test_automation_with_dynamically_validated_trigger(
 async def test_automation_with_integration_without_device_trigger(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test device automation trigger with integration without device trigger support."""
+    """Test device trigger with integration without device trigger support."""
     mock_integration(hass, MockModule(domain="test"))
     assert await async_setup_component(
         hass,
@@ -1732,7 +1732,7 @@ async def test_automation_with_device_component_not_loaded(
 async def test_async_get_device_automations_platform_reraises_exceptions(
     hass: HomeAssistant, exc: Exception
 ) -> None:
-    """Test InvalidDeviceAutomationConfig is raised when async_get_integration_with_requirements fails."""
+    """Test InvalidDeviceAutomationConfig is raised when get_integration fails."""
     await async_setup_component(hass, "device_automation", {})
     with (
         patch(

--- a/tests/components/devolo_home_control/test_light.py
+++ b/tests/components/devolo_home_control/test_light.py
@@ -23,7 +23,7 @@ from .mocks import BinarySwitchPropertyMock, HomeControlMock, HomeControlMockLig
 async def test_light_without_binary_sensor(
     hass: HomeAssistant, entity_registry: er.EntityRegistry, snapshot: SnapshotAssertion
 ) -> None:
-    """Test setup and state change of a light device that does not have an additional binary sensor."""
+    """Test setup and state change of a light without an additional binary sensor."""
     entry = configure_integration(hass)
     test_gateway = HomeControlMockLight()
     with patch(
@@ -88,7 +88,7 @@ async def test_light_without_binary_sensor(
 async def test_light_with_binary_sensor(
     hass: HomeAssistant, entity_registry: er.EntityRegistry, snapshot: SnapshotAssertion
 ) -> None:
-    """Test setup and state change of a light device that has an additional binary sensor."""
+    """Test setup and state change of a light with an additional binary sensor."""
     entry = configure_integration(hass)
     test_gateway = HomeControlMockLight()
     test_gateway.devices["Test"].binary_switch_property = {

--- a/tests/components/devolo_home_network/mock.py
+++ b/tests/components/devolo_home_network/mock.py
@@ -83,7 +83,7 @@ class MockDevice(Device):
 
 
 class MockDeviceWrongPassword(MockDevice):
-    """Mock of a devolo Home Network device, that always complains about a wrong password."""
+    """Mock of a devolo Home Network device that complains about a wrong password."""
 
     def __init__(
         self,

--- a/tests/components/devolo_home_network/test_sensor.py
+++ b/tests/components/devolo_home_network/test_sensor.py
@@ -143,11 +143,17 @@ async def test_update_plc_phyrates(
     freezer: FrozenDateTimeFactory,
     snapshot: SnapshotAssertion,
 ) -> None:
-    """Test state change of plc_downlink_phyrate and plc_uplink_phyrate sensor devices."""
+    """Test state change of plc_downlink_phyrate and plc_uplink_phyrate sensors."""
     entry = configure_integration(hass)
     device_name = entry.title.replace(" ", "_").lower()
-    entity_id_downlink = f"{SENSOR_DOMAIN}.{device_name}_plc_downlink_phy_rate_{PLCNET.devices[1].user_device_name}"
-    entity_id_uplink = f"{SENSOR_DOMAIN}.{device_name}_plc_uplink_phy_rate_{PLCNET.devices[1].user_device_name}"
+    entity_id_downlink = (
+        f"{SENSOR_DOMAIN}.{device_name}_plc_downlink_phy_rate_"
+        f"{PLCNET.devices[1].user_device_name}"
+    )
+    entity_id_uplink = (
+        f"{SENSOR_DOMAIN}.{device_name}_plc_uplink_phy_rate_"
+        f"{PLCNET.devices[1].user_device_name}"
+    )
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
@@ -190,7 +196,7 @@ async def test_update_plc_phyrates(
 async def test_update_last_update_auth_failed(
     hass: HomeAssistant, mock_device: MockDevice
 ) -> None:
-    """Test getting the last update state with wrong password triggers the reauth flow."""
+    """Test getting last update state with wrong password triggers reauth flow."""
     entry = configure_integration(hass)
     mock_device.device.async_uptime.side_effect = DevicePasswordProtected
 

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -973,7 +973,7 @@ async def test_device_tracker_hostname_and_macaddress_after_start_not_router(
 async def test_device_tracker_hostname_and_macaddress_after_start_hostname_missing(
     hass: HomeAssistant,
 ) -> None:
-    """Test matching based on hostname and macaddress after start but missing hostname."""
+    """Test matching based on hostname and macaddress after start, missing hostname."""
 
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
         device_tracker_watcher = _make_device_tracker_watcher(

--- a/tests/components/discord/test_notify.py
+++ b/tests/components/discord/test_notify.py
@@ -63,7 +63,7 @@ async def test_get_file_from_url_with_large_attachment(
     discord_aiohttp_mock_factory: AiohttpClientMocker,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test getting file from URL with large attachment (per Content-Length header) throws error."""
+    """Test getting file from URL with large attachment throws error."""
     headers = {"Content-Length": str(len(CONTENT) + 1)}
     discord_aiohttp_mock = discord_aiohttp_mock_factory(headers)
     with caplog.at_level(
@@ -83,7 +83,7 @@ async def test_get_file_from_url_with_large_attachment_no_header(
     discord_aiohttp_mock_factory: AiohttpClientMocker,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test getting file from URL with large attachment (per content length) throws error."""
+    """Test getting file from URL with large attachment without header throws error."""
     discord_aiohttp_mock = discord_aiohttp_mock_factory()
     with caplog.at_level(
         logging.WARNING, logger="homeassistant.components.discord.notify"

--- a/tests/components/dlink/test_init.py
+++ b/tests/components/dlink/test_init.py
@@ -53,7 +53,7 @@ async def test_async_setup_entry_not_ready(
     config_entry_with_uid: MockConfigEntry,
     mocked_plug_legacy_no_auth: MagicMock,
 ) -> None:
-    """Test that it throws ConfigEntryNotReady when exception occurs during legacy setup."""
+    """Test it throws ConfigEntryNotReady when exception occurs during legacy setup."""
     with patch_setup(mocked_plug_legacy_no_auth):
         await hass.config_entries.async_setup(config_entry_with_uid.entry_id)
     assert config_entry_with_uid.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/dlna_dmr/test_config_flow.py
+++ b/tests/components/dlna_dmr/test_config_flow.py
@@ -42,7 +42,7 @@ from .conftest import (
 
 from tests.common import MockConfigEntry
 
-# Auto-use the domain_data_mock and dmr_device_mock fixtures for every test in this module
+# Auto-use the domain_data_mock and dmr_device_mock fixtures for every test
 pytestmark = [
     pytest.mark.usefixtures("domain_data_mock"),
     pytest.mark.usefixtures("dmr_device_mock"),
@@ -404,7 +404,7 @@ async def test_ssdp_flow_duplicate_location(
 async def test_ssdp_duplicate_mac_ignored_entry(
     hass: HomeAssistant, config_entry_mock: MockConfigEntry
 ) -> None:
-    """Test SSDP with different UDN but matching MAC for ignored config entry is ignored."""
+    """Test SSDP with different UDN but matching MAC for ignored entry is ignored."""
     # Add an ignored entry
     config_entry_mock.source = config_entries.SOURCE_IGNORE
     config_entry_mock.add_to_hass(hass)

--- a/tests/components/dlna_dmr/test_media_player.py
+++ b/tests/components/dlna_dmr/test_media_player.py
@@ -1936,7 +1936,8 @@ async def test_ssdp_bootid(
     assert dmr_device_mock.async_subscribe_services.call_count == 1
     assert dmr_device_mock.async_unsubscribe_services.call_count == 0
 
-    # Send a new SSDP alive with an incremented boot ID, device should be dis/reconnected
+    # Send a new SSDP alive with an incremented boot ID,
+    # device should be dis/reconnected
     await ssdp_callback(
         SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,

--- a/tests/components/dlna_dms/conftest.py
+++ b/tests/components/dlna_dms/conftest.py
@@ -150,7 +150,7 @@ async def device_source_mock(
     ssdp_scanner_mock: Mock,
     dms_device_mock: Mock,
 ) -> AsyncGenerator[None]:
-    """Fixture to set up a DmsDeviceSource in a connected state and cleanup at completion."""
+    """Set up a DmsDeviceSource in a connected state and cleanup at completion."""
     config_entry_mock.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry_mock.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/dlna_dms/test_device_availability.py
+++ b/tests/components/dlna_dms/test_device_availability.py
@@ -599,7 +599,8 @@ async def test_ssdp_bootid(
     await assert_source_available(hass)
     assert upnp_factory_mock.async_create_device.await_count == 1
 
-    # Send a new SSDP alive with an incremented boot ID, device should be dis/reconnected
+    # Send a new SSDP alive with an incremented boot ID,
+    # device should be dis/reconnected
     await ssdp_callback(
         SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
@@ -625,7 +626,8 @@ async def test_repeated_connect(
     """Test trying to connect an already connected device is safely ignored."""
     upnp_factory_mock.async_create_device.reset_mock()
 
-    # Calling internal function directly to skip trying to time 2 SSDP messages carefully
+    # Calling internal function directly to skip trying to
+    # time 2 SSDP messages carefully
     domain_data = get_domain_data(hass)
     device_source = domain_data.sources[MOCK_SOURCE_ID]
     with caplog.at_level(logging.DEBUG):

--- a/tests/components/dlna_dms/test_dms_device_source.py
+++ b/tests/components/dlna_dms/test_dms_device_source.py
@@ -128,7 +128,7 @@ async def test_catch_request_error(hass: HomeAssistant, dms_device_mock: Mock) -
 async def test_catch_upnp_connection_error(
     hass: HomeAssistant, dms_device_mock: Mock
 ) -> None:
-    """Test UpnpConnectionError causes the device source to disconnect from the device."""
+    """Test UpnpConnectionError causes the device source to disconnect."""
     # First check the source can be used
     object_id = "foo"
     didl_item = didl_lite.Item(
@@ -389,7 +389,7 @@ async def test_resolve_path_browsed_nothing(
 
 
 async def test_resolve_path_quoted(hass: HomeAssistant, dms_device_mock: Mock) -> None:
-    """Test async_resolve_path: quotes and backslashes in the path get escaped correctly."""
+    """Test async_resolve_path: quotes and backslashes get escaped correctly."""
     dms_device_mock.async_search_directory.side_effect = [
         DmsDevice.BrowseResult(
             [
@@ -417,7 +417,10 @@ async def test_resolve_path_quoted(hass: HomeAssistant, dms_device_mock: Mock) -
         ),
         call(
             r'id_with quote" and back\slash',
-            search_criteria=r'@parentID="id_with quote\" and back\\slash" and dc:title="quote\"back\\slash"',
+            search_criteria=(
+                r'@parentID="id_with quote\" and back\\slash"'
+                r' and dc:title="quote\"back\\slash"'
+            ),
             metadata_filter=["id", "upnp:class", "dc:title"],
             requested_count=1,
         ),

--- a/tests/components/doorbell/test_trigger.py
+++ b/tests/components/doorbell/test_trigger.py
@@ -178,7 +178,8 @@ async def test_doorbell_trigger_options_validation(
                 },
             ],
         ),
-        # To unavailable - should not trigger, and first state after unavailable is skipped
+        # To unavailable - should not trigger, and first state
+        # after unavailable is skipped
         (
             "doorbell.rang",
             [
@@ -275,7 +276,7 @@ async def test_doorbell_rang_trigger(
     trigger: str,
     states: list[BasicTriggerStateDescription],
 ) -> None:
-    """Test that the doorbell rang trigger fires when a doorbell ring event is received."""
+    """Test that the doorbell rang trigger fires on a doorbell ring event."""
     calls: list[str] = []
     other_entity_ids = set(target_events["included_entities"]) - {entity_id}
 

--- a/tests/components/doorbird/test_config_flow.py
+++ b/tests/components/doorbird/test_config_flow.py
@@ -332,7 +332,7 @@ async def test_form_zeroconf_correct_oui_wrong_device(
     doorbird_api: DoorBird,
     doorbell_state_side_effect: Exception | None,
 ) -> None:
-    """Test we can setup from zeroconf with the correct OUI source but not a doorstation."""
+    """Test setup from zeroconf with the correct OUI source but not a doorstation."""
     doorbirdapi = get_mock_doorbird_api(info={"WIFI_MAC_ADDR": "macaddr"})
     type(doorbirdapi).doorbell_state = AsyncMock(side_effect=doorbell_state_side_effect)
 

--- a/tests/components/doorbird/test_device.py
+++ b/tests/components/doorbird/test_device.py
@@ -113,11 +113,15 @@ async def test_custom_url_used_for_favorites(
         "http": {
             "1": {
                 "title": "Home Assistant (mydoorbird_doorbell)",
-                "value": f"{custom_url}/api/doorbird/mydoorbird_doorbell?token=test-token",
+                "value": (
+                    f"{custom_url}/api/doorbird/mydoorbird_doorbell?token=test-token"
+                ),
             },
             "2": {
                 "title": "Home Assistant (mydoorbird_motion)",
-                "value": f"{custom_url}/api/doorbird/mydoorbird_motion?token=test-token",
+                "value": (
+                    f"{custom_url}/api/doorbird/mydoorbird_motion?token=test-token"
+                ),
             },
         }
     }

--- a/tests/components/droplet/test_config_flow.py
+++ b/tests/components/droplet/test_config_flow.py
@@ -108,7 +108,8 @@ async def test_user_setup_fail(
     assert result.get("type") is FlowResultType.FORM
     assert result.get("errors") == {"base": "cannot_connect"}
 
-    # The user should be able to try again. Maybe the droplet was disconnected from the network or something
+    # The user should be able to try again. Maybe the droplet
+    # was disconnected from the network or something
     attrs = {
         "get_device_id.return_value": MOCK_DEVICE_ID,
         "try_connect.return_value": True,

--- a/tests/components/dsmr/test_config_flow.py
+++ b/tests/components/dsmr/test_config_flow.py
@@ -101,7 +101,8 @@ async def test_setup_network_rfxtrx(
     assert result["step_id"] == "setup_network"
     assert result["errors"] == {}
 
-    # set-up DSMRProtocol to yield no valid telegram, this will retry with RFXtrxDSMRProtocol
+    # set-up DSMRProtocol to yield no valid telegram,
+    # this will retry with RFXtrxDSMRProtocol
     protocol.telegram = {}
 
     with patch("homeassistant.components.dsmr.async_setup_entry", return_value=True):
@@ -269,7 +270,8 @@ async def test_setup_serial_rfxtrx(
     assert result["step_id"] == "setup_serial"
     assert result["errors"] == {}
 
-    # set-up DSMRProtocol to yield no valid telegram, this will retry with RFXtrxDSMRProtocol
+    # set-up DSMRProtocol to yield no valid telegram,
+    # this will retry with RFXtrxDSMRProtocol
     protocol.telegram = {}
 
     with patch("homeassistant.components.dsmr.async_setup_entry", return_value=True):

--- a/tests/components/dsmr_reader/test_definitions.py
+++ b/tests/components/dsmr_reader/test_definitions.py
@@ -39,7 +39,7 @@ async def test_tariff_transform(input, expected) -> None:
 
 @pytest.mark.usefixtures("mqtt_mock")
 async def test_entity_tariff(hass: HomeAssistant) -> None:
-    """Test the state attribute of DSMRReaderSensorEntityDescription when a tariff transform is needed."""
+    """Test DSMRReaderSensorEntityDescription with a tariff transform."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         title=DOMAIN,
@@ -71,7 +71,7 @@ async def test_entity_tariff(hass: HomeAssistant) -> None:
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default", "mqtt_mock")
 async def test_entity_dsmr_transform(hass: HomeAssistant) -> None:
-    """Test the state attribute of DSMRReaderSensorEntityDescription when a dsmr transform is needed."""
+    """Test DSMRReaderSensorEntityDescription state when a dsmr transform is needed."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         title=DOMAIN,

--- a/tests/components/duco/test_config_flow.py
+++ b/tests/components/duco/test_config_flow.py
@@ -119,7 +119,7 @@ async def test_zeroconf_discovery_new_device(
     mock_duco_client: AsyncMock,
     mock_setup_entry: AsyncMock,
 ) -> None:
-    """Test zeroconf discovery of a new device shows confirmation form and creates entry."""
+    """Test zeroconf discovery shows confirmation form and creates entry."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},

--- a/tests/components/duco/test_init.py
+++ b/tests/components/duco/test_init.py
@@ -88,7 +88,7 @@ async def test_cleanup_orphaned_temperature_entities(
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test that stale temperature entity entries from prior versions are removed on setup."""
+    """Test stale temperature entities from prior versions are removed on setup."""
     mock_config_entry.add_to_hass(hass)
 
     old_unique_ids = [
@@ -133,7 +133,9 @@ async def test_setup_entry_creates_http_client(
         mock_client_class.return_value.async_get_diagnostics.return_value = [
             DiagComponent(component="Ventilation", status=DiagStatus.OK)
         ]
-        mock_client_class.return_value.async_get_write_requests_remaining.return_value = 100
+        (
+            mock_client_class.return_value.async_get_write_requests_remaining
+        ).return_value = 100
         mock_config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -104,7 +104,7 @@ async def test_coordinator_update_duco_error_marks_unavailable(
     mock_duco_client: AsyncMock,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test that sensor entities become unavailable when async_get_nodes raises DucoError."""
+    """Test sensor entities become unavailable when async_get_nodes raises DucoError."""
     mock_duco_client.async_get_nodes = AsyncMock(side_effect=DucoError("api error"))
 
     freezer.tick(SCAN_INTERVAL)
@@ -122,7 +122,7 @@ async def test_lan_info_duco_error_marks_unavailable(
     mock_duco_client: AsyncMock,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test that entities become unavailable when async_get_lan_info raises DucoError."""
+    """Test entities become unavailable when async_get_lan_info raises DucoError."""
     mock_duco_client.async_get_lan_info = AsyncMock(
         side_effect=DucoError("lan info error")
     )
@@ -143,7 +143,7 @@ async def test_new_node_added_dynamically(
     mock_nodes: list[Node],
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test that a new node appearing in coordinator data creates entities automatically."""
+    """Test a new node appearing in coordinator data creates entities automatically."""
     assert hass.states.get("sensor.new_rh_sensor_humidity") is None
 
     new_node = Node(
@@ -191,7 +191,7 @@ async def test_deregistered_node_removes_device(
     mock_config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test that a node disappearing from the API removes its device from the registry."""
+    """Test a node disappearing from the API removes its device from the registry."""
     device_registry = dr.async_get(hass)
 
     # Verify node 2 (UCCO2 RF sensor) device exists before deregistration.
@@ -265,7 +265,7 @@ async def test_previously_unknown_node_gets_entities_after_type_becomes_known(
     mock_nodes: list[Node],
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test that a node with UNKNOWN type is retried and gets entities once the type resolves."""
+    """Test UNKNOWN type node is retried and gets entities once the type resolves."""
     node_id = 99
     ventilation = NodeVentilationInfo(
         state="AUTO", time_state_remain=0, time_state_end=0, mode="-", flow_lvl_tgt=None

--- a/tests/components/dwd_weather_warnings/test_config_flow.py
+++ b/tests/components/dwd_weather_warnings/test_config_flow.py
@@ -143,7 +143,7 @@ async def test_create_entry_gps(
 async def test_config_flow_already_configured(
     hass: HomeAssistant, mock_dwdwfsapi: MagicMock
 ) -> None:
-    """Test aborting, if the warncell ID / name is already configured during the config."""
+    """Test aborting if the warncell ID / name is already configured."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=DEMO_CONFIG_ENTRY_REGION.copy(),

--- a/tests/components/dwd_weather_warnings/test_init.py
+++ b/tests/components/dwd_weather_warnings/test_init.py
@@ -55,7 +55,7 @@ async def test_load_unload_entry(
     mock_identifier_entry: MockConfigEntry,
     mock_dwdwfsapi: MagicMock,
 ) -> None:
-    """Test loading and unloading the integration with a region identifier based entry."""
+    """Test loading and unloading the integration with a region identifier entry."""
     entry = await init_integration(hass, mock_identifier_entry)
 
     assert entry.state is ConfigEntryState.LOADED
@@ -126,7 +126,7 @@ async def test_load_missing_device_tracker(
 async def test_load_missing_required_attribute(
     hass: HomeAssistant, mock_tracker_entry: MockConfigEntry
 ) -> None:
-    """Test loading the integration with a device tracker missing a required attribute."""
+    """Test loading the integration with a device tracker missing a required attr."""
     mock_tracker_entry.add_to_hass(hass)
     hass.states.async_set(
         mock_tracker_entry.data[CONF_REGION_DEVICE_TRACKER],

--- a/tests/components/dynalite/common.py
+++ b/tests/components/dynalite/common.py
@@ -32,7 +32,7 @@ async def get_entry_id_from_hass(hass: HomeAssistant) -> str:
 
 
 async def create_entity_from_device(hass: HomeAssistant, device: DynaliteBaseDevice):
-    """Set up the component and platform and create a light based on the device provided."""
+    """Set up the component and platform and create a light based on the device."""
     host = "1.2.3.4"
     entry = MockConfigEntry(domain=dynalite.DOMAIN, data={CONF_HOST: host})
     entry.add_to_hass(hass)
@@ -49,7 +49,7 @@ async def create_entity_from_device(hass: HomeAssistant, device: DynaliteBaseDev
 
 
 async def run_service_tests(hass: HomeAssistant, device, platform, services):
-    """Run a series of service calls and check that the entity and device behave correctly."""
+    """Run a series of service calls and check entity and device behave correctly."""
     for cur_item in services:
         service = cur_item[ATTR_SERVICE]
         args = cur_item.get(ATTR_ARGS, {})

--- a/tests/components/earn_e_p1/test_config_flow.py
+++ b/tests/components/earn_e_p1/test_config_flow.py
@@ -125,7 +125,10 @@ async def test_user_flow_discovery_no_serial_unexpected_error(
 async def test_user_flow_discovery_timeout_shows_manual_form(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
-    """Test user flow falls back to manual form when discovery times out, then recovers."""
+    """Test user flow falls back to manual form when discovery times out.
+
+    Then recovers.
+    """
     with patch(DISCOVER_PATH, return_value=[]):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -182,7 +185,7 @@ async def test_manual_entry_validation_errors(
     side_effect: Exception,
     error: str,
 ) -> None:
-    """Test manual entry: errors during validation show correct error, retry succeeds."""
+    """Test manual entry errors show correct error, retry succeeds."""
     with patch(DISCOVER_PATH, return_value=[]):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/easyenergy/test_sensor.py
+++ b/tests/components/easyenergy/test_sensor.py
@@ -142,8 +142,8 @@ async def test_energy_usage_today(
     )
     assert state.state == "2"
     assert (
-        state.attributes.get(ATTR_FRIENDLY_NAME)
-        == "Energy market price - Usage Hours priced equal or lower than current - today"
+        state.attributes.get(ATTR_FRIENDLY_NAME) == "Energy market price"
+        " - Usage Hours priced equal or lower than current - today"
     )
     assert ATTR_DEVICE_CLASS not in state.attributes
 
@@ -258,8 +258,8 @@ async def test_energy_return_today(
     )
     assert state.state == "23"
     assert (
-        state.attributes.get(ATTR_FRIENDLY_NAME)
-        == "Energy market price - Return Hours priced equal or higher than current - today"
+        state.attributes.get(ATTR_FRIENDLY_NAME) == "Energy market price"
+        " - Return Hours priced equal or higher than current - today"
     )
     assert ATTR_DEVICE_CLASS not in state.attributes
 

--- a/tests/components/ecobee/test_climate.py
+++ b/tests/components/ecobee/test_climate.py
@@ -545,7 +545,8 @@ async def test_set_sensors_used_in_climate(hass: HomeAssistant) -> None:
         # `temp` is the preset running because of a hold.
         mock_sensors.assert_called_once_with(0, "temp", sensor_ids=["rs:100"])
 
-    # Check that sensors are not updated when the sent sensors are the currently set sensors.
+    # Check that sensors are not updated when the sent sensors
+    # are the currently set sensors.
     with mock.patch("pyecobee.Ecobee.update_climate_sensors") as mock_sensors:
         await hass.services.async_call(
             DOMAIN,

--- a/tests/components/ecobee/test_config_flow.py
+++ b/tests/components/ecobee/test_config_flow.py
@@ -218,7 +218,7 @@ async def test_password_login_error_recovers(
     first_user_input: dict,
     expected_error: str,
 ) -> None:
-    """Test that authentication errors keep the user on the form and recover on retry."""
+    """Test auth errors keep the user on the form and recover on retry."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )

--- a/tests/components/ecovacs/test_vacuum.py
+++ b/tests/components/ecovacs/test_vacuum.py
@@ -204,7 +204,8 @@ async def test_clean_area_invalid_map_id(
         (
             "homeassistant.components.ecovacs.vacuum",
             logging.WARNING,
-            "No valid segments to clean after validation, skipping clean segments command",
+            "No valid segments to clean after validation,"
+            " skipping clean segments command",
         ),
     ]
     assert device._execute_command.call_count == 0
@@ -274,7 +275,8 @@ async def test_clean_area_room_from_not_current_map(
         (
             "homeassistant.components.ecovacs.vacuum",
             logging.WARNING,
-            'Map "Second map" is not currently selected, skipping segment "Bedroom" (1)',
+            'Map "Second map" is not currently selected,'
+            ' skipping segment "Bedroom" (1)',
         ),
     ]
     assert device._execute_command.call_count == 1

--- a/tests/components/eheimdigital/test_climate.py
+++ b/tests/components/eheimdigital/test_climate.py
@@ -73,7 +73,7 @@ async def test_dynamic_new_devices(
     snapshot: SnapshotAssertion,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test light platform setup with at first no devices and dynamically adding a device."""
+    """Test platform setup with no devices and dynamically adding one."""
     mock_config_entry.add_to_hass(hass)
 
     eheimdigital_hub_mock.return_value.devices = {}

--- a/tests/components/eheimdigital/test_light.py
+++ b/tests/components/eheimdigital/test_light.py
@@ -80,7 +80,7 @@ async def test_dynamic_new_devices(
     snapshot: SnapshotAssertion,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test light platform setup with at first no devices and dynamically adding a device."""
+    """Test platform setup with no devices and dynamically adding one."""
     mock_config_entry.add_to_hass(hass)
 
     eheimdigital_hub_mock.return_value.devices = {}

--- a/tests/components/ekeybionyx/conftest.py
+++ b/tests/components/ekeybionyx/conftest.py
@@ -96,8 +96,14 @@ def mock_webhooks(
             {
                 "functionWebhookId": "946DA01F-9ABD-4D9D-80C7-02AF85C822B9",
                 "integrationName": "Home Assistant",
-                "locationName": "A simple string containing 0 to 128 word, space and punctuation characters.",
-                "functionName": "A simple string containing 0 to 50 word, space and punctuation characters.",
+                "locationName": (
+                    "A simple string containing 0 to 128"
+                    " word, space and punctuation characters."
+                ),
+                "functionName": (
+                    "A simple string containing 0 to 50"
+                    " word, space and punctuation characters."
+                ),
                 "expiresAt": "2022-05-16T04:11:28.0000000+00:00",
                 "modificationState": None,
             }
@@ -164,9 +170,13 @@ def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
         data={
             "webhooks": [
                 {
-                    "webhook_id": "a2156edca7fb6671e13845314f6fc68622e5dd7c58f17663a487bd28cac247e7",
+                    "webhook_id": (
+                        "a2156edca7fb6671e13845314f6fc68622e5dd7c58f17663a487bd28cac247e7"
+                    ),
                     "name": "Test1",
-                    "auth": "f2156edca7fc6871e13845314a6fc68622e5ad7c58f17663a487ed28cac247f7",
+                    "auth": (
+                        "f2156edca7fc6871e13845314a6fc68622e5ad7c58f17663a487ed28cac247f7"
+                    ),
                     "ekey_id": "946DA01F-9ABD-4D9D-80C7-02AF85C822A8",
                 }
             ]

--- a/tests/components/ekeybionyx/test_config_flow.py
+++ b/tests/components/ekeybionyx/test_config_flow.py
@@ -138,7 +138,9 @@ async def test_full_flow(
             {
                 "webhook_id": "1234567890",
                 "name": "Test",
-                "auth": "f2156edca7fc6871e13845314a6fc68622e5ad7c58f17663a487ed28cac247f7",
+                "auth": (
+                    "f2156edca7fc6871e13845314a6fc68622e5ad7c58f17663a487ed28cac247f7"
+                ),
                 "ekey_id": "946DA01F-9ABD-4D9D-80C7-02AF85C822A8",
             }
         ]

--- a/tests/components/elevenlabs/test_tts.py
+++ b/tests/components/elevenlabs/test_tts.py
@@ -45,7 +45,10 @@ class _FakeResponse:
 
 
 class _AsyncByteStream:
-    """Async iterator that yields bytes and exposes response headers like ElevenLabs' stream."""
+    """Async iterator that yields bytes.
+
+    Exposes response headers like ElevenLabs' stream.
+    """
 
     def __init__(self, chunks: list[bytes], request_id: str | None = None) -> None:
         self._chunks = chunks
@@ -79,11 +82,12 @@ class _AsyncStreamResponse:
 
 @pytest.fixture
 def capture_stream_calls(monkeypatch: pytest.MonkeyPatch):
-    """Patches AsyncElevenLabs.text_to_speech.with_raw_response.stream and captures each call's kwargs.
+    """Patch text_to_speech.with_raw_response.stream, capture kwargs.
 
     Returns:
-      calls: list[dict] — kwargs passed into each stream() invocation
-      set_next_return(chunks, request_id): sets what the NEXT stream() call yields/returns
+      calls: list[dict] -- kwargs passed into each stream() invocation
+      set_next_return(chunks, request_id): sets what the NEXT
+          stream() call yields/returns
     """
     calls: list[dict] = []
     state = {"chunks": [b"X"], "request_id": "rid-1"}  # defaults; override per test
@@ -548,7 +552,8 @@ async def test_stream_tts_with_request_ids(
     """Test streaming TTS with request-id stitching."""
     calls, set_next_return, patch_stream = capture_stream_calls
 
-    # Access the TTS entity as in your existing tests; adjust if you use a fixture instead
+    # Access the TTS entity as in your existing tests;
+    # adjust if you use a fixture instead
     tts_entity = hass.data[tts.DOMAIN].get_entity("tts.elevenlabs_text_to_speech")
     patch_stream(tts_entity)
 

--- a/tests/components/elgato/test_config_flow.py
+++ b/tests/components/elgato/test_config_flow.py
@@ -390,7 +390,7 @@ async def test_reconfigure_flow_different_device(
     mock_elgato: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test reconfigure aborts when the device at the new host has a different serial."""
+    """Test reconfigure aborts when new host has a different serial."""
     mock_config_entry.add_to_hass(hass)
 
     result = await mock_config_entry.start_reconfigure_flow(hass)

--- a/tests/components/elkm1/test_config_flow.py
+++ b/tests/components/elkm1/test_config_flow.py
@@ -428,7 +428,7 @@ async def test_form_user_with_secure_elk_with_discovery(hass: HomeAssistant) -> 
 async def test_form_user_with_secure_elk_with_discovery_pick_manual(
     hass: HomeAssistant,
 ) -> None:
-    """Test we can setup a secure elk with discovery but user picks manual and directed discovery fails."""
+    """Test secure elk setup with discovery, manual pick, directed fail."""
 
     with _patch_discovery():
         result = await hass.config_entries.flow.async_init(
@@ -489,7 +489,7 @@ async def test_form_user_with_secure_elk_with_discovery_pick_manual(
 async def test_form_user_with_secure_elk_with_discovery_pick_manual_direct_discovery(
     hass: HomeAssistant,
 ) -> None:
-    """Test we can setup a secure elk with discovery but user picks manual and directed discovery succeeds."""
+    """Test secure elk setup with discovery, manual pick, directed success."""
 
     with _patch_discovery():
         result = await hass.config_entries.flow.async_init(
@@ -803,7 +803,8 @@ async def test_unknown_exception(hass: HomeAssistant) -> None:
         )
 
     assert result2["type"] is FlowResultType.FORM
-    # Simulate an unexpected exception (ValueError) and verify the flow returns an "unknown" error
+    # Simulate an unexpected exception (ValueError) and verify
+    # the flow returns an "unknown" error
     assert result2["errors"] == {"base": "unknown"}
 
     # Retry with successful connection
@@ -1284,7 +1285,7 @@ async def test_form_import_existing(hass: HomeAssistant) -> None:
         (config_entries.SOURCE_INTEGRATION_DISCOVERY, ELK_DISCOVERY_INFO),
     ],
 )
-async def test_discovered_by_dhcp_or_discovery_mac_address_mismatch_host_already_configured(
+async def test_discovered_by_dhcp_or_discovery_mac_mismatch_host_configured(
     hass: HomeAssistant, source, data
 ) -> None:
     """Test we abort if the host is already configured but the mac does not match."""
@@ -1337,7 +1338,7 @@ async def test_discovered_by_dhcp_or_discovery_adds_missing_unique_id(
 
 
 async def test_discovered_by_discovery_and_dhcp(hass: HomeAssistant) -> None:
-    """Test we get the form with discovery and abort for dhcp source when we get both."""
+    """Test we get the form with discovery and abort for dhcp source."""
 
     with _patch_discovery(), _patch_elk():
         result = await hass.config_entries.flow.async_init(
@@ -1548,7 +1549,7 @@ async def test_discovered_by_dhcp_udp_responds(hass: HomeAssistant) -> None:
 async def test_discovered_by_dhcp_udp_responds_with_nonsecure_port(
     hass: HomeAssistant,
 ) -> None:
-    """Test we can setup when discovered from dhcp but with udp response using the non-secure port."""
+    """Test setup from dhcp with udp response using non-secure port."""
 
     with _patch_discovery(device=ELK_NON_SECURE_DISCOVERY), _patch_elk():
         result = await hass.config_entries.flow.async_init(
@@ -1597,7 +1598,7 @@ async def test_discovered_by_dhcp_udp_responds_with_nonsecure_port(
 async def test_discovered_by_dhcp_udp_responds_existing_config_entry(
     hass: HomeAssistant,
 ) -> None:
-    """Test we can setup when discovered from dhcp but with udp response with an existing config entry."""
+    """Test setup from dhcp with udp response and existing config entry."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_HOST: "elks://6.6.6.6"},
@@ -2036,7 +2037,7 @@ async def test_reconfigure_nonsecure(
 async def test_reconfigure_tls(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
-    """Test reconfigure flow switching to TLS 1.2 protocol, validating host, username, and password update."""
+    """Test reconfigure flow switching to TLS 1.2 protocol."""
     mock_config_entry.add_to_hass(hass)
     await hass.async_block_till_done()
 
@@ -2223,7 +2224,8 @@ async def test_reconfigure_different_device(
         await hass.async_block_till_done()
         await hass.async_block_till_done()
 
-    # Abort occurs when the discovered device's unique_id does not match the existing config entry.
+    # Abort occurs when the discovered device's unique_id
+    # does not match the existing config entry.
     assert result2["type"] is FlowResultType.ABORT
     assert result2["reason"] == "unique_id_mismatch"
 
@@ -2292,7 +2294,7 @@ async def test_reconfigure_unknown_error(
 async def test_reconfigure_preserves_existing_config_entry_fields(
     hass: HomeAssistant,
 ) -> None:
-    """Test reconfigure only updates changed fields and preserves existing config entry data."""
+    """Test reconfigure only updates changed fields, preserves others."""
     # Simulate a config entry imported from yaml with extra fields
     initial_data = {
         CONF_HOST: "elks://1.2.3.4",

--- a/tests/components/elmax/test_config_flow.py
+++ b/tests/components/elmax/test_config_flow.py
@@ -326,7 +326,8 @@ async def test_zeroconf_panel_changed_ip(hass: HomeAssistant) -> None:
     )
     config_entry.add_to_hass(hass)
 
-    # Simulate a MDNS discovery finds the same panel with a different IP (MOCK_ZEROCONF_DISCOVERY_CHANGED_INFO).
+    # Simulate a MDNS discovery finds the same panel with a
+    # different IP (MOCK_ZEROCONF_DISCOVERY_CHANGED_INFO).
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
@@ -359,7 +360,8 @@ async def test_one_config_allowed_cloud(hass: HomeAssistant) -> None:
         unique_id=MOCK_PANEL_ID,
     ).add_to_hass(hass)
 
-    # Attempt to add another instance of the integration for the very same panel, it must fail.
+    # Attempt to add another instance of the integration
+    # for the very same panel, it must fail.
     show_form_result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -449,7 +449,8 @@ async def test_light_without_brightness_can_be_turned_on(
         hue_client,
         "light.no_brightness",
         True,
-        # Some remotes, like HarmonyHub send brightness value regardless of light's features
+        # Some remotes, like HarmonyHub send brightness
+        # value regardless of light's features
         brightness=0,
     )
 
@@ -1117,7 +1118,8 @@ async def test_put_light_state_fan(
     assert living_room_fan.state == "on"
     assert living_room_fan.attributes[fan.ATTR_PERCENTAGE] == 43
 
-    # Check setting the brightness of a fan to 0, 33%, 66% and 100% will respectively turn it off, low, medium or high
+    # Check setting the brightness of a fan to 0, 33%, 66% and 100%
+    # will respectively turn it off, low, medium or high.
     # We also check non-cached GET value to exercise the code.
     await perform_put_light_state(
         hass_hue, hue_client, "fan.living_room_fan", True, brightness=0
@@ -1450,13 +1452,16 @@ async def test_unauthorized_user_blocked(hue_client: TestClient) -> None:
 async def test_put_then_get_cached_properly(
     hass: HomeAssistant, hass_hue: HomeAssistant, hue_client: TestClient
 ) -> None:
-    """Test the setting of light states and an immediate readback reads the same values."""
+    """Test setting light states and immediate readback reads the same."""
 
     # Turn the bedroom light on first
     await hass_hue.services.async_call(
         light.DOMAIN,
         const.SERVICE_TURN_ON,
-        {const.ATTR_ENTITY_ID: "light.ceiling_lights", light.ATTR_BRIGHTNESS: 153},
+        {
+            const.ATTR_ENTITY_ID: "light.ceiling_lights",
+            light.ATTR_BRIGHTNESS: 153,
+        },
         blocking=True,
     )
 
@@ -1475,13 +1480,17 @@ async def test_put_then_get_cached_properly(
         brightness=254,
     )
 
-    # Check that a Hue brightness level of 254 becomes 255 in HA realm.
+    # Check that a Hue brightness level of 254 becomes 255
+    # in HA realm.
     assert (
         hass.states.get("light.ceiling_lights").attributes[light.ATTR_BRIGHTNESS] == 255
     )
 
-    # Make sure that the GET response is the same as the PUT response within 2 seconds if the service call is successful and the state doesn't change.
-    # We simulate a long latence for the actual setting of the entity by forcibly sitting different values directly.
+    # Make sure that the GET response is the same as the PUT
+    # response within 2 seconds if the service call is successful
+    # and the state doesn't change. We simulate a long latence for
+    # the actual setting of the entity by forcibly sitting different
+    # values directly.
     await hass_hue.services.async_call(
         light.DOMAIN,
         const.SERVICE_TURN_ON,
@@ -1489,7 +1498,8 @@ async def test_put_then_get_cached_properly(
         blocking=True,
     )
 
-    # go through api to get the state back, the value returned should match those set in the last PUT request.
+    # go through api to get the state back, the value returned
+    # should match those set in the last PUT request.
     ceiling_json = await perform_get_light_state(
         hue_client, "light.ceiling_lights", HTTPStatus.OK
     )
@@ -1498,7 +1508,9 @@ async def test_put_then_get_cached_properly(
     assert ceiling_json["state"][HUE_API_STATE_SAT] == 127
     assert ceiling_json["state"][HUE_API_STATE_BRI] == 254
 
-    # Make sure that the GET response does not use the cache if PUT response within 2 seconds if the service call is Unsuccessful and the state does not change.
+    # Make sure that the GET response does not use the cache if PUT
+    # response within 2 seconds if the service call is unsuccessful
+    # and the state does not change.
     await hass_hue.services.async_call(
         light.DOMAIN,
         const.SERVICE_TURN_OFF,
@@ -1548,7 +1560,8 @@ async def test_put_then_get_cached_properly(
         blocking=True,
     )
 
-    # go through api to get the state back, the value returned should match those set in the last PUT request.
+    # go through api to get the state back, the value returned
+    # should match those set in the last PUT request.
     ceiling_json = await perform_get_light_state(
         hue_client, "light.ceiling_lights", HTTPStatus.OK
     )
@@ -1561,7 +1574,8 @@ async def test_put_then_get_cached_properly(
     with patch.object(hue_api, "STATE_CACHED_TIMEOUT", 0.000001):
         await asyncio.sleep(0.000001)
 
-        # go through api to get the state back, the value returned should now match the actual values.
+        # go through api to get the state back, the value returned
+        # should now match the actual values.
         ceiling_json = await perform_get_light_state(
             hue_client, "light.ceiling_lights", HTTPStatus.OK
         )
@@ -1615,7 +1629,8 @@ async def test_put_than_get_when_service_call_fails(
     # Ensure we did not actually turn on
     assert hass.states.get("light.ceiling_lights").state == STATE_OFF
 
-    # go through api to get the state back, the value returned should NOT match those set in the last PUT request
+    # go through api to get the state back, the value returned
+    # should NOT match those set in the last PUT request
     # as the waiting to check the state change timed out
     ceiling_json = await perform_get_light_state(
         hue_client, "light.ceiling_lights", HTTPStatus.OK
@@ -1626,7 +1641,7 @@ async def test_put_than_get_when_service_call_fails(
 
 @pytest.mark.usefixtures("hass_hue")
 async def test_get_invalid_entity(hue_client: TestClient) -> None:
-    """Test the setting of light states and an immediate readback reads the same values."""
+    """Test setting light states and immediate readback."""
 
     # Check that we get an error with an invalid entity number.
     await perform_get_light_state_by_number(hue_client, 999, HTTPStatus.NOT_FOUND)
@@ -1654,7 +1669,8 @@ async def test_put_light_state_scene(
 
     assert hass_hue.states.get("light.kitchen_lights").state == STATE_ON
 
-    # Set the brightness on the entity; changing a scene brightness via the hue API will do nothing.
+    # Set the brightness on the entity; changing a scene
+    # brightness via the hue API will do nothing.
     await hass_hue.services.async_call(
         light.DOMAIN,
         const.SERVICE_TURN_ON,
@@ -1700,8 +1716,12 @@ async def test_only_change_contrast(
 
     # Check that only setting the contrast will also turn on the light.
     # pylint: disable-next=fixme
-    # TODO: It should be noted that a real Hue hub will not allow to change the brightness if the underlying entity is off.
-    # giving the error: [{"error":{"type":201,"address":"/lights/20/state/bri","description":"parameter, bri, is not modifiable. Device is set to off."}}]
+    # TODO: It should be noted that a real Hue hub will not
+    # allow to change the brightness if the underlying entity
+    # is off, giving the error:
+    # [{"error":{"type":201,"address":"/lights/20/state/bri",
+    # "description":"parameter, bri, is not modifiable.
+    # Device is set to off."}}]
     # emulated_hue however will always turn on the light.
     ceiling_lights = hass_hue.states.get("light.ceiling_lights")
     assert ceiling_lights.state == STATE_ON
@@ -1714,7 +1734,8 @@ async def test_only_change_hue_or_saturation(
     """Test setting either the hue or the saturation but not both."""
 
     # pylint: disable-next=fixme
-    # TODO: The handling of this appears wrong, as setting only one will set the other to 0.
+    # TODO: The handling of this appears wrong, as setting
+    # only one will set the other to 0.
     # The return values also appear wrong.
 
     # Turn the ceiling lights on first and set hue and saturation.

--- a/tests/components/energenie_power_sockets/test_config_flow.py
+++ b/tests/components/energenie_power_sockets/test_config_flow.py
@@ -103,7 +103,7 @@ async def test_user_flow_device_not_found(
     mock_get_device: MagicMock,
     mock_search_for_devices: MagicMock,
 ) -> None:
-    """Test configuration flow when the given device_id does not match any found devices."""
+    """Test config flow when device_id does not match any found devices."""
 
     mock_get_device.return_value = None
 

--- a/tests/components/energy/test_data.py
+++ b/tests/components/energy/test_data.py
@@ -88,7 +88,7 @@ async def test_energy_preferences_migration_from_old_version(
 async def test_battery_power_config_inverted_sets_stat_rate(
     hass: HomeAssistant,
 ) -> None:
-    """Test that battery with inverted power_config sets stat_rate to generated entity_id."""
+    """Test battery with inverted power_config sets stat_rate."""
     manager = EnergyManager(hass)
     await manager.async_initialize()
     manager.data = manager.default_preferences()

--- a/tests/components/energy/test_helpers.py
+++ b/tests/components/energy/test_helpers.py
@@ -23,8 +23,8 @@ def test_generate_power_sensor_unique_id_combined() -> None:
     }
     unique_id = generate_power_sensor_unique_id("battery", config)
     assert (
-        unique_id
-        == "energy_power_battery_combined_sensor_battery_discharge_sensor_battery_charge"
+        unique_id == "energy_power_battery_combined"
+        "_sensor_battery_discharge_sensor_battery_charge"
     )
 
 

--- a/tests/components/energy/test_sensor.py
+++ b/tests/components/energy/test_sensor.py
@@ -2737,7 +2737,8 @@ async def test_missing_price_entity(
     )
     await hass.async_block_till_done()
 
-    # Cost should be initialized (0.0 because it's the first update after price became available)
+    # Cost should be initialized (0.0 because it's the first
+    # update after price became available)
     state = hass.states.get("sensor.energy_consumption_cost")
     assert state.state == "0.0"
 

--- a/tests/components/energy/test_validate.py
+++ b/tests/components/energy/test_validate.py
@@ -826,7 +826,9 @@ async def test_validation_gas(
                     "affected_entities": {("sensor.gas_price_2", "EUR/invalid")},
                     "translation_placeholders": {
                         "price_units": (
-                            f"{ENERGY_PRICE_UNITS_STRING}, EUR/CCF, EUR/ft³, EUR/m³, EUR/L, EUR/MCF"
+                            f"{ENERGY_PRICE_UNITS_STRING},"
+                            " EUR/CCF, EUR/ft³, EUR/m³,"
+                            " EUR/L, EUR/MCF"
                         )
                     },
                 },
@@ -1040,7 +1042,9 @@ async def test_validation_water(
                     "type": "entity_unexpected_unit_water_price",
                     "affected_entities": {("sensor.water_price_2", "EUR/invalid")},
                     "translation_placeholders": {
-                        "price_units": "EUR/CCF, EUR/ft³, EUR/m³, EUR/gal, EUR/L, EUR/MCF"
+                        "price_units": (
+                            "EUR/CCF, EUR/ft³, EUR/m³, EUR/gal, EUR/L, EUR/MCF"
+                        )
                     },
                 },
             ],

--- a/tests/components/energy/test_websocket_api.py
+++ b/tests/components/energy/test_websocket_api.py
@@ -1063,7 +1063,7 @@ async def test_fossil_energy_consumption_checks(
 async def test_fossil_energy_consumption_check_missing_hour(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
-    """Test explicitly if the API keeps the first hour of data for the requested time frame."""
+    """Test the API keeps the first hour of data for the time frame."""
 
     now = dt_util.utcnow()
     later = dt_util.as_utc(dt_util.parse_datetime("2021-08-01 05:00:00"))

--- a/tests/components/energyid/test_config_flow.py
+++ b/tests/components/energyid/test_config_flow.py
@@ -83,7 +83,8 @@ async def test_config_flow_user_step_success_claimed(hass: HomeAssistant) -> Non
 
         # Check unique_id is set correctly
         entry = hass.config_entries.async_get_entry(result2["result"].entry_id)
-        # For initially claimed devices, unique_id should be the device_id, not record_number
+        # For initially claimed devices, unique_id should be
+        # the device_id, not record_number
         assert entry.unique_id.startswith("homeassistant_eid_")
         assert CONF_DEVICE_ID in entry.data
         assert entry.data[CONF_DEVICE_ID] == entry.unique_id
@@ -185,7 +186,8 @@ async def test_config_flow_claim_timeout(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        # After timeout, polling stops and user continues - should see external step again
+        # After timeout, polling stops and user continues
+        # - should see external step again
         assert mock_unclaimed_client.authenticate.call_count == 1
         assert result_after_timeout["type"] is FlowResultType.EXTERNAL_STEP
         assert result_after_timeout["step_id"] == "auth_and_claim"
@@ -392,7 +394,8 @@ async def test_config_flow_external_step_claimed_during_display(
         )
         assert result_external["type"] is FlowResultType.EXTERNAL_STEP
 
-        # User continues immediately - device is claimed, polling task should be cancelled
+        # User continues immediately - device is claimed,
+        # polling task should be cancelled
         result_claimed = await hass.config_entries.flow.async_configure(
             result_external["flow_id"]
         )
@@ -431,7 +434,8 @@ async def test_config_flow_auth_and_claim_step_not_claimed(hass: HomeAssistant) 
         )
         assert result2["type"] is FlowResultType.EXTERNAL_STEP
 
-        # User continues immediately - device still not claimed, polling task should be cancelled
+        # User continues immediately - device still not claimed,
+        # polling task should be cancelled
         result3 = await hass.config_entries.flow.async_configure(result2["flow_id"])
         assert result3["type"] is FlowResultType.EXTERNAL_STEP
         assert result3["step_id"] == "auth_and_claim"
@@ -593,7 +597,7 @@ async def test_async_get_supported_subentry_types(hass: HomeAssistant) -> None:
 
 
 async def test_polling_stops_on_invalid_auth_error(hass: HomeAssistant) -> None:
-    """Test that polling stops when invalid_auth error occurs during auth_and_claim polling."""
+    """Test polling stops on invalid_auth error during auth_and_claim."""
     mock_unclaimed_client = MagicMock()
     mock_unclaimed_client.authenticate = AsyncMock(return_value=False)
     mock_unclaimed_client.get_claim_info.return_value = {"claim_url": "http://claim.me"}
@@ -644,7 +648,7 @@ async def test_polling_stops_on_invalid_auth_error(hass: HomeAssistant) -> None:
 
 
 async def test_polling_stops_on_cannot_connect_error(hass: HomeAssistant) -> None:
-    """Test that polling stops when cannot_connect error occurs during auth_and_claim polling."""
+    """Test polling stops on cannot_connect error during auth_and_claim."""
     mock_unclaimed_client = MagicMock()
     mock_unclaimed_client.authenticate = AsyncMock(return_value=False)
     mock_unclaimed_client.get_claim_info.return_value = {"claim_url": "http://claim.me"}
@@ -691,7 +695,7 @@ async def test_polling_stops_on_cannot_connect_error(hass: HomeAssistant) -> Non
 
 
 async def test_auth_and_claim_subsequent_auth_error(hass: HomeAssistant) -> None:
-    """Test that auth_and_claim step handles authentication errors during polling attempts."""
+    """Test auth_and_claim handles auth errors during polling."""
     mock_unclaimed_client = MagicMock()
     mock_unclaimed_client.authenticate = AsyncMock(return_value=False)
     mock_unclaimed_client.get_claim_info.return_value = {"claim_url": "http://claim.me"}
@@ -795,7 +799,7 @@ async def test_reauth_with_error(hass: HomeAssistant) -> None:
 
 
 async def test_polling_cancellation_on_auth_failure(hass: HomeAssistant) -> None:
-    """Test that polling is cancelled when authentication fails during auth_and_claim."""
+    """Test polling is cancelled when auth fails during auth_and_claim."""
     call_count = 0
     auth_call_count = 0
 
@@ -865,7 +869,7 @@ async def test_polling_cancellation_on_auth_failure(hass: HomeAssistant) -> None
 
 
 async def test_polling_cancellation_on_success(hass: HomeAssistant) -> None:
-    """Test that polling is cancelled when device becomes claimed successfully during auth_and_claim."""
+    """Test polling is cancelled when device becomes claimed successfully."""
     call_count = 0
     auth_call_count = 0
 

--- a/tests/components/energyid/test_energyid_sensor_mapping_flow.py
+++ b/tests/components/energyid/test_energyid_sensor_mapping_flow.py
@@ -270,7 +270,7 @@ async def test_duplicate_entity_key(
 def test_validate_mapping_input_none_entity(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
-    """Test that _validate_mapping_input returns 'entity_required' error for None entity."""
+    """Test _validate_mapping_input returns error for None entity."""
     errors = _validate_mapping_input(None, set(), entity_registry)
     assert errors == {"base": "entity_required"}
 
@@ -278,7 +278,7 @@ def test_validate_mapping_input_none_entity(
 def test_validate_mapping_input_empty_string(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
-    """Test that _validate_mapping_input returns 'entity_required' error for empty string entity."""
+    """Test _validate_mapping_input returns error for empty string."""
     errors = _validate_mapping_input("", set(), entity_registry)
     assert errors == {"base": "entity_required"}
 
@@ -286,7 +286,7 @@ def test_validate_mapping_input_empty_string(
 def test_validate_mapping_input_already_mapped(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
-    """Test that _validate_mapping_input returns 'entity_already_mapped' error when entity is already mapped."""
+    """Test _validate_mapping_input returns error when entity is mapped."""
     entity_entry = entity_registry.async_get_or_create(
         "sensor", "test", "mapped_entity", suggested_object_id="mapped"
     )
@@ -300,7 +300,7 @@ def test_validate_mapping_input_already_mapped(
 def test_get_suggested_entities_with_state_class(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
-    """Test that _get_suggested_entities includes sensor entities with measurement state class."""
+    """Test _get_suggested_entities includes measurement sensors."""
     entity_entry = entity_registry.async_get_or_create(
         "sensor",
         "test",
@@ -347,7 +347,7 @@ def test_get_suggested_entities_with_state_class(
 def test_get_suggested_entities_with_device_class(
     hass: HomeAssistant, entity_registry: er.EntityRegistry, test_case: dict[str, Any]
 ) -> None:
-    """Test that _get_suggested_entities includes sensor entities with various device class configurations."""
+    """Test _get_suggested_entities includes various device classes."""
     entity_entry = entity_registry.async_get_or_create(
         "sensor",
         "test",
@@ -370,7 +370,7 @@ async def test_subentry_entity_not_found_after_validation(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test that subentry flow returns error when entity is validated but disappears before registry lookup."""
+    """Test subentry flow error when entity disappears before lookup."""
     mock_parent_entry = MockConfigEntry(
         domain=DOMAIN,
         data={

--- a/tests/components/energyid/test_init.py
+++ b/tests/components/energyid/test_init.py
@@ -96,7 +96,7 @@ async def test_setup_auth_error_401_triggers_reauth(
     mock_config_entry: MockConfigEntry,
     mock_webhook_client: MagicMock,
 ) -> None:
-    """Test 401 authentication error triggers reauth flow (covers __init__.py lines 85-86)."""
+    """Test 401 authentication error triggers reauth flow."""
     mock_webhook_client.authenticate.side_effect = ClientResponseError(
         request_info=MagicMock(),
         history=(),
@@ -122,7 +122,7 @@ async def test_setup_auth_error_403_triggers_reauth(
     mock_config_entry: MockConfigEntry,
     mock_webhook_client: MagicMock,
 ) -> None:
-    """Test 403 authentication error triggers reauth flow (covers __init__.py lines 85-86)."""
+    """Test 403 authentication error triggers reauth flow."""
     mock_webhook_client.authenticate.side_effect = ClientResponseError(
         request_info=MagicMock(),
         history=(),
@@ -1075,7 +1075,7 @@ async def test_config_entry_update_listener_called(hass: HomeAssistant) -> None:
 async def test_initial_state_conversion_error_valueerror(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
-    """Test ValueError/TypeError during initial state float conversion (lines 212-213)."""
+    """Test ValueError/TypeError during initial state float conversion."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -1144,7 +1144,8 @@ async def test_state_change_untracked_entity_explicit(hass: HomeAssistant) -> No
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-        # Change state of a completely unrelated entity that doesn't exist in any mapping
+        # Change state of a completely unrelated entity that
+        # doesn't exist in any mapping
         hass.states.async_set("sensor.random_unrelated_entity", "100")
         await hass.async_block_till_done()
 
@@ -1228,7 +1229,8 @@ async def test_entry_unloading_flag_state_change(hass: HomeAssistant) -> None:
         del entry.runtime_data
 
         # Try to trigger state change handler - should hit the check at line 305
-        # Since we can't easily trigger the actual callback, we'll just ensure the entry is cleaned up properly
+        # Since we can't easily trigger the actual callback,
+        # we'll just ensure the entry is cleaned up properly
 
         assert not hasattr(entry, "runtime_data")
 
@@ -1283,7 +1285,7 @@ async def test_initial_state_conversion_error(
     mock_webhook_client: MagicMock,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test ValueError/TypeError during initial state float conversion (lines 212-213)."""
+    """Test ValueError/TypeError during initial state float conversion."""
     # Create entity with non-numeric state that will cause conversion error
     entity_entry = entity_registry.async_get_or_create(
         "sensor",

--- a/tests/components/enigma2/conftest.py
+++ b/tests/components/enigma2/conftest.py
@@ -89,7 +89,11 @@ def openwebif_device_mock() -> Generator[AsyncMock]:
         device.get_all_bouquets.return_value = {
             "bouquets": [
                 [
-                    '1:7:1:0:0:0:0:0:0:0:FROM BOUQUET "userbouquet.favourites.tv" ORDER BY bouquet',
+                    (
+                        "1:7:1:0:0:0:0:0:0:0:FROM BOUQUET"
+                        ' "userbouquet.favourites.tv"'
+                        " ORDER BY bouquet"
+                    ),
                     "Favourites (TV)",
                 ]
             ]

--- a/tests/components/enigma2/test_init.py
+++ b/tests/components/enigma2/test_init.py
@@ -19,7 +19,7 @@ async def test_device_without_mac_address(
     openwebif_device_mock: AsyncMock,
     device_registry: dr.DeviceRegistry,
 ) -> None:
-    """Test that a device gets successfully registered when the device doesn't report a MAC address."""
+    """Test device registration when device doesn't report a MAC address."""
     openwebif_device_mock.get_about.return_value = await async_load_json_object_fixture(
         hass, "device_about_without_mac.json", DOMAIN
     )

--- a/tests/components/enphase_envoy/test_config_flow.py
+++ b/tests/components/enphase_envoy/test_config_flow.py
@@ -594,7 +594,9 @@ async def test_options_default(
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
-        OPTION_DIAGNOSTICS_INCLUDE_FIXTURES: OPTION_DIAGNOSTICS_INCLUDE_FIXTURES_DEFAULT_VALUE,
+        OPTION_DIAGNOSTICS_INCLUDE_FIXTURES: (
+            OPTION_DIAGNOSTICS_INCLUDE_FIXTURES_DEFAULT_VALUE
+        ),
         OPTION_DISABLE_KEEP_ALIVE: OPTION_DISABLE_KEEP_ALIVE_DEFAULT_VALUE,
     }
 
@@ -798,7 +800,7 @@ async def test_reconfigure_change_ip_to_existing(
     mock_setup_entry: AsyncMock,
     mock_envoy: AsyncMock,
 ) -> None:
-    """Test reconfiguration to existing entry with same ip does not harm existing one."""
+    """Test reconfiguration to existing entry with same ip."""
     await setup_integration(hass, config_entry)
     other_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/enphase_envoy/test_init.py
+++ b/tests/components/enphase_envoy/test_init.py
@@ -454,8 +454,8 @@ async def test_coordinator_firmware_refresh(
         await hass.async_block_till_done(wait_background_tasks=True)
 
         assert (
-            "Envoy firmware changed from: 7.6.175 to: 9.9.9999, reloading config entry Envoy 1234"
-            in caplog.text
+            "Envoy firmware changed from: 7.6.175 to: 9.9.9999,"
+            " reloading config entry Envoy 1234" in caplog.text
         )
         envoy = config_entry.runtime_data.envoy
         assert envoy.firmware == "9.9.9999"
@@ -581,7 +581,7 @@ async def test_coordinator_interface_information_mac_also_in_other_device(
     caplog: pytest.LogCaptureFixture,
     device_registry: dr.DeviceRegistry,
 ) -> None:
-    """Test coordinator interface mac verification with MAC also in other existing device."""
+    """Test coordinator interface mac verification with other device."""
     await setup_integration(hass, config_entry)
 
     caplog.set_level(logging.DEBUG)

--- a/tests/components/enphase_envoy/test_sensor.py
+++ b/tests/components/enphase_envoy/test_sensor.py
@@ -1467,12 +1467,13 @@ async def test_no_state_class_warnings(
     entity_registry: er.EntityRegistry,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test enphase_envoy sensor creation does not result in deviceclass/state_class warnings."""
+    """Test sensor creation has no deviceclass/state_class warnings."""
     logging.getLogger("homeassistant.components.enphase_envoy").setLevel(logging.DEBUG)
     with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SENSOR]):
         await setup_integration(hass, config_entry)
 
-    # Simple test to verify no sensor device class / state class mismatch warning is reported
+    # Verify no sensor device class / state class mismatch
+    # warning is reported
     #
     # assert "which is impossible considering" not in caplog.text
     assert "create a bug report at" not in caplog.text

--- a/tests/components/epic_games_store/conftest.py
+++ b/tests/components/epic_games_store/conftest.py
@@ -35,7 +35,7 @@ def mock_service_christmas_special():
 
 @pytest.fixture(name="service_attribute_not_found")
 def mock_service_attribute_not_found():
-    """Mock a successful service returning a not found attribute error with free & discount games."""
+    """Mock a successful service returning a not found attribute error."""
     with patch(
         "homeassistant.components.epic_games_store.coordinator.EpicGamesStoreAPI"
     ) as service_mock:

--- a/tests/components/epic_games_store/test_calendar.py
+++ b/tests/components/epic_games_store/test_calendar.py
@@ -56,7 +56,14 @@ async def test_discount_games(
         "start_time": "2022-10-18 08:00:00",
         "end_time": "2022-11-01 08:00:00",
         "location": "",
-        "description": "In Shadow of the Tomb Raider Definitive Edition experience the final chapter of Lara\u2019s origin as she is forged into the Tomb Raider she is destined to be.\n\nhttps://store.epicgames.com/fr/p/shadow-of-the-tomb-raider",
+        "description": (
+            "In Shadow of the Tomb Raider Definitive Edition"
+            " experience the final chapter of Lara\u2019s origin"
+            " as she is forged into the Tomb Raider she is"
+            " destined to be.\n\n"
+            "https://store.epicgames.com/fr/p/"
+            "shadow-of-the-tomb-raider"
+        ),
     }
 
 
@@ -81,7 +88,16 @@ async def test_free_games(
         "start_time": "2022-10-27 08:00:00",
         "end_time": "2022-11-03 08:00:00",
         "location": "",
-        "description": "Take control of the most technologically advanced army in the Imperium - The Adeptus Mechanicus. Your every decision will weigh heavily on the outcome of the mission, in this turn-based tactical game. Will you be blessed by the Omnissiah?\n\nhttps://store.epicgames.com/fr/p/warhammer-mechanicus-0e4b71",
+        "description": (
+            "Take control of the most technologically"
+            " advanced army in the Imperium - The Adeptus"
+            " Mechanicus. Your every decision will weigh"
+            " heavily on the outcome of the mission, in"
+            " this turn-based tactical game. Will you be"
+            " blessed by the Omnissiah?\n\n"
+            "https://store.epicgames.com/fr/p/"
+            "warhammer-mechanicus-0e4b71"
+        ),
     }
 
 

--- a/tests/components/epion/conftest.py
+++ b/tests/components/epion/conftest.py
@@ -9,7 +9,7 @@ from tests.common import load_json_object_fixture
 
 @pytest.fixture
 def mock_epion():
-    """Build a fixture for the Epion API that connects successfully and returns one device."""
+    """Build a fixture for the Epion API that connects successfully."""
     current_one_device_data = load_json_object_fixture(
         "epion/get_current_one_device.json"
     )

--- a/tests/components/esphome/test_assist_satellite.py
+++ b/tests/components/esphome/test_assist_satellite.py
@@ -77,7 +77,7 @@ async def test_no_satellite_without_voice_assistant(
     mock_client: APIClient,
     mock_esphome_device: MockESPHomeDeviceType,
 ) -> None:
-    """Test that an assist satellite entity is not created if a voice assistant is not present."""
+    """Test satellite entity is not created without a voice assistant."""
     mock_device = await mock_esphome_device(
         mock_client=mock_client,
         device_info={},
@@ -617,7 +617,7 @@ async def test_pipeline_media_player(
     mock_esphome_device: MockESPHomeDeviceType,
     mock_wav: bytes,
 ) -> None:
-    """Test a complete pipeline run with the TTS response sent to a media player instead of a speaker.
+    """Test pipeline run with TTS response sent to a media player.
 
     This test is not as comprehensive as test_pipeline_api_audio since we're
     mainly focused on tts_response_finished getting automatically called.
@@ -1785,7 +1785,7 @@ async def test_intent_progress_optimization(
     mock_client: APIClient,
     mock_esphome_device: MockESPHomeDeviceType,
 ) -> None:
-    """Test that intent progress events are only sent when early TTS streaming is available."""
+    """Test intent progress events only sent with early TTS streaming."""
     mock_device = await mock_esphome_device(
         mock_client=mock_client,
         device_info={
@@ -1981,7 +1981,7 @@ async def test_secondary_pipeline(
     mock_client: APIClient,
     mock_esphome_device: MockESPHomeDeviceType,
 ) -> None:
-    """Test that the secondary pipeline is used when the secondary wake word is given."""
+    """Test secondary pipeline is used with secondary wake word."""
     assert await async_setup_component(hass, "assist_pipeline", {})
     pipeline_data = hass.data[KEY_ASSIST_PIPELINE]
     pipeline_id_to_name: dict[str, str] = {}

--- a/tests/components/esphome/test_climate.py
+++ b/tests/components/esphome/test_climate.py
@@ -510,7 +510,7 @@ async def test_climate_set_temperature_unsupported_mode(
     mock_client: APIClient,
     mock_generic_device_entry: MockGenericDeviceEntryType,
 ) -> None:
-    """Test setting temperature in unsupported mode with two-point temperature support."""
+    """Test setting temp in unsupported mode with two-point support."""
     entity_info = [
         ClimateInfo(
             object_id="myclimate",

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -2699,7 +2699,7 @@ async def test_discovery_dhcp_no_probe_same_host_port_none(
 async def test_user_flow_starts_zwave_discovery(
     hass: HomeAssistant, mock_client: APIClient
 ) -> None:
-    """Test that the user flow starts Z-Wave JS discovery when device has Z-Wave capabilities."""
+    """Test user flow starts Z-Wave JS discovery with Z-Wave device."""
     # Mock device with Z-Wave capabilities
     mock_client.device_info = AsyncMock(
         return_value=DeviceInfo(
@@ -2781,7 +2781,7 @@ async def test_user_flow_starts_zwave_discovery(
 async def test_user_flow_no_zwave_discovery_without_home_id(
     hass: HomeAssistant, mock_client: APIClient
 ) -> None:
-    """Test that the user flow does not start Z-Wave JS discovery when zwave_home_id is not set."""
+    """Test user flow skips Z-Wave discovery when home_id is not set."""
     # Mock device with Z-Wave capabilities but no home ID
     mock_client.device_info = AsyncMock(
         return_value=DeviceInfo(
@@ -2834,7 +2834,7 @@ async def test_user_flow_no_zwave_discovery_without_home_id(
 async def test_user_flow_no_zwave_discovery_without_capabilities(
     hass: HomeAssistant, mock_client: APIClient
 ) -> None:
-    """Test that the user flow does not start Z-Wave JS discovery when device has no Z-Wave capabilities."""
+    """Test user flow skips Z-Wave discovery without Z-Wave capabilities."""
     # Mock device without Z-Wave capabilities
     mock_client.device_info = AsyncMock(
         return_value=DeviceInfo(

--- a/tests/components/esphome/test_dashboard.py
+++ b/tests/components/esphome/test_dashboard.py
@@ -114,7 +114,7 @@ async def test_setup_dashboard_fails(
     hass: HomeAssistant,
     hass_storage: dict[str, Any],
 ) -> None:
-    """Test that nothing is stored on failed dashboard setup when there was no dashboard before."""
+    """Test nothing is stored on failed setup without prior dashboard."""
     with patch(
         "homeassistant.components.esphome.coordinator.ESPHomeDashboardAPI.get_devices",
         side_effect=TimeoutError,

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -131,7 +131,7 @@ async def test_entities_removed_after_reload(
     hass_storage: dict[str, Any],
     mock_esphome_device: MockESPHomeDeviceType,
 ) -> None:
-    """Test entities and their registry entry are removed when static info changes after a reload."""
+    """Test entities are removed when static info changes after reload."""
     entity_info = [
         BinarySensorInfo(
             object_id="mybinary_sensor",
@@ -472,7 +472,7 @@ async def test_entity_without_name_device_with_friendly_name(
     hass_storage: dict[str, Any],
     mock_esphome_device: MockESPHomeDeviceType,
 ) -> None:
-    """Test name and entity_id for a device a friendly name and an entity without a name."""
+    """Test name and entity_id for device with friendly name."""
     entity_info = [
         BinarySensorInfo(
             object_id="mybinary_sensor",
@@ -1123,7 +1123,7 @@ async def test_entity_id_with_empty_sub_device_name(
     mock_client: APIClient,
     mock_esphome_device: MockESPHomeDeviceType,
 ) -> None:
-    """Test entity_id when sub device has empty name (falls back to main device name)."""
+    """Test entity_id when sub device has empty name."""
     # Define sub device with empty name
     sub_devices = [
         SubDeviceInfo(device_id=11111111, name="", area_id=0),  # Empty name
@@ -1168,7 +1168,7 @@ async def test_unique_id_migration_when_entity_moves_between_devices(
     mock_client: APIClient,
     mock_esphome_device: MockESPHomeDeviceType,
 ) -> None:
-    """Test that unique_id is migrated when entity moves between devices while entity_id stays the same."""
+    """Test unique_id is migrated when entity moves between devices."""
     # Initial setup: entity on main device
     device_info = {
         "name": "test",
@@ -1289,7 +1289,7 @@ async def test_unique_id_migration_sub_device_to_main_device(
     mock_client: APIClient,
     mock_esphome_device: MockESPHomeDeviceType,
 ) -> None:
-    """Test that unique_id is migrated when entity moves from sub-device to main device."""
+    """Test unique_id is migrated when entity moves to main device."""
     # Initial setup: entity on sub-device
     sub_devices = [
         SubDeviceInfo(device_id=22222222, name="kitchen_controller", area_id=0),
@@ -1480,7 +1480,7 @@ async def test_entity_device_id_rename_in_yaml(
     mock_client: APIClient,
     mock_esphome_device: MockESPHomeDeviceType,
 ) -> None:
-    """Test that entities are re-added as new when user renames device_id in YAML config."""
+    """Test entities re-added when user renames device_id in YAML."""
     # Initial setup: entity on sub-device with device_id 11111111
     sub_devices = [
         SubDeviceInfo(device_id=11111111, name="old_device", area_id=0),

--- a/tests/components/esphome/test_ffmpeg_proxy.py
+++ b/tests/components/esphome/test_ffmpeg_proxy.py
@@ -531,7 +531,7 @@ async def test_request_same_url_multiple_times(
     hass_client: ClientSessionGenerator,
     wav_file: str,
 ) -> None:
-    """Test that the ffmpeg process is restarted if the same URL is requested multiple times."""
+    """Test ffmpeg process is restarted if same URL requested again."""
     device_id = "1234"
 
     await async_setup_component(hass, esphome.DOMAIN, {esphome.DOMAIN: {}})

--- a/tests/components/esphome/test_init.py
+++ b/tests/components/esphome/test_init.py
@@ -37,7 +37,7 @@ async def test_remove_entry_clears_dynamic_encryption_key(
     mock_client,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test that removing an entry clears the dynamic encryption key from device and storage."""
+    """Test removing entry clears dynamic encryption key."""
     # Store the encryption key to simulate it was dynamically generated
     storage = await async_get_encryption_key_storage(hass)
     await storage.async_store_key(
@@ -62,7 +62,7 @@ async def test_remove_entry_clears_dynamic_encryption_key(
 
 @pytest.mark.usefixtures("mock_zeroconf")
 async def test_remove_entry_no_noise_psk(hass: HomeAssistant, mock_client) -> None:
-    """Test that removing an entry without noise_psk does not attempt to clear encryption key."""
+    """Test removing entry without noise_psk skips key clearing."""
     mock_config_entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -135,7 +135,7 @@ async def test_remove_entry_connection_error(
     mock_client,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test that connection error during key clearing does not remove key from storage."""
+    """Test connection error during key clearing preserves storage."""
     # Store the encryption key to simulate it was dynamically generated
     storage = await async_get_encryption_key_storage(hass)
     await storage.async_store_key(

--- a/tests/components/esphome/test_light.py
+++ b/tests/components/esphome/test_light.py
@@ -465,7 +465,7 @@ async def test_light_brightness_on_off_with_unknown_color_mode(
     mock_client: APIClient,
     mock_generic_device_entry: MockGenericDeviceEntryType,
 ) -> None:
-    """Test a generic light entity that only supports brightness along with an unknown color mode."""
+    """Test light entity with brightness and unknown color mode."""
     mock_client.api_version = APIVersion(1, 7)
     entity_info = [
         LightInfo(

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -1014,7 +1014,7 @@ async def test_connection_aborted_wrong_device(
     caplog: pytest.LogCaptureFixture,
     issue_registry: ir.IssueRegistry,
 ) -> None:
-    """Test we abort the connection if the unique id is a mac and neither name or mac match."""
+    """Test we abort if unique id is a mac and neither name nor mac match."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -2588,7 +2588,7 @@ async def test_manager_handle_dynamic_encryption_key_device_set_key_fails(
     mock_esphome_device: MockESPHomeDeviceType,
     hass_storage: dict[str, Any],
 ) -> None:
-    """Test _handle_dynamic_encryption_key when noise_encryption_set_key returns False."""
+    """Test dynamic encryption key when set_key returns False."""
     mac_address = "11:22:33:44:55:aa"
     test_key_bytes = b"test_key_32_bytes_long_exactly!"
     mock_token_bytes.return_value = test_key_bytes
@@ -2658,7 +2658,7 @@ async def test_manager_handle_dynamic_encryption_key_connection_error(
     mock_esphome_device: MockESPHomeDeviceType,
     hass_storage: dict[str, Any],
 ) -> None:
-    """Test _handle_dynamic_encryption_key when noise_encryption_set_key raises APIConnectionError."""
+    """Test dynamic encryption key when set_key raises APIConnectionError."""
     mac_address = "11:22:33:44:55:aa"
     test_key_bytes = b"test_key_32_bytes_long_exactly!"
     mock_token_bytes.return_value = test_key_bytes
@@ -2708,7 +2708,8 @@ async def test_manager_handle_dynamic_encryption_key_connection_error(
     await device.mock_disconnect(True)
     await device.mock_connect()
 
-    # Verify key generation was attempted twice (once during setup, once during reconnect)
+    # Verify key generation was attempted twice
+    # (once during setup, once during reconnect)
     # This is expected because the first attempt failed with connection error
     assert mock_token_bytes.call_count == 2
     mock_token_bytes.assert_called_with(32)
@@ -2796,7 +2797,7 @@ async def test_no_zwave_proxy_subscribe_without_feature_flags(
     mock_client: APIClient,
     mock_esphome_device: MockESPHomeDeviceType,
 ) -> None:
-    """Test Z-Wave proxy request subscription is not registered without feature flags."""
+    """Test Z-Wave proxy subscription skipped without feature flags."""
     device_info = {
         "name": "test-device",
         "mac_address": "11:22:33:44:55:AA",
@@ -2902,7 +2903,7 @@ async def test_execute_service_response_type_optional_without_return(
     mock_client: APIClient,
     mock_esphome_device: MockESPHomeDeviceType,
 ) -> None:
-    """Test execute_service with SupportsResponseType.OPTIONAL when caller doesn't request response."""
+    """Test execute_service OPTIONAL when caller skips response."""
     service = UserService(
         name="optional_service",
         key=1,
@@ -2945,7 +2946,7 @@ async def test_execute_service_response_type_optional_with_return(
     mock_client: APIClient,
     mock_esphome_device: MockESPHomeDeviceType,
 ) -> None:
-    """Test execute_service with SupportsResponseType.OPTIONAL when caller requests response."""
+    """Test execute_service OPTIONAL when caller requests response."""
     service = UserService(
         name="optional_service",
         key=1,

--- a/tests/components/esphome/test_media_player.py
+++ b/tests/components/esphome/test_media_player.py
@@ -59,7 +59,9 @@ async def test_media_player_entity(
             key=1,
             name="my media_player",
             supports_pause=True,
-            # PLAY_MEDIA,BROWSE_MEDIA,STOP,VOLUME_SET,VOLUME_MUTE,MEDIA_ANNOUNCE,PAUSE,PLAY,TURN_OFF,TURN_ON
+            # PLAY_MEDIA,BROWSE_MEDIA,STOP,VOLUME_SET,
+            # VOLUME_MUTE,MEDIA_ANNOUNCE,PAUSE,PLAY,
+            # TURN_OFF,TURN_ON
             feature_flags=1201037,
         )
     ]
@@ -314,7 +316,8 @@ async def test_media_player_entity_with_source(
             key=1,
             name="my media_player",
             supports_pause=True,
-            # PLAY_MEDIA,BROWSE_MEDIA,STOP,VOLUME_SET,VOLUME_MUTE,MEDIA_ANNOUNCE,PAUSE,PLAY
+            # PLAY_MEDIA,BROWSE_MEDIA,STOP,VOLUME_SET,
+            # VOLUME_MUTE,MEDIA_ANNOUNCE,PAUSE,PLAY
             feature_flags=1200653,
         )
     ]
@@ -431,7 +434,8 @@ async def test_media_player_proxy(
                 key=1,
                 name="my media_player",
                 supports_pause=True,
-                # PLAY_MEDIA,BROWSE_MEDIA,STOP,VOLUME_SET,VOLUME_MUTE,MEDIA_ANNOUNCE,PAUSE,PLAY
+                # PLAY_MEDIA,BROWSE_MEDIA,STOP,VOLUME_SET,
+                # VOLUME_MUTE,MEDIA_ANNOUNCE,PAUSE,PLAY
                 feature_flags=1200653,
                 supported_formats=[
                     MediaPlayerSupportedFormat(
@@ -591,7 +595,8 @@ async def test_media_player_formats_reload_preserves_data(
                 key=1,
                 name="Test Media Player",
                 supports_pause=True,
-                # PLAY_MEDIA,BROWSE_MEDIA,STOP,VOLUME_SET,VOLUME_MUTE,MEDIA_ANNOUNCE,PAUSE,PLAY
+                # PLAY_MEDIA,BROWSE_MEDIA,STOP,VOLUME_SET,
+                # VOLUME_MUTE,MEDIA_ANNOUNCE,PAUSE,PLAY
                 feature_flags=1200653,
                 supported_formats=supported_formats,
             )

--- a/tests/components/esphome/test_sensor.py
+++ b/tests/components/esphome/test_sensor.py
@@ -241,7 +241,7 @@ async def test_generic_numeric_sensor_legacy_last_reset_convert(
     mock_client: APIClient,
     mock_generic_device_entry: MockGenericDeviceEntryType,
 ) -> None:
-    """Test a state class of measurement with last reset type of auto is converted to total increasing."""
+    """Test measurement with last_reset auto converts to total_increasing."""
     entity_info = [
         SensorInfo(
             object_id="mysensor",

--- a/tests/components/esphome/test_update.py
+++ b/tests/components/esphome/test_update.py
@@ -311,7 +311,7 @@ async def test_update_entity_dashboard_discovered_after_startup_but_update_faile
     mock_esphome_device: MockESPHomeDeviceType,
     mock_dashboard: dict[str, Any],
 ) -> None:
-    """Test ESPHome update entity when dashboard is discovered after startup and the first update fails."""
+    """Test update entity when dashboard discovered after startup fails."""
     with patch(
         "homeassistant.components.esphome.coordinator.ESPHomeDashboardAPI.get_devices",
         side_effect=TimeoutError,
@@ -369,7 +369,7 @@ async def test_update_becomes_available_at_runtime(
     mock_esphome_device: MockESPHomeDeviceType,
     mock_dashboard: dict[str, Any],
 ) -> None:
-    """Test ESPHome update entity when the dashboard has no device at startup but gets them later."""
+    """Test update entity when dashboard has no device at startup."""
     await mock_esphome_device(
         mock_client=mock_client,
     )
@@ -402,7 +402,7 @@ async def test_update_entity_not_present_with_dashboard_but_unknown_device(
     mock_esphome_device: MockESPHomeDeviceType,
     mock_dashboard: dict[str, Any],
 ) -> None:
-    """Test ESPHome update entity does not get created if the device is unknown to the dashboard."""
+    """Test update entity not created if device is unknown to dashboard."""
     await mock_esphome_device(
         mock_client=mock_client,
     )

--- a/tests/components/eurotronic_cometblue/conftest.py
+++ b/tests/components/eurotronic_cometblue/conftest.py
@@ -130,8 +130,9 @@ class MockCometBlueBleakClient(CometBlueBleakClient):
         if char_specifier not in WRITEABLE_CHARACTERISTICS:
             raise BleakCharacteristicNotFoundError(char_specifier)
         data = bytearray(data)
-        # when writing temperature it is possible that 128 will be sent, meaning "no change"
-        # we have to restore the original value in this case to keep tests working
+        # when writing temperature it is possible that 128
+        # will be sent, meaning "no change"; we have to restore
+        # the original value in this case to keep tests working
         if char_specifier in WRITEABLE_CHARACTERISTICS_ALLOW_UNCHANGED:
             for i, byte in enumerate(data):
                 if byte == 128:

--- a/tests/components/eurotronic_cometblue/test_climate.py
+++ b/tests/components/eurotronic_cometblue/test_climate.py
@@ -112,7 +112,8 @@ async def test_climate_preset_away_active(
     mock_gatt_characteristics[cometblue_const.CHARACTERISTIC_HOLIDAY_1] = bytearray(
         [128, 1, 1, 26, 10, 2, 1, 26, 34]
     )
-    # Current target temperature must match holiday temperature for away preset to be active
+    # Current target temperature must match holiday temperature
+    # for away preset to be active
     mock_gatt_characteristics[cometblue_const.CHARACTERISTIC_TEMPERATURE] = bytearray(
         [47, 34, 34, 42, 0, 4, 10]
     )

--- a/tests/components/eurotronic_cometblue/test_config_flow.py
+++ b/tests/components/eurotronic_cometblue/test_config_flow.py
@@ -174,7 +174,8 @@ async def test_bluetooth_flow_errors(
     assert result["step_id"] == "bluetooth_confirm"
     assert result["errors"] == expected_error
 
-    # now retry without side effect, simulating a user correcting the issue (e.g. entering correct PIN)
+    # now retry without side effect, simulating a user
+    # correcting the issue (e.g. entering correct PIN)
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         FIXTURE_USER_INPUT,
@@ -220,7 +221,8 @@ async def test_name_from_discovery() -> None:
     # If for some reason no name can be derived, just return the default name
     assert name_from_discovery(None) == "Comet Blue"
 
-    # If the name is the same as the address, just return the address to avoid long names
+    # If the name is the same as the address, just return
+    # the address to avoid long names
     fake_info = deepcopy(FAKE_SERVICE_INFO)
     fake_info.name = str(fake_info.address)
     assert name_from_discovery(fake_info) == str(fake_info.address)

--- a/tests/components/event/test_init.py
+++ b/tests/components/event/test_init.py
@@ -353,7 +353,7 @@ async def test_doorbell_missing_ring_event_type(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test warning when a doorbell entity does not include the standard ring event type."""
+    """Test warning when doorbell entity lacks the ring event type."""
 
     async def async_setup_entry_init(
         hass: HomeAssistant, config_entry: ConfigEntry

--- a/tests/components/event/test_trigger.py
+++ b/tests/components/event/test_trigger.py
@@ -239,7 +239,8 @@ async def test_event_trigger_options_validation(
                 },
             ],
         ),
-        # To unavailable - should not trigger, and first state after unavailable is skipped
+        # To unavailable - should not trigger, and first state
+        # after unavailable is skipped
         (
             "event.received",
             {"event_type": ["button_press"]},
@@ -286,7 +287,7 @@ async def test_event_state_trigger(
     trigger_options: dict,
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test that the event trigger fires when an event entity receives a matching event."""
+    """Test event trigger fires on matching event entity event."""
     calls: list[str] = []
     other_entity_ids = set(target_events["included_entities"]) - {entity_id}
 

--- a/tests/components/evohome/conftest.py
+++ b/tests/components/evohome/conftest.py
@@ -159,7 +159,8 @@ async def setup_evohome(
     dt_util.set_default_time_zone(timezone(timedelta(minutes=utc_offset)))
 
     with (
-        # patch("homeassistant.components.evohome.ec1.EvohomeClient", return_value=None),
+        # patch("homeassistant.components.evohome.ec1.EvohomeClient",
+        #       return_value=None),
         patch("homeassistant.components.evohome.ec2.EvohomeClient") as mock_client,
         patch(
             "evohomeasync2.auth.CredentialsManagerBase._post_request",

--- a/tests/components/fan/test_reproduce_state.py
+++ b/tests/components/fan/test_reproduce_state.py
@@ -221,7 +221,10 @@ async def test_modern_turn_on_invalid(hass: HomeAssistant, start_state) -> None:
 async def test_modern_turn_on_percentage_from_different_speed(
     hass: HomeAssistant, start_state
 ) -> None:
-    """Test modern fan state reproduction, turning on with a different percentage of the state."""
+    """Test modern fan state reproduction.
+
+    Turning on with a different percentage of the state.
+    """
     hass.states.async_set(MODERN_FAN_ENTITY, "off", start_state)
 
     turn_on_calls = async_mock_service(hass, "fan", "turn_on")
@@ -250,7 +253,10 @@ async def test_modern_turn_on_percentage_from_different_speed(
 
 
 async def test_modern_turn_on_percentage_from_same_speed(hass: HomeAssistant) -> None:
-    """Test modern fan state reproduction, turning on with the same percentage as in the state."""
+    """Test modern fan state reproduction.
+
+    Turning on with the same percentage as in the state.
+    """
     hass.states.async_set(MODERN_FAN_ENTITY, "off", MODERN_FAN_OFF_PERCENTAGE15_STATE)
 
     turn_on_calls = async_mock_service(hass, "fan", "turn_on")
@@ -289,7 +295,10 @@ async def test_modern_turn_on_percentage_from_same_speed(hass: HomeAssistant) ->
 async def test_modern_turn_on_preset_mode_from_different_speed(
     hass: HomeAssistant, start_state
 ) -> None:
-    """Test modern fan state reproduction, turning on with a different preset mode from the state."""
+    """Test modern fan state reproduction.
+
+    Turning on with a different preset mode from the state.
+    """
     hass.states.async_set(MODERN_FAN_ENTITY, "off", start_state)
 
     turn_on_calls = async_mock_service(hass, "fan", "turn_on")
@@ -318,7 +327,10 @@ async def test_modern_turn_on_preset_mode_from_different_speed(
 
 
 async def test_modern_turn_on_preset_mode_from_same_speed(hass: HomeAssistant) -> None:
-    """Test modern fan state reproduction, turning on with the same preset mode as in the state."""
+    """Test modern fan state reproduction.
+
+    Turning on with the same preset mode as in the state.
+    """
     hass.states.async_set(
         MODERN_FAN_ENTITY, "off", MODERN_FAN_OFF_PPRESET_MODE_AUTO_STATE
     )
@@ -359,7 +371,10 @@ async def test_modern_turn_on_preset_mode_from_same_speed(hass: HomeAssistant) -
 async def test_modern_turn_on_preset_mode_reverse(
     hass: HomeAssistant, start_state
 ) -> None:
-    """Test modern fan state reproduction, turning on with preset mode "Auto" and reverse direction."""
+    """Test modern fan state reproduction.
+
+    Turning on with preset mode "Auto" and reverse direction.
+    """
     hass.states.async_set(MODERN_FAN_ENTITY, "off", start_state)
 
     turn_on_calls = async_mock_service(hass, "fan", "turn_on")

--- a/tests/components/fan/test_trigger.py
+++ b/tests/components/fan/test_trigger.py
@@ -95,7 +95,7 @@ async def test_fan_state_trigger_behavior_any(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test that the fan state trigger fires when any fan state changes to a specific state."""
+    """Test the fan state trigger fires on any fan state change."""
     await assert_trigger_behavior_any(
         hass,
         target_entities=target_fans,
@@ -138,7 +138,7 @@ async def test_fan_state_trigger_behavior_first(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test that the fan state trigger fires when the first fan changes to a specific state."""
+    """Test the fan trigger fires on the first fan state change."""
     await assert_trigger_behavior_first(
         hass,
         target_entities=target_fans,
@@ -181,7 +181,7 @@ async def test_fan_state_trigger_behavior_last(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test that the fan state trigger fires when the last fan changes to a specific state."""
+    """Test the fan trigger fires on the last fan state change."""
     await assert_trigger_behavior_last(
         hass,
         target_entities=target_fans,

--- a/tests/components/feedreader/test_init.py
+++ b/tests/components/feedreader/test_init.py
@@ -345,8 +345,9 @@ async def test_feed_errors(
         async_fire_time_changed(hass)
         await hass.async_block_till_done(wait_background_tasks=True)
         assert (
-            "Error fetching feed data from http://some.rss.local/rss_feed.xml : <urlopen error Test>"
-            in caplog.text
+            "Error fetching feed data from"
+            " http://some.rss.local/rss_feed.xml"
+            " : <urlopen error Test>" in caplog.text
         )
 
         # success

--- a/tests/components/ffmpeg/test_init.py
+++ b/tests/components/ffmpeg/test_init.py
@@ -217,7 +217,7 @@ async def test_async_get_image_with_width_height(hass: HomeAssistant) -> None:
 async def test_async_get_image_with_extra_cmd_overlapping_width_height(
     hass: HomeAssistant,
 ) -> None:
-    """Test fetching an image with and extra_cmd with width and height and a specific width and height."""
+    """Test fetching an image with extra_cmd with width/height."""
     with assert_setup_component(1):
         await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 

--- a/tests/components/file_upload/conftest.py
+++ b/tests/components/file_upload/conftest.py
@@ -9,6 +9,6 @@ import pytest
 def large_file_io() -> StringIO:
     """Generate a file on the fly. Simulates a large file."""
     return StringIO(
-        2
-        * "Home Assistant is awesome. Open source home automation that puts local control and privacy first."
+        2 * "Home Assistant is awesome. Open source home automation"
+        " that puts local control and privacy first."
     )

--- a/tests/components/fish_audio/test_config_flow.py
+++ b/tests/components/fish_audio/test_config_flow.py
@@ -270,7 +270,8 @@ async def test_subflow_reconfigure_already_configured(
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
-    # Try to reconfigure the first subentry to match the second one (which already exists)
+    # Try to reconfigure the first subentry to match the second
+    # one (which already exists)
     first_subentry = [
         s for s in mock_config_entry.subentries.values() if s.title == "Test Voice"
     ][0]

--- a/tests/components/fitbit/conftest.py
+++ b/tests/components/fitbit/conftest.py
@@ -125,7 +125,7 @@ def mock_imported_config_data(
     monitored_resources: list[str] | None,
     configured_unit_system: str | None,
 ) -> dict[str, Any]:
-    """Fixture for the fitbit sensor platform configuration data in configuration.yaml."""
+    """Fixture for the fitbit sensor platform config data."""
     config = {}
     if monitored_resources is not None:
         config["monitored_resources"] = monitored_resources

--- a/tests/components/flexit_bacnet/test_config_flow.py
+++ b/tests/components/flexit_bacnet/test_config_flow.py
@@ -54,9 +54,10 @@ async def test_flow_fails(
     mock_setup_entry,
     mock_flexit_bacnet,
 ) -> None:
-    """Test that we return 'cannot_connect' error when attempting to connect to an incorrect IP address.
+    """Test 'cannot_connect' error for incorrect IP address.
 
-    The flexit_bacnet library raises asyncio.exceptions.TimeoutError in that scenario.
+    The flexit_bacnet library raises
+    asyncio.exceptions.TimeoutError in that scenario.
     """
     mock_flexit_bacnet.update.side_effect = error
     result = await hass.config_entries.flow.async_configure(

--- a/tests/components/flume/conftest.py
+++ b/tests/components/flume/conftest.py
@@ -53,7 +53,11 @@ NOTIFICATION = {
     "device_id": "6248148189204194987",
     "user_id": USER_ID,
     "type": 1,
-    "message": "Low Flow Leak triggered at Home. Water has been running for 2 hours averaging 0.43 gallons every minute.",
+    "message": (
+        "Low Flow Leak triggered at Home."
+        " Water has been running for 2 hours"
+        " averaging 0.43 gallons every minute."
+    ),
     "created_datetime": "2020-01-15T16:33:39.000Z",
     "title": "Potential Leak Detected!",
     "read": True,

--- a/tests/components/fluss/test_init.py
+++ b/tests/components/fluss/test_init.py
@@ -62,7 +62,7 @@ async def test_status_authentication_error_marks_device_offline(
     mock_config_entry: MockConfigEntry,
     mock_api_client: AsyncMock,
 ) -> None:
-    """Test that an auth error from a per-device status call marks the device offline."""
+    """Test auth error from per-device status marks device offline."""
     mock_api_client.async_get_device_status.side_effect = (
         FlussApiClientAuthenticationError("permission revoked")
     )

--- a/tests/components/flux_led/conftest.py
+++ b/tests/components/flux_led/conftest.py
@@ -18,7 +18,7 @@ def mock_single_broadcast_address() -> Generator[None]:
 
 @pytest.fixture
 def mock_multiple_broadcast_addresses() -> Generator[None]:
-    """Mock network's async_async_get_ipv4_broadcast_addresses to return multiple addresses."""
+    """Mock network's get_ipv4_broadcast_addresses for multiple addresses."""
     with patch(
         "homeassistant.components.network.async_get_ipv4_broadcast_addresses",
         return_value={"10.255.255.255", "192.168.0.255"},

--- a/tests/components/flux_led/test_config_flow.py
+++ b/tests/components/flux_led/test_config_flow.py
@@ -437,7 +437,7 @@ async def test_manual_no_discovery_data(hass: HomeAssistant) -> None:
 
 
 async def test_discovered_by_discovery_and_dhcp(hass: HomeAssistant) -> None:
-    """Test we get the form with discovery and abort for dhcp source when we get both."""
+    """Test we get the form with discovery and abort for dhcp."""
 
     with _patch_discovery(), _patch_wifibulb():
         result = await hass.config_entries.flow.async_init(
@@ -607,7 +607,7 @@ async def test_discovered_by_dhcp_no_udp_response(hass: HomeAssistant) -> None:
 async def test_discovered_by_dhcp_partial_udp_response_fallback_tcp(
     hass: HomeAssistant,
 ) -> None:
-    """Test we can setup when discovered from dhcp but part of the udp response is missing."""
+    """Test setup from dhcp when part of the udp response is missing."""
 
     with _patch_discovery(no_device=True), _patch_wifibulb():
         result = await hass.config_entries.flow.async_init(
@@ -643,7 +643,7 @@ async def test_discovered_by_dhcp_partial_udp_response_fallback_tcp(
 async def test_discovered_by_dhcp_no_udp_response_or_tcp_response(
     hass: HomeAssistant,
 ) -> None:
-    """Test we can setup when discovered from dhcp but no udp response or tcp response."""
+    """Test setup from dhcp with no udp or tcp response."""
 
     with _patch_discovery(no_device=True), _patch_wifibulb(no_device=True):
         result = await hass.config_entries.flow.async_init(
@@ -684,7 +684,7 @@ async def test_discovered_by_dhcp_or_discovery_adds_missing_unique_id(
 async def test_mac_address_off_by_one_updated_via_discovery(
     hass: HomeAssistant,
 ) -> None:
-    """Test the mac address is updated when its off by one from integration discovery."""
+    """Test the mac address is updated when off by one."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: IP_ADDRESS}, unique_id=MAC_ADDRESS_ONE_OFF
     )
@@ -732,7 +732,7 @@ async def test_mac_address_off_by_one_not_updated_from_dhcp(
         (config_entries.SOURCE_INTEGRATION_DISCOVERY, FLUX_DISCOVERY),
     ],
 )
-async def test_discovered_by_dhcp_or_discovery_mac_address_mismatch_host_already_configured(
+async def test_dhcp_or_discovery_mac_mismatch_host_already_configured(
     hass: HomeAssistant, source, data
 ) -> None:
     """Test we abort if the host is already configured but the mac does not match."""

--- a/tests/components/flux_led/test_init.py
+++ b/tests/components/flux_led/test_init.py
@@ -187,7 +187,7 @@ async def test_coordinator_retry_right_away_on_discovery_already_setup(
 async def test_config_entry_fills_unique_id_with_directed_discovery(
     hass: HomeAssistant, discovery: dict[str, str], title: str
 ) -> None:
-    """Test that the unique id is added if its missing via directed (not broadcast) discovery."""
+    """Test unique id is added if missing via directed discovery."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: IP_ADDRESS}, unique_id=None, title=IP_ADDRESS
     )
@@ -290,7 +290,10 @@ async def test_unique_id_migrate_when_mac_discovered(
 async def test_unique_id_migrate_when_mac_discovered_via_discovery(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
-    """Test unique id migrated when mac discovered via discovery and the mac address from dhcp was one off."""
+    """Test unique id migrated when mac discovered via discovery.
+
+    The mac address from dhcp was one off.
+    """
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data={

--- a/tests/components/foscam/test_init.py
+++ b/tests/components/foscam/test_init.py
@@ -81,7 +81,7 @@ async def test_unique_id_migration_not_needed(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test that the unique ID for a sleep switch is not executed if already in right format."""
+    """Test unique ID for sleep switch skipped if already correct."""
     entry = MockConfigEntry(domain=DOMAIN, data=VALID_CONFIG, entry_id=ENTRY_ID)
     entry.add_to_hass(hass)
 

--- a/tests/components/freebox/conftest.py
+++ b/tests/components/freebox/conftest.py
@@ -107,13 +107,15 @@ def mock_router_bridge_mode(mock_device_registry_devices, router):
 
     router().lan.get_interfaces = AsyncMock(
         side_effect=HttpRequestError(
-            f"Request failed (APIResponse: {json.dumps(DATA_LAN_GET_HOSTS_LIST_MODE_BRIDGE)})"
+            "Request failed (APIResponse:"
+            f" {json.dumps(DATA_LAN_GET_HOSTS_LIST_MODE_BRIDGE)})"
         )
     )
 
     router().lan.get_hosts_list = AsyncMock(
         side_effect=HttpRequestError(
-            f"Request failed (APIResponse: {json.dumps(DATA_LAN_GET_HOSTS_LIST_MODE_BRIDGE)})"
+            "Request failed (APIResponse:"
+            f" {json.dumps(DATA_LAN_GET_HOSTS_LIST_MODE_BRIDGE)})"
         )
     )
 

--- a/tests/components/freebox/test_router.py
+++ b/tests/components/freebox/test_router.py
@@ -33,9 +33,11 @@ async def test_get_hosts_list_if_supported(
     """In router mode, get_hosts_list is supported and list is filled."""
     supports_hosts, fbx_devices = await get_hosts_list_if_supported(router())
     assert supports_hosts is True
-    # List must not be empty; but it's content depends on how many unit tests are executed...
+    # List must not be empty; but its content depends on
+    # how many unit tests are executed...
     assert fbx_devices
-    # We expect 4 devices from lan_get_hosts_list.json and 1 from lan_get_hosts_list_guest.json
+    # We expect 4 devices from lan_get_hosts_list.json
+    # and 1 from lan_get_hosts_list_guest.json
     assert len(fbx_devices) == 5
     assert "d633d0c8-958c-43cc-e807-d881b076924b" in str(fbx_devices)
     assert "d633d0c8-958c-42cc-e807-d881b476924b" in str(fbx_devices)

--- a/tests/components/freedompro/const.py
+++ b/tests/components/freedompro/const.py
@@ -2,85 +2,127 @@
 
 DEVICES = [
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*2VAS3HTWINNZ5N6HVEIPDJ6NX85P2-AM-GSYWUCNPU0",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*2VAS3HTWINNZ5N6HVEIPDJ6NX85P2-AM-GSYWUCNPU0"
+        ),
         "name": "Bathroom leak sensor",
         "type": "leakSensor",
         "characteristics": ["leakDetected"],
     },
     {
-        "uid": "2WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*2VAS3HTWINNZ5N6HVEIPDJ6NX85P2-AM-GSYWUCNPU0",
+        "uid": (
+            "2WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*2VAS3HTWINNZ5N6HVEIPDJ6NX85P2-AM-GSYWUCNPU0"
+        ),
         "name": "lock",
         "type": "lock",
         "characteristics": ["lock"],
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*ILYH1E3DWZOVMNEUIMDYMNLOW-LFRQFDPWWJOVHVDOS",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*ILYH1E3DWZOVMNEUIMDYMNLOW-LFRQFDPWWJOVHVDOS"
+        ),
         "name": "bedroom",
         "type": "fan",
         "characteristics": ["on", "rotationSpeed"],
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*SOT3NKALCRQMHUHJUF79NUG6UQP1IIQIN1PJVRRPT0C",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*SOT3NKALCRQMHUHJUF79NUG6UQP1IIQIN1PJVRRPT0C"
+        ),
         "name": "Contact sensor living room",
         "type": "contactSensor",
         "characteristics": ["contactSensorState"],
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*VTEPEDYE8DXGS8U94CJKQDLKMN6CUX1IJWSOER2HZCK",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*VTEPEDYE8DXGS8U94CJKQDLKMN6CUX1IJWSOER2HZCK"
+        ),
         "name": "Doorway motion sensor",
         "type": "motionSensor",
         "characteristics": ["motionDetected"],
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*QN-DDFMPEPRDOQV7W7JQG3NL0NPZGTLIBYT3HFSPNEY",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*QN-DDFMPEPRDOQV7W7JQG3NL0NPZGTLIBYT3HFSPNEY"
+        ),
         "name": "Garden humidity sensor",
         "type": "humiditySensor",
         "characteristics": ["currentRelativeHumidity"],
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*1JKU1MVWHQL-Z9SCUS85VFXMRGNDCDNDDUVVDKBU31W",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*1JKU1MVWHQL-Z9SCUS85VFXMRGNDCDNDDUVVDKBU31W"
+        ),
         "name": "Irrigation switch",
         "type": "switch",
         "characteristics": ["on"],
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*JHJZIZ9ORJNHB7DZNBNAOSEDECVTTZ48SABTCA3WA3M",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*JHJZIZ9ORJNHB7DZNBNAOSEDECVTTZ48SABTCA3WA3M"
+        ),
         "name": "lightbulb",
         "type": "lightbulb",
         "characteristics": ["on", "brightness", "saturation", "hue"],
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*SNG7Y3R1R0S_W5BCNPP1O5WUN2NCEOOT27EFSYT6JYS",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*SNG7Y3R1R0S_W5BCNPP1O5WUN2NCEOOT27EFSYT6JYS"
+        ),
         "name": "Living room occupancy sensor",
         "type": "occupancySensor",
         "characteristics": ["occupancyDetected"],
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*LWPVY7X1AX0DRWLYUUNZ3ZSTHMYNDDBQTPZCZQUUASA",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*LWPVY7X1AX0DRWLYUUNZ3ZSTHMYNDDBQTPZCZQUUASA"
+        ),
         "name": "Living room temperature sensor",
         "type": "temperatureSensor",
         "characteristics": ["currentTemperature"],
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*SXFMEXI4UMDBAMXXPI6LJV47O9NY-IRCAKZI7_MW0LY",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*SXFMEXI4UMDBAMXXPI6LJV47O9NY-IRCAKZI7_MW0LY"
+        ),
         "name": "Smoke sensor kitchen",
         "type": "smokeSensor",
         "characteristics": ["smokeDetected"],
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*R6V0FNNF7SACWZ8V9NCOX7UCYI4ODSYAOJWZ80PLJ3C",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*R6V0FNNF7SACWZ8V9NCOX7UCYI4ODSYAOJWZ80PLJ3C"
+        ),
         "name": "Bedroom CO2 sensor",
         "type": "carbonDioxideSensor",
         "characteristics": ["carbonDioxideDetected", "carbonDioxideLevel"],
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*3-QURR5Q6ADA8ML1TBRG59RRGM1F9LVUZLKPYKFJQHC",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*3-QURR5Q6ADA8ML1TBRG59RRGM1F9LVUZLKPYKFJQHC"
+        ),
         "name": "bedroomlight",
         "type": "lightbulb",
         "characteristics": ["on"],
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*TWMYQKL3UVED4HSIIB9GXJWJZBQCXG-9VE-N2IUAIWI",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*TWMYQKL3UVED4HSIIB9GXJWJZBQCXG-9VE-N2IUAIWI"
+        ),
         "name": "thermostat",
         "type": "thermostat",
         "characteristics": [
@@ -90,19 +132,28 @@ DEVICES = [
         ],
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*3XSSVIJWK-65HILWTC4WINQK46SP4OEZRCNO25VGWAS",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*3XSSVIJWK-65HILWTC4WINQK46SP4OEZRCNO25VGWAS"
+        ),
         "name": "blind",
         "type": "windowCovering",
         "characteristics": ["position"],
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*JVRAR_6WVL1Y0PJ5GFWGPMFV7FLVD4MZKBWXC_UFWYM",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*JVRAR_6WVL1Y0PJ5GFWGPMFV7FLVD4MZKBWXC_UFWYM"
+        ),
         "name": "Garden light sensors",
         "type": "lightSensor",
         "characteristics": ["currentAmbientLightLevel"],
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*0PUTVZVJJJL-ZHZZBHTIBS3-J-U7JYNPACFPJW0MD-I",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*0PUTVZVJJJL-ZHZZBHTIBS3-J-U7JYNPACFPJW0MD-I"
+        ),
         "name": "Living room outlet",
         "type": "outlet",
         "characteristics": ["on"],
@@ -111,85 +162,127 @@ DEVICES = [
 
 DEVICES_STATE = [
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*2VAS3HTWINNZ5N6HVEIPDJ6NX85P2-AM-GSYWUCNPU0",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*2VAS3HTWINNZ5N6HVEIPDJ6NX85P2-AM-GSYWUCNPU0"
+        ),
         "type": "leakSensor",
         "state": {"leakDetected": 0},
         "online": True,
     },
     {
-        "uid": "2WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*2VAS3HTWINNZ5N6HVEIPDJ6NX85P2-AM-GSYWUCNPU0",
+        "uid": (
+            "2WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*2VAS3HTWINNZ5N6HVEIPDJ6NX85P2-AM-GSYWUCNPU0"
+        ),
         "type": "lock",
         "state": {"lock": 0},
         "online": True,
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*ILYH1E3DWZOVMNEUIMDYMNLOW-LFRQFDPWWJOVHVDOS",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*ILYH1E3DWZOVMNEUIMDYMNLOW-LFRQFDPWWJOVHVDOS"
+        ),
         "type": "fan",
         "state": {"on": False, "rotationSpeed": 0},
         "online": True,
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*SOT3NKALCRQMHUHJUF79NUG6UQP1IIQIN1PJVRRPT0C",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*SOT3NKALCRQMHUHJUF79NUG6UQP1IIQIN1PJVRRPT0C"
+        ),
         "type": "contactSensor",
         "state": {"contactSensorState": False},
         "online": True,
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*VTEPEDYE8DXGS8U94CJKQDLKMN6CUX1IJWSOER2HZCK",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*VTEPEDYE8DXGS8U94CJKQDLKMN6CUX1IJWSOER2HZCK"
+        ),
         "type": "motionSensor",
         "state": {"motionDetected": False},
         "online": True,
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*QN-DDFMPEPRDOQV7W7JQG3NL0NPZGTLIBYT3HFSPNEY",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*QN-DDFMPEPRDOQV7W7JQG3NL0NPZGTLIBYT3HFSPNEY"
+        ),
         "type": "humiditySensor",
         "state": {"currentRelativeHumidity": 0},
         "online": True,
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*1JKU1MVWHQL-Z9SCUS85VFXMRGNDCDNDDUVVDKBU31W",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*1JKU1MVWHQL-Z9SCUS85VFXMRGNDCDNDDUVVDKBU31W"
+        ),
         "type": "switch",
         "state": {"on": False},
         "online": True,
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*JHJZIZ9ORJNHB7DZNBNAOSEDECVTTZ48SABTCA3WA3M",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*JHJZIZ9ORJNHB7DZNBNAOSEDECVTTZ48SABTCA3WA3M"
+        ),
         "type": "lightbulb",
         "state": {"on": True, "brightness": 0, "saturation": 0, "hue": 0},
         "online": True,
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*SNG7Y3R1R0S_W5BCNPP1O5WUN2NCEOOT27EFSYT6JYS",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*SNG7Y3R1R0S_W5BCNPP1O5WUN2NCEOOT27EFSYT6JYS"
+        ),
         "type": "occupancySensor",
         "state": {"occupancyDetected": False},
         "online": True,
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*LWPVY7X1AX0DRWLYUUNZ3ZSTHMYNDDBQTPZCZQUUASA",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*LWPVY7X1AX0DRWLYUUNZ3ZSTHMYNDDBQTPZCZQUUASA"
+        ),
         "type": "temperatureSensor",
         "state": {"currentTemperature": 0},
         "online": True,
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*SXFMEXI4UMDBAMXXPI6LJV47O9NY-IRCAKZI7_MW0LY",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*SXFMEXI4UMDBAMXXPI6LJV47O9NY-IRCAKZI7_MW0LY"
+        ),
         "type": "smokeSensor",
         "state": {"smokeDetected": False},
         "online": True,
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*R6V0FNNF7SACWZ8V9NCOX7UCYI4ODSYAOJWZ80PLJ3C",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*R6V0FNNF7SACWZ8V9NCOX7UCYI4ODSYAOJWZ80PLJ3C"
+        ),
         "type": "carbonDioxideSensor",
         "state": {"carbonDioxideDetected": False, "carbonDioxideLevel": 0},
         "online": True,
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*3-QURR5Q6ADA8ML1TBRG59RRGM1F9LVUZLKPYKFJQHC",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*3-QURR5Q6ADA8ML1TBRG59RRGM1F9LVUZLKPYKFJQHC"
+        ),
         "type": "lightbulb",
         "state": {"on": False},
         "online": True,
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*TWMYQKL3UVED4HSIIB9GXJWJZBQCXG-9VE-N2IUAIWI",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*TWMYQKL3UVED4HSIIB9GXJWJZBQCXG-9VE-N2IUAIWI"
+        ),
         "type": "thermostat",
         "state": {
             "heatingCoolingState": 1,
@@ -199,19 +292,28 @@ DEVICES_STATE = [
         "online": True,
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*3XSSVIJWK-65HILWTC4WINQK46SP4OEZRCNO25VGWAS",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*3XSSVIJWK-65HILWTC4WINQK46SP4OEZRCNO25VGWAS"
+        ),
         "type": "windowCovering",
         "state": {"position": 0},
         "online": True,
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*JVRAR_6WVL1Y0PJ5GFWGPMFV7FLVD4MZKBWXC_UFWYM",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*JVRAR_6WVL1Y0PJ5GFWGPMFV7FLVD4MZKBWXC_UFWYM"
+        ),
         "type": "lightSensor",
         "state": {"currentAmbientLightLevel": 0},
         "online": True,
     },
     {
-        "uid": "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*0PUTVZVJJJL-ZHZZBHTIBS3-J-U7JYNPACFPJW0MD-I",
+        "uid": (
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+            "-LQ*0PUTVZVJJJL-ZHZZBHTIBS3-J-U7JYNPACFPJW0MD-I"
+        ),
         "type": "outlet",
         "state": {"on": False},
         "online": True,

--- a/tests/components/freedompro/test_climate.py
+++ b/tests/components/freedompro/test_climate.py
@@ -27,7 +27,10 @@ from .conftest import get_states_response_for_uid
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
-uid = "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*TWMYQKL3UVED4HSIIB9GXJWJZBQCXG-9VE-N2IUAIWI"
+uid = (
+    "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+    "-LQ*TWMYQKL3UVED4HSIIB9GXJWJZBQCXG-9VE-N2IUAIWI"
+)
 
 
 async def test_climate_get_state(

--- a/tests/components/freedompro/test_fan.py
+++ b/tests/components/freedompro/test_fan.py
@@ -19,7 +19,10 @@ from .conftest import get_states_response_for_uid
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
-uid = "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*ILYH1E3DWZOVMNEUIMDYMNLOW-LFRQFDPWWJOVHVDOS"
+uid = (
+    "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+    "-LQ*ILYH1E3DWZOVMNEUIMDYMNLOW-LFRQFDPWWJOVHVDOS"
+)
 
 
 async def test_fan_get_state(

--- a/tests/components/freedompro/test_light.py
+++ b/tests/components/freedompro/test_light.py
@@ -40,8 +40,8 @@ async def test_light_get_state(
     entry = entity_registry.async_get(entity_id)
     assert entry
     assert (
-        entry.unique_id
-        == "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*JHJZIZ9ORJNHB7DZNBNAOSEDECVTTZ48SABTCA3WA3M"
+        entry.unique_id == "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+        "-LQ*JHJZIZ9ORJNHB7DZNBNAOSEDECVTTZ48SABTCA3WA3M"
     )
 
 
@@ -61,8 +61,8 @@ async def test_light_set_on(
     entry = entity_registry.async_get(entity_id)
     assert entry
     assert (
-        entry.unique_id
-        == "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*JHJZIZ9ORJNHB7DZNBNAOSEDECVTTZ48SABTCA3WA3M"
+        entry.unique_id == "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+        "-LQ*JHJZIZ9ORJNHB7DZNBNAOSEDECVTTZ48SABTCA3WA3M"
     )
 
     await hass.services.async_call(
@@ -93,8 +93,8 @@ async def test_light_set_off(
     entry = entity_registry.async_get(entity_id)
     assert entry
     assert (
-        entry.unique_id
-        == "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*3-QURR5Q6ADA8ML1TBRG59RRGM1F9LVUZLKPYKFJQHC"
+        entry.unique_id == "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+        "-LQ*3-QURR5Q6ADA8ML1TBRG59RRGM1F9LVUZLKPYKFJQHC"
     )
 
     await hass.services.async_call(
@@ -125,8 +125,8 @@ async def test_light_set_brightness(
     entry = entity_registry.async_get(entity_id)
     assert entry
     assert (
-        entry.unique_id
-        == "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*JHJZIZ9ORJNHB7DZNBNAOSEDECVTTZ48SABTCA3WA3M"
+        entry.unique_id == "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+        "-LQ*JHJZIZ9ORJNHB7DZNBNAOSEDECVTTZ48SABTCA3WA3M"
     )
 
     await hass.services.async_call(
@@ -158,8 +158,8 @@ async def test_light_set_hue(
     entry = entity_registry.async_get(entity_id)
     assert entry
     assert (
-        entry.unique_id
-        == "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*JHJZIZ9ORJNHB7DZNBNAOSEDECVTTZ48SABTCA3WA3M"
+        entry.unique_id == "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+        "-LQ*JHJZIZ9ORJNHB7DZNBNAOSEDECVTTZ48SABTCA3WA3M"
     )
 
     await hass.services.async_call(

--- a/tests/components/freedompro/test_lock.py
+++ b/tests/components/freedompro/test_lock.py
@@ -19,7 +19,10 @@ from .conftest import get_states_response_for_uid
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
-uid = "2WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*2VAS3HTWINNZ5N6HVEIPDJ6NX85P2-AM-GSYWUCNPU0"
+uid = (
+    "2WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+    "-LQ*2VAS3HTWINNZ5N6HVEIPDJ6NX85P2-AM-GSYWUCNPU0"
+)
 
 
 async def test_lock_get_state(

--- a/tests/components/freedompro/test_switch.py
+++ b/tests/components/freedompro/test_switch.py
@@ -14,7 +14,10 @@ from .conftest import get_states_response_for_uid
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
-uid = "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*1JKU1MVWHQL-Z9SCUS85VFXMRGNDCDNDDUVVDKBU31W"
+uid = (
+    "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU"
+    "-LQ*1JKU1MVWHQL-Z9SCUS85VFXMRGNDCDNDDUVVDKBU31W"
+)
 
 
 async def test_switch_get_state(

--- a/tests/components/freshr/test_config_flow.py
+++ b/tests/components/freshr/test_config_flow.py
@@ -226,7 +226,7 @@ async def test_form_already_configured_case_insensitive(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test config flow aborts when the same account is configured with different casing."""
+    """Test config flow aborts when same account has different casing."""
     mock_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/fritz/const.py
+++ b/tests/components/fritz/const.py
@@ -78,7 +78,16 @@ MOCK_FB_SERVICES: dict[str, dict[str, Any]] = {
     "LANConfigSecurity1": {
         "X_AVM-DE_GetCurrentUser": {
             "NewX_AVM-DE_CurrentUsername": "fake_user",
-            "NewX_AVM-DE_CurrentUserRights": "<rights><path>BoxAdmin</path><access>readwrite</access><path>Phone</path><access>readwrite</access><path>Dial</path><access>readwrite</access><path>NAS</path><access>none</access><path>HomeAuto</path><access>readwrite</access><path>App</path><access>readwrite</access></rights>",
+            "NewX_AVM-DE_CurrentUserRights": (
+                "<rights>"
+                "<path>BoxAdmin</path><access>readwrite</access>"
+                "<path>Phone</path><access>readwrite</access>"
+                "<path>Dial</path><access>readwrite</access>"
+                "<path>NAS</path><access>none</access>"
+                "<path>HomeAuto</path><access>readwrite</access>"
+                "<path>App</path><access>readwrite</access>"
+                "</rights>"
+            ),
         }
     },
     "Layer3Forwarding1": {
@@ -936,7 +945,9 @@ MOCK_HOST_ATTRIBUTES_DATA = [
         "X_AVM-DE_UpdateAvailable": False,
         "X_AVM-DE_UpdateSuccessful": "unknown",
         "X_AVM-DE_InfoURL": None,
-        "X_AVM-DE_MACAddressList": f"{MOCK_MESH_MASTER_MAC},{MOCK_MESH_MASTER_WIFI1_MAC}",
+        "X_AVM-DE_MACAddressList": (
+            f"{MOCK_MESH_MASTER_MAC},{MOCK_MESH_MASTER_WIFI1_MAC}"
+        ),
         "X_AVM-DE_Model": None,
         "X_AVM-DE_URL": f"http://{MOCK_IPS['fritz.box']}",
         "X_AVM-DE_Guest": False,
@@ -979,7 +990,19 @@ MOCK_HOST_ATTRIBUTES_DATA = [
 MOCK_CALL_DEFLECTION_DATA = {
     "X_AVM-DE_OnTel1": {
         "GetDeflections": {
-            "NewDeflectionList": "<List><Item><DeflectionId>0</DeflectionId><Enable>1</Enable><Type>fromAll</Type><Number></Number><DeflectionToNumber>+1234657890</DeflectionToNumber><Mode>eImmediately</Mode><Outgoing></Outgoing><PhonebookID></PhonebookID></Item></List>"
+            "NewDeflectionList": (
+                "<List><Item>"
+                "<DeflectionId>0</DeflectionId>"
+                "<Enable>1</Enable>"
+                "<Type>fromAll</Type>"
+                "<Number></Number>"
+                "<DeflectionToNumber>+1234657890"
+                "</DeflectionToNumber>"
+                "<Mode>eImmediately</Mode>"
+                "<Outgoing></Outgoing>"
+                "<PhonebookID></PhonebookID>"
+                "</Item></List>"
+            )
         }
     }
 }
@@ -1022,4 +1045,22 @@ MOCK_SSDP_DATA = SsdpServiceInfo(
     },
 )
 
-MOCK_REQUEST = b'<?xml version="1.0" encoding="utf-8"?><SessionInfo><SID>xxxxxxxxxxxxxxxx</SID><Challenge>xxxxxxxx</Challenge><BlockTime>0</BlockTime><Rights><Name>Dial</Name><Access>2</Access><Name>App</Name><Access>2</Access><Name>HomeAuto</Name><Access>2</Access><Name>BoxAdmin</Name><Access>2</Access><Name>Phone</Name><Access>2</Access><Name>NAS</Name><Access>2</Access></Rights><Users><User last="1">FakeFritzUser</User></Users></SessionInfo>\n'
+MOCK_REQUEST = (
+    b'<?xml version="1.0" encoding="utf-8"?>'
+    b"<SessionInfo>"
+    b"<SID>xxxxxxxxxxxxxxxx</SID>"
+    b"<Challenge>xxxxxxxx</Challenge>"
+    b"<BlockTime>0</BlockTime>"
+    b"<Rights>"
+    b"<Name>Dial</Name><Access>2</Access>"
+    b"<Name>App</Name><Access>2</Access>"
+    b"<Name>HomeAuto</Name><Access>2</Access>"
+    b"<Name>BoxAdmin</Name><Access>2</Access>"
+    b"<Name>Phone</Name><Access>2</Access>"
+    b"<Name>NAS</Name><Access>2</Access>"
+    b"</Rights>"
+    b"<Users>"
+    b'<User last="1">FakeFritzUser</User>'
+    b"</Users>"
+    b"</SessionInfo>\n"
+)

--- a/tests/components/fritz/test_button.py
+++ b/tests/components/fritz/test_button.py
@@ -192,7 +192,8 @@ async def test_wol_button_absent_for_non_lan_device(
     entry.add_to_hass(hass)
 
     printer_wifi_data = deepcopy(MOCK_MESH_DATA)
-    # initialization logic uses the connection type of the `node_interface_1_uid` pair of the printer
+    # initialization logic uses the connection type of the
+    # `node_interface_1_uid` pair of the printer
     # ni-230 is wifi interface of fritzbox
     printer_node_interface = printer_wifi_data["nodes"][1]["node_interfaces"][0]
     printer_node_interface["type"] = "WLAN"
@@ -294,7 +295,7 @@ async def test_firmware_update_button_deprecation_issue(
     fh_class_mock,
     fs_class_mock,
 ) -> None:
-    """Test deprecation issue is created when legacy firmware update button is enabled."""
+    """Test deprecation issue for legacy firmware update button."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
     entry.add_to_hass(hass)
 

--- a/tests/components/fritz/test_image.py
+++ b/tests/components/fritz/test_image.py
@@ -108,7 +108,9 @@ async def test_image_entity(
     access_token = state.attributes["access_token"]
     assert state.attributes == {
         "access_token": access_token,
-        "entity_picture": f"/api/image_proxy/image.mock_title_guestwifi?token={access_token}",
+        "entity_picture": (
+            f"/api/image_proxy/image.mock_title_guestwifi?token={access_token}"
+        ),
         "friendly_name": "Mock Title GuestWifi",
     }
 

--- a/tests/components/fritz/test_init.py
+++ b/tests/components/fritz/test_init.py
@@ -160,8 +160,8 @@ async def test_upnp_missing(
     assert entry.state is ConfigEntryState.SETUP_ERROR
     assert entry.state.recoverable is True
     assert (
-        "Config entry 'Mock Title' for fritz integration could not authenticate: Missing UPnP configuration"
-        in caplog.text
+        "Config entry 'Mock Title' for fritz integration"
+        " could not authenticate: Missing UPnP configuration" in caplog.text
     )
 
 

--- a/tests/components/fritz/test_services.py
+++ b/tests/components/fritz/test_services.py
@@ -140,8 +140,9 @@ async def test_service_set_guest_wifi_password_unloaded(
         )
         assert not mock_async_trigger_set_guest_password.called
         assert (
-            'ServiceValidationError: Failed to perform action "set_guest_wifi_password". Config entry for target not found'
-            in caplog.text
+            "ServiceValidationError: Failed to perform action"
+            ' "set_guest_wifi_password".'
+            " Config entry for target not found" in caplog.text
         )
 
 
@@ -324,8 +325,8 @@ async def test_service_dial_failed(
         )
         assert mock_async_trigger_dial.called
         assert (
-            "HomeAssistantError: Failed to dial, check if the click to dial service of the FRITZ!Box is activated"
-            in caplog.text
+            "HomeAssistantError: Failed to dial, check if the"
+            " click to dial service of the FRITZ!Box is activated" in caplog.text
         )
 
 
@@ -348,6 +349,7 @@ async def test_service_dial_unloaded(
         )
         assert not mock_async_trigger_dial.called
         assert (
-            f'ServiceValidationError: Failed to perform action "{SERVICE_DIAL}". Config entry for target not found'
-            in caplog.text
+            "ServiceValidationError: Failed to perform action"
+            f' "{SERVICE_DIAL}".'
+            " Config entry for target not found" in caplog.text
         )

--- a/tests/components/fritz/test_switch.py
+++ b/tests/components/fritz/test_switch.py
@@ -59,7 +59,11 @@ MOCK_WLANCONFIGS_SAME_SSID: dict[str, dict] = {
             "NewBasicAuthenticationMode": "None",
             "NewMaxCharsSSID": 32,
             "NewMinCharsSSID": 1,
-            "NewAllowedCharsSSID": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~",
+            "NewAllowedCharsSSID": (
+                "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                "abcdefghijklmnopqrstuvwxyz"
+                " !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+            ),
             "NewMinCharsPSK": 64,
             "NewMaxCharsPSK": 64,
             "NewAllowedCharsPSK": "0123456789ABCDEFabcdef",
@@ -83,7 +87,11 @@ MOCK_WLANCONFIGS_SAME_SSID: dict[str, dict] = {
             "NewBasicAuthenticationMode": "None",
             "NewMaxCharsSSID": 32,
             "NewMinCharsSSID": 1,
-            "NewAllowedCharsSSID": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~",
+            "NewAllowedCharsSSID": (
+                "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                "abcdefghijklmnopqrstuvwxyz"
+                " !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+            ),
             "NewMinCharsPSK": 64,
             "NewMaxCharsPSK": 64,
             "NewAllowedCharsPSK": "0123456789ABCDEFabcdef",
@@ -109,7 +117,11 @@ MOCK_WLANCONFIGS_DIFF_SSID: dict[str, dict] = {
             "NewBasicAuthenticationMode": "None",
             "NewMaxCharsSSID": 32,
             "NewMinCharsSSID": 1,
-            "NewAllowedCharsSSID": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~",
+            "NewAllowedCharsSSID": (
+                "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                "abcdefghijklmnopqrstuvwxyz"
+                " !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+            ),
             "NewMinCharsPSK": 64,
             "NewMaxCharsPSK": 64,
             "NewAllowedCharsPSK": "0123456789ABCDEFabcdef",
@@ -133,7 +145,11 @@ MOCK_WLANCONFIGS_DIFF_SSID: dict[str, dict] = {
             "NewBasicAuthenticationMode": "None",
             "NewMaxCharsSSID": 32,
             "NewMinCharsSSID": 1,
-            "NewAllowedCharsSSID": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~",
+            "NewAllowedCharsSSID": (
+                "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                "abcdefghijklmnopqrstuvwxyz"
+                " !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+            ),
             "NewMinCharsPSK": 64,
             "NewMaxCharsPSK": 64,
             "NewAllowedCharsPSK": "0123456789ABCDEFabcdef",
@@ -159,7 +175,11 @@ MOCK_WLANCONFIGS_DIFF2_SSID: dict[str, dict] = {
             "NewBasicAuthenticationMode": "None",
             "NewMaxCharsSSID": 32,
             "NewMinCharsSSID": 1,
-            "NewAllowedCharsSSID": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~",
+            "NewAllowedCharsSSID": (
+                "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                "abcdefghijklmnopqrstuvwxyz"
+                " !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+            ),
             "NewMinCharsPSK": 64,
             "NewMaxCharsPSK": 64,
             "NewAllowedCharsPSK": "0123456789ABCDEFabcdef",
@@ -183,7 +203,11 @@ MOCK_WLANCONFIGS_DIFF2_SSID: dict[str, dict] = {
             "NewBasicAuthenticationMode": "None",
             "NewMaxCharsSSID": 32,
             "NewMinCharsSSID": 1,
-            "NewAllowedCharsSSID": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~",
+            "NewAllowedCharsSSID": (
+                "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                "abcdefghijklmnopqrstuvwxyz"
+                " !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+            ),
             "NewMinCharsPSK": 64,
             "NewMaxCharsPSK": 64,
             "NewAllowedCharsPSK": "0123456789ABCDEFabcdef",

--- a/tests/components/fritzbox/test_climate.py
+++ b/tests/components/fritzbox/test_climate.py
@@ -514,7 +514,11 @@ async def test_set_temperature_lock(
 
     with pytest.raises(
         HomeAssistantError,
-        match="Can't change settings while manual access for telephone, app, or user interface is disabled on the device",
+        match=(
+            "Can't change settings while manual access for"
+            " telephone, app, or user interface is disabled"
+            " on the device"
+        ),
     ):
         await hass.services.async_call(
             CLIMATE_DOMAIN,
@@ -572,7 +576,11 @@ async def test_set_hvac_mode_lock(
 
     with pytest.raises(
         HomeAssistantError,
-        match="Can't change settings while manual access for telephone, app, or user interface is disabled on the device",
+        match=(
+            "Can't change settings while manual access for"
+            " telephone, app, or user interface is disabled"
+            " on the device"
+        ),
     ):
         await hass.services.async_call(
             CLIMATE_DOMAIN,
@@ -619,7 +627,9 @@ async def test_holidy_summer_mode(
 
     with pytest.raises(
         HomeAssistantError,
-        match="Can't change settings while holiday or summer mode is active on the device",
+        match=(
+            "Can't change settings while holiday or summer mode is active on the device"
+        ),
     ):
         await hass.services.async_call(
             "climate",
@@ -629,7 +639,9 @@ async def test_holidy_summer_mode(
         )
     with pytest.raises(
         HomeAssistantError,
-        match="Can't change settings while holiday or summer mode is active on the device",
+        match=(
+            "Can't change settings while holiday or summer mode is active on the device"
+        ),
     ):
         await hass.services.async_call(
             "climate",
@@ -653,7 +665,9 @@ async def test_holidy_summer_mode(
 
     with pytest.raises(
         HomeAssistantError,
-        match="Can't change settings while holiday or summer mode is active on the device",
+        match=(
+            "Can't change settings while holiday or summer mode is active on the device"
+        ),
     ):
         await hass.services.async_call(
             "climate",
@@ -663,7 +677,9 @@ async def test_holidy_summer_mode(
         )
     with pytest.raises(
         HomeAssistantError,
-        match="Can't change settings while holiday or summer mode is active on the device",
+        match=(
+            "Can't change settings while holiday or summer mode is active on the device"
+        ),
     ):
         await hass.services.async_call(
             "climate",

--- a/tests/components/fronius/__init__.py
+++ b/tests/components/fronius/__init__.py
@@ -39,7 +39,7 @@ async def setup_fronius_integration(
 def _load_and_patch_fixture(
     override_data: dict[str, list[tuple[list[str], Any]]],
 ) -> Callable[[str, str | None], str]:
-    """Return a fixture loader that patches values at nested keys for a given filename."""
+    """Return a fixture loader that patches nested key values."""
 
     def load_and_patch(filename: str, integration: str):
         """Load a fixture and patch given values."""

--- a/tests/components/fronius/test_coordinator.py
+++ b/tests/components/fronius/test_coordinator.py
@@ -70,5 +70,6 @@ async def test_adaptive_update_interval(
             freezer.tick(FroniusInverterUpdateCoordinator.default_interval)
             async_fire_time_changed(hass)
             await hass.async_block_till_done()
-        # BadStatusError does 3 silent retries for inverter endpoint * 3 request intervals = 9
+        # BadStatusError does 3 silent retries for inverter
+        # endpoint * 3 request intervals = 9
         assert mock_inverter_data.call_count == 9

--- a/tests/components/fronius/test_init.py
+++ b/tests/components/fronius/test_init.py
@@ -68,7 +68,7 @@ async def test_inverter_night_rescan(
     aioclient_mock: AiohttpClientMocker,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test dynamic adding of an inverter discovered automatically after a Home Assistant reboot during the night."""
+    """Test adding inverter discovered after HA reboot at night."""
     mock_responses(aioclient_mock, fixture_set="igplus_v2", night=True)
     config_entry = await setup_fronius_integration(hass, is_logger=True)
     assert config_entry.state is ConfigEntryState.LOADED

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -1158,7 +1158,7 @@ async def test_setup_with_development_pr_and_token(
     mock_github_api,
     aioclient_mock: AiohttpClientMocker,
 ) -> None:
-    """Test that setup succeeds when both development_pr and github_token are provided."""
+    """Test setup with both development_pr and github_token."""
     hass.config.config_dir = str(tmp_path)
 
     aioclient_mock.get(

--- a/tests/components/fujitsu_fglair/test_init.py
+++ b/tests/components/fujitsu_fglair/test_init.py
@@ -177,7 +177,7 @@ async def test_startup_exception(
     mock_config_entry: MockConfigEntry,
     exception: Exception,
 ) -> None:
-    """Make sure that no devices are added if there was an exception while logging in."""
+    """Make sure no devices are added if login raises an exception."""
     mock_ayla_api.async_sign_in.side_effect = exception
     await setup_integration(hass, mock_config_entry)
 

--- a/tests/components/fyta/conftest.py
+++ b/tests/components/fyta/conftest.py
@@ -34,7 +34,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 @pytest.fixture
 def mock_fyta_connector():
-    """Build a fixture for the Fyta API that connects successfully and returns one device."""
+    """Build a fixture for the Fyta API that connects and returns one device."""
 
     plants: dict[int, Plant] = {
         0: Plant.from_dict(load_json_object_fixture("plant_status1.json", DOMAIN)),

--- a/tests/components/fyta/test_init.py
+++ b/tests/components/fyta/test_init.py
@@ -106,7 +106,7 @@ async def test_raise_config_entry_not_ready_when_offline_and_expired(
     mock_config_entry: MockConfigEntry,
     mock_fyta_connector: AsyncMock,
 ) -> None:
-    """Config entry state is SETUP_RETRY when FYTA is offline and access_token is expired."""
+    """Config entry is SETUP_RETRY when FYTA is offline and token expired."""
 
     mock_fyta_connector.login.side_effect = FytaConnectionError
     mock_fyta_connector.expiration = datetime.fromisoformat(EXPIRATION_OLD).replace(


### PR DESCRIPTION
## Proposed change

Fix all 293 E501 (line too long) violations in `tests/components/` for integrations starting with d-f.

Part of a series to enforce the 88-character line length limit across the codebase. Changes are purely cosmetic — rewrapped comments, split long strings, shortened docstrings, and reformatted test data. No logic changes.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr