### PR TITLE
Bump rf-protocols to 3.2.0

### DIFF
--- a/homeassistant/components/honeywell_string_lights/manifest.json
+++ b/homeassistant/components/honeywell_string_lights/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "device",
   "iot_class": "assumed_state",
   "quality_scale": "bronze",
-  "requirements": ["rf-protocols==3.0.0"]
+  "requirements": ["rf-protocols==3.2.0"]
 }

--- a/homeassistant/components/novy_cooker_hood/manifest.json
+++ b/homeassistant/components/novy_cooker_hood/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "device",
   "iot_class": "assumed_state",
   "quality_scale": "gold",
-  "requirements": ["rf-protocols==3.0.0"]
+  "requirements": ["rf-protocols==3.2.0"]
 }

--- a/homeassistant/components/radio_frequency/manifest.json
+++ b/homeassistant/components/radio_frequency/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/radio_frequency",
   "integration_type": "entity",
   "quality_scale": "internal",
-  "requirements": ["rf-protocols==3.0.0"]
+  "requirements": ["rf-protocols==3.2.0"]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ python-slugify==8.0.4
 PyTurboJPEG==1.8.3
 PyYAML==6.0.3
 requests==2.33.1
-rf-protocols==3.0.0
+rf-protocols==3.2.0
 securetar==2026.4.1
 SQLAlchemy==2.0.49
 standard-aifc==3.13.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2873,7 +2873,7 @@ reolink-aio==0.19.1
 # homeassistant.components.honeywell_string_lights
 # homeassistant.components.novy_cooker_hood
 # homeassistant.components.radio_frequency
-rf-protocols==3.0.0
+rf-protocols==3.2.0
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2460,7 +2460,7 @@ reolink-aio==0.19.1
 # homeassistant.components.honeywell_string_lights
 # homeassistant.components.novy_cooker_hood
 # homeassistant.components.radio_frequency
-rf-protocols==3.0.0
+rf-protocols==3.2.0
 
 # homeassistant.components.rflink
 rflink==0.0.67


### PR DESCRIPTION
## Proposed change

Bumps `rf-protocols` from 3.0.0 to 3.2.0 in the three integrations that currently pin the library (`honeywell_string_lights`, `novy_cooker_hood`, `radio_frequency`) and the generated `requirements*.txt` files.

The 3.2.0 release adds the `EV1527Command` encoder needed by the new `vacmaster_cardio54` integration proposed in #170893. It does not change the existing `ModulationType` / `RadioFrequencyCommand` base classes that the three current consumers import, so the bump is a no-op at runtime for them.

- Library release notes: https://github.com/home-assistant-libs/rf-protocols/releases/tag/3.2.0
- Diff 3.0.0 ↔ 3.2.0: https://github.com/home-assistant-libs/rf-protocols/compare/3.0.0...3.2.0

Split out of #170893 per @MartinHjelmare's review request to keep the library bump as a dedicated PR.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to PR: #170893 (`vacmaster_cardio54` integration consumes `EV1527Command` from 3.2.0)
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr