### PR TITLE
Fix swallowed exceptions in `homeassistant` action handlers

### DIFF
--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -292,8 +292,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
         except (HomeAssistantError, FileNotFoundError) as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
-                translation_key="config_reload_failed",
-                translation_placeholders={"domain": DOMAIN, "error": str(err)},
+                translation_key="core_config_reload_failed",
+                translation_placeholders={"error": str(err)},
             ) from err
 
         # auth only processed during startup

--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -293,7 +293,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="config_reload_failed",
-                translation_placeholders={"error": str(err)},
+                translation_placeholders={"domain": DOMAIN, "error": str(err)},
             ) from err
 
         # auth only processed during startup

--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -289,10 +289,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
         """Service handler for reloading core config."""
         try:
             conf = await conf_util.async_hass_config_yaml(hass)
-        # pylint: disable-next=home-assistant-action-swallowed-exception
-        except HomeAssistantError as err:
-            _LOGGER.error(err)
-            return
+        except (HomeAssistantError, FileNotFoundError) as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="config_reload_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err
 
         # auth only processed during startup
         await core_config.async_process_ha_core_config(hass, conf.get(DOMAIN) or {})

--- a/homeassistant/components/homeassistant/scene.py
+++ b/homeassistant/components/homeassistant/scene.py
@@ -187,7 +187,7 @@ async def async_setup_platform(
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="config_reload_failed",
-                translation_placeholders={"error": str(err)},
+                translation_placeholders={"domain": SCENE_DOMAIN, "error": str(err)},
             ) from err
 
         integration = await async_get_integration(hass, SCENE_DOMAIN)

--- a/homeassistant/components/homeassistant/scene.py
+++ b/homeassistant/components/homeassistant/scene.py
@@ -183,10 +183,12 @@ async def async_setup_platform(
         """Reload the scene config."""
         try:
             config = await conf_util.async_hass_config_yaml(hass)
-        # pylint: disable-next=home-assistant-action-swallowed-exception
-        except HomeAssistantError as err:
-            _LOGGER.error(err)
-            return
+        except (HomeAssistantError, FileNotFoundError) as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="config_reload_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err
 
         integration = await async_get_integration(hass, SCENE_DOMAIN)
 

--- a/homeassistant/components/homeassistant/scene.py
+++ b/homeassistant/components/homeassistant/scene.py
@@ -186,8 +186,8 @@ async def async_setup_platform(
         except (HomeAssistantError, FileNotFoundError) as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
-                translation_key="config_reload_failed",
-                translation_placeholders={"domain": SCENE_DOMAIN, "error": str(err)},
+                translation_key="scene_config_reload_failed",
+                translation_placeholders={"error": str(err)},
             ) from err
 
         integration = await async_get_integration(hass, SCENE_DOMAIN)

--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -13,7 +13,7 @@
       "message": "Error importing config platform {domain}: {error}"
     },
     "config_reload_failed": {
-      "message": "Failed to reload core configuration - {error}."
+      "message": "Failed to reload core configuration - {error}"
     },
     "config_schema_unknown_err": {
       "message": "Unknown error calling {domain} CONFIG_SCHEMA - {error}."

--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -12,9 +12,6 @@
     "config_platform_import_err": {
       "message": "Error importing config platform {domain}: {error}"
     },
-    "config_reload_failed": {
-      "message": "Failed to reload the configuration for integration {domain} - {error}"
-    },
     "config_schema_unknown_err": {
       "message": "Unknown error calling {domain} CONFIG_SCHEMA - {error}."
     },
@@ -23,6 +20,9 @@
     },
     "config_validator_unknown_err": {
       "message": "Unknown error calling {domain} config validator - {error}."
+    },
+    "core_config_reload_failed": {
+      "message": "Failed to reload the Home Assistant Core configuration - {error}"
     },
     "max_length_exceeded": {
       "message": "Value {value} for property {property_name} has a maximum length of {max_length} characters."
@@ -50,6 +50,9 @@
     },
     "platform_schema_validator_err": {
       "message": "Unknown error when validating config for {domain} from integration {p_name} - {error}."
+    },
+    "scene_config_reload_failed": {
+      "message": "Failed to reload the Home Assistant scene platform configuration - {error}"
     },
     "service_config_entry_not_found": {
       "message": "Integration {domain} config entry with ID {entry_id} was not found."

--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -13,7 +13,7 @@
       "message": "Error importing config platform {domain}: {error}"
     },
     "config_reload_failed": {
-      "message": "Failed to reload core configuration - {error}"
+      "message": "Failed to reload Core configuration - {error}"
     },
     "config_schema_unknown_err": {
       "message": "Unknown error calling {domain} CONFIG_SCHEMA - {error}."

--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -13,7 +13,7 @@
       "message": "Error importing config platform {domain}: {error}"
     },
     "config_reload_failed": {
-      "message": "Failed to reload Core configuration - {error}"
+      "message": "Failed to reload the configuration for integration {domain} - {error}"
     },
     "config_schema_unknown_err": {
       "message": "Unknown error calling {domain} CONFIG_SCHEMA - {error}."

--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -12,6 +12,9 @@
     "config_platform_import_err": {
       "message": "Error importing config platform {domain}: {error}"
     },
+    "config_reload_failed": {
+      "message": "Failed to reload core configuration - {error}."
+    },
     "config_schema_unknown_err": {
       "message": "Unknown error calling {domain} CONFIG_SCHEMA - {error}."
     },

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -133,7 +133,7 @@ async def test_reload_core_conf(hass: HomeAssistant) -> None:
 @patch("homeassistant.components.homeassistant._LOGGER.error")
 @patch("homeassistant.core_config.async_process_ha_core_config")
 @pytest.mark.parametrize(
-    ("files_patch", "expcted_error"),
+    ("files_patch", "expected_error"),
     [
         (
             {config.YAML_CONFIG_FILE: yaml.dump(["invalid", "config"])},
@@ -146,8 +146,8 @@ async def test_reload_core_with_wrong_conf(
     mock_process,
     mock_error,
     hass: HomeAssistant,
-    files_patch: dict,
-    expcted_error: str,
+    files_patch: dict[str, str],
+    expected_error: str,
 ) -> None:
     """Test reload core conf service."""
     await async_setup_component(hass, ha.DOMAIN, {})
@@ -156,8 +156,8 @@ async def test_reload_core_with_wrong_conf(
         pytest.raises(
             HomeAssistantError,
             match=(
-                "Failed to reload the configuration for integration homeassistant - "
-                f"{expcted_error}"
+                "Failed to reload the Home Assistant Core configuration - "
+                f"{expected_error}"
             ),
         ),
     ):

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -151,7 +151,7 @@ async def test_reload_core_with_wrong_conf(
         patch_yaml_files(files_patch, True),
         pytest.raises(
             HomeAssistantError,
-            match=f"Failed to reload core configuration - {expcted_error}",
+            match=f"Failed to reload Core configuration - {expcted_error}",
         ),
     ):
         await hass.services.async_call(

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -138,8 +138,9 @@ async def test_reload_core_with_wrong_conf(
     """Test reload core conf service."""
     files = {config.YAML_CONFIG_FILE: yaml.dump(["invalid", "config"])}
     await async_setup_component(hass, ha.DOMAIN, {})
-    with patch_yaml_files(files, True) and pytest.raises(
-        HomeAssistantError, match="Failed to reload core configuration"
+    with (
+        patch_yaml_files(files, True),
+        pytest.raises(HomeAssistantError, match="Failed to reload core configuration"),
     ):
         await hass.services.async_call(
             ha.DOMAIN, SERVICE_RELOAD_CORE_CONFIG, blocking=True

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -143,7 +143,11 @@ async def test_reload_core_conf(hass: HomeAssistant) -> None:
     ],
 )
 async def test_reload_core_with_wrong_conf(
-    mock_process, mock_error, hass: HomeAssistant, files_patch: dict, expcted_error: str
+    mock_process,
+    mock_error,
+    hass: HomeAssistant,
+    files_patch: dict,
+    expcted_error: str,
 ) -> None:
     """Test reload core conf service."""
     await async_setup_component(hass, ha.DOMAIN, {})
@@ -151,7 +155,10 @@ async def test_reload_core_with_wrong_conf(
         patch_yaml_files(files_patch, True),
         pytest.raises(
             HomeAssistantError,
-            match=f"Failed to reload Core configuration - {expcted_error}",
+            match=(
+                "Failed to reload the configuration for integration homeassistant - "
+                f"{expcted_error}"
+            ),
         ),
     ):
         await hass.services.async_call(

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -138,12 +138,14 @@ async def test_reload_core_with_wrong_conf(
     """Test reload core conf service."""
     files = {config.YAML_CONFIG_FILE: yaml.dump(["invalid", "config"])}
     await async_setup_component(hass, ha.DOMAIN, {})
-    with patch_yaml_files(files, True):
+    with patch_yaml_files(files, True) and pytest.raises(
+        HomeAssistantError, match="Failed to reload core configuration"
+    ):
         await hass.services.async_call(
             ha.DOMAIN, SERVICE_RELOAD_CORE_CONFIG, blocking=True
         )
 
-    assert mock_error.called
+    assert mock_error.called is False
     assert mock_process.called is False
 
 

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -132,15 +132,27 @@ async def test_reload_core_conf(hass: HomeAssistant) -> None:
 @patch("homeassistant.config.os.path.isfile", Mock(return_value=True))
 @patch("homeassistant.components.homeassistant._LOGGER.error")
 @patch("homeassistant.core_config.async_process_ha_core_config")
+@pytest.mark.parametrize(
+    ("files_patch", "expcted_error"),
+    [
+        (
+            {config.YAML_CONFIG_FILE: yaml.dump(["invalid", "config"])},
+            "YAML file .*configuration.yaml does not contain a dict",
+        ),
+        ({"not_existing": "blabla"}, "File not found: .*configuration.yaml"),
+    ],
+)
 async def test_reload_core_with_wrong_conf(
-    mock_process, mock_error, hass: HomeAssistant
+    mock_process, mock_error, hass: HomeAssistant, files_patch: dict, expcted_error: str
 ) -> None:
     """Test reload core conf service."""
-    files = {config.YAML_CONFIG_FILE: yaml.dump(["invalid", "config"])}
     await async_setup_component(hass, ha.DOMAIN, {})
     with (
-        patch_yaml_files(files, True),
-        pytest.raises(HomeAssistantError, match="Failed to reload core configuration"),
+        patch_yaml_files(files_patch, True),
+        pytest.raises(
+            HomeAssistantError,
+            match=f"Failed to reload core configuration - {expcted_error}",
+        ),
     ):
         await hass.services.async_call(
             ha.DOMAIN, SERVICE_RELOAD_CORE_CONFIG, blocking=True

--- a/tests/components/homeassistant/test_scene.py
+++ b/tests/components/homeassistant/test_scene.py
@@ -4,15 +4,17 @@ from unittest.mock import patch
 
 import pytest
 import voluptuous as vol
+import yaml
 
+from homeassistant import config
 from homeassistant.components.homeassistant import scene as ha_scene
 from homeassistant.components.homeassistant.scene import EVENT_SCENE_RELOADED
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.setup import async_setup_component
 
-from tests.common import async_capture_events, async_mock_service
+from tests.common import async_capture_events, async_mock_service, patch_yaml_files
 
 
 async def test_reload_config_service(hass: HomeAssistant) -> None:
@@ -44,6 +46,33 @@ async def test_reload_config_service(hass: HomeAssistant) -> None:
     assert len(test_reloaded_event) == 2
     assert hass.states.get("scene.hallo") is None
     assert hass.states.get("scene.bye") is not None
+
+
+@pytest.mark.parametrize(
+    ("files_patch", "expcted_error"),
+    [
+        (
+            {config.YAML_CONFIG_FILE: yaml.dump(["invalid", "config"])},
+            "YAML file .*configuration.yaml does not contain a dict",
+        ),
+        ({"not_existing": "blabla"}, "File not found: .*configuration.yaml"),
+    ],
+)
+async def test_reload_config_service_failed(
+    hass: HomeAssistant, files_patch: dict, expcted_error: str
+) -> None:
+    """Test the reload config service."""
+    assert await async_setup_component(hass, "scene", {})
+    await hass.async_block_till_done()
+
+    with (
+        patch_yaml_files(files_patch, True),
+        pytest.raises(
+            HomeAssistantError,
+            match=f"Failed to reload core configuration - {expcted_error}",
+        ),
+    ):
+        await hass.services.async_call("scene", "reload", blocking=True)
 
 
 async def test_apply_service(hass: HomeAssistant) -> None:

--- a/tests/components/homeassistant/test_scene.py
+++ b/tests/components/homeassistant/test_scene.py
@@ -61,7 +61,7 @@ async def test_reload_config_service(hass: HomeAssistant) -> None:
 async def test_reload_config_service_failed(
     hass: HomeAssistant, files_patch: dict[str, str], expected_error: str
 ) -> None:
-    """Test the reload config service."""
+    """Test error handling when the reload config service fails."""
     assert await async_setup_component(hass, "scene", {})
     await hass.async_block_till_done()
 

--- a/tests/components/homeassistant/test_scene.py
+++ b/tests/components/homeassistant/test_scene.py
@@ -69,7 +69,7 @@ async def test_reload_config_service_failed(
         patch_yaml_files(files_patch, True),
         pytest.raises(
             HomeAssistantError,
-            match=f"Failed to reload core configuration - {expcted_error}",
+            match=f"Failed to reload Core configuration - {expcted_error}",
         ),
     ):
         await hass.services.async_call("scene", "reload", blocking=True)

--- a/tests/components/homeassistant/test_scene.py
+++ b/tests/components/homeassistant/test_scene.py
@@ -69,7 +69,10 @@ async def test_reload_config_service_failed(
         patch_yaml_files(files_patch, True),
         pytest.raises(
             HomeAssistantError,
-            match=f"Failed to reload Core configuration - {expcted_error}",
+            match=(
+                "Failed to reload the configuration for integration scene - "
+                f"{expcted_error}"
+            ),
         ),
     ):
         await hass.services.async_call("scene", "reload", blocking=True)

--- a/tests/components/homeassistant/test_scene.py
+++ b/tests/components/homeassistant/test_scene.py
@@ -49,7 +49,7 @@ async def test_reload_config_service(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    ("files_patch", "expcted_error"),
+    ("files_patch", "expected_error"),
     [
         (
             {config.YAML_CONFIG_FILE: yaml.dump(["invalid", "config"])},
@@ -59,7 +59,7 @@ async def test_reload_config_service(hass: HomeAssistant) -> None:
     ],
 )
 async def test_reload_config_service_failed(
-    hass: HomeAssistant, files_patch: dict, expcted_error: str
+    hass: HomeAssistant, files_patch: dict[str, str], expected_error: str
 ) -> None:
     """Test the reload config service."""
     assert await async_setup_component(hass, "scene", {})
@@ -70,8 +70,8 @@ async def test_reload_config_service_failed(
         pytest.raises(
             HomeAssistantError,
             match=(
-                "Failed to reload the configuration for integration scene - "
-                f"{expcted_error}"
+                "Failed to reload the Home Assistant scene platform configuration - "
+                f"{expected_error}"
             ),
         ),
     ):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This raises a proper translated `HomeAssistantError` on configration yaml reload failed. It also fetches a possible `FileNotFoundError` as `load_yaml_config_file` (_called by `conf_util.async_hass_config_yaml()`_) could raise `FileNotFoundError` or `HomeAssistantError`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170616
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
