### PR TITLE
Use config entry title for Avea light

### DIFF
--- a/homeassistant/components/avea/light.py
+++ b/homeassistant/components/avea/light.py
@@ -84,7 +84,9 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Avea light platform."""
-    async_add_entities([AveaLight(entry.runtime_data, entry)], update_before_add=True)
+    async_add_entities(
+        [AveaLight(entry.runtime_data, entry.title)], update_before_add=True
+    )
 
 
 def _discover_bulbs_for_import() -> list[dict[str, str]]:
@@ -169,10 +171,10 @@ class AveaLight(LightEntity):
     _attr_color_mode = ColorMode.HS
     _attr_supported_color_modes = {ColorMode.HS}
 
-    def __init__(self, light: avea.Bulb, entry: AveaConfigEntry) -> None:
+    def __init__(self, light: avea.Bulb, name: str) -> None:
         """Initialize an AveaLight."""
         self._light = light
-        self._attr_name = entry.title
+        self._attr_name = name
         self._attr_brightness = light.brightness
 
     def turn_on(self, **kwargs: Any) -> None:

--- a/homeassistant/components/avea/light.py
+++ b/homeassistant/components/avea/light.py
@@ -84,7 +84,7 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Avea light platform."""
-    async_add_entities([AveaLight(entry.runtime_data)], update_before_add=True)
+    async_add_entities([AveaLight(entry.runtime_data, entry)], update_before_add=True)
 
 
 def _discover_bulbs_for_import() -> list[dict[str, str]]:
@@ -169,10 +169,10 @@ class AveaLight(LightEntity):
     _attr_color_mode = ColorMode.HS
     _attr_supported_color_modes = {ColorMode.HS}
 
-    def __init__(self, light: avea.Bulb) -> None:
+    def __init__(self, light: avea.Bulb, entry: AveaConfigEntry) -> None:
         """Initialize an AveaLight."""
         self._light = light
-        self._attr_name = light.name
+        self._attr_name = entry.title
         self._attr_brightness = light.brightness
 
     def turn_on(self, **kwargs: Any) -> None:

--- a/homeassistant/components/avea/light.py
+++ b/homeassistant/components/avea/light.py
@@ -171,10 +171,10 @@ class AveaLight(LightEntity):
     _attr_color_mode = ColorMode.HS
     _attr_supported_color_modes = {ColorMode.HS}
 
-    def __init__(self, light: avea.Bulb, name: str) -> None:
+    def __init__(self, light: avea.Bulb, entry_title: str) -> None:
         """Initialize an AveaLight."""
         self._light = light
-        self._attr_name = name
+        self._attr_name = entry_title
         self._attr_brightness = light.brightness
 
     def turn_on(self, **kwargs: Any) -> None:

--- a/tests/components/avea/test_light.py
+++ b/tests/components/avea/test_light.py
@@ -15,7 +15,6 @@ from homeassistant.components.light import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
 
 from . import AVEA_DISCOVERY_INFO
 
@@ -26,7 +25,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 def mock_bulb() -> MagicMock:
     """Return a mocked Avea bulb."""
     bulb = MagicMock()
-    bulb.name = "Bedroom"
+    bulb.name = "Unknown"
     bulb.brightness = 0
     bulb.get_brightness.return_value = 0
     return bulb
@@ -54,7 +53,6 @@ async def setup_integration(
 
 async def test_init_state(
     hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
     setup_integration: MagicMock,
 ) -> None:
     """Test the initial state."""

--- a/tests/components/avea/test_light.py
+++ b/tests/components/avea/test_light.py
@@ -13,7 +13,7 @@ from homeassistant.components.light import (
     ATTR_SUPPORTED_COLOR_MODES,
     ColorMode,
 )
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME, STATE_OFF, STATE_ON
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from . import AVEA_DISCOVERY_INFO
@@ -59,7 +59,7 @@ async def test_init_state(
     state = hass.states.get("light.bedroom")
     assert state is not None
     assert state.state == STATE_OFF
-    assert state.attributes[ATTR_FRIENDLY_NAME] == "Bedroom"
+    assert state.name == "Bedroom"
     assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == [ColorMode.HS]
 
 

--- a/tests/components/avea/test_light.py
+++ b/tests/components/avea/test_light.py
@@ -13,7 +13,7 @@ from homeassistant.components.light import (
     ATTR_SUPPORTED_COLOR_MODES,
     ColorMode,
 )
-from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from . import AVEA_DISCOVERY_INFO
@@ -59,6 +59,7 @@ async def test_init_state(
     state = hass.states.get("light.bedroom")
     assert state is not None
     assert state.state == STATE_OFF
+    assert state.attributes[ATTR_FRIENDLY_NAME] == "Bedroom"
     assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == [ColorMode.HS]
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use the config entry title for the Avea light entity name instead of the initial `avea.Bulb.name` value.

The Avea library may still expose the default name `Unknown` when the entity is created, even though the config flow already validated the device and created the config entry with the correct title. This prevents newly configured bulbs from being added as `light.unknown` after discovery/config flow setup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
