### PR TITLE
Populate uid and recurrence_id in CalDAV calendar events

### DIFF
--- a/homeassistant/components/caldav/coordinator.py
+++ b/homeassistant/components/caldav/coordinator.py
@@ -79,6 +79,12 @@ class CalDavUpdateCoordinator(DataUpdateCoordinator[CalendarEvent | None]):
                     end=self.to_local(self.get_end_date(vevent)),
                     location=get_attr_value(vevent, "location"),
                     description=get_attr_value(vevent, "description"),
+                    uid=get_attr_value(vevent, "uid"),
+                    recurrence_id=(
+                        str(v)
+                        if (v := get_attr_value(vevent, "recurrence_id")) is not None
+                        else None
+                    ),
                 )
             )
 
@@ -175,6 +181,12 @@ class CalDavUpdateCoordinator(DataUpdateCoordinator[CalendarEvent | None]):
             end=self.to_local(self.get_end_date(vevent)),
             location=get_attr_value(vevent, "location"),
             description=get_attr_value(vevent, "description"),
+            uid=get_attr_value(vevent, "uid"),
+            recurrence_id=(
+                str(v)
+                if (v := get_attr_value(vevent, "recurrence_id")) is not None
+                else None
+            ),
         )
 
     @staticmethod

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -5,7 +5,7 @@ import datetime
 from http import HTTPStatus
 import logging
 from typing import Any
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, patch
 import zoneinfo
 
 from caldav.objects import Event
@@ -1065,11 +1065,65 @@ async def test_get_events_custom_calendars(
             "summary": "This is a normal event",
             "location": "Hamburg",
             "description": "Surprisingly rainy",
-            "uid": None,
+            "uid": "0",
             "recurrence_id": None,
             "rrule": None,
         }
     ]
+
+
+async def test_get_events_with_recurrence_id(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test that uid and recurrence_id are populated from VEVENT data."""
+    vevent_with_recurrence_id = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//E-Corp.//CalDAV Client//EN
+BEGIN:VEVENT
+UID:original-event-uid
+RECURRENCE-ID:20171127T170000Z
+DTSTAMP:20171125T000000Z
+DTSTART:20171127T180000Z
+DTEND:20171127T190000Z
+SUMMARY:Modified occurrence
+LOCATION:Hamburg
+DESCRIPTION:This occurrence was moved
+END:VEVENT
+END:VCALENDAR"""
+    calendar = Mock()
+    calendar.name = "Example"
+    calendar.get_supported_components = MagicMock(return_value=["VEVENT"])
+    calendar.search = MagicMock(
+        return_value=[
+            Event(
+                None, "0.ics", vevent_with_recurrence_id, calendar, "original-event-uid"
+            )
+        ]
+    )
+
+    with patch(
+        "homeassistant.components.caldav.calendar.caldav.DAVClient"
+    ) as mock_client:
+        mock_client.return_value.principal.return_value.calendars.return_value = [
+            calendar
+        ]
+        assert await async_setup_component(
+            hass, "calendar", {"calendar": CALDAV_CONFIG}
+        )
+        await hass.async_block_till_done()
+
+    client = await hass_client()
+    response = await client.get(
+        f"/api/calendars/{TEST_ENTITY}?start=2017-11-27&end=2017-11-28"
+    )
+    assert response.status == HTTPStatus.OK
+    events = await response.json()
+
+    assert len(events) == 1
+    assert events[0]["uid"] == "original-event-uid"
+    assert events[0]["recurrence_id"] == "2017-11-27 17:00:00+00:00"
+    assert events[0]["summary"] == "Modified occurrence"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The CalDAV integration was not passing `uid` or `recurrence_id` from the source VEVENT when constructing `CalendarEvent` objects, even though both fields are supported by `CalendarEvent` and other calendar integrations (local_calendar, google, remote_calendar) properly populate them.

This meant that both the REST API (`/api/calendars/<entity_id>`) and the `calendar.get_events` service returned `null` for `uid` and `recurrence_id` on every event, breaking downstream consumers that rely on `uid` to identify or deduplicate events.

This PR passes `uid` and `recurrence_id` from the vobject VEVENT to `CalendarEvent` in both code paths (`async_get_events` and `_async_update_data`).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170761
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr