### PR TITLE
Bump pyRFXtrx to 0.33.0

### DIFF
--- a/homeassistant/components/rfxtrx/manifest.json
+++ b/homeassistant/components/rfxtrx/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["RFXtrx"],
-  "requirements": ["pyRFXtrx==0.31.1"]
+  "requirements": ["pyRFXtrx==0.33.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1962,7 +1962,7 @@ pyHik==0.4.2
 pyHomee==1.3.8
 
 # homeassistant.components.rfxtrx
-pyRFXtrx==0.31.1
+pyRFXtrx==0.33.0
 
 # homeassistant.components.sony_projector
 pySDCP==1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1711,7 +1711,7 @@ pyHik==0.4.2
 pyHomee==1.3.8
 
 # homeassistant.components.rfxtrx
-pyRFXtrx==0.31.1
+pyRFXtrx==0.33.0
 
 # homeassistant.components.tibber
 pyTibber==0.37.5


### PR DESCRIPTION
## Proposed change

Bump `pyRFXtrx` from `0.31.1` to `0.33.0`.

## Why

`pyRFXtrx==0.31.1` (April 2024) has a latent race condition in the receive thread: when the underlying serial file descriptor is nulled (during reload, USB hiccup, or shutdown), the next iteration calls `os.read(self.fd, ...)` with `self.fd is None` and the thread dies with:

```
File "/usr/local/lib/python3.14/site-packages/RFXtrx/__init__.py", line 854, in _receive_packet
    data = self.serial.read(pkt[0]+1 - len(pkt))
File "/usr/local/lib/python3.14/site-packages/serial/serialposix.py", line 575, in read
    buf = os.read(self.fd, size - len(read))
TypeError: 'NoneType' object cannot be interpreted as an integer
```

Because the integration only checks `async_setup_entry`, HA reports the entry as `loaded` while the receive thread is dead. Sensors silently stop updating until the user manually reloads the config entry. With the move to Python 3.14 as the minimum supported runtime (2026.5), the race triggers reliably for at least some users on every restart; I hit it twice in 48 hours on RFXtrx433E + HAOS 17.3 + Core 2026.5.2.

Upstream addressed this in pyRFXtrx 0.33.0 (Danielhiversen/pyRFXtrx#160, commit `b21fb53`, released 2026-03-03) by catching `TypeError` in the `__errors` decorator so the transport surfaces a clean `RFXtrxTransportError` and the connect loop can recover. This PR just bumps the pinned version so users get the fix.

## Type of change

- [x] Dependency upgrade

## Additional information

- Upstream fix: https://github.com/Danielhiversen/pyRFXtrx/pull/160
- Upstream release: https://github.com/Danielhiversen/pyRFXtrx/releases/tag/0.33.0
- Related user report (this PR's author): https://github.com/Danielhiversen/pyRFXtrx/issues/165
- Changelog 0.31.1 -> 0.33.0:
  - 0.32.0: fix dummy serial returns empty packets; packaging modernization
  - 0.32.1: minor follow-up
  - 0.33.0: catch `TypeError` from serial shutdown race; split tamper status from security1

## Checklist

- [x] The code change is tested and works locally (running `pyRFXtrx==0.33.0` against my RFXtrx433E for the past hour with no thread death observed).
- [x] No new dependencies; only a version bump.
- [x] `requirements_all.txt` and `requirements_test_all.txt` updated in lockstep with `manifest.json`.
- [ ] Tests have been added (no integration-side change; behavior is library-internal).