### PR TITLE
Fix teleinfo USB discovery breaking unrelated serial ports

### DIFF
--- a/homeassistant/components/teleinfo/config_flow.py
+++ b/homeassistant/components/teleinfo/config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.components.usb import human_readable_device_name
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.helpers.service_info.usb import UsbServiceInfo
 
-from .const import CONF_SERIAL_PORT, DOMAIN
+from .const import CONF_SERIAL_PORT, CONF_USB_SERIAL_NUMBER, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,6 +32,7 @@ class TeleinfoConfigFlow(ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize the Teleinfo config flow."""
         self._discovered_device: str | None = None
+        self._discovered_usb_serial_number: str | None = None
 
     async def _validate_serial_port(
         self, serial_port: str
@@ -57,6 +58,17 @@ class TeleinfoConfigFlow(ConfigFlow, domain=DOMAIN):
             return errors, None
         return errors, decoded_data
 
+    async def _resolve_usb_serial_number(self, serial_port: str) -> str | None:
+        """Return the USB serial number for a serial port, if it is a USB device.
+
+        This only reads USB descriptors (no serial port is opened), so it is safe
+        to call without disturbing the device or other integrations.
+        """
+        device = await self.hass.async_add_executor_job(
+            usb.usb_device_from_path, serial_port
+        )
+        return device.serial_number if device is not None else None
+
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -64,17 +76,20 @@ class TeleinfoConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            errors, decoded_data = await self._validate_serial_port(
-                user_input[CONF_SERIAL_PORT]
-            )
+            serial_port = user_input[CONF_SERIAL_PORT]
+            errors, decoded_data = await self._validate_serial_port(serial_port)
             if not errors:
                 assert decoded_data is not None
                 adco = decoded_data["ADCO"]
                 await self.async_set_unique_id(adco)
                 self._abort_if_unique_id_configured()
+                data: dict[str, str] = {CONF_SERIAL_PORT: serial_port}
+                usb_serial_number = await self._resolve_usb_serial_number(serial_port)
+                if usb_serial_number is not None:
+                    data[CONF_USB_SERIAL_NUMBER] = usb_serial_number
                 return self.async_create_entry(
-                    title=f"Teleinfo ({user_input[CONF_SERIAL_PORT]})",
-                    data=user_input,
+                    title=f"Teleinfo ({serial_port})",
+                    data=data,
                 )
 
         return self.async_show_form(
@@ -84,23 +99,39 @@ class TeleinfoConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_usb(self, discovery_info: UsbServiceInfo) -> ConfigFlowResult:
-        """Handle USB discovery."""
+        """Handle USB discovery.
+
+        No serial port is opened here: the device is only opened once the user
+        explicitly confirms the discovery, so a discovered dongle that actually
+        belongs to another integration is never disturbed.
+        """
         # Resolve stable /dev/serial/by-id/ path
         dev_path = await self.hass.async_add_executor_job(
             usb.get_serial_by_id, discovery_info.device
         )
+        usb_serial_number = discovery_info.serial_number
 
-        # Validate by reading a real Teleinfo frame — silent abort on failure
-        errors, decoded_data = await self._validate_serial_port(dev_path)
-        if errors or decoded_data is None:
-            return self.async_abort(reason="not_teleinfo_device")
+        # If a config entry already exists for this dongle, update its serial
+        # port path (the dongle may have been re-plugged) and abort. The entry
+        # is keyed by the meter ADCO, which we cannot read without opening the
+        # port, so the dongle USB serial stored in the entry is used to match.
+        if usb_serial_number is not None:
+            for entry in self._async_current_entries(include_ignore=False):
+                if entry.data.get(CONF_USB_SERIAL_NUMBER) != usb_serial_number:
+                    continue
+                if entry.data.get(CONF_SERIAL_PORT) != dev_path:
+                    self.hass.config_entries.async_update_entry(
+                        entry,
+                        data={**entry.data, CONF_SERIAL_PORT: dev_path},
+                    )
+                return self.async_abort(reason="already_configured")
 
-        # Use ADCO (meter serial number) as unique_id — same as manual entry
-        adco = decoded_data["ADCO"]
-        await self.async_set_unique_id(adco)
-        self._abort_if_unique_id_configured(updates={CONF_SERIAL_PORT: dev_path})
+        # Dedupe concurrent discovery flows for the same dongle. The entry's
+        # unique_id becomes the meter ADCO once the user confirms.
+        await self.async_set_unique_id(usb_serial_number)
 
         self._discovered_device = dev_path
+        self._discovered_usb_serial_number = usb_serial_number
         self.context["title_placeholders"] = {
             "name": human_readable_device_name(
                 discovery_info.device,
@@ -120,9 +151,24 @@ class TeleinfoConfigFlow(ConfigFlow, domain=DOMAIN):
         if TYPE_CHECKING:
             assert self._discovered_device is not None
         if user_input is not None:
+            # The user confirmed: now it is safe to open the port and validate
+            # that this really is a Teleinfo meter.
+            errors, decoded_data = await self._validate_serial_port(
+                self._discovered_device
+            )
+            if errors or decoded_data is None:
+                return self.async_abort(reason="not_teleinfo_device")
+
+            adco = decoded_data["ADCO"]
+            await self.async_set_unique_id(adco)
+            self._abort_if_unique_id_configured()
+
+            data: dict[str, str] = {CONF_SERIAL_PORT: self._discovered_device}
+            if self._discovered_usb_serial_number is not None:
+                data[CONF_USB_SERIAL_NUMBER] = self._discovered_usb_serial_number
             return self.async_create_entry(
                 title=f"Teleinfo ({self._discovered_device})",
-                data={CONF_SERIAL_PORT: self._discovered_device},
+                data=data,
             )
         self._set_confirm_only()
         return self.async_show_form(step_id="usb_confirm")

--- a/homeassistant/components/teleinfo/config_flow.py
+++ b/homeassistant/components/teleinfo/config_flow.py
@@ -110,21 +110,24 @@ class TeleinfoConfigFlow(ConfigFlow, domain=DOMAIN):
             usb.get_serial_by_id, discovery_info.device
         )
         usb_serial_number = discovery_info.serial_number
+        # The USB matcher in manifest.json requires a `tinfo-*` serial number,
+        # so discovery is only ever invoked for devices that expose one.
+        assert usb_serial_number is not None
 
         # If a config entry already exists for this dongle, update its serial
         # port path (the dongle may have been re-plugged) and abort. The entry
         # is keyed by the meter ADCO, which we cannot read without opening the
         # port, so the dongle USB serial stored in the entry is used to match.
-        if usb_serial_number is not None:
-            for entry in self._async_current_entries(include_ignore=False):
-                if entry.data.get(CONF_USB_SERIAL_NUMBER) != usb_serial_number:
-                    continue
-                if entry.data.get(CONF_SERIAL_PORT) != dev_path:
-                    self.hass.config_entries.async_update_entry(
-                        entry,
-                        data={**entry.data, CONF_SERIAL_PORT: dev_path},
-                    )
-                return self.async_abort(reason="already_configured")
+        for entry in self._async_current_entries(include_ignore=False):
+            if entry.data.get(CONF_USB_SERIAL_NUMBER) != usb_serial_number:
+                continue
+            if entry.data.get(CONF_SERIAL_PORT) != dev_path:
+                self.hass.config_entries.async_update_entry(
+                    entry,
+                    data={**entry.data, CONF_SERIAL_PORT: dev_path},
+                    title=f"Teleinfo ({dev_path})",
+                )
+            return self.async_abort(reason="already_configured")
 
         # Dedupe concurrent discovery flows for the same dongle. The entry's
         # unique_id becomes the meter ADCO once the user confirms.
@@ -161,11 +164,15 @@ class TeleinfoConfigFlow(ConfigFlow, domain=DOMAIN):
 
             adco = decoded_data["ADCO"]
             await self.async_set_unique_id(adco)
-            self._abort_if_unique_id_configured()
-
             data: dict[str, str] = {CONF_SERIAL_PORT: self._discovered_device}
             if self._discovered_usb_serial_number is not None:
                 data[CONF_USB_SERIAL_NUMBER] = self._discovered_usb_serial_number
+            # If an entry already exists for this meter (e.g. added manually,
+            # or the dongle was replaced), refresh its serial port path and
+            # backfill the USB serial number so future rediscovery can match
+            # it without opening the port.
+            self._abort_if_unique_id_configured(updates=data)
+
             return self.async_create_entry(
                 title=f"Teleinfo ({self._discovered_device})",
                 data=data,

--- a/homeassistant/components/teleinfo/const.py
+++ b/homeassistant/components/teleinfo/const.py
@@ -2,3 +2,4 @@
 
 DOMAIN = "teleinfo"
 CONF_SERIAL_PORT = "serial_port"
+CONF_USB_SERIAL_NUMBER = "usb_serial_number"

--- a/homeassistant/components/teleinfo/manifest.json
+++ b/homeassistant/components/teleinfo/manifest.json
@@ -11,9 +11,9 @@
   "requirements": ["pyteleinfo==0.4.0"],
   "usb": [
     {
-      "vid": "0403",
       "pid": "6015",
-      "serial_number": "tinfo-*"
+      "serial_number": "tinfo-*",
+      "vid": "0403"
     }
   ]
 }

--- a/homeassistant/components/teleinfo/manifest.json
+++ b/homeassistant/components/teleinfo/manifest.json
@@ -11,12 +11,9 @@
   "requirements": ["pyteleinfo==0.4.0"],
   "usb": [
     {
+      "vid": "0403",
       "pid": "6015",
-      "vid": "0403"
-    },
-    {
-      "pid": "EA60",
-      "vid": "10C4"
+      "serial_number": "tinfo-*"
     }
   ]
 }

--- a/homeassistant/components/teleinfo/quality_scale.yaml
+++ b/homeassistant/components/teleinfo/quality_scale.yaml
@@ -23,7 +23,12 @@ rules:
   entity-unique-id: done
   has-entity-name: done
   runtime-data: done
-  test-before-configure: done
+  test-before-configure:
+    status: done
+    comment: >-
+      The serial port is read and a Teleinfo frame decoded before the entry is
+      created. For USB discovery this validation runs on the user-confirmed
+      step, so a discovered dongle is never opened automatically.
   test-before-setup: done
   unique-config-entry: done
 
@@ -50,8 +55,17 @@ rules:
   # Gold
   devices: done
   diagnostics: todo
-  discovery-update-info: done
-  discovery: done
+  discovery-update-info:
+    status: done
+    comment: >-
+      The dongle USB serial number is stored in the config entry; on
+      rediscovery the serial port path is updated from it without opening
+      the port.
+  discovery:
+    status: done
+    comment: >-
+      USB discovery is scoped to the Micro Teleinfo dongle by its TINFO-*
+      USB serial number to avoid matching unrelated serial adapters.
   docs-data-update: done
   docs-examples: done
   docs-known-limitations: done

--- a/homeassistant/generated/usb.py
+++ b/homeassistant/generated/usb.py
@@ -61,12 +61,8 @@ USB = [
     {
         "domain": "teleinfo",
         "pid": "6015",
+        "serial_number": "tinfo-*",
         "vid": "0403",
-    },
-    {
-        "domain": "teleinfo",
-        "pid": "EA60",
-        "vid": "10C4",
     },
     {
         "domain": "velbus",

--- a/tests/components/teleinfo/conftest.py
+++ b/tests/components/teleinfo/conftest.py
@@ -14,7 +14,7 @@ USB_DISCOVERY_INFO = UsbServiceInfo(
     device="/dev/ttyUSB0",
     pid="6015",
     vid="0403",
-    serial_number="AB1234",
+    serial_number="TINFO-144",
     manufacturer="FTDI",
     description="FT230X Basic UART",
 )
@@ -114,6 +114,16 @@ def mock_teleinfo() -> Generator[MagicMock]:
             mock.decode,
         ),
     ):
+        yield mock
+
+
+@pytest.fixture(autouse=True)
+def mock_usb_device_from_path() -> Generator[MagicMock]:
+    """Mock USB device lookup so the flow does no real serial port scan."""
+    with patch(
+        "homeassistant.components.usb.usb_device_from_path",
+        return_value=None,
+    ) as mock:
         yield mock
 
 

--- a/tests/components/teleinfo/test_config_flow.py
+++ b/tests/components/teleinfo/test_config_flow.py
@@ -5,7 +5,11 @@ from unittest.mock import MagicMock
 import pytest
 import serial
 
-from homeassistant.components.teleinfo.const import CONF_SERIAL_PORT, DOMAIN
+from homeassistant.components.teleinfo.const import (
+    CONF_SERIAL_PORT,
+    CONF_USB_SERIAL_NUMBER,
+    DOMAIN,
+)
 from homeassistant.config_entries import SOURCE_USB, SOURCE_USER
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -136,10 +140,60 @@ async def test_user_flow_decode_error(
 
 
 @pytest.mark.usefixtures("mock_teleinfo")
+async def test_user_flow_stores_usb_serial(
+    hass: HomeAssistant,
+    mock_serial_port: MagicMock,
+    mock_usb_device_from_path: MagicMock,
+) -> None:
+    """Test the manual flow stores the USB serial when the port is a USB device."""
+    mock_usb_device_from_path.return_value = MagicMock(serial_number="TINFO-144")
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_SERIAL_PORT: "/dev/ttyUSB0"}
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        CONF_SERIAL_PORT: "/dev/ttyUSB0",
+        CONF_USB_SERIAL_NUMBER: "TINFO-144",
+    }
+
+
+@pytest.mark.usefixtures("mock_teleinfo")
 async def test_usb_discovery_success(
     hass: HomeAssistant, mock_serial_port: MagicMock
 ) -> None:
-    """Test USB discovery happy path: detect → validate → confirm → create entry."""
+    """Test USB discovery happy path: detect → confirm → validate → create entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USB},
+        data=USB_DISCOVERY_INFO,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "usb_confirm"
+    # No serial port is opened until the user confirms.
+    assert mock_serial_port.call_count == 0
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Teleinfo (/dev/ttyUSB0)"
+    assert result["data"] == {
+        CONF_SERIAL_PORT: "/dev/ttyUSB0",
+        CONF_USB_SERIAL_NUMBER: "TINFO-144",
+    }
+    assert result["result"].unique_id == "021861348497"
+
+
+@pytest.mark.usefixtures("mock_teleinfo")
+async def test_usb_discovery_not_teleinfo(
+    hass: HomeAssistant, mock_serial_port: MagicMock
+) -> None:
+    """Test USB discovery aborts when the user confirms a non-Teleinfo device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USB},
@@ -149,26 +203,8 @@ async def test_usb_discovery_success(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "usb_confirm"
 
-    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "Teleinfo (/dev/ttyUSB0)"
-    assert result["data"] == {CONF_SERIAL_PORT: "/dev/ttyUSB0"}
-    assert result["result"].unique_id == "021861348497"
-
-
-@pytest.mark.usefixtures("mock_teleinfo")
-async def test_usb_discovery_not_teleinfo(
-    hass: HomeAssistant, mock_serial_port: MagicMock
-) -> None:
-    """Test USB discovery aborts when frame read times out (not a Teleinfo device)."""
     mock_serial_port.side_effect = TimeoutError("No data received")
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USB},
-        data=USB_DISCOVERY_INFO,
-    )
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "not_teleinfo_device"
@@ -178,13 +214,16 @@ async def test_usb_discovery_not_teleinfo(
 async def test_usb_discovery_already_configured_updates_path(
     hass: HomeAssistant, mock_serial_port: MagicMock
 ) -> None:
-    """Test USB discovery updates device path when dongle is re-plugged."""
+    """Test USB discovery updates device path when the dongle is re-plugged."""
 
-    # Existing entry with same ADCO but old path
+    # Existing entry for this dongle (matched by stored USB serial) with old path
     existing_entry = MockConfigEntry(
         title="Teleinfo (/dev/ttyUSB-old)",
         domain=DOMAIN,
-        data={CONF_SERIAL_PORT: "/dev/ttyUSB-old"},
+        data={
+            CONF_SERIAL_PORT: "/dev/ttyUSB-old",
+            CONF_USB_SERIAL_NUMBER: "TINFO-144",
+        },
         unique_id="021861348497",
     )
     existing_entry.add_to_hass(hass)
@@ -196,7 +235,7 @@ async def test_usb_discovery_already_configured_updates_path(
             device="/dev/ttyUSB-new",
             pid="6015",
             vid="0403",
-            serial_number="AB1234",
+            serial_number="TINFO-144",
             manufacturer="FTDI",
             description="FT230X Basic UART",
         ),
@@ -204,8 +243,37 @@ async def test_usb_discovery_already_configured_updates_path(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
-    # Path should be updated to the new device path
+    # Path updated without ever opening the serial port.
     assert existing_entry.data[CONF_SERIAL_PORT] == "/dev/ttyUSB-new"
+    assert mock_serial_port.call_count == 0
+
+
+@pytest.mark.usefixtures("mock_teleinfo")
+async def test_usb_discovery_already_configured_same_path(
+    hass: HomeAssistant, mock_serial_port: MagicMock
+) -> None:
+    """Test USB discovery aborts without changes when the dongle is unchanged."""
+    existing_entry = MockConfigEntry(
+        title="Teleinfo (/dev/ttyUSB0)",
+        domain=DOMAIN,
+        data={
+            CONF_SERIAL_PORT: "/dev/ttyUSB0",
+            CONF_USB_SERIAL_NUMBER: "TINFO-144",
+        },
+        unique_id="021861348497",
+    )
+    existing_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USB},
+        data=USB_DISCOVERY_INFO,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert existing_entry.data[CONF_SERIAL_PORT] == "/dev/ttyUSB0"
+    assert mock_serial_port.call_count == 0
 
 
 @pytest.mark.usefixtures("mock_teleinfo")
@@ -216,7 +284,8 @@ async def test_usb_discovery_manual_entry_duplicate(
 ) -> None:
     """Test USB discovery aborts when the meter was already added manually."""
 
-    # mock_config_entry has ADCO unique_id — same as what USB discovery will find
+    # mock_config_entry has ADCO unique_id but no stored USB serial (added
+    # manually), so it is only matched once the user confirms and we read ADCO.
     mock_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
@@ -224,6 +293,11 @@ async def test_usb_discovery_manual_entry_duplicate(
         context={"source": SOURCE_USB},
         data=USB_DISCOVERY_INFO,
     )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "usb_confirm"
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
@@ -234,15 +308,18 @@ async def test_usb_discovery_decode_error_aborts(
     mock_teleinfo: MagicMock,
     mock_serial_port: MagicMock,
 ) -> None:
-    """Test USB discovery aborts when frame is read but decode fails."""
-
-    mock_teleinfo.decode.side_effect = mock_teleinfo.TeleinfoError("bad frame")
-
+    """Test USB discovery aborts when the confirmed device fails to decode."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USB},
         data=USB_DISCOVERY_INFO,
     )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "usb_confirm"
+
+    mock_teleinfo.decode.side_effect = mock_teleinfo.TeleinfoError("bad frame")
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "not_teleinfo_device"

--- a/tests/components/teleinfo/test_config_flow.py
+++ b/tests/components/teleinfo/test_config_flow.py
@@ -245,6 +245,8 @@ async def test_usb_discovery_already_configured_updates_path(
     assert result["reason"] == "already_configured"
     # Path updated without ever opening the serial port.
     assert existing_entry.data[CONF_SERIAL_PORT] == "/dev/ttyUSB-new"
+    # Title is refreshed so it no longer disagrees with the configured path.
+    assert existing_entry.title == "Teleinfo (/dev/ttyUSB-new)"
     assert mock_serial_port.call_count == 0
 
 
@@ -301,6 +303,9 @@ async def test_usb_discovery_manual_entry_duplicate(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+    # The USB serial number is backfilled onto the manually-added entry so a
+    # future rediscovery can match it without opening the port.
+    assert mock_config_entry.data[CONF_USB_SERIAL_NUMBER] == "TINFO-144"
 
 
 async def test_usb_discovery_decode_error_aborts(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Teleinfo integration declared two USB discovery matchers for the generic
FTDI (`0403:6015`) and Silicon Labs CP2102N (`10C4:EA60`) USB‑to‑UART bridge
chips. These chips are used by a huge range of unrelated hardware (Zigbee
coordinators, Z‑Wave sticks, ESP boards, …). On every Home Assistant startup
and hotplug, USB discovery automatically invoked the Teleinfo config flow for
every such device, and `async_step_usb` immediately **opened the serial port**
to read a Teleinfo frame. Because serial port access is exclusive, this stole
or disturbed the port from integrations that legitimately own the device (most
visibly Zigbee2MQTT), and on many adapters the port open toggled DTR/RTS and
reset the device.

This PR fixes the root cause:

- **Narrowed the USB matcher.** The two broad matchers are replaced with a
  single `{ "vid": "0403", "pid": "6015", "serial_number": "tinfo-*" }`. Only
  the Micro Teleinfo dongle, which exposes a distinctive `TINFO-*` USB serial
  number, is auto‑discovered. The generic CP2102N matcher is dropped entirely
  (no USB descriptor can distinguish a CP2102N Teleinfo dongle from a Zigbee
  stick). CP2102N, Cartelectronic, generic‑descriptor FTDI and non‑USB (GPIO
  UART) setups continue to work via the existing manual config flow.

- **No serial port is opened during automatic discovery.** `async_step_usb`
  performs no serial I/O — it resolves the stable by‑id path, handles
  rediscovery, and shows the confirmation card. The Teleinfo frame is read
  (for `ADCO` extraction and `test-before-configure` validation) only in
  `async_step_usb_confirm`, i.e. **after the user explicitly confirms** the
  discovered dongle.

- **Meter `ADCO` remains the config‑entry `unique_id`.** Replacing a dongle
  therefore keeps the same device, entities and history. Since `ADCO` cannot
  be read without opening the port, the dongle USB serial number is now stored
  in the config entry (`usb_serial_number`) so that a re‑plugged dongle’s
  serial port path can be updated on rediscovery (`discovery-update-info`)
  without opening the port. The manual flow also stores this value when the
  configured port is a USB device, so a manually‑added Micro Teleinfo dongle
  is still recognised on rediscovery.

`quality_scale.yaml` rationale for `discovery`, `discovery-update-info` and
`test-before-configure` has been updated, and the config‑flow tests have been
reworked for the no‑probe‑at‑discovery behaviour with added coverage
(path update without opening the port, unchanged‑path no‑op, manual‑entry
dedupe at confirm, manual‑flow USB‑serial persistence).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
   - fixes #170875
   - fixes #170039
- This PR is related to issue: #170078 and Koenkk/zigbee2mqtt#31927
- Link to documentation pull request: home-assistant/home-assistant.io#45395
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Note: CP2102N, Cartelectronic and generic‑descriptor FTDI dongles are no
longer auto‑discovered and must be added manually. The `home-assistant.io`
documentation update describing manual setup for these dongles is
home-assistant/home-assistant.io#45395.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
