### PR TITLE
Fix line length violations in tests/components i

### DIFF
--- a/tests/components/ibeacon/__init__.py
+++ b/tests/components/ibeacon/__init__.py
@@ -26,7 +26,9 @@ BLUECHARM_BEACON_SERVICE_INFO_2 = BluetoothServiceInfo(
     manufacturer_data={76: b"\x02\x15BlueCharmBeacons\x0e\xfe\x13U\xc5"},
     service_data={
         "00002080-0000-1000-8000-00805f9b34fb": b"j\x0c\x0e\xfe\x13U",
-        "0000feaa-0000-1000-8000-00805f9b34fb": b" \x00\x0c\x00\x1c\x00\x00\x00\x06h\x00\x008\x10",
+        "0000feaa-0000-1000-8000-00805f9b34fb": (
+            b" \x00\x0c\x00\x1c\x00\x00\x00\x06h\x00\x008\x10"
+        ),
     },
     service_uuids=["0000feaa-0000-1000-8000-00805f9b34fb"],
     source="local",
@@ -47,7 +49,9 @@ NO_NAME_BEACON_SERVICE_INFO = BluetoothServiceInfo(
     manufacturer_data={76: b"\x02\x15NoNamearmBeacons\x0e\xfe\x13U\xc5"},
     service_data={
         "00002080-0000-1000-8000-00805f9b34fb": b"j\x0c\x0e\xfe\x13U",
-        "0000feaa-0000-1000-8000-00805f9b34fb": b" \x00\x0c\x00\x1c\x00\x00\x00\x06h\x00\x008\x10",
+        "0000feaa-0000-1000-8000-00805f9b34fb": (
+            b" \x00\x0c\x00\x1c\x00\x00\x00\x06h\x00\x008\x10"
+        ),
     },
     service_uuids=["0000feaa-0000-1000-8000-00805f9b34fb"],
     source="local",
@@ -90,7 +94,9 @@ FEASY_BEACON_SERVICE_INFO_1 = BluetoothServiceInfo(
         76: b"\x02\x15\xfd\xa5\x06\x93\xa4\xe2O\xb1\xaf\xcf\xc6\xeb\x07dx%'Qe\xc1\xfd"
     },
     service_data={
-        "0000feaa-0000-1000-8000-00805f9b34fb": b' \x00\x0c\x86\x80\x00\x00\x00\x93f\x0b\x7f\x93"',
+        "0000feaa-0000-1000-8000-00805f9b34fb": (
+            b' \x00\x0c\x86\x80\x00\x00\x00\x93f\x0b\x7f\x93"'
+        ),
         "0000fff0-0000-1000-8000-00805f9b34fb": b"'\x02\x17\x92\xdc\r0\x0e \xbad",
     },
     service_uuids=[
@@ -109,7 +115,9 @@ FEASY_BEACON_SERVICE_INFO_2 = BluetoothServiceInfo(
         76: b"\x02\x15\xd5F\xdf\x97GWG\xef\xbe\t>-\xcb\xdd\x0cw\xed\xd1;\xd2\xb5"
     },
     service_data={
-        "0000feaa-0000-1000-8000-00805f9b34fb": b' \x00\x0c\x86\x80\x00\x00\x00\x93f\x0b\x7f\x93"',
+        "0000feaa-0000-1000-8000-00805f9b34fb": (
+            b' \x00\x0c\x86\x80\x00\x00\x00\x93f\x0b\x7f\x93"'
+        ),
         "0000fff0-0000-1000-8000-00805f9b34fb": b"'\x02\x17\x92\xdc\r0\x0e \xbad",
     },
     service_uuids=[

--- a/tests/components/ibeacon/test_coordinator.py
+++ b/tests/components/ibeacon/test_coordinator.py
@@ -45,7 +45,7 @@ def mock_bluetooth(enable_bluetooth: None) -> None:
 
 
 async def test_many_groups_same_address_ignored(hass: HomeAssistant) -> None:
-    """Test the different uuid, major, minor from many addresses removes all associated entities."""
+    """Test rotating uuid/major/minor removes all associated entities."""
     entry = MockConfigEntry(
         domain=DOMAIN,
     )
@@ -180,7 +180,7 @@ async def test_default_name_allowlisted(hass: HomeAssistant) -> None:
 
 
 async def test_default_name_allowlisted_restore(hass: HomeAssistant) -> None:
-    """Test that ignored nameless iBeacons are restored when allowlist entry is added."""
+    """Test ignored nameless iBeacons restore on allowlist add."""
     entry = MockConfigEntry(
         domain=DOMAIN,
     )
@@ -211,7 +211,7 @@ async def test_default_name_allowlisted_restore(hass: HomeAssistant) -> None:
 
 
 async def test_default_name_allowlisted_restore_late(hass: HomeAssistant) -> None:
-    """Test that allowlisting an ignored but no longer advertised nameless iBeacon has no effect."""
+    """Test allowlisting a no-longer-advertised nameless iBeacon has no effect."""
     start_monotonic = time.monotonic()
 
     entry = MockConfigEntry(
@@ -260,7 +260,7 @@ async def test_default_name_allowlisted_restore_late(hass: HomeAssistant) -> Non
 
 
 async def test_rotating_major_minor_and_mac_with_name(hass: HomeAssistant) -> None:
-    """Test the different uuid, major, minor from many addresses removes all associated entities."""
+    """Test rotating major/minor/mac with name removes entities."""
     entry = MockConfigEntry(
         domain=DOMAIN,
     )
@@ -295,7 +295,7 @@ async def test_rotating_major_minor_and_mac_with_name(hass: HomeAssistant) -> No
 
 
 async def test_rotating_major_minor_and_mac_no_name(hass: HomeAssistant) -> None:
-    """Test no-name devices with different uuid, major, minor from many addresses removes all associated entities."""
+    """Test no-name devices with rotating major/minor/mac removes entities."""
     entry = MockConfigEntry(
         domain=DOMAIN,
     )

--- a/tests/components/ibeacon/test_device_tracker.py
+++ b/tests/components/ibeacon/test_device_tracker.py
@@ -148,7 +148,7 @@ async def test_device_tracker_random_address(hass: HomeAssistant) -> None:
 async def test_device_tracker_random_address_infrequent_changes(
     hass: HomeAssistant,
 ) -> None:
-    """Test creating and updating device_tracker with a random mac that only changes once per day."""
+    """Test device_tracker with a random mac changing once per day."""
     entry = MockConfigEntry(
         domain=DOMAIN,
     )

--- a/tests/components/icloud/test_account.py
+++ b/tests/components/icloud/test_account.py
@@ -77,7 +77,7 @@ async def test_setup_fails_when_userinfo_missing(
 
 
 class MockAppleDevice:
-    """Mock "Apple device" which implements the .status(...) method used by the account."""
+    """Mock Apple device implementing .status() used by the account."""
 
     def __init__(self, status_dict) -> None:
         """Set status."""
@@ -88,12 +88,12 @@ class MockAppleDevice:
         return self._status
 
     def __getitem__(self, key):
-        """Allow indexing the device itself (device[KEY]) to proxy into the raw status dict."""
+        """Allow indexing to proxy into the raw status dict."""
         return self._status.get(key)
 
 
 class MockDevicesContainer:
-    """Mock devices container which is iterable and indexable returning device status dicts."""
+    """Mock devices container, iterable and indexable."""
 
     def __init__(self, userinfo, devices) -> None:
         """Initialize with userinfo and list of device objects."""
@@ -118,7 +118,7 @@ class MockDevicesContainer:
 
 @pytest.fixture(name="mock_icloud_service")
 def mock_icloud_service_fixture():
-    """Mock PyiCloudService with devices container that is iterable and indexable returning status dict."""
+    """Mock PyiCloudService with iterable and indexable devices."""
     with patch(
         "homeassistant.components.icloud.account.PyiCloudService",
     ) as service_mock:

--- a/tests/components/icloud/test_config_flow.py
+++ b/tests/components/icloud/test_config_flow.py
@@ -102,7 +102,7 @@ def mock_controller_service_authenticated_no_device():
 
 @pytest.fixture(name="service_authenticated_not_trusted")
 def mock_controller_service_authenticated_not_trusted():
-    """Mock a successful service while already authenticated, but the session is not trusted."""
+    """Mock a successful service already authenticated but not trusted."""
     with patch(
         "homeassistant.components.icloud.config_flow.PyiCloudService"
     ) as service_mock:
@@ -399,7 +399,7 @@ async def test_password_update(
 
 
 async def test_password_update_wrong_password(hass: HomeAssistant) -> None:
-    """Test that during password reauthentication wrong password returns correct error."""
+    """Test password reauthentication with wrong password returns error."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", unique_id=USERNAME
     )

--- a/tests/components/idrive_e2/conftest.py
+++ b/tests/components/idrive_e2/conftest.py
@@ -53,7 +53,8 @@ def mock_client(agent_backup: AgentBackup) -> Generator[AsyncMock]:
         tar_file, metadata_file = suggested_filenames(agent_backup)
         # Mock the paginator for list_objects_v2
         client.get_paginator = MagicMock()
-        client.get_paginator.return_value.paginate.return_value.__aiter__.return_value = [
+        paginate = client.get_paginator.return_value.paginate
+        paginate.return_value.__aiter__.return_value = [
             {"Contents": [{"Key": tar_file}, {"Key": metadata_file}]}
         ]
         client.create_multipart_upload.return_value = {"UploadId": "upload_id"}
@@ -62,7 +63,8 @@ def mock_client(agent_backup: AgentBackup) -> Generator[AsyncMock]:
             "Buckets": [{"Name": USER_INPUT[CONF_BUCKET]}]
         }
 
-        # To simplify this mock, we assume that backup is always "iterated" over, while metadata is always "read" as a whole
+        # To simplify this mock, we assume that backup is always
+        # "iterated" over, while metadata is always "read" as a whole
         class MockStream:
             async def iter_chunks(self) -> AsyncIterator[bytes]:
                 yield b"backup data"

--- a/tests/components/idrive_e2/test_backup.py
+++ b/tests/components/idrive_e2/test_backup.py
@@ -184,9 +184,8 @@ async def test_agents_get_backup_does_not_throw_on_not_found(
     mock_client: MagicMock,
 ) -> None:
     """Test agent get backup does not throw on a backup not found."""
-    mock_client.get_paginator.return_value.paginate.return_value.__aiter__.return_value = [
-        {"Contents": []}
-    ]
+    paginate = mock_client.get_paginator.return_value.paginate
+    paginate.return_value.__aiter__.return_value = [{"Contents": []}]
 
     client = await hass_ws_client(hass)
     await client.send_json_auto_id({"type": "backup/details", "backup_id": "random"})
@@ -209,7 +208,8 @@ async def test_agents_list_backups_with_corrupted_metadata(
     agent = IDriveE2BackupAgent(hass, mock_config_entry)
 
     # Set up mock responses for both valid and corrupted metadata files
-    mock_client.get_paginator.return_value.paginate.return_value.__aiter__.return_value = [
+    paginate = mock_client.get_paginator.return_value.paginate
+    paginate.return_value.__aiter__.return_value = [
         {
             "Contents": [
                 {
@@ -279,9 +279,8 @@ async def test_agents_delete_not_throwing_on_not_found(
     mock_client: MagicMock,
 ) -> None:
     """Test agent delete backup does not throw on a backup not found."""
-    mock_client.get_paginator.return_value.paginate.return_value.__aiter__.return_value = [
-        {"Contents": []}
-    ]
+    paginate = mock_client.get_paginator.return_value.paginate
+    paginate.return_value.__aiter__.return_value = [{"Contents": []}]
 
     client = await hass_ws_client(hass)
 
@@ -423,7 +422,9 @@ async def test_multipart_upload_consistent_part_sizes(
     assert len(uploaded_part_sizes) >= 2, "Expected at least 2 parts"
     non_trailing_parts = uploaded_part_sizes[:-1]
     assert all(size == MULTIPART_MIN_PART_SIZE_BYTES for size in non_trailing_parts), (
-        f"All non-trailing parts should be {MULTIPART_MIN_PART_SIZE_BYTES} bytes, got {non_trailing_parts}"
+        f"All non-trailing parts should be"
+        f" {MULTIPART_MIN_PART_SIZE_BYTES} bytes,"
+        f" got {non_trailing_parts}"
     )
 
     # Verify the trailing part contains the remainder
@@ -534,10 +535,9 @@ async def test_error_during_delete(
     response = await client.receive_json()
 
     assert response["success"]
+    agent_key = f"{DOMAIN}.{mock_config_entry.entry_id}"
     assert response["result"] == {
-        "agent_errors": {
-            f"{DOMAIN}.{mock_config_entry.entry_id}": "Failed during async_delete_backup"
-        }
+        "agent_errors": {agent_key: "Failed during async_delete_backup"}
     }
 
 
@@ -563,7 +563,8 @@ async def test_cache_expiration(
     metadata_content = json.dumps(agent_backup.as_dict())
     mock_body = AsyncMock()
     mock_body.read.return_value = metadata_content.encode()
-    mock_client.get_paginator.return_value.paginate.return_value.__aiter__.return_value = [
+    paginate = mock_client.get_paginator.return_value.paginate
+    paginate.return_value.__aiter__.return_value = [
         {
             "Contents": [
                 {
@@ -666,7 +667,8 @@ async def test_list_backups_with_pagination(
 
     # Setup mock client
     mock_client = mock_config_entry.runtime_data
-    mock_client.get_paginator.return_value.paginate.return_value.__aiter__.return_value = [
+    paginate = mock_client.get_paginator.return_value.paginate
+    paginate.return_value.__aiter__.return_value = [
         page1,
         page2,
     ]

--- a/tests/components/igloohome/conftest.py
+++ b/tests/components/igloohome/conftest.py
@@ -57,7 +57,7 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 @pytest.fixture
 async def mock_auth() -> Generator[AsyncMock]:
-    """Set up the mock usages of the igloohome_api.Auth class. Defaults to always successfully operate."""
+    """Set up mock igloohome_api.Auth class, defaulting to success."""
     with patch(
         "homeassistant.components.igloohome.config_flow.IgloohomeAuth.async_get_access_token",
         return_value="mock_access_token",

--- a/tests/components/illuminance/test_trigger.py
+++ b/tests/components/illuminance/test_trigger.py
@@ -130,7 +130,7 @@ async def test_illuminance_trigger_binary_sensor_behavior_any(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test illuminance trigger fires for binary_sensor entities with device_class light."""
+    """Test trigger fires for binary_sensor with device_class light."""
     await assert_trigger_behavior_any(
         hass,
         target_entities=target_binary_sensors,
@@ -278,7 +278,7 @@ async def test_illuminance_trigger_sensor_behavior_any(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test illuminance trigger fires for sensor entities with device_class illuminance."""
+    """Test trigger fires for sensor with device_class illuminance."""
     await assert_trigger_behavior_any(
         hass,
         target_entities=target_sensors,
@@ -316,7 +316,7 @@ async def test_illuminance_trigger_sensor_crossed_threshold_behavior_first(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test illuminance crossed_threshold trigger fires on the first sensor state change."""
+    """Test crossed_threshold trigger fires on first sensor change."""
     await assert_trigger_behavior_first(
         hass,
         target_entities=target_sensors,
@@ -354,7 +354,7 @@ async def test_illuminance_trigger_sensor_crossed_threshold_behavior_last(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test illuminance crossed_threshold trigger fires when the last sensor changes state."""
+    """Test crossed_threshold trigger fires on last sensor change."""
     await assert_trigger_behavior_last(
         hass,
         target_entities=target_sensors,

--- a/tests/components/imap/test_init.py
+++ b/tests/components/imap/test_init.py
@@ -67,7 +67,7 @@ async def test_entry_startup_and_unload(
     verify_ssl: bool | None,
     enable_push: bool | None,
 ) -> None:
-    """Test imap entry startup and unload with push and polling coordinator and alternate ciphers."""
+    """Test imap entry startup/unload with push/polling and ciphers."""
     config = MOCK_CONFIG.copy()
     if cipher_list is not None:
         config["ssl_cipher_list"] = cipher_list

--- a/tests/components/imgw_pib/test_sensor.py
+++ b/tests/components/imgw_pib/test_sensor.py
@@ -40,7 +40,7 @@ async def test_availability(
     mock_imgw_pib_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Ensure that we mark the entities unavailable correctly when service is offline."""
+    """Ensure entities are marked unavailable when service is offline."""
     await init_integration(hass, mock_config_entry)
 
     state = hass.states.get(ENTITY_ID)

--- a/tests/components/immich/conftest.py
+++ b/tests/components/immich/conftest.py
@@ -113,7 +113,10 @@ def mock_immich_people() -> AsyncMock:
                 "id": "6176838a-ac5a-4d1f-9a35-91c591d962d8",
                 "name": "Me",
                 "birthDate": None,
-                "thumbnailPath": "upload/thumbs/e7ef5713-9dab-4bd4-b899-715b0ca4379e/61/76/6176838a-ac5a-4d1f-9a35-91c591d962d8.jpeg",
+                "thumbnailPath": (
+                    "upload/thumbs/e7ef5713-9dab-4bd4-b899-715b0ca4379e"
+                    "/61/76/6176838a-ac5a-4d1f-9a35-91c591d962d8.jpeg"
+                ),
                 "isHidden": False,
                 "isFavorite": False,
                 "updatedAt": "2025-05-11T11:07:41.651Z",
@@ -124,7 +127,10 @@ def mock_immich_people() -> AsyncMock:
                 "id": "3e66aa4a-a4a8-41a4-86fe-2ae5e490078f",
                 "name": "I",
                 "birthDate": None,
-                "thumbnailPath": "upload/thumbs/e7ef5713-9dab-4bd4-b899-715b0ca4379e/3e/66/3e66aa4a-a4a8-41a4-86fe-2ae5e490078f.jpeg",
+                "thumbnailPath": (
+                    "upload/thumbs/e7ef5713-9dab-4bd4-b899-715b0ca4379e"
+                    "/3e/66/3e66aa4a-a4a8-41a4-86fe-2ae5e490078f.jpeg"
+                ),
                 "isHidden": False,
                 "isFavorite": False,
                 "updatedAt": "2025-05-19T22:10:21.953Z",
@@ -135,7 +141,10 @@ def mock_immich_people() -> AsyncMock:
                 "id": "a3c83297-684a-4576-82dc-b07432e8a18f",
                 "name": "Myself",
                 "birthDate": None,
-                "thumbnailPath": "upload/thumbs/e7ef5713-9dab-4bd4-b899-715b0ca4379e/a3/c8/a3c83297-684a-4576-82dc-b07432e8a18f.jpeg",
+                "thumbnailPath": (
+                    "upload/thumbs/e7ef5713-9dab-4bd4-b899-715b0ca4379e"
+                    "/a3/c8/a3c83297-684a-4576-82dc-b07432e8a18f.jpeg"
+                ),
                 "isHidden": False,
                 "isFavorite": False,
                 "updatedAt": "2025-05-12T21:07:04.044Z",

--- a/tests/components/immich/const.py
+++ b/tests/components/immich/const.py
@@ -62,7 +62,11 @@ MOCK_ALBUM_WITH_ASSETS = ImmichAlbum.from_dict(
                 "deviceId": "WEB",
                 "libraryId": None,
                 "type": "IMAGE",
-                "originalPath": "upload/upload/e7ef5713-9dab-4bd4-b899-715b0ca4379e/b4/b8/b4b8ef00-8a6d-4056-91ff-7f86dc66e427.jpg",
+                "originalPath": (
+                    "upload/upload/e7ef5713-9dab-4bd4-b899"
+                    "-715b0ca4379e/b4/b8/"
+                    "b4b8ef00-8a6d-4056-91ff-7f86dc66e427.jpg"
+                ),
                 "originalFileName": "filename.jpg",
                 "originalMimeType": "image/jpeg",
                 "thumbhash": "1igGFALX8mVGdHc5aChJf5nxNg==",
@@ -90,7 +94,11 @@ MOCK_ALBUM_WITH_ASSETS = ImmichAlbum.from_dict(
                 "deviceId": "WEB",
                 "libraryId": None,
                 "type": "IMAGE",
-                "originalPath": "upload/upload/e7ef5713-9dab-4bd4-b899-715b0ca4379e/b4/b8/b4b8ef00-8a6d-4056-eeff-7f86dc66e427.mp4",
+                "originalPath": (
+                    "upload/upload/e7ef5713-9dab-4bd4-b899"
+                    "-715b0ca4379e/b4/b8/"
+                    "b4b8ef00-8a6d-4056-eeff-7f86dc66e427.mp4"
+                ),
                 "originalFileName": "filename.mp4",
                 "originalMimeType": "video/mp4",
                 "thumbhash": "1igGFALX8mVGdHc5aChJf5nxNg==",
@@ -121,10 +129,16 @@ MOCK_PEOPLE_ASSETS = [
             "id": "2242eda3-94c2-49ee-86d4-e9e071b6fbf4",
             "deviceAssetId": "1000092019",
             "ownerId": "e7ef5713-9dab-4bd4-b899-715b0ca4379e",
-            "deviceId": "5933dd9394fc6bf0493a26b4e38acca1076f30ab246442976d2917f1d57d99a1",
+            "deviceId": (
+                "5933dd9394fc6bf0493a26b4e38acca1076f30ab246442976d2917f1d57d99a1"
+            ),
             "libraryId": None,
             "type": "IMAGE",
-            "originalPath": "/usr/src/app/upload/upload/e7ef5713-9dab-4bd4-b899-715b0ca4379e/8e/a3/8ea31ee8-49c3-4be9-aa9d-b8ef26ba0abe.jpg",
+            "originalPath": (
+                "/usr/src/app/upload/upload/e7ef5713-9dab-4bd4"
+                "-b899-715b0ca4379e/8e/a3/"
+                "8ea31ee8-49c3-4be9-aa9d-b8ef26ba0abe.jpg"
+            ),
             "originalFileName": "20250714_201122.jpg",
             "originalMimeType": "image/jpeg",
             "thumbhash": "XRgGDILGeMlPaJaMWIeagJcJSA==",
@@ -152,10 +166,16 @@ MOCK_PEOPLE_ASSETS = [
             "id": "046ac0d9-8acd-44d8-953f-ecb3c786358a",
             "deviceAssetId": "1000092018",
             "ownerId": "e7ef5713-9dab-4bd4-b899-715b0ca4379e",
-            "deviceId": "5933dd9394fc6bf0493a26b4e38acca1076f30ab246442976d2917f1d57d99a1",
+            "deviceId": (
+                "5933dd9394fc6bf0493a26b4e38acca1076f30ab246442976d2917f1d57d99a1"
+            ),
             "libraryId": None,
             "type": "IMAGE",
-            "originalPath": "/usr/src/app/upload/upload/e7ef5713-9dab-4bd4-b899-715b0ca4379e/f5/b4/f5b4b200-47dd-45e8-98a4-4128df3f9189.jpg",
+            "originalPath": (
+                "/usr/src/app/upload/upload/e7ef5713-9dab-4bd4"
+                "-b899-715b0ca4379e/f5/b4/"
+                "f5b4b200-47dd-45e8-98a4-4128df3f9189.jpg"
+            ),
             "originalFileName": "20250714_201121.jpg",
             "originalMimeType": "image/jpeg",
             "thumbhash": "XRgGDILHeMlPeJaMSJmKgJcIWQ==",
@@ -189,7 +209,11 @@ MOCK_TAGS_ASSETS = [
             "deviceId": "CLI",
             "libraryId": None,
             "type": "IMAGE",
-            "originalPath": "/usr/src/app/upload/upload/e7ef5713-9dab-4bd4-b899-715b0ca4379e/07/d0/07d04d86-7188-4335-95ca-9bd9fd2b399d.JPG",
+            "originalPath": (
+                "/usr/src/app/upload/upload/e7ef5713-9dab-4bd4"
+                "-b899-715b0ca4379e/07/d0/"
+                "07d04d86-7188-4335-95ca-9bd9fd2b399d.JPG"
+            ),
             "originalFileName": "20110306_025024.jpg",
             "originalMimeType": "image/jpeg",
             "thumbhash": "WCgSFYRXaYdQiYineIiHd4SghQUY",
@@ -219,7 +243,11 @@ MOCK_TAGS_ASSETS = [
             "deviceId": "CLI",
             "libraryId": None,
             "type": "IMAGE",
-            "originalPath": "/usr/src/app/upload/upload/e7ef5713-9dab-4bd4-b899-715b0ca4379e/4a/f4/4af42484-86f8-47a0-958a-f32da89ee03a.JPG",
+            "originalPath": (
+                "/usr/src/app/upload/upload/e7ef5713-9dab-4bd4"
+                "-b899-715b0ca4379e/4a/f4/"
+                "4af42484-86f8-47a0-958a-f32da89ee03a.JPG"
+            ),
             "originalFileName": "20110306_024053.jpg",
             "originalMimeType": "image/jpeg",
             "thumbhash": "4AcKFYZPZnhSmGl5daaYeG859ytT",
@@ -250,10 +278,16 @@ MOCK_FAVORITE_ASSETS = [
             "createdAt": "2026-04-06T11:38:53.264Z",
             "deviceAssetId": "55039",
             "ownerId": "e7ef5713-9dab-4bd4-b899-715b0ca4379e",
-            "deviceId": "eca179936c70787e4f76e58338c617472c5f795d7961ae8a7207246919659b44",
+            "deviceId": (
+                "eca179936c70787e4f76e58338c617472c5f795d7961ae8a7207246919659b44"
+            ),
             "libraryId": None,
             "type": "IMAGE",
-            "originalPath": "/usr/src/app/upload/upload/e7ef5713-9dab-4bd4-b899-715b0ca4379e/17/af/17afbef0-dccf-42ad-9c90-618f981914f5.jpg",
+            "originalPath": (
+                "/usr/src/app/upload/upload/e7ef5713-9dab-4bd4"
+                "-b899-715b0ca4379e/17/af/"
+                "17afbef0-dccf-42ad-9c90-618f981914f5.jpg"
+            ),
             "originalFileName": "20260406_133809.jpg",
             "originalMimeType": "image/jpeg",
             "thumbhash": "YNcFRIZnd4qMdquQh4R4cHcGdw==",
@@ -284,10 +318,16 @@ MOCK_FAVORITE_ASSETS = [
             "createdAt": "2026-03-19T18:31:11.540Z",
             "deviceAssetId": "52952",
             "ownerId": "e7ef5713-9dab-4bd4-b899-715b0ca4379e",
-            "deviceId": "eca179936c70787e4f76e58338c617472c5f795d7961ae8a7207246919659b44",
+            "deviceId": (
+                "eca179936c70787e4f76e58338c617472c5f795d7961ae8a7207246919659b44"
+            ),
             "libraryId": None,
             "type": "IMAGE",
-            "originalPath": "/usr/src/app/upload/upload/e7ef5713-9dab-4bd4-b899-715b0ca4379e/f6/40/f640c504-bff3-43cc-b520-60a43269de4b.jpg",
+            "originalPath": (
+                "/usr/src/app/upload/upload/e7ef5713-9dab-4bd4"
+                "-b899-715b0ca4379e/f6/40/"
+                "f640c504-bff3-43cc-b520-60a43269de4b.jpg"
+            ),
             "originalFileName": "20260319_192209.jpg",
             "originalMimeType": "image/jpeg",
             "thumbhash": "VEkGDIIke5yIl5h/UUUgXQKmBg==",

--- a/tests/components/improv_ble/test_config_flow.py
+++ b/tests/components/improv_ble/test_config_flow.py
@@ -334,7 +334,8 @@ async def test_bluetooth_rediscovery_after_successful_provision(
     assert result["reason"] == "provision_successful"
 
     # Now inject the same device again (simulating factory reset)
-    # The match history was cleared after successful provision, so it should be rediscovered
+    # The match history was cleared after successful provision,
+    # so it should be rediscovered
     inject_bluetooth_service_info_bleak(hass, IMPROV_BLE_DISCOVERY_INFO)
     await hass.async_block_till_done()
 
@@ -898,8 +899,8 @@ async def test_provision_fails_invalid_data(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "invalid_improv_data"
     assert (
-        "Received invalid improv via BLE data '000000000000' from device with bluetooth address 'AA:BB:CC:DD:EE:F0'"
-        in caplog.text
+        "Received invalid improv via BLE data '000000000000'"
+        " from device with bluetooth address 'AA:BB:CC:DD:EE:F0'" in caplog.text
     )
 
 

--- a/tests/components/indevolt/test_button.py
+++ b/tests/components/indevolt/test_button.py
@@ -42,7 +42,7 @@ async def test_button_press_standby(
     mock_indevolt: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test pressing the standby button switches to real-time mode and sends standby action."""
+    """Test standby button switches to real-time mode and sends action."""
     with patch("homeassistant.components.indevolt.PLATFORMS", [Platform.BUTTON]):
         await setup_integration(hass, mock_config_entry)
 
@@ -101,7 +101,7 @@ async def test_button_press_standby_rejected_command(
     mock_indevolt: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test pressing standby raises HomeAssistantError when the device rejects the command."""
+    """Test standby raises HomeAssistantError when device rejects."""
     with patch("homeassistant.components.indevolt.PLATFORMS", [Platform.BUTTON]):
         await setup_integration(hass, mock_config_entry)
 
@@ -124,7 +124,7 @@ async def test_button_press_standby_portable_mode_error(
     mock_indevolt: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test pressing standby raises HomeAssistantError when device is in outdoor/portable mode."""
+    """Test standby raises error in outdoor/portable mode."""
 
     # Force outdoor/portable mode
     mock_indevolt.fetch_data.return_value[IndevoltConfig.READ_ENERGY_MODE] = (

--- a/tests/components/indevolt/test_select.py
+++ b/tests/components/indevolt/test_select.py
@@ -116,7 +116,7 @@ async def test_select_unavailable_outdoor_portable(
     mock_indevolt: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test that entity is unavailable when device is in outdoor/portable mode (value 0)."""
+    """Test entity is unavailable in outdoor/portable mode (value 0)."""
 
     # Update mock data to fake outdoor/portable mode
     mock_indevolt.fetch_data.return_value[IndevoltConfig.READ_ENERGY_MODE] = (

--- a/tests/components/indevolt/test_services.py
+++ b/tests/components/indevolt/test_services.py
@@ -124,7 +124,7 @@ async def test_service_target_soc_below_minimum(
     mock_config_entry: MockConfigEntry,
     service_name: str,
 ) -> None:
-    """Test charge and discharge service validation when SOC is below the library hard minimum."""
+    """Test charge/discharge validation when SOC is below hard minimum."""
     await setup_integration(hass, mock_config_entry)
 
     # Configure the API mock to raise SocBelowMinimumError
@@ -220,7 +220,7 @@ async def test_multi_device_partial_validation_failure(
     power: int,
     target_soc: int,
 ) -> None:
-    """Test charge and discharge with two devices where only the gen 1 device fails power validation."""
+    """Test charge/discharge where only gen 1 device fails power validation."""
 
     # Set up multiple devices (gen 1 & gen 2)
     await setup_integration(hass, mock_config_entry)
@@ -402,7 +402,7 @@ async def test_multi_device_execution_failure(
     mock_config_entry: MockConfigEntry,
     alt_mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test that multi_device_errors is raised when execution fails for multiple devices."""
+    """Test multi_device_errors raised when execution fails for multiple."""
 
     # Set up multiple devices (gen 1 & gen 2)
     await setup_integration(hass, mock_config_entry)

--- a/tests/components/inels/common.py
+++ b/tests/components/inels/common.py
@@ -25,7 +25,10 @@ DISCONNECTED_INELS_VALUE = b"off\n"
 def get_entity_id(entity_config: dict, index: int) -> str:
     """Construct the entity_id based on the entity_config."""
     unique_id = entity_config["unique_id"].lower()
-    base_id = f"{entity_config['entity_type']}.{MAC_ADDRESS}_{unique_id}_{entity_config['device_type']}"
+    base_id = (
+        f"{entity_config['entity_type']}.{MAC_ADDRESS}"
+        f"_{unique_id}_{entity_config['device_type']}"
+    )
     return f"{base_id}{f'_{index:03}'}" if index is not None else base_id
 
 
@@ -67,7 +70,7 @@ def set_mock_mqtt(
 async def old_entity_and_device_removal(
     hass: HomeAssistant, mock_mqtt, platform, entity_config, value_key, index
 ):
-    """Test that old entities are correctly identified and removed across different platforms."""
+    """Test old entities are identified and removed across platforms."""
 
     set_mock_mqtt(
         mock_mqtt,
@@ -114,7 +117,8 @@ async def old_entity_and_device_removal(
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    # The device was discovered, and at this point, the async_remove_old_entities function was called
+    # The device was discovered, and at this point,
+    # the async_remove_old_entities function was called
     assert config_entry.runtime_data.devices
     assert old_entity.entity_id not in config_entry.runtime_data.old_entities[platform]
 

--- a/tests/components/inels/conftest.py
+++ b/tests/components/inels/conftest.py
@@ -20,7 +20,7 @@ def mock_inelsmqtt_fixture():
         return mqtt.mock_messages
 
     def last_value(topic):
-        """Mock last_value to return None if mock_last_value is empty or topic doesn't exist."""
+        """Mock last_value returning None if empty or topic missing."""
         return mqtt.mock_last_value.get(topic) if mqtt.mock_last_value else None
 
     async def discovery_all():

--- a/tests/components/inels/test_config_flow.py
+++ b/tests/components/inels/test_config_flow.py
@@ -30,7 +30,7 @@ async def test_mqtt_config_single_instance(
 
 
 async def test_mqtt_setup(hass: HomeAssistant, mqtt_mock: MqttMockHAClient) -> None:
-    """When an MQTT message is received on the discovery topic, it triggers a config flow."""
+    """Test MQTT message on discovery topic triggers a config flow."""
     discovery_info = MqttServiceInfo(
         topic="inels/status/MAC_ADDRESS/gw",
         payload='{"CUType":"CU3-08M","Status":"Runfast","FW":"02.97.18"}',

--- a/tests/components/inels/test_switch.py
+++ b/tests/components/inels/test_switch.py
@@ -85,7 +85,7 @@ async def test_switch_availability(
     device_available,
     expected_state,
 ) -> None:
-    """Test switch availability and state under different gateway and device availability conditions."""
+    """Test switch availability under gateway/device conditions."""
 
     switch_state = await setup_entity(
         entity_config,

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -1162,7 +1162,7 @@ async def test_event_listener_filtered_allowlist(
 async def test_event_listener_filtered_denylist(
     hass: HomeAssistant, mock_client, config_base, get_write_api, get_mock_call
 ) -> None:
-    """Test the event listener against a domain/glob denylist with an entity id allowlist."""
+    """Test event listener with domain/glob denylist and entity allowlist."""
     await _setup(hass, mock_client, config_base, get_write_api)
     write_api = get_write_api(mock_client)
 

--- a/tests/components/infrared/conftest.py
+++ b/tests/components/infrared/conftest.py
@@ -16,7 +16,8 @@ async def mock_infrared_emitter_entity(
 ) -> MockInfraredEntity | MockInfraredEmitterEntity:
     """Return a mock infrared emitter entity.
 
-    This overrides the default common fixture to also test the deprecated MockInfraredEntity.
+    This overrides the default common fixture to also test the deprecated
+    MockInfraredEntity.
     """
     entity = request.param("test_ir_emitter")
     component = hass.data[DATA_COMPONENT]

--- a/tests/components/input_datetime/test_init.py
+++ b/tests/components/input_datetime/test_init.py
@@ -758,7 +758,8 @@ async def test_timestamp(hass: HomeAssistant) -> None:
     # initial has been converted to the set timezone
     state_with_tz = hass.states.get("input_datetime.test_datetime_initial_with_tz")
     assert state_with_tz is not None
-    # Timezone LA is UTC-8 => timestamp carries +01:00 => delta is -9 => 10:00 - 09:00 => 01:00
+    # Timezone LA is UTC-8 => timestamp carries +01:00
+    # => delta is -9 => 10:00 - 09:00 => 01:00
     assert state_with_tz.state == "2020-12-13 01:00:00"
     assert (
         dt_util.as_local(
@@ -773,7 +774,8 @@ async def test_timestamp(hass: HomeAssistant) -> None:
     )
     assert state_without_tz is not None
     assert state_without_tz.state == "2020-12-13 10:00:00"
-    # Timezone LA is UTC-8 => timestamp has no zone (= assumed local) => delta to UTC is +8 => 10:00 + 08:00 => 18:00
+    # Timezone LA is UTC-8 => timestamp has no zone (= assumed local)
+    # => delta to UTC is +8 => 10:00 + 08:00 => 18:00
     assert (
         dt_util.utc_from_timestamp(
             state_without_tz.attributes[ATTR_TIMESTAMP]

--- a/tests/components/input_number/test_reproduce_state.py
+++ b/tests/components/input_number/test_reproduce_state.py
@@ -52,7 +52,8 @@ async def test_reproducing_states(
     # Test setting state to number out of range
     await async_reproduce_state(hass, [State("input_number.test_number", "150")])
 
-    # The entity states should be unchanged after trying to set them to out-of-range number
+    # The entity states should be unchanged after trying to set
+    # them to out-of-range number
     assert hass.states.get("input_number.test_number").state == VALID_NUMBER2
 
     await async_reproduce_state(

--- a/tests/components/insteon/test_api_config.py
+++ b/tests/components/insteon/test_api_config.py
@@ -207,7 +207,7 @@ async def test_update_modem_config_bad(
 async def test_update_modem_config_bad_reconnect(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
-    """Test updating the Insteon modem configuration with bad connection information so reconnect to old."""
+    """Test bad connection info on modem update reconnects to old."""
 
     ws_client, mock_devices, _, _ = await async_mock_setup(
         hass,

--- a/tests/components/integration/test_init.py
+++ b/tests/components/integration/test_init.py
@@ -222,7 +222,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     sensor_device: dr.DeviceEntry,
     sensor_entity_entry: er.RegistryEntry,
 ) -> None:
-    """Test the integration config entry is removed when the source entity is removed."""
+    """Test config entry is removed when source entity is removed."""
     assert await hass.config_entries.async_setup(integration_config_entry.entry_id)
     await hass.async_block_till_done()
 
@@ -270,7 +270,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     sensor_device: dr.DeviceEntry,
     sensor_entity_entry: er.RegistryEntry,
 ) -> None:
-    """Test the integration config entry is removed when the source entity is removed."""
+    """Test config entry is removed when source entity is removed."""
     # Add another config entry to the sensor device
     other_config_entry = MockConfigEntry()
     other_config_entry.add_to_hass(hass)

--- a/tests/components/integration/test_sensor.py
+++ b/tests/components/integration/test_sensor.py
@@ -170,7 +170,8 @@ async def test_state(hass: HomeAssistant, method) -> None:
     state = hass.states.get("sensor.integration")
     assert state.state == STATE_UNAVAILABLE
 
-    # 1 hour after last update, power sensor is back to normal at 2 KiloWatts and stays for 1 hour += 2kWh
+    # 1 hour after last update, power sensor is back to normal
+    # at 2 KiloWatts and stays for 1 hour += 2kWh
     now += timedelta(seconds=3600)
     with freeze_time(now):
         hass.states.async_set(
@@ -979,7 +980,7 @@ async def test_on_valid_source_expect_update_on_time(
 async def test_on_0_source_expect_0_and_update_when_source_gets_positive(
     hass: HomeAssistant,
 ) -> None:
-    """Test whether time based integration updates the integral on a valid zero source."""
+    """Test time based integration updates integral on valid zero source."""
     start_time = dt_util.utcnow()
 
     with freeze_time(start_time) as freezer:
@@ -1012,7 +1013,7 @@ async def test_on_0_source_expect_0_and_update_when_source_gets_positive(
 async def test_on_unvailable_source_expect_no_update_on_time(
     hass: HomeAssistant,
 ) -> None:
-    """Test whether time based integration handles unavailability of the source properly."""
+    """Test time based integration handles source unavailability."""
 
     start_time = dt_util.utcnow()
     with freeze_time(start_time) as freezer:
@@ -1072,7 +1073,7 @@ async def test_on_statechanges_source_expect_no_update_on_time(
 async def test_on_no_max_sub_interval_expect_no_timebased_updates(
     hass: HomeAssistant,
 ) -> None:
-    """Test whether integratal is not updated by time when max_sub_interval is not configured."""
+    """Test integral not updated by time without max_sub_interval."""
 
     start_time = dt_util.utcnow()
     with freeze_time(start_time) as freezer:

--- a/tests/components/intelliclima/test_fan.py
+++ b/tests/components/intelliclima/test_fan.py
@@ -131,7 +131,7 @@ async def test_fan_set_preset_mode_service(
     hass: HomeAssistant,
     mock_cloud_interface: AsyncMock,
 ) -> None:
-    """Tests whether the set preset mode service is called and correct api call is followed."""
+    """Test set preset mode service triggers correct api call."""
 
     await hass.services.async_call(
         FAN_DOMAIN,
@@ -165,10 +165,11 @@ async def test_fan_set_percentage_zero_turns_off(
 @pytest.mark.parametrize(
     ("service_data", "expected_mode", "expected_speed"),
     [
-        # percentage=None, preset_mode=None -> defaults to previous speed > 75% (medium),
-        # previous mode > FanMode.inward
+        # percentage=None, preset_mode=None -> defaults to previous
+        # speed > 75% (medium), previous mode > FanMode.inward
         ({}, FanMode.inward, FanSpeed.medium),
-        # percentage=0, preset_mode=None -> default 25% (FanSpeed.sleep), previous mode (inward)
+        # percentage=0, preset_mode=None -> default 25%
+        # (FanSpeed.sleep), previous mode (inward)
         ({ATTR_PERCENTAGE: 0}, FanMode.inward, FanSpeed.sleep),
     ],
 )

--- a/tests/components/intelliclima/test_select.py
+++ b/tests/components/intelliclima/test_select.py
@@ -98,7 +98,7 @@ async def test_select_option_when_off_defaults_speed_to_sleep(
     mock_cloud_interface: AsyncMock,
     single_eco_device,
 ) -> None:
-    """When the device is off, selecting an option defaults the speed to FanSpeed.sleep."""
+    """Test selecting option when off defaults speed to sleep."""
     # Mutate the shared fixture object – coordinator.data points to the same reference.
     eco = list(single_eco_device.ecocomfort2_devices.values())[0]
     eco.mode_set = FanMode.off
@@ -119,7 +119,7 @@ async def test_select_option_in_auto_mode_defaults_speed_to_sleep(
     mock_cloud_interface: AsyncMock,
     single_eco_device,
 ) -> None:
-    """When speed_set is FanSpeed.auto_get (auto preset), selecting an option defaults to sleep speed."""
+    """Test selecting option in auto preset defaults to sleep speed."""
     eco = list(single_eco_device.ecocomfort2_devices.values())[0]
     eco.speed_set = FanSpeed.auto_get
     eco.mode_set = FanMode.sensor

--- a/tests/components/intellifire/conftest.py
+++ b/tests/components/intellifire/conftest.py
@@ -67,7 +67,9 @@ def mock_config_entry_current() -> MockConfigEntry:
             CONF_WEB_CLIENT_ID: "FA2B1C3045601234D0AE17D72F8E975",
             CONF_API_KEY: "B5C4DA27AAEF31D1FB21AFF9BFA6BCD2",
             CONF_AUTH_COOKIE: "B984F21A6378560019F8A1CDE41B6782",
-            CONF_USER_ID: "52C3F9E8B9D3AC99F8E4D12345678901FE9A2BC7D85F7654E28BF98BCD123456",
+            CONF_USER_ID: (
+                "52C3F9E8B9D3AC99F8E4D12345678901FE9A2BC7D85F7654E28BF98BCD123456"
+            ),
         },
         options={CONF_READ_MODE: API_MODE_LOCAL, CONF_CONTROL_MODE: API_MODE_LOCAL},
         unique_id="3FB284769E4736F30C8973A7ED358123",
@@ -89,7 +91,9 @@ def mock_config_entry_v1_2_old_options() -> MockConfigEntry:
             CONF_WEB_CLIENT_ID: "FA2B1C3045601234D0AE17D72F8E975",
             CONF_API_KEY: "B5C4DA27AAEF31D1FB21AFF9BFA6BCD2",
             CONF_AUTH_COOKIE: "B984F21A6378560019F8A1CDE41B6782",
-            CONF_USER_ID: "52C3F9E8B9D3AC99F8E4D12345678901FE9A2BC7D85F7654E28BF98BCD123456",
+            CONF_USER_ID: (
+                "52C3F9E8B9D3AC99F8E4D12345678901FE9A2BC7D85F7654E28BF98BCD123456"
+            ),
         },
         # Old option keys as they exist in upstream/dev
         options={"cloud_read": "cloud", "cloud_control": "local"},
@@ -109,7 +113,9 @@ def mock_config_entry_old() -> MockConfigEntry:
             CONF_HOST: "192.168.2.108",
             CONF_USERNAME: "grumpypanda@china.cn",
             CONF_PASSWORD: "you-stole-my-pandas",
-            CONF_USER_ID: "52C3F9E8B9D3AC99F8E4D12345678901FE9A2BC7D85F7654E28BF98BCD123456",
+            CONF_USER_ID: (
+                "52C3F9E8B9D3AC99F8E4D12345678901FE9A2BC7D85F7654E28BF98BCD123456"
+            ),
         },
     )
 

--- a/tests/components/intellifire/test_config_flow.py
+++ b/tests/components/intellifire/test_config_flow.py
@@ -203,7 +203,8 @@ async def test_dhcp_discovery_non_intellifire_device(
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "not_intellifire_device"
-    # Test is finished - the DHCP scanner detected a hostname that "might" be an IntelliFire device, but it was not.
+    # Test is finished - the DHCP scanner detected a hostname that
+    # "might" be an IntelliFire device, but it was not.
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
@@ -299,7 +300,7 @@ async def test_options_flow_local_read_unavailable(
     mock_config_entry_current: MockConfigEntry,
     mock_apis_single_fp,
 ) -> None:
-    """Test options flow shows error when local connectivity unavailable for read mode."""
+    """Test options flow error when local unavailable for read."""
     _mock_local, _mock_cloud, mock_fp = mock_apis_single_fp
 
     mock_config_entry_current.add_to_hass(hass)
@@ -332,7 +333,7 @@ async def test_options_flow_local_control_unavailable(
     mock_config_entry_current: MockConfigEntry,
     mock_apis_single_fp,
 ) -> None:
-    """Test options flow shows error when local connectivity unavailable for control mode."""
+    """Test options flow error when local unavailable for control."""
     _mock_local, _mock_cloud, mock_fp = mock_apis_single_fp
 
     mock_config_entry_current.add_to_hass(hass)
@@ -363,7 +364,7 @@ async def test_options_flow_cloud_read_unavailable(
     mock_config_entry_current: MockConfigEntry,
     mock_apis_single_fp,
 ) -> None:
-    """Test options flow shows error when cloud connectivity unavailable for read mode."""
+    """Test options flow error when cloud unavailable for read."""
     _mock_local, _mock_cloud, mock_fp = mock_apis_single_fp
 
     mock_config_entry_current.add_to_hass(hass)
@@ -396,7 +397,7 @@ async def test_options_flow_cloud_control_unavailable(
     mock_config_entry_current: MockConfigEntry,
     mock_apis_single_fp,
 ) -> None:
-    """Test options flow shows error when cloud connectivity unavailable for control mode."""
+    """Test options flow error when cloud unavailable for control."""
     _mock_local, _mock_cloud, mock_fp = mock_apis_single_fp
 
     mock_config_entry_current.add_to_hass(hass)

--- a/tests/components/intellifire/test_init.py
+++ b/tests/components/intellifire/test_init.py
@@ -70,7 +70,9 @@ async def test_migration_v1_1_error(hass: HomeAssistant, mock_apis_single_fp) ->
             CONF_HOST: "11.168.2.218",
             CONF_USERNAME: "grumpypanda@china.cn",
             CONF_PASSWORD: "you-stole-my-pandas",
-            CONF_USER_ID: "52C3F9E8B9D3AC99F8E4D12345678901FE9A2BC7D85F7654E28BF98BCD123456",
+            CONF_USER_ID: (
+                "52C3F9E8B9D3AC99F8E4D12345678901FE9A2BC7D85F7654E28BF98BCD123456"
+            ),
         },
     )
 
@@ -116,7 +118,9 @@ async def test_migration_v1_2_to_v1_3_defaults(
             CONF_WEB_CLIENT_ID: "FA2B1C3045601234D0AE17D72F8E975",
             CONF_API_KEY: "B5C4DA27AAEF31D1FB21AFF9BFA6BCD2",
             CONF_AUTH_COOKIE: "B984F21A6378560019F8A1CDE41B6782",
-            CONF_USER_ID: "52C3F9E8B9D3AC99F8E4D12345678901FE9A2BC7D85F7654E28BF98BCD123456",
+            CONF_USER_ID: (
+                "52C3F9E8B9D3AC99F8E4D12345678901FE9A2BC7D85F7654E28BF98BCD123456"
+            ),
         },
         options={},
         unique_id="3FB284769E4736F30C8973A7ED358123",
@@ -149,7 +153,9 @@ async def test_init_with_no_username(hass: HomeAssistant, mock_apis_single_fp) -
             CONF_WEB_CLIENT_ID: "FA2B1C3045601234D0AE17D72F8E975",
             CONF_API_KEY: "B5C4DA27AAEF31D1FB21AFF9BFA6BCD2",
             CONF_AUTH_COOKIE: "B984F21A6378560019F8A1CDE41B6782",
-            CONF_USER_ID: "52C3F9E8B9D3AC99F8E4D12345678901FE9A2BC7D85F7654E28BF98BCD123456",
+            CONF_USER_ID: (
+                "52C3F9E8B9D3AC99F8E4D12345678901FE9A2BC7D85F7654E28BF98BCD123456"
+            ),
         },
         options={CONF_READ_MODE: API_MODE_LOCAL, CONF_CONTROL_MODE: API_MODE_CLOUD},
         unique_id="3FB284769E4736F30C8973A7ED358123",
@@ -191,7 +197,7 @@ async def test_update_options_change_read_mode_only(
     mock_config_entry_current: MockConfigEntry,
     mock_apis_single_fp,
 ) -> None:
-    """Test that changing only read mode triggers set_read_mode but not set_control_mode."""
+    """Test changing read mode triggers set_read_mode only."""
     _mock_local, _mock_cloud, mock_fp = mock_apis_single_fp
 
     mock_config_entry_current.add_to_hass(hass)
@@ -225,7 +231,7 @@ async def test_update_options_change_control_mode_only(
     mock_config_entry_current: MockConfigEntry,
     mock_apis_single_fp,
 ) -> None:
-    """Test that changing only control mode triggers set_control_mode but not set_read_mode."""
+    """Test changing control mode triggers set_control_mode only."""
     _mock_local, _mock_cloud, mock_fp = mock_apis_single_fp
 
     mock_config_entry_current.add_to_hass(hass)
@@ -293,7 +299,7 @@ async def test_update_options_no_change(
     mock_config_entry_current: MockConfigEntry,
     mock_apis_single_fp,
 ) -> None:
-    """Test that no mode change triggers neither set method but refresh is still called."""
+    """Test no mode change skips set methods but still refreshes."""
     _mock_local, _mock_cloud, mock_fp = mock_apis_single_fp
 
     mock_config_entry_current.add_to_hass(hass)

--- a/tests/components/intent/test_timers.py
+++ b/tests/components/intent/test_timers.py
@@ -1471,7 +1471,7 @@ async def test_start_timer_with_conversation_command(
 async def test_start_timer_with_sentence_trigger_validation(
     hass: HomeAssistant, init_components
 ) -> None:
-    """Test starting a timer with a conversation command validates against sentence triggers."""
+    """Test timer with conversation command validates sentence triggers."""
     device_id = "test_device"
     timer_name = "test timer"
     test_command = "turn on the lights"
@@ -1541,13 +1541,14 @@ async def test_start_timer_with_invalid_conversation_command(
 async def test_start_timer_with_conversation_command_skip_validation(
     hass: HomeAssistant, init_components
 ) -> None:
-    """Test starting a timer with a conversation command skips validation for non-default agents."""
+    """Test timer with conversation command skips validation for non-default agents."""
     device_id = "test_device"
     timer_name = "test timer"
     invalid_command = "invalid command that does not exist"
     agent_id = "conversation.test_llm_agent"
 
-    # This should NOT raise an error because validation is skipped for all non-default agents
+    # This should NOT raise an error because validation is
+    # skipped for all non-default agents
     result = await intent.async_handle(
         hass,
         "test",

--- a/tests/components/intent_script/test_init.py
+++ b/tests/components/intent_script/test_init.py
@@ -179,7 +179,11 @@ async def test_intent_script_falsy_reprompt(hass: HomeAssistant) -> None:
                     },
                     "speech": {
                         "type": "ssml",
-                        "text": '<speak><amazon:effect name="whispered">Good morning {{ name }}</amazon:effect></speak>',
+                        "text": (
+                            '<speak><amazon:effect name="whispered">'
+                            "Good morning {{ name }}"
+                            "</amazon:effect></speak>"
+                        ),
                     },
                     "reprompt": {"text": "{{ null }}"},
                 }
@@ -194,9 +198,9 @@ async def test_intent_script_falsy_reprompt(hass: HomeAssistant) -> None:
     assert len(calls) == 1
     assert calls[0].data["hello"] == "Paulus"
 
-    assert (
-        response.speech["ssml"]["speech"]
-        == '<speak><amazon:effect name="whispered">Good morning Paulus</amazon:effect></speak>'
+    assert response.speech["ssml"]["speech"] == (
+        '<speak><amazon:effect name="whispered">'
+        "Good morning Paulus</amazon:effect></speak>"
     )
 
     assert not (response.reprompt)
@@ -340,9 +344,10 @@ async def test_intent_script_action_validation(
                                     "conditions": [
                                         {
                                             "condition": "state",
-                                            # Use entity registry ID instead of entity_id
-                                            # This requires async_validate_actions_config
-                                            # to resolve to the actual entity_id
+                                            # Use entity registry ID
+                                            # instead of entity_id.
+                                            # async_validate_actions_config
+                                            # resolves to actual entity_id
                                             "entity_id": entry.id,
                                             "state": "on",
                                         }
@@ -365,7 +370,8 @@ async def test_intent_script_action_validation(
                     ],
                     "speech": {"text": "Done"},
                 },
-                # This intent has an invalid entity registry ID and should fail validation
+                # This intent has an invalid entity registry ID
+                # and should fail validation
                 "InvalidIntent": {
                     "action": [
                         {

--- a/tests/components/iometer/test_binary_sensor.py
+++ b/tests/components/iometer/test_binary_sensor.py
@@ -51,7 +51,8 @@ async def test_connection_status_sensors(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    mock_iometer_client.get_current_status.return_value.device.core.connection_status = "disconnected"
+    status = mock_iometer_client.get_current_status.return_value
+    status.device.core.connection_status = "disconnected"
 
     freezer.tick(delta=timedelta(minutes=1))
     async_fire_time_changed(hass)
@@ -86,7 +87,8 @@ async def test_attachment_status_sensors(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    mock_iometer_client.get_current_status.return_value.device.core.attachment_status = "detached"
+    status = mock_iometer_client.get_current_status.return_value
+    status.device.core.attachment_status = "detached"
 
     freezer.tick(delta=timedelta(minutes=1))
     async_fire_time_changed(hass)
@@ -121,7 +123,8 @@ async def test_attachment_status_sensors_unkown(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    mock_iometer_client.get_current_status.return_value.device.core.attachment_status = None
+    status = mock_iometer_client.get_current_status.return_value
+    status.device.core.attachment_status = None
 
     freezer.tick(delta=timedelta(minutes=1))
     async_fire_time_changed(hass)

--- a/tests/components/iotty/test_api.py
+++ b/tests/components/iotty/test_api.py
@@ -32,7 +32,7 @@ async def test_api_create_ok(
     aiohttp_client_session: None,
     local_oauth_impl: ClientSession,
 ) -> None:
-    """Test API creation. We're checking that we can create an IottyProxy without raising."""
+    """Test we can create an IottyProxy without raising."""
 
     mock_config_entry.add_to_hass(hass)
     assert mock_config_entry.data["auth_implementation"] is not None

--- a/tests/components/ipp/test_config_flow.py
+++ b/tests/components/ipp/test_config_flow.py
@@ -512,7 +512,7 @@ async def test_full_zeroconf_tls_flow_implementation(
 
 
 async def test_zeroconf_empty_unique_id_uses_serial(hass: HomeAssistant) -> None:
-    """Test zeroconf flow if printer lacks (empty) unique identification with serial fallback."""
+    """Test zeroconf flow with empty unique ID uses serial fallback."""
     fixture = await hass.async_add_executor_job(
         load_fixture, "ipp/printer_without_uuid.json"
     )

--- a/tests/components/ipp/test_diagnostics.py
+++ b/tests/components/ipp/test_diagnostics.py
@@ -1,4 +1,4 @@
-"""Tests for the diagnostics data provided by the Internet Printing Protocol (IPP) integration."""
+"""Tests for the diagnostics data provided by the IPP integration."""
 
 import pytest
 from syrupy.assertion import SnapshotAssertion

--- a/tests/components/irm_kmi/conftest.py
+++ b/tests/components/irm_kmi/conftest.py
@@ -41,7 +41,7 @@ def mock_setup_entry() -> Generator[None]:
 
 @pytest.fixture
 def mock_get_forecast_in_benelux():
-    """Mock a call to IrmKmiApiClient.get_forecasts_coord() so that it returns something valid and in the Benelux."""
+    """Mock get_forecasts_coord() returning valid data in Benelux."""
     with patch(
         "homeassistant.components.irm_kmi.config_flow.IrmKmiApiClient.get_forecasts_coord",
         return_value={"cityName": "Brussels", "country": "BE"},
@@ -51,7 +51,7 @@ def mock_get_forecast_in_benelux():
 
 @pytest.fixture
 def mock_get_forecast_out_benelux_then_in_belgium():
-    """Mock a call to IrmKmiApiClient.get_forecasts_coord() so that it returns something outside Benelux."""
+    """Mock get_forecasts_coord() returning outside then inside Benelux."""
     with patch(
         "homeassistant.components.irm_kmi.config_flow.IrmKmiApiClient.get_forecasts_coord",
         side_effect=[
@@ -64,7 +64,7 @@ def mock_get_forecast_out_benelux_then_in_belgium():
 
 @pytest.fixture
 def mock_get_forecast_api_error():
-    """Mock a call to IrmKmiApiClient.get_forecasts_coord() so that it raises an error."""
+    """Mock get_forecasts_coord() so that it raises an error."""
     with patch(
         "homeassistant.components.irm_kmi.config_flow.IrmKmiApiClient.get_forecasts_coord",
         side_effect=IrmKmiApiError,
@@ -88,7 +88,7 @@ def mock_irm_kmi_api(request: pytest.FixtureRequest) -> Generator[MagicMock]:
 
 @pytest.fixture
 def mock_irm_kmi_api_nl():
-    """Mock a call to IrmKmiApiClientHa.get_forecasts_coord() to return a forecast in The Netherlands."""
+    """Mock get_forecasts_coord() to return a Netherlands forecast."""
     fixture: str = "forecast_nl.json"
     forecast = json.loads(load_fixture(fixture, "irm_kmi"))
     with patch(
@@ -100,7 +100,7 @@ def mock_irm_kmi_api_nl():
 
 @pytest.fixture
 def mock_irm_kmi_api_high_low_temp():
-    """Mock a call to IrmKmiApiClientHa.get_forecasts_coord() to return high_low_temp.json forecast."""
+    """Mock get_forecasts_coord() to return high_low_temp forecast."""
     fixture: str = "high_low_temp.json"
     forecast = json.loads(load_fixture(fixture, "irm_kmi"))
     with patch(
@@ -112,7 +112,7 @@ def mock_irm_kmi_api_high_low_temp():
 
 @pytest.fixture
 def mock_exception_irm_kmi_api(request: pytest.FixtureRequest) -> Generator[MagicMock]:
-    """Return a mocked IrmKmi api client that will raise an error upon refreshing data."""
+    """Return a mocked IrmKmi api client that raises on refresh."""
     with patch(
         "homeassistant.components.irm_kmi.IrmKmiApiClientHa", autospec=True
     ) as irm_kmi_api_mock:

--- a/tests/components/irm_kmi/test_weather.py
+++ b/tests/components/irm_kmi/test_weather.py
@@ -75,7 +75,7 @@ async def test_weather_higher_temp_at_night(
     mock_irm_kmi_api_high_low_temp: AsyncMock,
     forecast_type: str,
 ) -> None:
-    """Test that the templow is always lower than temperature, even when API returns the opposite."""
+    """Test templow is always lower than temperature."""
     # Test case for https://github.com/jdejaegh/irm-kmi-ha/issues/8
     mock_config_entry.add_to_hass(hass)
 

--- a/tests/components/islamic_prayer_times/test_sensor.py
+++ b/tests/components/islamic_prayer_times/test_sensor.py
@@ -32,8 +32,10 @@ async def set_utc(hass: HomeAssistant) -> None:
         ("Midnight", "sensor.islamic_prayer_times_midnight_time"),
     ],
 )
-# In our example data, Islamic midnight occurs at 00:44 (yesterday's times, occurs today) and 00:45 (today's times, occurs tomorrow),
-# hence we check that the times roll over at exactly the desired minute
+# In our example data, Islamic midnight occurs at 00:44
+# (yesterday's times, occurs today) and 00:45 (today's times,
+# occurs tomorrow), hence we check that the times roll over at
+# exactly the desired minute
 @pytest.mark.parametrize(
     ("offset", "prayer_times"),
     [

--- a/tests/components/ituran/test_sensor.py
+++ b/tests/components/ituran/test_sensor.py
@@ -98,7 +98,7 @@ async def test_availability(
     mock_ituran: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test ICE sensor is marked as unavailable when we can't reach the Ituran service."""
+    """Test ICE sensor unavailable when Ituran service unreachable."""
     await __test_availability(hass, freezer, mock_ituran, mock_config_entry)
 
 
@@ -110,7 +110,7 @@ async def test_ev_availability(
     mock_ituran: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test EV sensor is marked as unavailable when we can't reach the Ituran service."""
+    """Test EV sensor unavailable when Ituran service unreachable."""
     ev_entities = [
         "sensor.mock_model_battery",
         "sensor.mock_model_remaining_range",

--- a/tests/components/izone/test_climate.py
+++ b/tests/components/izone/test_climate.py
@@ -119,7 +119,7 @@ async def test_target_temperature_feature_zone_without_sensor(
     mock_discovery: AsyncMock,
     mock_controller: AsyncMock,
 ) -> None:
-    """Test TARGET_TEMPERATURE feature enabled when any zone lacks temperature sensor."""
+    """Test TARGET_TEMPERATURE enabled when zone lacks temp sensor."""
     await setup_integration(hass, mock_config_entry)
     await setup_controller(hass, mock_discovery, mock_controller)
 
@@ -190,7 +190,7 @@ async def test_target_temperature_feature_multiple_zones_one_without_sensor(
     mock_discovery: AsyncMock,
     mock_controller: AsyncMock,
 ) -> None:
-    """Test TARGET_TEMPERATURE feature enabled with multiple zones when one lacks sensor."""
+    """Test TARGET_TEMPERATURE enabled with multiple zones, one no sensor."""
     await setup_integration(hass, mock_config_entry)
     await setup_controller(hass, mock_discovery, mock_controller)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix all 119 E501 (line too long) violations in `tests/components/` for integrations starting with i.

Part of a series to enforce the 88-character line length limit across the codebase. Changes are purely cosmetic — rewrapped comments, split long strings, shortened docstrings, and reformatted test data. No logic changes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
