### PR TITLE
fix(service.py): lazy-load base components

### DIFF
--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -79,31 +79,6 @@ ALL_SERVICE_DESCRIPTIONS_CACHE: HassKey[
 ] = HassKey("all_service_descriptions_cache")
 
 
-_BASE_COMPONENT_NAMES = frozenset(
-    {
-        "ai_task",
-        "alarm_control_panel",
-        "assist_satellite",
-        "calendar",
-        "camera",
-        "climate",
-        "cover",
-        "fan",
-        "humidifier",
-        "light",
-        "lock",
-        "media_player",
-        "notify",
-        "remote",
-        "siren",
-        "todo",
-        "update",
-        "vacuum",
-        "water_heater",
-    }
-)
-
-
 def _validate_option_or_feature(option_or_feature: str, label: str) -> Any:
     """Validate attribute option or supported feature."""
     try:
@@ -113,10 +88,13 @@ def _validate_option_or_feature(option_or_feature: str, label: str) -> Any:
             f"Invalid {label} '{option_or_feature}', expected <domain>.<enum>.<member>"
         ) from exc
 
-    if domain not in _BASE_COMPONENT_NAMES:
-        raise vol.Invalid(f"Unknown base component '{domain}'")
-
-    base_component = importlib.import_module(f"homeassistant.components.{domain}")
+    base_component_module_name = f"homeassistant.components.{domain}"
+    try:
+        base_component = importlib.import_module(base_component_module_name)
+    except ModuleNotFoundError as exc:
+        if exc.name == base_component_module_name:
+            raise vol.Invalid(f"Unknown base component '{domain}'") from exc
+        raise
 
     try:
         attribute_enum = getattr(base_component, enum)

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -4,10 +4,10 @@ import asyncio
 from collections.abc import Callable, Coroutine, Iterable, Mapping, Sequence
 import dataclasses
 from enum import Enum
-from functools import cache, partial
+from functools import partial
+import importlib
 import inspect
 import logging
-from types import ModuleType
 from typing import TYPE_CHECKING, Any, TypedDict, cast, override
 
 import voluptuous as vol
@@ -79,52 +79,29 @@ ALL_SERVICE_DESCRIPTIONS_CACHE: HassKey[
 ] = HassKey("all_service_descriptions_cache")
 
 
-@cache
-def _base_components() -> dict[str, ModuleType]:
-    """Return a cached lookup of base components."""
-    from homeassistant.components import (  # noqa: PLC0415
-        ai_task,
-        alarm_control_panel,
-        assist_satellite,
-        calendar,
-        camera,
-        climate,
-        cover,
-        fan,
-        humidifier,
-        light,
-        lock,
-        media_player,
-        notify,
-        remote,
-        siren,
-        todo,
-        update,
-        vacuum,
-        water_heater,
-    )
-
-    return {
-        "ai_task": ai_task,
-        "alarm_control_panel": alarm_control_panel,
-        "assist_satellite": assist_satellite,
-        "calendar": calendar,
-        "camera": camera,
-        "climate": climate,
-        "cover": cover,
-        "fan": fan,
-        "humidifier": humidifier,
-        "light": light,
-        "lock": lock,
-        "media_player": media_player,
-        "notify": notify,
-        "remote": remote,
-        "siren": siren,
-        "todo": todo,
-        "update": update,
-        "vacuum": vacuum,
-        "water_heater": water_heater,
+_BASE_COMPONENT_NAMES = frozenset(
+    {
+        "ai_task",
+        "alarm_control_panel",
+        "assist_satellite",
+        "calendar",
+        "camera",
+        "climate",
+        "cover",
+        "fan",
+        "humidifier",
+        "light",
+        "lock",
+        "media_player",
+        "notify",
+        "remote",
+        "siren",
+        "todo",
+        "update",
+        "vacuum",
+        "water_heater",
     }
+)
 
 
 def _validate_option_or_feature(option_or_feature: str, label: str) -> Any:
@@ -136,9 +113,10 @@ def _validate_option_or_feature(option_or_feature: str, label: str) -> Any:
             f"Invalid {label} '{option_or_feature}', expected <domain>.<enum>.<member>"
         ) from exc
 
-    base_components = _base_components()
-    if not (base_component := base_components.get(domain)):
+    if domain not in _BASE_COMPONENT_NAMES:
         raise vol.Invalid(f"Unknown base component '{domain}'")
+
+    base_component = importlib.import_module(f"homeassistant.components.{domain}")
 
     try:
         attribute_enum = getattr(base_component, enum)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This fixes service.py to only loads base components where and when they are actually used. This has the advantage of being slightly simpler anyway.

`importlib` works the same way as python `import` and *does* cache imports. The `@cache` annotation wasn't actually useful in the original code anyway.

Context: I am trying to make a minimal home-assistant configuration and ai_task pulls in two large external dependencies, `hassil` and `haffmpeg` that are otherwise not needed. Having them be lazy loaded means I can better identify where they are used.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: no linked issue
- This PR is related to issue: no linked issue
- Link to documentation pull request: not relevant
- Link to developer documentation pull request: not relevant
- Link to frontend pull request: not relevant

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
