### PR TITLE
Patch pyserial on startup to force serial port locking

### DIFF
--- a/homeassistant/block_shared_serial.py
+++ b/homeassistant/block_shared_serial.py
@@ -1,4 +1,4 @@
-"""Block shared access to serial ports by forcing pyserial exclusivvity.
+"""Block shared access to serial ports by forcing pyserial exclusivity.
 
 Also wires up a `serial` logger around port opens, since pyserial itself is silent.
 """

--- a/homeassistant/block_shared_serial.py
+++ b/homeassistant/block_shared_serial.py
@@ -42,7 +42,7 @@ def _logged_rfc2217_open(self: Rfc2217Serial) -> None:
 def enable() -> None:
     """Default `exclusive` to True and log every pyserial port open."""
     if SocketSerial.open is _logged_socket_open:
-        raise RuntimeError("Shared serial blocking is already enabled")
+        return
 
     defaults = {
         name: param.default

--- a/homeassistant/block_shared_serial.py
+++ b/homeassistant/block_shared_serial.py
@@ -11,7 +11,7 @@ from serial import Serial as PlatformSerial, SerialBase
 from serial.rfc2217 import Serial as Rfc2217Serial
 from serial.urlhandler.protocol_socket import Serial as SocketSerial
 
-_LOGGER = logging.getLogger("serial")
+_LOGGER = logging.getLogger("pySerial")
 
 _original_init = SerialBase.__init__
 _original_open = PlatformSerial.open
@@ -34,16 +34,16 @@ def _logged_platform_open(self: PlatformSerial) -> None:
 
 @wraps(_original_socket_open)
 def _logged_socket_open(self: SocketSerial) -> None:
-    _LOGGER.debug("Opening socket serial port %s", self.port)
+    _LOGGER.debug("Opening serial port %s", self.port)
     _original_socket_open(self)
-    _LOGGER.debug("Opened socket serial port %s", self.port)
+    _LOGGER.debug("Opened serial port %s", self.port)
 
 
 @wraps(_original_rfc2217_open)
 def _logged_rfc2217_open(self: Rfc2217Serial) -> None:
-    _LOGGER.debug("Opening RFC 2217 serial port %s", self.port)
+    _LOGGER.debug("Opening serial port %s", self.port)
     _original_rfc2217_open(self)
-    _LOGGER.debug("Opened RFC 2217 serial port %s", self.port)
+    _LOGGER.debug("Opened serial port %s", self.port)
 
 
 def enable() -> None:
@@ -51,7 +51,7 @@ def enable() -> None:
     if SerialBase.__init__ is _exclusive_init:
         raise RuntimeError("Shared serial blocking is already enabled")
 
-    setattr(SerialBase, "__init__", _exclusive_init)  # noqa: B010
-    setattr(PlatformSerial, "open", _logged_platform_open)  # noqa: B010
-    setattr(SocketSerial, "open", _logged_socket_open)  # noqa: B010
-    setattr(Rfc2217Serial, "open", _logged_rfc2217_open)  # noqa: B010
+    SerialBase.__init__ = _exclusive_init  # type:ignore[method-assign]
+    PlatformSerial.open = _logged_platform_open  # type:ignore[method-assign]
+    SocketSerial.open = _logged_socket_open  # type:ignore[method-assign]
+    Rfc2217Serial.open = _logged_rfc2217_open  # type:ignore[method-assign]

--- a/homeassistant/block_shared_serial.py
+++ b/homeassistant/block_shared_serial.py
@@ -1,0 +1,57 @@
+"""Block shared access to serial ports by forcing pyserial exclusivvity.
+
+Also wires up a `serial` logger around port opens, since pyserial itself is silent.
+"""
+
+from functools import wraps
+import logging
+from typing import Any
+
+from serial import Serial as PlatformSerial, SerialBase
+from serial.rfc2217 import Serial as Rfc2217Serial
+from serial.urlhandler.protocol_socket import Serial as SocketSerial
+
+_LOGGER = logging.getLogger("serial")
+
+_original_init = SerialBase.__init__
+_original_open = PlatformSerial.open
+_original_socket_open = SocketSerial.open
+_original_rfc2217_open = Rfc2217Serial.open
+
+
+@wraps(_original_init)
+def _exclusive_init(self: SerialBase, *args: Any, **kwargs: Any) -> None:
+    kwargs["exclusive"] = True
+    _original_init(self, *args, **kwargs)
+
+
+@wraps(_original_open)
+def _logged_platform_open(self: PlatformSerial) -> None:
+    _LOGGER.debug("Opening serial port %s", self.port)
+    _original_open(self)
+    _LOGGER.debug("Opened serial port %s", self.port)
+
+
+@wraps(_original_socket_open)
+def _logged_socket_open(self: SocketSerial) -> None:
+    _LOGGER.debug("Opening socket serial port %s", self.port)
+    _original_socket_open(self)
+    _LOGGER.debug("Opened socket serial port %s", self.port)
+
+
+@wraps(_original_rfc2217_open)
+def _logged_rfc2217_open(self: Rfc2217Serial) -> None:
+    _LOGGER.debug("Opening RFC 2217 serial port %s", self.port)
+    _original_rfc2217_open(self)
+    _LOGGER.debug("Opened RFC 2217 serial port %s", self.port)
+
+
+def enable() -> None:
+    """Force exclusive locking and log every pyserial port open."""
+    if SerialBase.__init__ is _exclusive_init:
+        raise RuntimeError("Shared serial blocking is already enabled")
+
+    setattr(SerialBase, "__init__", _exclusive_init)  # noqa: B010
+    setattr(PlatformSerial, "open", _logged_platform_open)  # noqa: B010
+    setattr(SocketSerial, "open", _logged_socket_open)  # noqa: B010
+    setattr(Rfc2217Serial, "open", _logged_rfc2217_open)  # noqa: B010

--- a/homeassistant/block_shared_serial.py
+++ b/homeassistant/block_shared_serial.py
@@ -4,8 +4,8 @@ Also wires up a `serial` logger around port opens, since pyserial itself is sile
 """
 
 from functools import wraps
+import inspect
 import logging
-from typing import Any
 
 from serial import Serial as PlatformSerial, SerialBase
 from serial.rfc2217 import Serial as Rfc2217Serial
@@ -13,16 +13,9 @@ from serial.urlhandler.protocol_socket import Serial as SocketSerial
 
 _LOGGER = logging.getLogger("pySerial")
 
-_original_init = SerialBase.__init__
 _original_open = PlatformSerial.open
 _original_socket_open = SocketSerial.open
 _original_rfc2217_open = Rfc2217Serial.open
-
-
-@wraps(_original_init)
-def _exclusive_init(self: SerialBase, *args: Any, **kwargs: Any) -> None:
-    kwargs["exclusive"] = True
-    _original_init(self, *args, **kwargs)
 
 
 @wraps(_original_open)
@@ -47,11 +40,18 @@ def _logged_rfc2217_open(self: Rfc2217Serial) -> None:
 
 
 def enable() -> None:
-    """Force exclusive locking and log every pyserial port open."""
-    if SerialBase.__init__ is _exclusive_init:
+    """Default `exclusive` to True and log every pyserial port open."""
+    if SocketSerial.open is _logged_socket_open:
         raise RuntimeError("Shared serial blocking is already enabled")
 
-    SerialBase.__init__ = _exclusive_init  # type:ignore[method-assign]
+    defaults = {
+        name: param.default
+        for name, param in inspect.signature(SerialBase.__init__).parameters.items()
+        if param.default is not param.empty
+    }
+    defaults["exclusive"] = True
+    SerialBase.__init__.__defaults__ = tuple(defaults.values())
+
     PlatformSerial.open = _logged_platform_open  # type:ignore[method-assign]
     SocketSerial.open = _logged_socket_open  # type:ignore[method-assign]
     Rfc2217Serial.open = _logged_rfc2217_open  # type:ignore[method-assign]

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -24,6 +24,7 @@ import yarl
 
 from . import (
     block_async_io,
+    block_shared_serial,
     config as conf_util,
     config_entries,
     core,
@@ -336,6 +337,7 @@ async def async_setup_hass(
     _LOGGER.info("Config directory: %s", runtime_config.config_dir)
 
     block_async_io.enable()
+    block_shared_serial.enable()
 
     if not (recovery_mode := runtime_config.recovery_mode):
         config_dict = None

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -57,6 +57,7 @@ PyJWT==2.12.1
 pymicro-vad==1.0.1
 PyNaCl==1.6.2
 pyOpenSSL==26.2.0
+pyserial==3.5
 pyspeex-noise==1.0.2
 python-slugify==8.0.4
 PyTurboJPEG==1.8.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,8 @@ dependencies = [
   "Pillow==12.2.0",
   "propcache==0.4.1",
   "pyOpenSSL==26.2.0",
+  # We patch pyserial at runtime in `block_shared_serial` and need it to be available
+  "pyserial==3.5",
   "orjson==3.11.9",
   "packaging>=23.1",
   "psutil-home-assistant==0.0.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,7 @@ psutil-home-assistant==0.0.1
 PyJWT==2.12.1
 pymicro-vad==1.0.1
 pyOpenSSL==26.2.0
+pyserial==3.5
 pyspeex-noise==1.0.2
 python-slugify==8.0.4
 PyTurboJPEG==1.8.3

--- a/tests/test_block_shared_serial.py
+++ b/tests/test_block_shared_serial.py
@@ -1,4 +1,4 @@
-"""Tests for the block_shared_serial pyserial monkey-patches."""
+"""Tests for the block_shared_serial pyserial patches."""
 
 from collections.abc import Generator
 import logging
@@ -15,39 +15,39 @@ from homeassistant import block_shared_serial
 
 @pytest.fixture(autouse=True)
 def restore_pyserial() -> Generator[None]:
-    """Restore the patched pyserial methods after each test."""
+    """Restore pyserial state after each test."""
+    original_defaults = SerialBase.__init__.__defaults__
     try:
         yield
     finally:
-        SerialBase.__init__ = block_shared_serial._original_init
+        SerialBase.__init__.__defaults__ = original_defaults
         PlatformSerial.open = block_shared_serial._original_open
         SocketSerial.open = block_shared_serial._original_socket_open
         Rfc2217Serial.open = block_shared_serial._original_rfc2217_open
 
 
-@pytest.mark.parametrize("requested", [None, False, True])
-async def test_init_forces_exclusive(requested: bool | None) -> None:
-    """Test that __init__ always coerces exclusive to True after enable()."""
-    base1 = SerialBase(exclusive=requested)
-    assert base1.exclusive is requested
-
+async def test_default_exclusive_becomes_true() -> None:
+    """When `exclusive` is omitted, it defaults to True after enable()."""
+    assert SerialBase()._exclusive is None
     block_shared_serial.enable()
-    base2 = SerialBase(exclusive=requested)
-    assert base2.exclusive is True
+    assert SerialBase()._exclusive is True
+
+
+@pytest.mark.parametrize("value", [None, False, True])
+async def test_explicit_exclusive_is_preserved(value: bool | None) -> None:
+    """Explicit `exclusive` arguments are honored after enable()."""
+    block_shared_serial.enable()
+    assert SerialBase(exclusive=value)._exclusive is value
 
 
 @pytest.mark.parametrize(
     "uri",
-    [
-        "/dev/this-does-not-exist",
-        "socket://127.0.0.1:1",
-        "rfc2217://127.0.0.1:1",
-    ],
+    ["/dev/this-does-not-exist", "socket://127.0.0.1:1", "rfc2217://127.0.0.1:1"],
 )
 async def test_serial_open_logs(caplog: pytest.LogCaptureFixture, uri: str) -> None:
-    """Test that opening a serial port emits a debug log on the serial logger."""
+    """Opening a serial port emits a debug log on the pySerial logger."""
     block_shared_serial.enable()
-    caplog.set_level(logging.DEBUG, logger="serial")
+    caplog.set_level(logging.DEBUG, logger="pySerial")
 
     with (  # noqa: SIM117
         pytest.raises(SerialException),
@@ -61,7 +61,7 @@ async def test_serial_open_logs(caplog: pytest.LogCaptureFixture, uri: str) -> N
 
 
 async def test_enable_multiple_times() -> None:
-    """Test that calling enable() twice raises RuntimeError."""
+    """Calling enable() twice raises RuntimeError."""
     block_shared_serial.enable()
 
     with pytest.raises(RuntimeError, match="Shared serial blocking is already enabled"):

--- a/tests/test_block_shared_serial.py
+++ b/tests/test_block_shared_serial.py
@@ -1,0 +1,68 @@
+"""Tests for the block_shared_serial pyserial monkey-patches."""
+
+from collections.abc import Generator
+import logging
+from unittest.mock import patch
+
+import pytest
+import serial
+from serial import Serial as PlatformSerial, SerialBase, SerialException
+from serial.rfc2217 import Serial as Rfc2217Serial
+from serial.urlhandler.protocol_socket import Serial as SocketSerial
+
+from homeassistant import block_shared_serial
+
+
+@pytest.fixture(autouse=True)
+def restore_pyserial() -> Generator[None]:
+    """Restore the patched pyserial methods after each test."""
+    try:
+        yield
+    finally:
+        SerialBase.__init__ = block_shared_serial._original_init
+        PlatformSerial.open = block_shared_serial._original_open
+        SocketSerial.open = block_shared_serial._original_socket_open
+        Rfc2217Serial.open = block_shared_serial._original_rfc2217_open
+
+
+@pytest.mark.parametrize("requested", [None, False, True])
+async def test_init_forces_exclusive(requested: bool | None) -> None:
+    """Test that __init__ always coerces exclusive to True after enable()."""
+    base1 = SerialBase(exclusive=requested)
+    assert base1.exclusive is requested
+
+    block_shared_serial.enable()
+    base2 = SerialBase(exclusive=requested)
+    assert base2.exclusive is True
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "/dev/this-does-not-exist",
+        "socket://127.0.0.1:1",
+        "rfc2217://127.0.0.1:1",
+    ],
+)
+async def test_serial_open_logs(caplog: pytest.LogCaptureFixture, uri: str) -> None:
+    """Test that opening a serial port emits a debug log on the serial logger."""
+    block_shared_serial.enable()
+    caplog.set_level(logging.DEBUG, logger="serial")
+
+    with (  # noqa: SIM117
+        pytest.raises(SerialException),
+        # We bypass `HASocketBlockedError` checks on purpose
+        patch("socket.socket", side_effect=RuntimeError("Cannot open socket")),
+    ):
+        with serial.serial_for_url(uri):
+            pass
+
+    assert f"Opening serial port {uri}" in caplog.text
+
+
+async def test_enable_multiple_times() -> None:
+    """Test that calling enable() twice raises RuntimeError."""
+    block_shared_serial.enable()
+
+    with pytest.raises(RuntimeError, match="Shared serial blocking is already enabled"):
+        block_shared_serial.enable()

--- a/tests/test_block_shared_serial.py
+++ b/tests/test_block_shared_serial.py
@@ -60,9 +60,9 @@ async def test_serial_open_logs(caplog: pytest.LogCaptureFixture, uri: str) -> N
     assert f"Opening serial port {uri}" in caplog.text
 
 
-async def test_enable_multiple_times() -> None:
-    """Calling enable() twice raises RuntimeError."""
+async def test_enable_is_idempotent() -> None:
+    """Calling enable() twice leaves the existing wrappers in place."""
     block_shared_serial.enable()
-
-    with pytest.raises(RuntimeError, match="Shared serial blocking is already enabled"):
-        block_shared_serial.enable()
+    wrapped_open = SocketSerial.open
+    block_shared_serial.enable()
+    assert SocketSerial.open is wrapped_open


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Existing code relying on pyserial defaulting to disabling exclusivity checks for serial ports will stop working. I do not think any exists but I haven't checked every custom component. This behavior should be considered a bug and be fixed.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR patches pyserial at runtime and mutates the signature of `SerialBase.__init__` and sets `exclusive=True`. Exclusivity for serial ports relies on `flock`, which is opt-in for every participant: if one integration uses `exclusive=True` but another does not, exclusivity [is not honored](https://github.com/home-assistant/core/pull/170901). This is a bad default and has caused too many problems already.

pyserial does not log when it connects to serial ports so there is no way at runtime to know if a port is being opened or not so I've patched its `open` functions for the common serial transports to log. This will allow you to read debug logs to figure out what integration is loading and opening serial ports if downstream functionality breaks due to exclusivity checks.

([serialx](https://github.com/puddly/serialx) both logs and uses exclusive access by default so existing integrations are encouraged to migrate)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
