### PR TITLE
Fix line length violations in tests/components h

### DIFF
--- a/tests/components/habitica/test_config_flow.py
+++ b/tests/components/habitica/test_config_flow.py
@@ -639,7 +639,10 @@ async def test_add_party_member_not_in_a_party(
 
 @pytest.mark.usefixtures("habitica")
 async def test_add_party_member_entry_disabled(hass: HomeAssistant) -> None:
-    """Test we abort add party member subentry flow when the main config entry is disabled."""
+    """Test we abort add party member subentry flow.
+
+    Specifically when the main config entry is disabled.
+    """
 
     config_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/habitica/test_services.py
+++ b/tests/components/habitica/test_services.py
@@ -260,7 +260,8 @@ async def test_cast_skill(
             },
             ERROR_NOT_FOUND,
             ServiceValidationError,
-            "Unable to cast skill, your character does not have the skill or spell smash",
+            "Unable to cast skill, your character does not have"
+            " the skill or spell smash",
         ),
         (
             {
@@ -269,7 +270,8 @@ async def test_cast_skill(
             },
             ERROR_NOT_AUTHORIZED,
             ServiceValidationError,
-            "Unable to cast skill, not enough mana. Your character has 50 MP, but the skill costs 10 MP",
+            "Unable to cast skill, not enough mana. Your character"
+            " has 50 MP, but the skill costs 10 MP",
         ),
         (
             {
@@ -403,7 +405,8 @@ async def test_handle_quests(
         (
             ERROR_NOT_AUTHORIZED,
             ServiceValidationError,
-            "Action not allowed, only quest leader or group leader can perform this action",
+            "Action not allowed, only quest leader or group leader"
+            " can perform this action",
         ),
         (
             ERROR_BAD_REQUEST,
@@ -591,7 +594,8 @@ async def test_score_task(
             },
             ERROR_NOT_AUTHORIZED,
             HomeAssistantError,
-            "Unable to buy reward, not enough gold. Your character has 137.63 GP, but the reward costs 10.00 GP",
+            "Unable to buy reward, not enough gold. Your character"
+            " has 137.63 GP, but the reward costs 10.00 GP",
         ),
     ],
 )
@@ -776,7 +780,8 @@ async def test_transformation(
             ERROR_NOT_FOUND,
             None,
             ServiceValidationError,
-            "Unable to find target, you are currently not in a party. You can only target yourself",
+            "Unable to find target, you are currently not in a"
+            " party. You can only target yourself",
         ),
         (
             {
@@ -1053,7 +1058,10 @@ async def test_task_not_found(
 
     with pytest.raises(
         ServiceValidationError,
-        match="Unable to complete action, could not find the task '7f902bbc-eb3d-4a8f-82cf-4e2025d69af1'",
+        match=(
+            "Unable to complete action, could not find the task"
+            " '7f902bbc-eb3d-4a8f-82cf-4e2025d69af1'"
+        ),
     ):
         await hass.services.async_call(
             DOMAIN,

--- a/tests/components/habitica/test_todo.py
+++ b/tests/components/habitica/test_todo.py
@@ -194,7 +194,8 @@ async def test_uncomplete_todo_item(
     [
         (
             ERROR_NOT_FOUND,
-            r"Unable to update the score for your Habitica to-do `.+`, please try again",
+            r"Unable to update the score for your Habitica"
+            r" to-do `.+`, please try again",
             ServiceValidationError,
         ),
         (
@@ -451,7 +452,8 @@ async def test_add_todo_item_exception(
     habitica.create_task.side_effect = exception
     with pytest.raises(
         expected_exception=expected_exception,
-        # match="Unable to create new to-do `test-summary` for Habitica, please try again",
+        # match="Unable to create new to-do `test-summary`
+        # for Habitica, please try again",
         match=exc_msg,
     ):
         await hass.services.async_call(
@@ -567,7 +569,8 @@ async def test_delete_completed_todo_items(
     [
         (
             ERROR_NOT_FOUND,
-            "Unable to delete completed to-do items from Habitica to-do list, please try again",
+            "Unable to delete completed to-do items from"
+            " Habitica to-do list, please try again",
             ServiceValidationError,
         ),
         (

--- a/tests/components/harmony/test_remote.py
+++ b/tests/components/harmony/test_remote.py
@@ -293,7 +293,7 @@ async def test_async_send_command_custom_delay(
     mock_write_config,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Ensure calls to send remote commands properly propagate to devices with custom delays."""
+    """Ensure calls to send remote commands propagate to devices with custom delays."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="123",

--- a/tests/components/hassio/test_addon_manager.py
+++ b/tests/components/hassio/test_addon_manager.py
@@ -45,7 +45,8 @@ async def test_not_installed_raises_exception(addon_manager: AddonManager) -> No
             "Add-on test not supported on this platform, supported architectures: test"
         ),
         AddonNotSupportedHomeAssistantVersionError(
-            "Add-on test not supported on this system, requires Home Assistant version 2026.1.0 or greater"
+            "Add-on test not supported on this system, requires"
+            " Home Assistant version 2026.1.0 or greater"
         ),
         AddonNotSupportedMachineTypeError(
             "Add-on test not supported on this machine, supported machine types: test"

--- a/tests/components/hassio/test_backup.py
+++ b/tests/components/hassio/test_backup.py
@@ -2187,7 +2187,9 @@ async def test_reader_writer_create_remote_backup(
             {"include_homeassistant": False},
             {
                 "code": "home_assistant_error",
-                "message": "Cannot create a backup with database but without Home Assistant",
+                "message": (
+                    "Cannot create a backup with database but without Home Assistant"
+                ),
             },
         ),
         (

--- a/tests/components/hassio/test_binary_sensor.py
+++ b/tests/components/hassio/test_binary_sensor.py
@@ -212,7 +212,7 @@ async def test_mount_refresh_after_issue(
     supervisor_client: AsyncMock,
     hass_supervisor_ws_client: WebSocketGenerator,
 ) -> None:
-    """Test hassio mount state is refreshed after an issue was send by the supervisor."""
+    """Test hassio mount state is refreshed after an issue was sent by supervisor."""
     # Add a mount.
     mock_mounts: list[CIFSMountResponse | NFSMountResponse] = [
         CIFSMountResponse(

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -791,7 +791,7 @@ async def test_invalid_service_calls_folder_duplicates(hass: HomeAssistant) -> N
 async def test_partial_backup_legacy_homeassistant_folder(
     hass: HomeAssistant, supervisor_client: AsyncMock
 ) -> None:
-    """Test that the legacy "homeassistant" folder is translated to homeassistant=True."""
+    """Test legacy "homeassistant" folder is translated to homeassistant=True."""
     assert await async_setup_component(hass, "hassio", {})
     supervisor_client.backups.partial_backup.return_value = NewBackup(
         job_id=uuid4(), slug="partial"
@@ -885,7 +885,7 @@ async def test_entry_load_and_unload(hass: HomeAssistant) -> None:
 
 
 async def test_migration_off_hassio(hass: HomeAssistant) -> None:
-    """Test that when a user moves instance off Hass.io, config entry gets cleaned up."""
+    """Test when a user moves instance off Hass.io, config entry gets cleaned up."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
     config_entry.add_to_hass(hass)
     assert not await hass.config_entries.async_setup(config_entry.entry_id)
@@ -930,7 +930,8 @@ async def test_device_registry_calls(
 
     addons_list.return_value.pop(0)
 
-    # Test that when addon is removed, next update will remove the add-on and subsequent updates won't
+    # Test that when addon is removed, next update will remove the
+    # add-on and subsequent updates won't
     async_fire_time_changed(hass, dt_util.now() + timedelta(hours=1))
     await hass.async_block_till_done(wait_background_tasks=True)
     assert len(device_registry.devices) == 5

--- a/tests/components/hassio/test_issues.py
+++ b/tests/components/hassio/test_issues.py
@@ -59,7 +59,7 @@ def mock_resolution_info(
     suggestions_by_issue: dict[UUID, list[Suggestion]] | None = None,
     suggestion_result: SupervisorError | None = None,
 ) -> None:
-    """Mock resolution/info endpoint with unsupported/unhealthy reasons and/or issues."""
+    """Mock resolution/info endpoint with unsupported/unhealthy reasons."""
     supervisor_client.resolution.info.return_value = ResolutionInfo(
         unsupported=unsupported or [],
         unhealthy=unhealthy or [],
@@ -171,7 +171,7 @@ async def test_unhealthy_reasons(
     hass_ws_client: WebSocketGenerator,
     unhealthy_reason: UnhealthyReason,
 ) -> None:
-    """Test all unhealthy reasons in client library are properly made into repairs with a translation."""
+    """Test all unhealthy reasons in client library are made into repairs."""
     mock_resolution_info(supervisor_client, unhealthy=[unhealthy_reason])
 
     result = await async_setup_component(hass, "hassio", {})
@@ -226,7 +226,7 @@ async def test_unsupported_reasons(
     hass_ws_client: WebSocketGenerator,
     unsupported_reason: UnsupportedReason,
 ) -> None:
-    """Test all unsupported reasons in client library are properly made into repairs with a translation."""
+    """Test all unsupported reasons in client library are made into repairs."""
     mock_resolution_info(supervisor_client, unsupported=[unsupported_reason])
 
     result = await async_setup_component(hass, "hassio", {})
@@ -561,7 +561,7 @@ async def test_new_unsupported_unhealthy_reason(
     supervisor_client: AsyncMock,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
-    """New unsupported/unhealthy reasons result in a generic repair until next core update."""
+    """New unsupported/unhealthy reasons result in a generic repair."""
     mock_resolution_info(
         supervisor_client,
         unsupported=["fake_unsupported"],

--- a/tests/components/hassio/test_repairs.py
+++ b/tests/components/hassio/test_repairs.py
@@ -215,7 +215,10 @@ async def test_supervisor_issue_repair_flow_with_multiple_suggestions_and_confir
     hass_client: ClientSessionGenerator,
     issue_registry: ir.IssueRegistry,
 ) -> None:
-    """Test fix flow for supervisor issue with multiple suggestions and choice requires confirmation."""
+    """Test fix flow for supervisor issue with multiple suggestions.
+
+    Tests suggestions requiring confirmation.
+    """
     mock_resolution_info(
         supervisor_client,
         issues=[
@@ -330,7 +333,7 @@ async def test_supervisor_issue_repair_flow_skip_confirmation(
     hass_client: ClientSessionGenerator,
     issue_registry: ir.IssueRegistry,
 ) -> None:
-    """Test confirmation skipped for fix flow for supervisor issue with one suggestion."""
+    """Test confirmation skipped for fix flow for supervisor issue."""
     mock_resolution_info(
         supervisor_client,
         issues=[
@@ -1245,7 +1248,7 @@ async def test_supervisor_issue_deprecated_arch_addon(
     hass_client: ClientSessionGenerator,
     issue_registry: ir.IssueRegistry,
 ) -> None:
-    """Test fix flow for supervisor issue for add-on using deprecated architecture or machine."""
+    """Test fix flow for supervisor issue for add-on with deprecated arch."""
     mock_resolution_info(
         supervisor_client,
         issues=[

--- a/tests/components/hassio/test_update.py
+++ b/tests/components/hassio/test_update.py
@@ -1366,7 +1366,7 @@ async def test_update_supervisor_progress(
     hass_supervisor_ws_client: WebSocketGenerator,
     supervisor_info: AsyncMock,
 ) -> None:
-    """Test progress reporting for a Supervisor update that was not initiated via the entity.
+    """Test progress reporting for a Supervisor update not initiated via entity.
 
     Covers CLI-triggered and Supervisor self-update flows: the entity must
     show download progress from job events and stay in the installing state
@@ -1495,7 +1495,8 @@ async def test_update_supervisor_stays_in_progress_until_restart(
     )
 
     # The install HTTP call returned, but Supervisor is still restarting.
-    # The base UpdateEntity reset _attr_in_progress; _update_ongoing keeps us in progress.
+    # The base UpdateEntity reset _attr_in_progress;
+    # _update_ongoing keeps us in progress.
     assert hass.states.get(entity_id).attributes.get("in_progress") is True
 
     # Supervisor comes up with the new version and fires STARTUP_COMPLETE.
@@ -1534,7 +1535,7 @@ async def test_update_supervisor_completes_on_any_version_change(
     supervisor_client: AsyncMock,
     supervisor_info: AsyncMock,
 ) -> None:
-    """Test completion is detected when installed version changes from the pre-install one.
+    """Test completion is detected when installed version changes.
 
     If upstream publishes an even newer release between install-start and the
     post-restart refresh, installed_version will not equal latest_version but

--- a/tests/components/hassio/test_websocket_api.py
+++ b/tests/components/hassio/test_websocket_api.py
@@ -319,8 +319,9 @@ async def test_websocket_non_admin_user(
         json={"result": "ok", "data": {}},
     )
 
-    # Should return the fields frontend needs (name, version, state, slug and ingress_url)
-    # but not options, as user is not admin and options can contain sensitive information
+    # Should return the fields frontend needs
+    # (name, version, state, slug and ingress_url) but not options,
+    # as user is not admin and options can contain sensitive information
     await websocket_client.send_json(
         {
             WS_ID: 1,

--- a/tests/components/hdfury/conftest.py
+++ b/tests/components/hdfury/conftest.py
@@ -77,7 +77,10 @@ def mock_hdfury_client() -> Generator[AsyncMock]:
                 "AUDOUT": "bitstream 48kHz",
                 "EARCRX": "eARC/ARC not active",
                 "SINK0": "LG TV SSCR2: 4K120 444 FRL6 VRR DSC ALLM DV HDR10 HLG",
-                "EDIDA0": "MAT Atmos, DD Atmos, DD, DTS:X+IMAX, DTSHD, DTS, LPCM 2.0 192kHz 24b",
+                "EDIDA0": (
+                    "MAT Atmos, DD Atmos, DD, DTS:X+IMAX,"
+                    " DTSHD, DTS, LPCM 2.0 192kHz 24b"
+                ),
                 "SINK1": "Signify FCD: 4K60 444 DV HDR10+ HLG",
                 "EDIDA1": "DD, DTS, LPCM 2.0 48kHz 24b",
                 "SINK2": "Bose CineMate: 4K60 420 ",

--- a/tests/components/hdmi_cec/test_init.py
+++ b/tests/components/hdmi_cec/test_init.py
@@ -297,7 +297,10 @@ async def test_service_update_devices(
             "",
             1,
             marks=pytest.mark.xfail(
-                reason="While the code allows for an empty string the schema doesn't allow it",
+                reason=(
+                    "While the code allows for an empty string"
+                    " the schema doesn't allow it"
+                ),
                 raises=vol.MultipleInvalid,
             ),
         ),
@@ -386,7 +389,11 @@ async def test_service_volume_release(
             "",
             101,
             marks=pytest.mark.xfail(
-                reason="The documentation mention it's allowed to pass an empty string, but the schema does not allow this",
+                reason=(
+                    "The documentation mention it's allowed to"
+                    " pass an empty string, but the schema"
+                    " does not allow this"
+                ),
                 raises=vol.MultipleInvalid,
             ),
         ),
@@ -417,7 +424,11 @@ async def test_service_volume_mute(
             {"cmd": "36"},
             "ff:36",
             marks=pytest.mark.xfail(
-                reason="String is converted in hex value, the final result looks like 'ff:24', not what you'd expect."
+                reason=(
+                    "String is converted in hex value, the final"
+                    " result looks like 'ff:24', not what"
+                    " you'd expect."
+                )
             ),
         ),
         ({"cmd": 54}, "ff:36"),
@@ -425,7 +436,11 @@ async def test_service_volume_mute(
             {"cmd": "36", "src": "1", "dst": "0"},
             "10:36",
             marks=pytest.mark.xfail(
-                reason="String is converted in hex value, the final result looks like 'ff:24', not what you'd expect."
+                reason=(
+                    "String is converted in hex value, the final"
+                    " result looks like 'ff:24', not what"
+                    " you'd expect."
+                )
             ),
         ),
         ({"cmd": 54, "src": "1", "dst": "0"}, "10:36"),
@@ -433,7 +448,10 @@ async def test_service_volume_mute(
             {"cmd": "64", "src": "1", "dst": "0", "att": "4f:44"},
             "10:64:4f:44",
             marks=pytest.mark.xfail(
-                reason="`att` only accepts a int or a HEX value, it seems good to allow for raw data here.",
+                reason=(
+                    "`att` only accepts a int or a HEX value,"
+                    " it seems good to allow for raw data here."
+                ),
                 raises=vol.MultipleInvalid,
             ),
         ),
@@ -457,7 +475,11 @@ async def test_service_volume_mute(
             {"cmd": "0A", "src": "1", "dst": "0", "att": ["1B", "44"]},
             "10:0a:1b:44",
             marks=pytest.mark.xfail(
-                reason="While the code shows that it's possible to passthrough a list, the call schema does not allow it.",
+                reason=(
+                    "While the code shows that it's possible to"
+                    " passthrough a list, the call schema does"
+                    " not allow it."
+                ),
                 raises=(vol.MultipleInvalid, TypeError),
             ),
         ),

--- a/tests/components/hdmi_cec/test_media_player.py
+++ b/tests/components/hdmi_cec/test_media_player.py
@@ -192,7 +192,10 @@ async def test_service_off(
                 MPEF.STOP,
             ),
             marks=pytest.mark.xfail(
-                reason="Checking for the wrong attribute, should be checking `type_id`, is checking `type`."
+                reason=(
+                    "Checking for the wrong attribute, should be"
+                    " checking `type_id`, is checking `type`."
+                )
             ),
         ),
         pytest.param(
@@ -213,7 +216,10 @@ async def test_service_off(
                 MPEF.NEXT_TRACK,
             ),
             marks=pytest.mark.xfail(
-                reason="Checking for the wrong attribute, should be checking `type_id`, is checking `type`."
+                reason=(
+                    "Checking for the wrong attribute, should be"
+                    " checking `type_id`, is checking `type`."
+                )
             ),
         ),
         pytest.param(

--- a/tests/components/hdmi_cec/test_switch.py
+++ b/tests/components/hdmi_cec/test_switch.py
@@ -157,7 +157,10 @@ async def test_device_status_change(
     state = hass.states.get("switch.hdmi_3")
     if power_status in (POWER_ON, 4) and status is not None:
         pytest.xfail(
-            reason="`CecSwitchEntity.is_on` returns `False` here instead of `true` as expected."
+            reason=(
+                "`CecSwitchEntity.is_on` returns `False` here"
+                " instead of `true` as expected."
+            )
         )
     assert state.state == expected_state
 
@@ -202,7 +205,10 @@ async def test_friendly_name(
             {},
             {},
             marks=pytest.mark.xfail(
-                reason="physical address logic returns a string 'None' instead of not being set."
+                reason=(
+                    "physical address logic returns a string"
+                    " 'None' instead of not being set."
+                )
             ),
         ),
         (

--- a/tests/components/hegel/test_config_flow.py
+++ b/tests/components/hegel/test_config_flow.py
@@ -146,7 +146,7 @@ async def test_ssdp_discovery_success(
 async def test_ssdp_discovery_from_ssdp_location(
     hass: HomeAssistant, mock_hegel_client: MagicMock
 ) -> None:
-    """Test SSDP discovery extracts host from ssdp_location when presentationURL is not available."""
+    """Test SSDP discovery extracts host from ssdp_location when no presentationURL."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_SSDP},
@@ -240,7 +240,7 @@ async def test_ssdp_discovery_already_configured_updates_host(
     mock_config_entry: MockConfigEntry,
     mock_hegel_client: MagicMock,
 ) -> None:
-    """Test SSDP discovery updates host when device is already configured with different IP."""
+    """Test SSDP discovery updates host when device is configured with different IP."""
     new_host = "192.168.1.50"
 
     mock_config_entry.add_to_hass(hass)

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -182,7 +182,7 @@ async def test_discovery_aborts_same_system(
     config_entry: MockConfigEntry,
     system: HeosSystem,
 ) -> None:
-    """Test discovery does not update when current host is part of discovered's system."""
+    """Test discovery does not update when current host is in discovered system."""
     config_entry.add_to_hass(hass)
     assert config_entry.data[CONF_HOST] == "127.0.0.1"
 
@@ -313,7 +313,7 @@ async def test_zeroconf_discovery_aborts_same_system(
     config_entry: MockConfigEntry,
     system: HeosSystem,
 ) -> None:
-    """Test discovery does not update when current host is part of discovered's system."""
+    """Test discovery does not update when current host is in discovered system."""
     config_entry.add_to_hass(hass)
     assert config_entry.data[CONF_HOST] == "127.0.0.1"
 
@@ -562,7 +562,7 @@ async def test_options_flow_missing_one_param_recovers(
     user_input: dict[str, str],
     expected_errors: dict[str, str],
 ) -> None:
-    """Test options flow signs-in after recovering from only username or password being entered."""
+    """Test options flow signs-in after recovering from partial credentials."""
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     controller.mock_set_connection_state(ConnectionState.CONNECTED)
@@ -783,7 +783,7 @@ async def test_reauth_flow_missing_one_param_recovers(
     user_input: dict[str, str],
     expected_errors: dict[str, str],
 ) -> None:
-    """Test reauth flow signs-in after recovering from only username or password being entered."""
+    """Test reauth flow signs-in after recovering from partial credentials."""
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     controller.mock_set_connection_state(ConnectionState.CONNECTED)

--- a/tests/components/heos/test_init.py
+++ b/tests/components/heos/test_init.py
@@ -52,7 +52,7 @@ async def test_async_setup_entry_with_options_loads_platforms(
     controller: MockHeos,
     new_mock: Mock,
 ) -> None:
-    """Test load connects to heos with options, retrieves players, and loads platforms."""
+    """Test load connects to heos with options, retrieves players, and loads."""
     config_entry_options.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry_options.entry_id)
 
@@ -115,8 +115,9 @@ async def test_async_setup_entry_not_signed_in_loads_platforms(
     assert controller.get_input_sources.call_count == 1
     controller.disconnect.assert_not_called()
     assert (
-        "The HEOS System is not logged in: Enter credentials in the integration options to access favorites and streaming services"
-        in caplog.text
+        "The HEOS System is not logged in: Enter credentials in"
+        " the integration options to access favorites and"
+        " streaming services" in caplog.text
     )
 
 

--- a/tests/components/here_travel_time/test_sensor.py
+++ b/tests/components/here_travel_time/test_sensor.py
@@ -255,9 +255,10 @@ async def test_public_transport(hass: HomeAssistant) -> None:
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
     await hass.async_block_till_done()
 
-    assert (
-        hass.states.get("sensor.test_duration").attributes.get(ATTR_ATTRIBUTION)
-        == "http://creativecommons.org/licenses/by/3.0/it/,Some line names used in this product or service were edited to align with official transportation maps."
+    assert hass.states.get("sensor.test_duration").attributes.get(ATTR_ATTRIBUTION) == (
+        "http://creativecommons.org/licenses/by/3.0/it/,"
+        "Some line names used in this product or service were"
+        " edited to align with official transportation maps."
     )
     assert hass.states.get("sensor.test_distance").state == "1.883"
 

--- a/tests/components/history/test_init.py
+++ b/tests/components/history/test_init.py
@@ -29,7 +29,7 @@ from tests.typing import ClientSessionGenerator
 
 
 def listeners_without_writes(listeners: dict[str, int]) -> dict[str, int]:
-    """Return listeners without final write listeners since we are not testing for these."""
+    """Return listeners without final write listeners."""
     return {
         key: value
         for key, value in listeners.items()

--- a/tests/components/history/test_websocket_api.py
+++ b/tests/components/history/test_websocket_api.py
@@ -24,7 +24,10 @@ from tests.typing import WebSocketGenerator
 
 
 def listeners_without_writes(listeners: dict[str, int]) -> dict[str, int]:
-    """Return listeners without final write listeners since we are not testing for these."""
+    """Return listeners without final write listeners.
+
+    We are not testing for these.
+    """
     return {
         key: value
         for key, value in listeners.items()
@@ -835,7 +838,7 @@ async def test_history_stream_bad_end_time(
 async def test_history_stream_live_no_attributes_minimal_response(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
-    """Test history stream with history and live data and no_attributes and minimal_response."""
+    """Test history stream with live data, no_attributes and minimal_response."""
     now = dt_util.utcnow()
     await async_setup_component(
         hass,
@@ -1251,7 +1254,10 @@ async def test_history_stream_live_no_attributes(
 async def test_history_stream_live_no_attributes_minimal_response_specific_entities(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
-    """Test history stream with history and live data and no_attributes and minimal_response with specific entities."""
+    """Test history stream with no_attributes and minimal_response.
+
+    Uses specific entities.
+    """
     now = dt_util.utcnow()
     wanted_entities = ["sensor.two", "sensor.four", "sensor.one"]
     await async_setup_component(
@@ -1507,7 +1513,10 @@ async def test_history_stream_before_history_starts(
 async def test_history_stream_for_entity_with_no_possible_changes(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
-    """Test history stream for future with no possible changes where end time is less than or equal to now."""
+    """Test history stream with no possible changes.
+
+    End time is less than or equal to now.
+    """
     await async_setup_component(
         hass,
         "history",

--- a/tests/components/history_stats/test_init.py
+++ b/tests/components/history_stats/test_init.py
@@ -121,7 +121,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     sensor_device: dr.DeviceEntry,
     sensor_entity_entry: er.RegistryEntry,
 ) -> None:
-    """Test the history_stats config entry is removed when the source entity is removed."""
+    """Test config entry is removed when source entity is removed."""
     assert await hass.config_entries.async_setup(history_stats_config_entry.entry_id)
     await hass.async_block_till_done()
 
@@ -171,7 +171,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     sensor_device: dr.DeviceEntry,
     sensor_entity_entry: er.RegistryEntry,
 ) -> None:
-    """Test the history_stats config entry is removed when the source entity is removed."""
+    """Test config entry is removed when source entity is removed."""
     # Add another config entry to the sensor device
     other_config_entry = MockConfigEntry()
     other_config_entry.add_to_hass(hass)

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -647,9 +647,9 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_sin
     utcnow = dt_util.utcnow()
     start_time = utcnow.replace(hour=0, minute=0, second=0, microsecond=0)
 
-    # Start     t0        t1        t2       Startup                                       End
-    # |--20min--|--20min--|--10min--|--10min--|---------30min---------|---15min--|---15min--|
-    # |---on----|---on----|---on----|---on----|----------on-----------|---off----|----on----|
+    # Start   t0       t1       t2      Startup             End
+    # |-20min-|-20min-|-10min-|-10min-|----30min----|15min|15min|
+    # |--on---|--on---|--on---|--on---|-----on------|off--|on---|
 
     def _fake_states(*args, **kwargs):
         return {
@@ -739,18 +739,21 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_sin
     assert hass.states.get("sensor.sensor1").state == "1.75"
 
 
-async def test_async_start_from_history_and_switch_to_watching_state_changes_single_expanding_window(
+async def test_async_start_from_history_switch_to_state_changes_expanding_window(
     recorder_mock: Recorder,
     hass: HomeAssistant,
 ) -> None:
-    """Test we startup from history and switch to watching state changes with an expanding end time."""
+    """Test startup from history, switch to watching state changes.
+
+    Uses an expanding end time.
+    """
     await hass.config.async_set_time_zone("UTC")
     utcnow = dt_util.utcnow()
     start_time = utcnow.replace(hour=0, minute=0, second=0, microsecond=0)
 
-    # Start     t0        t1        t2       Startup                                       End
-    # |--20min--|--20min--|--10min--|--10min--|---------30min---------|---15min--|---15min--|
-    # |---on----|---on----|---on----|---on----|----------on-----------|---off----|----on----|
+    # Start   t0       t1       t2      Startup             End
+    # |-20min-|-20min-|-10min-|-10min-|----30min----|15min|15min|
+    # |--on---|--on---|--on---|--on---|-----on------|off--|on---|
 
     def _fake_states(*args, **kwargs):
         return {
@@ -865,9 +868,9 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_mul
     utcnow = dt_util.utcnow()
     start_time = utcnow.replace(hour=0, minute=0, second=0, microsecond=0)
 
-    # Start     t0        t1        t2       Startup                                       End
-    # |--20min--|--20min--|--10min--|--10min--|---------30min---------|---15min--|---15min--|
-    # |---on----|---on----|---on----|---on----|----------on-----------|---off----|----on----|
+    # Start   t0       t1       t2      Startup             End
+    # |-20min-|-20min-|-10min-|-10min-|----30min----|15min|15min|
+    # |--on---|--on---|--on---|--on---|-----on------|off--|on---|
 
     def _fake_states(*args, **kwargs):
         return {
@@ -1155,7 +1158,8 @@ async def test_start_from_history_then_watch_state_changes_sliding(
         async_fire_time_changed(hass, time)
         await hass.async_block_till_done()
 
-    # Sliding window will have started to erase the initial on period, so now it will only be on for 10 minutes
+    # Sliding window will have started to erase the initial on
+    # period, so now it will only be on for 10 minutes
     assert hass.states.get("sensor.sensor0").state == "0.17"
     assert hass.states.get("sensor.sensor1").state == "16.7"
     assert hass.states.get("sensor.sensor2").state == "1"
@@ -1169,7 +1173,8 @@ async def test_start_from_history_then_watch_state_changes_sliding(
         async_fire_time_changed(hass, time)
         await hass.async_block_till_done()
 
-    # Sliding window will continue to erase the initial on period, so now it will only be on for 5 minutes
+    # Sliding window will continue to erase the initial on period,
+    # so now it will only be on for 5 minutes
     assert hass.states.get("sensor.sensor0").state == "0.08"
     assert hass.states.get("sensor.sensor1").state == "8.3"
     assert hass.states.get("sensor.sensor2").state == "1"
@@ -1202,9 +1207,9 @@ async def test_does_not_work_into_the_future(
     utcnow = dt_util.utcnow()
     start_time = utcnow.replace(hour=0, minute=0, second=0, microsecond=0)
 
-    # Start     t0        t1        t2       Startup                                       End
-    # |--20min--|--20min--|--10min--|--10min--|---------30min---------|---15min--|---15min--|
-    # |---on----|---on----|---on----|---on----|----------on-----------|---off----|----on----|
+    # Start   t0       t1       t2      Startup             End
+    # |-20min-|-20min-|-10min-|-10min-|----30min----|15min|15min|
+    # |--on---|--on---|--on---|--on---|-----on------|off--|on---|
 
     def _fake_states(*args, **kwargs):
         return {
@@ -1233,7 +1238,9 @@ async def test_does_not_work_into_the_future(
                             "entity_id": "binary_sensor.state",
                             "name": "sensor1",
                             "state": "on",
-                            "start": "{{ utcnow().replace(hour=23, minute=0, second=0) }}",
+                            "start": (
+                                "{{ utcnow().replace(hour=23, minute=0, second=0) }}"
+                            ),
                             "duration": {"hours": 1},
                             "type": "time",
                         },
@@ -1242,7 +1249,9 @@ async def test_does_not_work_into_the_future(
                             "entity_id": "binary_sensor.state",
                             "name": "sensor2",
                             "state": "on",
-                            "start": "{{ utcnow().replace(hour=23, minute=0, second=0) }}",
+                            "start": (
+                                "{{ utcnow().replace(hour=23, minute=0, second=0) }}"
+                            ),
                             "duration": {"hours": 1},
                             "type": "time",
                             "unique_id": "6b1f54e3-4065-43ca-8492-d0d4506a573a",
@@ -1505,7 +1514,7 @@ async def test_measure_sliding_window(
 async def test_measure_from_end_going_backwards(
     recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
-    """Test the history statistics sensor with a moving end and a duration to find the start."""
+    """Test history stats sensor with moving end and duration."""
     start_time = dt_util.utcnow() - timedelta(minutes=60)
     t0 = start_time + timedelta(minutes=20)
     t1 = t0 + timedelta(minutes=10)
@@ -1687,7 +1696,7 @@ async def test_state_change_during_window_rollover(
     recorder_mock: Recorder,
     hass: HomeAssistant,
 ) -> None:
-    """Test when the tracked sensor and the start/end window change during the same update."""
+    """Test tracked sensor and start/end window change in same update."""
     await hass.config.async_set_time_zone("UTC")
     utcnow = dt_util.utcnow()
     start_time = utcnow.replace(hour=23, minute=0, second=0, microsecond=0)
@@ -1704,7 +1713,8 @@ async def test_state_change_during_window_rollover(
             ]
         }
 
-    # The test begins at 23:00, and queries from the database that the sensor has been on since 12:00.
+    # The test begins at 23:00, and queries from the database that
+    # the sensor has been on since 12:00.
     with (
         patch(
             "homeassistant.components.recorder.history.state_changes_during_period",
@@ -1722,7 +1732,9 @@ async def test_state_change_during_window_rollover(
                         "entity_id": "binary_sensor.state",
                         "name": "sensor1",
                         "state": "on",
-                        "start": "{{ today_at('12:00') if now().hour == 1 else today_at() }}",
+                        "start": (
+                            "{{ today_at('12:00') if now().hour == 1 else today_at() }}"
+                        ),
                         "end": "{{ now() }}",
                         "type": "time",
                     }
@@ -1736,7 +1748,8 @@ async def test_state_change_during_window_rollover(
 
     assert hass.states.get("sensor.sensor1").state == "11.0"
 
-    # Advance 59 minutes, to record the last minute update just before midnight, just like a real system would do.
+    # Advance 59 minutes, to record the last minute update just
+    # before midnight, just like a real system would do.
     t2 = start_time + timedelta(minutes=59, microseconds=300)  # 23:59
     with freeze_time(t2):
         async_fire_time_changed(hass, t2)
@@ -1744,17 +1757,21 @@ async def test_state_change_during_window_rollover(
 
     assert hass.states.get("sensor.sensor1").state == "11.98"
 
-    # One minute has passed and the time has now rolled over into a new day, resetting the recorder window.
+    # One minute has passed and the time has now rolled over into a
+    # new day, resetting the recorder window.
     # The sensor will be ON since midnight.
     t3 = t2 + timedelta(minutes=1)  # 00:01
     with freeze_time(t3):
-        # The sensor turns off around this time, before the sensor does its normal polled update.
+        # The sensor turns off around this time, before the sensor
+        # does its normal polled update.
         hass.states.async_set("binary_sensor.state", "off")
         await hass.async_block_till_done(wait_background_tasks=True)
 
     assert hass.states.get("sensor.sensor1").state == "0.0"
 
-    # More time passes, and the history stats does a polled update again. It should be 0 since the sensor has been off since midnight.
+    # More time passes, and the history stats does a polled update
+    # again. It should be 0 since the sensor has been off since
+    # midnight.
     # Turn the sensor back on.
     t4 = t3 + timedelta(minutes=10)  # 00:10
     with freeze_time(t4):
@@ -1773,7 +1790,8 @@ async def test_state_change_during_window_rollover(
 
     assert hass.states.get("sensor.sensor1").state == STATE_UNKNOWN
 
-    # Start time has moved back to start of today. Turn the sensor on at the same time it is recomputed
+    # Start time has moved back to start of today. Turn the sensor
+    # on at the same time it is recomputed
     # Should query the recorder this time due to start time moving backwards in time.
     t6 = t5 + timedelta(hours=1)  # 02:10
 
@@ -1810,7 +1828,8 @@ async def test_state_change_during_window_rollover(
 
     assert hass.states.get("sensor.sensor1").state == "1.0"
 
-    # Another hour passes since the re-query. Total 'On' time should be 2 hours (00:10-1:10, 2:10-now (3:10))
+    # Another hour passes since the re-query. Total 'On' time should
+    # be 2 hours (00:10-1:10, 2:10-now (3:10))
     t7 = t6 + timedelta(hours=1)  # 03:10
     with freeze_time(t7):
         async_fire_time_changed(hass, t7)
@@ -1825,7 +1844,7 @@ async def test_end_time_with_microseconds_zeroed(
     async_setup_recorder_instance: RecorderInstanceGenerator,
     hass: HomeAssistant,
 ) -> None:
-    """Test the history statistics sensor that has the end time microseconds zeroed out."""
+    """Test history stats sensor with end time microseconds zeroed."""
     await hass.config.async_set_time_zone(time_zone)
     start_of_today = dt_util.now().replace(
         day=9, month=7, year=1986, hour=0, minute=0, second=0, microsecond=0
@@ -1875,7 +1894,10 @@ async def test_end_time_with_microseconds_zeroed(
                         "entity_id": "binary_sensor.heatpump_compressor_state",
                         "name": "heatpump_compressor_today",
                         "state": "on",
-                        "start": "{{ now().replace(hour=0, minute=0, second=0, microsecond=0) }}",
+                        "start": (
+                            "{{ now().replace(hour=0, minute=0,"
+                            " second=0, microsecond=0) }}"
+                        ),
                         "end": "{{ now().replace(microsecond=0) }}",
                         "type": "time",
                     },
@@ -1884,7 +1906,10 @@ async def test_end_time_with_microseconds_zeroed(
                         "entity_id": "binary_sensor.heatpump_compressor_state",
                         "name": "heatpump_compressor_today2",
                         "state": "on",
-                        "start": "{{ now().replace(hour=0, minute=0, second=0, microsecond=0) }}",
+                        "start": (
+                            "{{ now().replace(hour=0, minute=0,"
+                            " second=0, microsecond=0) }}"
+                        ),
                         "end": "{{ now().replace(microsecond=0) }}",
                         "type": "time",
                         "unique_id": "6b1f54e3-4065-43ca-8492-d0d4506a573a",
@@ -2072,7 +2097,10 @@ async def test_history_stats_handles_floored_timestamps(
                         "entity_id": "binary_sensor.state",
                         "name": "sensor1",
                         "state": "on",
-                        "start": "{{ utcnow().replace(hour=0, minute=0, second=0, microsecond=100) }}",
+                        "start": (
+                            "{{ utcnow().replace(hour=0, minute=0,"
+                            " second=0, microsecond=100) }}"
+                        ),
                         "duration": {"hours": 2},
                         "type": "time",
                     }
@@ -2271,7 +2299,10 @@ async def test_async_around_min_state_duration_sliding_window(
     recorder_mock: Recorder,
     hass: HomeAssistant,
 ) -> None:
-    """Test min_state_duration with sliding window where block duration crosses threshold."""
+    """Test min_state_duration with sliding window.
+
+    Block duration crosses threshold.
+    """
     await hass.config.async_set_time_zone("UTC")
     utcnow = dt_util.utcnow()
     start_time = utcnow.replace(hour=1, minute=0, second=0, microsecond=0)

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -647,9 +647,9 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_sin
     utcnow = dt_util.utcnow()
     start_time = utcnow.replace(hour=0, minute=0, second=0, microsecond=0)
 
-    # Start   t0       t1       t2      Startup             End
-    # |-20min-|-20min-|-10min-|-10min-|----30min----|15min|15min|
-    # |--on---|--on---|--on---|--on---|-----on------|off--|on---|
+    # Start     t0        t1        t2       Startup                                       End  # noqa: E501, RUF100
+    # |--20min--|--20min--|--10min--|--10min--|---------30min---------|---15min--|---15min--|  # noqa: E501, RUF100
+    # |---on----|---on----|---on----|---on----|----------on-----------|---off----|----on----|  # noqa: E501, RUF100
 
     def _fake_states(*args, **kwargs):
         return {
@@ -739,7 +739,7 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_sin
     assert hass.states.get("sensor.sensor1").state == "1.75"
 
 
-async def test_async_start_from_history_switch_to_state_changes_expanding_window(
+async def test_async_start_from_history_and_switch_to_watching_state_changes_single_expanding_window(  # noqa: E501, RUF100
     recorder_mock: Recorder,
     hass: HomeAssistant,
 ) -> None:
@@ -751,9 +751,9 @@ async def test_async_start_from_history_switch_to_state_changes_expanding_window
     utcnow = dt_util.utcnow()
     start_time = utcnow.replace(hour=0, minute=0, second=0, microsecond=0)
 
-    # Start   t0       t1       t2      Startup             End
-    # |-20min-|-20min-|-10min-|-10min-|----30min----|15min|15min|
-    # |--on---|--on---|--on---|--on---|-----on------|off--|on---|
+    # Start     t0        t1        t2       Startup                                       End  # noqa: E501, RUF100
+    # |--20min--|--20min--|--10min--|--10min--|---------30min---------|---15min--|---15min--|  # noqa: E501, RUF100
+    # |---on----|---on----|---on----|---on----|----------on-----------|---off----|----on----|  # noqa: E501, RUF100
 
     def _fake_states(*args, **kwargs):
         return {
@@ -868,9 +868,9 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_mul
     utcnow = dt_util.utcnow()
     start_time = utcnow.replace(hour=0, minute=0, second=0, microsecond=0)
 
-    # Start   t0       t1       t2      Startup             End
-    # |-20min-|-20min-|-10min-|-10min-|----30min----|15min|15min|
-    # |--on---|--on---|--on---|--on---|-----on------|off--|on---|
+    # Start     t0        t1        t2       Startup                                       End  # noqa: E501, RUF100
+    # |--20min--|--20min--|--10min--|--10min--|---------30min---------|---15min--|---15min--|  # noqa: E501, RUF100
+    # |---on----|---on----|---on----|---on----|----------on-----------|---off----|----on----|  # noqa: E501, RUF100
 
     def _fake_states(*args, **kwargs):
         return {
@@ -1207,9 +1207,9 @@ async def test_does_not_work_into_the_future(
     utcnow = dt_util.utcnow()
     start_time = utcnow.replace(hour=0, minute=0, second=0, microsecond=0)
 
-    # Start   t0       t1       t2      Startup             End
-    # |-20min-|-20min-|-10min-|-10min-|----30min----|15min|15min|
-    # |--on---|--on---|--on---|--on---|-----on------|off--|on---|
+    # Start     t0        t1        t2       Startup                                       End  # noqa: E501, RUF100
+    # |--20min--|--20min--|--10min--|--10min--|---------30min---------|---15min--|---15min--|  # noqa: E501, RUF100
+    # |---on----|---on----|---on----|---on----|----------on-----------|---off----|----on----|  # noqa: E501, RUF100
 
     def _fake_states(*args, **kwargs):
         return {

--- a/tests/components/hive/test_init.py
+++ b/tests/components/hive/test_init.py
@@ -34,7 +34,10 @@ _HUB_BASE = {
 
 
 def _make_mock_hive(hub_extra: dict) -> MagicMock:
-    """Return a mocked Hive instance whose startSession returns a minimal devices dict."""
+    """Return a mocked Hive instance.
+
+    startSession returns a minimal devices dict.
+    """
     hub_data = {**_HUB_BASE, **hub_extra}
     mock_hive = MagicMock()
     mock_hive.session.startSession = AsyncMock(return_value={"parent": [hub_data]})

--- a/tests/components/home_connect/test_binary_sensor.py
+++ b/tests/components/home_connect/test_binary_sensor.py
@@ -50,7 +50,7 @@ async def test_paired_depaired_devices_flow(
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     appliance: HomeAppliance,
 ) -> None:
-    """Test that removed devices are correctly removed from and added to hass on API events."""
+    """Test device removal and re-addition on API events."""
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
 
@@ -173,7 +173,7 @@ async def test_binary_sensors_entity_availability(
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     appliance: HomeAppliance,
 ) -> None:
-    """Test if binary sensor entities availability are based on the appliance connection state."""
+    """Test binary sensor availability based on appliance connection."""
     entity_ids = [
         "binary_sensor.washer_remote_control",
     ]

--- a/tests/components/home_connect/test_button.py
+++ b/tests/components/home_connect/test_button.py
@@ -44,7 +44,7 @@ async def test_paired_depaired_devices_flow(
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     appliance: HomeAppliance,
 ) -> None:
-    """Test that removed devices are correctly removed from and added to hass on API events."""
+    """Test device removal and re-addition on API events."""
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
 
@@ -178,7 +178,7 @@ async def test_button_entity_availability(
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     appliance: HomeAppliance,
 ) -> None:
-    """Test if button entities availability are based on the appliance connection state."""
+    """Test button entities availability based on appliance connection."""
     entity_ids = [
         "button.washer_pause_program",
         "button.washer_stop_program",
@@ -244,7 +244,7 @@ async def test_button_functionality(
     expected_kwargs: dict[str, Any],
     appliance: HomeAppliance,
 ) -> None:
-    """Test if button entities availability are based on the appliance connection state."""
+    """Test button entities availability based on appliance connection."""
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
 
@@ -267,7 +267,7 @@ async def test_command_button_exception(
     config_entry: MockConfigEntry,
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
 ) -> None:
-    """Test if button entities availability are based on the appliance connection state."""
+    """Test button entities availability based on appliance connection."""
     entity_id = "button.washer_pause_program"
 
     client_with_exception.get_available_commands = AsyncMock(
@@ -302,7 +302,7 @@ async def test_stop_program_button_exception(
     config_entry: MockConfigEntry,
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
 ) -> None:
-    """Test if button entities availability are based on the appliance connection state."""
+    """Test button entities availability based on appliance connection."""
     entity_id = "button.washer_stop_program"
 
     assert await integration_setup(client_with_exception)

--- a/tests/components/home_connect/test_climate.py
+++ b/tests/components/home_connect/test_climate.py
@@ -86,7 +86,7 @@ async def test_paired_depaired_devices_flow(
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     appliance: HomeAppliance,
 ) -> None:
-    """Test that removed devices are correctly removed from and added to hass on API events."""
+    """Test device removal and re-addition on API events."""
     client.get_available_program = AsyncMock(
         return_value=ProgramDefinition(
             ProgramKey.UNKNOWN,
@@ -212,7 +212,7 @@ async def test_climate_entity_availability(
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     appliance: HomeAppliance,
 ) -> None:
-    """Test if climate entities availability are based on the appliance connection state."""
+    """Test climate entity availability based on appliance connection."""
     entity_ids = [
         "climate.air_conditioner",
     ]
@@ -270,7 +270,7 @@ async def test_entity_not_added_if_no_air_conditioner_programs(
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     program_keys: list[ProgramKey],
 ) -> None:
-    """Test that the air conditioner entity is not added if there are no air conditioner programs."""
+    """Test AC entity is not added without AC programs."""
     client.get_all_programs.side_effect = None
     client.get_all_programs.return_value = ArrayOfPrograms(
         [
@@ -561,7 +561,7 @@ async def test_not_supported_functionality_if_not_power_setting(
     config_entry: MockConfigEntry,
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
 ) -> None:
-    """Test the off HVAC mode, and turn on/off is not supported when the setting is not present."""
+    """Test off HVAC mode and turn on/off unsupported without setting."""
     client.get_settings = AsyncMock(return_value=ArrayOfSettings([]))
 
     assert await integration_setup(client)
@@ -794,7 +794,10 @@ async def test_fan_mode_functionality(
         option_key=option_key,
         value=allowed_values[0]
         if allowed_values
-        else "HeatingVentilationAirConditioning.AirConditioner.EnumType.FanSpeedMode.Automatic",
+        else (
+            "HeatingVentilationAirConditioning"
+            ".AirConditioner.EnumType.FanSpeedMode.Automatic"
+        ),
     )
     entity_state = hass.states.get(entity_id)
     assert entity_state
@@ -852,7 +855,7 @@ async def test_fan_mode_feature_supported(
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     appliance: HomeAppliance,
 ) -> None:
-    """Test that fan feature is supported depending on the fan speed mode option availability."""
+    """Test fan feature support based on fan speed mode option."""
     client.get_available_program = AsyncMock(
         return_value=ProgramDefinition(
             ProgramKey.HEATING_VENTILATION_AIR_CONDITIONING_AIR_CONDITIONER_AUTO,
@@ -931,7 +934,7 @@ async def test_preset_mode_feature_not_supported_on_missing_active_clean(
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     program_keys: list[ProgramKey],
 ) -> None:
-    """Test that the preset modes are not supported if active clean program is missing."""
+    """Test preset modes not supported if active clean program missing."""
     client.get_all_programs.side_effect = None
     client.get_all_programs.return_value = ArrayOfPrograms(
         [

--- a/tests/components/home_connect/test_coordinator.py
+++ b/tests/components/home_connect/test_coordinator.py
@@ -234,9 +234,10 @@ async def test_coordinator_update_failing(
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     mock_method: str,
 ) -> None:
-    """Test that although is not possible to get settings and status, the config entry is loaded.
+    """Test config entry loads even when settings/status fetch fails.
 
-    This is for cases where some appliances are reachable and some are not in the same configuration entry.
+    This is for cases where some appliances are reachable and some are not in the same
+    configuration entry.
     """
     setattr(client, mock_method, AsyncMock(side_effect=HomeConnectError()))
 
@@ -345,7 +346,7 @@ async def tests_receive_setting_and_status_for_first_time_at_events(
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     appliance: HomeAppliance,
 ) -> None:
-    """Test that the event listener is capable of receiving settings and status for the first time."""
+    """Test event listener receives settings and status initially."""
     client.get_setting = AsyncMock(return_value=ArrayOfSettings([]))
     client.get_status = AsyncMock(return_value=ArrayOfStatus([]))
 
@@ -399,7 +400,7 @@ async def test_event_listener_error(
     config_entry: MockConfigEntry,
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
 ) -> None:
-    """Test that the configuration entry is reloaded when the event stream raises an API error."""
+    """Test config entry reloads on event stream API error."""
     client_with_exception.stream_all_events = MagicMock(
         side_effect=HomeConnectApiError("error.key", "error description")
     )
@@ -816,7 +817,7 @@ async def test_auth_error_while_updating_appliance(
     config_entry: MockConfigEntry,
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
 ) -> None:
-    """Test that the configuration entry is set to require reauth when an auth error happens."""
+    """Test config entry requires reauth on auth error."""
     entity_id = "switch.dishwasher_power"
 
     assert await integration_setup(client)
@@ -1012,7 +1013,7 @@ async def test_option_values_kept_after_changing_program(
     appliance: HomeAppliance,
     event_key: EventKey,
 ) -> None:
-    """Test that when a program is changed, the options are kept and defaults are not used."""
+    """Test program change keeps options instead of using defaults."""
     appliance_ha_id = appliance.ha_id
     entity_id = "switch.dishwasher_half_load"
     client.get_available_program = AsyncMock(

--- a/tests/components/home_connect/test_entity.py
+++ b/tests/components/home_connect/test_entity.py
@@ -79,7 +79,9 @@ def platforms() -> list[str]:
             "Dishwasher",
             {
                 OptionKey.DISHCARE_DISHWASHER_HALF_LOAD: "switch.dishwasher_half_load",
-                OptionKey.DISHCARE_DISHWASHER_SILENCE_ON_DEMAND: "switch.dishwasher_silence_on_demand",
+                OptionKey.DISHCARE_DISHWASHER_SILENCE_ON_DEMAND: (
+                    "switch.dishwasher_silence_on_demand"
+                ),
                 OptionKey.DISHCARE_DISHWASHER_ECO_DRY: "switch.dishwasher_eco_dry",
             },
             [(STATE_ON, True), (STATE_OFF, False), (None, None)],
@@ -107,7 +109,7 @@ async def test_program_options_retrieval(
     option_without_default: tuple[OptionKey, str],
     option_without_constraints: tuple[OptionKey, str],
 ) -> None:
-    """Test that the options are correctly retrieved at the start and updated on program updates."""
+    """Test options are retrieved at start and updated on programs."""
     original_get_all_programs_mock = client.get_all_programs.side_effect
     options_values = [
         Option(
@@ -222,7 +224,8 @@ async def test_program_options_retrieval(
     await hass.async_block_till_done()
 
     # Verify default values
-    # Every time the program is updated, the available options should use the default value if existing
+    # Every time the program is updated, the available options should use the default
+    # value if existing
     for entity_id, available in zip(
         option_entity_id.values(), options_availability_stage_2, strict=True
     ):
@@ -332,7 +335,7 @@ async def test_program_options_retrieval_after_appliance_connection(
     option_key: OptionKey,
     option_entity_id: str,
 ) -> None:
-    """Test that the options are correctly retrieved at the start and updated on program updates."""
+    """Test options are retrieved at start and updated on programs."""
     appliance.connected = False
     client.get_available_program = AsyncMock(
         return_value=ProgramDefinition(

--- a/tests/components/home_connect/test_fan.py
+++ b/tests/components/home_connect/test_fan.py
@@ -88,7 +88,7 @@ async def test_paired_depaired_devices_flow(
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     appliance: HomeAppliance,
 ) -> None:
-    """Test that removed devices are correctly removed from and added to hass on API events."""
+    """Test device removal and re-addition on API events."""
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
 
@@ -453,7 +453,10 @@ async def test_preset_mode_functionality(
         option_key=option_key,
         value=allowed_values[0]
         if allowed_values
-        else "HeatingVentilationAirConditioning.AirConditioner.EnumType.FanSpeedMode.Automatic",
+        else (
+            "HeatingVentilationAirConditioning"
+            ".AirConditioner.EnumType.FanSpeedMode.Automatic"
+        ),
     )
     entity_state = hass.states.get(entity_id)
     assert entity_state
@@ -606,7 +609,7 @@ async def test_added_entity_automatically(
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     appliance: HomeAppliance,
 ) -> None:
-    """Test that no fan entity is created if no fan options are available but when they are added later, the entity is created."""
+    """Test fan entity created only after fan options become available."""
     entity_id = "fan.air_conditioner"
     client.get_available_program = AsyncMock(
         return_value=ProgramDefinition(

--- a/tests/components/home_connect/test_init.py
+++ b/tests/components/home_connect/test_init.py
@@ -252,7 +252,7 @@ async def test_required_program_or_at_least_an_option(
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     appliance: HomeAppliance,
 ) -> None:
-    "Test that the set_program_and_options does raise an exception if no program nor options are set."
+    """Test set_program_and_options raises if no program nor options."""
 
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
@@ -354,7 +354,7 @@ async def test_entity_migration(
 
 
 async def test_bsh_key_transformations() -> None:
-    """Test that the key transformations are compatible valid translations keys and can be reversed."""
+    """Test key transformations produce valid translation keys."""
     program = "Dishcare.Dishwasher.Program.Eco50"
     translation_key = bsh_key_to_translation_key(program)
     assert RE_TRANSLATION_KEY.match(translation_key)

--- a/tests/components/home_connect/test_light.py
+++ b/tests/components/home_connect/test_light.py
@@ -63,7 +63,7 @@ async def test_paired_depaired_devices_flow(
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     appliance: HomeAppliance,
 ) -> None:
-    """Test that removed devices are correctly removed from and added to hass on API events."""
+    """Test device removal and re-addition on API events."""
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
 
@@ -180,7 +180,7 @@ async def test_light_availability(
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     appliance: HomeAppliance,
 ) -> None:
-    """Test if light entities availability are based on the appliance connection state."""
+    """Test light entities availability based on appliance connection."""
     entity_ids = [
         "light.hood_functional_light",
     ]
@@ -299,7 +299,9 @@ async def test_light_availability(
             "light.hood_ambient_light",
             {
                 SettingKey.BSH_COMMON_AMBIENT_LIGHT_ENABLED: True,
-                SettingKey.BSH_COMMON_AMBIENT_LIGHT_COLOR: BSH_AMBIENT_LIGHT_COLOR_CUSTOM_COLOR,
+                SettingKey.BSH_COMMON_AMBIENT_LIGHT_COLOR: (
+                    BSH_AMBIENT_LIGHT_COLOR_CUSTOM_COLOR
+                ),
                 SettingKey.BSH_COMMON_AMBIENT_LIGHT_CUSTOM_COLOR: "#ffff00",
             },
             SERVICE_TURN_ON,
@@ -313,7 +315,9 @@ async def test_light_availability(
             "light.hood_ambient_light",
             {
                 SettingKey.BSH_COMMON_AMBIENT_LIGHT_ENABLED: True,
-                SettingKey.BSH_COMMON_AMBIENT_LIGHT_COLOR: BSH_AMBIENT_LIGHT_COLOR_CUSTOM_COLOR,
+                SettingKey.BSH_COMMON_AMBIENT_LIGHT_COLOR: (
+                    BSH_AMBIENT_LIGHT_COLOR_CUSTOM_COLOR
+                ),
                 SettingKey.BSH_COMMON_AMBIENT_LIGHT_CUSTOM_COLOR: "#b5adcc",
             },
             SERVICE_TURN_ON,
@@ -384,7 +388,9 @@ async def test_light_functionality(
         (
             "light.hood_ambient_light",
             {
-                EventKey.BSH_COMMON_SETTING_AMBIENT_LIGHT_COLOR: "BSH.Common.EnumType.AmbientLightColor.Color1",
+                EventKey.BSH_COMMON_SETTING_AMBIENT_LIGHT_COLOR: (
+                    "BSH.Common.EnumType.AmbientLightColor.Color1"
+                ),
             },
             "Hood",
         ),
@@ -400,7 +406,7 @@ async def test_light_color_different_than_custom(
     events: dict[EventKey, Any],
     appliance: HomeAppliance,
 ) -> None:
-    """Test that light color attributes are not set if color is different than custom."""
+    """Test light color attributes not set if color differs from custom."""
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
     await hass.services.async_call(
@@ -529,7 +535,9 @@ async def test_light_color_different_than_custom(
             {
                 SettingKey.BSH_COMMON_AMBIENT_LIGHT_ENABLED: True,
                 SettingKey.BSH_COMMON_AMBIENT_LIGHT_BRIGHTNESS: 70,
-                SettingKey.BSH_COMMON_AMBIENT_LIGHT_COLOR: BSH_AMBIENT_LIGHT_COLOR_CUSTOM_COLOR,
+                SettingKey.BSH_COMMON_AMBIENT_LIGHT_COLOR: (
+                    BSH_AMBIENT_LIGHT_COLOR_CUSTOM_COLOR
+                ),
                 SettingKey.BSH_COMMON_AMBIENT_LIGHT_CUSTOM_COLOR: "#ffff00",
             },
             SERVICE_TURN_ON,
@@ -541,7 +549,9 @@ async def test_light_color_different_than_custom(
             "light.hood_ambient_light",
             {
                 SettingKey.BSH_COMMON_AMBIENT_LIGHT_ENABLED: True,
-                SettingKey.BSH_COMMON_AMBIENT_LIGHT_COLOR: BSH_AMBIENT_LIGHT_COLOR_CUSTOM_COLOR,
+                SettingKey.BSH_COMMON_AMBIENT_LIGHT_COLOR: (
+                    BSH_AMBIENT_LIGHT_COLOR_CUSTOM_COLOR
+                ),
                 SettingKey.BSH_COMMON_AMBIENT_LIGHT_CUSTOM_COLOR: "#b5adcc",
             },
             SERVICE_TURN_ON,

--- a/tests/components/home_connect/test_number.py
+++ b/tests/components/home_connect/test_number.py
@@ -73,7 +73,7 @@ async def test_paired_depaired_devices_flow(
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     appliance: HomeAppliance,
 ) -> None:
-    """Test that removed devices are correctly removed from and added to hass on API events."""
+    """Test device removal and re-addition on API events."""
     client.get_available_program = AsyncMock(
         return_value=ProgramDefinition(
             ProgramKey.UNKNOWN,
@@ -203,7 +203,7 @@ async def test_number_entity_availability(
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     appliance: HomeAppliance,
 ) -> None:
-    """Test if number entities availability are based on the appliance connection state."""
+    """Test number entities availability based on appliance connection."""
     entity_ids = [
         f"{NUMBER_DOMAIN.lower()}.oven_alarm_clock",
         f"{NUMBER_DOMAIN.lower()}.oven_setpoint_temperature",
@@ -398,7 +398,7 @@ async def test_fetch_constraints_after_rate_limit_error(
     step_size: int,
     unit_of_measurement: str,
 ) -> None:
-    """Test that, if a API rate limit error is raised, the constraints are fetched later."""
+    """Test constraints are fetched later on rate limit error."""
 
     def get_settings_side_effect(ha_id: str):
         if ha_id != appliance.ha_id:

--- a/tests/components/home_connect/test_select.py
+++ b/tests/components/home_connect/test_select.py
@@ -75,7 +75,7 @@ async def test_paired_depaired_devices_flow(
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     appliance: HomeAppliance,
 ) -> None:
-    """Test that removed devices are correctly removed from and added to hass on API events."""
+    """Test device removal and re-addition on API events."""
     client.get_available_program = AsyncMock(
         return_value=ProgramDefinition(
             ProgramKey.UNKNOWN,
@@ -217,7 +217,7 @@ async def test_select_entity_availability(
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     appliance: HomeAppliance,
 ) -> None:
-    """Test if select entities availability are based on the appliance connection state."""
+    """Test select entities availability based on appliance connection."""
     entity_ids = ["select.washer_active_program", "select.washer_temperature"]
     client.get_available_program = AsyncMock(
         return_value=ProgramDefinition(

--- a/tests/components/home_connect/test_sensor.py
+++ b/tests/components/home_connect/test_sensor.py
@@ -40,7 +40,9 @@ TEST_HC_APP = "Dishwasher"
 
 EVENT_PROG_DELAYED_START = {
     EventType.STATUS: {
-        EventKey.BSH_COMMON_STATUS_OPERATION_STATE: "BSH.Common.EnumType.OperationState.DelayedStart",
+        EventKey.BSH_COMMON_STATUS_OPERATION_STATE: (
+            "BSH.Common.EnumType.OperationState.DelayedStart"
+        ),
     },
     EventType.EVENT: {
         EventKey.BSH_COMMON_OPTION_REMAINING_PROGRAM_TIME: 30,
@@ -51,7 +53,9 @@ EVENT_PROG_DELAYED_START = {
 
 EVENT_PROG_RUN = {
     EventType.STATUS: {
-        EventKey.BSH_COMMON_STATUS_OPERATION_STATE: "BSH.Common.EnumType.OperationState.Run",
+        EventKey.BSH_COMMON_STATUS_OPERATION_STATE: (
+            "BSH.Common.EnumType.OperationState.Run"
+        ),
     },
     EventType.EVENT: {
         EventKey.BSH_COMMON_OPTION_REMAINING_PROGRAM_TIME: 0,
@@ -65,7 +69,9 @@ EVENT_PROG_UPDATE_1 = {
         EventKey.BSH_COMMON_OPTION_PROGRAM_PROGRESS: 80,
     },
     EventType.STATUS: {
-        EventKey.BSH_COMMON_STATUS_OPERATION_STATE: "BSH.Common.EnumType.OperationState.Run",
+        EventKey.BSH_COMMON_STATUS_OPERATION_STATE: (
+            "BSH.Common.EnumType.OperationState.Run"
+        ),
     },
 }
 
@@ -75,7 +81,9 @@ EVENT_PROG_UPDATE_2 = {
         EventKey.BSH_COMMON_OPTION_PROGRAM_PROGRESS: 99,
     },
     EventType.STATUS: {
-        EventKey.BSH_COMMON_STATUS_OPERATION_STATE: "BSH.Common.EnumType.OperationState.Run",
+        EventKey.BSH_COMMON_STATUS_OPERATION_STATE: (
+            "BSH.Common.EnumType.OperationState.Run"
+        ),
     },
 }
 
@@ -86,13 +94,17 @@ EVENT_PROG_UPDATE_3 = {
         EventKey.BSH_COMMON_OPTION_PROGRAM_PROGRESS: 99,
     },
     EventType.STATUS: {
-        EventKey.BSH_COMMON_STATUS_OPERATION_STATE: "BSH.Common.EnumType.OperationState.Run",
+        EventKey.BSH_COMMON_STATUS_OPERATION_STATE: (
+            "BSH.Common.EnumType.OperationState.Run"
+        ),
     },
 }
 
 EVENT_PROG_END = {
     EventType.STATUS: {
-        EventKey.BSH_COMMON_STATUS_OPERATION_STATE: "BSH.Common.EnumType.OperationState.Ready",
+        EventKey.BSH_COMMON_STATUS_OPERATION_STATE: (
+            "BSH.Common.EnumType.OperationState.Ready"
+        ),
     },
 }
 
@@ -113,7 +125,7 @@ async def test_paired_depaired_devices_flow(
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     appliance: HomeAppliance,
 ) -> None:
-    """Test that removed devices are correctly removed from and added to hass on API events."""
+    """Test device removal and re-addition on API events."""
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
 
@@ -231,7 +243,7 @@ async def test_sensor_entity_availability(
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     appliance: HomeAppliance,
 ) -> None:
-    """Test if sensor entities availability are based on the appliance connection state."""
+    """Test sensor entities availability based on appliance connection."""
     entity_ids = [
         "sensor.dishwasher_operation_state",
         "sensor.dishwasher_salt_nearly_empty",

--- a/tests/components/home_connect/test_services.py
+++ b/tests/components/home_connect/test_services.py
@@ -75,7 +75,9 @@ SERVICES_SET_PROGRAM_AND_OPTIONS = [
             "device_id": "DEVICE_ID",
             "affects_to": "active_program",
             "program": "consumer_products_coffee_maker_program_beverage_coffee",
-            "consumer_products_coffee_maker_option_bean_amount": "consumer_products_coffee_maker_enum_type_bean_amount_normal",
+            "consumer_products_coffee_maker_option_bean_amount": (
+                "consumer_products_coffee_maker_enum_type_bean_amount_normal"
+            ),
         },
         "blocking": True,
     },
@@ -85,7 +87,9 @@ SERVICES_SET_PROGRAM_AND_OPTIONS = [
         "service_data": {
             "device_id": "DEVICE_ID",
             "affects_to": "active_program",
-            "consumer_products_coffee_maker_option_coffee_milk_ratio": "consumer_products_coffee_maker_enum_type_coffee_milk_ratio_50_percent",
+            "consumer_products_coffee_maker_option_coffee_milk_ratio": (
+                "consumer_products_coffee_maker_enum_type_coffee_milk_ratio_50_percent"
+            ),
         },
         "blocking": True,
     },
@@ -124,14 +128,16 @@ def test_services_yaml_set_program_and_options_option_keys() -> None:
     for group in groups.values():
         for option, option_data in group["fields"].items():
             assert option in PROGRAM_ENUM_OPTIONS or option in PROGRAM_OPTIONS, (
-                f"{option} is missing from both PROGRAM_ENUM_OPTIONS and PROGRAM_OPTIONS"
+                f"{option} is missing from both"
+                " PROGRAM_ENUM_OPTIONS and PROGRAM_OPTIONS"
             )
             if option in PROGRAM_ENUM_OPTIONS:
                 enum_values = set(PROGRAM_ENUM_OPTIONS[option][1])
                 assert enum_values == set(
                     option_data["selector"]["select"]["options"]
                 ), (
-                    f"Options for {option} do not match between services.yaml and constants.py"
+                    f"Options for {option} do not match between"
+                    " services.yaml and constants.py"
                 )
                 assert "example" in option_data, (
                     f"Example value for {option} is missing"

--- a/tests/components/home_connect/test_switch.py
+++ b/tests/components/home_connect/test_switch.py
@@ -69,7 +69,7 @@ async def test_paired_depaired_devices_flow(
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     appliance: HomeAppliance,
 ) -> None:
-    """Test that removed devices are correctly removed from and added to hass on API events."""
+    """Test device removal and re-addition on API events."""
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
 
@@ -190,7 +190,7 @@ async def test_switch_entity_availability(
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     appliance: HomeAppliance,
 ) -> None:
-    """Test if switch entities availability are based on the appliance connection state."""
+    """Test switch entities availability based on appliance connection."""
     entity_ids = [
         "switch.dishwasher_power",
         "switch.dishwasher_child_lock",

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -212,8 +212,8 @@ async def test_turn_on_skips_domains_without_service(
         "context": service_call.context,
     }
     assert (
-        "The service homeassistant.turn_on does not support entities binary_sensor.blub, sensor.bla"
-        in caplog.text
+        "The service homeassistant.turn_on does not support"
+        " entities binary_sensor.blub, sensor.bla" in caplog.text
     )
 
 
@@ -340,8 +340,8 @@ async def test_not_allowing_recursion(
             blocking=True,
         )
         assert (
-            f"Called service homeassistant.{service} with invalid entities homeassistant.light"
-            in caplog.text
+            f"Called service homeassistant.{service} with"
+            " invalid entities homeassistant.light" in caplog.text
         ), service
 
 
@@ -612,7 +612,8 @@ async def test_reload_all(
         pytest.raises(
             HomeAssistantError,
             match=(
-                "Cannot quick reload all YAML configurations because the configuration is "
+                "Cannot quick reload all YAML configurations"
+                " because the configuration is "
                 "not valid: Oh no, drama!"
             ),
         ),

--- a/tests/components/homeassistant/triggers/test_numeric_state.py
+++ b/tests/components/homeassistant/triggers/test_numeric_state.py
@@ -988,7 +988,9 @@ async def test_template_string(
                 "trigger": {
                     "platform": "numeric_state",
                     "entity_id": "test.entity",
-                    "value_template": "{{ state.attributes.test_attribute | multiply(10) }}",
+                    "value_template": (
+                        "{{ state.attributes.test_attribute | multiply(10) }}"
+                    ),
                     "below": below,
                 },
                 "action": {
@@ -1988,7 +1990,9 @@ async def test_template_variable(
                 "trigger": {
                     "platform": "numeric_state",
                     "entity_id": "test.entity",
-                    "value_template": "{{ state.attributes.test_attribute[2] * multiplier}}",
+                    "value_template": (
+                        "{{ state.attributes.test_attribute[2] * multiplier}}"
+                    ),
                     "below": 10,
                 },
                 "action": {"service": "test.automation"},

--- a/tests/components/homeassistant/triggers/test_time.py
+++ b/tests/components/homeassistant/triggers/test_time.py
@@ -102,7 +102,10 @@ async def test_if_fires_using_at_input_datetime(
 
     time_that_will_not_match_right_away = trigger_dt - timedelta(minutes=1)
 
-    some_data = "{{ trigger.platform }}-{{ trigger.now.day }}-{{ trigger.now.hour }}-{{trigger.entity_id}}"
+    some_data = (
+        "{{ trigger.platform }}-{{ trigger.now.day }}"
+        "-{{ trigger.now.hour }}-{{trigger.entity_id}}"
+    )
 
     freezer.move_to(dt_util.as_utc(time_that_will_not_match_right_away))
     assert await async_setup_component(
@@ -205,7 +208,10 @@ async def test_if_fires_using_at_input_datetime_with_offset(
 
     time_that_will_not_match_right_away = trigger_dt - timedelta(minutes=1)
 
-    some_data = "{{ trigger.platform }}-{{ trigger.now.day }}-{{ trigger.now.hour }}-{{trigger.entity_id}}"
+    some_data = (
+        "{{ trigger.platform }}-{{ trigger.now.day }}"
+        "-{{ trigger.now.hour }}-{{trigger.entity_id}}"
+    )
 
     freezer.move_to(dt_util.as_utc(time_that_will_not_match_right_away))
     assert await async_setup_component(
@@ -545,7 +551,10 @@ async def test_if_fires_using_at_sensor(
 
     time_that_will_not_match_right_away = trigger_dt - timedelta(minutes=1)
 
-    some_data = "{{ trigger.platform }}-{{ trigger.now.day }}-{{ trigger.now.hour }}-{{trigger.entity_id}}"
+    some_data = (
+        "{{ trigger.platform }}-{{ trigger.now.day }}"
+        "-{{ trigger.now.hour }}-{{trigger.entity_id}}"
+    )
 
     freezer.move_to(dt_util.as_utc(time_that_will_not_match_right_away))
     assert await async_setup_component(
@@ -664,7 +673,11 @@ async def test_if_fires_using_at_sensor_with_offset(
 
     time_that_will_not_match_right_away = trigger_dt - timedelta(minutes=1)
 
-    some_data = "{{ trigger.platform }}-{{ trigger.now.day }}-{{ trigger.now.hour }}-{{ trigger.now.minute }}-{{ trigger.now.second }}-{{trigger.entity_id}}"
+    some_data = (
+        "{{ trigger.platform }}-{{ trigger.now.day }}"
+        "-{{ trigger.now.hour }}-{{ trigger.now.minute }}"
+        "-{{ trigger.now.second }}-{{trigger.entity_id}}"
+    )
 
     freezer.move_to(dt_util.as_utc(time_that_will_not_match_right_away))
     assert await async_setup_component(
@@ -693,8 +706,9 @@ async def test_if_fires_using_at_sensor_with_offset(
 
     assert len(service_calls) == 1
     assert (
-        service_calls[0].data["some"]
-        == f"time-{trigger_dt.day}-{trigger_dt.hour}-{trigger_dt.minute}-{trigger_dt.second}-sensor.next_alarm"
+        service_calls[0].data["some"] == f"time-{trigger_dt.day}-{trigger_dt.hour}"
+        f"-{trigger_dt.minute}-{trigger_dt.second}"
+        "-sensor.next_alarm"
     )
 
     start_dt += timedelta(days=1, hours=1)
@@ -712,8 +726,9 @@ async def test_if_fires_using_at_sensor_with_offset(
 
     assert len(service_calls) == 2
     assert (
-        service_calls[1].data["some"]
-        == f"time-{trigger_dt.day}-{trigger_dt.hour}-{trigger_dt.minute}-{trigger_dt.second}-sensor.next_alarm"
+        service_calls[1].data["some"] == f"time-{trigger_dt.day}-{trigger_dt.hour}"
+        f"-{trigger_dt.minute}-{trigger_dt.second}"
+        "-sensor.next_alarm"
     )
 
 
@@ -788,7 +803,12 @@ async def test_datetime_in_past_on_load(
                 "action": {
                     "service": "test.automation",
                     "data_template": {
-                        "some": "{{ trigger.platform }}-{{ trigger.now.day }}-{{ trigger.now.hour }}-{{trigger.entity_id}}"
+                        "some": (
+                            "{{ trigger.platform }}"
+                            "-{{ trigger.now.day }}"
+                            "-{{ trigger.now.hour }}"
+                            "-{{trigger.entity_id}}"
+                        )
                     },
                 },
             }
@@ -909,7 +929,9 @@ async def test_if_fires_using_weekday_single(
                 "action": {
                     "service": "test.automation",
                     "data_template": {
-                        "some": "{{ trigger.platform }} - {{ trigger.now.strftime('%A') }}",
+                        "some": (
+                            "{{ trigger.platform }} - {{ trigger.now.strftime('%A') }}"
+                        ),
                     },
                 },
             }
@@ -957,7 +979,9 @@ async def test_if_fires_using_weekday_multiple(
                 "action": {
                     "service": "test.automation",
                     "data_template": {
-                        "some": "{{ trigger.platform }} - {{ trigger.now.strftime('%A') }}",
+                        "some": (
+                            "{{ trigger.platform }} - {{ trigger.now.strftime('%A') }}"
+                        ),
                     },
                 },
             }
@@ -1032,7 +1056,9 @@ async def test_if_fires_using_weekday_with_entity(
                 "action": {
                     "service": "test.automation",
                     "data_template": {
-                        "some": "{{ trigger.platform }} - {{ trigger.now.strftime('%A') }}",
+                        "some": (
+                            "{{ trigger.platform }} - {{ trigger.now.strftime('%A') }}"
+                        ),
                         "entity": "{{ trigger.entity_id }}",
                     },
                 },

--- a/tests/components/homeassistant_connect_zbt2/test_config_flow.py
+++ b/tests/components/homeassistant_connect_zbt2/test_config_flow.py
@@ -305,7 +305,8 @@ async def test_options_flow(
         patch(
             "homeassistant.components.homeassistant_hardware.firmware_config_flow.probe_silabs_firmware_info",
             side_effect=[
-                # First call: probe before installation (returns current SPINEL firmware)
+                # First call: probe before installation (returns current SPINEL
+                # firmware)
                 FirmwareInfo(
                     device=usb_data.device,
                     firmware_type=ApplicationType.SPINEL,
@@ -443,7 +444,7 @@ async def test_duplicate_discovery_updates_usb_path(hass: HomeAssistant) -> None
 
 
 async def test_firmware_callback_auto_creates_entry(hass: HomeAssistant) -> None:
-    """Test that firmware notification triggers import flow that auto-creates config entry."""
+    """Test firmware notification triggers import flow creating entry."""
     await async_setup_component(hass, HOMEASSISTANT_HARDWARE_DOMAIN, {})
     await async_setup_component(hass, USB_DOMAIN, {})
 

--- a/tests/components/homeassistant_connect_zbt2/test_diagnostics.py
+++ b/tests/components/homeassistant_connect_zbt2/test_diagnostics.py
@@ -1,4 +1,4 @@
-"""Tests for the diagnostics data provided by the Home Assistant Connect ZBT-2 integration."""
+"""Tests for the Home Assistant Connect ZBT-2 diagnostics data."""
 
 from syrupy.assertion import SnapshotAssertion
 from syrupy.filters import props

--- a/tests/components/homeassistant_connect_zbt2/test_init.py
+++ b/tests/components/homeassistant_connect_zbt2/test_init.py
@@ -23,7 +23,7 @@ from tests.components.usb.conftest import force_usb_polling_watcher  # noqa: F40
 
 
 async def test_config_entry_migration_v2(hass: HomeAssistant) -> None:
-    """Test migrating config entries from v1.1 to v1.2 to use the serial number as unique ID."""
+    """Test migrating config entries from v1.1 to v1.2 for serial unique ID."""
 
     config_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/homeassistant_connect_zbt2/test_update.py
+++ b/tests/components/homeassistant_connect_zbt2/test_update.py
@@ -72,7 +72,9 @@ async def test_zbt2_update_entity(hass: HomeAssistant) -> None:
         FirmwareInfo(
             device=USB_DATA_ZBT2.device,
             firmware_type=ApplicationType.SPINEL,
-            firmware_version="SL-OPENTHREAD/2.4.4.0_GitHub-7074a43e4; EFR32; Oct 21 2024 14:40:57",
+            firmware_version=(
+                "SL-OPENTHREAD/2.4.4.0_GitHub-7074a43e4; EFR32; Oct 21 2024 14:40:57"
+            ),
             owners=[],
             source="otbr",
         ),

--- a/tests/components/homeassistant_hardware/test_config_flow.py
+++ b/tests/components/homeassistant_hardware/test_config_flow.py
@@ -1075,7 +1075,8 @@ async def test_config_flow_pick_firmware_shows_migrate_options_with_existing_zha
     assert init_result["type"] is FlowResultType.MENU
     assert init_result["step_id"] == "pick_firmware"
 
-    # Should show migrate option for Zigbee since ZHA exists (migrating from ZHA to Zigbee)
+    # Should show migrate option for Zigbee since ZHA exists (migrating from ZHA to
+    # Zigbee)
     menu_options = init_result["menu_options"]
     assert "pick_firmware_zigbee_migrate" in menu_options
     assert "pick_firmware_thread" in menu_options  # Normal option for Thread
@@ -1100,7 +1101,8 @@ async def test_config_flow_pick_firmware_shows_migrate_options_with_existing_otb
     assert init_result["type"] is FlowResultType.MENU
     assert init_result["step_id"] == "pick_firmware"
 
-    # Should show migrate option for Thread since OTBR exists (migrating from OTBR to Thread)
+    # Should show migrate option for Thread since OTBR exists (migrating from OTBR to
+    # Thread)
     menu_options = init_result["menu_options"]
     assert "pick_firmware_thread_migrate" in menu_options
     assert "pick_firmware_zigbee" in menu_options  # Normal option for Zigbee

--- a/tests/components/homeassistant_hardware/test_update.py
+++ b/tests/components/homeassistant_hardware/test_update.py
@@ -575,7 +575,10 @@ async def test_update_entity_graceful_firmware_type_callback_errors(
             FirmwareInfo(
                 device=TEST_DEVICE,
                 firmware_type=ApplicationType.SPINEL,
-                firmware_version="SL-OPENTHREAD/2.4.4.0_GitHub-7074a43e4; EFR32; Oct 21 2024 14:40:57",
+                firmware_version=(
+                    "SL-OPENTHREAD/2.4.4.0_GitHub-7074a43e4;"
+                    " EFR32; Oct 21 2024 14:40:57"
+                ),
                 owners=[],
                 source="probe",
             ),
@@ -607,7 +610,8 @@ async def test_early_firmware_check_on_unknown_state(
     )
     await hass.async_block_till_done()
 
-    # The entity should immediately show update available (no manual update_entity call needed)
+    # The entity should immediately show update available (no manual update_entity call
+    # needed)
     state = hass.states.get(TEST_UPDATE_ENTITY_ID)
     assert state is not None
     assert state.state == "on"

--- a/tests/components/homeassistant_sky_connect/test_config_flow.py
+++ b/tests/components/homeassistant_sky_connect/test_config_flow.py
@@ -448,7 +448,7 @@ async def test_firmware_callback_auto_creates_entry(
     model: str,
     hass: HomeAssistant,
 ) -> None:
-    """Test that firmware notification triggers import flow that auto-creates config entry."""
+    """Test firmware notification triggers import flow creating entry."""
     await async_setup_component(hass, HOMEASSISTANT_HARDWARE_DOMAIN, {})
     await async_setup_component(hass, USB_DOMAIN, {})
 
@@ -515,7 +515,7 @@ async def test_firmware_callback_auto_creates_entry(
 async def test_duplicate_usb_discovery_aborts_early(
     usb_data: UsbServiceInfo, model: str, hass: HomeAssistant
 ) -> None:
-    """Test USB discovery aborts early when unique_id exists before serial path resolution."""
+    """Test USB discovery aborts early when unique_id already exists."""
     # Create existing config entry
     config_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/homeassistant_sky_connect/test_hardware.py
+++ b/tests/components/homeassistant_sky_connect/test_hardware.py
@@ -10,7 +10,11 @@ from tests.common import MockConfigEntry
 from tests.typing import WebSocketGenerator
 
 CONFIG_ENTRY_DATA = {
-    "device": "/dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_9e2adbd75b8beb119fe564a0f320645d-if00-port0",
+    "device": (
+        "/dev/serial/by-id/"
+        "usb-Nabu_Casa_SkyConnect_v1.0"
+        "_9e2adbd75b8beb119fe564a0f320645d-if00-port0"
+    ),
     "vid": "10C4",
     "pid": "EA60",
     "serial_number": "9e2adbd75b8beb119fe564a0f320645d",
@@ -20,7 +24,11 @@ CONFIG_ENTRY_DATA = {
 }
 
 CONFIG_ENTRY_DATA_2 = {
-    "device": "/dev/serial/by-id/usb-Nabu_Casa_Home_Assistant_Connect_ZBT-1_3c0ed67c628beb11b1cd64a0f320645d-if00-port0",
+    "device": (
+        "/dev/serial/by-id/"
+        "usb-Nabu_Casa_Home_Assistant_Connect_ZBT-1"
+        "_3c0ed67c628beb11b1cd64a0f320645d-if00-port0"
+    ),
     "vid": "10C4",
     "pid": "EA60",
     "serial_number": "3c0ed67c628beb11b1cd64a0f320645d",
@@ -30,7 +38,11 @@ CONFIG_ENTRY_DATA_2 = {
 }
 
 CONFIG_ENTRY_DATA_BAD = {
-    "device": "/dev/serial/by-id/usb-Nabu_Casa_Home_Assistant_Connect_ZBT-1_a87b7d75b18beb119fe564a0f320645d-if00-port0",
+    "device": (
+        "/dev/serial/by-id/"
+        "usb-Nabu_Casa_Home_Assistant_Connect_ZBT-1"
+        "_a87b7d75b18beb119fe564a0f320645d-if00-port0"
+    ),
 }
 
 

--- a/tests/components/homeassistant_sky_connect/test_init.py
+++ b/tests/components/homeassistant_sky_connect/test_init.py
@@ -41,7 +41,11 @@ async def test_config_entry_migration_v2(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         unique_id="some_unique_id",
         data={
-            "device": "/dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_9e2adbd75b8beb119fe564a0f320645d-if00-port0",
+            "device": (
+                "/dev/serial/by-id/"
+                "usb-Nabu_Casa_SkyConnect_v1.0"
+                "_9e2adbd75b8beb119fe564a0f320645d-if00-port0"
+            ),
             "vid": "10C4",
             "pid": "EA60",
             "serial_number": "3c0ed67c628beb11b1cd64a0f320645d",
@@ -56,7 +60,11 @@ async def test_config_entry_migration_v2(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.components.homeassistant_sky_connect.guess_firmware_info",
         return_value=FirmwareInfo(
-            device="/dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_9e2adbd75b8beb119fe564a0f320645d-if00-port0",
+            device=(
+                "/dev/serial/by-id/"
+                "usb-Nabu_Casa_SkyConnect_v1.0"
+                "_9e2adbd75b8beb119fe564a0f320645d-if00-port0"
+            ),
             firmware_version=None,
             firmware_type=ApplicationType.SPINEL,
             source="otbr",
@@ -70,7 +78,11 @@ async def test_config_entry_migration_v2(hass: HomeAssistant) -> None:
     assert config_entry.unique_id == "3c0ed67c628beb11b1cd64a0f320645d"
     assert config_entry.data == {
         "description": "SkyConnect v1.0",
-        "device": "/dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_9e2adbd75b8beb119fe564a0f320645d-if00-port0",
+        "device": (
+            "/dev/serial/by-id/"
+            "usb-Nabu_Casa_SkyConnect_v1.0"
+            "_9e2adbd75b8beb119fe564a0f320645d-if00-port0"
+        ),
         "vid": "10C4",
         "pid": "EA60",
         "serial_number": "3c0ed67c628beb11b1cd64a0f320645d",
@@ -111,7 +123,8 @@ async def test_config_entry_migration_v2(hass: HomeAssistant) -> None:
             },
             {
                 "unique_id": (
-                    "10C4:EA60_9e2adbd75b8beb119fe564a0f320645d_Nabu Casa_SkyConnect v1.0"
+                    "10C4:EA60_9e2adbd75b8beb119fe564a0f320645d"
+                    "_Nabu Casa_SkyConnect v1.0"
                 ),
                 "source": "import",
                 "data": {
@@ -135,7 +148,8 @@ async def test_config_entry_migration_v2(hass: HomeAssistant) -> None:
         (
             {
                 "unique_id": (
-                    "10C4:EA60_3c0ed67c628beb11b1cd64a0f320645d_Nabu_Casa_SkyConnect v1.0"
+                    "10C4:EA60_3c0ed67c628beb11b1cd64a0f320645d"
+                    "_Nabu_Casa_SkyConnect v1.0"
                 ),
                 "source": "usb",
                 "data": {
@@ -155,7 +169,8 @@ async def test_config_entry_migration_v2(hass: HomeAssistant) -> None:
             },
             {
                 "unique_id": (
-                    "10C4:EA60_3c0ed67c628beb11b1cd64a0f320645d_Nabu_Casa_SkyConnect v1.0"
+                    "10C4:EA60_3c0ed67c628beb11b1cd64a0f320645d"
+                    "_Nabu_Casa_SkyConnect v1.0"
                 ),
                 "source": "import",
                 "data": {
@@ -295,7 +310,11 @@ async def test_setup_fails_on_missing_usb_port(hass: HomeAssistant) -> None:
         unique_id="some_unique_id",
         data={
             "description": "SkyConnect v1.0",
-            "device": "/dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_9e2adbd75b8beb119fe564a0f320645d-if00-port0",
+            "device": (
+                "/dev/serial/by-id/"
+                "usb-Nabu_Casa_SkyConnect_v1.0"
+                "_9e2adbd75b8beb119fe564a0f320645d-if00-port0"
+            ),
             "vid": "10C4",
             "pid": "EA60",
             "serial_number": "3c0ed67c628beb11b1cd64a0f320645d",
@@ -343,7 +362,11 @@ async def test_usb_device_reactivity(hass: HomeAssistant) -> None:
         unique_id="some_unique_id",
         data={
             "description": "SkyConnect v1.0",
-            "device": "/dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_9e2adbd75b8beb119fe564a0f320645d-if00-port0",
+            "device": (
+                "/dev/serial/by-id/"
+                "usb-Nabu_Casa_SkyConnect_v1.0"
+                "_9e2adbd75b8beb119fe564a0f320645d-if00-port0"
+            ),
             "vid": "10C4",
             "pid": "EA60",
             "serial_number": "3c0ed67c628beb11b1cd64a0f320645d",
@@ -374,7 +397,11 @@ async def test_usb_device_reactivity(hass: HomeAssistant) -> None:
         with patch_scanned_serial_ports(
             return_value=[
                 USBDevice(
-                    device="/dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_9e2adbd75b8beb119fe564a0f320645d-if00-port0",
+                    device=(
+                        "/dev/serial/by-id/"
+                        "usb-Nabu_Casa_SkyConnect_v1.0"
+                        "_9e2adbd75b8beb119fe564a0f320645d-if00-port0"
+                    ),
                     vid="10C4",
                     pid="EA60",
                     serial_number="3c0ed67c628beb11b1cd64a0f320645d",
@@ -411,7 +438,11 @@ async def test_bad_config_entry_fixing(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         unique_id="some_unique_id-9e2adbd75b8beb119fe564a0f320645d",
         data={
-            "device": "/dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_9e2adbd75b8beb119fe564a0f320645d-if00-port0",
+            "device": (
+                "/dev/serial/by-id/"
+                "usb-Nabu_Casa_SkyConnect_v1.0"
+                "_9e2adbd75b8beb119fe564a0f320645d-if00-port0"
+            ),
             "vid": "10C4",
             "pid": "EA60",
             "serial_number": "9e2adbd75b8beb119fe564a0f320645d",
@@ -431,7 +462,11 @@ async def test_bad_config_entry_fixing(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         unique_id="some_unique_id-3c0ed67c628beb11b1cd64a0f320645d",
         data={
-            "device": "/dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_3c0ed67c628beb11b1cd64a0f320645d-if00-port0",
+            "device": (
+                "/dev/serial/by-id/"
+                "usb-Nabu_Casa_SkyConnect_v1.0"
+                "_3c0ed67c628beb11b1cd64a0f320645d-if00-port0"
+            ),
             "vid": "10C4",
             "pid": "EA60",
             "serial_number": "3c0ed67c628beb11b1cd64a0f320645d",
@@ -449,7 +484,11 @@ async def test_bad_config_entry_fixing(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         unique_id="some_unique_id-9f6c4bba657cc9a4f0cea48bc5948562",
         data={
-            "device": "/dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_9f6c4bba657cc9a4f0cea48bc5948562-if00-port0",
+            "device": (
+                "/dev/serial/by-id/"
+                "usb-Nabu_Casa_SkyConnect_v1.0"
+                "_9f6c4bba657cc9a4f0cea48bc5948562-if00-port0"
+            ),
         },
         version=1,
         minor_version=2,
@@ -462,7 +501,11 @@ async def test_bad_config_entry_fixing(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         unique_id="some_unique_id-4f5f3b26d59f8714a78b599690741999",
         data={
-            "device": "/dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_4f5f3b26d59f8714a78b599690741999-if00-port0",
+            "device": (
+                "/dev/serial/by-id/"
+                "usb-Nabu_Casa_SkyConnect_v1.0"
+                "_4f5f3b26d59f8714a78b599690741999-if00-port0"
+            ),
         },
         version=1,
         minor_version=2,

--- a/tests/components/homeassistant_sky_connect/test_update.py
+++ b/tests/components/homeassistant_sky_connect/test_update.py
@@ -72,7 +72,9 @@ async def test_zbt1_update_entity(hass: HomeAssistant) -> None:
         FirmwareInfo(
             device=USB_DATA_ZBT1.device,
             firmware_type=ApplicationType.SPINEL,
-            firmware_version="SL-OPENTHREAD/2.4.4.0_GitHub-7074a43e4; EFR32; Oct 21 2024 14:40:57",
+            firmware_version=(
+                "SL-OPENTHREAD/2.4.4.0_GitHub-7074a43e4; EFR32; Oct 21 2024 14:40:57"
+            ),
             owners=[],
             source="otbr",
         ),

--- a/tests/components/homeassistant_sky_connect/test_util.py
+++ b/tests/components/homeassistant_sky_connect/test_util.py
@@ -16,7 +16,11 @@ SKYCONNECT_CONFIG_ENTRY = MockConfigEntry(
     domain=DOMAIN,
     unique_id="some_unique_id",
     data={
-        "device": "/dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_9e2adbd75b8beb119fe564a0f320645d-if00-port0",
+        "device": (
+            "/dev/serial/by-id/"
+            "usb-Nabu_Casa_SkyConnect_v1.0"
+            "_9e2adbd75b8beb119fe564a0f320645d-if00-port0"
+        ),
         "vid": "10C4",
         "pid": "EA60",
         "serial_number": "3c0ed67c628beb11b1cd64a0f320645d",
@@ -31,7 +35,11 @@ CONNECT_ZBT1_CONFIG_ENTRY = MockConfigEntry(
     domain=DOMAIN,
     unique_id="some_unique_id",
     data={
-        "device": "/dev/serial/by-id/usb-Nabu_Casa_Home_Assistant_Connect_ZBT-1_9e2adbd75b8beb119fe564a0f320645d-if00-port0",
+        "device": (
+            "/dev/serial/by-id/"
+            "usb-Nabu_Casa_Home_Assistant_Connect_ZBT-1"
+            "_9e2adbd75b8beb119fe564a0f320645d-if00-port0"
+        ),
         "vid": "10C4",
         "pid": "EA60",
         "serial_number": "3c0ed67c628beb11b1cd64a0f320645d",

--- a/tests/components/homeassistant_yellow/test_config_flow.py
+++ b/tests/components/homeassistant_yellow/test_config_flow.py
@@ -377,7 +377,8 @@ async def test_firmware_options_flow_zigbee(hass: HomeAssistant) -> None:
         patch(
             "homeassistant.components.homeassistant_hardware.firmware_config_flow.probe_silabs_firmware_info",
             side_effect=[
-                # First call: probe before installation (returns current SPINEL firmware)
+                # First call: probe before installation (returns current SPINEL
+                # firmware)
                 FirmwareInfo(
                     device=RADIO_DEVICE,
                     firmware_type=ApplicationType.SPINEL,

--- a/tests/components/homeassistant_yellow/test_update.py
+++ b/tests/components/homeassistant_yellow/test_update.py
@@ -78,7 +78,9 @@ async def test_yellow_update_entity(hass: HomeAssistant) -> None:
         FirmwareInfo(
             device=RADIO_DEVICE,
             firmware_type=ApplicationType.SPINEL,
-            firmware_version="SL-OPENTHREAD/2.4.4.0_GitHub-7074a43e4; EFR32; Oct 21 2024 14:40:57",
+            firmware_version=(
+                "SL-OPENTHREAD/2.4.4.0_GitHub-7074a43e4; EFR32; Oct 21 2024 14:40:57"
+            ),
             owners=[],
             source="otbr",
         ),

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -71,7 +71,10 @@ async def test_accessory_cancels_track_state_change_on_stop(
 async def test_home_accessory(hass: HomeAssistant, hk_driver) -> None:
     """Test HomeAccessory class."""
     entity_id = "sensor.accessory"
-    entity_id2 = "light.accessory_that_exceeds_the_maximum_maximum_maximum_maximum_maximum_maximum_maximum_allowed_length"
+    entity_id2 = (
+        "light.accessory_that_exceeds_the_maximum_maximum"
+        "_maximum_maximum_maximum_maximum_maximum_allowed_length"
+    )
 
     hass.states.async_set(entity_id, None)
     hass.states.async_set(entity_id2, STATE_UNAVAILABLE)
@@ -107,14 +110,29 @@ async def test_home_accessory(hass: HomeAssistant, hk_driver) -> None:
     acc3 = HomeAccessory(
         hass,
         hk_driver,
-        "Home Accessory that exceeds the maximum maximum maximum maximum maximum maximum length",
+        (
+            "Home Accessory that exceeds the maximum maximum"
+            " maximum maximum maximum maximum length"
+        ),
         entity_id2,
         4,
         {
-            ATTR_MODEL: "Awesome Model that exceeds the maximum maximum maximum maximum maximum maximum length",
-            ATTR_MANUFACTURER: "Lux Brands that exceeds the maximum maximum maximum maximum maximum maximum length",
-            ATTR_SW_VERSION: "0.4.3 that exceeds the maximum maximum maximum maximum maximum maximum length",
-            ATTR_INTEGRATION: "luxe that exceeds the maximum maximum maximum maximum maximum maximum length",
+            ATTR_MODEL: (
+                "Awesome Model that exceeds the maximum maximum"
+                " maximum maximum maximum maximum length"
+            ),
+            ATTR_MANUFACTURER: (
+                "Lux Brands that exceeds the maximum maximum"
+                " maximum maximum maximum maximum length"
+            ),
+            ATTR_SW_VERSION: (
+                "0.4.3 that exceeds the maximum maximum"
+                " maximum maximum maximum maximum length"
+            ),
+            ATTR_INTEGRATION: (
+                "luxe that exceeds the maximum maximum"
+                " maximum maximum maximum maximum length"
+            ),
         },
     )
     assert acc3.available is False
@@ -140,14 +158,26 @@ async def test_home_accessory(hass: HomeAssistant, hk_driver) -> None:
     acc4 = HomeAccessory(
         hass,
         hk_driver,
-        "Home Accessory that exceeds the maximum maximum maximum maximum maximum maximum length",
+        (
+            "Home Accessory that exceeds the maximum maximum"
+            " maximum maximum maximum maximum length"
+        ),
         entity_id2,
         5,
         {
-            ATTR_MODEL: "Awesome Model that exceeds the maximum maximum maximum maximum maximum maximum length",
-            ATTR_MANUFACTURER: "Lux Brands that exceeds the maximum maximum maximum maximum maximum maximum length",
+            ATTR_MODEL: (
+                "Awesome Model that exceeds the maximum maximum"
+                " maximum maximum maximum maximum length"
+            ),
+            ATTR_MANUFACTURER: (
+                "Lux Brands that exceeds the maximum maximum"
+                " maximum maximum maximum maximum length"
+            ),
             ATTR_SW_VERSION: "will_not_match_regex",
-            ATTR_INTEGRATION: "luxe that exceeds the maximum maximum maximum maximum maximum maximum length",
+            ATTR_INTEGRATION: (
+                "luxe that exceeds the maximum maximum"
+                " maximum maximum maximum maximum length"
+            ),
         },
     )
     assert acc4.available is False
@@ -503,7 +533,7 @@ async def test_linked_battery_charging_sensor(
 async def test_linked_battery_sensor_and_linked_battery_charging_sensor(
     hass: HomeAssistant, hk_driver, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test battery service with linked_battery_sensor and a linked_battery_charging_sensor."""
+    """Test battery service with linked battery and charging sensors."""
     entity_id = "homekit.accessory"
     linked_battery = "sensor.battery"
     linked_battery_charging_sensor = "binary_sensor.battery_charging"
@@ -552,7 +582,7 @@ async def test_linked_battery_sensor_and_linked_battery_charging_sensor(
 async def test_missing_linked_battery_charging_sensor(
     hass: HomeAssistant, hk_driver, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test battery service with linked_battery_charging_sensor that is mapping to a missing entity."""
+    """Test battery service with charging sensor mapped to missing entity."""
     entity_id = "homekit.accessory"
     linked_battery_charging_sensor = "binary_sensor.battery_charging"
     hass.states.async_set(entity_id, "open", {ATTR_BATTERY_LEVEL: 100})

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -163,7 +163,7 @@ async def test_setup_in_bridge_mode_name_taken(hass: HomeAssistant) -> None:
 async def test_setup_creates_entries_for_accessory_mode_devices(
     hass: HomeAssistant,
 ) -> None:
-    """Test we can setup a new instance and we create entries for accessory mode devices."""
+    """Test setup creates entries for accessory mode devices."""
     hass.states.async_set("camera.one", "on")
     hass.states.async_set("camera.existing", "on")
     hass.states.async_set("lock.new", "on")
@@ -505,7 +505,7 @@ async def test_options_flow_devices(
 async def test_options_flow_devices_preserved_when_advanced_off(
     port_mock, hass: HomeAssistant
 ) -> None:
-    """Test devices are preserved if they were added in advanced mode but it was turned off."""
+    """Test devices preserved when advanced mode is turned off."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_NAME: "mock_name", CONF_PORT: 12345},

--- a/tests/components/homekit/test_diagnostics.py
+++ b/tests/components/homekit/test_diagnostics.py
@@ -324,7 +324,7 @@ async def test_config_entry_with_trigger_accessory(
     demo_cleanup,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test generating diagnostics for a bridge config entry with a trigger accessory."""
+    """Test diagnostics for a bridge config entry with trigger accessory."""
     assert await async_setup_component(hass, "homeassistant", {})
     assert await async_setup_component(hass, "demo", {"demo": {}})
     hk_driver.publish = MagicMock()

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -1870,7 +1870,7 @@ async def test_homekit_ignored_missing_devices(
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test HomeKit handles a device in the entity registry but missing from the device registry.
+    """Test HomeKit handles entity with missing device registry entry.
 
     If the entity registry is updated to remove entities linked to non-existent devices,
     or set the link to None, this test can be removed.

--- a/tests/components/homekit/test_type_cameras.py
+++ b/tests/components/homekit/test_type_cameras.py
@@ -47,8 +47,17 @@ from homeassistant.util import dt as dt_util
 from tests.components.camera.common import mock_turbo_jpeg
 
 MOCK_AUDIO_PROXY_PORT = 23456
-MOCK_START_STREAM_TLV = "ARUCAQEBEDMD1QMXzEaatnKSQ2pxovYCNAEBAAIJAQECAgECAwEAAwsBAgAFAgLQAgMBHgQXAQFjAgQ768/RAwIrAQQEAAAAPwUCYgUDLAEBAwIMAQEBAgEAAwECBAEUAxYBAW4CBCzq28sDAhgABAQAAKBABgENBAEA"
-MOCK_END_POINTS_TLV = "ARAzA9UDF8xGmrZykkNqcaL2AgEAAxoBAQACDTE5Mi4xNjguMjA4LjUDAi7IBAKkxwQlAQEAAhDN0+Y0tZ4jzoO0ske9UsjpAw6D76oVXnoi7DbawIG4CwUlAQEAAhCyGcROB8P7vFRDzNF2xrK1Aw6NdcLugju9yCfkWVSaVAYEDoAsAAcEpxV8AA=="
+MOCK_START_STREAM_TLV = (
+    "ARUCAQEBEDMD1QMXzEaatnKSQ2pxovYCNAEBAAIJAQECAgECAwEAAwsBAg"
+    "AFAgLQAgMBHgQXAQFjAgQ768/RAwIrAQQEAAAAPwUCYgUDLAEBAwIMAQEBAg"
+    "EAAwECBAEUAxYBAW4CBCzq28sDAhgABAQAAKBABgENBAEA"
+)
+MOCK_END_POINTS_TLV = (
+    "ARAzA9UDF8xGmrZykkNqcaL2AgEAAxoBAQACDTE5Mi4xNjguMjA4LjUDAi7"
+    "IBAKkxwQlAQEAAhDN0+Y0tZ4jzoO0ske9UsjpAw6D76oVXnoi7DbawIG4Cw"
+    "UlAQEAAhCyGcROB8P7vFRDzNF2xrK1Aw6NdcLugju9yCfkWVSaVAYEDoAsA"
+    "AcEpxV8AA=="
+)
 MOCK_START_STREAM_SESSION_UUID = UUID("3303d503-17cc-469a-b672-92436a71a2f6")
 
 PID_THAT_WILL_NEVER_BE_ALIVE = 2147483647
@@ -217,13 +226,18 @@ async def test_camera_stream_source_configured(hass: HomeAssistant, run_driver) 
         await _async_stop_all_streams(hass, acc)
 
     expected_output = (
-        "-map 0:v:0 -an -c:v libx264 -profile:v high -tune zerolatency -pix_fmt "
-        "yuv420p -r 30 -b:v 299k -bufsize 1196k -maxrate 299k -payload_type 99 -ssrc {v_ssrc} -f "
-        "rtp -srtp_out_suite AES_CM_128_HMAC_SHA1_80 -srtp_out_params "
+        "-map 0:v:0 -an -c:v libx264 -profile:v high "
+        "-tune zerolatency -pix_fmt yuv420p -r 30 -b:v 299k "
+        "-bufsize 1196k -maxrate 299k -payload_type 99 "
+        "-ssrc {v_ssrc} -f rtp -srtp_out_suite "
+        "AES_CM_128_HMAC_SHA1_80 -srtp_out_params "
         "zdPmNLWeI86DtLJHvVLI6YPvqhVeeiLsNtrAgbgL "
-        "srtp://192.168.208.5:51246?rtcpport=51246&localrtpport=51246&pkt_size=1316 -map 0:a:0 "
-        "-vn -c:a libopus -application lowdelay -ac 1 -ar 24k -b:a 24k -bufsize 96k "
-        f"-frame_duration 20 -payload_type 110 -ssrc {{a_ssrc}} -f rtp "
+        "srtp://192.168.208.5:51246"
+        "?rtcpport=51246&localrtpport=51246&pkt_size=1316 "
+        "-map 0:a:0 -vn -c:a libopus -application lowdelay "
+        "-ac 1 -ar 24k -b:a 24k -bufsize 96k "
+        "-frame_duration 20 -payload_type 110 "
+        f"-ssrc {{a_ssrc}} -f rtp "
         f"rtp://127.0.0.1:{MOCK_AUDIO_PROXY_PORT}?pkt_size=188"
     )
 
@@ -426,11 +440,14 @@ async def test_camera_stream_source_found(hass: HomeAssistant, run_driver) -> No
         await _async_stop_all_streams(hass, acc)
 
     expected_output = (
-        "-map 0:v:0 -an -c:v libx264 -profile:v high -tune zerolatency -pix_fmt "
-        "yuv420p -r 30 -b:v 299k -bufsize 1196k -maxrate 299k -payload_type 99 -ssrc {v_ssrc} -f "
-        "rtp -srtp_out_suite AES_CM_128_HMAC_SHA1_80 -srtp_out_params "
+        "-map 0:v:0 -an -c:v libx264 -profile:v high "
+        "-tune zerolatency -pix_fmt yuv420p -r 30 -b:v 299k "
+        "-bufsize 1196k -maxrate 299k -payload_type 99 "
+        "-ssrc {v_ssrc} -f rtp -srtp_out_suite "
+        "AES_CM_128_HMAC_SHA1_80 -srtp_out_params "
         "zdPmNLWeI86DtLJHvVLI6YPvqhVeeiLsNtrAgbgL "
-        "srtp://192.168.208.5:51246?rtcpport=51246&localrtpport=51246&pkt_size=1316"
+        "srtp://192.168.208.5:51246"
+        "?rtcpport=51246&localrtpport=51246&pkt_size=1316"
     )
 
     working_ffmpeg.open.assert_called_with(
@@ -597,11 +614,16 @@ async def test_camera_stream_source_configured_and_copy_codec(
         await _async_stop_all_streams(hass, acc)
 
     expected_output = (
-        "-map 0:v:0 -an -c:v copy -tune zerolatency -pix_fmt yuv420p -r 30 -b:v 299k "
-        "-bufsize 1196k -maxrate 299k -payload_type 99 -ssrc {v_ssrc} -f rtp -srtp_out_suite "
-        "AES_CM_128_HMAC_SHA1_80 -srtp_out_params zdPmNLWeI86DtLJHvVLI6YPvqhVeeiLsNtrAgbgL "
-        "srtp://192.168.208.5:51246?rtcpport=51246&localrtpport=51246&pkt_size=1316 -map 0:a:0 "
-        "-vn -c:a copy -ac 1 -ar 24k -b:a 24k -bufsize 96k "
+        "-map 0:v:0 -an -c:v copy -tune zerolatency "
+        "-pix_fmt yuv420p -r 30 -b:v 299k -bufsize 1196k "
+        "-maxrate 299k -payload_type 99 -ssrc {v_ssrc} -f "
+        "rtp -srtp_out_suite AES_CM_128_HMAC_SHA1_80 "
+        "-srtp_out_params "
+        "zdPmNLWeI86DtLJHvVLI6YPvqhVeeiLsNtrAgbgL "
+        "srtp://192.168.208.5:51246"
+        "?rtcpport=51246&localrtpport=51246&pkt_size=1316 "
+        "-map 0:a:0 -vn -c:a copy -ac 1 -ar 24k "
+        "-b:a 24k -bufsize 96k "
         f"-payload_type 110 -ssrc {{a_ssrc}} -f rtp "
         f"rtp://127.0.0.1:{MOCK_AUDIO_PROXY_PORT}?pkt_size=188"
     )
@@ -619,7 +641,7 @@ async def test_camera_stream_source_configured_and_copy_codec(
 async def test_camera_stream_source_configured_and_override_profile_names(
     hass: HomeAssistant, run_driver
 ) -> None:
-    """Test a camera that can stream with a configured source over overridden profile names."""
+    """Test camera streaming with configured source and profile overrides."""
     await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
     await async_setup_component(
         hass, camera.DOMAIN, {camera.DOMAIN: {"platform": "demo"}}
@@ -672,11 +694,17 @@ async def test_camera_stream_source_configured_and_override_profile_names(
         await _async_stop_all_streams(hass, acc)
 
     expected_output = (
-        "-map 0:v:0 -an -c:v h264_v4l2m2m -profile:v 4 -tune zerolatency -pix_fmt yuv420p -r 30 -b:v 299k "
-        "-bufsize 1196k -maxrate 299k -payload_type 99 -ssrc {v_ssrc} -f rtp -srtp_out_suite "
-        "AES_CM_128_HMAC_SHA1_80 -srtp_out_params zdPmNLWeI86DtLJHvVLI6YPvqhVeeiLsNtrAgbgL "
-        "srtp://192.168.208.5:51246?rtcpport=51246&localrtpport=51246&pkt_size=1316 -map 0:a:0 "
-        "-vn -c:a copy -ac 1 -ar 24k -b:a 24k -bufsize 96k "
+        "-map 0:v:0 -an -c:v h264_v4l2m2m -profile:v 4 "
+        "-tune zerolatency -pix_fmt yuv420p -r 30 "
+        "-b:v 299k -bufsize 1196k -maxrate 299k "
+        "-payload_type 99 -ssrc {v_ssrc} -f rtp "
+        "-srtp_out_suite AES_CM_128_HMAC_SHA1_80 "
+        "-srtp_out_params "
+        "zdPmNLWeI86DtLJHvVLI6YPvqhVeeiLsNtrAgbgL "
+        "srtp://192.168.208.5:51246"
+        "?rtcpport=51246&localrtpport=51246&pkt_size=1316 "
+        "-map 0:a:0 -vn -c:a copy -ac 1 -ar 24k "
+        "-b:a 24k -bufsize 96k "
         f"-payload_type 110 -ssrc {{a_ssrc}} -f rtp "
         f"rtp://127.0.0.1:{MOCK_AUDIO_PROXY_PORT}?pkt_size=188"
     )
@@ -748,11 +776,17 @@ async def test_camera_streaming_fails_after_starting_ffmpeg(
         await _async_stop_all_streams(hass, acc)
 
     expected_output = (
-        "-map 0:v:0 -an -c:v h264_omx -profile:v high -tune zerolatency -pix_fmt yuv420p -r 30 -b:v 299k "
-        "-bufsize 1196k -maxrate 299k -payload_type 99 -ssrc {v_ssrc} -f rtp -srtp_out_suite "
-        "AES_CM_128_HMAC_SHA1_80 -srtp_out_params zdPmNLWeI86DtLJHvVLI6YPvqhVeeiLsNtrAgbgL "
-        "srtp://192.168.208.5:51246?rtcpport=51246&localrtpport=51246&pkt_size=1316 -map 0:a:0 "
-        "-vn -c:a copy -ac 1 -ar 24k -b:a 24k -bufsize 96k "
+        "-map 0:v:0 -an -c:v h264_omx -profile:v high "
+        "-tune zerolatency -pix_fmt yuv420p -r 30 "
+        "-b:v 299k -bufsize 1196k -maxrate 299k "
+        "-payload_type 99 -ssrc {v_ssrc} -f rtp "
+        "-srtp_out_suite AES_CM_128_HMAC_SHA1_80 "
+        "-srtp_out_params "
+        "zdPmNLWeI86DtLJHvVLI6YPvqhVeeiLsNtrAgbgL "
+        "srtp://192.168.208.5:51246"
+        "?rtcpport=51246&localrtpport=51246&pkt_size=1316 "
+        "-map 0:a:0 -vn -c:a copy -ac 1 -ar 24k "
+        "-b:a 24k -bufsize 96k "
         f"-payload_type 110 -ssrc {{a_ssrc}} -f rtp "
         f"rtp://127.0.0.1:{MOCK_AUDIO_PROXY_PORT}?pkt_size=188"
     )

--- a/tests/components/homekit/test_type_covers.py
+++ b/tests/components/homekit/test_type_covers.py
@@ -693,7 +693,7 @@ async def test_windowcovering_restore(
 async def test_garage_door_with_linked_obstruction_sensor(
     hass: HomeAssistant, hk_driver
 ) -> None:
-    """Test if accessory and HA are updated accordingly with a linked obstruction sensor."""
+    """Test accessory and HA update with linked obstruction sensor."""
     linked_obstruction_sensor_entity_id = "binary_sensor.obstruction"
     entity_id = "cover.garage_door"
 

--- a/tests/components/homekit/test_type_lights.py
+++ b/tests/components/homekit/test_type_lights.py
@@ -1398,7 +1398,7 @@ async def test_light_rgb_with_white_switch_to_temp(
     supported_color_modes,
     state_props,
 ) -> None:
-    """Test lights with RGBW/RGBWW that preserves brightness when switching to color temp."""
+    """Test RGBW/RGBWW lights preserve brightness on color temp switch."""
     entity_id = "light.demo"
 
     hass.states.async_set(

--- a/tests/components/homekit/test_type_switches.py
+++ b/tests/components/homekit/test_type_switches.py
@@ -889,7 +889,7 @@ async def test_valve_with_duration_characteristics(
 async def test_duration_characteristic_properties(
     hass: HomeAssistant, hk_driver, events: list[Event]
 ) -> None:
-    """Test SetDuration and RemainingDuration characteristic properties from linked entity attributes."""
+    """Test duration characteristic properties from linked attributes."""
     entity_id = "switch.sprinkler"
     linked_duration_entity = "input_number.valve_duration"
     linked_end_time_entity = "sensor.valve_end_time"
@@ -1038,7 +1038,7 @@ async def test_duration_characteristic_properties(
 async def test_remaining_duration_characteristic_fallback(
     hass: HomeAssistant, hk_driver, events: list[Event]
 ) -> None:
-    """Test remaining duration falls back to default run time only if valve is active."""
+    """Test remaining duration falls back to default only if valve active."""
     entity_id = "switch.sprinkler"
 
     hass.states.async_set(entity_id, STATE_OFF)
@@ -1067,7 +1067,8 @@ async def test_remaining_duration_characteristic_fallback(
     assert acc.char_in_use.value == 0
     assert acc.get_remaining_duration() == 0
 
-    # Case 2: Remaining duration should fall back to default duration when accessory is in use
+    # Case 2: Remaining duration should fall back to default duration when accessory is
+    # in use
     hass.states.async_set(entity_id, STATE_ON)
     await hass.async_block_till_done()
     assert acc.char_in_use.value == 1

--- a/tests/components/homekit/test_type_thermostats.py
+++ b/tests/components/homekit/test_type_thermostats.py
@@ -548,8 +548,8 @@ async def test_thermostat_auto(
     assert acc.char_cooling_thresh_temp.value == 25.0
     assert len(events) == 1
     assert (
-        events[-1].data[ATTR_VALUE]
-        == "CoolingThresholdTemperature to 25.0°C, HeatingThresholdTemperature to 20.0°C"
+        events[-1].data[ATTR_VALUE] == "CoolingThresholdTemperature to 25.0\u00b0C,"
+        " HeatingThresholdTemperature to 20.0\u00b0C"
     )
 
 
@@ -656,8 +656,9 @@ async def test_thermostat_mode_and_temp_change(
     assert len(events) == 2
     assert events[-2].data[ATTR_VALUE] == "TargetHeatingCoolingState to 3"
     assert (
-        events[-1].data[ATTR_VALUE]
-        == "TargetHeatingCoolingState to 3, CoolingThresholdTemperature to 25.0°C, HeatingThresholdTemperature to 20.0°C"
+        events[-1].data[ATTR_VALUE] == "TargetHeatingCoolingState to 3,"
+        " CoolingThresholdTemperature to 25.0\u00b0C,"
+        " HeatingThresholdTemperature to 20.0\u00b0C"
     )
 
 
@@ -729,7 +730,7 @@ async def test_thermostat_humidity(
 async def test_thermostat_humidity_with_target_humidity(
     hass: HomeAssistant, hk_driver
 ) -> None:
-    """Test if accessory and HA are updated accordingly with humidity without target hudmidity.
+    """Test accessory and HA updates with humidity without target.
 
     This test is for thermostats that do not support target humidity but
     have a current humidity sensor.
@@ -1287,7 +1288,7 @@ async def test_thermostat_hvac_modes_with_auto_only(
 async def test_thermostat_hvac_modes_with_heat_only(
     hass: HomeAssistant, hk_driver
 ) -> None:
-    """Test if unsupported HVAC modes are deactivated in HomeKit and siri calls get converted to heat."""
+    """Test unsupported HVAC modes deactivated, siri calls convert to heat."""
     entity_id = "climate.test"
 
     hass.states.async_set(
@@ -1367,7 +1368,7 @@ async def test_thermostat_hvac_modes_with_heat_only(
 async def test_thermostat_hvac_modes_with_cool_only(
     hass: HomeAssistant, hk_driver
 ) -> None:
-    """Test if unsupported HVAC modes are deactivated in HomeKit and siri calls get converted to cool."""
+    """Test unsupported HVAC modes deactivated, siri calls convert to cool."""
     entity_id = "climate.test"
 
     hass.states.async_set(
@@ -1422,7 +1423,7 @@ async def test_thermostat_hvac_modes_with_cool_only(
 async def test_thermostat_hvac_modes_with_heat_cool_only(
     hass: HomeAssistant, hk_driver
 ) -> None:
-    """Test if unsupported HVAC modes are deactivated in HomeKit and siri calls get converted to heat or cool."""
+    """Test unsupported HVAC modes deactivated, siri converts to heat/cool."""
     entity_id = "climate.test"
 
     hass.states.async_set(
@@ -2080,7 +2081,7 @@ async def test_thermostat_with_no_modes_when_we_first_see(
 async def test_thermostat_with_no_off_after_recheck(
     hass: HomeAssistant, hk_driver
 ) -> None:
-    """Test if a thermostat that is not ready when we first see it that actually does not have off."""
+    """Test thermostat without off mode discovered after recheck."""
     entity_id = "climate.test"
 
     base_attrs = {

--- a/tests/components/homekit/test_type_triggers.py
+++ b/tests/components/homekit/test_type_triggers.py
@@ -23,7 +23,7 @@ async def test_programmable_switch_button_fires_on_trigger(
     demo_cleanup,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test that DeviceTriggerAccessory fires the programmable switch event on trigger."""
+    """Test DeviceTriggerAccessory fires programmable switch event."""
     hk_driver.publish = MagicMock()
 
     demo_config_entry = MockConfigEntry(domain="domain")

--- a/tests/components/homekit/test_util.py
+++ b/tests/components/homekit/test_util.py
@@ -133,15 +133,19 @@ def test_validate_entity_config() -> None:
         {
             "switch.test": {
                 CONF_TYPE: "sprinkler",
-                CONF_LINKED_VALVE_DURATION: "number.valve_duration",  # Must be input_number entity
-                CONF_LINKED_VALVE_END_TIME: "datetime.valve_end_time",  # Must be sensor (timestamp) entity
+                # Must be input_number entity
+                CONF_LINKED_VALVE_DURATION: "number.valve_duration",
+                # Must be sensor (timestamp) entity
+                CONF_LINKED_VALVE_END_TIME: "datetime.valve_end_time",
             }
         },
         {"fan.test": {CONF_TYPE: "invalid_type"}},
         {
             "valve.test": {
-                CONF_LINKED_VALVE_END_TIME: "datetime.valve_end_time",  # Must be sensor (timestamp) entity
-                CONF_LINKED_VALVE_DURATION: "number.valve_duration",  # Must be input_number
+                # Must be sensor (timestamp) entity
+                CONF_LINKED_VALVE_END_TIME: "datetime.valve_end_time",
+                # Must be input_number
+                CONF_LINKED_VALVE_DURATION: "number.valve_duration",
             }
         },
         {

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -317,21 +317,26 @@ async def setup_test_component(
 async def assert_devices_and_entities_created(
     hass: HomeAssistant, expected: DeviceTestInfo
 ):
-    """Check that all expected devices and entities are loaded and enumerated as expected."""
+    """Check all expected devices and entities are loaded correctly."""
     entity_registry = er.async_get(hass)
     device_registry = dr.async_get(hass)
 
     async def _do_assertions(expected: DeviceTestInfo) -> dr.DeviceEntry:
         # Note: homekit_controller currently uses a 3-tuple for device identifiers
-        # The current standard is a 2-tuple (hkc was not migrated when this change was brought in)
+        # The current standard is a 2-tuple (hkc was not migrated when this change was
+        # brought in)
 
         # There are currently really 3 cases here:
-        # - We can match exactly one device by serial number. This won't work for devices like the Ryse.
+        # - We can match exactly one device by serial number. This won't work for
+        # devices like the Ryse.
         #   These have nlank or broken serial numbers.
-        # - The device unique id is "00:00:00:00:00:00" - this is the pairing id. This is only set for
+        # - The device unique id is "00:00:00:00:00:00" - this is the pairing id. This
+        # is only set for
         #   the root (bridge) device.
-        # - The device unique id is "00:00:00:00:00:00-X", where X is a HAP aid. This is only set when
-        #   we have detected broken serial numbers (and serial number is not used as an identifier).
+        # - The device unique id is "00:00:00:00:00:00-X", where X is a HAP aid. This is
+        # only set when
+        # we have detected broken serial numbers (and serial number is not used as an
+        # identifier).
 
         device = device_registry.async_get_device(
             identifiers={(IDENTIFIER_ACCESSORY_ID, expected.unique_id)}
@@ -347,7 +352,8 @@ async def assert_devices_and_entities_created(
         assert device.sw_version == expected.sw_version
 
         # We might have matched the device by one identifier only
-        # Lets check that the other one is correct. Otherwise the test might silently be wrong.
+        # Lets check that the other one is correct. Otherwise the test might silently be
+        # wrong.
         accessory_id_set = False
 
         for key, value in device.identifiers:
@@ -355,7 +361,8 @@ async def assert_devices_and_entities_created(
                 assert value == expected.unique_id
                 accessory_id_set = True
 
-        # If unique_id or serial is provided it MUST actually appear in the device registry entry.
+        # If unique_id or serial is provided it MUST actually appear in the device
+        # registry entry.
         assert (not expected.unique_id) ^ accessory_id_set
 
         for entity_info in expected.entities:

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -327,16 +327,15 @@ async def assert_devices_and_entities_created(
         # brought in)
 
         # There are currently really 3 cases here:
-        # - We can match exactly one device by serial number. This won't work for
-        # devices like the Ryse.
-        #   These have nlank or broken serial numbers.
-        # - The device unique id is "00:00:00:00:00:00" - this is the pairing id. This
-        # is only set for
+        # - We can match exactly one device by serial number. This won't
+        #   work for devices like the Ryse.
+        #   These have blank or broken serial numbers.
+        # - The device unique id is "00:00:00:00:00:00" - this is the pairing id.
+        #   This is only set for
         #   the root (bridge) device.
-        # - The device unique id is "00:00:00:00:00:00-X", where X is a HAP aid. This is
-        # only set when
-        # we have detected broken serial numbers (and serial number is not used as an
-        # identifier).
+        # - The device unique id is "00:00:00:00:00:00-X", where X is a HAP aid.
+        #   This is only set when we have detected broken serial numbers
+        #   (and serial number is not used as an identifier).
 
         device = device_registry.async_get_device(
             identifiers={(IDENTIFIER_ACCESSORY_ID, expected.unique_id)}

--- a/tests/components/homekit_controller/conftest.py
+++ b/tests/components/homekit_controller/conftest.py
@@ -29,7 +29,7 @@ def freeze_time_in_future() -> Generator[FrozenDateTimeFactory]:
 
 @pytest.fixture
 def controller() -> Generator[FakeController]:
-    """Replace aiohomekit.Controller with an instance of aiohomekit.testing.FakeController."""
+    """Replace aiohomekit.Controller with a FakeController instance."""
     instance = FakeController()
     with patch(
         "homeassistant.components.homekit_controller.utils.Controller",

--- a/tests/components/homekit_controller/test_button.py
+++ b/tests/components/homekit_controller/test_button.py
@@ -50,7 +50,8 @@ async def test_press_button(
         hass, get_next_aid(), create_switch_with_setup_button
     )
 
-    # Helper will be for the primary entity, which is the outlet. Make a helper for the button.
+    # Helper will be for the primary entity, which is the outlet. Make a helper for the
+    # button.
     button = Helper(
         hass,
         "button.testdevice_setup",
@@ -81,7 +82,8 @@ async def test_ecobee_clear_hold_press_button(
         hass, get_next_aid(), create_switch_with_ecobee_clear_hold_button
     )
 
-    # Helper will be for the primary entity, which is the outlet. Make a helper for the button.
+    # Helper will be for the primary entity, which is the outlet. Make a helper for the
+    # button.
     clear_hold = Helper(
         hass,
         "button.testdevice_clear_hold",

--- a/tests/components/homekit_controller/test_climate.py
+++ b/tests/components/homekit_controller/test_climate.py
@@ -306,7 +306,7 @@ async def test_climate_change_thermostat_temperature_range(
 async def test_climate_change_thermostat_temperature_range_iphone(
     hass: HomeAssistant, get_next_aid: Callable[[], int]
 ) -> None:
-    """Test that we can set all three set points at once (iPhone heat_cool mode support)."""
+    """Test setting all three set points at once (iPhone heat_cool)."""
     helper = await setup_test_component(hass, get_next_aid(), create_thermostat_service)
 
     await hass.services.async_call(
@@ -439,7 +439,7 @@ async def test_climate_check_min_max_values_per_mode_sspa_device(
 async def test_climate_set_thermostat_temp_on_sspa_device(
     hass: HomeAssistant, get_next_aid: Callable[[], int]
 ) -> None:
-    """Test setting temperature in different modes on device with single set point in auto."""
+    """Test setting temperature on device with single set point in auto."""
     helper = await setup_test_component(
         hass, get_next_aid(), create_thermostat_single_set_point_auto
     )
@@ -687,7 +687,9 @@ async def test_hvac_mode_vs_hvac_action(
         ServicesTypes.THERMOSTAT,
         {
             CharacteristicsTypes.FAN_STATE_CURRENT: CurrentFanStateValues.ACTIVE,
-            CharacteristicsTypes.HEATING_COOLING_CURRENT: HeatingCoolingCurrentValues.IDLE,
+            CharacteristicsTypes.HEATING_COOLING_CURRENT: (
+                HeatingCoolingCurrentValues.IDLE
+            ),
             CharacteristicsTypes.HEATING_COOLING_TARGET: HeatingCoolingTargetValues.OFF,
             CharacteristicsTypes.FAN_STATE_CURRENT: CurrentFanStateValues.ACTIVE,
         },
@@ -811,7 +813,9 @@ async def test_heater_cooler_change_thermostat_state(
     helper.async_assert_service_values(
         ServicesTypes.HEATER_COOLER,
         {
-            CharacteristicsTypes.TARGET_HEATER_COOLER_STATE: TargetHeaterCoolerStateValues.HEAT,
+            CharacteristicsTypes.TARGET_HEATER_COOLER_STATE: (
+                TargetHeaterCoolerStateValues.HEAT
+            ),
         },
     )
 
@@ -824,7 +828,9 @@ async def test_heater_cooler_change_thermostat_state(
     helper.async_assert_service_values(
         ServicesTypes.HEATER_COOLER,
         {
-            CharacteristicsTypes.TARGET_HEATER_COOLER_STATE: TargetHeaterCoolerStateValues.COOL,
+            CharacteristicsTypes.TARGET_HEATER_COOLER_STATE: (
+                TargetHeaterCoolerStateValues.COOL
+            ),
         },
     )
 
@@ -837,7 +843,9 @@ async def test_heater_cooler_change_thermostat_state(
     helper.async_assert_service_values(
         ServicesTypes.HEATER_COOLER,
         {
-            CharacteristicsTypes.TARGET_HEATER_COOLER_STATE: TargetHeaterCoolerStateValues.AUTOMATIC,
+            CharacteristicsTypes.TARGET_HEATER_COOLER_STATE: (
+                TargetHeaterCoolerStateValues.AUTOMATIC
+            ),
         },
     )
 
@@ -889,7 +897,9 @@ async def test_can_turn_on_after_off(
         ServicesTypes.HEATER_COOLER,
         {
             CharacteristicsTypes.ACTIVE: ActivationStateValues.ACTIVE,
-            CharacteristicsTypes.TARGET_HEATER_COOLER_STATE: TargetHeaterCoolerStateValues.HEAT,
+            CharacteristicsTypes.TARGET_HEATER_COOLER_STATE: (
+                TargetHeaterCoolerStateValues.HEAT
+            ),
         },
     )
 
@@ -1060,8 +1070,12 @@ async def test_heater_cooler_read_thermostat_state(
         {
             CharacteristicsTypes.TEMPERATURE_CURRENT: 19,
             CharacteristicsTypes.TEMPERATURE_COOLING_THRESHOLD: 21,
-            CharacteristicsTypes.CURRENT_HEATER_COOLER_STATE: CurrentHeaterCoolerStateValues.HEATING,
-            CharacteristicsTypes.TARGET_HEATER_COOLER_STATE: TargetHeaterCoolerStateValues.HEAT,
+            CharacteristicsTypes.CURRENT_HEATER_COOLER_STATE: (
+                CurrentHeaterCoolerStateValues.HEATING
+            ),
+            CharacteristicsTypes.TARGET_HEATER_COOLER_STATE: (
+                TargetHeaterCoolerStateValues.HEAT
+            ),
             CharacteristicsTypes.SWING_MODE: SwingModeValues.DISABLED,
         },
     )
@@ -1078,8 +1092,12 @@ async def test_heater_cooler_read_thermostat_state(
         {
             CharacteristicsTypes.TEMPERATURE_CURRENT: 21,
             CharacteristicsTypes.TEMPERATURE_COOLING_THRESHOLD: 19,
-            CharacteristicsTypes.CURRENT_HEATER_COOLER_STATE: CurrentHeaterCoolerStateValues.COOLING,
-            CharacteristicsTypes.TARGET_HEATER_COOLER_STATE: TargetHeaterCoolerStateValues.COOL,
+            CharacteristicsTypes.CURRENT_HEATER_COOLER_STATE: (
+                CurrentHeaterCoolerStateValues.COOLING
+            ),
+            CharacteristicsTypes.TARGET_HEATER_COOLER_STATE: (
+                TargetHeaterCoolerStateValues.COOL
+            ),
             CharacteristicsTypes.SWING_MODE: SwingModeValues.DISABLED,
         },
     )
@@ -1094,8 +1112,12 @@ async def test_heater_cooler_read_thermostat_state(
         {
             CharacteristicsTypes.TEMPERATURE_CURRENT: 21,
             CharacteristicsTypes.TEMPERATURE_COOLING_THRESHOLD: 21,
-            CharacteristicsTypes.CURRENT_HEATER_COOLER_STATE: CurrentHeaterCoolerStateValues.COOLING,
-            CharacteristicsTypes.TARGET_HEATER_COOLER_STATE: TargetHeaterCoolerStateValues.AUTOMATIC,
+            CharacteristicsTypes.CURRENT_HEATER_COOLER_STATE: (
+                CurrentHeaterCoolerStateValues.COOLING
+            ),
+            CharacteristicsTypes.TARGET_HEATER_COOLER_STATE: (
+                TargetHeaterCoolerStateValues.AUTOMATIC
+            ),
             CharacteristicsTypes.SWING_MODE: SwingModeValues.DISABLED,
         },
     )
@@ -1119,8 +1141,12 @@ async def test_heater_cooler_hvac_mode_vs_hvac_action(
         {
             CharacteristicsTypes.TEMPERATURE_CURRENT: 22,
             CharacteristicsTypes.TEMPERATURE_HEATING_THRESHOLD: 21,
-            CharacteristicsTypes.CURRENT_HEATER_COOLER_STATE: CurrentHeaterCoolerStateValues.IDLE,
-            CharacteristicsTypes.TARGET_HEATER_COOLER_STATE: TargetHeaterCoolerStateValues.HEAT,
+            CharacteristicsTypes.CURRENT_HEATER_COOLER_STATE: (
+                CurrentHeaterCoolerStateValues.IDLE
+            ),
+            CharacteristicsTypes.TARGET_HEATER_COOLER_STATE: (
+                TargetHeaterCoolerStateValues.HEAT
+            ),
             CharacteristicsTypes.SWING_MODE: SwingModeValues.DISABLED,
         },
     )
@@ -1136,8 +1162,12 @@ async def test_heater_cooler_hvac_mode_vs_hvac_action(
         {
             CharacteristicsTypes.TEMPERATURE_CURRENT: 19,
             CharacteristicsTypes.TEMPERATURE_HEATING_THRESHOLD: 21,
-            CharacteristicsTypes.CURRENT_HEATER_COOLER_STATE: CurrentHeaterCoolerStateValues.HEATING,
-            CharacteristicsTypes.TARGET_HEATER_COOLER_STATE: TargetHeaterCoolerStateValues.HEAT,
+            CharacteristicsTypes.CURRENT_HEATER_COOLER_STATE: (
+                CurrentHeaterCoolerStateValues.HEATING
+            ),
+            CharacteristicsTypes.TARGET_HEATER_COOLER_STATE: (
+                TargetHeaterCoolerStateValues.HEAT
+            ),
             CharacteristicsTypes.SWING_MODE: SwingModeValues.DISABLED,
         },
     )
@@ -1190,13 +1220,18 @@ async def test_heater_cooler_turn_off(
         hass, get_next_aid(), create_heater_cooler_service
     )
 
-    # Simulate that the device is turned off but CURRENT_HEATER_COOLER_STATE still returns HEATING/COOLING
+    # Simulate that the device is turned off but CURRENT_HEATER_COOLER_STATE still
+    # returns HEATING/COOLING
     await helper.async_update(
         ServicesTypes.HEATER_COOLER,
         {
             CharacteristicsTypes.ACTIVE: ActivationStateValues.INACTIVE,
-            CharacteristicsTypes.CURRENT_HEATER_COOLER_STATE: CurrentHeaterCoolerStateValues.HEATING,
-            CharacteristicsTypes.TARGET_HEATER_COOLER_STATE: TargetHeaterCoolerStateValues.HEAT,
+            CharacteristicsTypes.CURRENT_HEATER_COOLER_STATE: (
+                CurrentHeaterCoolerStateValues.HEATING
+            ),
+            CharacteristicsTypes.TARGET_HEATER_COOLER_STATE: (
+                TargetHeaterCoolerStateValues.HEAT
+            ),
         },
     )
 

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -158,7 +158,7 @@ def test_insecure_pairing_codes(pairing_code) -> None:
 
 @pytest.mark.parametrize("pairing_code", VALID_PAIRING_CODES)
 def test_valid_pairing_codes(pairing_code) -> None:
-    """Test ensure_pin_format corrects format for a valid pin in an alternative format."""
+    """Test ensure_pin_format corrects format for valid pin."""
     valid_pin = config_flow.ensure_pin_format(pairing_code).split("-")
     assert len(valid_pin) == 3
     assert len(valid_pin[0]) == 3
@@ -367,7 +367,7 @@ async def test_discovery_ignored_model(hass: HomeAssistant, controller) -> None:
 async def test_discovery_ignored_hk_bridge(
     hass: HomeAssistant, controller, device_registry: dr.DeviceRegistry
 ) -> None:
-    """Ensure we ignore homekit bridges and accessories created by the homekit integration."""
+    """Ensure we ignore bridges and accessories from the homekit integration."""
     device = setup_mock_accessory(controller)
     discovery_info = get_device_discovery_info(device)
 
@@ -420,7 +420,7 @@ async def test_discovery_does_not_ignore_non_homekit(
 
 
 async def test_discovery_broken_pairing_flag(hass: HomeAssistant, controller) -> None:
-    """There is already a config entry for the pairing and its pairing flag is wrong in zeroconf.
+    """Test handling existing pairing with wrong zeroconf pairing flag.
 
     We have seen this particular implementation error in 2 different devices.
     """
@@ -643,7 +643,8 @@ async def test_pair_try_later_errors_on_start(
         data=discovery_info,
     )
 
-    # User initiates pairing - device refuses to enter pairing mode but may be successful after entering pairing mode or rebooting
+    # User initiates pairing - device refuses to enter pairing mode but may be
+    # successful after entering pairing mode or rebooting
     test_exc = exception("error")
     with patch.object(device, "async_start_pairing", side_effect=test_exc):
         result2 = await hass.config_entries.flow.async_configure(result["flow_id"])
@@ -1014,7 +1015,7 @@ async def test_discovery_dismiss_existing_flow_on_paired(
 async def test_mdns_update_to_paired_during_pairing(
     hass: HomeAssistant, controller
 ) -> None:
-    """Test we do not abort pairing if mdns is updated to reflect paired during pairing."""
+    """Test we do not abort pairing if mdns reflects paired during pairing."""
     device = setup_mock_accessory(controller)
     discovery_info = get_device_discovery_info(device)
     discovery_info_paired = get_device_discovery_info(device, paired=True)

--- a/tests/components/homekit_controller/test_connection.py
+++ b/tests/components/homekit_controller/test_connection.py
@@ -43,7 +43,7 @@ from tests.common import MockConfigEntry
 
 @dataclasses.dataclass
 class DeviceMigrationTest:
-    """Holds the expected state before and after testing a device identifier migration."""
+    """Holds expected state before and after device identifier migration."""
 
     fixture: str
     manufacturer: str
@@ -52,7 +52,8 @@ class DeviceMigrationTest:
 
 
 DEVICE_MIGRATION_TESTS = [
-    # 0401.3521.0679 was incorrectly treated as a serial number, it should be stripped out during migration
+    # 0401.3521.0679 was incorrectly treated as a serial number, it should be stripped
+    # out during migration
     DeviceMigrationTest(
         fixture="ryse_smart_bridge_four_shades.json",
         manufacturer="RYSE Inc.",
@@ -61,7 +62,8 @@ DEVICE_MIGRATION_TESTS = [
         },
         after={(IDENTIFIER_ACCESSORY_ID, "00:00:00:00:00:00:aid:1")},
     ),
-    # This shade has a serial of 1.0.0, which we should already ignore. Make sure it gets migrated to a 2-tuple
+    # This shade has a serial of 1.0.0, which we should already ignore. Make sure it
+    # gets migrated to a 2-tuple
     DeviceMigrationTest(
         fixture="ryse_smart_bridge_four_shades.json",
         manufacturer="RYSE Inc.",
@@ -93,7 +95,8 @@ DEVICE_MIGRATION_TESTS = [
             (IDENTIFIER_ACCESSORY_ID, "00:00:00:00:00:00:aid:6623462389072572"),
         },
     ),
-    # Test migrating a Koogeek LS1. This is just for completeness (testing hub and hub-less devices)
+    # Test migrating a Koogeek LS1. This is just for completeness (testing hub and
+    # hub-less devices)
     DeviceMigrationTest(
         fixture="koogeek_ls1.json",
         manufacturer="Koogeek",
@@ -147,7 +150,7 @@ async def test_migrate_device_id_no_serial(
     device_registry: dr.DeviceRegistry,
     variant: DeviceMigrationTest,
 ) -> None:
-    """Test that a Ryse smart bridge with four shades can be migrated correctly in HA."""
+    """Test Ryse smart bridge with four shades can be migrated in HA."""
     accessories = await setup_accessories_from_file(hass, variant.fixture)
 
     fake_controller = await setup_platform(hass)
@@ -230,7 +233,9 @@ async def test_thread_provision_no_creds(hass: HomeAssistant) -> None:
             "button",
             "press",
             {
-                "entity_id": "button.nanoleaf_strip_3b32_provision_preferred_thread_credentials"
+                "entity_id": (
+                    "button.nanoleaf_strip_3b32_provision_preferred_thread_credentials"
+                )
             },
             blocking=True,
         )
@@ -289,7 +294,9 @@ async def test_thread_provision(
         "button",
         "press",
         {
-            "entity_id": "button.nanoleaf_strip_3b32_provision_preferred_thread_credentials"
+            "entity_id": (
+                "button.nanoleaf_strip_3b32_provision_preferred_thread_credentials"
+            )
         },
         blocking=True,
     )
@@ -306,7 +313,7 @@ async def test_thread_provision(
 
 
 async def test_thread_provision_migration_failed(hass: HomeAssistant) -> None:
-    """Test that when a device 'migrates' but doesn't show up in CoAP, we remain in BLE mode."""
+    """Test device remains in BLE mode when CoAP migration fails."""
     await async_add_dataset(
         hass,
         "Tests",
@@ -345,7 +352,9 @@ async def test_thread_provision_migration_failed(hass: HomeAssistant) -> None:
             "button",
             "press",
             {
-                "entity_id": "button.nanoleaf_strip_3b32_provision_preferred_thread_credentials"
+                "entity_id": (
+                    "button.nanoleaf_strip_3b32_provision_preferred_thread_credentials"
+                )
             },
             blocking=True,
         )
@@ -356,7 +365,7 @@ async def test_thread_provision_migration_failed(hass: HomeAssistant) -> None:
 async def test_poll_firmware_version_only_all_watchable_accessory_mode(
     hass: HomeAssistant, get_next_aid: Callable[[], int]
 ) -> None:
-    """Test that we only poll firmware if available and all chars are watchable accessory mode."""
+    """Test firmware poll only when all chars are watchable."""
 
     def _create_accessory(accessory: Accessory) -> Service:
         service = accessory.add_service(ServicesTypes.LIGHTBULB, name="TestDevice")
@@ -380,7 +389,8 @@ async def test_poll_firmware_version_only_all_watchable_accessory_mode(
         state = await helper.poll_and_get_state()
         assert state.state == STATE_OFF
         assert mock_get_characteristics.call_count == 2
-        # Verify everything is polled (convert to set for comparison since batching changes the type)
+        # Verify everything is polled (convert to set for comparison since batching
+        # changes the type)
         assert set(mock_get_characteristics.call_args_list[0][0][0]) == {
             (1, 10),
             (1, 11),
@@ -531,7 +541,8 @@ async def test_poll_all_on_startup_refreshes_stale_values(
         len(polled_chars) == 79
     )  # The Ecobee fixture has exactly 79 readable characteristics
 
-    # Check that the climate entity has the fresh temperature (22.5°C) not the stale fixture value (21.8°C)
+    # Check that the climate entity has the fresh temperature (22.5°C) not the stale
+    # fixture value (21.8°C)
     state = hass.states.get("climate.homew")
     assert state is not None
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 22.5
@@ -540,7 +551,7 @@ async def test_poll_all_on_startup_refreshes_stale_values(
 async def test_characteristic_polling_batching(
     hass: HomeAssistant, get_next_aid: Callable[[], int]
 ) -> None:
-    """Test that characteristic polling is batched to MAX_CHARACTERISTICS_PER_REQUEST."""
+    """Test characteristic polling is batched to max per request."""
 
     # Create a large accessory with many characteristics (more than 49)
     def create_large_accessory_with_many_chars(accessory: Accessory) -> None:
@@ -596,7 +607,8 @@ async def test_characteristic_polling_batching(
     # Check that no batch exceeded MAX_CHARACTERISTICS_PER_REQUEST
     for i, batch in enumerate(get_chars_calls):
         assert len(batch) <= MAX_CHARACTERISTICS_PER_REQUEST, (
-            f"Batch {i} size {len(batch)} exceeded maximum {MAX_CHARACTERISTICS_PER_REQUEST}"
+            f"Batch {i} size {len(batch)} exceeded maximum"
+            f" {MAX_CHARACTERISTICS_PER_REQUEST}"
         )
 
     # Verify the total number of characteristics polled
@@ -609,12 +621,14 @@ async def test_characteristic_polling_batching(
 
     # The first batch should be full (49 characteristics)
     assert len(get_chars_calls[0]) == 49, (
-        f"First batch should have exactly 49 characteristics, got {len(get_chars_calls[0])}"
+        "First batch should have exactly 49 characteristics,"
+        f" got {len(get_chars_calls[0])}"
     )
 
     # The second batch should have exactly 1 characteristic
     assert len(get_chars_calls[1]) == 1, (
-        f"Second batch should have exactly 1 characteristic, got {len(get_chars_calls[1])}"
+        "Second batch should have exactly 1 characteristic,"
+        f" got {len(get_chars_calls[1])}"
     )
 
 

--- a/tests/components/homekit_controller/test_init.py
+++ b/tests/components/homekit_controller/test_init.py
@@ -278,7 +278,7 @@ async def test_snapshots(
     snapshot: SnapshotAssertion,
     example: str,
 ) -> None:
-    """Detect regressions in enumerating a homekit accessory database and building entities."""
+    """Detect regressions in enumerating accessory DB and building entities."""
     accessories = await setup_accessories_from_file(hass, example)
     config_entry, _ = await setup_test_accessories(hass, accessories)
 

--- a/tests/components/homekit_controller/test_light.py
+++ b/tests/components/homekit_controller/test_light.py
@@ -452,7 +452,7 @@ async def test_only_migrate_once(
     entity_registry: er.EntityRegistry,
     get_next_aid: Callable[[], int],
 ) -> None:
-    """Test a we handle migration happening after an upgrade and than a downgrade and then an upgrade."""
+    """Test handling migration across upgrade/downgrade/upgrade cycle."""
     aid = get_next_aid()
     old_light_entry = entity_registry.async_get_or_create(
         "light",

--- a/tests/components/homekit_controller/test_media_player.py
+++ b/tests/components/homekit_controller/test_media_player.py
@@ -24,7 +24,8 @@ from .common import setup_test_component
 def create_tv_service(accessory: Accessory) -> Service:
     """Define tv characteristics.
 
-    The TV is not currently documented publicly - this is based on observing really TV's that have HomeKit support.
+    The TV is not currently documented publicly - this is based on observing really TV's
+    that have HomeKit support.
     """
     tv_service = accessory.add_service(ServicesTypes.TELEVISION)
 

--- a/tests/components/homekit_controller/test_number.py
+++ b/tests/components/homekit_controller/test_number.py
@@ -62,7 +62,8 @@ async def test_read_number(
         hass, get_next_aid(), create_switch_with_spray_level
     )
 
-    # Helper will be for the primary entity, which is the outlet. Make a helper for the sensor.
+    # Helper will be for the primary entity, which is the outlet. Make a helper for the
+    # sensor.
     spray_level = Helper(
         hass,
         "number.testdevice_spray_quantity",
@@ -92,7 +93,8 @@ async def test_write_number(
         hass, get_next_aid(), create_switch_with_spray_level
     )
 
-    # Helper will be for the primary entity, which is the outlet. Make a helper for the sensor.
+    # Helper will be for the primary entity, which is the outlet. Make a helper for the
+    # sensor.
     spray_level = Helper(
         hass,
         "number.testdevice_spray_quantity",

--- a/tests/components/homekit_controller/test_select.py
+++ b/tests/components/homekit_controller/test_select.py
@@ -66,7 +66,8 @@ async def test_read_current_mode(
         hass, get_next_aid(), create_service_with_ecobee_mode
     )
 
-    # Helper will be for the primary entity, which is the service. Make a helper for the sensor.
+    # Helper will be for the primary entity, which is the service. Make a helper for the
+    # sensor.
     ecobee_mode = Helper(
         hass,
         "select.testdevice_current_mode",
@@ -109,7 +110,8 @@ async def test_write_current_mode(
     )
     helper.accessory.services.first(service_type=ServicesTypes.THERMOSTAT)
 
-    # Helper will be for the primary entity, which is the service. Make a helper for the sensor.
+    # Helper will be for the primary entity, which is the service. Make a helper for the
+    # sensor.
     current_mode = Helper(
         hass,
         "select.testdevice_current_mode",
@@ -160,7 +162,8 @@ async def test_read_select(
         hass, get_next_aid(), create_service_with_temperature_units
     )
 
-    # Helper will be for the primary entity, which is the service. Make a helper for the sensor.
+    # Helper will be for the primary entity, which is the service. Make a helper for the
+    # sensor.
     select_entity = Helper(
         hass,
         "select.testdevice_temperature_display_units",
@@ -195,7 +198,8 @@ async def test_write_select(
     )
     helper.accessory.services.first(service_type=ServicesTypes.THERMOSTAT)
 
-    # Helper will be for the primary entity, which is the service. Make a helper for the sensor.
+    # Helper will be for the primary entity, which is the service. Make a helper for the
+    # sensor.
     current_mode = Helper(
         hass,
         "select.testdevice_temperature_display_units",

--- a/tests/components/homekit_controller/test_sensor.py
+++ b/tests/components/homekit_controller/test_sensor.py
@@ -114,7 +114,7 @@ async def test_temperature_sensor_read_state(
 async def test_temperature_sensor_not_added_twice(
     hass: HomeAssistant, get_next_aid: Callable[[], int]
 ) -> None:
-    """A standalone temperature sensor should not get a characteristic AND a service entity."""
+    """Test standalone temperature sensor gets only one entity."""
     helper = await setup_test_component(
         hass, get_next_aid(), create_temperature_sensor_service, suffix="temperature"
     )
@@ -351,7 +351,8 @@ async def test_switch_with_sensor(
     """Test a switch service that has a sensor characteristic is correctly handled."""
     helper = await setup_test_component(hass, get_next_aid(), create_switch_with_sensor)
 
-    # Helper will be for the primary entity, which is the outlet. Make a helper for the sensor.
+    # Helper will be for the primary entity, which is the outlet. Make a helper for the
+    # sensor.
     energy_helper = Helper(
         hass,
         "sensor.testdevice_power",
@@ -387,7 +388,8 @@ async def test_sensor_unavailable(
     on_char = outlet[CharacteristicsTypes.ON]
     realtime_energy = outlet[CharacteristicsTypes.VENDOR_KOOGEEK_REALTIME_ENERGY]
 
-    # Helper will be for the primary entity, which is the outlet. Make a helper for the sensor.
+    # Helper will be for the primary entity, which is the outlet. Make a helper for the
+    # sensor.
     energy_helper = Helper(
         hass,
         "sensor.testdevice_power",

--- a/tests/components/homematicip_cloud/helper.py
+++ b/tests/components/homematicip_cloud/helper.py
@@ -77,7 +77,9 @@ async def async_manipulate_test_data(
                 None,
             )
             assert functional_channel is not None, (
-                f"No functional channel with index {channel_real_index} found in hmip_device.functionalChannels"
+                f"No functional channel with index"
+                f" {channel_real_index} found in"
+                " hmip_device.functionalChannels"
             )
         else:
             functional_channel = channels[channel]

--- a/tests/components/homematicip_cloud/test_helpers.py
+++ b/tests/components/homematicip_cloud/test_helpers.py
@@ -12,7 +12,8 @@ async def test_is_error_response() -> None:
     assert not is_error_response("")
     assert is_error_response(
         json.loads(
-            '{"errorCode": "INVALID_NUMBER_PARAMETER_VALUE", "minValue": 0.0, "maxValue": 1.01}'
+            '{"errorCode": "INVALID_NUMBER_PARAMETER_VALUE",'
+            ' "minValue": 0.0, "maxValue": 1.01}'
         )
     )
     assert not is_error_response(json.loads('{"errorCode": ""}'))

--- a/tests/components/homematicip_cloud/test_sensor.py
+++ b/tests/components/homematicip_cloud/test_sensor.py
@@ -518,7 +518,7 @@ async def test_hmip_passage_detector_delta_counter(
 async def test_hmip_floor_terminal_block_mechanic_channel_1_valve_position(
     hass: HomeAssistant, default_mock_hap_factory: HomematicipHAP
 ) -> None:
-    """Test HomematicipFloorTerminalBlockMechanicChannelValve Channel 1 HmIP-FALMOT-C12."""
+    """Test FloorTerminalBlockMechanicChannelValve Ch 1 FALMOT-C12."""
     entity_id = "sensor.fussbodenheizungsaktor_heizkreislauf_1_og_bad_r"
     entity_name = "Fußbodenheizungsaktor Heizkreislauf (1) OG Bad r"
     device_model = "HmIP-FALMOT-C12"

--- a/tests/components/homevolt/test_config_flow.py
+++ b/tests/components/homevolt/test_config_flow.py
@@ -367,7 +367,7 @@ async def test_zeroconf_confirm_with_password_success(
     mock_homevolt_client: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test zeroconf confirm collects password and creates entry when auth is required."""
+    """Test zeroconf confirm collects password when auth is required."""
 
     mock_homevolt_client.update_info.side_effect = HomevoltAuthenticationError
 

--- a/tests/components/homevolt/test_switch.py
+++ b/tests/components/homevolt/test_switch.py
@@ -63,7 +63,7 @@ async def test_switch_turn_on_off(
     service: str,
     client_method_name: str,
 ) -> None:
-    """Test turning the switch on or off calls client, refreshes coordinator, and updates state."""
+    """Test switch on/off calls client and updates state."""
     client_method = getattr(mock_homevolt_client, client_method_name)
 
     async def update_local_mode(*args: object, **kwargs: object) -> None:

--- a/tests/components/homewizard/test_config_flow.py
+++ b/tests/components/homewizard/test_config_flow.py
@@ -626,7 +626,7 @@ async def test_manual_flow_works_with_v2_api_support(
     mock_homewizardenergy_v2: MagicMock,
     mock_setup_entry: AsyncMock,
 ) -> None:
-    """Test config flow accepts user configuration and triggers authorization when detected v2 support."""
+    """Test config flow triggers authorization on v2 support detection."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -666,7 +666,7 @@ async def test_manual_flow_detects_failed_user_authorization(
     mock_homewizardenergy_v2: MagicMock,
     mock_setup_entry: AsyncMock,
 ) -> None:
-    """Test config flow accepts user configuration and detects failed button press by user."""
+    """Test config flow detects failed button press by user."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/homewizard/test_init.py
+++ b/tests/components/homewizard/test_init.py
@@ -156,7 +156,7 @@ async def test_load_creates_repair_issue_when_name_is_updated(
     mock_config_entry: MockConfigEntry,
     mock_homewizardenergy: MagicMock,
 ) -> None:
-    """Test setup creates repair issue for v2 API upgrade and updates title when device name changes."""
+    """Test repair issue for v2 API and title update on name change."""
     mock_config_entry.add_to_hass(hass)
     await hass.async_block_till_done()
 

--- a/tests/components/homewizard/test_select.py
+++ b/tests/components/homewizard/test_select.py
@@ -181,7 +181,11 @@ async def test_select_unauthorized_error(
     mock_homewizardenergy.batteries.side_effect = UnauthorizedError
     with pytest.raises(
         HomeAssistantError,
-        match=r"^The local API is unauthorized\. Restore API access by following the instructions in the repair issue$",
+        match=(
+            r"^The local API is unauthorized\. Restore API"
+            r" access by following the instructions in the"
+            r" repair issue$"
+        ),
     ):
         await hass.services.async_call(
             SELECT_DOMAIN,

--- a/tests/components/homewizard/test_sensor.py
+++ b/tests/components/homewizard/test_sensor.py
@@ -938,7 +938,7 @@ async def test_uptime_sensor_does_not_update_timestamp_on_data_update(
     hass: HomeAssistant,
     mock_homewizardenergy: MagicMock,
 ) -> None:
-    """Test that the uptime sensor does not update its timestamp when refreshing data."""
+    """Test uptime sensor does not update its timestamp when refreshing."""
     entity_id = "sensor.device_uptime"
 
     mock_homewizardenergy.combined.return_value = CombinedModels(

--- a/tests/components/honeywell/test_climate.py
+++ b/tests/components/honeywell/test_climate.py
@@ -58,7 +58,7 @@ FAN_ACTION = "fan_action"
 async def test_no_thermostat_options(
     hass: HomeAssistant, device: MagicMock, config_entry: MagicMock
 ) -> None:
-    """Test the setup of the climate entities when there are no additional options available."""
+    """Test climate entity setup without additional options."""
     device._data = {}
     await init_integration(hass, config_entry)
     assert hass.states.get("climate.device1")
@@ -1105,7 +1105,8 @@ async def test_async_update_errors(
     state = hass.states.get(entity_id)
     assert state.state == "off"
 
-    # Due to server instability, only mark entity unavailable after RETRY update attempts
+    # Due to server instability, only mark entity unavailable after RETRY update
+    # attempts
     for _ in range(RETRY):
         async_fire_time_changed(
             hass,
@@ -1172,7 +1173,8 @@ async def test_async_update_errors(
 
     device.refresh.side_effect = ClientConnectionError
 
-    # Due to server instability, only mark entity unavailable after RETRY update attempts
+    # Due to server instability, only mark entity unavailable after RETRY update
+    # attempts
     for _ in range(RETRY):
         async_fire_time_changed(
             hass,

--- a/tests/components/honeywell/test_humidity.py
+++ b/tests/components/honeywell/test_humidity.py
@@ -19,7 +19,7 @@ from . import init_integration
 async def test_humidifier_service_calls(
     hass: HomeAssistant, device: MagicMock, config_entry: MagicMock
 ) -> None:
-    """Test the setup of the climate entities when there are no additional options available."""
+    """Test humidity entity setup without additional options."""
     device.has_humidifier = True
     await init_integration(hass, config_entry)
     entity_id = f"humidifier.{device.name}_humidifier"
@@ -53,7 +53,7 @@ async def test_humidifier_service_calls(
 async def test_dehumidifier_service_calls(
     hass: HomeAssistant, device: MagicMock, config_entry: MagicMock
 ) -> None:
-    """Test the setup of the climate entities when there are no additional options available."""
+    """Test humidity entity setup without additional options."""
     device.has_dehumidifier = True
     await init_integration(hass, config_entry)
     entity_id = f"humidifier.{device.name}_dehumidifier"

--- a/tests/components/html5/conftest.py
+++ b/tests/components/html5/conftest.py
@@ -20,7 +20,10 @@ MOCK_CONF = {
     ATTR_VAPID_EMAIL: "test@example.com",
     ATTR_VAPID_PRV_KEY: "h6acSRds8_KR8hT9djD8WucTL06Gfe29XXyZ1KcUjN8",
 }
-MOCK_CONF_PUB_KEY = "BIUtPN7Rq_8U7RBEqClZrfZ5dR9zPCfvxYPtLpWtRVZTJEc7lzv2dhzDU6Aw1m29Ao0-UA1Uq6XO9Df8KALBKqA"
+MOCK_CONF_PUB_KEY = (
+    "BIUtPN7Rq_8U7RBEqClZrfZ5dR9zPCfvxYPtLpWtRVZTJEc7lzv2dhzDU6Aw1m29"
+    "Ao0-UA1Uq6XO9Df8KALBKqA"
+)
 
 
 @pytest.fixture(name="config_entry")

--- a/tests/components/html5/test_notify.py
+++ b/tests/components/html5/test_notify.py
@@ -155,7 +155,10 @@ async def test_dismissing_message(mock_wp: AsyncMock, hass: HomeAssistant) -> No
     await service.async_dismiss(target=["device", "non_existing"], data={"tag": "test"})
 
     mock_wp.send_async.assert_awaited_once_with(
-        data='{"tag": "test", "dismiss": true, "data": {"jwt": "JWT"}, "timestamp": 1234567890000}',
+        data=(
+            '{"tag": "test", "dismiss": true,'
+            ' "data": {"jwt": "JWT"}, "timestamp": 1234567890000}'
+        ),
         headers=VAPID_HEADERS,
         ttl=86400,
     )
@@ -181,7 +184,15 @@ async def test_sending_message(mock_wp: AsyncMock, hass: HomeAssistant) -> None:
     )
 
     mock_wp.send_async.assert_awaited_once_with(
-        data='{"badge": "/static/images/notification-badge.png", "body": "Hello", "data": {"url": "/", "jwt": "JWT"}, "icon": "beer.png", "tag": "12345678-1234-5678-1234-567812345678", "title": "Home Assistant", "timestamp": 1234567890000}',
+        data=(
+            '{"badge": "/static/images/notification-badge.png",'
+            ' "body": "Hello",'
+            ' "data": {"url": "/", "jwt": "JWT"},'
+            ' "icon": "beer.png",'
+            ' "tag": "12345678-1234-5678-1234-567812345678",'
+            ' "title": "Home Assistant",'
+            ' "timestamp": 1234567890000}'
+        ),
         headers=VAPID_HEADERS,
         ttl=86400,
     )
@@ -208,7 +219,15 @@ async def test_fcm_key_include(mock_wp: AsyncMock, hass: HomeAssistant) -> None:
     await service.async_send_message("Hello", target=["chrome"])
 
     mock_wp.send_async.assert_awaited_once_with(
-        data='{"badge": "/static/images/notification-badge.png", "body": "Hello", "data": {"url": "/", "jwt": "JWT"}, "icon": "/static/icons/favicon-192x192.png", "tag": "12345678-1234-5678-1234-567812345678", "title": "Home Assistant", "timestamp": 1234567890000}',
+        data=(
+            '{"badge": "/static/images/notification-badge.png",'
+            ' "body": "Hello",'
+            ' "data": {"url": "/", "jwt": "JWT"},'
+            ' "icon": "/static/icons/favicon-192x192.png",'
+            ' "tag": "12345678-1234-5678-1234-567812345678",'
+            ' "title": "Home Assistant",'
+            ' "timestamp": 1234567890000}'
+        ),
         headers=VAPID_HEADERS,
         ttl=86400,
     )
@@ -237,7 +256,15 @@ async def test_fcm_send_with_unknown_priority(
     await service.async_send_message("Hello", target=["chrome"], priority="undefined")
 
     mock_wp.send_async.assert_awaited_once_with(
-        data='{"badge": "/static/images/notification-badge.png", "body": "Hello", "data": {"url": "/", "jwt": "JWT"}, "icon": "/static/icons/favicon-192x192.png", "tag": "12345678-1234-5678-1234-567812345678", "title": "Home Assistant", "timestamp": 1234567890000}',
+        data=(
+            '{"badge": "/static/images/notification-badge.png",'
+            ' "body": "Hello",'
+            ' "data": {"url": "/", "jwt": "JWT"},'
+            ' "icon": "/static/icons/favicon-192x192.png",'
+            ' "tag": "12345678-1234-5678-1234-567812345678",'
+            ' "title": "Home Assistant",'
+            ' "timestamp": 1234567890000}'
+        ),
         headers=VAPID_HEADERS,
         ttl=86400,
     )
@@ -263,7 +290,15 @@ async def test_fcm_no_targets(mock_wp: AsyncMock, hass: HomeAssistant) -> None:
     await service.async_send_message("Hello")
 
     mock_wp.send_async.assert_awaited_once_with(
-        data='{"badge": "/static/images/notification-badge.png", "body": "Hello", "data": {"url": "/", "jwt": "JWT"}, "icon": "/static/icons/favicon-192x192.png", "tag": "12345678-1234-5678-1234-567812345678", "title": "Home Assistant", "timestamp": 1234567890000}',
+        data=(
+            '{"badge": "/static/images/notification-badge.png",'
+            ' "body": "Hello",'
+            ' "data": {"url": "/", "jwt": "JWT"},'
+            ' "icon": "/static/icons/favicon-192x192.png",'
+            ' "tag": "12345678-1234-5678-1234-567812345678",'
+            ' "title": "Home Assistant",'
+            ' "timestamp": 1234567890000}'
+        ),
         headers=VAPID_HEADERS,
         ttl=86400,
     )
@@ -289,7 +324,15 @@ async def test_fcm_additional_data(mock_wp: AsyncMock, hass: HomeAssistant) -> N
     await service.async_send_message("Hello", data={"mykey": "myvalue"})
 
     mock_wp.send_async.assert_awaited_once_with(
-        data='{"badge": "/static/images/notification-badge.png", "body": "Hello", "data": {"mykey": "myvalue", "url": "/", "jwt": "JWT"}, "icon": "/static/icons/favicon-192x192.png", "tag": "12345678-1234-5678-1234-567812345678", "title": "Home Assistant", "timestamp": 1234567890000}',
+        data=(
+            '{"badge": "/static/images/notification-badge.png",'
+            ' "body": "Hello",'
+            ' "data": {"mykey": "myvalue", "url": "/", "jwt": "JWT"},'
+            ' "icon": "/static/icons/favicon-192x192.png",'
+            ' "tag": "12345678-1234-5678-1234-567812345678",'
+            ' "title": "Home Assistant",'
+            ' "timestamp": 1234567890000}'
+        ),
         headers=VAPID_HEADERS,
         ttl=86400,
     )
@@ -665,7 +708,15 @@ async def test_callback_view_with_jwt(
     )
 
     mock_wp.send_async.assert_awaited_once_with(
-        data='{"badge": "/static/images/notification-badge.png", "body": "Hello", "data": {"url": "/", "jwt": "JWT"}, "icon": "beer.png", "tag": "12345678-1234-5678-1234-567812345678", "title": "Home Assistant", "timestamp": 1234567890000}',
+        data=(
+            '{"badge": "/static/images/notification-badge.png",'
+            ' "body": "Hello",'
+            ' "data": {"url": "/", "jwt": "JWT"},'
+            ' "icon": "beer.png",'
+            ' "tag": "12345678-1234-5678-1234-567812345678",'
+            ' "title": "Home Assistant",'
+            ' "timestamp": 1234567890000}'
+        ),
         headers=VAPID_HEADERS,
         ttl=86400,
     )
@@ -709,7 +760,15 @@ async def test_send_fcm_without_targets(
     )
 
     mock_wp.send_async.assert_awaited_once_with(
-        data='{"badge": "/static/images/notification-badge.png", "body": "Hello", "data": {"url": "/", "jwt": "JWT"}, "icon": "beer.png", "tag": "12345678-1234-5678-1234-567812345678", "title": "Home Assistant", "timestamp": 1234567890000}',
+        data=(
+            '{"badge": "/static/images/notification-badge.png",'
+            ' "body": "Hello",'
+            ' "data": {"url": "/", "jwt": "JWT"},'
+            ' "icon": "beer.png",'
+            ' "tag": "12345678-1234-5678-1234-567812345678",'
+            ' "title": "Home Assistant",'
+            ' "timestamp": 1234567890000}'
+        ),
         headers=VAPID_HEADERS,
         ttl=86400,
     )

--- a/tests/components/http/test_ban.py
+++ b/tests/components/http/test_ban.py
@@ -148,7 +148,8 @@ async def test_access_from_banned_ip_with_invalid_ip_entry(
     manager = app[KEY_BAN_MANAGER]
     assert len(manager.ip_bans_lookup) == len(BANNED_IPS)
 
-    # Valid banned IPs should still be blocked (even though they came after invalid ones)
+    # Valid banned IPs should still be blocked (even though they came after invalid
+    # ones)
     for remote_addr in BANNED_IPS:
         set_real_ip(remote_addr)
         resp = await client.get("/")
@@ -373,12 +374,15 @@ async def test_ip_bans_file_creation(
         assert len(notifications) == 2
         assert (
             notifications["http-login"]["message"]
-            == "Login attempt or request with invalid authentication from example.com (200.201.202.204). See the log for details."
+            == "Login attempt or request with invalid authentication"
+            " from example.com (200.201.202.204)."
+            " See the log for details."
         )
 
         assert (
-            "Login attempt or request with invalid authentication from example.com (200.201.202.204). Requested URL: '/example'."
-            in caplog.text
+            "Login attempt or request with invalid authentication"
+            " from example.com (200.201.202.204)."
+            " Requested URL: '/example'." in caplog.text
         )
 
 

--- a/tests/components/http/test_forwarded.py
+++ b/tests/components/http/test_forwarded.py
@@ -486,8 +486,8 @@ async def test_x_forwarded_proto_incorrect_number_of_elements(
 
     assert resp.status == HTTPStatus.BAD_REQUEST
     assert (
-        f"Incorrect number of elements in X-Forward-Proto. Expected 1 or {expected}, got {got}"
-        in caplog.text
+        "Incorrect number of elements in X-Forward-Proto."
+        f" Expected 1 or {expected}, got {got}" in caplog.text
     )
 
 

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -317,7 +317,7 @@ async def test_peer_cert(hass: HomeAssistant, tmp_path: Path) -> None:
 async def test_emergency_ssl_certificate_when_invalid(
     hass: HomeAssistant, tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test http can startup with an emergency self signed cert when the current one is broken."""
+    """Test http starts with emergency self-signed cert on invalid cert."""
 
     cert_path, key_path = await hass.async_add_executor_job(
         _setup_broken_ssl_pem_files, tmp_path
@@ -338,8 +338,9 @@ async def test_emergency_ssl_certificate_when_invalid(
     await hass.async_start()
     await hass.async_block_till_done()
     assert (
-        "Home Assistant is running in recovery mode with an emergency self signed ssl certificate because the configured SSL certificate was not usable"
-        in caplog.text
+        "Home Assistant is running in recovery mode with an emergency"
+        " self signed ssl certificate because the configured SSL"
+        " certificate was not usable" in caplog.text
     )
 
     assert hass.http.site is not None
@@ -365,7 +366,7 @@ async def test_emergency_ssl_certificate_not_used_when_not_recovery_mode(
 async def test_emergency_ssl_certificate_when_invalid_get_url_fails(
     hass: HomeAssistant, tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test http falls back to no ssl when an emergency cert cannot be created when the configured one is broken.
+    """Test http falls back to no ssl when emergency cert creation fails.
 
     Ensure we can still start of we cannot determine the external url as well.
     """
@@ -392,8 +393,9 @@ async def test_emergency_ssl_certificate_when_invalid_get_url_fails(
 
     assert len(mock_get_url.mock_calls) == 1
     assert (
-        "Home Assistant is running in recovery mode with an emergency self signed ssl certificate because the configured SSL certificate was not usable"
-        in caplog.text
+        "Home Assistant is running in recovery mode with an emergency"
+        " self signed ssl certificate because the configured SSL"
+        " certificate was not usable" in caplog.text
     )
 
     assert hass.http.site is not None
@@ -402,7 +404,7 @@ async def test_emergency_ssl_certificate_when_invalid_get_url_fails(
 async def test_invalid_ssl_and_cannot_create_emergency_cert(
     hass: HomeAssistant, tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test http falls back to no ssl when an emergency cert cannot be created when the configured one is broken."""
+    """Test http falls back to no ssl on emergency cert creation failure."""
 
     cert_path, key_path = await hass.async_add_executor_job(
         _setup_broken_ssl_pem_files, tmp_path
@@ -433,7 +435,7 @@ async def test_invalid_ssl_and_cannot_create_emergency_cert(
 async def test_invalid_ssl_and_cannot_create_emergency_cert_with_ssl_peer_cert(
     hass: HomeAssistant, tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test http falls back to no ssl when an emergency cert cannot be created when the configured one is broken.
+    """Test no-ssl fallback with peer cert when emergency cert fails.
 
     When there is a peer cert verification and we cannot create
     an emergency cert (probably will never happen since this means

--- a/tests/components/http/test_view.py
+++ b/tests/components/http/test_view.py
@@ -41,8 +41,8 @@ async def test_invalid_json(caplog: pytest.LogCaptureFixture) -> None:
         HomeAssistantView.json({"hello": Decimal("2.0")})
 
     assert (
-        "Unable to serialize to JSON. Bad data found at $.hello=2.0(<class 'decimal.Decimal'>"
-        in caplog.text
+        "Unable to serialize to JSON. Bad data found at"
+        " $.hello=2.0(<class 'decimal.Decimal'>" in caplog.text
     )
 
 
@@ -128,7 +128,7 @@ async def test_requires_auth_includes_www_authenticate(
 async def test_requires_auth_omits_www_authenticate_without_url(
     mock_request: Mock,
 ) -> None:
-    """Test that 401 responses omit WWW-Authenticate header when no URL is configured."""
+    """Test 401 responses omit WWW-Authenticate when no URL configured."""
     mock_request.get = Mock(return_value=False)
     with (
         patch(

--- a/tests/components/huawei_lte/test_config_flow.py
+++ b/tests/components/huawei_lte/test_config_flow.py
@@ -181,35 +181,55 @@ def login_requests_mock(requests_mock: requests_mock.Mocker) -> requests_mock.Mo
     [
         (
             {
-                "text": f"<error><code>{LoginErrorEnum.USERNAME_WRONG}</code><message/></error>",
+                "text": (
+                    "<error><code>"
+                    f"{LoginErrorEnum.USERNAME_WRONG}"
+                    "</code><message/></error>"
+                ),
             },
             {},
             {CONF_USERNAME: "incorrect_username"},
         ),
         (
             {
-                "text": f"<error><code>{LoginErrorEnum.PASSWORD_WRONG}</code><message/></error>",
+                "text": (
+                    "<error><code>"
+                    f"{LoginErrorEnum.PASSWORD_WRONG}"
+                    "</code><message/></error>"
+                ),
             },
             {},
             {CONF_PASSWORD: "incorrect_password"},
         ),
         (
             {
-                "text": f"<error><code>{LoginErrorEnum.USERNAME_PWD_WRONG}</code><message/></error>",
+                "text": (
+                    "<error><code>"
+                    f"{LoginErrorEnum.USERNAME_PWD_WRONG}"
+                    "</code><message/></error>"
+                ),
             },
             {},
             {CONF_USERNAME: "invalid_auth"},
         ),
         (
             {
-                "text": f"<error><code>{LoginErrorEnum.USERNAME_PWD_OVERRUN}</code><message/></error>",
+                "text": (
+                    "<error><code>"
+                    f"{LoginErrorEnum.USERNAME_PWD_OVERRUN}"
+                    "</code><message/></error>"
+                ),
             },
             {},
             {"base": "login_attempts_exceeded"},
         ),
         (
             {
-                "text": f"<error><code>{ResponseCodeEnum.ERROR_SYSTEM_UNKNOWN}</code><message/></error>",
+                "text": (
+                    "<error><code>"
+                    f"{ResponseCodeEnum.ERROR_SYSTEM_UNKNOWN}"
+                    "</code><message/></error>"
+                ),
             },
             {},
             {"base": "response_error"},
@@ -343,7 +363,9 @@ async def test_ssdp(
         ssdp_st="upnp:rootdevice",
         ssdp_location=f"{url}:60957/rootDesc.xml",
         upnp={
-            ATTR_UPNP_DEVICE_TYPE: "urn:schemas-upnp-org:device:InternetGatewayDevice:1",
+            ATTR_UPNP_DEVICE_TYPE: (
+                "urn:schemas-upnp-org:device:InternetGatewayDevice:1"
+            ),
             ATTR_UPNP_MANUFACTURER: "Huawei",
             ATTR_UPNP_MANUFACTURER_URL: "http://www.huawei.com/",
             ATTR_UPNP_MODEL_NAME: "Huawei router",

--- a/tests/components/hue/test_binary_sensor.py
+++ b/tests/components/hue/test_binary_sensor.py
@@ -123,7 +123,8 @@ async def test_binary_sensor_add_update(
     test_entity = hass.states.get(test_entity_id)
     assert test_entity is not None
     assert test_entity.state == "on"
-    # NEW: prefer motion_report.motion when present (should turn on even if plain motion is False)
+    # NEW: prefer motion_report.motion when present (should turn on even if plain motion
+    # is False)
     updated_sensor = {
         **FAKE_BINARY_SENSOR,
         "motion": {

--- a/tests/components/hue/test_light_v2.py
+++ b/tests/components/hue/test_light_v2.py
@@ -372,7 +372,8 @@ async def test_light_added(hass: HomeAssistant, mock_bridge_v2: Mock) -> None:
     # verify entity does not exist before we start
     assert hass.states.get(test_entity_id) is None
 
-    # Add new fake entity (and attached device and zigbee_connectivity) by emitting events
+    # Add new fake entity (and attached device and zigbee_connectivity) by emitting
+    # events
     mock_bridge_v2.api.emit_event("add", FAKE_LIGHT)
     await hass.async_block_till_done()
 
@@ -531,7 +532,8 @@ async def test_grouped_lights(
     # While we have a group on, test the color aggregation logic, XY first
 
     # Turn off one of the bulbs in the group
-    # "hue_light_with_color_and_color_temperature_1" corresponds to "02cba059-9c2c-4d45-97e4-4f79b1bfbaa1"
+    # "hue_light_with_color_and_color_temperature_1" corresponds to
+    # "02cba059-9c2c-4d45-97e4-4f79b1bfbaa1"
     mock_bridge_v2.mock_requests.clear()
     single_light_id = "light.hue_light_with_color_and_color_temperature_1"
     await hass.services.async_call(
@@ -548,13 +550,15 @@ async def test_grouped_lights(
     mock_bridge_v2.api.emit_event("update", event)
     await hass.async_block_till_done()
 
-    # The group should still show the same XY color since other lights maintain their color
+    # The group should still show the same XY color since other lights maintain their
+    # color
     test_light = hass.states.get(test_light_id)
     assert test_light is not None
     assert test_light.state == "on"
     assert test_light.attributes["xy_color"] == (0.123, 0.123)
 
-    # Turn the light back on with a white XY color (different from the rest of the group)
+    # Turn the light back on with a white XY color (different from the rest of the
+    # group)
     await hass.services.async_call(
         "light",
         "turn_on",
@@ -587,8 +591,10 @@ async def test_grouped_lights(
     assert abs(group_x - expected_x) < 0.001  # Allow small floating point differences
     assert abs(group_y - expected_y) < 0.001
 
-    # Test turning off another light in the group, leaving only two lights on - one white and one original color
-    # "hue_light_with_color_and_color_temperature_2" corresponds to "b3fe71ef-d0ef-48de-9355-d9e604377df0"
+    # Test turning off another light in the group, leaving only two lights on - one
+    # white and one original color
+    # "hue_light_with_color_and_color_temperature_2" corresponds to
+    # "b3fe71ef-d0ef-48de-9355-d9e604377df0"
     second_light_id = "light.hue_light_with_color_and_color_temperature_2"
     await hass.services.async_call(
         "light",
@@ -897,7 +903,8 @@ async def test_grouped_lights(
         blocking=True,
     )
 
-    # PUT request should have been sent to ONLY the grouped_light resource with correct params
+    # PUT request should have been sent to ONLY the grouped_light resource with correct
+    # params
     assert len(mock_bridge_v2.mock_requests) == 1
     assert mock_bridge_v2.mock_requests[0]["method"] == "put"
     assert mock_bridge_v2.mock_requests[0]["json"]["on"]["on"] is False

--- a/tests/components/hue/test_migration.py
+++ b/tests/components/hue/test_migration.py
@@ -83,7 +83,8 @@ async def test_light_entity_migration(
     ):
         await hue.migration.handle_v2_migration(hass, config_entry)
 
-    # migrated device should now have the new identifier (guid) instead of old style (mac)
+    # migrated device should now have the new identifier (guid) instead of old style
+    # (mac)
     migrated_device = device_registry.async_get(device.id)
     assert migrated_device is not None
     assert migrated_device.identifiers == {
@@ -142,7 +143,8 @@ async def test_sensor_entity_migration(
     ):
         await hue.migration.handle_v2_migration(hass, config_entry)
 
-    # migrated device should now have the new identifier (guid) instead of old style (mac)
+    # migrated device should now have the new identifier (guid) instead of old style
+    # (mac)
     migrated_device = device_registry.async_get(device.id)
     assert migrated_device is not None
     assert migrated_device.identifiers == {

--- a/tests/components/hue/test_switch.py
+++ b/tests/components/hue/test_switch.py
@@ -29,7 +29,8 @@ async def test_switch(
     assert test_entity.state == "on"
     assert test_entity.attributes["device_class"] == "switch"
 
-    # test config switch to enable/disable a behavior_instance resource (=builtin automation)
+    # test config switch to enable/disable a behavior_instance resource (=builtin
+    # automation)
     test_entity = hass.states.get("switch.philips_hue_automation_timer_test")
     assert test_entity is not None
     assert test_entity.name == "Philips hue Automation: Timer Test"
@@ -113,7 +114,8 @@ async def test_switch_added(hass: HomeAssistant, mock_bridge_v2: Mock) -> None:
     # verify entity does not exist before we start
     assert hass.states.get(test_entity_id) is None
 
-    # Add new fake entity (and attached device and zigbee_connectivity) by emitting events
+    # Add new fake entity (and attached device and zigbee_connectivity) by emitting
+    # events
     mock_bridge_v2.api.emit_event("add", FAKE_BINARY_SENSOR)
     await hass.async_block_till_done()
 

--- a/tests/components/huisbaasje/test_sensor.py
+++ b/tests/components/huisbaasje/test_sensor.py
@@ -317,7 +317,7 @@ async def test_setup_entry(hass: HomeAssistant) -> None:
 
 
 async def test_setup_entry_absent_measurement(hass: HomeAssistant) -> None:
-    """Test for successfully loading sensor states when response does not contain all measurements."""
+    """Test loading sensor states when some measurements are absent."""
     with (
         patch(
             "energyflip.EnergyFlip.authenticate", return_value=None

--- a/tests/components/humidifier/test_device_condition.py
+++ b/tests/components/humidifier/test_device_condition.py
@@ -215,7 +215,10 @@ async def test_if_state(
                     "action": {
                         "service": "test.automation",
                         "data_template": {
-                            "some": "is_mode - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                            "some": (
+                                "is_mode - {{ trigger.platform }}"
+                                " - {{ trigger.event.event_type }}"
+                            )
                         },
                     },
                 },
@@ -293,7 +296,10 @@ async def test_if_state_legacy(
                     "action": {
                         "service": "test.automation",
                         "data_template": {
-                            "some": "is_mode - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                            "some": (
+                                "is_mode - {{ trigger.platform }}"
+                                " - {{ trigger.event.event_type }}"
+                            )
                         },
                     },
                 },

--- a/tests/components/humidifier/test_trigger.py
+++ b/tests/components/humidifier/test_trigger.py
@@ -118,7 +118,7 @@ async def test_humidifier_state_trigger_behavior_any(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test that the humidifier state trigger fires when any humidifier state changes to a specific state."""
+    """Test humidifier state trigger fires on any state change."""
     await assert_trigger_behavior_any(
         hass,
         target_entities=target_humidifiers,
@@ -176,7 +176,7 @@ async def test_humidifier_state_attribute_trigger_behavior_any(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test that the humidifier state trigger fires when any humidifier state changes to a specific state."""
+    """Test humidifier attribute trigger fires on any state change."""
     await assert_trigger_behavior_any(
         hass,
         target_entities=target_humidifiers,
@@ -219,7 +219,7 @@ async def test_humidifier_state_trigger_behavior_first(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test that the humidifier state trigger fires when the first humidifier changes to a specific state."""
+    """Test humidifier trigger fires on first entity state change."""
     await assert_trigger_behavior_first(
         hass,
         target_entities=target_humidifiers,
@@ -277,7 +277,7 @@ async def test_humidifier_state_attribute_trigger_behavior_first(
     trigger_options: dict[str, Any],
     states: list[tuple[tuple[str, dict], int]],
 ) -> None:
-    """Test that the humidifier state trigger fires when the first humidifier state changes to a specific state."""
+    """Test humidifier attribute trigger fires on first state change."""
     await assert_trigger_behavior_first(
         hass,
         target_entities=target_humidifiers,
@@ -320,7 +320,7 @@ async def test_humidifier_state_trigger_behavior_last(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test that the humidifier state trigger fires when the last humidifier changes to a specific state."""
+    """Test humidifier trigger fires on last entity state change."""
     await assert_trigger_behavior_last(
         hass,
         target_entities=target_humidifiers,
@@ -378,7 +378,7 @@ async def test_humidifier_state_attribute_trigger_behavior_last(
     trigger_options: dict[str, Any],
     states: list[tuple[tuple[str, dict], int]],
 ) -> None:
-    """Test that the humidifier state trigger fires when the last humidifier state changes to a specific state."""
+    """Test humidifier attribute trigger fires on last state change."""
     await assert_trigger_behavior_last(
         hass,
         target_entities=target_humidifiers,

--- a/tests/components/humidity/test_trigger.py
+++ b/tests/components/humidity/test_trigger.py
@@ -177,7 +177,7 @@ async def test_humidity_trigger_sensor_crossed_threshold_behavior_first(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test humidity crossed_threshold trigger fires on the first sensor state change."""
+    """Test humidity crossed_threshold trigger fires on first sensor change."""
     await assert_trigger_behavior_first(
         hass,
         target_entities=target_sensors,
@@ -215,7 +215,7 @@ async def test_humidity_trigger_sensor_crossed_threshold_behavior_last(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test humidity crossed_threshold trigger fires when the last sensor changes state."""
+    """Test crossed_threshold trigger fires when last sensor changes."""
     await assert_trigger_behavior_last(
         hass,
         target_entities=target_sensors,
@@ -302,7 +302,7 @@ async def test_humidity_trigger_climate_crossed_threshold_behavior_first(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test humidity crossed_threshold trigger fires on the first climate state change."""
+    """Test humidity crossed_threshold trigger fires on first climate change."""
     await assert_trigger_behavior_first(
         hass,
         target_entities=target_climates,
@@ -341,7 +341,7 @@ async def test_humidity_trigger_climate_crossed_threshold_behavior_last(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test humidity crossed_threshold trigger fires when the last climate changes state."""
+    """Test crossed_threshold trigger fires on last climate change."""
     await assert_trigger_behavior_last(
         hass,
         target_entities=target_climates,
@@ -428,7 +428,7 @@ async def test_humidity_trigger_humidifier_crossed_threshold_behavior_first(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test humidity crossed_threshold trigger fires on the first humidifier state change."""
+    """Test crossed_threshold trigger fires on first humidifier change."""
     await assert_trigger_behavior_first(
         hass,
         target_entities=target_humidifiers,
@@ -467,7 +467,7 @@ async def test_humidity_trigger_humidifier_crossed_threshold_behavior_last(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test humidity crossed_threshold trigger fires when the last humidifier changes state."""
+    """Test crossed_threshold trigger fires on last humidifier change."""
     await assert_trigger_behavior_last(
         hass,
         target_entities=target_humidifiers,
@@ -554,7 +554,7 @@ async def test_humidity_trigger_weather_crossed_threshold_behavior_first(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test humidity crossed_threshold trigger fires on the first weather state change."""
+    """Test humidity crossed_threshold trigger fires on first weather change."""
     await assert_trigger_behavior_first(
         hass,
         target_entities=target_weathers,
@@ -593,7 +593,7 @@ async def test_humidity_trigger_weather_crossed_threshold_behavior_last(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test humidity crossed_threshold trigger fires when the last weather changes state."""
+    """Test crossed_threshold trigger fires on last weather change."""
     await assert_trigger_behavior_last(
         hass,
         target_entities=target_weathers,

--- a/tests/components/husqvarna_automower/__init__.py
+++ b/tests/components/husqvarna_automower/__init__.py
@@ -9,8 +9,7 @@ async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) 
     """Fixture for setting up the component."""
     # We lock the timezone, because the timezone is passed to the library to generate
     # some values like the next start sensor. This is needed, as the device is not aware
-    # of its own timezone. So we assume the device is in the timezone which is selected
-    # in
+    # of its own timezone. So we assume the device is in the timezone selected in
     # the Home Assistant config.
     await hass.config.async_set_time_zone("Europe/Berlin")
     config_entry.add_to_hass(hass)

--- a/tests/components/husqvarna_automower/__init__.py
+++ b/tests/components/husqvarna_automower/__init__.py
@@ -9,7 +9,8 @@ async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) 
     """Fixture for setting up the component."""
     # We lock the timezone, because the timezone is passed to the library to generate
     # some values like the next start sensor. This is needed, as the device is not aware
-    # of its own timezone. So we assume the device is in the timezone which is selected in
+    # of its own timezone. So we assume the device is in the timezone which is selected
+    # in
     # the Home Assistant config.
     await hass.config.async_set_time_zone("Europe/Berlin")
     config_entry.add_to_hass(hass)

--- a/tests/components/husqvarna_automower/test_config_flow.py
+++ b/tests/components/husqvarna_automower/test_config_flow.py
@@ -252,7 +252,7 @@ async def test_reauth_wrong_account(
     reason: str,
     scope: str,
 ) -> None:
-    """Test the reauthentication aborts, if user tries to reauthenticate with another account."""
+    """Test reauth aborts when user tries a different account."""
 
     mock_config_entry.add_to_hass(hass)
 

--- a/tests/components/husqvarna_automower/test_event.py
+++ b/tests/components/husqvarna_automower/test_event.py
@@ -35,7 +35,7 @@ async def test_event(
     values: dict[str, MowerAttributes],
     automower_ws_ready: list[Callable[[], None]],
 ) -> None:
-    """Test that a new message arriving over the websocket creates and updates the sensor."""
+    """Test websocket message creates and updates the sensor."""
     callbacks: list[Callable[[SingleMessageData], None]] = []
 
     @callback

--- a/tests/components/husqvarna_automower/test_init.py
+++ b/tests/components/husqvarna_automower/test_init.py
@@ -268,9 +268,9 @@ async def test_constant_polling(
 ) -> None:
     """Verify WebSocket updates do not interrupt regular polling.
 
-    The test simulates a WebSocket update that changes an entity's state, then advances
-    time
-    to trigger a scheduled poll to confirm polled data also arrives.
+    The test simulates a WebSocket update that changes an entity's state, then
+    advances time to trigger a scheduled poll to confirm polled data also
+    arrives.
     """
     test_values = deepcopy(values)
     callback_holder: dict[str, Callable] = {}

--- a/tests/components/husqvarna_automower/test_init.py
+++ b/tests/components/husqvarna_automower/test_init.py
@@ -266,9 +266,10 @@ async def test_constant_polling(
     values: dict[str, MowerAttributes],
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Verify that receiving a WebSocket update does not interrupt the regular polling cycle.
+    """Verify WebSocket updates do not interrupt regular polling.
 
-    The test simulates a WebSocket update that changes an entity's state, then advances time
+    The test simulates a WebSocket update that changes an entity's state, then advances
+    time
     to trigger a scheduled poll to confirm polled data also arrives.
     """
     test_values = deepcopy(values)

--- a/tests/components/husqvarna_automower_ble/conftest.py
+++ b/tests/components/husqvarna_automower_ble/conftest.py
@@ -52,7 +52,7 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 def mock_get_manufacturer_data(
     hass: HomeAssistant, enable_bluetooth: None
 ) -> Generator[None]:
-    """Mock async_get_manufacturer_data to return decoded data from injected service infos."""
+    """Mock async_get_manufacturer_data to return injected data."""
 
     async def _get_manufacturer_data(
         addresses: set[str], **kwargs

--- a/tests/components/husqvarna_automower_ble/test_config_flow.py
+++ b/tests/components/husqvarna_automower_ble/test_config_flow.py
@@ -293,7 +293,7 @@ async def test_bluetooth_not_pairable_logs_on_connect(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test that the not-pairable warning is logged only when a connection is attempted."""
+    """Test not-pairable warning is logged only when connection is attempted."""
 
     inject_bluetooth_service_info(hass, AUTOMOWER_NOT_PAIRABLE_SERVICE_INFO)
     await hass.async_block_till_done(wait_background_tasks=True)

--- a/tests/components/hvv_departures/test_config_flow.py
+++ b/tests/components/hvv_departures/test_config_flow.py
@@ -303,7 +303,12 @@ async def test_options_flow(hass: HomeAssistant) -> None:
                 {
                     "serviceID": "HHA-U:U1_HHA-U",
                     "stationIDs": ["Master:10902"],
-                    "label": "Fuhlsbüttel Nord / Ochsenzoll / Norderstedt Mitte / Kellinghusenstraße / Ohlsdorf / Garstedt",
+                    "label": (
+                        "Fuhlsbüttel Nord / Ochsenzoll /"
+                        " Norderstedt Mitte /"
+                        " Kellinghusenstraße /"
+                        " Ohlsdorf / Garstedt"
+                    ),
                     "serviceName": "U1",
                 }
             ],

--- a/tests/components/hydrawise/test_sensor.py
+++ b/tests/components/hydrawise/test_sensor.py
@@ -90,7 +90,7 @@ async def test_no_sensor_and_water_state(
     controller_water_use_summary: ControllerWaterUseSummary,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
 ) -> None:
-    """Test rain sensor, flow sensor, and water use in the absence of flow and rain sensors."""
+    """Test sensors in the absence of flow and rain sensors."""
     controller.sensors = []
     controller_water_use_summary.total_use = None
     controller_water_use_summary.total_active_use = None

--- a/tests/components/hyperion/test_config_flow.py
+++ b/tests/components/hyperion/test_config_flow.py
@@ -573,7 +573,7 @@ async def test_auth_create_token_success(hass: HomeAssistant) -> None:
 async def test_auth_create_token_success_but_login_fail(
     hass: HomeAssistant,
 ) -> None:
-    """Verify correct behaviour when a token is successfully created but the login fails."""
+    """Verify behaviour when token is created but login fails."""
     result = await _init_flow(hass)
 
     client = create_mock_client()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix 387 of 389 E501 (line too long) violations in `tests/components/` for integrations starting with h.

Two violations are intentionally left: `tests/components/hvv_departures/test_config_flow.py` has `codespell:ignore` directives that must remain on the same line as the misspelling.

Part of a series to enforce the 88-character line length limit across the codebase. Changes are purely cosmetic — rewrapped comments, split long strings, shortened docstrings, and reformatted test data. No logic changes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
