### PR TITLE
Fix deprecated async_get_bytes_total in asuswrt

### DIFF
--- a/homeassistant/components/asuswrt/bridge.py
+++ b/homeassistant/components/asuswrt/bridge.py
@@ -324,7 +324,7 @@ class AsusWrtLegacyBridge(AsusWrtBridge):
     @handle_errors_and_zip((IndexError, OSError, ValueError), SENSORS_BYTES)
     async def _get_bytes(self) -> tuple[float | None, float | None]:
         """Fetch byte information from the router."""
-        return await self._api.async_get_bytes_total()
+        return await self._api.async_get_rx(), await self._api.async_get_tx()
 
     @handle_errors_and_zip((IndexError, OSError, ValueError), SENSORS_RATES)
     async def _get_rates(self) -> tuple[float, float]:


### PR DESCRIPTION
## Proposed change

`aioasuswrt` 1.5.4 deprecated `async_get_bytes_total()` — it now logs a warning and returns `(0, 0)` instead of real data, causing byte sensors to always read zero and spamming the log on every poll.

Replace the single deprecated call in `_get_bytes` with direct calls to `async_get_rx()` and `async_get_tx()`, which are the underlying methods the old function previously called.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #154753
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [ ] I have followed the [perfect PR recommendations](https://developers.home-assistant.io/docs/development_guidelines/)
- [ ] The code has been formatted using Ruff (`python3 -m script.hassfmt`)
- [ ] Tests have been added to verify that the new code works.