### PR TITLE
Disable USB discovery for teleinfo

### DIFF
--- a/homeassistant/components/teleinfo/config_flow.py
+++ b/homeassistant/components/teleinfo/config_flow.py
@@ -90,16 +90,6 @@ class TeleinfoConfigFlow(ConfigFlow, domain=DOMAIN):
             usb.get_serial_by_id, discovery_info.device
         )
 
-        # Validate by reading a real Teleinfo frame — silent abort on failure
-        errors, decoded_data = await self._validate_serial_port(dev_path)
-        if errors or decoded_data is None:
-            return self.async_abort(reason="not_teleinfo_device")
-
-        # Use ADCO (meter serial number) as unique_id — same as manual entry
-        adco = decoded_data["ADCO"]
-        await self.async_set_unique_id(adco)
-        self._abort_if_unique_id_configured(updates={CONF_SERIAL_PORT: dev_path})
-
         self._discovered_device = dev_path
         self.context["title_placeholders"] = {
             "name": human_readable_device_name(
@@ -120,6 +110,20 @@ class TeleinfoConfigFlow(ConfigFlow, domain=DOMAIN):
         if TYPE_CHECKING:
             assert self._discovered_device is not None
         if user_input is not None:
+            # Validate by reading a real Teleinfo frame — silent abort on failure
+            errors, decoded_data = await self._validate_serial_port(
+                self._discovered_device
+            )
+            if errors or decoded_data is None:
+                return self.async_abort(reason="not_teleinfo_device")
+
+            # Use ADCO (meter serial number) as unique_id — same as manual entry
+            adco = decoded_data["ADCO"]
+            await self.async_set_unique_id(adco)
+            self._abort_if_unique_id_configured(
+                updates={CONF_SERIAL_PORT: self._discovered_device}
+            )
+
             return self.async_create_entry(
                 title=f"Teleinfo ({self._discovered_device})",
                 data={CONF_SERIAL_PORT: self._discovered_device},

--- a/homeassistant/components/teleinfo/manifest.json
+++ b/homeassistant/components/teleinfo/manifest.json
@@ -8,6 +8,5 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "quality_scale": "silver",
-  "requirements": ["pyteleinfo==0.4.0"],
-  "usb": []
+  "requirements": ["pyteleinfo==0.4.0"]
 }

--- a/homeassistant/components/teleinfo/manifest.json
+++ b/homeassistant/components/teleinfo/manifest.json
@@ -9,14 +9,5 @@
   "iot_class": "local_polling",
   "quality_scale": "silver",
   "requirements": ["pyteleinfo==0.4.0"],
-  "usb": [
-    {
-      "pid": "6015",
-      "vid": "0403"
-    },
-    {
-      "pid": "EA60",
-      "vid": "10C4"
-    }
-  ]
+  "usb": []
 }

--- a/homeassistant/generated/usb.py
+++ b/homeassistant/generated/usb.py
@@ -59,16 +59,6 @@ USB = [
         "vid": "04B4",
     },
     {
-        "domain": "teleinfo",
-        "pid": "6015",
-        "vid": "0403",
-    },
-    {
-        "domain": "teleinfo",
-        "pid": "EA60",
-        "vid": "10C4",
-    },
-    {
         "domain": "velbus",
         "pid": "0B1B",
         "vid": "10CF",

--- a/tests/components/teleinfo/test_config_flow.py
+++ b/tests/components/teleinfo/test_config_flow.py
@@ -170,6 +170,11 @@ async def test_usb_discovery_not_teleinfo(
         data=USB_DISCOVERY_INFO,
     )
 
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "usb_confirm"
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "not_teleinfo_device"
 
@@ -202,6 +207,11 @@ async def test_usb_discovery_already_configured_updates_path(
         ),
     )
 
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "usb_confirm"
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     # Path should be updated to the new device path
@@ -225,6 +235,11 @@ async def test_usb_discovery_manual_entry_duplicate(
         data=USB_DISCOVERY_INFO,
     )
 
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "usb_confirm"
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
@@ -243,6 +258,11 @@ async def test_usb_discovery_decode_error_aborts(
         context={"source": SOURCE_USB},
         data=USB_DISCOVERY_INFO,
     )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "usb_confirm"
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "not_teleinfo_device"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Disable USB discovery for the teleinfo integration. The current USB filters are too broad and match _a lot_ of devices. This, coupled with a bug that causes the integration to auto-probe discovered serial ports without confirmation, causes serial issues elsewhere in Core and other addons.

I've also fixed the underlying discovery confirmation bug defensively, just in case some other codepath that I'm not aware of can trigger it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170875, fixes #170039, fixes #170078
- This PR is related to issue: https://github.com/Koenkk/zigbee2mqtt/issues/31927
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
