### PR TITLE
Use correct state_class for utility meters with device classes that don't support total_increasing

### DIFF
--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -13,6 +13,7 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import (
     ATTR_LAST_RESET,
+    DEVICE_CLASS_STATE_CLASSES,
     DEVICE_CLASS_UNITS,
     RestoreSensor,
     SensorDeviceClass,
@@ -695,12 +696,18 @@ class UtilityMeterSensor(RestoreSensor):
 
     @property
     def state_class(self) -> SensorStateClass:
-        """Return the device class of the sensor."""
-        return (
-            SensorStateClass.TOTAL
-            if self._sensor_net_consumption
-            else SensorStateClass.TOTAL_INCREASING
-        )
+        """Return the state class of the sensor."""
+        if self._sensor_net_consumption:
+            return SensorStateClass.TOTAL
+        if (
+            self._input_device_class is not None
+            and SensorStateClass.TOTAL_INCREASING
+            not in DEVICE_CLASS_STATE_CLASSES.get(
+                self._input_device_class, {SensorStateClass.TOTAL_INCREASING}
+            )
+        ):
+            return SensorStateClass.TOTAL
+        return SensorStateClass.TOTAL_INCREASING
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -657,6 +657,40 @@ async def test_device_class(
         assert state.attributes.get(attr) == value
 
 
+async def test_state_class_monetary_device_class(hass: HomeAssistant) -> None:
+    """Test that monetary device class uses state_class total, not total_increasing."""
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            "utility_meter": {
+                "cost_meter": {
+                    "source": "sensor.energy_cost",
+                }
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+
+    hass.states.async_set(
+        "sensor.energy_cost",
+        2,
+        {
+            ATTR_DEVICE_CLASS: SensorDeviceClass.MONETARY,
+            ATTR_UNIT_OF_MEASUREMENT: "EUR",
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.cost_meter")
+    assert state is not None
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.MONETARY
+    assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.TOTAL
+
+
 @pytest.mark.parametrize(
     ("yaml_config", "config_entry_config"),
     [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The utility meter sensor unconditionally uses `state_class: total_increasing` for non-net-consumption meters. This is invalid for device classes like `monetary`, which only supports `state_class: total`. This causes a warning on every state update:

```
Entity sensor.daily_cost is using state class 'total_increasing' which is
impossible considering device class ('monetary') it is using; expected None
or one of 'total'
```

The fix looks up `DEVICE_CLASS_STATE_CLASSES` to check whether the input sensor's device class actually supports `total_increasing`. If it doesn't, `total` is used instead. This works generically for any current or future device class constraint, not just `monetary`.

The existing `last_reset` handling in `extra_state_attributes` already supports `total` state class correctly (it's the same code path used by `net_consumption`), so no additional changes are needed for long-term statistics.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #115692
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr