### PR TITLE
Make infrared test messages strict again

### DIFF
--- a/tests/components/infrared/test_init.py
+++ b/tests/components/infrared/test_init.py
@@ -1,5 +1,6 @@
 """Tests for the Infrared integration setup."""
 
+import re
 from unittest.mock import AsyncMock, Mock
 
 from freezegun.api import FrozenDateTimeFactory
@@ -109,7 +110,7 @@ async def test_async_send_command_entity_not_found(hass: HomeAssistant) -> None:
     """Test async_send_command raises error when entity not found."""
     with pytest.raises(
         HomeAssistantError,
-        match="Infrared entity `infrared.nonexistent_entity` not found",
+        match=re.escape("Infrared entity `infrared.nonexistent_entity` not found"),
     ):
         await async_send_command(hass, "infrared.nonexistent_entity", TEST_COMMAND)
 
@@ -121,7 +122,9 @@ async def test_async_send_command_rejects_receiver(
     """Test async_send_command rejects a receiver entity."""
     with pytest.raises(
         HomeAssistantError,
-        match=f"Infrared entity `{mock_infrared_receiver_entity.entity_id}` not found",
+        match=re.escape(
+            f"Infrared entity `{mock_infrared_receiver_entity.entity_id}` not found"
+        ),
     ):
         await async_send_command(
             hass, mock_infrared_receiver_entity.entity_id, TEST_COMMAND
@@ -262,7 +265,7 @@ async def test_async_subscribe_receiver_not_found(
     """Test async_subscribe_receiver raises when the entity is missing or invalid."""
     with pytest.raises(
         HomeAssistantError,
-        match=f"Infrared receiver entity `{entity_id_or_uuid}` not found",
+        match=re.escape(f"Infrared receiver entity `{entity_id_or_uuid}` not found"),
     ):
         async_subscribe_receiver(hass, entity_id_or_uuid, lambda _: None)
 
@@ -274,7 +277,7 @@ async def test_async_subscribe_receiver_rejects_emitter(
     """Test async_subscribe_receiver rejects an emitter entity."""
     with pytest.raises(
         HomeAssistantError,
-        match=(
+        match=re.escape(
             f"Infrared receiver entity `{mock_infrared_emitter_entity.entity_id}`"
             " not found"
         ),

--- a/tests/components/infrared/test_init.py
+++ b/tests/components/infrared/test_init.py
@@ -109,7 +109,7 @@ async def test_async_send_command_entity_not_found(hass: HomeAssistant) -> None:
     """Test async_send_command raises error when entity not found."""
     with pytest.raises(
         HomeAssistantError,
-        match="Infrared entity .+ not found",
+        match="Infrared entity `infrared.nonexistent_entity` not found",
     ):
         await async_send_command(hass, "infrared.nonexistent_entity", TEST_COMMAND)
 
@@ -121,7 +121,7 @@ async def test_async_send_command_rejects_receiver(
     """Test async_send_command rejects a receiver entity."""
     with pytest.raises(
         HomeAssistantError,
-        match="Infrared entity .+ not found",
+        match=f"Infrared entity `{mock_infrared_receiver_entity.entity_id}` not found",
     ):
         await async_send_command(
             hass, mock_infrared_receiver_entity.entity_id, TEST_COMMAND
@@ -262,7 +262,7 @@ async def test_async_subscribe_receiver_not_found(
     """Test async_subscribe_receiver raises when the entity is missing or invalid."""
     with pytest.raises(
         HomeAssistantError,
-        match="Infrared receiver entity .+ not found",
+        match=f"Infrared receiver entity `{entity_id_or_uuid}` not found",
     ):
         async_subscribe_receiver(hass, entity_id_or_uuid, lambda _: None)
 
@@ -274,7 +274,10 @@ async def test_async_subscribe_receiver_rejects_emitter(
     """Test async_subscribe_receiver rejects an emitter entity."""
     with pytest.raises(
         HomeAssistantError,
-        match="Infrared receiver entity .+ not found",
+        match=(
+            f"Infrared receiver entity `{mock_infrared_emitter_entity.entity_id}`"
+            " not found"
+        ),
     ):
         async_subscribe_receiver(
             hass, mock_infrared_emitter_entity.entity_id, lambda _: None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Address https://github.com/home-assistant/core/pull/170854/changes#r3251931122

Copilot loosened the matches for some reason, but they can stay strict.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
