### PR TITLE
Fix line length violations in tests/components m

### DIFF
--- a/tests/components/mastodon/test_diagnostics.py
+++ b/tests/components/mastodon/test_diagnostics.py
@@ -36,7 +36,7 @@ async def test_entry_diagnostics_fallback_to_instance_v1(
     mock_config_entry: MockConfigEntry,
     snapshot: SnapshotAssertion,
 ) -> None:
-    """Test config entry diagnostics with fallback to instance_v1 when instance_v2 raises MastodonNotFoundError."""
+    """Test diagnostics fallback to instance_v1 when instance_v2 raises error."""
     mock_mastodon_client.instance_v2.side_effect = MastodonNotFoundError(
         "Instance v2 not found"
     )

--- a/tests/components/mastodon/test_services.py
+++ b/tests/components/mastodon/test_services.py
@@ -617,7 +617,7 @@ async def test_post_path_not_whitelisted(
     mock_mastodon_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test the post service raising an error because the file path is not whitelisted."""
+    """Test post service error when file path is not whitelisted."""
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
@@ -641,7 +641,7 @@ async def test_idempotency_key_too_short(
     mock_mastodon_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test the post service raising an error because the idempotency key is too short."""
+    """Test post service error when idempotency key is too short."""
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/matrix/test_commands.py
+++ b/tests/components/matrix/test_commands.py
@@ -27,7 +27,7 @@ SUBSET_ROOMS = (TEST_ROOM_B_ID, TEST_ROOM_C_ID)
 
 @dataclass
 class CommandTestParameters:
-    """Dataclass of parameters representing the command config parameters and expected result state.
+    """Command config parameters and expected result state.
 
     Switches behavior based on `room_id` and `expected_event_room_data`.
     """

--- a/tests/components/matrix/test_login.py
+++ b/tests/components/matrix/test_login.py
@@ -12,7 +12,7 @@ from .conftest import TEST_DEVICE_ID, TEST_MXID, TEST_PASSWORD, TEST_TOKEN
 
 @dataclass
 class LoginTestParameters:
-    """Dataclass of parameters representing the login parameters and expected result state."""
+    """Login parameters and expected result state."""
 
     password: str
     access_token: dict[str, str]
@@ -34,7 +34,8 @@ good_password_bad_token = LoginTestParameters(
     expected_login_state=True,
     expected_caplog_messages={
         "Restoring login from stored access token",
-        "Restoring login from access token failed: M_UNKNOWN_TOKEN, Invalid access token passed.",
+        "Restoring login from access token failed:"
+        " M_UNKNOWN_TOKEN, Invalid access token passed.",
         "Logging in using password",
     },
 )
@@ -45,7 +46,8 @@ bad_password_good_access_token = LoginTestParameters(
     expected_login_state=True,
     expected_caplog_messages={
         "Restoring login from stored access token",
-        f"Successfully restored login from access token: user_id '{TEST_MXID}', device_id '{TEST_DEVICE_ID}'",
+        "Successfully restored login from access token:"
+        f" user_id '{TEST_MXID}', device_id '{TEST_DEVICE_ID}'",
     },
 )
 
@@ -55,7 +57,8 @@ bad_password_bad_access_token = LoginTestParameters(
     expected_login_state=False,
     expected_caplog_messages={
         "Restoring login from stored access token",
-        "Restoring login from access token failed: M_UNKNOWN_TOKEN, Invalid access token passed.",
+        "Restoring login from access token failed:"
+        " M_UNKNOWN_TOKEN, Invalid access token passed.",
         "Logging in using password",
         "Login by password failed: status_code, LoginError",
     },

--- a/tests/components/matrix/test_rooms.py
+++ b/tests/components/matrix/test_rooms.py
@@ -36,8 +36,8 @@ async def test_join(
     matrix_bot._listening_rooms = {TEST_BAD_ROOM: TEST_BAD_ROOM}
     await matrix_bot._join_rooms()
     assert (
-        f"Could not join room '{TEST_BAD_ROOM}': JoinError: Not allowed to join this room."
-        in caplog.messages
+        f"Could not join room '{TEST_BAD_ROOM}':"
+        " JoinError: Not allowed to join this room." in caplog.messages
     )
 
 

--- a/tests/components/matrix/test_send_message.py
+++ b/tests/components/matrix/test_send_message.py
@@ -81,6 +81,6 @@ async def test_unsendable_message(
     await hass.services.async_call(DOMAIN, SERVICE_SEND_MESSAGE, data, blocking=True)
 
     assert (
-        f"Unable to deliver message to room '{TEST_BAD_ROOM}': ErrorResponse: Cannot send a message in this room."
-        in caplog.messages
+        f"Unable to deliver message to room '{TEST_BAD_ROOM}':"
+        " ErrorResponse: Cannot send a message in this room." in caplog.messages
     )

--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -150,7 +150,7 @@ async def test_device_registry_single_node_composed_device(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
 ) -> None:
-    """Test that a composed device within a standalone node only creates one HA device entry."""
+    """Test composed device in standalone node creates one device entry."""
     assert len(device_registry.devices) == 1
 
 

--- a/tests/components/matter/test_button.py
+++ b/tests/components/matter/test_button.py
@@ -113,7 +113,7 @@ async def test_heiman_temporary_mute_button(
 async def test_heiman_temporary_mute_button_not_discovered_without_muting_command(
     hass: HomeAssistant,
 ) -> None:
-    """Test that the temporary mute button is not created when MutingSensor is absent from AcceptedCommandList."""
+    """Test mute button not created when MutingSensor absent from commands."""
     assert hass.states.get("button.smoke_sensor_temporary_mute") is None
 
 

--- a/tests/components/matter/test_climate.py
+++ b/tests/components/matter/test_climate.py
@@ -625,7 +625,7 @@ async def test_eve_thermo_v5_presets(
     assert state
     assert state.attributes["preset_mode"] == "home"
 
-    # Test that preset_mode is updated when ActivePresetHandle changes to different preset
+    # Test preset_mode updates when ActivePresetHandle changes
     set_node_attribute(
         matter_node,
         1,

--- a/tests/components/matter/test_cover.py
+++ b/tests/components/matter/test_cover.py
@@ -160,7 +160,7 @@ async def test_cover_lift_only(
     matter_node: MatterNode,
     entity_id: str,
 ) -> None:
-    """Test window covering devices with lift feature and without position aware lift feature."""
+    """Test window covering with lift but without position aware lift."""
 
     set_node_attribute(matter_node, 1, 258, 14, None)
     set_node_attribute(matter_node, 1, 258, 10, 0b000000)
@@ -291,7 +291,7 @@ async def test_cover_tilt_only(
     matter_node: MatterNode,
     entity_id: str,
 ) -> None:
-    """Test window covering devices with tilt feature and without position aware tilt feature."""
+    """Test window covering with tilt but without position aware tilt."""
 
     set_node_attribute(matter_node, 1, 258, 65529, [0, 1, 2])
     await trigger_subscription_callback(hass, matter_client)

--- a/tests/components/matter/test_entity.py
+++ b/tests/components/matter/test_entity.py
@@ -408,8 +408,9 @@ async def test_bridged_entity_subscribes_to_reachable_attribute(
         and call.kwargs.get("event_filter") == EventType.ATTRIBUTE_UPDATED
         for call in subscribe_calls
     ), (
-        f"Expected a subscribe_events call with attr_path_filter={_REACHABLE_ATTR_PATH!r} "
-        "and event_filter=ATTRIBUTE_UPDATED, but none was found."
+        "Expected a subscribe_events call with attr_path_filter="
+        f"{_REACHABLE_ATTR_PATH!r} and event_filter=ATTRIBUTE_UPDATED,"
+        " but none was found."
     )
 
 
@@ -433,7 +434,9 @@ async def test_non_bridged_entity_does_not_subscribe_to_reachable(
         and "/57/17" in call.kwargs["attr_path_filter"]
         for call in subscribe_calls
     ), (
-        "Unexpected subscribe_events call for BridgedDeviceBasicInformation.Reachable on a non-bridged entity."
+        "Unexpected subscribe_events call for"
+        " BridgedDeviceBasicInformation.Reachable"
+        " on a non-bridged entity."
     )
 
 
@@ -517,7 +520,8 @@ async def test_composed_entity_unavailable_when_parent_node_goes_offline(
         hass,
         "fritz_bridge",
         matter_client,
-        # fake as reachable at startup so we can test the node going offline while reachable
+        # fake as reachable at startup so we can test the node
+        # going offline while reachable
         {_COMPOSED_PARENT_REACHABLE_ATTR_PATH: True},
     )
 
@@ -550,7 +554,7 @@ async def test_composed_entity_subscribes_to_parent_reachable_attribute(
     hass: HomeAssistant,
     matter_client: MagicMock,
 ) -> None:
-    """Test that composed entity subscribes to parent BridgedDeviceBasicInformation.Reachable.
+    """Test composed entity subscribes to parent Reachable.
 
     When an endpoint belongs to a composed device, the BridgedDeviceBasicInformation
     cluster lives on the parent endpoint. The entity must create an ATTRIBUTE_UPDATED
@@ -565,6 +569,7 @@ async def test_composed_entity_subscribes_to_parent_reachable_attribute(
         and call.kwargs.get("event_filter") == EventType.ATTRIBUTE_UPDATED
         for call in subscribe_calls
     ), (
-        f"Expected a subscribe_events call with attr_path_filter={_COMPOSED_PARENT_REACHABLE_ATTR_PATH!r} "
-        "and event_filter=ATTRIBUTE_UPDATED, but none was found."
+        "Expected a subscribe_events call with attr_path_filter="
+        f"{_COMPOSED_PARENT_REACHABLE_ATTR_PATH!r}"
+        " and event_filter=ATTRIBUTE_UPDATED, but none was found."
     )

--- a/tests/components/matter/test_event.py
+++ b/tests/components/matter/test_event.py
@@ -87,7 +87,8 @@ async def test_generic_switch_multi_node(
     state_button_2 = hass.states.get("event.mock_generic_switch_button_fancy_button")
     assert state_button_2
     assert state_button_2.state == "unknown"
-    # name should be 'DeviceName Button (Fancy Button)' due to ha_entitylabel 'Fancy Button'
+    # name should be 'DeviceName Button (Fancy Button)' due to
+    # ha_entitylabel 'Fancy Button'
     assert state_button_2.name == "Mock Generic Switch Button (Fancy Button)"
     # check event_types from featuremap 30 (0b11110) and MultiPressMax 4
     assert state_button_2.attributes[ATTR_EVENT_TYPES] == [

--- a/tests/components/matter/test_light.py
+++ b/tests/components/matter/test_light.py
@@ -249,8 +249,9 @@ async def test_color_temperature_light(
     )
     matter_client.send_device_command.reset_mock()
     # Change color temperature with 15 Kelvin to test capping of mireds at 65279
-    # 15 Kelvin is 66666 Mireds which is above the maximum of 65279 Mireds permitted by Matter,
-    # so it should be capped at 65279 mireds which is 15.3 Kelvin
+    # 15 Kelvin is 66666 Mireds which is above the maximum of
+    # 65279 Mireds permitted by Matter, so it should be capped at
+    # 65279 mireds which is 15.3 Kelvin
     await hass.services.async_call(
         "light",
         "turn_on",

--- a/tests/components/matter/test_lock.py
+++ b/tests/components/matter/test_lock.py
@@ -1469,7 +1469,7 @@ async def test_set_lock_credential_auto_find_defaults_to_five(
     matter_client: MagicMock,
     matter_node: MatterNode,
 ) -> None:
-    """Test set_lock_credential falls back to 5 slots when capacity attribute is None."""
+    """Test set_lock_credential falls back to 5 slots when capacity is None."""
     # All GetCredentialStatus calls return occupied
     matter_client.send_device_command = AsyncMock(
         return_value={
@@ -1658,7 +1658,7 @@ async def test_get_lock_credential_status_with_fabric_indices(
     expected_creator: int | None,
     expected_last_modified: int | None,
 ) -> None:
-    """Test get_lock_credential_status returns fabric indices and normalizes NullValue."""
+    """Test get_lock_credential_status returns fabric indices."""
     matter_client.send_device_command = AsyncMock(
         return_value={
             "credentialExists": True,
@@ -1828,7 +1828,7 @@ async def test_set_lock_credential_rfid_auto_find_slot(
     matter_client: MagicMock,
     matter_node: MatterNode,
 ) -> None:
-    """Test set_lock_credential auto-finds RFID slot using NumberOfRFIDUsersSupported."""
+    """Test set_lock_credential auto-finds RFID slot."""
     # Place the empty slot at index 3 (the last position within
     # NumberOfRFIDUsersSupported=3) so the test would fail if the code
     # used a smaller bound like NumberOfCredentialsSupportedPerUser=2
@@ -1957,7 +1957,7 @@ async def test_set_lock_credential_fingerprint_auto_find_slot(
     matter_client: MagicMock,
     matter_node: MatterNode,
 ) -> None:
-    """Test set_lock_credential auto-finds fingerprint slot using NumberOfTotalUsersSupported."""
+    """Test set_lock_credential auto-finds fingerprint slot."""
     # Place the empty slot at index 3 (the last position within
     # NumberOfTotalUsersSupported=3) so the test would fail if the code
     # used NumberOfPINUsersSupported (10) or NumberOfCredentialsSupportedPerUser (2).

--- a/tests/components/matter/test_number.py
+++ b/tests/components/matter/test_number.py
@@ -38,7 +38,7 @@ async def test_level_control_config_entities(
     matter_client: MagicMock,
     matter_node: MatterNode,
 ) -> None:
-    """Test number entities are created for the LevelControl cluster (config) attributes."""
+    """Test number entities are created for LevelControl cluster attributes."""
     state = hass.states.get("number.mock_dimmable_light_on_level")
     assert state
     assert state.state == "255"
@@ -208,7 +208,7 @@ async def test_matter_exception_on_write_attribute(
     matter_client: MagicMock,
     matter_node: MatterNode,
 ) -> None:
-    """Test if a MatterError gets converted to HomeAssistantError by using a dimmable_light fixture."""
+    """Test MatterError converts to HomeAssistantError for dimmable_light."""
     state = hass.states.get("number.mock_dimmable_light_on_level")
     assert state
     matter_client.write_attribute.side_effect = MatterError("Boom")
@@ -253,15 +253,12 @@ async def test_pump_level(
         blocking=True,
     )
     assert matter_client.send_device_command.call_count == 1
-    assert (
-        matter_client.send_device_command.call_args
-        == call(
-            node_id=matter_node.node_id,
-            endpoint_id=1,
-            command=clusters.LevelControl.Commands.MoveToLevel(
-                level=150
-            ),  # 75 * 2 = 150, as the value is multiplied by 2 in the HA to native value conversion
-        )
+    assert matter_client.send_device_command.call_args == call(
+        node_id=matter_node.node_id,
+        endpoint_id=1,
+        # 75 * 2 = 150, value is multiplied by 2 in HA to
+        # native value conversion
+        command=clusters.LevelControl.Commands.MoveToLevel(level=150),
     )
 
 

--- a/tests/components/matter/test_select.py
+++ b/tests/components/matter/test_select.py
@@ -127,7 +127,7 @@ async def test_list_select_entities(
     matter_client: MagicMock,
     matter_node: MatterNode,
 ) -> None:
-    """Test ListSelect entities are discovered and working from a laundrywasher fixture."""
+    """Test ListSelect entities from a laundrywasher fixture."""
     state = hass.states.get("select.laundrywasher_temperature_level")
     assert state
     assert state.state == "Colors"
@@ -203,7 +203,7 @@ async def test_map_select_entities(
     matter_client: MagicMock,
     matter_node: MatterNode,
 ) -> None:
-    """Test MatterMapSelectEntity entities are discovered and working from a laundrywasher fixture."""
+    """Test MatterMapSelectEntity entities from a laundrywasher fixture."""
     # NumberOfRinses
     state = hass.states.get("select.laundrywasher_number_of_rinses")
     assert state
@@ -221,7 +221,7 @@ async def test_pump(
     matter_client: MagicMock,
     matter_node: MatterNode,
 ) -> None:
-    """Test MatterAttributeSelectEntity entities are discovered and working from a pump fixture."""
+    """Test MatterAttributeSelectEntity entities from a pump fixture."""
     # OperationMode
     state = hass.states.get("select.mock_pump_mode")
     assert state
@@ -240,7 +240,7 @@ async def test_microwave_oven(
     matter_client: MagicMock,
     matter_node: MatterNode,
 ) -> None:
-    """Test ListSelect entity is discovered and working from a microwave oven fixture."""
+    """Test ListSelect entity from a microwave oven fixture."""
 
     # SupportedWatts    from MicrowaveOvenControl cluster (1/96/6)
     # SelectedWattIndex from MicrowaveOvenControl cluster (1/96/7)
@@ -346,7 +346,8 @@ async def test_door_lock_operating_mode_select(
     state = hass.states.get(entity_id)
     assert state.state == "privacy"
 
-    # Select another supported option (NoRemoteLockUnlock) via service to validate mapping
+    # Select another supported option (NoRemoteLockUnlock) via service
+    # to validate mapping
     matter_client.write_attribute.reset_mock()
     await hass.services.async_call(
         "select",

--- a/tests/components/matter/test_sensor.py
+++ b/tests/components/matter/test_sensor.py
@@ -477,7 +477,7 @@ async def test_draft_electrical_measurement_sensor(
     matter_client: MagicMock,
     matter_node: MatterNode,
 ) -> None:
-    """Test Draft Electrical Measurement cluster sensors, using Yandex Smart Socket fixture."""
+    """Test Draft Electrical Measurement sensors with Yandex Smart Socket."""
     state = hass.states.get("sensor.yndx_00540_power")
     assert state
     assert state.state == "70.0"

--- a/tests/components/matter/test_switch.py
+++ b/tests/components/matter/test_switch.py
@@ -97,7 +97,7 @@ async def test_turn_off(
 
 @pytest.mark.parametrize("node_fixture", ["mock_switch_unit"])
 async def test_switch_unit(hass: HomeAssistant, matter_node: MatterNode) -> None:
-    """Test if a switch entity is discovered from any (non-light) OnOf cluster device."""
+    """Test switch entity discovered from any (non-light) OnOff device."""
     # A switch entity should be discovered as fallback for ANY Matter device (endpoint)
     # that has the OnOff cluster and does not fall into an explicit discovery schema
     # by another platform (e.g. light, lock etc.).
@@ -122,7 +122,7 @@ async def test_numeric_switch(
     matter_client: MagicMock,
     matter_node: MatterNode,
 ) -> None:
-    """Test numeric switch entity is discovered and working using an Eve Thermo fixture ."""
+    """Test numeric switch entity using an Eve Thermo fixture."""
     state = hass.states.get("switch.eve_thermo_20ebp1701_child_lock")
     assert state
     assert state.state == "off"
@@ -176,7 +176,7 @@ async def test_matter_exception_on_command(
     matter_client: MagicMock,
     matter_node: MatterNode,
 ) -> None:
-    """Test if a MatterError gets converted to HomeAssistantError by using a switch fixture."""
+    """Test MatterError converts to HomeAssistantError for switch."""
     state = hass.states.get("switch.mock_onoffpluginunit")
     assert state
     matter_client.send_device_command.side_effect = MatterError("Boom")

--- a/tests/components/matter/test_vacuum.py
+++ b/tests/components/matter/test_vacuum.py
@@ -179,14 +179,16 @@ async def test_vacuum_updates(
     assert state
     assert state.state == "returning"
 
-    # confirm state is 'idle' by setting the operational state to 0x01 (running) but mode is idle
+    # confirm state is 'idle' by setting the operational state to
+    # 0x01 (running) but mode is idle
     set_node_attribute(matter_node, 1, 97, 4, 0x01)
     await trigger_subscription_callback(hass, matter_client)
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "idle"
 
-    # confirm state is 'idle' by setting the operational state to 0x01 (running) but mode is cleaning
+    # confirm state is 'idle' by setting the operational state to
+    # 0x01 (running) but mode is cleaning
     set_node_attribute(matter_node, 1, 97, 4, 0x01)
     await trigger_subscription_callback(hass, matter_client)
     state = hass.states.get(entity_id)

--- a/tests/components/matter/test_valve.py
+++ b/tests/components/matter/test_valve.py
@@ -43,7 +43,7 @@ async def test_valve(
     matter_client: MagicMock,
     matter_node: MatterNode,
 ) -> None:
-    """Test valve entity is created for a Matter ValveConfigurationAndControl Cluster."""
+    """Test valve entity for Matter ValveConfigurationAndControl."""
     entity_id = "valve.mock_valve"
     state = hass.states.get(entity_id)
     assert state

--- a/tests/components/matter/test_water_heater.py
+++ b/tests/components/matter/test_water_heater.py
@@ -233,7 +233,8 @@ async def test_update_from_water_heater(
     assert state
     assert state.state == STATE_OFF
 
-    # confirm water heater state returns to 'eco' when SystemMode is set back to 4 (kHeat)
+    # confirm water heater state returns to 'eco' when SystemMode is
+    # set back to 4 (kHeat)
     set_node_attribute(matter_node, 2, 513, 28, 4)
     await trigger_subscription_callback(hass, matter_client)
     state = hass.states.get(entity_id)

--- a/tests/components/mcp/test_config_flow.py
+++ b/tests/components/mcp/test_config_flow.py
@@ -279,7 +279,7 @@ async def test_server_missing_capbilities(
 async def test_oauth_discovery_flow_without_credentials(
     hass: HomeAssistant, mock_mcp_client: Mock
 ) -> None:
-    """Test for an OAuth discoveryflow for an MCP server where the user has not yet entered credentials."""
+    """Test OAuth discoveryflow when user has no credentials yet."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -299,8 +299,8 @@ async def test_oauth_discovery_flow_without_credentials(
         },
     )
 
-    # The config flow will abort and the user will be taken to the application credentials UI
-    # to enter their credentials.
+    # The config flow will abort and the user will be taken to the
+    # application credentials UI to enter their credentials.
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "missing_credentials"
 
@@ -478,7 +478,9 @@ async def test_authentication_flow(
             SCOPES_SUPPORTED,
         ),
         (
-            'Bearer error="invalid_token", resource_metadata="https://example.com/custom-discovery" scope="read write"',
+            'Bearer error="invalid_token",'
+            ' resource_metadata="https://example.com/custom-discovery"'
+            ' scope="read write"',
             "https://example.com/custom-discovery",
             ["read", "write"],
         ),
@@ -505,8 +507,9 @@ async def test_authentication_discovery_via_header(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    # MCP Server returns 401 when first trying to connect via config flow validate_input. The response
-    # value has a WWW-Authenticate header with a full URL for the resource metadata.
+    # MCP Server returns 401 when first trying to connect via config
+    # flow validate_input. The response value has a WWW-Authenticate
+    # header with a full URL for the resource metadata.
     mock_mcp_client.side_effect = httpx.HTTPStatusError(
         "Authentication required",
         request=None,
@@ -624,8 +627,9 @@ async def test_invalid_protected_resource_metadata(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    # MCP Server returns 401 when first trying to connect via config flow validate_input. The response
-    # value has a WWW-Authenticate header with a full URL for the resource metadata.
+    # MCP Server returns 401 when first trying to connect via config
+    # flow validate_input. The response value has a WWW-Authenticate
+    # header with a full URL for the resource metadata.
     resource_metadata_url = "https://example.com/custom-discovery"
     mock_mcp_client.side_effect = httpx.HTTPStatusError(
         "Authentication required",
@@ -633,7 +637,10 @@ async def test_invalid_protected_resource_metadata(
         response=httpx.Response(
             401,
             headers={
-                "WWW-Authenticate": f'Bearer error="invalid_token", resource_metadata="{resource_metadata_url}"',
+                "WWW-Authenticate": (
+                    'Bearer error="invalid_token",'
+                    f' resource_metadata="{resource_metadata_url}"'
+                ),
             },
         ),
     )

--- a/tests/components/mealie/test_calendar.py
+++ b/tests/components/mealie/test_calendar.py
@@ -93,7 +93,7 @@ async def test_legacy_calendars(
     mock_mealie_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test that only legacy calendars are created for Mealie versions prior to 3.7.0."""
+    """Test only legacy calendars created for Mealie versions < 3.7.0."""
 
     mock_mealie_client.get_about.return_value = About(version="v3.6.0")
 

--- a/tests/components/media_player/test_device_condition.py
+++ b/tests/components/media_player/test_device_condition.py
@@ -155,7 +155,10 @@ async def test_if_state(
                     "action": {
                         "service": "test.automation",
                         "data_template": {
-                            "some": "is_on - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                            "some": (
+                                "is_on - {{ trigger.platform }}"
+                                " - {{ trigger.event.event_type }}"
+                            )
                         },
                     },
                 },
@@ -173,7 +176,10 @@ async def test_if_state(
                     "action": {
                         "service": "test.automation",
                         "data_template": {
-                            "some": "is_off - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                            "some": (
+                                "is_off - {{ trigger.platform }}"
+                                " - {{ trigger.event.event_type }}"
+                            )
                         },
                     },
                 },
@@ -191,7 +197,10 @@ async def test_if_state(
                     "action": {
                         "service": "test.automation",
                         "data_template": {
-                            "some": "is_idle - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                            "some": (
+                                "is_idle - {{ trigger.platform }}"
+                                " - {{ trigger.event.event_type }}"
+                            )
                         },
                     },
                 },
@@ -209,7 +218,10 @@ async def test_if_state(
                     "action": {
                         "service": "test.automation",
                         "data_template": {
-                            "some": "is_paused - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                            "some": (
+                                "is_paused - {{ trigger.platform }}"
+                                " - {{ trigger.event.event_type }}"
+                            )
                         },
                     },
                 },
@@ -227,7 +239,10 @@ async def test_if_state(
                     "action": {
                         "service": "test.automation",
                         "data_template": {
-                            "some": "is_playing - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                            "some": (
+                                "is_playing - {{ trigger.platform }}"
+                                " - {{ trigger.event.event_type }}"
+                            )
                         },
                     },
                 },
@@ -245,7 +260,10 @@ async def test_if_state(
                     "action": {
                         "service": "test.automation",
                         "data_template": {
-                            "some": "is_buffering - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                            "some": (
+                                "is_buffering - {{ trigger.platform }}"
+                                " - {{ trigger.event.event_type }}"
+                            )
                         },
                     },
                 },
@@ -356,7 +374,10 @@ async def test_if_state_legacy(
                     "action": {
                         "service": "test.automation",
                         "data_template": {
-                            "some": "is_on - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                            "some": (
+                                "is_on - {{ trigger.platform }}"
+                                " - {{ trigger.event.event_type }}"
+                            )
                         },
                     },
                 },

--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -585,7 +585,7 @@ async def test_get_async_get_browse_image_quoting(
 
 
 async def test_play_media_via_selector(hass: HomeAssistant) -> None:
-    """Test that play_media data under 'media' is remapped to top level keys for backward compatibility."""
+    """Test play_media data under 'media' is remapped for backward compat."""
     await async_setup_component(
         hass, "media_player", {"media_player": {"platform": "demo"}}
     )

--- a/tests/components/media_player/test_trigger.py
+++ b/tests/components/media_player/test_trigger.py
@@ -236,7 +236,7 @@ async def test_media_player_state_trigger_behavior_any(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test that the media player state trigger fires when any media player state changes to a specific state."""
+    """Test media player state trigger fires for any state change."""
     await assert_trigger_behavior_any(
         hass,
         target_entities=target_media_players,
@@ -284,7 +284,7 @@ async def test_media_player_state_trigger_behavior_first(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test that the media player state trigger fires when the first media player changes to a specific state."""
+    """Test media player state trigger fires on first entity change."""
     await assert_trigger_behavior_first(
         hass,
         target_entities=target_media_players,
@@ -332,7 +332,7 @@ async def test_media_player_state_trigger_behavior_last(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test that the media player state trigger fires when the last media player changes to a specific state."""
+    """Test media player state trigger fires on last entity change."""
     await assert_trigger_behavior_last(
         hass,
         target_entities=target_media_players,
@@ -419,7 +419,7 @@ async def test_media_player_volume_trigger_behavior_first(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test the media_player volume crossed threshold trigger fires for the first matching entity."""
+    """Test volume crossed threshold trigger fires for first entity."""
     await assert_trigger_behavior_first(
         hass,
         target_entities=target_media_players,
@@ -459,7 +459,7 @@ async def test_media_player_volume_trigger_behavior_last(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test the media_player volume crossed threshold trigger fires for the last matching entity."""
+    """Test volume crossed threshold trigger fires for last entity."""
     await assert_trigger_behavior_last(
         hass,
         target_entities=target_media_players,
@@ -533,7 +533,7 @@ async def test_media_player_trigger_ignores_limit_entity_with_wrong_unit(
 async def test_muted_trigger_ignores_entities_without_volume_attributes(
     hass: HomeAssistant,
 ) -> None:
-    """Test that the muted trigger does not fire for entities without volume attributes."""
+    """Test muted trigger ignores entities without volume attributes."""
     entity_id = "media_player.no_volume"
     calls: list[str] = []
 
@@ -572,7 +572,7 @@ async def test_muted_trigger_ignores_entities_without_volume_attributes(
 async def test_muted_trigger_does_not_fire_on_losing_volume_attributes(
     hass: HomeAssistant,
 ) -> None:
-    """Test that the trigger does not fire when a muted entity loses volume attributes."""
+    """Test trigger skips when muted entity loses volume attributes."""
     entity_id = "media_player.loses_volume"
     calls: list[str] = []
 
@@ -601,7 +601,7 @@ async def test_muted_trigger_does_not_fire_on_losing_volume_attributes(
 async def test_unmuted_trigger_does_not_fire_when_entity_gains_volume_attributes(
     hass: HomeAssistant,
 ) -> None:
-    """Test that media_player.unmuted does not fire when an entity gains volume attributes already-unmuted.
+    """Test unmuted trigger skips when entity gains volume attrs already-unmuted.
 
     `is_muted` defaults to False for a state without volume attributes, so a
     transition `(PLAYING, {})` -> `(PLAYING, {muted=False})` keeps `is_muted`

--- a/tests/components/media_source/test_http.py
+++ b/tests/components/media_source/test_http.py
@@ -92,7 +92,9 @@ async def test_websocket_resolve_media(
             {
                 "id": 1,
                 "type": "media_source/resolve_media",
-                "media_content_id": f"{const.URI_SCHEME}{media_source.DOMAIN}/local/{filename}",
+                "media_content_id": (
+                    f"{const.URI_SCHEME}{media_source.DOMAIN}/local/{filename}"
+                ),
             }
         )
 

--- a/tests/components/melnor/conftest.py
+++ b/tests/components/melnor/conftest.py
@@ -24,7 +24,10 @@ FAKE_SERVICE_INFO_1 = BluetoothServiceInfoBleak(
     address=FAKE_ADDRESS_1,
     rssi=-63,
     manufacturer_data={
-        13: b"Y\x08\x02\x8f\x00\x00\x00\x00\x00\x00\xf0\x00\x00\xf0\x00\x00\xf0\x00\x00\xf0*\x9b\xcf\xbc"
+        13: (
+            b"Y\x08\x02\x8f\x00\x00\x00\x00\x00\x00"
+            b"\xf0\x00\x00\xf0\x00\x00\xf0\x00\x00\xf0*\x9b\xcf\xbc"
+        )
     },
     service_uuids=[],
     service_data={},
@@ -41,7 +44,10 @@ FAKE_SERVICE_INFO_2 = BluetoothServiceInfoBleak(
     address=FAKE_ADDRESS_2,
     rssi=-63,
     manufacturer_data={
-        13: b"Y\x08\x02\x8f\x00\x00\x00\x00\x00\x00\xf0\x00\x00\xf0\x00\x00\xf0\x00\x00\xf0*\x9b\xcf\xbc"
+        13: (
+            b"Y\x08\x02\x8f\x00\x00\x00\x00\x00\x00"
+            b"\xf0\x00\x00\xf0\x00\x00\xf0\x00\x00\xf0*\x9b\xcf\xbc"
+        )
     },
     service_uuids=[],
     service_data={},
@@ -264,7 +270,7 @@ def patch_async_discovered_service_info(
 def patch_async_ble_device_from_address(
     return_value: BluetoothServiceInfoBleak | None = FAKE_SERVICE_INFO_1,
 ):
-    """Patch async_ble_device_from_address to return a mocked BluetoothServiceInfoBleak."""
+    """Patch async_ble_device_from_address to return a mock."""
     return patch(
         "homeassistant.components.bluetooth.async_ble_device_from_address",
         return_value=return_value,

--- a/tests/components/miele/test_sensor.py
+++ b/tests/components/miele/test_sensor.py
@@ -97,7 +97,8 @@ async def test_oven_temperatures_scenario(
 ) -> None:
     """Parametrized test for verifying temperature sensors for oven devices."""
 
-    # Initial state when the oven is created for the first time — no core probe entities yet
+    # Initial state when oven is created for the first time
+    # — no core probe entities yet
     check_sensor_state(hass, "sensor.oven_temperature", "unknown", 0)
     check_sensor_state(hass, "sensor.oven_target_temperature", "unknown", 0)
     check_sensor_state(hass, "sensor.oven_core_temperature", None, 0)
@@ -216,7 +217,7 @@ async def test_oven_core_probe_sensors_unknown_when_inactive(
     device_fixture: MieleDevices,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Oven food-probe (core) sensors must not expose API inactive sentinels as temperatures.
+    """Oven food-probe sensors must not expose API inactive sentinels.
 
     Miele uses raw value -32768 (centidegrees) when the probe is not in use. After the
     probe has reported a valid reading once, those entities must stay in the UI but
@@ -270,7 +271,7 @@ async def test_oven_core_probe_unknown_when_inactive_raw_scaled(
     device_fixture: MieleDevices,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Some ovens report int16-min as centidegrees (-32768 -> -327.68 °C); others as -3276800 raw (-32768 °C).
+    """Some ovens report int16-min differently; both must be unknown.
 
     Both must map to unknown, not a numeric sensor state.
     """
@@ -306,7 +307,7 @@ async def test_temperature_sensor_registry_lookup(
     device_fixture: MieleDevices,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test that core temperature sensor is provided by the integration after looking up in entity registry."""
+    """Test core temperature sensor provided after entity registry lookup."""
 
     # Initial state, the oven is showing core temperature (probe)
     freezer.tick(timedelta(seconds=130))
@@ -391,7 +392,7 @@ async def test_laundry_wash_scenario(
     device_fixture: MieleDevices,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Parametrized test for verifying time sensors for wahsing machine devices when API glitches at program end."""
+    """Test time sensors for washing machine when API glitches at end."""
 
     step = 0
     freezer.move_to("2025-05-31T12:00:00+00:00")
@@ -408,7 +409,8 @@ async def test_laundry_wash_scenario(
     check_sensor_state(hass, "sensor.washing_machine_spin_speed", "unknown", step)
     # OFF -> remaining forced to unknown
     check_sensor_state(hass, "sensor.washing_machine_remaining_time", "unknown", step)
-    # OFF -> elapsed forced to unknown (some devices continue reporting last value of last cycle)
+    # OFF -> elapsed forced to unknown (some devices continue
+    # reporting last value of last cycle)
     check_sensor_state(hass, "sensor.washing_machine_elapsed_time", "unknown", step)
     check_sensor_state(hass, "sensor.washing_machine_start", "unknown", step)
     check_sensor_state(hass, "sensor.washing_machine_finish", "unknown", step)
@@ -456,7 +458,8 @@ async def test_laundry_wash_scenario(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    # at this point, appliance is working, but it started reporting a value from last cycle, so it is forced to 0
+    # at this point, appliance is working, but it started reporting a
+    # value from last cycle, so it is forced to 0
     check_sensor_state(hass, "sensor.washing_machine_energy_consumption", "0", step)
     check_sensor_state(hass, "sensor.washing_machine_water_consumption", "0", step)
 
@@ -578,7 +581,8 @@ async def test_laundry_wash_scenario(
     check_sensor_state(hass, "sensor.washing_machine_spin_speed", "1200", step)
     # PROGRAM_ENDED -> remaining time forced to 0
     check_sensor_state(hass, "sensor.washing_machine_remaining_time", "0", step)
-    # PROGRAM_ENDED -> elapsed time kept from last program (some devices immediately go to 0)
+    # PROGRAM_ENDED -> elapsed time kept from last program
+    # (some devices immediately go to 0)
     check_sensor_state(hass, "sensor.washing_machine_elapsed_time", "109", step)
     check_sensor_state(
         hass, "sensor.washing_machine_start", "2025-05-31T12:18:00+00:00", step
@@ -586,7 +590,8 @@ async def test_laundry_wash_scenario(
     check_sensor_state(
         hass, "sensor.washing_machine_finish", "2025-05-31T14:15:00+00:00", step
     )
-    # consumption values now are reporting last known value, API might start reporting null object
+    # consumption values now report last known value,
+    # API might start reporting null object
     check_sensor_state(hass, "sensor.washing_machine_energy_consumption", "0.1", step)
     check_sensor_state(hass, "sensor.washing_machine_water_consumption", "7", step)
 
@@ -637,7 +642,7 @@ async def test_laundry_dry_scenario(
     device_fixture: MieleDevices,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Parametrized test for verifying time sensors for tumble dryer devices when API reports time value from last cycle, when device is off."""
+    """Test time sensors for tumble dryer when API reports stale time."""
 
     step = 0
     freezer.move_to("2025-05-31T12:00:00+00:00")
@@ -647,7 +652,8 @@ async def test_laundry_dry_scenario(
     check_sensor_state(hass, "sensor.tumble_dryer_program", "no_program", step)
     check_sensor_state(hass, "sensor.tumble_dryer_program_phase", "not_running", step)
     check_sensor_state(hass, "sensor.tumble_dryer_drying_step", "unknown", step)
-    # OFF -> elapsed, remaining forced to unknown (some devices continue reporting last value of last cycle)
+    # OFF -> elapsed, remaining forced to unknown (some devices
+    # continue reporting last value of last cycle)
     check_sensor_state(hass, "sensor.tumble_dryer_remaining_time", "unknown", step)
     check_sensor_state(hass, "sensor.tumble_dryer_elapsed_time", "unknown", step)
     check_sensor_state(hass, "sensor.tumble_dryer_start", "unknown", step)
@@ -711,7 +717,8 @@ async def test_laundry_dry_scenario(
     check_sensor_state(hass, "sensor.tumble_dryer_drying_step", "normal", step)
     # PROGRAM_ENDED -> remaining time forced to 0
     check_sensor_state(hass, "sensor.tumble_dryer_remaining_time", "0", step)
-    # PROGRAM_ENDED -> elapsed time kept from last program (some devices immediately go to 0)
+    # PROGRAM_ENDED -> elapsed time kept from last program
+    # (some devices immediately go to 0)
     check_sensor_state(hass, "sensor.tumble_dryer_elapsed_time", "20", step)
     check_sensor_state(
         hass, "sensor.tumble_dryer_start", "2025-05-31T12:10:00+00:00", step
@@ -862,7 +869,7 @@ def test_convert_temperature(
     index: int,
     expected: float | None,
 ) -> None:
-    """Cover _convert_temperature branches (sentinels, scaling, bounds, valid values)."""
+    """Cover _convert_temperature branches."""
     assert _convert_temperature(entries, index) == expected
 
 

--- a/tests/components/mikrotik/__init__.py
+++ b/tests/components/mikrotik/__init__.py
@@ -91,7 +91,12 @@ DEVICE_1_WIRELESS = {
     "signal-to-noise": 52,
     "signal-strength-ch0": -63,
     "signal-strength-ch1": -69,
-    "strength-at-rates": "-62@1Mbps 16s330ms,-64@6Mbps 13s560ms,-65@HT20-3 52m6s30ms,-66@HT20-4 52m4s350ms,-66@HT20-5 51m58s580ms,-65@HT20-6 51m24s780ms,-65@HT20-7 5s680ms",
+    "strength-at-rates": (
+        "-62@1Mbps 16s330ms,-64@6Mbps 13s560ms,"
+        "-65@HT20-3 52m6s30ms,-66@HT20-4 52m4s350ms,"
+        "-66@HT20-5 51m58s580ms,-65@HT20-6 51m24s780ms,"
+        "-65@HT20-7 5s680ms"
+    ),
     "tx-ccq": 93,
     "p-throughput": 54928,
     "last-ip": "0.0.0.1",

--- a/tests/components/mill/test_climate.py
+++ b/tests/components/mill/test_climate.py
@@ -174,7 +174,8 @@ async def functional_cloud_heater(
     def heater_control(device_id: str, power_status: bool):
         assert device_id == HEATER_ID, "set_temperature called with wrong device_id"
 
-        # power_status gives the "do we want to heat, Y/N", while is_heating is based on temperature and internal state and whatnot.
+        # power_status gives the "do we want to heat, Y/N", while
+        # is_heating is based on temperature and internal state.
         cloud_heater.power_status = power_status
 
         calculate_heating()
@@ -225,7 +226,7 @@ async def local_heater_set_target_temperature(
 async def local_heater_set_mode_control_individually(
     mock_mill_local: MagicMock, local_heater: MagicMock
 ):
-    """Gets mock for the local heater `set_operation_mode_control_individually` method."""
+    """Get mock for set_operation_mode_control_individually."""
     return mock_mill_local.set_operation_mode_control_individually
 
 
@@ -359,13 +360,15 @@ async def functional_local_heater(
             SERVICE_SET_TEMPERATURE,
             {ATTR_TEMPERATURE: TEST_SET_TEMPERATURE, ATTR_HVAC_MODE: HVACMode.COOL},
             pytest.raises(HomeAssistantError),
-            # MillHeater will set the temperature before calling async_handle_set_hvac_mode,
-            #   meaning an invalid HVAC mode will raise only after the temperature is set.
+            # MillHeater will set the temperature before calling
+            # async_handle_set_hvac_mode, meaning an invalid HVAC mode
+            # will raise only after the temperature is set.
             [],
             [call(HEATER_ID, float(TEST_SET_TEMPERATURE))],
             HVACMode.OFF,
-            # likewise, in this test, it hasn't had the chance to update its ambient temperature,
-            # because the exception is raised before a refresh can be requested from the coordinator
+            # likewise, in this test, it hasn't had the chance to update
+            # its ambient temperature, because the exception is raised
+            # before a refresh can be requested from the coordinator
             {ATTR_TEMPERATURE: TEST_AMBIENT_TEMPERATURE},
         ),
     ],
@@ -386,7 +389,7 @@ async def test_cloud_heater(
     after_state: HVACMode,
     after_attrs: dict,
 ) -> None:
-    """Tests setting HVAC mode (directly or through set_temperature) for a cloud heater."""
+    """Tests setting HVAC mode for a cloud heater."""
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state is not None
@@ -511,14 +514,16 @@ async def test_cloud_heater(
             SERVICE_SET_TEMPERATURE,
             {ATTR_TEMPERATURE: TEST_SET_TEMPERATURE, ATTR_HVAC_MODE: HVACMode.COOL},
             pytest.raises(HomeAssistantError),
-            # LocalMillHeater will set the temperature before calling async_handle_set_hvac_mode,
-            #   meaning an invalid HVAC mode will raise only after the temperature is set.
+            # LocalMillHeater will set the temperature before calling
+            # async_handle_set_hvac_mode, meaning an invalid HVAC mode
+            # will raise only after the temperature is set.
             [],
             [],
             [call(float(TEST_SET_TEMPERATURE))],
             HVACMode.OFF,
-            # likewise, in this test, it hasn't had the chance to update its ambient temperature,
-            # because the exception is raised before a refresh can be requested from the coordinator
+            # likewise, in this test, it hasn't had the chance to update
+            # its ambient temperature, because the exception is raised
+            # before a refresh can be requested from the coordinator
             {ATTR_TEMPERATURE: TEST_AMBIENT_TEMPERATURE},
         ),
     ],
@@ -540,7 +545,7 @@ async def test_local_heater(
     after_state: HVACMode,
     after_attrs: dict,
 ) -> None:
-    """Tests setting HVAC mode (directly or through set_temperature) for a local heater."""
+    """Tests setting HVAC mode for a local heater."""
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state is not None

--- a/tests/components/minecraft_server/test_config_flow.py
+++ b/tests/components/minecraft_server/test_config_flow.py
@@ -61,7 +61,7 @@ async def test_full_flow_java(hass: HomeAssistant) -> None:
 
 
 async def test_full_flow_bedrock(hass: HomeAssistant) -> None:
-    """Test config entry in case of a successful connection to a Bedrock Edition server."""
+    """Test config entry for successful Bedrock Edition connection."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -90,7 +90,7 @@ async def test_full_flow_bedrock(hass: HomeAssistant) -> None:
 
 
 async def test_full_flow_legacy_java(hass: HomeAssistant) -> None:
-    """Test config entry in case of a successful connection to a legacy Java Edition server."""
+    """Test config entry for successful legacy Java Edition connection."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -208,7 +208,7 @@ async def test_service_already_configured_legacy_java(
 
 
 async def test_recovery_java(hass: HomeAssistant) -> None:
-    """Test config flow recovery with a Java Edition server (successful connection after a failed connection)."""
+    """Test config flow recovery with a Java Edition server."""
     with (
         patch(
             "homeassistant.components.minecraft_server.api.BedrockServer.lookup",
@@ -257,7 +257,7 @@ async def test_recovery_java(hass: HomeAssistant) -> None:
 
 
 async def test_recovery_bedrock(hass: HomeAssistant) -> None:
-    """Test config flow recovery with a Bedrock Edition server (successful connection after a failed connection)."""
+    """Test config flow recovery with a Bedrock Edition server."""
     with (
         patch(
             "homeassistant.components.minecraft_server.api.BedrockServer.lookup",
@@ -302,7 +302,7 @@ async def test_recovery_bedrock(hass: HomeAssistant) -> None:
 
 
 async def test_recovery_legacy_java(hass: HomeAssistant) -> None:
-    """Test config flow recovery with a legacy Java Edition server (successful connection after a failed connection)."""
+    """Test config flow recovery with a legacy Java Edition server."""
     with (
         patch(
             "homeassistant.components.minecraft_server.api.BedrockServer.lookup",

--- a/tests/components/minecraft_server/test_diagnostics.py
+++ b/tests/components/minecraft_server/test_diagnostics.py
@@ -49,7 +49,8 @@ async def test_config_entry_diagnostics(
 ) -> None:
     """Test fetching of the config entry diagnostics."""
 
-    # Use 'request' fixture to access 'mock_config_entry' fixture, as it cannot be used directly in 'parametrize'.
+    # Use 'request' fixture to access 'mock_config_entry' fixture,
+    # as it cannot be used directly in 'parametrize'.
     mock_config_entry = request.getfixturevalue(mock_config_entry)
     mock_config_entry.add_to_hass(hass)
 

--- a/tests/components/minecraft_server/test_init.py
+++ b/tests/components/minecraft_server/test_init.py
@@ -208,7 +208,7 @@ async def test_entry_migration(
     entity_registry: er.EntityRegistry,
     v1_mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test entry migration from version 1 to 3, where host and port is required for the connection to the server."""
+    """Test entry migration v1 to v3, where host and port are required."""
     v1_mock_config_entry.add_to_hass(hass)
 
     device_entry_id = create_v1_mock_device_entry(hass, v1_mock_config_entry.entry_id)
@@ -264,16 +264,16 @@ async def test_entry_migration(
     entity_entry = entity_registry.async_get(
         binary_sensor_entity_id_key_mapping["entity_id"]
     )
-    assert (
-        entity_entry.unique_id
-        == f"{migrated_config_entry.entry_id}-{binary_sensor_entity_id_key_mapping['key']}"
+    expected_uid = (
+        f"{migrated_config_entry.entry_id}-{binary_sensor_entity_id_key_mapping['key']}"
     )
+    assert entity_entry.unique_id == expected_uid
 
 
 async def test_entry_migration_host_only(
     hass: HomeAssistant, v1_mock_config_entry: MockConfigEntry
 ) -> None:
-    """Test entry migration from version 1 to 3, where host alone is sufficient for the connection to the server."""
+    """Test entry migration v1 to v3, where host alone is sufficient."""
     v1_mock_config_entry.add_to_hass(hass)
 
     device_entry_id = create_v1_mock_device_entry(hass, v1_mock_config_entry.entry_id)

--- a/tests/components/mitsubishi_comfort/test_init.py
+++ b/tests/components/mitsubishi_comfort/test_init.py
@@ -97,7 +97,7 @@ async def test_setup_entry_skips_incomplete_devices(
     mock_device_info: DeviceInfo,
     mock_setup_integration: tuple[AsyncMock, MagicMock],
 ) -> None:
-    """Test setup skips incomplete devices and only creates entities for complete ones."""
+    """Test setup skips incomplete devices and creates complete ones."""
     incomplete_info = DeviceInfo(
         serial="SERIAL002",
         label="Bedroom",

--- a/tests/components/mobile_app/test_http_api.py
+++ b/tests/components/mobile_app/test_http_api.py
@@ -167,7 +167,7 @@ async def test_registration_with_cloud_local_only_user(
     hass_client: ClientSessionGenerator,
     hass_admin_user: MockUser,
 ) -> None:
-    """Test that cloudhook_url and remote_ui_url are not returned for local_only users."""
+    """Test cloudhook_url and remote_ui_url not returned for local users."""
     hass_admin_user.local_only = True
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 

--- a/tests/components/mobile_app/test_init.py
+++ b/tests/components/mobile_app/test_init.py
@@ -486,7 +486,7 @@ async def test_cloudhook_change_listener_deletion(
     hass: HomeAssistant,
     hass_admin_user: MockUser,
 ) -> None:
-    """Test cloudhook change listener removes cloudhook from config entry on deletion."""
+    """Test cloudhook listener removes cloudhook from entry on deletion."""
     webhook_id = "test-webhook-id"
     config_entry = MockConfigEntry(
         data={

--- a/tests/components/mobile_app/test_notify.py
+++ b/tests/components/mobile_app/test_notify.py
@@ -433,7 +433,10 @@ async def test_local_push_only(
     """Test a local only push registration."""
     with pytest.raises(
         HomeAssistantError,
-        match=r"Device.*websocket-push-webhook-id.*not connected to local push notifications",
+        match=(
+            r"Device.*websocket-push-webhook-id"
+            r".*not connected to local push notifications"
+        ),
     ):
         await hass.services.async_call(
             "notify",
@@ -489,9 +492,11 @@ async def test_notify_multiple_targets(
 ) -> None:
     """Test notify to multiple targets.
 
-    Messages will be sent to three targerts, one (with webhook id `webhook_id_2`) will be remote target
-    and will send the notification via HTTP request, the other two (`mock-webhook_id` and`websocket-push-webhook-id`)
-    will be local push only and will be sent via websocket.
+    Messages will be sent to three targets, one (with webhook id
+    `webhook_id_2`) will be remote target and will send the notification
+    via HTTP request, the other two (`mock-webhook_id` and
+    `websocket-push-webhook-id`) will be local push only and will be
+    sent via websocket.
     """
 
     # Setup mock for non-local push notification target
@@ -538,7 +543,7 @@ async def test_notify_multiple_targets(
         blocking=True,
     )
 
-    # Assert that the notification has been sent to the non-local push notification target
+    # Assert notification sent to non-local push notification target
     assert len(aioclient_mock.mock_calls) == 1
     call = aioclient_mock.mock_calls
     call_json = call[0][2]
@@ -548,7 +553,7 @@ async def test_notify_multiple_targets(
     assert call_json["registration_info"]["app_version"] == "1.0"
     assert call_json["registration_info"]["webhook_id"] == "webhook_id_2"
 
-    # Assert that the notification has been sent to the two local push notification targets
+    # Assert notification sent to the two local push targets
     for sub_id in local_push_sub_ids:
         msg_result = await client.receive_json()
         assert msg_result["event"] == {"message": "Hello world"}
@@ -618,7 +623,7 @@ async def test_notify_multiple_targets_if_any_disconnected(
             blocking=True,
         )
 
-    # Assert that the notification has been sent to the non-local push notification target
+    # Assert notification sent to non-local push notification target
     assert len(aioclient_mock.mock_calls) == 1
     call = aioclient_mock.mock_calls
     call_json = call[0][2]
@@ -836,7 +841,7 @@ async def test_send_message_exceptions(
 
 @pytest.mark.usefixtures("setup_websocket_channel_only_push")
 async def test_send_message_local_push_exception(hass: HomeAssistant) -> None:
-    """Test sending message via notify.send_message action through local push with exceptions."""
+    """Test send_message via local push with exceptions."""
     with pytest.raises(HomeAssistantError) as err:
         await hass.services.async_call(
             NOTIFY_DOMAIN,

--- a/tests/components/mobile_app/test_pending_updates.py
+++ b/tests/components/mobile_app/test_pending_updates.py
@@ -349,7 +349,7 @@ async def test_multiple_pending_updates_for_different_sensors(
     create_registrations: tuple[dict[str, Any], dict[str, Any]],
     webhook_client: TestClient,
 ) -> None:
-    """Test that multiple sensors can be updated while disabled and applied when re-enabled."""
+    """Test sensors updated while disabled are applied when re-enabled."""
     webhook_id = create_registrations[1]["webhook_id"]
     webhook_url = f"/api/webhook/{webhook_id}"
 

--- a/tests/components/mobile_app/test_sensor.py
+++ b/tests/components/mobile_app/test_sensor.py
@@ -153,7 +153,8 @@ async def test_sensor(
             212,
             253,
         ),
-        # The unique_id doesn't match that of the mobile app's battery temperature sensor
+        # The unique_id doesn't match that of the mobile app's
+        # battery temperature sensor
         (
             "battery_temp",
             US_CUSTOMARY_SYSTEM,

--- a/tests/components/mobile_app/test_webhook.py
+++ b/tests/components/mobile_app/test_webhook.py
@@ -119,7 +119,10 @@ async def test_webhook_handle_render_template(
         "one": "Hello world",
         "two": {"error": "TypeError: object of type 'datetime.datetime' has no len()"},
         "three": {
-            "error": "TemplateSyntaxError: expected token 'end of print statement', got 'integer'"
+            "error": (
+                "TemplateSyntaxError: expected token"
+                " 'end of print statement', got 'integer'"
+            )
         },
     }
 
@@ -383,7 +386,7 @@ async def test_webhook_handle_get_config_with_cloudhook_local_only_user(
     create_registrations: tuple[dict[str, Any], dict[str, Any]],
     webhook_client: TestClient,
 ) -> None:
-    """Test get_config doesn't return cloudhook_url or remote_ui_url for local_only users."""
+    """Test get_config omits cloudhook/remote_ui_url for local users."""
     hass_admin_user.local_only = True
 
     webhook_id = create_registrations[1]["webhook_id"]
@@ -968,7 +971,7 @@ async def test_webhook_camera_stream_stream_available_but_errors(
     create_registrations: tuple[dict[str, Any], dict[str, Any]],
     webhook_client: TestClient,
 ) -> None:
-    """Test fetching camera stream URLs for an HLS/stream-supporting camera but that streaming errors."""
+    """Test fetching camera stream URLs when streaming errors."""
     hass.states.async_set(
         "camera.stream_camera",
         "idle",

--- a/tests/components/modbus/test_binary_sensor.py
+++ b/tests/components/modbus/test_binary_sensor.py
@@ -237,7 +237,8 @@ async def test_service_binary_sensor_update(
 ENTITY_ID2 = f"{ENTITY_ID}_1"
 
 
-# The new update secures the sensors are read at startup, so restore_state delivers old data.
+# The new update secures the sensors are read at startup, so
+# restore_state delivers old data.
 @pytest.mark.skip
 @pytest.mark.parametrize(
     "mock_test_state",

--- a/tests/components/modbus/test_climate.py
+++ b/tests/components/modbus/test_climate.py
@@ -1781,7 +1781,7 @@ async def test_no_discovery_info_climate(
 async def test_update_current_temp_scale_and_offset(
     hass: HomeAssistant, mock_modbus_ha, result, register_words
 ) -> None:
-    """Test behavior with different configurations for current temperature scaling/offset."""
+    """Test current temperature scaling/offset configurations."""
     mock_modbus_ha.read_holding_registers.return_value = ReadResult(register_words)
 
     await hass.services.async_call(
@@ -1887,7 +1887,7 @@ async def test_update_current_temp_scale_and_offset(
 async def test_update_target_temp_scale_and_offset(
     hass: HomeAssistant, mock_modbus_ha, result, register_words
 ) -> None:
-    """Test behavior with different configurations for target temperature scaling / offset."""
+    """Test target temperature scaling/offset configurations."""
     mock_modbus_ha.read_holding_registers.return_value = ReadResult(register_words)
 
     await hass.services.async_call(

--- a/tests/components/modbus/test_light.py
+++ b/tests/components/modbus/test_light.py
@@ -418,7 +418,8 @@ async def test_color_temp_brightness_light(
             call.args[0] == expected_register and call.kwargs["value"] == expected_value
             for call in calls
         ), (
-            f"Expected register {expected_register} with value {expected_value} not found in calls {calls}"
+            f"Expected register {expected_register} with value"
+            f" {expected_value} not found in calls {calls}"
         )
     await hass.services.async_call(
         LIGHT_DOMAIN,

--- a/tests/components/modbus/test_sensor.py
+++ b/tests/components/modbus/test_sensor.py
@@ -230,7 +230,10 @@ async def test_config_sensor(hass: HomeAssistant, mock_modbus) -> None:
                     },
                 ]
             },
-            f"{TEST_ENTITY_NAME}: Size of structure is 16 bytes but `{CONF_COUNT}: 2` is 4 bytes",
+            (
+                f"{TEST_ENTITY_NAME}: Size of structure is 16 bytes"
+                f" but `{CONF_COUNT}: 2` is 4 bytes"
+            ),
         ),
         (
             {
@@ -258,7 +261,10 @@ async def test_config_sensor(hass: HomeAssistant, mock_modbus) -> None:
                     },
                 ]
             },
-            f"{TEST_ENTITY_NAME}: Size of structure is 0 bytes but `{CONF_COUNT}: 4` is 8 bytes",
+            (
+                f"{TEST_ENTITY_NAME}: Size of structure is 0 bytes"
+                f" but `{CONF_COUNT}: 4` is 8 bytes"
+            ),
         ),
         (
             {
@@ -272,7 +278,10 @@ async def test_config_sensor(hass: HomeAssistant, mock_modbus) -> None:
                     },
                 ]
             },
-            f"{TEST_ENTITY_NAME}: Size of structure is 1 bytes but `{CONF_COUNT}: 4` is 8 bytes",
+            (
+                f"{TEST_ENTITY_NAME}: Size of structure is 1 bytes"
+                f" but `{CONF_COUNT}: 4` is 8 bytes"
+            ),
         ),
         (
             {
@@ -287,7 +296,11 @@ async def test_config_sensor(hass: HomeAssistant, mock_modbus) -> None:
                     },
                 ]
             },
-            f"{TEST_ENTITY_NAME}: `{CONF_SWAP}:{CONF_SWAP_WORD}` illegal with `{CONF_DATA_TYPE}: {DataType.CUSTOM}`",
+            (
+                f"{TEST_ENTITY_NAME}:"
+                f" `{CONF_SWAP}:{CONF_SWAP_WORD}` illegal with"
+                f" `{CONF_DATA_TYPE}: {DataType.CUSTOM}`"
+            ),
         ),
     ],
 )

--- a/tests/components/moisture/test_trigger.py
+++ b/tests/components/moisture/test_trigger.py
@@ -127,7 +127,7 @@ async def test_moisture_trigger_binary_sensor_behavior_any(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test moisture trigger fires for binary_sensor entities with device_class moisture."""
+    """Test moisture trigger fires for moisture binary_sensors."""
     await assert_trigger_behavior_any(
         hass,
         target_entities=target_binary_sensors,
@@ -310,7 +310,7 @@ async def test_moisture_trigger_sensor_crossed_threshold_behavior_first(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test moisture crossed_threshold trigger fires on the first sensor state change."""
+    """Test crossed_threshold trigger fires on first sensor change."""
     await assert_trigger_behavior_first(
         hass,
         target_entities=target_sensors,
@@ -348,7 +348,7 @@ async def test_moisture_trigger_sensor_crossed_threshold_behavior_last(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test moisture crossed_threshold trigger fires when the last sensor changes state."""
+    """Test crossed_threshold trigger fires on last sensor change."""
     await assert_trigger_behavior_last(
         hass,
         target_entities=target_sensors,

--- a/tests/components/mold_indicator/test_init.py
+++ b/tests/components/mold_indicator/test_init.py
@@ -212,7 +212,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     expected_helper_device_id: str | None,
     expected_events: list[str],
 ) -> None:
-    """Test the mold_indicator config entry is removed when the source entity is removed."""
+    """Test config entry removed when the source entity is removed."""
     source_entity_entry = entity_registry.async_get(source_entity_id)
 
     assert await hass.config_entries.async_setup(mold_indicator_config_entry.entry_id)
@@ -274,7 +274,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     expected_helper_device_id: str | None,
     expected_events: list[str],
 ) -> None:
-    """Test the mold_indicator config entry is removed when the source entity is removed."""
+    """Test config entry removed when the source entity is removed."""
     source_entity_entry = entity_registry.async_get(source_entity_id)
 
     # Add another config entry to the source device

--- a/tests/components/mold_indicator/test_sensor.py
+++ b/tests/components/mold_indicator/test_sensor.py
@@ -316,7 +316,7 @@ async def test_sensor_changed(hass: HomeAssistant) -> None:
 
 @pytest.mark.parametrize("new_state", [STATE_UNAVAILABLE, STATE_UNKNOWN])
 async def test_unavailable_sensor_recovery(hass: HomeAssistant, new_state: str) -> None:
-    """Test recovery when sensor becomes unavailable/unknown and then available again."""
+    """Test recovery when sensor becomes unavailable then available."""
     assert await async_setup_component(
         hass,
         sensor.DOMAIN,

--- a/tests/components/mqtt/common.py
+++ b/tests/components/mqtt/common.py
@@ -235,7 +235,9 @@ MOCK_SUBENTRY_CLIMATE_COMPONENT = {
         "swing_horizontal_mode_command_topic": "swing-horizontal-mode-command-topic",
         "swing_horizontal_mode_command_template": "{{ value }}",
         "swing_horizontal_mode_state_topic": "swing-horizontal-mode-state-topic",
-        "swing_horizontal_mode_state_template": "{{ value_json.swing_horizontal_mode }}",
+        "swing_horizontal_mode_state_template": (
+            "{{ value_json.swing_horizontal_mode }}"
+        ),
         "swing_horizontal_modes": ["off", "on"],
     },
 }
@@ -1695,7 +1697,8 @@ async def help_test_encoding_subscribable_topics(
         state = hass.states.get(entity_id)
 
         if init_payload_value:
-            # Sometimes a device needs to have an initialization pay load, e.g. to switch the device on.
+            # Sometimes a device needs to have an initialization
+            # pay load, e.g. to switch the device on.
             async_fire_mqtt_message(hass, init_payload_topic, init_payload_value)
             await hass.async_block_till_done()
 
@@ -2586,7 +2589,9 @@ async def help_test_publishing_with_custom_encoding(
             test_config_setup["encoding"] = test_data["encoding"]
         if template and test_data["cmd_tpl"]:
             test_config_setup[template] = (
-                f"{{{{ (('%.1f'|format({tpl_par}))[0] if is_number({tpl_par}) else {tpl_par}[0]) | ord | pack('b') }}}}"
+                f"{{{{ (('%.1f'|format({tpl_par}))[0]"
+                f" if is_number({tpl_par})"
+                f" else {tpl_par}[0]) | ord | pack('b') }}}}"
             )
         setup_config.append(test_config_setup)
 
@@ -2642,8 +2647,8 @@ async def help_test_publishing_with_custom_encoding(
         blocking=True,
     )
     assert (
-        f"Can't pass-through payload for publishing {payload} on cmd/test3 with no encoding set, need 'bytes'"
-        in caplog.text
+        f"Can't pass-through payload for publishing {payload} on"
+        " cmd/test3 with no encoding set, need 'bytes'" in caplog.text
     )
 
     # 4) test with invalid encoding set should fail
@@ -2654,8 +2659,8 @@ async def help_test_publishing_with_custom_encoding(
         blocking=True,
     )
     assert (
-        f"Can't encode payload for publishing {payload} on cmd/test4 with encoding invalid"
-        in caplog.text
+        f"Can't encode payload for publishing {payload} on"
+        " cmd/test4 with encoding invalid" in caplog.text
     )
 
     # 5) test with command template and raw encoding if specified

--- a/tests/components/mqtt/test_alarm_control_panel.py
+++ b/tests/components/mqtt/test_alarm_control_panel.py
@@ -1465,6 +1465,6 @@ async def test_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"some_var": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -211,7 +211,7 @@ async def test_expiration_on_discovery_and_discovery_update_of_binary_sensor(
     caplog: pytest.LogCaptureFixture,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test that binary_sensor with expire_after set behaves correctly on discovery and discovery update."""
+    """Test binary_sensor with expire_after on discovery and update."""
     await mqtt_mock_entry()
     config = {
         "name": "Test",
@@ -222,7 +222,8 @@ async def test_expiration_on_discovery_and_discovery_update_of_binary_sensor(
 
     config_msg = json.dumps(config)
 
-    # Set time and publish config message to create binary_sensor via discovery with 4 s expiry
+    # Set time and publish config message to create binary_sensor
+    # via discovery with 4 s expiry
     realnow = dt_util.utcnow()
     now = datetime(realnow.year + 1, 1, 1, 1, tzinfo=dt_util.UTC)
     freezer.move_to(now)
@@ -452,13 +453,15 @@ async def test_setting_sensor_value_via_mqtt_message_and_template2(
                     "state_topic": "test-topic",
                     "payload_on": "ON",
                     "payload_off": "OFF",
-                    "value_template": "{%if value|unpack('b')-%}ON{%else%}OFF{%-endif-%}",
+                    "value_template": (
+                        "{%if value|unpack('b')-%}ON{%else%}OFF{%-endif-%}"
+                    ),
                 }
             }
         }
     ],
 )
-async def test_setting_sensor_value_via_mqtt_message_and_template_and_raw_state_encoding(
+async def test_setting_sensor_value_via_mqtt_msg_and_template_and_raw_state_encoding(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
     caplog: pytest.LogCaptureFixture,
@@ -1264,6 +1267,6 @@ async def test_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"some_var": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )

--- a/tests/components/mqtt/test_client.py
+++ b/tests/components/mqtt/test_client.py
@@ -1101,8 +1101,9 @@ async def test_unsubscribe_race(
     assert not calls_a
     assert calls_b
 
-    # We allow either calls [subscribe, unsubscribe, subscribe], [subscribe, subscribe] or
-    # when both subscriptions were combined [subscribe]
+    # We allow either calls [subscribe, unsubscribe, subscribe],
+    # [subscribe, subscribe] or when both subscriptions were
+    # combined [subscribe]
     expected_calls_1 = [
         call.subscribe([("test/state", 0)]),
         call.unsubscribe("test/state"),
@@ -1287,7 +1288,8 @@ async def test_triggers_reauth_flow_if_auth_fails(
 ) -> None:
     """Test re-auth is triggered if authentication is failing."""
     mqtt_client_mock = setup_with_birth_msg_client_mock
-    # test with rc = 4 -> CONNACK_REFUSED_NOT_AUTHORIZED and 5 -> CONNACK_REFUSED_BAD_USERNAME_PASSWORD
+    # test with rc = 4 -> CONNACK_REFUSED_NOT_AUTHORIZED
+    # and 5 -> CONNACK_REFUSED_BAD_USERNAME_PASSWORD
     mqtt_client_mock.on_disconnect(Mock(), None, 0, MockMqttReasonCode(), None)
     mqtt_client_mock.on_connect(Mock(), None, None, reason_code)
     await hass.async_block_till_done()
@@ -1305,16 +1307,19 @@ async def test_handle_mqtt_on_callback(
     """Test receiving an ACK callback before waiting for it."""
     mqtt_client_mock = setup_with_birth_msg_client_mock
     with patch.object(mqtt_client_mock, "get_mid", return_value=100):
-        # Simulate an ACK for mid == 100, this will call mqtt_mock._async_get_mid_future(mid)
+        # Simulate an ACK for mid == 100, this will call
+        # mqtt_mock._async_get_mid_future(mid)
         mqtt_client_mock.on_publish(
             mqtt_client_mock, None, 100, MockMqttReasonCode(), None
         )
         await hass.async_block_till_done()
         # Make sure the ACK has been received
         await hass.async_block_till_done()
-        # Now call publish without call back, this will call _async_async_wait_for_mid(msg_info.mid)
+        # Now call publish without call back, this will call
+        # _async_async_wait_for_mid(msg_info.mid)
         await mqtt.async_publish(hass, "no_callback/test-topic", "test-payload")
-        # Since the mid event was already set, we should not see any timeout warning in the log
+        # Since the mid event was already set, we should not see
+        # any timeout warning in the log
         await hass.async_block_till_done()
         assert "No ACK from MQTT server" not in caplog.text
 

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -1430,7 +1430,9 @@ async def test_get_target_temperature_low_high_with_templates(
                     "temperature_low_command_topic": "temperature-low-topic",
                     "temperature_high_command_topic": "temperature-high-topic",
                     "fan_mode_command_topic": "fan-mode-topic",
-                    "swing_horizontal_mode_command_topic": "swing-horizontal-mode-topic",
+                    "swing_horizontal_mode_command_topic": (
+                        "swing-horizontal-mode-topic"
+                    ),
                     "swing_mode_command_topic": "swing-mode-topic",
                     "preset_mode_command_topic": "preset-mode-topic",
                     "preset_modes": [
@@ -1596,7 +1598,9 @@ async def test_get_with_templates(
                     "temperature_low_command_topic": "temperature-low-topic",
                     "temperature_high_command_topic": "temperature-high-topic",
                     "fan_mode_command_topic": "fan-mode-topic",
-                    "swing_horizontal_mode_command_topic": "swing-horizontal-mode-topic",
+                    "swing_horizontal_mode_command_topic": (
+                        "swing-horizontal-mode-topic"
+                    ),
                     "swing_mode_command_topic": "swing-mode-topic",
                     "preset_mode_command_topic": "preset-mode-topic",
                     "preset_modes": [
@@ -1613,7 +1617,9 @@ async def test_get_with_templates(
                     "power_command_template": "power: {{ value }}",
                     "preset_mode_command_template": "preset_mode: {{ value }}",
                     "mode_command_template": "mode: {{ value }}",
-                    "swing_horizontal_mode_command_template": "swing_horizontal_mode: {{ value }}",
+                    "swing_horizontal_mode_command_template": (
+                        "swing_horizontal_mode: {{ value }}"
+                    ),
                     "swing_mode_command_template": "swing_mode: {{ value }}",
                     "temperature_command_template": "temp: {{ value }}",
                     "temperature_high_command_template": "temp_hi: {{ value }}",
@@ -2497,7 +2503,9 @@ async def test_unload_entry(
                     "current_temperature_topic": "current-temperature-topic",
                     "preset_mode_state_topic": "preset-mode-state-topic",
                     "preset_modes": ["eco", "away"],
-                    "swing_horizontal_mode_state_topic": "swing-horizontal-mode-state-topic",
+                    "swing_horizontal_mode_state_topic": (
+                        "swing-horizontal-mode-state-topic"
+                    ),
                     "swing_mode_state_topic": "swing-mode-state-topic",
                     "target_humidity_state_topic": "target-humidity-state-topic",
                     "temperature_high_state_topic": "temperature-high-state-topic",
@@ -2567,8 +2575,8 @@ async def test_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"some_var": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )
 
 

--- a/tests/components/mqtt/test_config_flow.py
+++ b/tests/components/mqtt/test_config_flow.py
@@ -1716,7 +1716,7 @@ async def test_step_reauth(
 async def test_step_hassio_reauth(
     hass: HomeAssistant, mock_try_connection: MagicMock, addon_info: AsyncMock
 ) -> None:
-    """Test that the reauth step works in case the Mosquitto broker add-on was re-installed."""
+    """Test reauth step works when Mosquitto add-on was re-installed."""
 
     # Set up entry data based on the discovery data, but with a stale password
     entry_data = {
@@ -2051,7 +2051,8 @@ async def test_try_connection_with_advanced_parameters(
     assert result["reason"] == "reconfigure_successful"
     await hass.async_block_till_done()
 
-    # check if the username and password was set from config flow and not from configuration.yaml
+    # check if the username and password was set from config flow
+    # and not from configuration.yaml
     assert mock_try_connection_success.username_pw_set.mock_calls[0][1] == (
         "us3r",
         "p4ss",
@@ -2182,7 +2183,8 @@ async def test_setup_with_advanced_settings(
     assert result["data_schema"].schema[mqtt.CONF_WS_PATH]
     assert result["data_schema"].schema[mqtt.CONF_WS_HEADERS]
 
-    # third iteration, advanced settings with client cert and key set and bad json payload
+    # third iteration, advanced settings with client cert and key
+    # set and bad json payload
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={
@@ -2198,7 +2200,9 @@ async def test_setup_with_advanced_settings(
             mqtt.CONF_TLS_INSECURE: True,
             mqtt.CONF_TRANSPORT: "websockets",
             mqtt.CONF_WS_PATH: "/custom_path/",
-            mqtt.CONF_WS_HEADERS: '{"header_1": "content_header_1", "header_2": "content_header_2"',
+            mqtt.CONF_WS_HEADERS: (
+                '{"header_1": "content_header_1", "header_2": "content_header_2"'
+            ),
         },
     )
 
@@ -2223,7 +2227,9 @@ async def test_setup_with_advanced_settings(
             mqtt.CONF_TLS_INSECURE: True,
             mqtt.CONF_TRANSPORT: "websockets",
             mqtt.CONF_WS_PATH: "/custom_path/",
-            mqtt.CONF_WS_HEADERS: '{"header_1": "content_header_1", "header_2": "content_header_2"}',
+            mqtt.CONF_WS_HEADERS: (
+                '{"header_1": "content_header_1", "header_2": "content_header_2"}'
+            ),
         },
     )
 
@@ -2844,11 +2850,15 @@ async def test_migrate_of_incompatible_config_entry(
                     "temperature_low_command_topic": "temperature-low-command-topic",
                     "temperature_low_command_template": "{{ value }}",
                     "temperature_low_state_topic": "temperature-low-state-topic",
-                    "temperature_low_state_template": "{{ value_json.temperature_low }}",
+                    "temperature_low_state_template": (
+                        "{{ value_json.temperature_low }}"
+                    ),
                     "temperature_high_command_topic": "temperature-high-command-topic",
                     "temperature_high_command_template": "{{ value }}",
                     "temperature_high_state_topic": "temperature-high-state-topic",
-                    "temperature_high_state_template": "{{ value_json.temperature_high }}",
+                    "temperature_high_state_template": (
+                        "{{ value_json.temperature_high }}"
+                    ),
                     "min_temp": 8,
                     "max_temp": 28,
                     "precision": "0.1",
@@ -2942,7 +2952,9 @@ async def test_migrate_of_incompatible_config_entry(
                     "target_humidity_command_topic": "target-humidity-command-topic",
                     "target_humidity_command_template": "{{ value }}",
                     "target_humidity_state_topic": "target-humidity-state-topic",
-                    "target_humidity_state_template": "{{ value_json.target_humidity }}",
+                    "target_humidity_state_template": (
+                        "{{ value_json.target_humidity }}"
+                    ),
                     "min_humidity": 20,
                     "max_humidity": 80,
                 },
@@ -2982,10 +2994,16 @@ async def test_migrate_of_incompatible_config_entry(
                 },
                 # swing horizontal mode
                 "climate_swing_horizontal_mode_settings": {
-                    "swing_horizontal_mode_command_topic": "swing-horizontal-mode-command-topic",
+                    "swing_horizontal_mode_command_topic": (
+                        "swing-horizontal-mode-command-topic"
+                    ),
                     "swing_horizontal_mode_command_template": "{{ value }}",
-                    "swing_horizontal_mode_state_topic": "swing-horizontal-mode-state-topic",
-                    "swing_horizontal_mode_state_template": "{{ value_json.swing_horizontal_mode }}",
+                    "swing_horizontal_mode_state_topic": (
+                        "swing-horizontal-mode-state-topic"
+                    ),
+                    "swing_horizontal_mode_state_template": (
+                        "{{ value_json.swing_horizontal_mode }}"
+                    ),
                     "swing_horizontal_modes": ["off", "on"],
                 },
             },
@@ -3068,13 +3086,17 @@ async def test_migrate_of_incompatible_config_entry(
                 (
                     {"value_template": "{{ json_value.state }}"},
                     {
-                        "value_template": "cover_value_template_must_be_used_with_state_topic"
+                        "value_template": (
+                            "cover_value_template_must_be_used_with_state_topic"
+                        )
                     },
                 ),
                 (
                     {"cover_position_settings": {"set_position_topic": "test-topic"}},
                     {
-                        "cover_position_settings": "cover_get_and_set_position_must_be_set_together"
+                        "cover_position_settings": (
+                            "cover_get_and_set_position_must_be_set_together"
+                        )
                     },
                 ),
                 (
@@ -3084,7 +3106,11 @@ async def test_migrate_of_incompatible_config_entry(
                         }
                     },
                     {
-                        "cover_position_settings": "cover_set_position_template_must_be_used_with_set_position_topic"
+                        "cover_position_settings": (
+                            "cover_set_position_template"
+                            "_must_be_used_with"
+                            "_set_position_topic"
+                        )
                     },
                 ),
                 (
@@ -3094,19 +3120,29 @@ async def test_migrate_of_incompatible_config_entry(
                         }
                     },
                     {
-                        "cover_position_settings": "cover_get_position_template_must_be_used_with_get_position_topic"
+                        "cover_position_settings": (
+                            "cover_get_position_template"
+                            "_must_be_used_with"
+                            "_get_position_topic"
+                        )
                     },
                 ),
                 (
                     {"cover_position_settings": {"set_position_topic": "{{ value }}"}},
                     {
-                        "cover_position_settings": "cover_get_and_set_position_must_be_set_together"
+                        "cover_position_settings": (
+                            "cover_get_and_set_position_must_be_set_together"
+                        )
                     },
                 ),
                 (
                     {"cover_tilt_settings": {"tilt_command_template": "{{ value }}"}},
                     {
-                        "cover_tilt_settings": "cover_tilt_command_template_must_be_used_with_tilt_command_topic"
+                        "cover_tilt_settings": (
+                            "cover_tilt_command_template"
+                            "_must_be_used_with"
+                            "_tilt_command_topic"
+                        )
                     },
                 ),
                 (
@@ -3116,7 +3152,11 @@ async def test_migrate_of_incompatible_config_entry(
                         }
                     },
                     {
-                        "cover_tilt_settings": "cover_tilt_status_template_must_be_used_with_tilt_status_topic"
+                        "cover_tilt_settings": (
+                            "cover_tilt_status_template"
+                            "_must_be_used_with"
+                            "_tilt_status_topic"
+                        )
                     },
                 ),
             ),
@@ -3245,7 +3285,9 @@ async def test_migrate_of_incompatible_config_entry(
                         },
                     },
                     {
-                        "fan_preset_mode_settings": "fan_preset_mode_reset_in_preset_modes_list",
+                        "fan_preset_mode_settings": (
+                            "fan_preset_mode_reset_in_preset_modes_list"
+                        ),
                     },
                 ),
                 (
@@ -3268,7 +3310,9 @@ async def test_migrate_of_incompatible_config_entry(
                         },
                     },
                     {
-                        "fan_speed_settings": "fan_speed_range_max_must_be_greater_than_speed_range_min",
+                        "fan_speed_settings": (
+                            "fan_speed_range_max_must_be_greater_than_speed_range_min"
+                        ),
                     },
                 ),
             ),
@@ -4474,11 +4518,15 @@ async def test_subentry_reconfigure_edit_entity_multi_entitites(
                     "temperature_low_command_topic": "temperature-low-command-topic",
                     "temperature_low_command_template": "{{ value }}",
                     "temperature_low_state_topic": "temperature-low-state-topic",
-                    "temperature_low_state_template": "{{ value_json.temperature_low }}",
+                    "temperature_low_state_template": (
+                        "{{ value_json.temperature_low }}"
+                    ),
                     "temperature_high_command_topic": "temperature-high-command-topic",
                     "temperature_high_command_template": "{{ value }}",
                     "temperature_high_state_topic": "temperature-high-state-topic",
-                    "temperature_high_state_template": "{{ value_json.temperature_high }}",
+                    "temperature_high_state_template": (
+                        "{{ value_json.temperature_high }}"
+                    ),
                     "min_temp": 8,
                     "max_temp": 28,
                     "precision": "0.1",
@@ -4522,11 +4570,15 @@ async def test_subentry_reconfigure_edit_entity_multi_entitites(
                     "temperature_low_command_topic": "temperature-low-command-topic",
                     "temperature_low_command_template": "{{ value }}",
                     "temperature_low_state_topic": "temperature-low-state-topic",
-                    "temperature_low_state_template": "{{ value_json.temperature_low }}",
+                    "temperature_low_state_template": (
+                        "{{ value_json.temperature_low }}"
+                    ),
                     "temperature_high_command_topic": "temperature-high-command-topic",
                     "temperature_high_command_template": "{{ value }}",
                     "temperature_high_state_topic": "temperature-high-state-topic",
-                    "temperature_high_state_template": "{{ value_json.temperature_high }}",
+                    "temperature_high_state_template": (
+                        "{{ value_json.temperature_high }}"
+                    ),
                     "min_temp": 8,
                     "max_temp": 28,
                     "precision": "0.1",
@@ -5393,7 +5445,7 @@ async def test_subentry_configflow_section_feature(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
-    """Test the subentry ConfigFlow sections are hidden when they have no configurable options."""
+    """Test subentry sections are hidden with no configurable options."""
     await mqtt_mock_entry()
     config_entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
 

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -583,7 +583,8 @@ async def test_state_via_template_with_json_value(
 
     async_fire_mqtt_message(hass, "state-topic", '{ "Var2": "other" }')
     assert (
-        "Template variable warning: 'dict object' has no attribute 'Var1' when rendering"
+        "Template variable warning: 'dict object' has no"
+        " attribute 'Var1' when rendering"
     ) in caplog.text
 
 
@@ -2167,7 +2168,8 @@ async def test_tilt_via_topic_template_json_value(
     async_fire_mqtt_message(hass, "tilt-status-topic", '{"Var2": 10}')
 
     assert (
-        "Template variable warning: 'dict object' has no attribute 'Var1' when rendering"
+        "Template variable warning: 'dict object' has no"
+        " attribute 'Var1' when rendering"
     ) in caplog.text
 
 
@@ -2824,7 +2826,7 @@ async def test_entity_debug_info_message(
 async def test_state_and_position_topics_state_not_set_via_position_topic(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
-    """Test state is not set via position topic when both state and position topics are set."""
+    """Test state is not set via position topic when both are set."""
     await mqtt_mock_entry()
 
     state = hass.states.get("cover.test")
@@ -2999,7 +3001,8 @@ async def test_position_via_position_topic_template_json_value(
     async_fire_mqtt_message(hass, "get-position-topic", '{"Var2": 60}')
 
     assert (
-        "Template variable warning: 'dict object' has no attribute 'Var1' when rendering"
+        "Template variable warning: 'dict object' has no"
+        " attribute 'Var1' when rendering"
     ) in caplog.text
 
 
@@ -3099,7 +3102,7 @@ async def test_position_via_position_topic_template_return_json_warning(
     caplog: pytest.LogCaptureFixture,
     mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
-    """Test position by updating status via position template returning json without position attribute."""
+    """Test position via template returning json without position."""
     await mqtt_mock_entry()
 
     async_fire_mqtt_message(hass, "get-position-topic", "55")
@@ -3121,8 +3124,12 @@ async def test_position_via_position_topic_template_return_json_warning(
                     "command_topic": "command-topic",
                     "set_position_topic": "set-position-topic",
                     "position_topic": "get-position-topic",
-                    "position_template": '\
-                {{ {"position" : value, "tilt_position" : (value | int / 2)| int } | tojson }}',
+                    "position_template": (
+                        '{{ {"position" : value,'
+                        ' "tilt_position" :'
+                        " (value | int / 2)| int }"
+                        " | tojson }}"
+                    ),
                 }
             }
         }
@@ -3282,7 +3289,7 @@ async def test_position_via_position_topic_template_return_invalid_json(
     caplog: pytest.LogCaptureFixture,
     mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
-    """Test position by updating status via position template and returning invalid json."""
+    """Test position via template returning invalid json."""
     await mqtt_mock_entry()
 
     async_fire_mqtt_message(hass, "get-position-topic", "55")
@@ -3312,7 +3319,8 @@ async def test_set_position_topic_without_get_position_topic_error(
     """Test error when set_position_topic is used without position_topic."""
     assert await mqtt_mock_entry()
     assert (
-        f"'{CONF_SET_POSITION_TOPIC}' must be set together with '{CONF_GET_POSITION_TOPIC}'."
+        f"'{CONF_SET_POSITION_TOPIC}' must be set together"
+        f" with '{CONF_GET_POSITION_TOPIC}'."
     ) in caplog.text
 
 
@@ -3364,8 +3372,8 @@ async def test_position_template_without_position_topic_error(
     """Test error when position_template is used and position_topic is missing."""
     assert await mqtt_mock_entry()
     assert (
-        f"'{CONF_GET_POSITION_TEMPLATE}' must be set together with '{CONF_GET_POSITION_TOPIC}'."
-        in caplog.text
+        f"'{CONF_GET_POSITION_TEMPLATE}' must be set together"
+        f" with '{CONF_GET_POSITION_TOPIC}'." in caplog.text
     )
 
 
@@ -3387,11 +3395,11 @@ async def test_position_template_without_position_topic_error(
 async def test_set_position_template_without_set_position_topic(
     caplog: pytest.LogCaptureFixture, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
-    """Test error when set_position_template is used and set_position_topic is missing."""
+    """Test error when set_position_template has no topic."""
     assert await mqtt_mock_entry()
     assert (
-        f"'{CONF_SET_POSITION_TEMPLATE}' must be set together with '{CONF_SET_POSITION_TOPIC}'."
-        in caplog.text
+        f"'{CONF_SET_POSITION_TEMPLATE}' must be set together"
+        f" with '{CONF_SET_POSITION_TOPIC}'." in caplog.text
     )
 
 
@@ -3413,11 +3421,11 @@ async def test_set_position_template_without_set_position_topic(
 async def test_tilt_command_template_without_tilt_command_topic(
     caplog: pytest.LogCaptureFixture, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
-    """Test error when tilt_command_template is used and tilt_command_topic is missing."""
+    """Test error when tilt_command_template has no topic."""
     assert await mqtt_mock_entry()
     assert (
-        f"'{CONF_TILT_COMMAND_TEMPLATE}' must be set together with '{CONF_TILT_COMMAND_TOPIC}'."
-        in caplog.text
+        f"'{CONF_TILT_COMMAND_TEMPLATE}' must be set together"
+        f" with '{CONF_TILT_COMMAND_TOPIC}'." in caplog.text
     )
 
 
@@ -3439,11 +3447,11 @@ async def test_tilt_command_template_without_tilt_command_topic(
 async def test_tilt_status_template_without_tilt_status_topic_topic(
     caplog: pytest.LogCaptureFixture, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
-    """Test error when tilt_status_template is used and tilt_status_topic is missing."""
+    """Test error when tilt_status_template has no topic."""
     assert await mqtt_mock_entry()
     assert (
-        f"'{CONF_TILT_STATUS_TEMPLATE}' must be set together with '{CONF_TILT_STATUS_TOPIC}'."
-        in caplog.text
+        f"'{CONF_TILT_STATUS_TEMPLATE}' must be set together"
+        f" with '{CONF_TILT_STATUS_TOPIC}'." in caplog.text
     )
 
 
@@ -3642,8 +3650,8 @@ async def test_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"some_var": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )
 
 

--- a/tests/components/mqtt/test_date.py
+++ b/tests/components/mqtt/test_date.py
@@ -375,7 +375,10 @@ async def test_discovery_update_unchanged_update(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
     """Test update of discovered update."""
-    data1 = '{ "name": "Beer", "state_topic": "date-topic", "command_topic": "command-topic"}'
+    data1 = (
+        '{ "name": "Beer", "state_topic": "date-topic",'
+        ' "command_topic": "command-topic"}'
+    )
     with patch(
         "homeassistant.components.mqtt.date.MqttDateEntity.discovery_update"
     ) as discovery_update:
@@ -582,6 +585,6 @@ async def test_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"some_var": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )

--- a/tests/components/mqtt/test_datetime.py
+++ b/tests/components/mqtt/test_datetime.py
@@ -492,7 +492,10 @@ async def test_discovery_update_unchanged_update(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
     """Test update of discovered update."""
-    data1 = '{ "name": "Beer", "state_topic": "state-topic", "command_topic": "command-topic"}'
+    data1 = (
+        '{ "name": "Beer", "state_topic": "state-topic",'
+        ' "command_topic": "command-topic"}'
+    )
     with patch(
         "homeassistant.components.mqtt.datetime.MqttDateTime.discovery_update"
     ) as discovery_update:
@@ -701,6 +704,6 @@ async def test_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"some_var": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )

--- a/tests/components/mqtt/test_device_tracker.py
+++ b/tests/components/mqtt/test_device_tracker.py
@@ -348,7 +348,8 @@ async def test_setting_device_tracker_value_via_mqtt_message_and_template(
         "{"
         '"name": "test", '
         '"state_topic": "test-topic", '
-        '"value_template": "{% if value is equalto \\"proxy_for_home\\" %}home{% else %}not_home{% endif %}" '
+        '"value_template": "{% if value is equalto \\"proxy_for_home\\"'
+        ' %}home{% else %}not_home{% endif %}" '
         "}",
     )
     await hass.async_block_till_done()
@@ -435,7 +436,8 @@ async def test_setting_device_tracker_location_via_lat_lon_message(
     async_fire_mqtt_message(
         hass,
         "attributes-topic",
-        '{"latitude":32.87336,"longitude": -117.22743, "gps_accuracy":1.5, "source_type": "router"}',
+        '{"latitude":32.87336,"longitude": -117.22743,'
+        ' "gps_accuracy":1.5, "source_type": "router"}',
     )
     state = hass.states.get("device_tracker.test")
     assert state.attributes["latitude"] == 32.87336
@@ -486,7 +488,8 @@ async def test_setting_device_tracker_location_via_lat_lon_message(
     async_fire_mqtt_message(
         hass,
         "attributes-topic",
-        '{"latitude": "32.87336","longitude": "-117.22743", "gps_accuracy": "1.5", "source_type": "router"}',
+        '{"latitude": "32.87336","longitude": "-117.22743",'
+        ' "gps_accuracy": "1.5", "source_type": "router"}',
     )
     state = hass.states.get("device_tracker.test")
     assert "latitude" not in state.attributes
@@ -501,7 +504,8 @@ async def test_setting_device_tracker_location_via_lat_lon_message(
     async_fire_mqtt_message(
         hass,
         "attributes-topic",
-        '{"latitude": 32.871234,"longitude": -117.21234, "gps_accuracy": "invalid", "source_type": "router"}',
+        '{"latitude": 32.871234,"longitude": -117.21234,'
+        ' "gps_accuracy": "invalid", "source_type": "router"}',
     )
     state = hass.states.get("device_tracker.test")
     assert state.state == STATE_NOT_HOME
@@ -514,7 +518,8 @@ async def test_setting_device_tracker_location_via_lat_lon_message(
     async_fire_mqtt_message(
         hass,
         "attributes-topic",
-        '{"latitude": null,"longitude": "-117.22743", "gps_accuracy": 1, "source_type": "router"}',
+        '{"latitude": null,"longitude": "-117.22743",'
+        ' "gps_accuracy": 1, "source_type": "router"}',
     )
     state = hass.states.get("device_tracker.test")
     assert "latitude" not in state.attributes
@@ -525,7 +530,8 @@ async def test_setting_device_tracker_location_via_lat_lon_message(
     async_fire_mqtt_message(
         hass,
         "attributes-topic",
-        '{"latitude": 32.87336,"longitude": "unknown", "gps_accuracy": 1, "source_type": "router"}',
+        '{"latitude": 32.87336,"longitude": "unknown",'
+        ' "gps_accuracy": 1, "source_type": "router"}',
     )
     state = hass.states.get("device_tracker.test")
     assert "latitude" not in state.attributes
@@ -770,6 +776,6 @@ async def test_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"some_var": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )

--- a/tests/components/mqtt/test_device_trigger.py
+++ b/tests/components/mqtt/test_device_trigger.py
@@ -491,8 +491,8 @@ async def test_non_unique_triggers(
     # and therefore it was not set up.
     assert device_entry.name == "beer"
     assert (
-        "Config for device trigger bla2 conflicts with existing device trigger, cannot set up trigger"
-        in caplog.text
+        "Config for device trigger bla2 conflicts with existing"
+        " device trigger, cannot set up trigger" in caplog.text
     )
 
     assert await async_setup_component(

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -324,7 +324,7 @@ async def test_invalid_device_discovery_config(
     mqtt_mock_entry: MqttMockHAClientGenerator,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test sending in JSON that violates the discovery schema if device or platform key is missing."""
+    """Test JSON violating schema when device or platform key missing."""
     await mqtt_mock_entry()
     async_fire_mqtt_message(
         hass,
@@ -632,7 +632,8 @@ async def test_discovery_integration_info(
         "Processing device discovery for 'bla' from external "
         "application bla2mqtt, version: 1.0"
         in caplog.text
-        or f"Found new component: binary_sensor {discovery_id} from external application bla2mqtt, version: 1.0"
+        or f"Found new component: binary_sensor {discovery_id}"
+        " from external application bla2mqtt, version: 1.0"
         in caplog.text
     )
     caplog.clear()
@@ -2976,7 +2977,7 @@ async def test_unique_id_collission_has_priority(
     mqtt_mock_entry: MqttMockHAClientGenerator,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test the unique_id collision detection has priority over registry disabled items."""
+    """Test unique_id collision has priority over disabled items."""
     await mqtt_mock_entry()
     config = {
         "state_topic": "homeassistant_test/sensor/sbfspot_0/sbfspot_12345/",
@@ -2989,7 +2990,8 @@ async def test_unique_id_collission_has_priority(
             "connections": [["mac", "12:34:56:AB:CD:EF"]],
         },
     }
-    # discover an entity that is not unique and disabled by default (part 1), will be added
+    # discover an entity that is not unique and disabled by default
+    # (part 1), will be added
     config_not_unique1 = copy.deepcopy(config)
     config_not_unique1["name"] = "sbfspot_12345_1"
     config_not_unique1["unique_id"] = "not_unique"
@@ -2998,7 +3000,8 @@ async def test_unique_id_collission_has_priority(
         "homeassistant/sensor/sbfspot_0/sbfspot_12345_1/config",
         json.dumps(config_not_unique1),
     )
-    # discover an entity that is not unique (part 2), will not be added, and the registry entry is cleared
+    # discover an entity that is not unique (part 2), will not be
+    # added, and the registry entry is cleared
     config_not_unique2 = copy.deepcopy(config_not_unique1)
     config_not_unique2["name"] = "sbfspot_12345_2"
     async_fire_mqtt_message(
@@ -3242,7 +3245,7 @@ async def test_discovery_with_late_via_device_update(
     tag_mock: AsyncMock,
     single_configs: list[tuple[str, dict[str, Any]]],
 ) -> None:
-    """Test a via device is available and the discovery of the via device is is set via an update."""
+    """Test via device discovery is set via an update."""
     await mqtt_mock_entry()
 
     await hass.async_block_till_done()

--- a/tests/components/mqtt/test_event.py
+++ b/tests/components/mqtt/test_event.py
@@ -191,7 +191,11 @@ async def test_setting_event_value_with_invalid_payload(
                     "name": "test",
                     "state_topic": "test-topic",
                     "event_types": ["press"],
-                    "value_template": '{"event_type": "press", "val": "{{ value_json.val | is_defined }}", "par": "{{ value_json.par }}"}',
+                    "value_template": (
+                        '{"event_type": "press",'
+                        ' "val": "{{ value_json.val | is_defined }}",'
+                        ' "par": "{{ value_json.par }}"}'
+                    ),
                 }
             }
         }
@@ -811,6 +815,6 @@ async def test_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"some_var": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )

--- a/tests/components/mqtt/test_fan.py
+++ b/tests/components/mqtt/test_fan.py
@@ -2430,6 +2430,6 @@ async def test_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"some_var": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )

--- a/tests/components/mqtt/test_humidifier.py
+++ b/tests/components/mqtt/test_humidifier.py
@@ -1323,7 +1323,10 @@ async def test_discovery_removal_humidifier(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
     """Test removal of discovered humidifier."""
-    data = '{ "name": "test", "command_topic": "test_topic", "target_humidity_command_topic": "test-topic2" }'
+    data = (
+        '{ "name": "test", "command_topic": "test_topic",'
+        ' "target_humidity_command_topic": "test-topic2" }'
+    )
     await help_test_discovery_removal(hass, mqtt_mock_entry, humidifier.DOMAIN, data)
 
 
@@ -1350,7 +1353,10 @@ async def test_discovery_update_unchanged_humidifier(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
     """Test update of discovered humidifier."""
-    data1 = '{ "name": "Beer", "command_topic": "test_topic", "target_humidity_command_topic": "test-topic2" }'
+    data1 = (
+        '{ "name": "Beer", "command_topic": "test_topic",'
+        ' "target_humidity_command_topic": "test-topic2" }'
+    )
     with patch(
         "homeassistant.components.mqtt.fan.MqttFan.discovery_update"
     ) as discovery_update:
@@ -1365,7 +1371,10 @@ async def test_discovery_broken(
 ) -> None:
     """Test handling of bad discovery message."""
     data1 = '{ "name": "Beer" }'
-    data2 = '{ "name": "Milk", "command_topic": "test_topic", "target_humidity_command_topic": "test-topic2" }'
+    data2 = (
+        '{ "name": "Milk", "command_topic": "test_topic",'
+        ' "target_humidity_command_topic": "test-topic2" }'
+    )
     await help_test_discovery_broken(
         hass, mqtt_mock_entry, humidifier.DOMAIN, data1, data2
     )
@@ -1622,6 +1631,6 @@ async def test_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"some_var": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )

--- a/tests/components/mqtt/test_image.py
+++ b/tests/components/mqtt/test_image.py
@@ -825,6 +825,6 @@ async def test_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"some_var": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -109,7 +109,12 @@ async def test_command_template_value(hass: HomeAssistant) -> None:
             "command_topic": "test/select",
             "name": "Test Select",
             "options": ["milk", "beer"],
-            "command_template": '{"option": "{{ value }}", "entity_id": "{{ entity_id }}", "name": "{{ name }}", "this_object_state": "{{ this.state }}"}',
+            "command_template": (
+                '{"option": "{{ value }}",'
+                ' "entity_id": "{{ entity_id }}",'
+                ' "name": "{{ name }}",'
+                ' "this_object_state": "{{ this.state }}"}'
+            ),
         }
     ],
 )
@@ -140,7 +145,12 @@ async def test_command_template_variables(
 
     mqtt_mock.async_publish.assert_called_once_with(
         topic,
-        '{"option": "beer", "entity_id": "select.test_select", "name": "Test Select", "this_object_state": "milk"}',
+        (
+            '{"option": "beer",'
+            ' "entity_id": "select.test_select",'
+            ' "name": "Test Select",'
+            ' "this_object_state": "milk"}'
+        ),
         0,
         False,
         message_expiry_interval=None,
@@ -274,7 +284,9 @@ async def test_service_call_mqtt_entry_does_not_publish(
     assert await async_setup_component(hass, mqtt.DOMAIN, {})
     with pytest.raises(
         ServiceValidationError,
-        match='Cannot publish to topic "test_topic", make sure MQTT is set up correctly',
+        match=(
+            'Cannot publish to topic "test_topic", make sure MQTT is set up correctly'
+        ),
     ):
         await hass.services.async_call(
             mqtt.DOMAIN,
@@ -434,8 +446,9 @@ async def test_publish_function_with_bad_encoding_conditions(
         hass, "some-topic", "test-payload", qos=0, retain=False, encoding=None
     )
     assert (
-        "Can't pass-through payload for publishing test-payload on some-topic with no encoding set, need 'bytes' got <class 'str'>"
-        in caplog.text
+        "Can't pass-through payload for publishing test-payload"
+        " on some-topic with no encoding set, need 'bytes'"
+        " got <class 'str'>" in caplog.text
     )
     caplog.clear()
     await mqtt.async_publish(
@@ -447,8 +460,8 @@ async def test_publish_function_with_bad_encoding_conditions(
         encoding="invalid_encoding",
     )
     assert (
-        "Can't encode payload for publishing test-payload on some-topic with encoding invalid_encoding"
-        in caplog.text
+        "Can't encode payload for publishing test-payload on"
+        " some-topic with encoding invalid_encoding" in caplog.text
     )
 
 
@@ -873,8 +886,8 @@ async def test_setup_manual_mqtt_with_platform_key(
     """Test set up a manual MQTT item with a platform key."""
     assert await mqtt_mock_entry()
     assert (
-        "extra keys not allowed @ data['platform'] for manually configured MQTT light item"
-        in caplog.text
+        "extra keys not allowed @ data['platform']"
+        " for manually configured MQTT light item" in caplog.text
     )
 
 
@@ -891,7 +904,7 @@ async def test_setup_manual_mqtt_with_invalid_config(
 async def test_default_entry_setting_are_applied(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:
-    """Test if the MQTT component loads when config entry data not has all default settings."""
+    """Test MQTT loads when config entry lacks all default settings."""
     data = (
         '{ "device":{"identifiers":["0AFFD2"]},'
         '  "state_topic": "foobar/sensor",'
@@ -1334,7 +1347,7 @@ async def test_debug_info_multiple_entities_triggers(
     device_registry: dr.DeviceRegistry,
     mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
-    """Test we get correct debug_info for a device with multiple entities and triggers."""
+    """Test debug_info for a device with multiple entities."""
     await mqtt_mock_entry()
     config: list[_DebugInfo] = [
         {
@@ -1833,8 +1846,14 @@ async def test_disabling_and_enabling_entry(
     entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     assert entry.state is ConfigEntryState.LOADED
     # Late discovery of a mqtt entity
-    config_tag = '{"topic": "0AFFD2/tag_scanned", "value_template": "{{ value_json.PN532.UID }}"}'
-    config_alarm_control_panel = '{"name": "test_new", "state_topic": "home/alarm", "command_topic": "home/alarm/set"}'
+    config_tag = (
+        '{"topic": "0AFFD2/tag_scanned",'
+        ' "value_template": "{{ value_json.PN532.UID }}"}'
+    )
+    config_alarm_control_panel = (
+        '{"name": "test_new", "state_topic": "home/alarm",'
+        ' "command_topic": "home/alarm/set"}'
+    )
     config_light = '{"name": "test_new", "command_topic": "test-topic_new"}'
 
     with patch(
@@ -1864,8 +1883,8 @@ async def test_disabling_and_enabling_entry(
         in caplog.text
     )
     assert (
-        "MQTT integration is disabled, skipping setup of discovered item MQTT alarm_control_panel"
-        in caplog.text
+        "MQTT integration is disabled, skipping setup of"
+        " discovered item MQTT alarm_control_panel" in caplog.text
     )
     assert (
         "MQTT integration is disabled, skipping setup of discovered item MQTT light"

--- a/tests/components/mqtt/test_lawn_mower.py
+++ b/tests/components/mqtt/test_lawn_mower.py
@@ -559,7 +559,10 @@ async def test_discovery_update_unchanged_lawn_mower(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
     """Test update of discovered lawn_mower."""
-    data1 = '{ "name": "Beer", "activity_state_topic": "test-topic", "command_topic": "test-topic", "actions": ["milk", "beer"]}'
+    data1 = (
+        '{ "name": "Beer", "activity_state_topic": "test-topic",'
+        ' "command_topic": "test-topic", "actions": ["milk", "beer"]}'
+    )
     with patch(
         "homeassistant.components.mqtt.lawn_mower.MqttLawnMower.discovery_update"
     ) as discovery_update:
@@ -574,7 +577,10 @@ async def test_discovery_broken(
 ) -> None:
     """Test handling of bad discovery message."""
     data1 = '{ "invalid" }'
-    data2 = '{ "name": "Milk", "activity_state_topic": "test-topic", "pause_command_topic": "test-topic"}'
+    data2 = (
+        '{ "name": "Milk", "activity_state_topic": "test-topic",'
+        ' "pause_command_topic": "test-topic"}'
+    )
 
     await help_test_discovery_broken(
         hass, mqtt_mock_entry, lawn_mower.DOMAIN, data1, data2
@@ -866,7 +872,10 @@ async def test_persistent_state_after_reconfig(
 ) -> None:
     """Test of the state is persistent after reconfiguring the lawn_mower activity."""
     await mqtt_mock_entry()
-    discovery_data = '{ "name": "Garden", "activity_state_topic": "test-topic", "command_topic": "test-topic"}'
+    discovery_data = (
+        '{ "name": "Garden", "activity_state_topic": "test-topic",'
+        ' "command_topic": "test-topic"}'
+    )
     await help_test_discovery_setup(hass, LAWN_MOWER_DOMAIN, discovery_data, "garden")
 
     # assign an initial state
@@ -875,7 +884,10 @@ async def test_persistent_state_after_reconfig(
     assert state.state == "docked"
 
     # change the config
-    discovery_data = '{ "name": "Garden", "activity_state_topic": "test-topic2", "command_topic": "test-topic"}'
+    discovery_data = (
+        '{ "name": "Garden", "activity_state_topic": "test-topic2",'
+        ' "command_topic": "test-topic"}'
+    )
     await help_test_discovery_setup(hass, LAWN_MOWER_DOMAIN, discovery_data, "garden")
 
     # assert the state persistent
@@ -942,6 +954,6 @@ async def test_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"some_var": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -553,10 +553,18 @@ async def test_controlling_state_via_topic(
                         "name": "test",
                         "state_topic": "test_light_color_temp/status",
                         "command_topic": "test_light_color_temp/set",
-                        "brightness_state_topic": "test_light_color_temp/brightness/status",
-                        "brightness_command_topic": "test_light_color_temp/brightness/set",
-                        "color_temp_state_topic": "test_light_color_temp/color_temp/status",
-                        "color_temp_command_topic": "test_light_color_temp/color_temp/set",
+                        "brightness_state_topic": (
+                            "test_light_color_temp/brightness/status"
+                        ),
+                        "brightness_command_topic": (
+                            "test_light_color_temp/brightness/set"
+                        ),
+                        "color_temp_state_topic": (
+                            "test_light_color_temp/color_temp/status"
+                        ),
+                        "color_temp_command_topic": (
+                            "test_light_color_temp/color_temp/set"
+                        ),
                         "color_temp_kelvin": False,
                     }
                 }
@@ -571,10 +579,18 @@ async def test_controlling_state_via_topic(
                         "name": "test",
                         "state_topic": "test_light_color_temp/status",
                         "command_topic": "test_light_color_temp/set",
-                        "brightness_state_topic": "test_light_color_temp/brightness/status",
-                        "brightness_command_topic": "test_light_color_temp/brightness/set",
-                        "color_temp_state_topic": "test_light_color_temp/color_temp/status",
-                        "color_temp_command_topic": "test_light_color_temp/color_temp/set",
+                        "brightness_state_topic": (
+                            "test_light_color_temp/brightness/status"
+                        ),
+                        "brightness_command_topic": (
+                            "test_light_color_temp/brightness/set"
+                        ),
+                        "color_temp_state_topic": (
+                            "test_light_color_temp/color_temp/status"
+                        ),
+                        "color_temp_command_topic": (
+                            "test_light_color_temp/color_temp/set"
+                        ),
                         "color_temp_kelvin": True,
                     }
                 }
@@ -1581,8 +1597,12 @@ async def test_sending_mqtt_rgbww_command_with_template(
                     light.DOMAIN: {
                         "name": "test",
                         "command_topic": "test_light_color_temp/set",
-                        "color_temp_command_topic": "test_light_color_temp/color_temp/set",
-                        "color_temp_command_template": "{{ (1000 / value) | round(0) }}",
+                        "color_temp_command_topic": (
+                            "test_light_color_temp/color_temp/set"
+                        ),
+                        "color_temp_command_template": (
+                            "{{ (1000 / value) | round(0) }}"
+                        ),
                         "color_temp_kelvin": False,
                         "payload_on": "on",
                         "payload_off": "off",
@@ -1598,7 +1618,9 @@ async def test_sending_mqtt_rgbww_command_with_template(
                     light.DOMAIN: {
                         "name": "test",
                         "command_topic": "test_light_color_temp/set",
-                        "color_temp_command_topic": "test_light_color_temp/color_temp/set",
+                        "color_temp_command_topic": (
+                            "test_light_color_temp/color_temp/set"
+                        ),
                         "color_temp_command_template": "{{ (0.5 * value) | round(0) }}",
                         "color_temp_kelvin": True,
                         "payload_on": "on",
@@ -2276,7 +2298,9 @@ async def test_on_command_rgb_template(
                     "name": "test",
                     "command_topic": "test_light/set",
                     "rgbw_command_topic": "test_light/rgbw",
-                    "rgbw_command_template": "{{ red }}/{{ green }}/{{ blue }}/{{ white }}",
+                    "rgbw_command_template": (
+                        "{{ red }}/{{ green }}/{{ blue }}/{{ white }}"
+                    ),
                 }
             }
         }
@@ -2385,10 +2409,14 @@ async def test_on_command_rgbww_template(
                     "on_command_type": "brightness",
                     "brightness_value_template": "{{ value_json.Dimmer }}",
                     "rgb_command_topic": "tasmota_B94927/cmnd/Color2",
-                    "rgb_value_template": "{{value_json.Color.split(',')[0:3]|join(',')}}",
+                    "rgb_value_template": (
+                        "{{value_json.Color.split(',')[0:3]|join(',')}}"
+                    ),
                     "white_command_topic": "tasmota_B94927/cmnd/White",
                     "white_scale": 100,
-                    "color_mode_value_template": "{% if value_json.White %} white {% else %} rgb {% endif %}",
+                    "color_mode_value_template": (
+                        "{% if value_json.White %} white {% else %} rgb {% endif %}"
+                    ),
                     "qos": "0",
                 }
             }
@@ -3058,7 +3086,11 @@ async def test_discovery_update_light_topic_and_template(
             [
                 (
                     "test_light_rgb/state1",
-                    '{"state1":{"state":"ON", "brightness":100, "ct":123, "white":100, "fx":"cycle"}}',
+                    (
+                        '{"state1":{"state":"ON",'
+                        ' "brightness":100, "ct":123,'
+                        ' "white":100, "fx":"cycle"}}'
+                    ),
                 )
             ],
             "on",
@@ -3109,7 +3141,11 @@ async def test_discovery_update_light_topic_and_template(
             [
                 (
                     "test_light_rgb/state2",
-                    '{"state2":{"state":"ON", "brightness":50, "ct":200, "white":50, "fx":"loop"}}',
+                    (
+                        '{"state2":{"state":"ON",'
+                        ' "brightness":50, "ct":200,'
+                        ' "white":50, "fx":"loop"}}'
+                    ),
                 )
             ],
             "on",
@@ -3123,15 +3159,27 @@ async def test_discovery_update_light_topic_and_template(
             [
                 (
                     "test_light_rgb/state1",
-                    '{"state1":{"state":"ON", "brightness":100, "ct":123, "fx":"cycle"}}',
+                    (
+                        '{"state1":{"state":"ON",'
+                        ' "brightness":100, "ct":123,'
+                        ' "fx":"cycle"}}'
+                    ),
                 ),
                 (
                     "test_light_rgb/state1",
-                    '{"state2":{"state":"ON", "brightness":100, "ct":123, "fx":"cycle"}}',
+                    (
+                        '{"state2":{"state":"ON",'
+                        ' "brightness":100, "ct":123,'
+                        ' "fx":"cycle"}}'
+                    ),
                 ),
                 (
                     "test_light_rgb/state2",
-                    '{"state1":{"state":"ON", "brightness":100, "ct":123, "fx":"cycle"}}',
+                    (
+                        '{"state1":{"state":"ON",'
+                        ' "brightness":100, "ct":123,'
+                        ' "fx":"cycle"}}'
+                    ),
                 ),
             ],
             "on",
@@ -3316,7 +3364,11 @@ async def test_discovery_update_light_template(
             [
                 (
                     "test_light_rgb/state1",
-                    '{"state1":{"state":"ON", "brightness":100, "ct":123, "white":100, "fx":"cycle"}}',
+                    (
+                        '{"state1":{"state":"ON",'
+                        ' "brightness":100, "ct":123,'
+                        ' "white":100, "fx":"cycle"}}'
+                    ),
                 )
             ],
             "on",
@@ -3367,7 +3419,11 @@ async def test_discovery_update_light_template(
             [
                 (
                     "test_light_rgb/state1",
-                    '{"state2":{"state":"ON", "brightness":50, "ct":200, "white":50, "fx":"loop"}}',
+                    (
+                        '{"state2":{"state":"ON",'
+                        ' "brightness":50, "ct":200,'
+                        ' "white":50, "fx":"loop"}}'
+                    ),
                 )
             ],
             "on",
@@ -3381,7 +3437,11 @@ async def test_discovery_update_light_template(
             [
                 (
                     "test_light_rgb/state1",
-                    '{"state1":{"state":"ON", "brightness":100, "ct":123, "fx":"cycle"}}',
+                    (
+                        '{"state1":{"state":"ON",'
+                        ' "brightness":100, "ct":123,'
+                        ' "fx":"cycle"}}'
+                    ),
                 ),
             ],
             "on",
@@ -3962,7 +4022,9 @@ async def test_sending_mqtt_effect_command_with_template(
                     "name": "test",
                     "command_topic": "test_light_hs/set",
                     "hs_command_topic": "test_light_hs/hs_color/set",
-                    "hs_command_template": '{"hue": {{ hue | int }}, "sat": {{ sat | int}}}',
+                    "hs_command_template": (
+                        '{"hue": {{ hue | int }}, "sat": {{ sat | int}}}'
+                    ),
                     "qos": 0,
                 }
             }
@@ -4157,6 +4219,6 @@ async def test_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"some_var": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -376,7 +376,8 @@ async def test_controlling_state_with_unknown_color_mode(
     async_fire_mqtt_message(
         hass,
         "test_light",
-        '{"state": "ON", "brightness": 50, "color_mode": "color_temp", "color_temp": 192}',
+        '{"state": "ON", "brightness": 50,'
+        ' "color_mode": "color_temp", "color_temp": 192}',
     )
     state = hass.states.get("light.test")
     assert state.state == STATE_ON
@@ -663,7 +664,8 @@ async def test_color_temp_only(
     async_fire_mqtt_message(
         hass,
         "test_light_rgb",
-        '{"state":"ON", "color_mode": "color_temp", "color_temp": 250, "brightness": 50}',
+        '{"state":"ON", "color_mode": "color_temp",'
+        ' "color_temp": 250, "brightness": 50}',
     )
 
     state = hass.states.get("light.test")
@@ -1024,8 +1026,8 @@ async def test_controlling_state_via_topic(
         hass, "test_light_rgb", '{"state":"ON", "color_mode":"rgb"}'
     )
     assert (
-        "Invalid or incomplete color value '{'state': 'ON', 'color_mode': 'rgb'}' received"
-        in caplog.text
+        "Invalid or incomplete color value"
+        " '{'state': 'ON', 'color_mode': 'rgb'}' received" in caplog.text
     )
     caplog.clear()
 
@@ -1036,8 +1038,9 @@ async def test_controlling_state_via_topic(
         '{"state":"ON", "color_mode":"rgb", "color":{"r":64,"g":128,"b":"cow"}}',
     )
     assert (
-        "Invalid or incomplete color value '{'state': 'ON', 'color_mode': 'rgb', 'color': {'r': 64, 'g': 128, 'b': 'cow'}}' received"
-        in caplog.text
+        "Invalid or incomplete color value '{'state': 'ON',"
+        " 'color_mode': 'rgb', 'color':"
+        " {'r': 64, 'g': 128, 'b': 'cow'}}' received" in caplog.text
     )
 
 
@@ -1069,7 +1072,7 @@ async def test_controlling_state_via_topic(
 async def test_sending_mqtt_commands_and_optimistic(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
-    """Test the sending of command in optimistic mode for a light supporting color mode."""
+    """Test optimistic mode commands for a color mode light."""
     supported_color_modes = ["color_temp", "hs", "rgb", "rgbw", "rgbww", "white", "xy"]
     fake_state = State(
         "light.test",
@@ -1488,7 +1491,8 @@ async def test_sending_rgb_color_no_brightness2(
             call(
                 "test_light_rgb/set",
                 JsonValidator(
-                    '{"state": "ON", "color": {"r": 32, "g": 16, "b": 8, "c": 4, "w": 2}}'
+                    '{"state": "ON", "color":'
+                    ' {"r": 32, "g": 16, "b": 8, "c": 4, "w": 2}}'
                 ),
                 0,
                 False,
@@ -2854,7 +2858,10 @@ async def test_reloadable(
     [
         (
             "state_topic",
-            '{ "state": "ON", "brightness": 200, "color_mode":"hs", "color":{"h":180,"s":50} }',
+            (
+                '{ "state": "ON", "brightness": 200,'
+                ' "color_mode":"hs", "color":{"h":180,"s":50} }'
+            ),
             "brightness",
             200,
             None,
@@ -2974,18 +2981,38 @@ async def test_setup_manual_entity_from_yaml(
         ),
         (
             "test-topic",
-            '{"state":"ON","brightness":255,"color_mode":"rgb","color":{"r":128,"g":128,"b":255}}',
-            '{"state":"ON","brightness":255,"color_mode":"rgb","color": {"r":255,"g":128,"b":255}}',
+            (
+                '{"state":"ON","brightness":255,'
+                '"color_mode":"rgb",'
+                '"color":{"r":128,"g":128,"b":255}}'
+            ),
+            (
+                '{"state":"ON","brightness":255,'
+                '"color_mode":"rgb",'
+                '"color": {"r":255,"g":128,"b":255}}'
+            ),
         ),
         (
             "test-topic",
-            '{"state":"ON","color_mode":"rgbw","color":{"r":128,"g":128,"b":255,"w":128}}',
-            '{"state":"ON","color_mode":"rgbw","color": {"r":128,"g":128,"b":255,"w":255}}',
+            (
+                '{"state":"ON","color_mode":"rgbw",'
+                '"color":{"r":128,"g":128,"b":255,"w":128}}'
+            ),
+            (
+                '{"state":"ON","color_mode":"rgbw",'
+                '"color": {"r":128,"g":128,"b":255,"w":255}}'
+            ),
         ),
         (
             "test-topic",
-            '{"state":"ON","color_mode":"rgbww","color":{"r":128,"g":128,"b":255,"c":32,"w":128}}',
-            '{"state":"ON","color_mode":"rgbww","color": {"r":128,"g":128,"b":255,"c":16,"w":128}}',
+            (
+                '{"state":"ON","color_mode":"rgbww",'
+                '"color":{"r":128,"g":128,"b":255,"c":32,"w":128}}'
+            ),
+            (
+                '{"state":"ON","color_mode":"rgbww",'
+                '"color": {"r":128,"g":128,"b":255,"c":16,"w":128}}'
+            ),
         ),
     ],
 )

--- a/tests/components/mqtt/test_light_template.py
+++ b/tests/components/mqtt/test_light_template.py
@@ -190,7 +190,9 @@ async def test_rgb_light(
                         "schema": "template",
                         "name": "test",
                         "command_topic": "test_light/set",
-                        "command_on_template": "on,{{ brightness|d }},{{ color_temp|d }}",
+                        "command_on_template": (
+                            "on,{{ brightness|d }},{{ color_temp|d }}"
+                        ),
                         "command_off_template": "off",
                         "brightness_template": "{{ value.split(',')[1] }}",
                         "color_temp_template": "{{ value.split(',')[2] }}",
@@ -207,7 +209,9 @@ async def test_rgb_light(
                         "schema": "template",
                         "name": "test",
                         "command_topic": "test_light/set",
-                        "command_on_template": "on,{{ brightness|d }},{{ color_temp|d }}",
+                        "command_on_template": (
+                            "on,{{ brightness|d }},{{ color_temp|d }}"
+                        ),
                         "command_off_template": "off",
                         "brightness_template": "{{ value.split(',')[1] }}",
                         "color_temp_template": "{{ value.split(',')[2] }}",
@@ -1545,8 +1549,8 @@ async def test_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"some_var": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )
 
 
@@ -1576,8 +1580,8 @@ async def test_rgb_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"r": 255, "g": 255, "b": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )
 
 

--- a/tests/components/mqtt/test_lock.py
+++ b/tests/components/mqtt/test_lock.py
@@ -1147,6 +1147,6 @@ async def test_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"some_var": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )

--- a/tests/components/mqtt/test_mixins.py
+++ b/tests/components/mqtt/test_mixins.py
@@ -464,8 +464,8 @@ async def test_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"some_var": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )
 
 

--- a/tests/components/mqtt/test_number.py
+++ b/tests/components/mqtt/test_number.py
@@ -502,7 +502,7 @@ async def test_run_number_service_optimistic(
 async def test_run_number_service_optimistic_with_command_template(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
-    """Test that set_value service works in optimistic mode and with a command_template."""
+    """Test set_value in optimistic mode with a command_template."""
     topic = "test/number"
 
     RESTORE_DATA = {
@@ -626,7 +626,7 @@ async def test_run_number_service(
 async def test_run_number_service_with_command_template(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
-    """Test that set_value service works in non optimistic mode and with a command_template."""
+    """Test set_value service with a command_template."""
     cmd_topic = "test/number/set"
     state_topic = "test/number"
 
@@ -1365,6 +1365,6 @@ async def test_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"some_var": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )

--- a/tests/components/mqtt/test_select.py
+++ b/tests/components/mqtt/test_select.py
@@ -227,7 +227,7 @@ async def test_run_select_service_optimistic(
 async def test_run_select_service_optimistic_with_command_template(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
-    """Test that set_value service works in optimistic mode and with a command_template."""
+    """Test set_value in optimistic mode with a command_template."""
     fake_state = State("select.test_select", "milk")
     mock_restore_cache(hass, (fake_state,))
 
@@ -312,7 +312,7 @@ async def test_run_select_service(
 async def test_run_select_service_with_command_template(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
-    """Test that set_value service works in non optimistic mode and with a command_template."""
+    """Test set_value service with a command_template."""
     cmd_topic = "test/select/set"
     state_topic = "test/select"
 
@@ -503,7 +503,10 @@ async def test_discovery_update_unchanged_select(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
     """Test update of discovered select."""
-    data1 = '{ "name": "Beer", "state_topic": "test-topic", "command_topic": "test-topic", "options": ["milk", "beer"]}'
+    data1 = (
+        '{ "name": "Beer", "state_topic": "test-topic",'
+        ' "command_topic": "test-topic", "options": ["milk", "beer"]}'
+    )
     with patch(
         "homeassistant.components.mqtt.select.MqttSelect.discovery_update"
     ) as discovery_update:
@@ -518,7 +521,10 @@ async def test_discovery_broken(
 ) -> None:
     """Test handling of bad discovery message."""
     data1 = '{ "name": "Beer" }'
-    data2 = '{ "name": "Milk", "state_topic": "test-topic", "command_topic": "test-topic", "options": ["milk", "beer"]}'
+    data2 = (
+        '{ "name": "Milk", "state_topic": "test-topic",'
+        ' "command_topic": "test-topic", "options": ["milk", "beer"]}'
+    )
 
     await help_test_discovery_broken(hass, mqtt_mock_entry, select.DOMAIN, data1, data2)
 
@@ -769,7 +775,10 @@ async def test_persistent_state_after_reconfig(
 ) -> None:
     """Test of the state is persistent after reconfiguring the select options."""
     await mqtt_mock_entry()
-    discovery_data = '{ "name": "Milk", "state_topic": "test-topic", "command_topic": "test-topic", "options": ["milk", "beer"]}'
+    discovery_data = (
+        '{ "name": "Milk", "state_topic": "test-topic",'
+        ' "command_topic": "test-topic", "options": ["milk", "beer"]}'
+    )
     await help_test_discovery_setup(hass, SELECT_DOMAIN, discovery_data, "milk")
 
     # assign an initial state
@@ -779,7 +788,10 @@ async def test_persistent_state_after_reconfig(
     assert state.attributes["options"] == ["milk", "beer"]
 
     # remove "milk" option
-    discovery_data = '{ "name": "Milk", "state_topic": "test-topic", "command_topic": "test-topic", "options": ["beer"]}'
+    discovery_data = (
+        '{ "name": "Milk", "state_topic": "test-topic",'
+        ' "command_topic": "test-topic", "options": ["beer"]}'
+    )
     await help_test_discovery_setup(hass, SELECT_DOMAIN, discovery_data, "milk")
 
     # assert the state persistent
@@ -848,6 +860,6 @@ async def test_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"some_var": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -409,7 +409,8 @@ async def test_setting_numeric_sensor_native_value_handling_via_mqtt_message(
     state = hass.states.get("sensor.test")
     assert state.state == "21"
 
-    # omitting value, causing it to be ignored, native sensor value should not change (template warning will be logged though)
+    # omitting value, causing it to be ignored, native sensor value
+    # should not change (template warning will be logged though)
     async_fire_mqtt_message(hass, "test-topic", '{ "current": 5.34 }')
     state = hass.states.get("sensor.test")
     assert state.state == "21"
@@ -585,7 +586,9 @@ async def test_setting_sensor_value_via_mqtt_json_message(
                 sensor.DOMAIN: {
                     "name": "test",
                     "state_topic": "test-topic",
-                    "value_template": "{{ value_json.val | is_defined }}-{{ value_json.par }}",
+                    "value_template": (
+                        "{{ value_json.val | is_defined }}-{{ value_json.par }}"
+                    ),
                 }
             }
         }
@@ -671,7 +674,11 @@ async def test_setting_sensor_last_reset_via_mqtt_json_message(
                     "state_topic": "test-topic",
                     "unit_of_measurement": "kWh",
                     "value_template": "{{ value_json.value | float / 60000 }}",
-                    "last_reset_value_template": "{{ utcnow().fromtimestamp(value_json.time / 1000, tz=utcnow().tzinfo) }}",
+                    "last_reset_value_template": (
+                        "{{ utcnow().fromtimestamp("
+                        "value_json.time / 1000,"
+                        " tz=utcnow().tzinfo) }}"
+                    ),
                 },
             }
         },
@@ -1154,7 +1161,7 @@ async def test_equivalent_unit_of_measurement_received_without_device_class(
 async def test_valid_device_class_and_uom(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
-    """Test device_class option with valid values and test with an empty unit of measurement."""
+    """Test device_class with valid values and empty unit."""
     await mqtt_mock_entry()
 
     state = hass.states.get("sensor.test_1")
@@ -1223,8 +1230,8 @@ async def test_invalid_state_class_with_unit_of_measurement(
     """Test state_class option with invalid unit of measurement."""
     assert await mqtt_mock_entry()
     assert (
-        "The unit of measurement 'deg' is not valid together with state class 'measurement_angle'"
-        in caplog.text
+        "The unit of measurement 'deg' is not valid together"
+        " with state class 'measurement_angle'" in caplog.text
     )
 
 
@@ -1963,8 +1970,8 @@ async def test_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"some_var": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )
 
 
@@ -2008,11 +2015,11 @@ async def test_value_incorrect_state_class_config(
     caplog: pytest.LogCaptureFixture,
     hass_config: ConfigType,
 ) -> None:
-    """Test a sensor config with incorrect state_class config fails from yaml or discovery."""
+    """Test incorrect state_class config fails from yaml or discovery."""
     await mqtt_mock_entry()
     assert (
-        "The option `last_reset_value_template` cannot be used together with state class"
-        in caplog.text
+        "The option `last_reset_value_template` cannot be used"
+        " together with state class" in caplog.text
     )
     caplog.clear()
 
@@ -2022,6 +2029,6 @@ async def test_value_incorrect_state_class_config(
     )
     await hass.async_block_till_done()
     assert (
-        "The option `last_reset_value_template` cannot be used together with state class"
-        in caplog.text
+        "The option `last_reset_value_template` cannot be used"
+        " together with state class" in caplog.text
     )

--- a/tests/components/mqtt/test_siren.py
+++ b/tests/components/mqtt/test_siren.py
@@ -223,7 +223,7 @@ async def test_controlling_state_and_attributes_with_json_message_without_templa
     mqtt_mock_entry: MqttMockHAClientGenerator,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test the controlling state via topic and JSON message without a value template."""
+    """Test controlling state via topic and JSON without template."""
     await mqtt_mock_entry()
 
     state = hass.states.get("siren.test")
@@ -264,8 +264,10 @@ async def test_controlling_state_and_attributes_with_json_message_without_templa
     )
     state = hass.states.get("siren.test")
     assert (
-        "Unable to update siren state attributes from payload '{'duration': 6, 'volume_level': 2, 'tone': 'ping'}': value must be at most 1 for dictionary value @ data['volume_level']"
-        in caplog.text
+        "Unable to update siren state attributes from payload"
+        " '{'duration': 6, 'volume_level': 2, 'tone': 'ping'}':"
+        " value must be at most 1 for dictionary value"
+        " @ data['volume_level']" in caplog.text
     )
     # Only the on/of state was updated, not the attributes
     assert state.state == STATE_ON
@@ -1134,6 +1136,6 @@ async def test_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"some_var": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )

--- a/tests/components/mqtt/test_switch.py
+++ b/tests/components/mqtt/test_switch.py
@@ -830,6 +830,6 @@ async def test_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"some_var": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )

--- a/tests/components/mqtt/test_tag.py
+++ b/tests/components/mqtt/test_tag.py
@@ -251,7 +251,10 @@ async def test_if_fires_on_mqtt_message_after_update_with_template(
     config1 = copy.deepcopy(DEFAULT_CONFIG_JSON)
     config2 = copy.deepcopy(DEFAULT_CONFIG_JSON)
     config2["value_template"] = "{{ value_json.RDM6300.UID }}"
-    tag_scan_2 = '{"Time":"2020-09-28T17:02:10","RDM6300":{"UID":"E9F35959", "DATA":"ILOVETASMOTA"}}'
+    tag_scan_2 = (
+        '{"Time":"2020-09-28T17:02:10",'
+        '"RDM6300":{"UID":"E9F35959", "DATA":"ILOVETASMOTA"}}'
+    )
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config1))
     await hass.async_block_till_done()
@@ -931,6 +934,6 @@ async def test_value_template_fails(
     await hass.async_block_till_done()
 
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )

--- a/tests/components/mqtt/test_text.py
+++ b/tests/components/mqtt/test_text.py
@@ -198,8 +198,8 @@ async def test_controlling_validation_state_via_topic(
     async_fire_mqtt_message(hass, "state-topic", "other")
     await hass.async_block_till_done()
     assert (
-        "Entity text.test provides state other which does not match expected pattern (y|n)"
-        in caplog.text
+        "Entity text.test provides state other which does not"
+        " match expected pattern (y|n)" in caplog.text
     )
     state = hass.states.get("text.test")
     assert state.state == "yes"
@@ -209,8 +209,8 @@ async def test_controlling_validation_state_via_topic(
     async_fire_mqtt_message(hass, "state-topic", "yesyesyesyes")
     await hass.async_block_till_done()
     assert (
-        "Entity text.test provides state yesyesyesyes which is too long (maximum length 10)"
-        in caplog.text
+        "Entity text.test provides state yesyesyesyes which is"
+        " too long (maximum length 10)" in caplog.text
     )
     state = hass.states.get("text.test")
     assert state.state == "yes"
@@ -577,7 +577,10 @@ async def test_discovery_update_unchanged_update(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
     """Test update of discovered update."""
-    data1 = '{ "name": "Beer", "state_topic": "text-topic", "command_topic": "command-topic"}'
+    data1 = (
+        '{ "name": "Beer", "state_topic": "text-topic",'
+        ' "command_topic": "command-topic"}'
+    )
     with patch(
         "homeassistant.components.mqtt.text.MqttTextEntity.discovery_update"
     ) as discovery_update:
@@ -848,6 +851,6 @@ async def test_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"some_var": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )

--- a/tests/components/mqtt/test_time.py
+++ b/tests/components/mqtt/test_time.py
@@ -377,7 +377,10 @@ async def test_discovery_update_unchanged_update(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
     """Test update of discovered update."""
-    data1 = '{ "name": "Beer", "state_topic": "time-topic", "command_topic": "command-topic"}'
+    data1 = (
+        '{ "name": "Beer", "state_topic": "time-topic",'
+        ' "command_topic": "command-topic"}'
+    )
     with patch(
         "homeassistant.components.mqtt.time.MqttTimeEntity.discovery_update"
     ) as discovery_update:
@@ -584,6 +587,6 @@ async def test_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"some_var": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )

--- a/tests/components/mqtt/test_trigger.py
+++ b/tests/components/mqtt/test_trigger.py
@@ -202,8 +202,8 @@ async def test_non_allowed_templates(
     )
 
     assert (
-        "Got error 'TemplateError: Use of 'states' is not supported in limited templates' when setting up triggers"
-        in caplog.text
+        "Got error 'TemplateError: Use of 'states' is not"
+        " supported in limited templates' when setting up triggers" in caplog.text
     )
 
 

--- a/tests/components/mqtt/test_update.py
+++ b/tests/components/mqtt/test_update.py
@@ -149,7 +149,7 @@ async def test_run_update_setup(
 async def test_run_update_setup_float(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
-    """Test that it fetches the given payload when the version is parsable as a number."""
+    """Test payload fetching when version is parsable as a number."""
     installed_version_topic = "test/installed-version"
     latest_version_topic = "test/latest-version"
     await mqtt_mock_entry()
@@ -231,9 +231,15 @@ async def test_value_template(
                 update.DOMAIN: {
                     "state_topic": "test/update",
                     "value_template": (
-                        "{\"latest_version\":\"{{ value_json['update']['latest_version'] }}\","
-                        "\"installed_version\":\"{{ value_json['update']['installed_version'] }}\","
-                        "\"update_percentage\":{{ value_json['update'].get('progress', 'null') }}}"
+                        '{"latest_version":'
+                        "\"{{ value_json['update']"
+                        "['latest_version'] }}\","
+                        '"installed_version":'
+                        "\"{{ value_json['update']"
+                        "['installed_version'] }}\","
+                        '"update_percentage":'
+                        "{{ value_json['update']"
+                        ".get('progress', 'null') }}}"
                     ),
                     "name": "Test Update",
                 }
@@ -246,7 +252,7 @@ async def test_errornous_value_template(
     mqtt_mock_entry: MqttMockHAClientGenerator,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test that it fetches the given payload with a template or handles the exception."""
+    """Test payload fetching with template or exception handling."""
     state_topic = "test/update"
     await mqtt_mock_entry()
 
@@ -307,7 +313,7 @@ async def test_errornous_value_template(
 async def test_value_template_float(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
-    """Test that it fetches the given payload with a template when the version is parsable as a number."""
+    """Test template payload when version is parsable as a number."""
     installed_version_topic = "test/installed-version"
     latest_version_topic = "test/latest-version"
     await mqtt_mock_entry()
@@ -747,7 +753,10 @@ async def test_discovery_update_unchanged_update(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
     """Test update of discovered update."""
-    data1 = '{ "name": "Beer", "state_topic": "installed-topic", "latest_version_topic": "latest-topic"}'
+    data1 = (
+        '{ "name": "Beer", "state_topic": "installed-topic",'
+        ' "latest_version_topic": "latest-topic"}'
+    )
     with patch(
         "homeassistant.components.mqtt.update.MqttUpdate.discovery_update"
     ) as discovery_update:
@@ -762,7 +771,10 @@ async def test_discovery_broken(
 ) -> None:
     """Test handling of bad discovery message."""
     data1 = '{ "name": "Beer" }'
-    data2 = '{ "name": "Milk", "state_topic": "installed-topic", "latest_version_topic": "latest-topic" }'
+    data2 = (
+        '{ "name": "Milk", "state_topic": "installed-topic",'
+        ' "latest_version_topic": "latest-topic" }'
+    )
 
     await help_test_discovery_broken(hass, mqtt_mock_entry, update.DOMAIN, data1, data2)
 
@@ -932,8 +944,8 @@ async def test_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"some_var": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )
 
 

--- a/tests/components/mqtt/test_vacuum.py
+++ b/tests/components/mqtt/test_vacuum.py
@@ -328,7 +328,7 @@ async def test_clean_segments_initial_setup_without_repair_issue(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
-    """Test initial setup does not fire repair flow after cleanable segments are received."""
+    """Test setup does not fire repair after segments are received."""
     await mqtt_mock_entry()
     # Receive a valid state
     state = hass.states.get("vacuum.test")
@@ -521,7 +521,10 @@ async def test_clean_segments_command_template(
                     },
                 ),
             ),
-            "Option `clean_segments_command_topic` requires `unique_id` to be configured",
+            (
+                "Option `clean_segments_command_topic`"
+                " requires `unique_id` to be configured"
+            ),
         ),
     ],
 )
@@ -606,7 +609,7 @@ async def test_clean_area_feature_preserved_on_config_update(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
-    """Test the clean area feature is preserved when config is updated with the same topic.
+    """Test clean area is preserved when config is updated.
 
     When a new config arrives that still has `clean_segments_command_topic` and
     segments were previously received from state, the CLEAN_AREA feature should

--- a/tests/components/mqtt/test_valve.py
+++ b/tests/components/mqtt/test_valve.py
@@ -270,9 +270,10 @@ async def test_state_via_state_topic_through_position(
 ) -> None:
     """Test the controlling state via topic through position.
 
-    Test is still possible to process a `opening` or `closing` state update.
-    Additional we test json messages can be processed containing both position and state.
-    Incoming rendered positions are clamped between 0..100.
+    Test is still possible to process a `opening` or `closing`
+    state update. Additional we test json messages can be
+    processed containing both position and state. Incoming
+    rendered positions are clamped between 0..100.
     """
     await mqtt_mock_entry()
 
@@ -307,7 +308,8 @@ async def test_opening_closing_state_is_reset(
 ) -> None:
     """Test the controlling state via topic through position.
 
-    Test  a `opening` or `closing` state update is reset correctly after sequential updates.
+    Test a `opening` or `closing` state update is reset
+    correctly after sequential updates.
     """
     await mqtt_mock_entry()
 
@@ -380,7 +382,8 @@ async def test_invalid_state_updates(
 ) -> None:
     """Test the controlling state via topic through position.
 
-    Test  a `opening` or `closing` state update is reset correctly after sequential updates.
+    Test a `opening` or `closing` state update is reset
+    correctly after sequential updates.
     """
     await mqtt_mock_entry()
 
@@ -435,10 +438,11 @@ async def test_state_via_state_trough_position_with_alt_range(
     asserted_state: str,
     valve_position: int | None,
 ) -> None:
-    """Test the controlling state via topic through position and an alternative range.
+    """Test controlling state via position with alternative range.
 
-    Test is still possible to process a `opening` or `closing` state update.
-    Additional we test json messages can be processed containing both position and state.
+    Test is still possible to process a `opening` or `closing`
+    state update. Additional we test json messages can be
+    processed containing both position and state.
     Incoming rendered positions are clamped between 0..100.
     """
     await mqtt_mock_entry()
@@ -1484,6 +1488,6 @@ async def test_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"some_var": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )

--- a/tests/components/mqtt/test_water_heater.py
+++ b/tests/components/mqtt/test_water_heater.py
@@ -1270,6 +1270,6 @@ async def test_value_template_fails(
     await mqtt_mock_entry()
     async_fire_mqtt_message(hass, "test-topic", '{"some_var": null }')
     assert (
-        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' rendering template"
-        in caplog.text
+        "TypeError: unsupported operand type(s) for *:"
+        " 'NoneType' and 'int' rendering template" in caplog.text
     )

--- a/tests/components/music_assistant/test_config_flow.py
+++ b/tests/components/music_assistant/test_config_flow.py
@@ -569,7 +569,7 @@ async def test_zeroconf_old_schema_addon_not_ignored(
     hass: HomeAssistant,
     mock_get_server_info: AsyncMock,
 ) -> None:
-    """Test zeroconf discovery does NOT ignore add-on servers with old schema version."""
+    """Test zeroconf discovery does NOT ignore old schema add-ons."""
     old_schema_addon_data = deepcopy(ZEROCONF_DATA)
     old_schema_version = AUTH_SCHEMA_VERSION - 1
     old_schema_addon_data.properties["schema_version"] = str(old_schema_version)

--- a/tests/components/music_assistant/test_media_player.py
+++ b/tests/components/music_assistant/test_media_player.py
@@ -793,7 +793,7 @@ async def test_media_image_prefers_current_media(
     hass: HomeAssistant,
     music_assistant_client: MagicMock,
 ) -> None:
-    """Test that entity_picture uses player.current_media.image_url over static queue image."""
+    """Test entity_picture prefers current_media.image_url over queue."""
     await setup_integration_from_fixtures(hass, music_assistant_client)
     entity_id = "media_player.test_group_player_1"
     mass_player_id = "test_group_player_1"
@@ -831,7 +831,7 @@ async def test_media_image_falls_back_to_queue_item(
     hass: HomeAssistant,
     music_assistant_client: MagicMock,
 ) -> None:
-    """Test that entity_picture falls back to queue item image when current_media has none."""
+    """Test entity_picture falls back to queue image when none."""
     await setup_integration_from_fixtures(hass, music_assistant_client)
     entity_id = "media_player.test_group_player_1"
     mass_player_id = "test_group_player_1"

--- a/tests/components/music_assistant/test_number.py
+++ b/tests/components/music_assistant/test_number.py
@@ -139,7 +139,7 @@ async def test_ignored(
 async def test_name_translation_availability(
     hass: HomeAssistant,
 ) -> None:
-    """Verify, that the list of available translation keys is reflected in strings.json."""
+    """Verify available translation keys are in strings.json."""
     # verify, that PLAYER_OPTIONS_TRANSLATION_KEYS_NUMBER matches strings.json
     translations = await async_get_translations(
         hass, language=LOCALE_EN, category="entity", integrations=[DOMAIN]

--- a/tests/components/music_assistant/test_select.py
+++ b/tests/components/music_assistant/test_select.py
@@ -141,7 +141,7 @@ async def test_ignored(
 async def test_name_translation_availability(
     hass: HomeAssistant,
 ) -> None:
-    """Verify, that the list of available translation keys is reflected in strings.json."""
+    """Verify available translation keys are in strings.json."""
     # verify, that PLAYER_OPTIONS_SELECT matches strings.json
     translations = await async_get_translations(
         hass, language=LOCALE_EN, category="entity", integrations=[DOMAIN]

--- a/tests/components/music_assistant/test_switch.py
+++ b/tests/components/music_assistant/test_switch.py
@@ -119,7 +119,7 @@ async def test_ignored(
 async def test_name_translation_availability(
     hass: HomeAssistant,
 ) -> None:
-    """Verify, that the list of available translation keys is reflected in strings.json."""
+    """Verify available translation keys are in strings.json."""
     # verify, that PLAYER_OPTIONS_TRANSLATION_KEYS_SWITCH matches strings.json
     translations = await async_get_translations(
         hass, language=LOCALE_EN, category="entity", integrations=[DOMAIN]

--- a/tests/components/music_assistant/test_text.py
+++ b/tests/components/music_assistant/test_text.py
@@ -120,7 +120,7 @@ async def test_ignored(
 async def test_name_translation_availability(
     hass: HomeAssistant,
 ) -> None:
-    """Verify, that the list of available translation keys is reflected in strings.json."""
+    """Verify available translation keys are in strings.json."""
     # verify, that PLAYER_OPTIONS_TRANSLATION_KEYS_text matches strings.json
     translations = await async_get_translations(
         hass, language=LOCALE_EN, category="entity", integrations=[DOMAIN]

--- a/tests/components/myneomitis/test_climate.py
+++ b/tests/components/myneomitis/test_climate.py
@@ -217,7 +217,7 @@ async def test_set_temperature_sub_device_missing_parents(
     mock_config_entry: MockConfigEntry,
     mock_pyaxenco_client: AsyncMock,
 ) -> None:
-    """Missing parents/rfid for sub-device should fail temperature set without API call."""
+    """Missing parents/rfid should fail temp set without API call."""
     bad_sub = {**CLIMATE_SUB_DEVICE, "parents": {}, "rfid": None}
     mock_pyaxenco_client.get_devices.return_value = [bad_sub]
 
@@ -403,7 +403,7 @@ async def test_ntd_changeover_sets_cool(
     mock_config_entry: MockConfigEntry,
     mock_pyaxenco_client: AsyncMock,
 ) -> None:
-    """NTD devices with changeOverUser==1 should expose COOL and OFF modes and start in COOL."""
+    """NTD with changeOverUser==1 should expose COOL/OFF and start COOL."""
     mock_pyaxenco_client.get_devices.return_value = [CLIMATE_NTD_COOL]
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)

--- a/tests/components/mysensors/test_config_flow.py
+++ b/tests/components/mysensors/test_config_flow.py
@@ -113,7 +113,9 @@ async def test_config_serial(hass: HomeAssistant) -> None:
     flow_id = step["flow_id"]
 
     with (
-        patch(  # mock is_serial_port because otherwise the test will be platform dependent (/dev/ttyACMx vs COMx)
+        patch(
+            # mock is_serial_port because otherwise the test will
+            # be platform dependent (/dev/ttyACMx vs COMx)
             "homeassistant.components.mysensors.config_flow.is_serial_port",
             return_value=True,
         ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix all 336 E501 (line too long) violations in `tests/components/` for integrations starting with m.

Part of a series to enforce the 88-character line length limit across the codebase. Changes are purely cosmetic — rewrapped comments, split long strings, shortened docstrings, and reformatted test data. No logic changes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
