### PR TITLE
Reduce GoodWe connect retries to avoid blocking startup

### DIFF
--- a/homeassistant/components/goodwe/__init__.py
+++ b/homeassistant/components/goodwe/__init__.py
@@ -25,7 +25,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: GoodweConfigEntry) -> bo
             host=host,
             port=port,
             family=model_family,
-            retries=10,
+            retries=3,
         )
     except InverterError as err:
         try:

--- a/homeassistant/components/goodwe/config_flow.py
+++ b/homeassistant/components/goodwe/config_flow.py
@@ -71,8 +71,8 @@ class GoodweFlowHandler(ConfigFlow, domain=DOMAIN):
         """Detects the port of the Inverter."""
         port = GOODWE_UDP_PORT
         try:
-            inverter = await connect(host=host, port=port, retries=10)
+            inverter = await connect(host=host, port=port, retries=3)
         except InverterError:
             port = GOODWE_TCP_PORT
-            inverter = await connect(host=host, port=port, retries=10)
+            inverter = await connect(host=host, port=port, retries=3)
         return inverter, port

--- a/tests/components/goodwe/test_init.py
+++ b/tests/components/goodwe/test_init.py
@@ -1,8 +1,11 @@
 """Test the GoodWe initialization."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+
+from goodwe import InverterError
 
 from homeassistant.components.goodwe import CONF_MODEL_FAMILY, DOMAIN
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -34,3 +37,34 @@ async def test_migration(
     assert config_entry.data[CONF_HOST] == TEST_HOST
     assert config_entry.data[CONF_MODEL_FAMILY] == "MagicMock"
     assert config_entry.data[CONF_PORT] == TEST_PORT
+
+
+async def test_setup_connect_not_ready(hass: HomeAssistant) -> None:
+    """Test that setup raises ConfigEntryNotReady when inverter is unreachable."""
+    config_entry = MockConfigEntry(
+        version=2,
+        domain=DOMAIN,
+        data={
+            CONF_HOST: TEST_HOST,
+            CONF_PORT: TEST_PORT,
+            CONF_MODEL_FAMILY: "ET",
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.goodwe.connect",
+            side_effect=InverterError,
+        ) as mock_connect,
+        patch(
+            "homeassistant.components.goodwe.config_flow.connect",
+            side_effect=InverterError,
+        ),
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+    # Verify connect is called with limited retries to avoid blocking startup
+    assert mock_connect.call_args.kwargs["retries"] <= 3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The GoodWe integration uses `retries=10` when connecting to the inverter during setup and port detection. With a 1-second timeout per attempt, this means setup blocks for 30-80+ seconds when the inverter is unreachable (common at night for solar inverters). This delays the entire HA startup, including add-ons like Zigbee2MQTT.

This reduces `retries` to 3 (the library default) in both `async_setup_entry` and `async_detect_inverter_port`. When the inverter is offline, setup now fails quickly and raises `ConfigEntryNotReady`, which lets HA's built-in retry mechanism handle reconnection without blocking startup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #161460
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr