### PR TITLE
Bump homematicip to 2.12.0

### DIFF
--- a/homeassistant/components/homematicip_cloud/manifest.json
+++ b/homeassistant/components/homematicip_cloud/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "loggers": ["homematicip"],
-  "requirements": ["homematicip==2.11.0"]
+  "requirements": ["homematicip==2.12.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1275,7 +1275,7 @@ homekit-audio-proxy==1.2.1
 homelink-integration-api==0.0.1
 
 # homeassistant.components.homematicip_cloud
-homematicip==2.11.0
+homematicip==2.12.0
 
 # homeassistant.components.homevolt
 homevolt==0.5.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1142,7 +1142,7 @@ homekit-audio-proxy==1.2.1
 homelink-integration-api==0.0.1
 
 # homeassistant.components.homematicip_cloud
-homematicip==2.11.0
+homematicip==2.12.0
 
 # homeassistant.components.homevolt
 homevolt==0.5.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps the `homematicip` library from 2.11.0 to 2.12.0.

2.12.0 adds:
- Support for HmIP-FDC (Full Flush Door Controller / Türöffner-Aktor): impulse-driven door opener with two `MULTI_MODE_LOCK_INPUT_CHANNEL` inputs and eight `ACCESS_AUTHORIZATION_CHANNEL` channels.
- `pull_latch` / `async_pull_latch` on `AccessAuthorizationChannel` (via the cloud's `device/control/pullLatch` endpoint). This is the correct way to trigger a door opener on HmIP-FLC / HmIP-DLD: calling `startImpulse` on the underlying `DOOR_SWITCH_CHANNEL` fails with `CLIENT_ACCESS_DENIED` for non-admin clients, so the cloud routes the impulse through the access-authorization profile.
- `DOOR_LOCK_AUTHORIZATION_PROFILE` group type with a dedicated `DoorLockAuthorizationProfileGroup` class (previously the group fell back to the base `Group` and emitted a "no class for group" warning).
- Four `ChannelEventTypes` enum values for `SINGLE_KEY_CHANNEL` button events: `KEY_PRESS_SHORT`, `KEY_PRESS_LONG_START`, `KEY_PRESS_LONG`, `KEY_PRESS_LONG_STOP`.

Also enables additional ruff rule sets in the library (`ASYNC`, `A`, `C4`, `ISC`, `TCH`, `TID`, `PERF`, `PT`, `RSE`) and fixes the resulting ~22 violations. Notable internal renames on the private `set_attr_from_dict` helper (`id` → `gid` / `device_id`, `dict` → `data`, `type` → `enum_type`). One public-API parameter name (`anonymizeConfig(format=...)`) is preserved with `# noqa` for backwards compatibility.

Drop-in upgrade: no public API from 2.11.0 was removed or renamed.

Library release: https://github.com/hahn-th/homematicip-rest-api/releases/tag/2.12.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
