### PR TITLE
Fix flaky recorder entity registry collision tests

### DIFF
--- a/tests/components/recorder/test_entity_registry.py
+++ b/tests/components/recorder/test_entity_registry.py
@@ -1,7 +1,9 @@
 """The tests for sensor recorder platform."""
 
+from datetime import timedelta
 from unittest.mock import patch
 
+from freezegun import freeze_time
 import pytest
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -220,11 +222,12 @@ async def test_rename_entity_collision(
     assert_dict_of_states_equal_without_context_and_last_changed(states, hist)
     assert len(hist["sensor.test1"]) == 3
 
-    hass.states.async_set("sensor.test99", "collision")
-    hass.states.async_remove("sensor.test99")
+    with freeze_time(four - timedelta(seconds=1)):
+        hass.states.async_set("sensor.test99", "collision")
+        hass.states.async_remove("sensor.test99")
 
-    await hass.async_block_till_done()
-    await async_wait_recording_done(hass)
+        await hass.async_block_till_done()
+        await async_wait_recording_done(hass)
 
     # Rename entity sensor.test1 to sensor.test99
     entity_registry.async_update_entity("sensor.test1", new_entity_id="sensor.test99")
@@ -290,11 +293,12 @@ async def test_rename_entity_collision_without_states_meta_safeguard(
     assert_dict_of_states_equal_without_context_and_last_changed(states, hist)
     assert len(hist["sensor.test1"]) == 3
 
-    hass.states.async_set("sensor.test99", "collision")
-    hass.states.async_remove("sensor.test99")
+    with freeze_time(four - timedelta(seconds=1)):
+        hass.states.async_set("sensor.test99", "collision")
+        hass.states.async_remove("sensor.test99")
 
-    await hass.async_block_till_done()
-    await async_wait_recording_done(hass)
+        await hass.async_block_till_done()
+        await async_wait_recording_done(hass)
 
     # Verify history before collision
     hist = history.get_significant_states(


### PR DESCRIPTION
## Breaking change


## Proposed change

`test_rename_entity_collision` and `test_rename_entity_collision_without_states_meta_safeguard` in `tests/components/recorder/test_entity_registry.py` are flaky.

`record_states()` computes `zero = get_start_time(utcnow())`, which rounds *down* to the nearest 5-minute boundary, and `four = zero + 300s` — i.e. `four` is the *next* 5-minute boundary. The recorded `sensor.test1` states are dated under `freeze_time`, but the `sensor.test99` collision (`async_set` + `async_remove`) was recorded at real wall-clock time. The history assertions query the fixed `[zero, four]` window.

When a run happens to start late in a 5-minute window and crosses the next boundary before `sensor.test99` is recorded, those rows land *after* `four` and `get_significant_states(hass, zero, four, ...)` excludes them, raising `KeyError: 'sensor.test99'`.

Example failure: https://github.com/home-assistant/core/actions/runs/25975513036/job/76354961664

This records the `sensor.test99` collision under `freeze_time` (just inside the window, since the query upper bound is exclusive), so its timestamps are deterministic — consistent with how `record_states()` already freezes time for every other recorded state. The collision-detection logic under test does not depend on the rows' timestamps, so coverage is unchanged.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr