### PR TITLE
Fix utility meter next_reset shifting forward on entity rename

### DIFF
--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -629,7 +629,9 @@ class UtilityMeterSensor(RestoreSensor):
                 self._collecting = lambda: None
             # Reconfigure the scheduler from the restored last_reset so that
             # next_reset is not shifted forward on entity restore/rename.
-            self._config_scheduler(self._last_reset)
+            self._config_scheduler(
+                dt_util.as_local(self._last_reset) if self._last_reset else None
+            )
 
         await self._program_reset()
 

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -406,7 +406,7 @@ class UtilityMeterSensor(RestoreSensor):
         self._current_tz = None
         self._config_scheduler()
 
-    def _config_scheduler(self, start_time=None):
+    def _config_scheduler(self, start_time: datetime | None = None) -> None:
         self.scheduler = (
             CronSim(
                 self._cron_pattern,

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -406,11 +406,12 @@ class UtilityMeterSensor(RestoreSensor):
         self._current_tz = None
         self._config_scheduler()
 
-    def _config_scheduler(self):
+    def _config_scheduler(self, start_time=None):
         self.scheduler = (
             CronSim(
                 self._cron_pattern,
-                dt_util.now(
+                start_time
+                or dt_util.now(
                     dt_util.get_default_time_zone()
                 ),  # we need timezone for DST purposes (see issue #102984)
             )
@@ -608,8 +609,6 @@ class UtilityMeterSensor(RestoreSensor):
         # and we need to reconfigure the scheduler
         self._current_tz = self.hass.config.time_zone
 
-        await self._program_reset()
-
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass, SIGNAL_RESET_METER, self.async_reset_meter
@@ -628,6 +627,11 @@ class UtilityMeterSensor(RestoreSensor):
             if last_sensor_data.status == COLLECTING:
                 # Null lambda to allow cancelling the collection on tariff change
                 self._collecting = lambda: None
+            # Reconfigure the scheduler from the restored last_reset so that
+            # next_reset is not shifted forward on entity restore/rename.
+            self._config_scheduler(self._last_reset)
+
+        await self._program_reset()
 
         @callback
         def async_source_tracking(event):

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -1847,10 +1847,13 @@ async def test_next_reset_not_shifted_on_restore(hass: HomeAssistant) -> None:
 
     state = hass.states.get("sensor.energy_bill")
     assert state is not None
-    # The missed reset should have fired as a catch-up, updating last_reset.
-    # Without the fix, last_reset stays at the original value because
-    # the scheduler starts from now() and skips the missed period.
+    # The missed reset should have fired as a catch-up, updating last_reset
+    # and recording the previous period value. Without the fix, last_reset
+    # stays at the original value because the scheduler starts from now()
+    # and skips the missed period entirely.
     assert state.attributes.get("last_reset") != last_reset
+    assert state.attributes.get("last_period") == "3"
+    assert state.state == "0"
 
 
 async def test_self_reset_daily(hass: HomeAssistant) -> None:

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -1799,6 +1799,60 @@ async def test_tz_changes(hass: HomeAssistant) -> None:
     assert state.attributes.get("next_reset") != "2024-10-28T00:00:00+01:00"
 
 
+async def test_next_reset_not_shifted_on_restore(hass: HomeAssistant) -> None:
+    """Test that a missed reset fires on restore after entity rename.
+
+    When an entity is restored (e.g. after rename) and a reset was missed,
+    the scheduler should catch up from last_reset rather than starting from
+    now(), which would skip the missed reset entirely.
+    """
+    last_reset = "2024-10-27T00:00:00+00:00"
+
+    mock_restore_cache_with_extra_data(
+        hass,
+        [
+            (
+                State(
+                    "sensor.energy_bill",
+                    "3",
+                    attributes={
+                        ATTR_STATUS: COLLECTING,
+                        ATTR_LAST_RESET: last_reset,
+                        ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR,
+                    },
+                ),
+                {
+                    "native_value": {
+                        "__type": "<class 'decimal.Decimal'>",
+                        "decimal_str": "3",
+                    },
+                    "native_unit_of_measurement": "kWh",
+                    "last_reset": last_reset,
+                    "last_period": "0",
+                    "last_valid_state": "3",
+                    "status": "collecting",
+                    "input_device_class": "energy",
+                },
+            ),
+        ],
+    )
+
+    # Restore at noon on Oct 28 - the Oct 28 midnight reset was missed
+    now = dt_util.parse_datetime("2024-10-28T12:00:00+00:00")
+    with freeze_time(now):
+        assert await async_setup_component(hass, DOMAIN, gen_config("daily"))
+        await hass.async_block_till_done()
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.energy_bill")
+    assert state is not None
+    # The missed reset should have fired as a catch-up, updating last_reset.
+    # Without the fix, last_reset stays at the original value because
+    # the scheduler starts from now() and skips the missed period.
+    assert state.attributes.get("last_reset") != last_reset
+
+
 async def test_self_reset_daily(hass: HomeAssistant) -> None:
     """Test daily reset of meter."""
     await _test_self_reset(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When a utility meter entity is renamed (or otherwise restored), `next_reset` shifts forward by one period. This happens because `_program_reset()` was called before state restoration in `async_added_to_hass`, so the CronSim scheduler started from `now()` instead of from the restored `last_reset`. Any reset that should have occurred between `last_reset` and `now()` was silently skipped.

The fix moves `_program_reset()` to after state restoration and reconfigures the scheduler from the restored `last_reset` when available. This ensures the scheduler picks up any missed resets (which then fire as catch-ups) rather than skipping them.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170548
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr