### PR TITLE
Mount MariaDB/MySQL data directory on tmpfs in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1246,7 +1246,10 @@ jobs:
           - 5432:5432
         env:
           POSTGRES_PASSWORD: password
-        options: --health-cmd="pg_isready -hlocalhost -Upostgres" --health-interval=5s --health-timeout=2s --health-retries=3
+        options: >-
+          --health-cmd="pg_isready -hlocalhost -Upostgres"
+          --health-interval=5s --health-timeout=2s --health-retries=3
+          --tmpfs /var/lib/postgresql/data:rw,size=2g,mode=1777
     needs:
       - info
       - base

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1088,7 +1088,7 @@ jobs:
         options: >-
           --health-cmd="if command -v mariadb-admin >/dev/null; then mariadb-admin ping -uroot -ppassword; else mysqladmin ping -uroot -ppassword; fi"
           --health-interval=5s --health-timeout=2s --health-retries=3
-          --tmpfs /var/lib/mysql:rw,size=2g,mode=1777
+          --tmpfs /var/lib/mysql:size=2g,mode=0750
     needs:
       - info
       - base
@@ -1249,7 +1249,7 @@ jobs:
         options: >-
           --health-cmd="pg_isready -hlocalhost -Upostgres"
           --health-interval=5s --health-timeout=2s --health-retries=3
-          --tmpfs /var/lib/postgresql/data:rw,size=2g,mode=1777
+          --tmpfs /var/lib/postgresql/data:size=2g,mode=0700
     needs:
       - info
       - base

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1088,6 +1088,7 @@ jobs:
         options: >-
           --health-cmd="if command -v mariadb-admin >/dev/null; then mariadb-admin ping -uroot -ppassword; else mysqladmin ping -uroot -ppassword; fi"
           --health-interval=5s --health-timeout=2s --health-retries=3
+          --tmpfs /var/lib/mysql:rw,size=2g,mode=1777
     needs:
       - info
       - base


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Mounts the MariaDB/MySQL and PostgreSQL data directories on tmpfs in CI to cut database-test run time.

Across recent CI runs the `mysql:8.0.32` matrix entry consistently took ~13-15 min for the `history`/`logbook`/`recorder`/`sensor` suite — regularly close to (and occasionally tipping over) the 20-min step timeout, e.g. https://github.com/home-assistant/core/actions/runs/25881331158/job/76062228714.

The cost is dominated by per-test `CREATE DATABASE` / `DROP DATABASE` DDL: the fixture in `tests/conftest.py` creates and drops the database around every test (~1900 times), and on MySQL 8.0 each DDL operation incurs redo-log and (now transactional) data-dictionary fsyncs. Mounting `/var/lib/mysql` on tmpfs makes those writes free. The CI data directory is ephemeral by design (created/dropped per test), so losing it when the service container stops is a non-event. 2 GB is a cap, not a reservation — tmpfs allocates lazily and real usage is well under that.

### Measured impact

Baseline numbers are means across 5 recent successful dev runs.

| Matrix entry | Baseline | This PR | Delta |
|---|---|---|---|
| `mariadb:10.3.32` | ~9.0m | 7m27s | −1.6m |
| `mariadb:10.6.10` | ~8.7m | 6m55s | −1.8m |
| `mariadb:10.10.3` | ~8.4m | 7m22s | −1.0m |
| `mariadb:10.11.2` | ~9.0m | 6m31s | −2.5m |
| `mariadb:11.4.9` | ~8.8m | 7m27s | −1.4m |
| **`mysql:8.0.32`** | **~13.9m** | **10m12s** | **−3.7m** |
| `postgres:12.14` | ~9.3m | 8m23s | −0.9m |
| `postgres:15.2` | ~9.5m | 9m2s | −0.5m |

`mysql:8.0.32` is the biggest win and goes from ~5 min of headroom against the 20 min step timeout to ~10 min. PostgreSQL gains are modest — its DDL is cheaper to begin with — but still positive.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr