### PR TITLE
Tighten manifest schemas for USB discovery

### DIFF
--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -561,6 +561,14 @@ async def async_get_usb(hass: HomeAssistant) -> list[USBMatcher]:
         if not integration.usb:
             continue
         for entry in integration.usb:
+            if not {"vid", "pid", "manufacturer", "description"} <= entry.keys():
+                _LOGGER.warning(
+                    "Ignoring USB discovery entry %s for custom integration %s: "
+                    "matchers must include vid, pid, manufacturer, and description",
+                    entry,
+                    integration.domain,
+                )
+                continue
             usb.append(
                 cast(
                     USBMatcher,

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -263,15 +263,17 @@ INTEGRATION_MANIFEST_SCHEMA = vol.Schema(
             )
         ],
         vol.Optional("usb"): [
-            vol.Schema(
-                {
-                    vol.Optional("vid"): vol.All(str, verify_uppercase),
-                    vol.Optional("pid"): vol.All(str, verify_uppercase),
-                    vol.Optional("serial_number"): vol.All(str, verify_lowercase),
-                    vol.Optional("manufacturer"): vol.All(str, verify_lowercase),
-                    vol.Optional("description"): vol.All(str, verify_lowercase),
-                    vol.Optional("known_devices"): [str],
-                }
+            vol.All(
+                vol.Schema(
+                    {
+                        vol.Required("vid"): vol.All(str, verify_uppercase),
+                        vol.Required("pid"): vol.All(str, verify_uppercase),
+                        vol.Required("manufacturer"): vol.All(str, verify_lowercase),
+                        vol.Required("description"): vol.All(str, verify_lowercase),
+                        vol.Optional("serial_number"): vol.All(str, verify_lowercase),
+                        vol.Optional("known_devices"): [str],
+                    }
+                ),
             )
         ],
         vol.Required("documentation"): vol.All(vol.Url(), core_documentation_url),
@@ -310,11 +312,44 @@ VIRTUAL_INTEGRATION_MANIFEST_SCHEMA = vol.Schema(
     }
 )
 
+# Integrations whose USB discovery entries predate the stricter
+# vid+pid+manufacturer+description requirement. They should be migrated.
+USB_LEGACY_DOMAINS = {
+    "homeassistant_connect_zbt2",
+    "homeassistant_sky_connect",
+    "insteon",
+    "modem_callerid",
+    "teleinfo",
+    "velbus",
+    "zha",
+    "zwave_js",
+}
+
+LEGACY_USB_MANIFEST_SCHEMA = INTEGRATION_MANIFEST_SCHEMA.extend(
+    {
+        vol.Optional("usb"): [
+            vol.Schema(
+                {
+                    vol.Required("vid"): vol.All(str, verify_uppercase),
+                    # Velbus does not list USB PIDs
+                    vol.Optional("pid"): vol.All(str, verify_uppercase),
+                    vol.Optional("serial_number"): vol.All(str, verify_lowercase),
+                    vol.Optional("manufacturer"): vol.All(str, verify_lowercase),
+                    vol.Optional("description"): vol.All(str, verify_lowercase),
+                    vol.Optional("known_devices"): [str],
+                }
+            )
+        ],
+    }
+)
+
 
 def manifest_schema(value: dict[str, Any]) -> vol.Schema:
     """Validate integration manifest."""
     if value.get("integration_type") == IntegrationType.VIRTUAL:
         return VIRTUAL_INTEGRATION_MANIFEST_SCHEMA(value)
+    if value["domain"] in USB_LEGACY_DOMAINS:
+        return LEGACY_USB_MANIFEST_SCHEMA(value)
     return INTEGRATION_MANIFEST_SCHEMA(value)
 
 

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -319,7 +319,6 @@ USB_LEGACY_DOMAINS = {
     "homeassistant_sky_connect",
     "insteon",
     "modem_callerid",
-    "teleinfo",
     "velbus",
     "zha",
     "zwave_js",

--- a/tests/hassfest/test_usb.py
+++ b/tests/hassfest/test_usb.py
@@ -1,0 +1,55 @@
+"""Tests for the hassfest USB manifest schema."""
+
+import pytest
+import voluptuous as vol
+
+from script.hassfest.manifest import USB_LEGACY_DOMAINS, manifest_schema
+
+
+def _manifest_with_usb(domain: str, usb: list[dict]) -> dict:
+    return {
+        "domain": domain,
+        "name": domain,
+        "documentation": f"https://www.home-assistant.io/integrations/{domain}",
+        "codeowners": ["@home-assistant"],
+        "iot_class": "local_push",
+        "usb": usb,
+    }
+
+
+def test_entry_with_all_required_fields_passes() -> None:
+    """A USB entry with vid, pid, manufacturer and description is accepted."""
+    manifest_schema(
+        _manifest_with_usb(
+            "test",
+            [
+                {
+                    "vid": "10C4",
+                    "pid": "EA60",
+                    "manufacturer": "silicon labs",
+                    "description": "*cc2652*",
+                }
+            ],
+        )
+    )
+
+
+@pytest.mark.parametrize("missing", ["vid", "pid", "manufacturer", "description"])
+def test_entry_missing_required_field_rejected(missing: str) -> None:
+    """An entry missing any required field is rejected for non-legacy domains."""
+    entry = {
+        "vid": "10C4",
+        "pid": "EA60",
+        "manufacturer": "silicon labs",
+        "description": "*cc2652*",
+    }
+    del entry[missing]
+
+    with pytest.raises(vol.Invalid):
+        manifest_schema(_manifest_with_usb("test", [entry]))
+
+
+def test_legacy_domain_allows_vid_only_entry() -> None:
+    """Legacy domains keep the loose schema (vid required, rest optional)."""
+    legacy_domain = next(iter(USB_LEGACY_DOMAINS))
+    manifest_schema(_manifest_with_usb(legacy_domain, [{"vid": "10BF"}]))

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -805,15 +805,17 @@ def _get_test_integration_with_usb_matcher(
                 {
                     "vid": "10C4",
                     "pid": "EA60",
+                    "manufacturer": "silicon labs",
+                    "description": "*cc2652*",
                     "known_devices": ["slae.sh cc2652rb stick"],
                 },
-                {"vid": "1CF1", "pid": "0030", "known_devices": ["Conbee II"]},
                 {
-                    "vid": "1A86",
-                    "pid": "7523",
-                    "known_devices": ["Electrolama zig-a-zig-ah"],
+                    "vid": "1CF1",
+                    "pid": "0030",
+                    "manufacturer": "dresden elektronik",
+                    "description": "*conbee*",
+                    "known_devices": ["Conbee II"],
                 },
-                {"vid": "10C4", "pid": "8A2A", "known_devices": ["Nortek HUSBZB-1"]},
             ],
         },
     )
@@ -987,11 +989,64 @@ async def test_get_usb(hass: HomeAssistant) -> None:
         usb = await loader.async_get_usb(hass)
         usb_for_domain = [entry for entry in usb if entry["domain"] == "test_1"]
         assert usb_for_domain == [
-            {"domain": "test_1", "vid": "10C4", "pid": "EA60"},
-            {"domain": "test_1", "vid": "1CF1", "pid": "0030"},
-            {"domain": "test_1", "vid": "1A86", "pid": "7523"},
-            {"domain": "test_1", "vid": "10C4", "pid": "8A2A"},
+            {
+                "domain": "test_1",
+                "vid": "10C4",
+                "pid": "EA60",
+                "manufacturer": "silicon labs",
+                "description": "*cc2652*",
+            },
+            {
+                "domain": "test_1",
+                "vid": "1CF1",
+                "pid": "0030",
+                "manufacturer": "dresden elektronik",
+                "description": "*conbee*",
+            },
         ]
+
+
+async def test_get_usb_drops_incomplete_entries(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """USB matchers missing vid, pid, manufacturer, or description are dropped."""
+    integration = loader.Integration(
+        hass,
+        "homeassistant.components.test",
+        None,
+        {
+            "name": "test",
+            "domain": "test",
+            "config_flow": True,
+            "dependencies": [],
+            "requirements": [],
+            "usb": [
+                {
+                    "vid": "10C4",
+                    "pid": "EA60",
+                    "manufacturer": "silicon labs",
+                    "description": "*cc2652*",
+                },
+                {"vid": "10C4", "pid": "EA60"},
+            ],
+        },
+    )
+
+    with patch("homeassistant.loader.async_get_custom_components") as mock_get:
+        mock_get.return_value = {"test": integration}
+        usb = await loader.async_get_usb(hass)
+
+    assert [entry for entry in usb if entry["domain"] == "test"] == [
+        {
+            "domain": "test",
+            "vid": "10C4",
+            "pid": "EA60",
+            "manufacturer": "silicon labs",
+            "description": "*cc2652*",
+        },
+    ]
+    assert "Ignoring USB discovery entry" in caplog.text
+    assert "custom integration test" in caplog.text
 
 
 async def test_get_homekit(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
All integrations that use USB discovery must now provide `manufacturer`, `description`, `vid`, and `pid`. Before, we allowed just `vid` and `pid`. Custom components not following the new schema will generate a warning.

Existing Core integrations have been excluded from this check but should also be migrated.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
To avoid issues with integrations using overly-broad USB discovery filters (e.g. https://github.com/home-assistant/core/pull/170901/), we should require USB discovery to use as many filters as possible. We currently allow just `VID:PID`, which can match _every_ serial adapter by an entire company (e.g. Silicon Labs), which is not the point of USB discovery.

This PR tightens the manifest schema and will require all new integrations to provide more USB discovery information. Existing integrations are excluded from the check but should also be migrated, this is something for the integration code owners to help out with.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
