### PR TITLE
Add reconfigure flow to cert_expiry

### DIFF
--- a/homeassistant/components/cert_expiry/config_flow.py
+++ b/homeassistant/components/cert_expiry/config_flow.py
@@ -123,16 +123,14 @@ class CertexpiryConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="reconfigure",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(
-                        CONF_HOST, default=reconfigure_entry.data[CONF_HOST]
-                    ): str,
-                    vol.Required(
-                        CONF_PORT,
-                        default=reconfigure_entry.data.get(CONF_PORT, DEFAULT_PORT),
-                    ): int,
-                }
+            data_schema=self.add_suggested_values_to_schema(
+                vol.Schema(
+                    {
+                        vol.Required(CONF_HOST): str,
+                        vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+                    }
+                ),
+                user_input or reconfigure_entry.data,
             ),
             errors=self._errors,
         )

--- a/homeassistant/components/cert_expiry/config_flow.py
+++ b/homeassistant/components/cert_expiry/config_flow.py
@@ -95,3 +95,44 @@ class CertexpiryConfigFlow(ConfigFlow, domain=DOMAIN):
             ),
             errors=self._errors,
         )
+
+    async def async_step_reconfigure(
+        self,
+        user_input: Mapping[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of an existing entry."""
+        self._errors = {}
+        reconfigure_entry = self._get_reconfigure_entry()
+
+        if user_input is not None:
+            host = user_input[CONF_HOST]
+            port = user_input.get(CONF_PORT, DEFAULT_PORT)
+
+            if (
+                host != reconfigure_entry.data[CONF_HOST]
+                or port != reconfigure_entry.data[CONF_PORT]
+            ):
+                self._async_abort_entries_match({CONF_HOST: host, CONF_PORT: port})
+
+            if await self._test_connection(user_input):
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry,
+                    data_updates={CONF_HOST: host, CONF_PORT: port},
+                    unique_id=f"{host}:{port}",
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_HOST, default=reconfigure_entry.data[CONF_HOST]
+                    ): str,
+                    vol.Required(
+                        CONF_PORT,
+                        default=reconfigure_entry.data.get(CONF_PORT, DEFAULT_PORT),
+                    ): int,
+                }
+            ),
+            errors=self._errors,
+        )

--- a/homeassistant/components/cert_expiry/strings.json
+++ b/homeassistant/components/cert_expiry/strings.json
@@ -2,7 +2,8 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
-      "import_failed": "Import from config failed"
+      "import_failed": "Import from config failed",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     },
     "error": {
       "connection_refused": "Connection refused when connecting to host",
@@ -11,6 +12,13 @@
       "resolve_failed": "This host cannot be resolved"
     },
     "step": {
+      "reconfigure": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]"
+        },
+        "title": "Reconfigure the certificate to test"
+      },
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",

--- a/tests/components/cert_expiry/test_config_flow.py
+++ b/tests/components/cert_expiry/test_config_flow.py
@@ -125,3 +125,92 @@ async def test_abort_on_socket_failed(hass: HomeAssistant) -> None:
         )
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {CONF_HOST: "connection_reset"}
+
+
+async def test_reconfigure_successful(hass: HomeAssistant) -> None:
+    """Test reconfiguration of an existing entry updates its data and unique_id."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: HOST, CONF_PORT: PORT},
+        unique_id=f"{HOST}:{PORT}",
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    new_host = "new.example.com"
+    new_port = 8443
+    with patch(
+        "homeassistant.components.cert_expiry.config_flow.get_cert_expiry_timestamp"
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_HOST: new_host, CONF_PORT: new_port}
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data[CONF_HOST] == new_host
+    assert entry.data[CONF_PORT] == new_port
+    assert entry.unique_id == f"{new_host}:{new_port}"
+
+
+async def test_reconfigure_validation_failure(hass: HomeAssistant) -> None:
+    """Test reconfiguration form re-shows errors on validation failure."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: HOST, CONF_PORT: PORT},
+        unique_id=f"{HOST}:{PORT}",
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    with patch(
+        "homeassistant.components.cert_expiry.helper.async_get_cert",
+        side_effect=socket.gaierror(),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_HOST: "unresolvable.example.com", CONF_PORT: PORT},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"] == {CONF_HOST: "resolve_failed"}
+    assert entry.data[CONF_HOST] == HOST
+
+
+async def test_reconfigure_already_exists(hass: HomeAssistant) -> None:
+    """Test reconfiguration aborts when target host:port matches another entry."""
+    other_host = "other.example.com"
+    other_port = 8443
+    MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: other_host, CONF_PORT: other_port},
+        unique_id=f"{other_host}:{other_port}",
+    ).add_to_hass(hass)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: HOST, CONF_PORT: PORT},
+        unique_id=f"{HOST}:{PORT}",
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: other_host, CONF_PORT: other_port},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert entry.data[CONF_HOST] == HOST
+    assert entry.data[CONF_PORT] == PORT

--- a/tests/components/cert_expiry/test_config_flow.py
+++ b/tests/components/cert_expiry/test_config_flow.py
@@ -156,8 +156,19 @@ async def test_reconfigure_successful(hass: HomeAssistant) -> None:
     assert entry.unique_id == f"{new_host}:{new_port}"
 
 
-async def test_reconfigure_validation_failure(hass: HomeAssistant) -> None:
-    """Test reconfiguration form re-shows errors on validation failure."""
+@pytest.mark.parametrize(
+    ("side_effect", "error_key"),
+    [
+        (socket.gaierror(), "resolve_failed"),
+        (TimeoutError, "connection_timeout"),
+        (ConnectionRefusedError, "connection_refused"),
+        (ConnectionResetError, "connection_reset"),
+    ],
+)
+async def test_reconfigure_validation_failure_recovers(
+    hass: HomeAssistant, side_effect: Exception, error_key: str
+) -> None:
+    """Test the reconfigure form re-shows on failure then recovers on retry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_HOST: HOST, CONF_PORT: PORT},
@@ -169,19 +180,37 @@ async def test_reconfigure_validation_failure(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reconfigure"
 
+    new_host = "new.example.com"
+    new_port = 8443
+
     with patch(
         "homeassistant.components.cert_expiry.helper.async_get_cert",
-        side_effect=socket.gaierror(),
+        side_effect=side_effect,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input={CONF_HOST: "unresolvable.example.com", CONF_PORT: PORT},
+            user_input={CONF_HOST: new_host, CONF_PORT: new_port},
         )
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reconfigure"
-    assert result["errors"] == {CONF_HOST: "resolve_failed"}
+    assert result["errors"] == {CONF_HOST: error_key}
     assert entry.data[CONF_HOST] == HOST
+    assert entry.data[CONF_PORT] == PORT
+
+    with patch(
+        "homeassistant.components.cert_expiry.config_flow.get_cert_expiry_timestamp"
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_HOST: new_host, CONF_PORT: new_port},
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data[CONF_HOST] == new_host
+    assert entry.data[CONF_PORT] == new_port
+    assert entry.unique_id == f"{new_host}:{new_port}"
 
 
 async def test_reconfigure_already_exists(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

Adds an `async_step_reconfigure` to the cert_expiry config flow so users can update the host and port of an existing entry without removing and re-adding the integration.

The flow:
- Pre-populates the form with the entry's current host/port.
- If host or port is changed, aborts with `already_configured` if another entry already uses the new combination.
- Re-uses the existing `_test_connection` validation (same exception handling as the user step).
- On success, updates the entry's data and unique_id (which is `f"{host}:{port}"`) and reloads via `async_update_reload_and_abort`.

`strings.json` gains a `reconfigure` step section and the standard `reconfigure_successful` abort. Tests cover the happy path, validation failure (unresolvable host), and the duplicate-target abort.

Part of a coordinated Bronze campaign on cert_expiry. Related: #170491 (quality_scale.yaml by @HoffmanEl). Once both land, `reconfiguration-flow` in cert_expiry's quality_scale.yaml can be flipped from `todo` to `done`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #170491

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [x] I have followed the [perfect PR recommendations](https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr)
- [x] The code has been formatted using Ruff.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
