### PR TITLE
Fix line length violations in tests/components s

### DIFF
--- a/tests/components/sabnzbd/test_button.py
+++ b/tests/components/sabnzbd/test_button.py
@@ -76,7 +76,8 @@ async def test_buttons_exception(
 
     with pytest.raises(
         HomeAssistantError,
-        match="Unable to send command to SABnzbd due to a connection error, try again later",
+        match="Unable to send command to SABnzbd due to a connection"
+        " error, try again later",
     ):
         await hass.services.async_call(
             BUTTON_DOMAIN,

--- a/tests/components/sabnzbd/test_config_flow.py
+++ b/tests/components/sabnzbd/test_config_flow.py
@@ -156,7 +156,7 @@ async def test_abort_already_configured(
 async def test_abort_reconfigure_successful(
     hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
-    """Test that the reconfigure flow aborts successfully if SABnzbd instance is already configured."""
+    """Test reconfigure flow aborts if SABnzbd is already configured."""
     result = await config_entry.start_reconfigure_flow(hass)
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}

--- a/tests/components/sabnzbd/test_number.py
+++ b/tests/components/sabnzbd/test_number.py
@@ -81,7 +81,8 @@ async def test_number_exception(
 
     with pytest.raises(
         HomeAssistantError,
-        match="Unable to send command to SABnzbd due to a connection error, try again later",
+        match="Unable to send command to SABnzbd due to a connection"
+        " error, try again later",
     ):
         await hass.services.async_call(
             NUMBER_DOMAIN,

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -495,7 +495,7 @@ async def test_ssdp_no_manufacturer(hass: HomeAssistant) -> None:
 async def test_ssdp_legacy_not_remote_control_receiver_udn(
     hass: HomeAssistant, data: SsdpServiceInfo
 ) -> None:
-    """Test we abort if the st is not usable for legacy discovery since it will have a different UDN."""
+    """Test we abort if st is not usable for legacy discovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_SSDP}, data=data
     )
@@ -505,7 +505,7 @@ async def test_ssdp_legacy_not_remote_control_receiver_udn(
 
 @pytest.mark.usefixtures("remote_legacy", "rest_api_failing")
 async def test_ssdp_noprefix(hass: HomeAssistant) -> None:
-    """Test starting a flow from discovery when friendly name doesn't start with [TV]."""
+    """Test discovery flow when friendly name has no [TV] prefix."""
     ssdp_data = deepcopy(MOCK_SSDP_DATA)
     ssdp_data.upnp[ATTR_UPNP_FRIENDLY_NAME] = ssdp_data.upnp[ATTR_UPNP_FRIENDLY_NAME][
         4:
@@ -1481,7 +1481,7 @@ async def test_update_zeroconf_discovery_preserved_unique_id(
 async def test_update_missing_mac_unique_id_added_ssdp_location_updated_from_ssdp(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
-    """Test missing mac and unique id with outdated ssdp_location with the wrong st added via ssdp."""
+    """Test missing mac/unique id with outdated ssdp_location and wrong st."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -1513,10 +1513,10 @@ async def test_update_missing_mac_unique_id_added_ssdp_location_updated_from_ssd
 @pytest.mark.usefixtures(
     "remote_websocket", "rest_api", "remote_encrypted_websocket_failing"
 )
-async def test_update_missing_mac_unique_id_added_ssdp_location_rendering_st_updated_from_ssdp(
+async def test_update_missing_mac_unique_id_ssdp_location_rendering_st_from_ssdp(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
-    """Test missing mac and unique id with outdated ssdp_location with the correct st added via ssdp."""
+    """Test missing mac/unique id with outdated ssdp_location, correct st."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -1549,10 +1549,10 @@ async def test_update_missing_mac_unique_id_added_ssdp_location_rendering_st_upd
 @pytest.mark.usefixtures(
     "remote_websocket", "rest_api", "remote_encrypted_websocket_failing"
 )
-async def test_update_missing_mac_unique_id_added_ssdp_location_main_tv_agent_st_updated_from_ssdp(
+async def test_update_missing_mac_unique_id_ssdp_location_tv_agent_st_from_ssdp(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
-    """Test missing mac and unique id with outdated ssdp_location with the correct st added via ssdp."""
+    """Test missing mac/unique id with outdated ssdp_location, correct st."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -1778,7 +1778,7 @@ async def test_update_ssdp_location_unique_id_added_from_ssdp(
 async def test_update_ssdp_location_unique_id_added_from_ssdp_with_rendering_control_st(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
-    """Test missing ssdp_location, and unique id added via ssdp with rendering control st."""
+    """Test missing ssdp_location and unique id with rendering st."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={**ENTRYDATA_LEGACY, CONF_MAC: "aa:bb:aa:aa:aa:aa"},

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -495,7 +495,7 @@ async def test_ssdp_no_manufacturer(hass: HomeAssistant) -> None:
 async def test_ssdp_legacy_not_remote_control_receiver_udn(
     hass: HomeAssistant, data: SsdpServiceInfo
 ) -> None:
-    """Test we abort if st is not usable for legacy discovery."""
+    """Test we abort if it is not usable for legacy discovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_SSDP}, data=data
     )

--- a/tests/components/sanix/conftest.py
+++ b/tests/components/sanix/conftest.py
@@ -26,7 +26,7 @@ from tests.common import MockConfigEntry, load_json_object_fixture
 
 @pytest.fixture
 def mock_sanix():
-    """Build a fixture for the Sanix API that connects successfully and returns measurements."""
+    """Build a fixture for the Sanix API that connects successfully."""
     fixture = load_json_object_fixture("get_measurements.json", DOMAIN)
     with (
         patch(

--- a/tests/components/satel_integra/conftest.py
+++ b/tests/components/satel_integra/conftest.py
@@ -108,7 +108,9 @@ def mock_config_entry_with_subentries(
             MOCK_PARTITION_SUBENTRY.subentry_id: MOCK_PARTITION_SUBENTRY,
             MOCK_ZONE_SUBENTRY.subentry_id: MOCK_ZONE_SUBENTRY,
             MOCK_OUTPUT_SUBENTRY.subentry_id: MOCK_OUTPUT_SUBENTRY,
-            MOCK_SWITCHABLE_OUTPUT_SUBENTRY.subentry_id: MOCK_SWITCHABLE_OUTPUT_SUBENTRY,
+            MOCK_SWITCHABLE_OUTPUT_SUBENTRY.subentry_id: (
+                MOCK_SWITCHABLE_OUTPUT_SUBENTRY
+            ),
         }
     )
     return mock_config_entry

--- a/tests/components/satel_integra/test_alarm_control_panel.py
+++ b/tests/components/satel_integra/test_alarm_control_panel.py
@@ -108,7 +108,7 @@ async def test_alarm_status_callback(
     source_state: AlarmState,
     resulting_state: AlarmControlPanelState,
 ) -> None:
-    """Test alarm control panel correctly changes state after a callback from the panel."""
+    """Test alarm panel state changes after a panel callback."""
     await setup_integration(hass, mock_config_entry_with_subentries)
 
     assert (

--- a/tests/components/satel_integra/test_binary_sensor.py
+++ b/tests/components/satel_integra/test_binary_sensor.py
@@ -124,7 +124,8 @@ async def test_binary_sensor_callback(
     assert hass.states.get("binary_sensor.zone").state == STATE_OFF
     assert hass.states.get("binary_sensor.output").state == STATE_OFF
 
-    # The client library should always report all entries, but test that we set the status correctly if it doesn't
+    # The client library should always report all entries, but test
+    # that we set the status correctly if it doesn't
     output_update_method({2: 1})
     zone_update_method({2: 1})
     assert hass.states.get("binary_sensor.zone").state == STATE_UNKNOWN

--- a/tests/components/satel_integra/test_switch.py
+++ b/tests/components/satel_integra/test_switch.py
@@ -121,7 +121,8 @@ async def test_switch_callback(
     output_update_method({1: 0})
     assert hass.states.get("switch.switchable_output").state == STATE_OFF
 
-    # The client library should always report all entries, but test that we set the status correctly if it doesn't
+    # The client library should always report all entries, but test
+    # that we set the status correctly if it doesn't
     output_update_method({2: 1})
     assert hass.states.get("switch.switchable_output").state == STATE_UNKNOWN
 

--- a/tests/components/schedule/test_trigger.py
+++ b/tests/components/schedule/test_trigger.py
@@ -106,7 +106,7 @@ async def test_schedule_state_trigger_behavior_any(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test that the schedule state trigger fires when any schedule state changes to a specific state."""
+    """Test schedule state trigger fires on any state change."""
     await assert_trigger_behavior_any(
         hass,
         target_entities=target_schedules,
@@ -149,7 +149,7 @@ async def test_schedule_state_trigger_behavior_first(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test that the schedule state trigger fires when the first schedule changes to a specific state."""
+    """Test schedule trigger fires on first schedule state change."""
     await assert_trigger_behavior_first(
         hass,
         target_entities=target_schedules,
@@ -192,7 +192,7 @@ async def test_schedule_state_trigger_behavior_last(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test that the schedule state trigger fires when the last schedule changes to a specific state."""
+    """Test schedule trigger fires on last schedule state change."""
     await assert_trigger_behavior_last(
         hass,
         target_entities=target_schedules,
@@ -211,7 +211,7 @@ async def test_schedule_state_trigger_back_to_back(
     schedule_setup: Callable[..., Coroutine[Any, Any, bool]],
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test that the schedule state trigger fires when transitioning between two back-to-back schedule blocks."""
+    """Test trigger fires when transitioning between back-to-back blocks."""
     calls: list[str] = []
     freezer.move_to("2022-08-30 13:20:00-07:00")
     entity_id = "schedule.from_yaml"

--- a/tests/components/scrape/__init__.py
+++ b/tests/components/scrape/__init__.py
@@ -49,19 +49,26 @@ class MockRestData:
             self.data = (
                 # Default
                 "<div class='current-version material-card text'>"
-                "<h1>Current Version: 2021.12.10</h1>Released: <span class='release-date'>January 17, 2022</span>"
-                "<div class='links' style='links'><a href='/latest-release-notes/'>Release notes</a></div></div>"
+                "<h1>Current Version: 2021.12.10</h1>Released: "
+                "<span class='release-date'>January 17, 2022</span>"
+                "<div class='links' style='links'>"
+                "<a href='/latest-release-notes/'>Release notes</a>"
+                "</div></div>"
                 "<template>Trying to get</template>"
                 "<div class='current-time'>"
-                "<h1>Current Time:</h1><span class='utc-time'>2022-12-22T13:15:30Z</span>"
+                "<h1>Current Time:</h1>"
+                "<span class='utc-time'>2022-12-22T13:15:30Z</span>"
                 "</div>"
             )
         if self.payload == "test_scrape_sensor2":
             self.data = (
                 # Hidden version
                 "<div class='current-version material-card text'>"
-                "<h1>Hidden Version: 2021.12.10</h1>Released: <span class='release-date'>January 17, 2022</span>"
-                "<div class='links' style='links'><a href='/latest-release-notes/'>Release notes</a></div></div>"
+                "<h1>Hidden Version: 2021.12.10</h1>Released: "
+                "<span class='release-date'>January 17, 2022</span>"
+                "<div class='links' style='links'>"
+                "<a href='/latest-release-notes/'>Release notes</a>"
+                "</div></div>"
                 "<template>Trying to get</template>"
             )
         if self.payload == "test_scrape_uom_and_classes":
@@ -80,16 +87,19 @@ class MockRestData:
             self.data = (
                 '<?xml version="1.0" encoding="UTF-8"?>'
                 "<rss><channel><title>Test RSS Feed</title>"
-                "<item><title>Test Item</title><link>https://example.com/item</link></item>"
+                "<item><title>Test Item</title>"
+                "<link>https://example.com/item</link></item>"
                 "</channel></rss>"
             )
         if self.payload == "test_scrape_xml_fallback":
-            # XML/RSS content with non-XML Content-Type for testing content-based detection
+            # XML/RSS content with non-XML Content-Type for testing
+            # content-based detection
             self.headers = {"Content-Type": "text/html"}
             self.data = (
                 '<?xml version="1.0" encoding="UTF-8"?>'
                 "<rss><channel><title>Test RSS Feed</title>"
-                "<item><title>Test Item</title><link>https://example.com/item</link></item>"
+                "<item><title>Test Item</title>"
+                "<link>https://example.com/item</link></item>"
                 "</channel></rss>"
             )
         if self.payload == "test_scrape_html5_with_xml_declaration":

--- a/tests/components/scrape/test_sensor.py
+++ b/tests/components/scrape/test_sensor.py
@@ -416,7 +416,9 @@ async def test_scrape_sensor_device_date(hass: HomeAssistant) -> None:
                         "select": ".release-date",
                         "name": "HA Date",
                         "device_class": "date",
-                        "value_template": "{{ strptime(value, '%B %d, %Y').strftime('%Y-%m-%d') }}",
+                        "value_template": (
+                            "{{ strptime(value, '%B %d, %Y').strftime('%Y-%m-%d') }}"
+                        ),
                     }
                 ],
             ),
@@ -620,8 +622,16 @@ async def test_templates_with_yaml(hass: HomeAssistant) -> None:
                         CONF_SELECT: ".current-version h1",
                         CONF_INDEX: 0,
                         CONF_UNIQUE_ID: "3699ef88-69e6-11ed-a1eb-0242ac120002",
-                        CONF_ICON: '{% if states("sensor.input1")=="on" %} mdi:on {% else %} mdi:off {% endif %}',
-                        CONF_PICTURE: '{% if states("sensor.input1")=="on" %} /local/picture1.jpg {% else %} /local/picture2.jpg {% endif %}',
+                        CONF_ICON: (
+                            '{% if states("sensor.input1")=="on" %}'
+                            " mdi:on {% else %} mdi:off {% endif %}"
+                        ),
+                        CONF_PICTURE: (
+                            '{% if states("sensor.input1")=="on" %}'
+                            " /local/picture1.jpg"
+                            " {% else %} /local/picture2.jpg"
+                            " {% endif %}"
+                        ),
                         CONF_AVAILABILITY: '{{ states("sensor.input2")=="on" }}',
                     }
                 ]
@@ -706,8 +716,16 @@ async def test_templates_with_yaml(hass: HomeAssistant) -> None:
                         "advanced": {
                             CONF_VALUE_TEMPLATE: "{{ value.split(':')[1] }}",
                             CONF_AVAILABILITY: '{{ states("sensor.input1")=="on" }}',
-                            CONF_ICON: 'mdi:o{{ "n" if states("sensor.input1")=="on" else "ff" }}',
-                            CONF_PICTURE: 'o{{ "n" if states("sensor.input1")=="on" else "ff" }}.jpg',
+                            CONF_ICON: (
+                                'mdi:o{{ "n" if'
+                                ' states("sensor.input1")=="on"'
+                                ' else "ff" }}'
+                            ),
+                            CONF_PICTURE: (
+                                'o{{ "n" if'
+                                ' states("sensor.input1")=="on"'
+                                ' else "ff" }}.jpg'
+                            ),
                         },
                     },
                     # "subentry_id": "01JZN07D8D23994A49YKS649S7",
@@ -781,8 +799,9 @@ async def test_template_render_with_availability_syntax_error(
     assert state.state == "2021.12.10"
 
     assert (
-        "Error rendering availability template for sensor.current_version: UndefinedError: 'what_the_heck' is undefined"
-        in caplog.text
+        "Error rendering availability template for"
+        " sensor.current_version: UndefinedError:"
+        " 'what_the_heck' is undefined" in caplog.text
     )
 
 

--- a/tests/components/screenlogic/__init__.py
+++ b/tests/components/screenlogic/__init__.py
@@ -17,7 +17,10 @@ _LOGGER = logging.getLogger(__name__)
 
 
 GATEWAY_IMPORT_PATH = "homeassistant.components.screenlogic.ScreenLogicGateway"
-GATEWAY_DISCOVERY_IMPORT_PATH = "homeassistant.components.screenlogic.coordinator.async_discover_gateways_by_unique_id"
+GATEWAY_DISCOVERY_IMPORT_PATH = (
+    "homeassistant.components.screenlogic"
+    ".coordinator.async_discover_gateways_by_unique_id"
+)
 
 
 def num_key_string_to_int(data: dict) -> dict:

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -1051,7 +1051,9 @@ async def test_concurrent_script(hass: HomeAssistant, concurrently) -> None:
                     "sequence": [
                         call_script_2,
                         {
-                            "wait_template": "{{ is_state('input_boolean.test1', 'on') }}"
+                            "wait_template": (
+                                "{{ is_state('input_boolean.test1', 'on') }}"
+                            )
                         },
                         {"action": "test.script", "data": {"value": "script1"}},
                     ],
@@ -1061,7 +1063,9 @@ async def test_concurrent_script(hass: HomeAssistant, concurrently) -> None:
                     "sequence": [
                         {"action": "test.script", "data": {"value": "script2a"}},
                         {
-                            "wait_template": "{{ is_state('input_boolean.test2', 'on') }}"
+                            "wait_template": (
+                                "{{ is_state('input_boolean.test2', 'on') }}"
+                            )
                         },
                         {"action": "test.script", "data": {"value": "script2b"}},
                     ],
@@ -1130,7 +1134,9 @@ async def test_script_variables(
                     "variables": {
                         "this_variable": "{{this.entity_id}}",
                         "test_var": "from_config",
-                        "templated_config_var": "{{ var_from_service | default('config-default') }}",
+                        "templated_config_var": (
+                            "{{ var_from_service | default('config-default') }}"
+                        ),
                     },
                     "sequence": [
                         {
@@ -1219,7 +1225,7 @@ async def test_script_variables(
 async def test_script_this_var_always(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test script always has reference to this, even with no variables are configured."""
+    """Test script has reference to this even without variables."""
 
     assert await async_setup_component(
         hass,
@@ -1600,7 +1606,8 @@ async def test_script_service_changed_entity_id(
     assert len(calls) == 1
     assert calls[0].data["entity_id"] == "script.custom_entity_id"
 
-    # Change entity while the script entity is loaded, and make sure the service still works
+    # Change entity while the script entity is loaded, and make sure
+    # the service still works
     entry = entity_registry.async_update_entity(
         entry.entity_id, new_entity_id="script.custom_entity_id_2"
     )
@@ -1666,7 +1673,8 @@ async def test_blueprint_script(hass: HomeAssistant, calls: list[ServiceCall]) -
                 "a_number": 5,
             },
             "Blueprint 'Call service' generated invalid script",
-            "value should be a string for dictionary value @ data['sequence'][0]['action']",
+            "value should be a string for dictionary value"
+            " @ data['sequence'][0]['action']",
         ),
     ],
 )

--- a/tests/components/select/test_condition.py
+++ b/tests/components/select/test_condition.py
@@ -227,7 +227,7 @@ async def test_input_select_condition_behavior_all(
 async def test_select_condition_evaluates_both_domains(
     hass: HomeAssistant,
 ) -> None:
-    """Test that the select condition evaluates both select and input_select entities."""
+    """Test select condition evaluates both select and input_select."""
     entity_id_select = "select.test_select"
     entity_id_input_select = "input_select.test_input_select"
 

--- a/tests/components/select/test_device_condition.py
+++ b/tests/components/select/test_device_condition.py
@@ -138,7 +138,10 @@ async def test_if_selected_option(
                     "action": {
                         "service": "test.automation",
                         "data": {
-                            "result": "option1 - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                            "result": (
+                                "option1 - {{ trigger.platform }}"
+                                " - {{ trigger.event.event_type }}"
+                            )
                         },
                     },
                 },
@@ -157,7 +160,10 @@ async def test_if_selected_option(
                     "action": {
                         "service": "test.automation",
                         "data": {
-                            "result": "option2 - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                            "result": (
+                                "option2 - {{ trigger.platform }}"
+                                " - {{ trigger.event.event_type }}"
+                            )
                         },
                     },
                 },
@@ -227,7 +233,10 @@ async def test_if_selected_option_legacy(
                     "action": {
                         "service": "test.automation",
                         "data": {
-                            "result": "option1 - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                            "result": (
+                                "option1 - {{ trigger.platform }}"
+                                " - {{ trigger.event.event_type }}"
+                            )
                         },
                     },
                 },

--- a/tests/components/select/test_device_trigger.py
+++ b/tests/components/select/test_device_trigger.py
@@ -141,7 +141,8 @@ async def test_if_fires_on_state_change(
                         "data": {
                             "some": (
                                 "to - {{ trigger.platform}} - "
-                                "{{ trigger.entity_id}} - {{ trigger.from_state.state}} - "
+                                "{{ trigger.entity_id}} - "
+                                "{{ trigger.from_state.state}} - "
                                 "{{ trigger.to_state.state}} - {{ trigger.for }} - "
                                 "{{ trigger.id}}"
                             )
@@ -162,7 +163,8 @@ async def test_if_fires_on_state_change(
                         "data": {
                             "some": (
                                 "from - {{ trigger.platform}} - "
-                                "{{ trigger.entity_id}} - {{ trigger.from_state.state}} - "
+                                "{{ trigger.entity_id}} - "
+                                "{{ trigger.from_state.state}} - "
                                 "{{ trigger.to_state.state}} - {{ trigger.for }} - "
                                 "{{ trigger.id}}"
                             )
@@ -184,7 +186,8 @@ async def test_if_fires_on_state_change(
                         "data": {
                             "some": (
                                 "from-to - {{ trigger.platform}} - "
-                                "{{ trigger.entity_id}} - {{ trigger.from_state.state}} - "
+                                "{{ trigger.entity_id}} - "
+                                "{{ trigger.from_state.state}} - "
                                 "{{ trigger.to_state.state}} - {{ trigger.for }} - "
                                 "{{ trigger.id}}"
                             )
@@ -263,7 +266,8 @@ async def test_if_fires_on_state_change_legacy(
                         "data": {
                             "some": (
                                 "to - {{ trigger.platform}} - "
-                                "{{ trigger.entity_id}} - {{ trigger.from_state.state}} - "
+                                "{{ trigger.entity_id}} - "
+                                "{{ trigger.from_state.state}} - "
                                 "{{ trigger.to_state.state}} - {{ trigger.for }} - "
                                 "{{ trigger.id}}"
                             )

--- a/tests/components/sensibo/test_climate.py
+++ b/tests/components/sensibo/test_climate.py
@@ -303,7 +303,8 @@ async def test_climate_horizontal_swing(
 
     with pytest.raises(
         HomeAssistantError,
-        match="Climate horizontal swing mode not_in_ha is not supported by the integration",
+        match="Climate horizontal swing mode not_in_ha is not"
+        " supported by the integration",
     ):
         await hass.services.async_call(
             CLIMATE_DOMAIN,
@@ -1252,7 +1253,7 @@ async def test_climate_fan_mode_and_swing_mode_not_supported(
     mock_client: MagicMock,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test the Sensibo climate fan_mode and swing_mode not supported is raising error."""
+    """Test unsupported fan_mode and swing_mode raises error."""
 
     state = hass.states.get("climate.hallway")
     assert state.attributes["fan_mode"] == "high"

--- a/tests/components/sensor/common.py
+++ b/tests/components/sensor/common.py
@@ -51,7 +51,9 @@ UNITS_OF_MEASUREMENT = {
     SensorDeviceClass.AREA: UnitOfArea.SQUARE_METERS,
     SensorDeviceClass.ATMOSPHERIC_PRESSURE: UnitOfPressure.HPA,
     SensorDeviceClass.BATTERY: PERCENTAGE,
-    SensorDeviceClass.BLOOD_GLUCOSE_CONCENTRATION: UnitOfBloodGlucoseConcentration.MILLIGRAMS_PER_DECILITER,
+    SensorDeviceClass.BLOOD_GLUCOSE_CONCENTRATION: (
+        UnitOfBloodGlucoseConcentration.MILLIGRAMS_PER_DECILITER
+    ),
     SensorDeviceClass.CO2: CONCENTRATION_PARTS_PER_MILLION,
     SensorDeviceClass.CO: CONCENTRATION_PARTS_PER_MILLION,
     SensorDeviceClass.CONDUCTIVITY: UnitOfConductivity.SIEMENS_PER_CM,
@@ -84,7 +86,9 @@ UNITS_OF_MEASUREMENT = {
     SensorDeviceClass.POWER: UnitOfPower.KILO_WATT,
     SensorDeviceClass.POWER_FACTOR: PERCENTAGE,
     SensorDeviceClass.PRECIPITATION: UnitOfPrecipitationDepth.MILLIMETERS,
-    SensorDeviceClass.PRECIPITATION_INTENSITY: UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR,
+    SensorDeviceClass.PRECIPITATION_INTENSITY: (
+        UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR
+    ),
     SensorDeviceClass.PRESSURE: UnitOfPressure.HPA,
     SensorDeviceClass.REACTIVE_ENERGY: UnitOfReactiveEnergy.VOLT_AMPERE_REACTIVE_HOUR,
     SensorDeviceClass.REACTIVE_POWER: UnitOfReactivePower.VOLT_AMPERE_REACTIVE,
@@ -96,7 +100,9 @@ UNITS_OF_MEASUREMENT = {
     SensorDeviceClass.TEMPERATURE_DELTA: UnitOfTemperature.CELSIUS,
     SensorDeviceClass.TIMESTAMP: None,
     SensorDeviceClass.UPTIME: None,
-    SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS: CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS: (
+        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+    ),
     SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS_PARTS: CONCENTRATION_PARTS_PER_MILLION,
     SensorDeviceClass.VOLTAGE: UnitOfElectricPotential.VOLT,
     SensorDeviceClass.VOLUME: UnitOfVolume.LITERS,

--- a/tests/components/sensor/test_device_condition.py
+++ b/tests/components/sensor/test_device_condition.py
@@ -246,7 +246,7 @@ async def test_get_conditions_no_unit_or_stateclass(
     unit,
     condition_types,
 ) -> None:
-    """Test we get the expected conditions from an entity with no unit or state class."""
+    """Test conditions from entity with no unit or state class."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
     device_entry = device_registry.async_get_or_create(

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -640,7 +640,8 @@ async def test_translated_unit(
     with patch(
         "homeassistant.helpers.entity_platform.translation.async_get_translations",
         return_value={
-            "component.test.entity.sensor.test_translation_key.unit_of_measurement": "Tests"
+            "component.test.entity.sensor"
+            ".test_translation_key.unit_of_measurement": "Tests"
         },
     ):
         entity0 = MockSensor(
@@ -672,7 +673,8 @@ async def test_translated_unit_with_native_unit_raises(
     with patch(
         "homeassistant.helpers.entity_platform.translation.async_get_translations",
         return_value={
-            "component.test.entity.sensor.test_translation_key.unit_of_measurement": "Tests"
+            "component.test.entity.sensor"
+            ".test_translation_key.unit_of_measurement": "Tests"
         },
     ):
         entity0 = MockSensor(
@@ -698,12 +700,13 @@ async def test_translated_unit_with_native_unit_raises(
 async def test_unit_translation_key_without_platform_raises(
     hass: HomeAssistant,
 ) -> None:
-    """Test that unit translation key property raises if the entity has no platform yet."""
+    """Test unit translation key raises without platform."""
 
     with patch(
         "homeassistant.helpers.entity_platform.translation.async_get_translations",
         return_value={
-            "component.test.entity.sensor.test_translation_key.unit_of_measurement": "Tests"
+            "component.test.entity.sensor"
+            ".test_translation_key.unit_of_measurement": "Tests"
         },
     ):
         entity0 = MockSensor(
@@ -1610,7 +1613,8 @@ async def test_unit_conversion_priority_precision(
     assert float(state.state) == pytest.approx(custom_state)
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == custom_unit
 
-    # Set a display_precision, this should have priority over suggested_display_precision
+    # Set a display_precision, this should have priority over
+    # suggested_display_precision
     entity_registry.async_update_entity_options(
         entity0.entity_id,
         "sensor",
@@ -1715,7 +1719,8 @@ async def test_unit_conversion_priority_suggested_unit_change(
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
-    # Registered entity -> Follow automatic unit conversion the first time the entity was seen
+    # Registered entity -> Follow automatic unit conversion the first
+    # time the entity was seen
     state = hass.states.get(entity0.entity_id)
     assert float(state.state) == pytest.approx(float(original_value))
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == original_unit
@@ -3037,7 +3042,8 @@ async def test_suggested_unit_guard_invalid_unit(
 ) -> None:
     """Test suggested_unit_of_measurement guard.
 
-    An invalid suggested unit creates a log entry and the suggested unit will be ignored.
+    An invalid suggested unit creates a log entry and the suggested
+    unit will be ignored.
     """
     state_value = 10
     invalid_suggested_unit = "invalid_unit"
@@ -3058,8 +3064,8 @@ async def test_suggested_unit_guard_invalid_unit(
     assert not entity_registry.async_get("sensor.invalid")
 
     assert (
-        "Entity <class 'tests.components.sensor.common.MockSensor'> suggest an incorrect unit of measurement: invalid_unit"
-        in caplog.text
+        "Entity <class 'tests.components.sensor.common.MockSensor'>"
+        " suggest an incorrect unit of measurement: invalid_unit" in caplog.text
     )
 
 

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -542,7 +542,7 @@ async def test_compile_hourly_statistics_with_some_same_last_updated_angle(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test compiling hourly statistics with the some of the same last updated value for measurement_angle.
+    """Test compiling stats with same last_updated for angle.
 
     If the last updated value is the same we will have a zero duration.
     """
@@ -1096,7 +1096,7 @@ async def test_compile_hourly_statistics_wrong_unit(
     caplog: pytest.LogCaptureFixture,
     attributes,
 ) -> None:
-    """Test compiling hourly statistics for sensor with unit not matching device class."""
+    """Test stats for sensor with unit not matching device class."""
     zero = get_start_time(dt_util.utcnow())
     await async_setup_component(hass, "sensor", {})
     # Wait for the sensor recorder platform to be added
@@ -1953,9 +1953,10 @@ async def test_compile_hourly_sum_statistics_negative_state(
     state = states[entity_id][offending_state].state
     last_updated = states[entity_id][offending_state].last_updated.isoformat()
     assert (
-        f"Entity {entity_id} {warning_1}has state class total_increasing, but its state "
-        f"is negative. Triggered by state {state} with last_updated set to {last_updated}."
-        in caplog.text
+        f"Entity {entity_id} {warning_1}has state class"
+        f" total_increasing, but its state "
+        f"is negative. Triggered by state {state}"
+        f" with last_updated set to {last_updated}." in caplog.text
     )
     assert warning_2 in caplog.text
 
@@ -2261,7 +2262,8 @@ async def test_compile_hourly_sum_statistics_total_increasing_small_dip(
     last_updated = states["sensor.test1"][6].last_updated.isoformat()
     assert (
         "Entity sensor.test1 has state class total_increasing, but its state is not "
-        f"strictly increasing. Triggered by state {state} (previous state: {previous_state}) "
+        f"strictly increasing. Triggered by state {state}"
+        f" (previous state: {previous_state}) "
         f"with last_updated set to {last_updated}. Please create a bug report at "
         "https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue"
     ) in caplog.text
@@ -2689,7 +2691,7 @@ async def test_compile_hourly_statistics_unchanged_angle(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test compiling hourly statistics, with no changes during the hour for measurement_angle."""
+    """Test compiling hourly stats, no changes for measurement_angle."""
     zero = get_start_time(dt_util.utcnow())
     await async_setup_component(hass, "sensor", {})
     # Wait for the sensor recorder platform to be added
@@ -2864,7 +2866,7 @@ async def test_compile_hourly_statistics_unavailable_angle(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test compiling hourly statistics, with one sensor being unavailable for measurement_angle.
+    """Test hourly stats with one sensor unavailable for angle.
 
     sensor.test1 is unavailable and should not have statistics generated
     sensor.test2 should have statistics generated
@@ -4155,7 +4157,7 @@ async def test_compile_hourly_statistics_custom_equivalent_units(
     min: float,
     max: float,
 ) -> None:
-    """Test compiling hourly statistics where units change during an hour and the integration provides custom equivalent units."""
+    """Test stats where units change with custom equivalent units."""
     zero = get_start_time(dt_util.utcnow())
     await async_setup_component(hass, "sensor", {})
     # Wait for the sensor recorder platform to be added
@@ -4359,9 +4361,10 @@ async def test_compile_hourly_statistics_changing_device_class_1(
     min,
     max,
 ) -> None:
-    """Test compiling hourly statistics where device class changes from one hour to the next.
+    """Test stats where device class changes between hours.
 
-    In this test, the device class is first None, then set to a specific device class.
+    In this test, the device class is first None, then set to a
+    specific device class.
 
     Changing device class may influence the unit class.
     """
@@ -4578,9 +4581,10 @@ async def test_compile_hourly_statistics_changing_device_class_2(
     min,
     max,
 ) -> None:
-    """Test compiling hourly statistics where device class changes from one hour to the next.
+    """Test stats where device class changes between hours.
 
-    In this test, the device class is first set to a specific device class, then set to None.
+    In this test, the device class is first set to a specific device
+    class, then set to None.
     """
     zero = get_start_time(dt_util.utcnow())
     await async_setup_component(hass, "sensor", {})

--- a/tests/components/sensorpro/__init__.py
+++ b/tests/components/sensorpro/__init__.py
@@ -57,7 +57,10 @@ SENSORPRO_SERVICE_INFO = make_bluetooth_service_info(
     rssi=-60,
     service_data={},
     manufacturer_data={
-        43605: b"\x01\x01\xa4\xc18.\xcan\x01\x07\n\x02\x13\x9dd\x00\x01\x01\x01\xa4\xc18.\xcan\x01\x07\n\x02\x13\x9dd\x00\x01"
+        43605: (
+            b"\x01\x01\xa4\xc18.\xcan\x01\x07\n\x02\x13\x9dd\x00\x01"
+            b"\x01\x01\xa4\xc18.\xcan\x01\x07\n\x02\x13\x9dd\x00\x01"
+        )
     },
     service_uuids=[],
     source="local",

--- a/tests/components/sensoterra/const.py
+++ b/tests/components/sensoterra/const.py
@@ -1,6 +1,10 @@
 """Constants for the test Sensoterra integration."""
 
-API_TOKEN = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE4NTYzMDQwMDAsInN1YiI6IjM5In0.yxdXXlc1DqopqDRHfAVzFrMqZJl6nKLpu1dV8alHvVY"
+API_TOKEN = (
+    "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9"
+    ".eyJleHAiOjE4NTYzMDQwMDAsInN1YiI6IjM5In0"
+    ".yxdXXlc1DqopqDRHfAVzFrMqZJl6nKLpu1dV8alHvVY"
+)
 API_EMAIL = "test-email@example.com"
 API_PASSWORD = "test-password"
 HASS_UUID = "phony-unique-id"

--- a/tests/components/sftp_storage/test_backup.py
+++ b/tests/components/sftp_storage/test_backup.py
@@ -127,7 +127,9 @@ async def test_agents_list_backups_fail(
     assert response["success"]
     assert response["result"]["backups"] == []
     assert response["result"]["agent_errors"] == {
-        f"{DOMAIN}.{TEST_AGENT_ID}": "Remote server error while attempting to list backups: Error message"
+        f"{DOMAIN}.{TEST_AGENT_ID}": (
+            "Remote server error while attempting to list backups: Error message"
+        )
     }
 
 
@@ -151,8 +153,9 @@ async def test_agents_list_backups_include_bad_metadata(
     # Called two times, one for bad backup metadata and once for good
     assert mock_ssh_connection._sftp._mock_open._mock_read.call_count == 2
     assert (
-        "Failed to load backup metadata from file: /backup_location/invalid.metadata.json. Expecting value: line 1 column 1 (char 0)"
-        in caplog.messages
+        "Failed to load backup metadata from file:"
+        " /backup_location/invalid.metadata.json."
+        " Expecting value: line 1 column 1 (char 0)" in caplog.messages
     )
 
 
@@ -207,7 +210,8 @@ async def test_agents_download_fail(
     """Test agent download backup fails."""
     mock_ssh_connection.mock_setup_backup(BACKUP_METADATA)
 
-    # This will cause `FileNotFoundError` exception in `BackupAgentClient.iter_file() method.`
+    # This will cause `FileNotFoundError` exception in
+    # `BackupAgentClient.iter_file() method.`
     mock_ssh_connection._sftp._mock_exists.side_effect = [True, False]
     client = await hass_client()
     resp = await client.get(
@@ -215,7 +219,8 @@ async def test_agents_download_fail(
     )
     assert resp.status == 404
 
-    # This will raise `RuntimeError` causing Internal Server Error, mimicking that the SFTP setup failed.
+    # This will raise `RuntimeError` causing Internal Server Error,
+    # mimicking that the SFTP setup failed.
     mock_ssh_connection._sftp = None
     resp = await client.get(
         f"/api/backup/download/{TEST_AGENT_BACKUP.backup_id}?agent_id={DOMAIN}.{TEST_AGENT_ID}"
@@ -351,7 +356,10 @@ async def test_agents_delete(
             SFTPError(0, "manual"),
             {
                 "agent_errors": {
-                    f"{DOMAIN}.{TEST_AGENT_ID}": f"Failed to delete backup id: {TEST_AGENT_BACKUP.backup_id}: manual"
+                    f"{DOMAIN}.{TEST_AGENT_ID}": (
+                        f"Failed to delete backup id:"
+                        f" {TEST_AGENT_BACKUP.backup_id}: manual"
+                    )
                 }
             },
         ),

--- a/tests/components/sftp_storage/test_init.py
+++ b/tests/components/sftp_storage/test_init.py
@@ -54,7 +54,8 @@ async def test_setup_and_unload(
 
     assert entries[0].state is ConfigEntryState.NOT_LOADED
     assert (
-        f"Unloading {DOMAIN} integration for host {entries[0].data[CONF_USERNAME]}@{entries[0].data[CONF_HOST]}"
+        f"Unloading {DOMAIN} integration for host"
+        f" {entries[0].data[CONF_USERNAME]}@{entries[0].data[CONF_HOST]}"
         in caplog.messages
     )
 
@@ -91,8 +92,9 @@ async def test_setup_unexpected_error(
     assert len(entries) == 1
     assert entries[0].state is ConfigEntryState.SETUP_ERROR
     assert (
-        "Failure while attempting to establish SSH connection. Please check SSH credentials and if changed, re-install the integration"
-        in caplog.text
+        "Failure while attempting to establish SSH connection."
+        " Please check SSH credentials and if changed,"
+        " re-install the integration" in caplog.text
     )
 
 
@@ -135,15 +137,16 @@ async def test_async_remove_entry(
     assert private_key.exists()
     assert new_private_key.exists()
 
-    # Remove first config entry - the private key from second will still be in filesystem
-    # as well as integration storage directory
+    # Remove first config entry - the private key from second will
+    # still be in filesystem as well as integration storage directory
     assert await hass.config_entries.async_remove(config_entry.entry_id)
     assert not private_key.exists()
     assert new_private_key.exists()
     assert new_private_key.parent.exists()
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
-    # Remove the second config entry, ensuring all files and integration storage directory removed.
+    # Remove the second config entry, ensuring all files and
+    # integration storage directory removed.
     assert await hass.config_entries.async_remove(new_config_entry.entry_id)
     assert not new_private_key.exists()
     assert not new_private_key.parent.exists()

--- a/tests/components/sharkiq/const.py
+++ b/tests/components/sharkiq/const.py
@@ -39,7 +39,8 @@ SHARK_METADATA_DICT = [
     }
 ]
 
-# Dummy shark.properties_full for testing.  NB: this only includes those properties in the tests
+# Dummy shark.properties_full for testing.
+# NB: this only includes those properties in the tests
 SHARK_PROPERTIES_DICT = {
     "Battery_Capacity": {"base_type": "integer", "read_only": True, "value": 50},
     "Charging_Status": {"base_type": "boolean", "read_only": True, "value": 0},

--- a/tests/components/shell_command/test_init.py
+++ b/tests/components/shell_command/test_init.py
@@ -346,7 +346,7 @@ async def test_repair_issue_on_reserved_reload_name(
 async def test_repair_issue_on_reload_service_reload(
     hass: HomeAssistant, issue_registry: ir.IssueRegistry, hass_admin_user: MockUser
 ) -> None:
-    """Test repair issue is created if 'reload' is used in YAML and reload service is called."""
+    """Test repair issue when 'reload' is used in YAML config."""
     config = {shell_command.DOMAIN: {"test": "echo ok"}}
     await async_setup_component(hass, shell_command.DOMAIN, config)
     await hass.async_block_till_done()

--- a/tests/components/shelly/__init__.py
+++ b/tests/components/shelly/__init__.py
@@ -75,7 +75,7 @@ async def init_integration(
 async def mock_block_device_push_update_failure(
     hass: HomeAssistant, mock_block_device: Mock
 ) -> None:
-    """Create updates with COAP_REPLY indicating push update failure for block device."""
+    """Create COAP_REPLY updates indicating push update failure."""
     for _ in range(MAX_PUSH_UPDATE_FAILURES):
         mock_block_device.mock_update_reply()
         await hass.async_block_till_done()

--- a/tests/components/shelly/test_binary_sensor.py
+++ b/tests/components/shelly/test_binary_sensor.py
@@ -535,7 +535,7 @@ async def test_rpc_remove_virtual_binary_sensor_when_mode_toggle(
     mock_rpc_device: Mock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test if the virtual binary sensor will be removed if the mode has been changed to a toggle."""
+    """Test virtual binary sensor removal when mode changes to toggle."""
     config = deepcopy(mock_rpc_device.config)
     config["boolean:200"] = {"name": None, "meta": {"ui": {"view": "toggle"}}}
     monkeypatch.setattr(mock_rpc_device, "config", config)
@@ -567,7 +567,7 @@ async def test_rpc_remove_virtual_binary_sensor_when_orphaned(
     device_registry: DeviceRegistry,
     mock_rpc_device: Mock,
 ) -> None:
-    """Check whether the virtual binary sensor will be removed if it has been removed from the device configuration."""
+    """Test virtual binary sensor removal from device configuration."""
     config_entry = await init_integration(hass, 3, skip_setup=True)
 
     # create orphaned entity on main device

--- a/tests/components/shelly/test_button.py
+++ b/tests/components/shelly/test_button.py
@@ -95,11 +95,13 @@ async def test_rpc_button(
     [
         (
             DeviceConnectionError,
-            "Device communication error occurred while calling action for button.test_name_restart of Test name",
+            "Device communication error occurred while calling action"
+            " for button.test_name_restart of Test name",
         ),
         (
             RpcCallError(999),
-            "RPC call error occurred while calling action for button.test_name_restart of Test name",
+            "RPC call error occurred while calling action"
+            " for button.test_name_restart of Test name",
         ),
     ],
 )
@@ -233,11 +235,13 @@ async def test_rpc_blu_trv_button(
     [
         (
             DeviceConnectionError,
-            "Device communication error occurred while calling action for button.trv_name_calibrate of Test name",
+            "Device communication error occurred while calling action"
+            " for button.trv_name_calibrate of Test name",
         ),
         (
             RpcCallError(999),
-            "RPC call error occurred while calling action for button.trv_name_calibrate of Test name",
+            "RPC call error occurred while calling action"
+            " for button.trv_name_calibrate of Test name",
         ),
     ],
 )
@@ -344,7 +348,7 @@ async def test_rpc_remove_virtual_button_when_orphaned(
     device_registry: DeviceRegistry,
     mock_rpc_device: Mock,
 ) -> None:
-    """Check whether the virtual button will be removed if it has been removed from the device configuration."""
+    """Test virtual button removal from device configuration."""
     config_entry = await init_integration(hass, 3, skip_setup=True)
     device_entry = register_device(device_registry, config_entry)
     entity_id = register_entity(

--- a/tests/components/shelly/test_climate.py
+++ b/tests/components/shelly/test_climate.py
@@ -493,7 +493,8 @@ async def test_block_set_mode_connection_error(
 
     with pytest.raises(
         HomeAssistantError,
-        match="Device communication error occurred while calling action for climate.test_name of Test name",
+        match="Device communication error occurred while calling action"
+        " for climate.test_name of Test name",
     ):
         await hass.services.async_call(
             CLIMATE_DOMAIN,
@@ -878,11 +879,13 @@ async def test_blu_trv_climate_hvac_action(
     [
         (
             DeviceConnectionError,
-            "Device communication error occurred while calling action for climate.trv_name of Test name",
+            "Device communication error occurred while calling action"
+            " for climate.trv_name of Test name",
         ),
         (
             RpcCallError(999),
-            "RPC call error occurred while calling action for climate.trv_name of Test name",
+            "RPC call error occurred while calling action"
+            " for climate.trv_name of Test name",
         ),
     ],
 )

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -62,7 +62,7 @@ from tests.typing import WebSocketGenerator
 async def _async_inject_ble_discovery(
     hass: HomeAssistant, info: BluetoothServiceInfoBleak
 ) -> None:
-    """Inject BLE discovery info and wait for processing without triggering config flows."""
+    """Inject BLE discovery info and wait for processing."""
     with patch.object(hass.config_entries.flow, "async_init"):
         inject_bluetooth_service_info_bleak(hass, info)
         await hass.async_block_till_done()
@@ -103,19 +103,25 @@ BLE_MANUFACTURER_DATA_RPC = {
 BLE_MANUFACTURER_DATA_NO_RPC = {
     0x0BA9: bytes([0x01, 0x02, 0x00])
 }  # Flags without RPC bit
-BLE_MANUFACTURER_DATA_WITH_MAC = {
-    0x0BA9: bytes.fromhex("0105000b30100a70d6c297bacc")
-}  # Flags (0x01, 0x05, 0x00), Model (0x0b, 0x30, 0x10), MAC (0x0a, 0x70, 0xd6, 0xc2, 0x97, 0xba, 0xcc)
-# Device WiFi MAC: 70d6c297bacc (little-endian) -> CCBA97C2D670 (reversed to big-endian)
-# BLE MAC is typically device MAC + 2: CCBA97C2D670 + 2 = CC:BA:97:C2:D6:72
+BLE_MANUFACTURER_DATA_WITH_MAC = {0x0BA9: bytes.fromhex("0105000b30100a70d6c297bacc")}
+# Flags (0x01, 0x05, 0x00), Model (0x0b, 0x30, 0x10),
+# MAC (0x0a, 0x70, 0xd6, 0xc2, 0x97, 0xba, 0xcc)
+# Device WiFi MAC: 70d6c297bacc (little-endian) ->
+# CCBA97C2D670 (reversed to big-endian)
+# BLE MAC is typically device MAC + 2:
+# CCBA97C2D670 + 2 = CC:BA:97:C2:D6:72
 
 BLE_MANUFACTURER_DATA_WITH_MAC_UNKNOWN_MODEL = {
     0x0BA9: bytes.fromhex("0105000b99990a70d6c297bacc")
-}  # Flags (0x01, 0x05, 0x00), Model (0x0b, 0x99, 0x99) - unknown model ID, MAC (0x0a, 0x70, 0xd6, 0xc2, 0x97, 0xba, 0xcc)
+}
+# Flags (0x01, 0x05, 0x00), Model (0x0b, 0x99, 0x99) -
+# unknown model ID, MAC (0x0a, 0x70, 0xd6, 0xc2, 0x97, 0xba, 0xcc)
 
 BLE_MANUFACTURER_DATA_FOR_CLEAR_TEST = {
     0x0BA9: bytes.fromhex("0105000b30100a00eeddccbbaa")
-}  # Flags (0x01, 0x05, 0x00), Model (0x0b, 0x30, 0x10), MAC (0x0a, 0x00, 0xee, 0xdd, 0xcc, 0xbb, 0xaa)
+}
+# Flags (0x01, 0x05, 0x00), Model (0x0b, 0x30, 0x10),
+# MAC (0x0a, 0x00, 0xee, 0xdd, 0xcc, 0xbb, 0xaa)
 # Device WiFi MAC: 00eeddccbbaa (little-endian) -> AABBCCDDEE00 (reversed to big-endian)
 
 BLE_DISCOVERY_INFO = BluetoothServiceInfoBleak(
@@ -1375,7 +1381,7 @@ async def test_user_flow_aborts_when_another_flow_finishes_while_in_progress(
     hass: HomeAssistant,
     mock_discovery: AsyncMock,
 ) -> None:
-    """Test that user flow aborts when another flow finishes and creates a config entry."""
+    """Test user flow aborts when another flow creates config entry."""
     # Mock zeroconf discovery
     mock_discovery.return_value = [MOCK_HTTP_ZEROCONF_SERVICE_INFO]
 
@@ -1394,7 +1400,8 @@ async def test_user_flow_aborts_when_another_flow_finishes_while_in_progress(
     assert "AABBCCDDEEFF" in options
     assert options["AABBCCDDEEFF"] == "shellyplus2pm-AABBCCDDEEFF"
 
-    # Now simulate another flow configuring the device while user is on the selection form
+    # Now simulate another flow configuring the device while user is
+    # on the selection form
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="AABBCCDDEEFF",
@@ -2698,7 +2705,7 @@ async def test_zeroconf_already_configured_triggers_refresh_mac_in_name(
 async def test_zeroconf_already_configured_triggers_refresh(
     hass: HomeAssistant, mock_rpc_device: Mock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Test zeroconf discovery triggers refresh when the mac is obtained via get_info."""
+    """Test zeroconf discovery triggers refresh via get_info mac."""
     entry = MockConfigEntry(
         domain="shelly",
         unique_id="AABBCCDDEEFF",
@@ -2867,7 +2874,7 @@ async def test_zeroconf_sleeping_device_attempts_configure_ws_disabled(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test zeroconf discovery configures a sleeping device outbound websocket when its disabled."""
+    """Test zeroconf configures sleeping device outbound websocket."""
     monkeypatch.setattr(mock_rpc_device, "connected", False)
     monkeypatch.setattr(mock_rpc_device, "initialized", False)
     monkeypatch.setitem(mock_rpc_device.status["sys"], "wakeup_period", 1000)
@@ -3297,7 +3304,7 @@ async def test_bluetooth_discovery(
 async def test_bluetooth_provisioning_clears_match_history(
     hass: HomeAssistant, mock_setup: AsyncMock, mock_ble_rpc_device: AsyncMock
 ) -> None:
-    """Test bluetooth provisioning clears match history at discovery start and after successful provisioning."""
+    """Test bluetooth provisioning clears match history."""
     # Configure mock BLE device for this test
     mock_ble_rpc_device.wifi_scan.return_value = [
         {"ssid": "MyNetwork", "rssi": -50, "auth": 2}
@@ -3352,7 +3359,8 @@ async def test_bluetooth_provisioning_clears_match_history(
         assert result["result"].unique_id == "AABBCCDDEE00"
 
         # Verify match history was cleared once during provisioning
-        # Only count calls with our test device's address to avoid interference from other tests
+        # Only count calls with our test device's address to avoid
+        # interference from other tests
         our_device_calls = [
             call
             for call in mock_clear.call_args_list
@@ -3382,7 +3390,7 @@ async def test_bluetooth_discovery_no_rpc_over_ble(
 async def test_bluetooth_factory_reset_rediscovery(
     hass: HomeAssistant, mock_setup: AsyncMock, mock_ble_rpc_device: AsyncMock
 ) -> None:
-    """Test device can be rediscovered after factory reset when RPC-over-BLE is re-enabled."""
+    """Test device rediscovery after factory reset with BLE."""
     # Configure mock BLE device for this test
     mock_ble_rpc_device.wifi_scan.return_value = [
         {"ssid": "MyNetwork", "rssi": -50, "auth": 2}
@@ -3484,7 +3492,8 @@ async def test_bluetooth_discovery_mac_in_manufacturer_data(
     # Should successfully extract MAC from manufacturer data
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "bluetooth_confirm"
-    # MAC from manufacturer data: 70d6c297bacc (reversed) = CC:BA:97:C2:D6:70 = CCBA97C2D670
+    # MAC from manufacturer data: 70d6c297bacc (reversed) =
+    # CC:BA:97:C2:D6:70 = CCBA97C2D670
     # Model ID 0x1030 = Shelly 1 Mini Gen4
     # Device name should use model name from model ID: Shelly1MiniGen4-<MAC>
     assert result["description_placeholders"]["name"] == "Shelly1MiniGen4-CCBA97C2D670"
@@ -3507,7 +3516,8 @@ async def test_bluetooth_discovery_mac_unknown_model(
     # Should successfully extract MAC from manufacturer data
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "bluetooth_confirm"
-    # MAC from manufacturer data: 70d6c297bacc (reversed) = CC:BA:97:C2:D6:70 = CCBA97C2D670
+    # MAC from manufacturer data: 70d6c297bacc (reversed) =
+    # CC:BA:97:C2:D6:70 = CCBA97C2D670
     # Model ID 0x9999 is unknown - should fall back to generic "Shelly-<MAC>"
     assert result["description_placeholders"]["name"] == "Shelly-CCBA97C2D670"
 
@@ -4298,7 +4308,7 @@ async def test_bluetooth_provision_with_zeroconf_discovery_fast_path(
     mock_setup: AsyncMock,
     mock_ble_rpc_device: AsyncMock,
 ) -> None:
-    """Test zeroconf discovery arrives during WiFi provisioning (fast path - line 551)."""
+    """Test zeroconf arrives during WiFi provisioning fast path."""
     # Configure mock BLE device
     mock_ble_rpc_device.wifi_scan.return_value = [
         {"ssid": "MyNetwork", "rssi": -50, "auth": 2}
@@ -4456,7 +4466,7 @@ async def test_bluetooth_provision_timeout_ble_fallback_succeeds(
     mock_ble_rpc_device: AsyncMock,
     mock_ble_rpc_device_class: MagicMock,
 ) -> None:
-    """Test WiFi provisioning times out, active lookup fails, but BLE fallback succeeds."""
+    """Test WiFi provisioning timeout with BLE fallback success."""
     # Configure mock BLE device
     mock_ble_rpc_device.wifi_scan.return_value = [
         {"ssid": "MyNetwork", "rssi": -50, "auth": 2}
@@ -4493,7 +4503,8 @@ async def test_bluetooth_provision_timeout_ble_fallback_succeeds(
     mock_ble_rpc_device_class.create.side_effect = mock_create
 
     # Confirm and scan, then select network and enter password
-    # Provision WiFi but no zeroconf discovery arrives, active lookup fails, BLE fallback succeeds
+    # Provision WiFi but no zeroconf discovery arrives,
+    # active lookup fails, BLE fallback succeeds
     with (
         patch(
             "homeassistant.components.shelly.config_flow.PROVISIONING_TIMEOUT",
@@ -4536,7 +4547,7 @@ async def test_bluetooth_provision_timeout_ble_fallback_fails(
     hass: HomeAssistant,
     mock_ble_rpc_device: AsyncMock,
 ) -> None:
-    """Test WiFi provisioning times out, active lookup fails, and BLE fallback also fails."""
+    """Test WiFi provisioning timeout with BLE fallback failure."""
     # Configure mock BLE device
     mock_ble_rpc_device.wifi_scan.return_value = [
         {"ssid": "MyNetwork", "rssi": -50, "auth": 2}
@@ -4598,7 +4609,7 @@ async def test_bluetooth_provision_timeout_ble_exception(
     hass: HomeAssistant,
     mock_ble_rpc_device: AsyncMock,
 ) -> None:
-    """Test WiFi provisioning times out, active lookup fails, and BLE raises exception."""
+    """Test WiFi provisioning timeout with BLE raising exception."""
     # Configure mock BLE device for initial wifi scan
     mock_ble_rpc_device.wifi_scan.return_value = [
         {"ssid": "MyNetwork", "rssi": -50, "auth": 2}
@@ -4616,11 +4627,13 @@ async def test_bluetooth_provision_timeout_ble_exception(
     # Scan for networks first
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
-    # Now configure update_status to raise exception (BLE raises exception during IP fetch)
+    # Now configure update_status to raise exception
+    # (BLE raises exception during IP fetch)
     mock_ble_rpc_device.update_status.side_effect = DeviceConnectionError
 
     # Confirm and scan, select network and enter password
-    # Provision WiFi but no zeroconf discovery, active lookup fails, BLE raises exception
+    # Provision WiFi but no zeroconf discovery, active lookup fails,
+    # BLE raises exception
     # Keep patches active until all background tasks complete to avoid socket errors
     with (
         patch(

--- a/tests/components/shelly/test_coordinator.py
+++ b/tests/components/shelly/test_coordinator.py
@@ -558,7 +558,7 @@ async def test_rpc_ignore_virtual_click_event(
     events: list[Event],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test RPC virtual click events are ignored as they are triggered by the integration."""
+    """Test RPC virtual click events triggered by integration."""
     await init_integration(hass, 2)
 
     # Generate a virtual button event

--- a/tests/components/shelly/test_cover.py
+++ b/tests/components/shelly/test_cover.py
@@ -346,7 +346,8 @@ async def test_rpc_cover_position_update(
     assert state.attributes[ATTR_CURRENT_POSITION] == 0
     assert state.state == CoverState.CLOSED
 
-    # Ensure update_position does not call update_cover_status when the cover is not moving
+    # Ensure update_position does not call update_cover_status
+    # when the cover is not moving
     await mock_polling_rpc_update(hass, freezer, RPC_COVER_UPDATE_TIME_SEC)
     mock_rpc_device.update_cover_status.assert_not_called()
 

--- a/tests/components/shelly/test_device_trigger.py
+++ b/tests/components/shelly/test_device_trigger.py
@@ -400,7 +400,7 @@ async def test_rpc_no_runtime_data(
     mock_rpc_device: Mock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test the device trigger for the RPC device when there is no runtime_data in the entry."""
+    """Test RPC device trigger when entry has no runtime_data."""
     entry = await init_integration(hass, 2)
     # Cache initial runtime_data
     runtime_data = entry.runtime_data
@@ -450,7 +450,7 @@ async def test_block_no_runtime_data(
     mock_block_device: Mock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test the device trigger for the block device when there is no runtime_data in the entry."""
+    """Test block device trigger when entry has no runtime_data."""
     entry = await init_integration(hass, 1)
     # Cache initial runtime_data
     runtime_data = entry.runtime_data

--- a/tests/components/shelly/test_diagnostics.py
+++ b/tests/components/shelly/test_diagnostics.py
@@ -160,7 +160,13 @@ async def test_rpc_config_entry_diagnostics(
                 "raw_advertisement_data": {
                     "AA:BB:CC:DD:EE:FF": {
                         "__type": "<class 'bytes'>",
-                        "repr": "b'\\x02\\x01\\x06\\t\\xffY\\x00\\xd1\\xfb;t\\xc8\\x90\\x11\\x07\\x1b\\xc5\\xd5\\xa5\\x02\\x00\\xb8\\x9f\\xe6\\x11M\"\\x00\\r\\xa2\\xcb\\x06\\x16\\x00\\rH\\x10a'",
+                        "repr": (
+                            "b'\\x02\\x01\\x06\\t\\xffY\\x00\\xd1"
+                            "\\xfb;t\\xc8\\x90\\x11\\x07\\x1b\\xc5"
+                            "\\xd5\\xa5\\x02\\x00\\xb8\\x9f\\xe6"
+                            '\\x11M"\\x00\\r\\xa2\\xcb\\x06\\x16'
+                            "\\x00\\rH\\x10a'"
+                        ),
                     }
                 },
                 "type": "ShellyBLEScanner",
@@ -219,7 +225,7 @@ async def test_rpc_config_entry_diagnostics_no_ws(
     mock_rpc_device: Mock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test config entry diagnostics for rpc device which doesn't support ws outbound."""
+    """Test diagnostics for rpc device without ws outbound."""
     config = deepcopy(mock_rpc_device.config)
     config.pop("ws")
     monkeypatch.setattr(mock_rpc_device, "config", config)

--- a/tests/components/shelly/test_media_player.py
+++ b/tests/components/shelly/test_media_player.py
@@ -140,7 +140,12 @@ STATUS_AUDIO_FILE = {
             "artist": "Artist",
             "duration": 132415,
             "position": 64644,
-            "thumb": "data:image/webp;base64,UklGRkAAAABXRUJQVlA4WAoAAAAQAAAAAAAAAAAAQUxQSAIAAAAAAFZQOCAYAAAAMAEAnQEqAQABAAFAJiWkAANwAP79NmgA",
+            "thumb": (
+                "data:image/webp;base64,"
+                "UklGRkAAAABXRUJQVlA4WAoAAAAQAAAAAAAAAAAA"
+                "QUxQSAIAAAAAAFZQOCAYAAAAMAEAnQEqAQABAAFA"
+                "JiWkAANwAP79NmgA"
+            ),
             "title": "Title",
         },
         "media_type": "AUDIO",
@@ -564,11 +569,13 @@ async def test_rpc_media_player_browse_media_unsupported_media_type(
     [
         (
             DeviceConnectionError,
-            "Device communication error occurred while calling action for media_player.test_name of Test name",
+            "Device communication error occurred while calling action"
+            " for media_player.test_name of Test name",
         ),
         (
             RpcCallError(999),
-            "RPC call error occurred while calling action for media_player.test_name of Test name",
+            "RPC call error occurred while calling action"
+            " for media_player.test_name of Test name",
         ),
         (
             InvalidAuthError,

--- a/tests/components/shelly/test_number.py
+++ b/tests/components/shelly/test_number.py
@@ -217,7 +217,8 @@ async def test_block_set_value_connection_error(
 
     with pytest.raises(
         HomeAssistantError,
-        match="Device communication error occurred while calling action for number.test_name_valve_position of Test name",
+        match="Device communication error occurred while calling"
+        " action for number.test_name_valve_position of Test name",
     ):
         await hass.services.async_call(
             NUMBER_DOMAIN,
@@ -358,7 +359,7 @@ async def test_rpc_remove_virtual_number_when_mode_label(
     mock_rpc_device: Mock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test if the virtual number will be removed if the mode has been changed to a label."""
+    """Test virtual number removal when mode changes to label."""
     config = deepcopy(mock_rpc_device.config)
     config["number:200"] = {
         "name": None,
@@ -395,7 +396,7 @@ async def test_rpc_remove_virtual_number_when_orphaned(
     device_registry: DeviceRegistry,
     mock_rpc_device: Mock,
 ) -> None:
-    """Check whether the virtual number will be removed if it has been removed from the device configuration."""
+    """Test virtual number removal from device configuration."""
     config_entry = await init_integration(hass, 3, skip_setup=True)
     device_entry = register_device(device_registry, config_entry)
     entity_id = register_entity(
@@ -503,11 +504,13 @@ async def test_blu_trv_valve_pos_set_value(
     [
         (
             DeviceConnectionError,
-            "Device communication error occurred while calling action for number.trv_name_external_temperature of Test name",
+            "Device communication error occurred while calling action"
+            " for number.trv_name_external_temperature of Test name",
         ),
         (
             RpcCallError(999),
-            "RPC call error occurred while calling action for number.trv_name_external_temperature of Test name",
+            "RPC call error occurred while calling action"
+            " for number.trv_name_external_temperature of Test name",
         ),
     ],
 )

--- a/tests/components/shelly/test_select.py
+++ b/tests/components/shelly/test_select.py
@@ -112,7 +112,7 @@ async def test_rpc_remove_virtual_enum_when_mode_label(
     mock_rpc_device: Mock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test if the virtual enum will be removed if the mode has been changed to a label."""
+    """Test virtual enum removal when mode changes to label."""
     config = deepcopy(mock_rpc_device.config)
     config["enum:200"] = {
         "name": None,
@@ -150,7 +150,7 @@ async def test_rpc_remove_virtual_enum_when_orphaned(
     device_registry: DeviceRegistry,
     mock_rpc_device: Mock,
 ) -> None:
-    """Check whether the virtual enum will be removed if it has been removed from the device configuration."""
+    """Test virtual enum removal from device configuration."""
     config_entry = await init_integration(hass, 3, skip_setup=True)
     device_entry = register_device(device_registry, config_entry)
     entity_id = register_entity(
@@ -173,11 +173,13 @@ async def test_rpc_remove_virtual_enum_when_orphaned(
     [
         (
             DeviceConnectionError,
-            "Device communication error occurred while calling action for select.test_name_enum_203 of Test name",
+            "Device communication error occurred while calling action"
+            " for select.test_name_enum_203 of Test name",
         ),
         (
             RpcCallError(999),
-            "RPC call error occurred while calling action for select.test_name_enum_203 of Test name",
+            "RPC call error occurred while calling action"
+            " for select.test_name_enum_203 of Test name",
         ),
     ],
 )

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -1266,7 +1266,7 @@ async def test_rpc_remove_text_virtual_sensor_when_mode_field(
     mock_rpc_device: Mock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test if the virtual text sensor will be removed if the mode has been changed to a field."""
+    """Test virtual text sensor removal when mode changes to field."""
     config = deepcopy(mock_rpc_device.config)
     config["text:200"] = {"name": None, "meta": {"ui": {"view": "field"}}}
     monkeypatch.setattr(mock_rpc_device, "config", config)
@@ -1298,7 +1298,7 @@ async def test_rpc_remove_text_virtual_sensor_when_orphaned(
     device_registry: DeviceRegistry,
     mock_rpc_device: Mock,
 ) -> None:
-    """Check whether the virtual text sensor will be removed if it has been removed from the device configuration."""
+    """Test virtual text sensor removal from device configuration."""
     config_entry = await init_integration(hass, 3, skip_setup=True)
     device_entry = register_device(device_registry, config_entry)
     entity_id = register_entity(
@@ -1371,7 +1371,7 @@ async def test_rpc_remove_number_virtual_sensor_when_mode_field(
     mock_rpc_device: Mock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test if the virtual number sensor will be removed if the mode has been changed to a field."""
+    """Test virtual number sensor removal when mode changes to field."""
     config = deepcopy(mock_rpc_device.config)
     config["number:200"] = {
         "name": None,
@@ -1408,7 +1408,7 @@ async def test_rpc_remove_number_virtual_sensor_when_orphaned(
     device_registry: DeviceRegistry,
     mock_rpc_device: Mock,
 ) -> None:
-    """Check whether the virtual number sensor will be removed if it has been removed from the device configuration."""
+    """Test virtual number sensor removal from device configuration."""
     config_entry = await init_integration(hass, 3, skip_setup=True)
     device_entry = register_device(device_registry, config_entry)
     entity_id = register_entity(
@@ -1485,7 +1485,7 @@ async def test_rpc_remove_enum_virtual_sensor_when_mode_dropdown(
     mock_rpc_device: Mock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test if the virtual enum sensor will be removed if the mode has been changed to a dropdown."""
+    """Test virtual enum sensor removal when mode changes to dropdown."""
     config = deepcopy(mock_rpc_device.config)
     config["enum:200"] = {
         "name": None,
@@ -1526,7 +1526,7 @@ async def test_rpc_remove_enum_virtual_sensor_when_orphaned(
     device_registry: DeviceRegistry,
     mock_rpc_device: Mock,
 ) -> None:
-    """Check whether the virtual enum sensor will be removed if it has been removed from the device configuration."""
+    """Test virtual enum sensor removal from device configuration."""
     config_entry = await init_integration(hass, 3, skip_setup=True)
     device_entry = register_device(device_registry, config_entry)
     entity_id = register_entity(

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -264,7 +264,8 @@ async def test_block_set_state_connection_error(
 
     with pytest.raises(
         HomeAssistantError,
-        match="Device communication error occurred while calling action for switch.test_name_channel_1 of Test name",
+        match="Device communication error occurred while calling"
+        " action for switch.test_name_channel_1 of Test name",
     ):
         await hass.services.async_call(
             SWITCH_DOMAIN,
@@ -497,11 +498,13 @@ async def test_rpc_device_switch_type_lights_mode(
     [
         (
             DeviceConnectionError,
-            "Device communication error occurred while calling action for switch.test_name_test_switch_0 of Test name",
+            "Device communication error occurred while calling action"
+            " for switch.test_name_test_switch_0 of Test name",
         ),
         (
             RpcCallError(-1, "error"),
-            "RPC call error occurred while calling action for switch.test_name_test_switch_0 of Test name",
+            "RPC call error occurred while calling action"
+            " for switch.test_name_test_switch_0 of Test name",
         ),
     ],
 )
@@ -687,7 +690,7 @@ async def test_rpc_remove_virtual_switch_when_mode_label(
     mock_rpc_device: Mock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test if the virtual switch will be removed if the mode has been changed to a label."""
+    """Test virtual switch removal when mode changes to label."""
     config = deepcopy(mock_rpc_device.config)
     config["boolean:200"] = {"name": None, "meta": {"ui": {"view": "label"}}}
     monkeypatch.setattr(mock_rpc_device, "config", config)
@@ -719,7 +722,7 @@ async def test_rpc_remove_virtual_switch_when_orphaned(
     device_registry: DeviceRegistry,
     mock_rpc_device: Mock,
 ) -> None:
-    """Check whether the virtual switch will be removed if it has been removed from the device configuration."""
+    """Test virtual switch removal from device configuration."""
     config_entry = await init_integration(hass, 3, skip_setup=True)
 
     # create orphaned entity on main device

--- a/tests/components/shelly/test_text.py
+++ b/tests/components/shelly/test_text.py
@@ -92,7 +92,7 @@ async def test_rpc_remove_virtual_text_when_mode_label(
     mock_rpc_device: Mock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test if the virtual text will be removed if the mode has been changed to a label."""
+    """Test virtual text removal when mode changes to label."""
     config = deepcopy(mock_rpc_device.config)
     config["text:200"] = {"name": None, "meta": {"ui": {"view": "label"}}}
     monkeypatch.setattr(mock_rpc_device, "config", config)
@@ -124,7 +124,7 @@ async def test_rpc_remove_virtual_text_when_orphaned(
     device_registry: DeviceRegistry,
     mock_rpc_device: Mock,
 ) -> None:
-    """Check whether the virtual text will be removed if it has been removed from the device configuration."""
+    """Test virtual text removal from device configuration."""
     config_entry = await init_integration(hass, 3, skip_setup=True)
     device_entry = register_device(device_registry, config_entry)
     entity_id = register_entity(
@@ -147,11 +147,13 @@ async def test_rpc_remove_virtual_text_when_orphaned(
     [
         (
             DeviceConnectionError,
-            "Device communication error occurred while calling action for text.test_name_text_203 of Test name",
+            "Device communication error occurred while calling action"
+            " for text.test_name_text_203 of Test name",
         ),
         (
             RpcCallError(999),
-            "RPC call error occurred while calling action for text.test_name_text_203 of Test name",
+            "RPC call error occurred while calling action"
+            " for text.test_name_text_203 of Test name",
         ),
     ],
 )

--- a/tests/components/shelly/test_update.py
+++ b/tests/components/shelly/test_update.py
@@ -195,7 +195,8 @@ async def test_block_update_connection_error(
 
     with pytest.raises(
         HomeAssistantError,
-        match="Device communication error occurred while triggering OTA update for Test name",
+        match="Device communication error occurred while triggering"
+        " OTA update for Test name",
     ):
         await hass.services.async_call(
             UPDATE_DOMAIN,
@@ -691,7 +692,8 @@ async def test_rpc_beta_update(
     [
         (
             DeviceConnectionError,
-            "Device communication error occurred while triggering OTA update for Test name",
+            "Device communication error occurred while triggering"
+            " OTA update for Test name",
         ),
         (
             RpcCallError(-1, "error"),

--- a/tests/components/shopping_list/test_todo.py
+++ b/tests/components/shopping_list/test_todo.py
@@ -70,7 +70,7 @@ async def test_get_items(
     sl_setup: None,
     ws_get_items: WsGetItemsType,
 ) -> None:
-    """Test creating a shopping list item with the WS API and verifying with To-do API."""
+    """Test creating a shopping list item via WS API."""
     client = await hass_ws_client(hass)
 
     state = hass.states.get(TEST_ENTITY)

--- a/tests/components/sia/test_config_flow.py
+++ b/tests/components/sia/test_config_flow.py
@@ -163,7 +163,7 @@ async def test_form_start_user(flow_at_user_step: ConfigFlowResult) -> None:
 
 
 async def test_form_start_account(flow_at_add_account_step: ConfigFlowResult) -> None:
-    """Start the form and check if you get the right id and schema for the additional account step."""
+    """Test the additional account step form id and schema."""
     assert flow_at_add_account_step["step_id"] == "add_account"
     assert flow_at_add_account_step["errors"] is None
     assert flow_at_add_account_step["data_schema"] == ACCOUNT_SCHEMA

--- a/tests/components/signal_messenger/test_notify.py
+++ b/tests/components/signal_messenger/test_notify.py
@@ -160,8 +160,8 @@ def test_send_message_styled_with_bad_data_throws_vol_error(
 
     assert "Sending signal message" in caplog.text
     assert (
-        "value must be one of ['normal', 'styled'] for dictionary value @ data['text_mode']"
-        in str(exc.value)
+        "value must be one of ['normal', 'styled'] for dictionary"
+        " value @ data['text_mode']" in str(exc.value)
     )
 
 
@@ -296,7 +296,7 @@ def test_get_attachments_with_large_attachment(
     signal_requests_mock_factory: Mocker,
     hass: HomeAssistant,
 ) -> None:
-    """Test getting attachments as URL with large attachment (per Content-Length header) throws error."""
+    """Test URL attachment with large Content-Length throws error."""
     signal_requests_mock = signal_requests_mock_factory(True, str(len(CONTENT) + 1))
     with pytest.raises(ValueError) as exc:
         signal_notification_service.get_attachments_as_bytes(
@@ -313,7 +313,7 @@ def test_get_attachments_with_large_attachment_no_header(
     signal_requests_mock_factory: Mocker,
     hass: HomeAssistant,
 ) -> None:
-    """Test getting attachments as URL with large attachment (per content length) throws error."""
+    """Test URL attachment with large content length throws error."""
     signal_requests_mock = signal_requests_mock_factory()
     with pytest.raises(ValueError) as exc:
         signal_notification_service.get_attachments_as_bytes(
@@ -398,7 +398,7 @@ def test_get_attachments_with_verify_set_true(
     signal_requests_mock_factory: Mocker,
     hass: HomeAssistant,
 ) -> None:
-    """Test getting attachments as URL with verify_ssl set to true results in verify=true."""
+    """Test URL attachment with verify_ssl=true uses verify=true."""
     signal_requests_mock = signal_requests_mock_factory()
     data = {"verify_ssl": True, "urls": [URL_ATTACHMENT]}
     signal_notification_service.get_attachments_as_bytes(data, len(CONTENT), hass)
@@ -413,7 +413,7 @@ def test_get_attachments_with_verify_set_false(
     signal_requests_mock_factory: Mocker,
     hass: HomeAssistant,
 ) -> None:
-    """Test getting attachments as URL with verify_ssl set to false results in verify=false."""
+    """Test URL attachment with verify_ssl=false uses verify=false."""
     signal_requests_mock = signal_requests_mock_factory()
     data = {"verify_ssl": False, "urls": [URL_ATTACHMENT]}
     signal_notification_service.get_attachments_as_bytes(data, len(CONTENT), hass)
@@ -427,7 +427,7 @@ def test_get_attachments_with_verify_set_garbage(
     signal_notification_service: SignalNotificationService,
     hass: HomeAssistant,
 ) -> None:
-    """Test getting attachments as URL with verify_ssl set to garbage results in None."""
+    """Test URL attachment with verify_ssl=garbage returns None."""
     data = {"verify_ssl": "test", "urls": [URL_ATTACHMENT]}
     result = signal_notification_service.get_attachments_as_bytes(
         data, len(CONTENT), hass

--- a/tests/components/simplisafe/test_init.py
+++ b/tests/components/simplisafe/test_init.py
@@ -85,7 +85,7 @@ async def test_coordinator_update_failure_keeps_entity_available(
     freezer: FrozenDateTimeFactory,
     exc: type[SimplipyError],
 ) -> None:
-    """Test that a single coordinator failure does not immediately mark entities unavailable."""
+    """Test single coordinator failure doesn't mark entities unavailable."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
@@ -117,8 +117,9 @@ async def test_websocket_event_updates_entity_state(
 
     assert hass.states.get("lock.front_door_lock").state == "locked"
 
-    # Fire an "unlock" websocket event for the test lock (system_id=12345, serial="987").
-    # CID 9700 maps to EVENT_LOCK_UNLOCKED in the simplipy event mapping.
+    # Fire an "unlock" websocket event for the test lock
+    # (system_id=12345, serial="987").
+    # CID 9700 maps to EVENT_LOCK_UNLOCKED in simplipy event mapping.
     event_callback(
         WebsocketEvent(
             event_cid=9700,

--- a/tests/components/siren/test_trigger.py
+++ b/tests/components/siren/test_trigger.py
@@ -96,7 +96,7 @@ async def test_siren_state_trigger_behavior_any(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test that the siren state trigger fires when any siren state changes to a specific state."""
+    """Test siren state trigger fires on any state change."""
     await assert_trigger_behavior_any(
         hass,
         target_entities=target_sirens,
@@ -139,7 +139,7 @@ async def test_siren_state_trigger_behavior_first(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test that the siren state trigger fires when the first siren changes to a specific state."""
+    """Test siren trigger fires on first siren state change."""
     await assert_trigger_behavior_first(
         hass,
         target_entities=target_sirens,
@@ -182,7 +182,7 @@ async def test_siren_state_trigger_behavior_last(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test that the siren state trigger fires when the last siren changes to a specific state."""
+    """Test siren trigger fires on last siren state change."""
     await assert_trigger_behavior_last(
         hass,
         target_entities=target_sirens,

--- a/tests/components/sleepiq/test_button.py
+++ b/tests/components/sleepiq/test_button.py
@@ -32,7 +32,9 @@ async def test_button_calibrate(
         BUTTON_DOMAIN,
         "press",
         {
-            ATTR_ENTITY_ID: f"button.{BED_NAME_LOWER}_sleepnumber_{BED_NAME_LOWER}_calibrate"
+            ATTR_ENTITY_ID: (
+                f"button.{BED_NAME_LOWER}_sleepnumber_{BED_NAME_LOWER}_calibrate"
+            )
         },
         blocking=True,
     )
@@ -65,7 +67,9 @@ async def test_button_stop_pump(
         BUTTON_DOMAIN,
         "press",
         {
-            ATTR_ENTITY_ID: f"button.{BED_NAME_LOWER}_sleepnumber_{BED_NAME_LOWER}_stop_pump"
+            ATTR_ENTITY_ID: (
+                f"button.{BED_NAME_LOWER}_sleepnumber_{BED_NAME_LOWER}_stop_pump"
+            )
         },
         blocking=True,
     )

--- a/tests/components/sleepiq/test_light.py
+++ b/tests/components/sleepiq/test_light.py
@@ -43,7 +43,9 @@ async def test_light_set_states(hass: HomeAssistant, mock_asyncsleepiq) -> None:
         LIGHT_DOMAIN,
         "turn_on",
         {
-            ATTR_ENTITY_ID: f"light.{BED_NAME_LOWER}_sleepnumber_{BED_NAME_LOWER}_light_1"
+            ATTR_ENTITY_ID: (
+                f"light.{BED_NAME_LOWER}_sleepnumber_{BED_NAME_LOWER}_light_1"
+            )
         },
         blocking=True,
     )
@@ -54,7 +56,9 @@ async def test_light_set_states(hass: HomeAssistant, mock_asyncsleepiq) -> None:
         LIGHT_DOMAIN,
         "turn_off",
         {
-            ATTR_ENTITY_ID: f"light.{BED_NAME_LOWER}_sleepnumber_{BED_NAME_LOWER}_light_1"
+            ATTR_ENTITY_ID: (
+                f"light.{BED_NAME_LOWER}_sleepnumber_{BED_NAME_LOWER}_light_1"
+            )
         },
         blocking=True,
     )

--- a/tests/components/sleepiq/test_number.py
+++ b/tests/components/sleepiq/test_number.py
@@ -74,7 +74,10 @@ async def test_firmness(
         NUMBER_DOMAIN,
         SERVICE_SET_VALUE,
         {
-            ATTR_ENTITY_ID: f"number.{BED_NAME_LOWER}_sleepnumber_{BED_NAME_LOWER}_{SLEEPER_L_NAME_LOWER}_firmness",
+            ATTR_ENTITY_ID: (
+                f"number.{BED_NAME_LOWER}_sleepnumber"
+                f"_{BED_NAME_LOWER}_{SLEEPER_L_NAME_LOWER}_firmness"
+            ),
             ATTR_VALUE: 42,
         },
         blocking=True,
@@ -88,7 +91,7 @@ async def test_firmness(
 async def test_actuators(
     hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_asyncsleepiq
 ) -> None:
-    """Test the SleepIQ actuator position values for a bed with adjustable head and foot."""
+    """Test SleepIQ actuator position values for adjustable bed."""
     entry = await setup_platform(hass, NUMBER_DOMAIN)
 
     state = hass.states.get(
@@ -152,7 +155,10 @@ async def test_actuators(
         NUMBER_DOMAIN,
         SERVICE_SET_VALUE,
         {
-            ATTR_ENTITY_ID: f"number.{BED_NAME_LOWER}_sleepnumber_{BED_NAME_LOWER}_right_head_position",
+            ATTR_ENTITY_ID: (
+                f"number.{BED_NAME_LOWER}_sleepnumber"
+                f"_{BED_NAME_LOWER}_right_head_position"
+            ),
             ATTR_VALUE: 42,
         },
         blocking=True,
@@ -196,7 +202,11 @@ async def test_foot_warmer_timer(
         NUMBER_DOMAIN,
         SERVICE_SET_VALUE,
         {
-            ATTR_ENTITY_ID: f"number.{BED_NAME_LOWER}_sleepnumber_{BED_NAME_LOWER}_{SLEEPER_L_NAME_LOWER}_foot_warming_timer",
+            ATTR_ENTITY_ID: (
+                f"number.{BED_NAME_LOWER}_sleepnumber"
+                f"_{BED_NAME_LOWER}"
+                f"_{SLEEPER_L_NAME_LOWER}_foot_warming_timer"
+            ),
             ATTR_VALUE: 300,
         },
         blocking=True,
@@ -235,7 +245,11 @@ async def test_core_climate_timer(
         NUMBER_DOMAIN,
         SERVICE_SET_VALUE,
         {
-            ATTR_ENTITY_ID: f"number.{BED_NAME_LOWER}_sleepnumber_{BED_NAME_LOWER}_{SLEEPER_L_NAME_LOWER}_core_climate_timer",
+            ATTR_ENTITY_ID: (
+                f"number.{BED_NAME_LOWER}_sleepnumber"
+                f"_{BED_NAME_LOWER}"
+                f"_{SLEEPER_L_NAME_LOWER}_core_climate_timer"
+            ),
             ATTR_VALUE: 420,
         },
         blocking=True,

--- a/tests/components/sleepiq/test_select.py
+++ b/tests/components/sleepiq/test_select.py
@@ -79,7 +79,10 @@ async def test_split_foundation_preset(
         SELECT_DOMAIN,
         SERVICE_SELECT_OPTION,
         {
-            ATTR_ENTITY_ID: f"select.{BED_NAME_LOWER}_sleepnumber_{BED_NAME_LOWER}_foundation_preset_left",
+            ATTR_ENTITY_ID: (
+                f"select.{BED_NAME_LOWER}_sleepnumber"
+                f"_{BED_NAME_LOWER}_foundation_preset_left"
+            ),
             ATTR_OPTION: "Zero G",
         },
         blocking=True,
@@ -120,7 +123,10 @@ async def test_single_foundation_preset(
         SELECT_DOMAIN,
         SERVICE_SELECT_OPTION,
         {
-            ATTR_ENTITY_ID: f"select.{BED_NAME_LOWER}_sleepnumber_{BED_NAME_LOWER}_foundation_preset",
+            ATTR_ENTITY_ID: (
+                f"select.{BED_NAME_LOWER}_sleepnumber"
+                f"_{BED_NAME_LOWER}_foundation_preset"
+            ),
             ATTR_OPTION: "Zero G",
         },
         blocking=True,
@@ -163,7 +169,11 @@ async def test_foot_warmer(
         SELECT_DOMAIN,
         SERVICE_SELECT_OPTION,
         {
-            ATTR_ENTITY_ID: f"select.{BED_NAME_LOWER}_sleepnumber_{BED_NAME_LOWER}_{SLEEPER_L_NAME_LOWER}_foot_warmer",
+            ATTR_ENTITY_ID: (
+                f"select.{BED_NAME_LOWER}_sleepnumber"
+                f"_{BED_NAME_LOWER}"
+                f"_{SLEEPER_L_NAME_LOWER}_foot_warmer"
+            ),
             ATTR_OPTION: "off",
         },
         blocking=True,
@@ -194,7 +204,11 @@ async def test_foot_warmer(
         SELECT_DOMAIN,
         SERVICE_SELECT_OPTION,
         {
-            ATTR_ENTITY_ID: f"select.{BED_NAME_LOWER}_sleepnumber_{BED_NAME_LOWER}_{SLEEPER_R_NAME_LOWER}_foot_warmer",
+            ATTR_ENTITY_ID: (
+                f"select.{BED_NAME_LOWER}_sleepnumber"
+                f"_{BED_NAME_LOWER}"
+                f"_{SLEEPER_R_NAME_LOWER}_foot_warmer"
+            ),
             ATTR_OPTION: "high",
         },
         blocking=True,
@@ -237,7 +251,11 @@ async def test_core_climate(
         SELECT_DOMAIN,
         SERVICE_SELECT_OPTION,
         {
-            ATTR_ENTITY_ID: f"select.{BED_NAME_LOWER}_sleepnumber_{BED_NAME_LOWER}_{SLEEPER_L_NAME_LOWER}_core_climate",
+            ATTR_ENTITY_ID: (
+                f"select.{BED_NAME_LOWER}_sleepnumber"
+                f"_{BED_NAME_LOWER}"
+                f"_{SLEEPER_L_NAME_LOWER}_core_climate"
+            ),
             ATTR_OPTION: "off",
         },
         blocking=True,
@@ -268,7 +286,11 @@ async def test_core_climate(
         SELECT_DOMAIN,
         SERVICE_SELECT_OPTION,
         {
-            ATTR_ENTITY_ID: f"select.{BED_NAME_LOWER}_sleepnumber_{BED_NAME_LOWER}_{SLEEPER_R_NAME_LOWER}_core_climate",
+            ATTR_ENTITY_ID: (
+                f"select.{BED_NAME_LOWER}_sleepnumber"
+                f"_{BED_NAME_LOWER}"
+                f"_{SLEEPER_R_NAME_LOWER}_core_climate"
+            ),
             ATTR_OPTION: "heating_high",
         },
         blocking=True,

--- a/tests/components/sleepiq/test_switch.py
+++ b/tests/components/sleepiq/test_switch.py
@@ -36,7 +36,9 @@ async def test_switch_set_states(hass: HomeAssistant, mock_asyncsleepiq) -> None
         SWITCH_DOMAIN,
         "turn_off",
         {
-            ATTR_ENTITY_ID: f"switch.{BED_NAME_LOWER}_sleepnumber_{BED_NAME_LOWER}_pause_mode"
+            ATTR_ENTITY_ID: (
+                f"switch.{BED_NAME_LOWER}_sleepnumber_{BED_NAME_LOWER}_pause_mode"
+            )
         },
         blocking=True,
     )
@@ -47,7 +49,9 @@ async def test_switch_set_states(hass: HomeAssistant, mock_asyncsleepiq) -> None
         SWITCH_DOMAIN,
         "turn_on",
         {
-            ATTR_ENTITY_ID: f"switch.{BED_NAME_LOWER}_sleepnumber_{BED_NAME_LOWER}_pause_mode"
+            ATTR_ENTITY_ID: (
+                f"switch.{BED_NAME_LOWER}_sleepnumber_{BED_NAME_LOWER}_pause_mode"
+            )
         },
         blocking=True,
     )

--- a/tests/components/slide_local/conftest.py
+++ b/tests/components/slide_local/conftest.py
@@ -36,7 +36,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 @pytest.fixture
 def mock_slide_api() -> Generator[AsyncMock]:
-    """Build a fixture for the SlideLocalApi that connects successfully and returns one device."""
+    """Build a fixture for the SlideLocalApi that connects successfully."""
 
     with (
         patch(

--- a/tests/components/slide_local/test_switch.py
+++ b/tests/components/slide_local/test_switch.py
@@ -91,7 +91,10 @@ async def test_service_exception(
 
     with pytest.raises(
         HomeAssistantError,
-        match=f"Error while sending the request setting Touch&Go to {service[5:]} to the device",
+        match=(
+            "Error while sending the request setting Touch&Go"
+            f" to {service[5:]} to the device"
+        ),
     ):
         await hass.services.async_call(
             SWITCH_DOMAIN,

--- a/tests/components/smappee/test_config_flow.py
+++ b/tests/components/smappee/test_config_flow.py
@@ -146,7 +146,7 @@ async def test_connection_error(hass: HomeAssistant) -> None:
 
 
 async def test_user_local_connection_error(hass: HomeAssistant) -> None:
-    """Test we show user form on Smappee connection error in local next generation option."""
+    """Test user form on Smappee local connection error."""
     with (
         patch("pysmappee.api.SmappeeLocalApi.logon", return_value=None),
         patch("pysmappee.mqtt.SmappeeLocalMqtt.start_attempt", return_value=True),
@@ -373,7 +373,7 @@ async def test_zeroconf_abort_if_cloud_device_exists(hass: HomeAssistant) -> Non
 async def test_zeroconf_confirm_abort_if_cloud_device_exists(
     hass: HomeAssistant,
 ) -> None:
-    """Test we abort zeroconf confirm flow if Smappee Cloud device already configured."""
+    """Test zeroconf abort if Cloud device already configured."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},

--- a/tests/components/smartthings/test_init.py
+++ b/tests/components/smartthings/test_init.py
@@ -61,11 +61,13 @@ async def test_fixtures() -> None:
     for fixture_name in DEVICE_FIXTURES:
         for device_details in get_device_response(fixture_name).items:
             assert device_details.device_id not in device_ids, (
-                f"Duplicate device ID {device_details.device_id} found in fixture {fixture_name}"
+                f"Duplicate device ID {device_details.device_id}"
+                f" found in fixture {fixture_name}"
             )
             device_ids.add(device_details.device_id)
             assert (label := device_details.label.lower()) not in device_labels, (
-                f"Duplicate device label {device_details.label} found in fixture {fixture_name}"
+                f"Duplicate device label {device_details.label}"
+                f" found in fixture {fixture_name}"
             )
             device_labels.add(label)
 

--- a/tests/components/smartthings/test_light.py
+++ b/tests/components/smartthings/test_light.py
@@ -656,7 +656,7 @@ async def test_lamp_switch_not_used_when_off_in_supported_levels(
     service: str,
     argument: str,
 ) -> None:
-    """Test samsungce.lamp on/off uses brightness commands when 'off' is in supported levels, even with switch capability."""
+    """Test samsungce.lamp uses brightness when 'off' in levels."""
     # Modify the device status to include "off" in supported brightness levels
     # This simulates a device where the switch doesn't control the lamp
     set_attribute_value(

--- a/tests/components/smartthings/test_sensor.py
+++ b/tests/components/smartthings/test_sensor.py
@@ -152,7 +152,7 @@ async def test_create_issue_with_items(
     expected_state: str,
     version: str,
 ) -> None:
-    """Test we create an issue when an automation or script is using a deprecated entity."""
+    """Test issue for automation/script using deprecated entity."""
     issue_id = f"deprecated_{issue_string}_{entity_id}"
 
     entity_entry = entity_registry.async_get_or_create(
@@ -211,7 +211,9 @@ async def test_create_issue_with_items(
     assert issue.translation_placeholders == {
         "entity_id": entity_id,
         "entity_name": suggested_object_id,
-        "items": "- [test](/config/automation/edit/test)\n- [test](/config/script/edit/test)",
+        "items": (
+            "- [test](/config/automation/edit/test)\n- [test](/config/script/edit/test)"
+        ),
     }
     assert issue.breaks_in_ha_version == version
 
@@ -316,7 +318,7 @@ async def test_create_issue(
     expected_state: str,
     version: str,
 ) -> None:
-    """Test we create an issue when an automation or script is using a deprecated entity."""
+    """Test issue for automation/script using deprecated entity."""
     issue_id = f"deprecated_{issue_string}_{entity_id}"
 
     entity_entry = entity_registry.async_get_or_create(

--- a/tests/components/smartthings/test_switch.py
+++ b/tests/components/smartthings/test_switch.py
@@ -308,7 +308,7 @@ async def test_create_issue_with_items(
     suggested_object_id: str,
     issue_string: str,
 ) -> None:
-    """Test we create an issue when an automation or script is using a deprecated entity."""
+    """Test issue for automation/script using deprecated entity."""
     entity_id = f"switch.{suggested_object_id}"
     issue_id = f"deprecated_switch_{issue_string}_{entity_id}"
 
@@ -368,7 +368,9 @@ async def test_create_issue_with_items(
     assert issue.translation_placeholders == {
         "entity_id": entity_id,
         "entity_name": suggested_object_id,
-        "items": "- [test](/config/automation/edit/test)\n- [test](/config/script/edit/test)",
+        "items": (
+            "- [test](/config/automation/edit/test)\n- [test](/config/script/edit/test)"
+        ),
     }
 
     entity_registry.async_update_entity(
@@ -469,7 +471,7 @@ async def test_create_issue(
     issue_string: str,
     version: str,
 ) -> None:
-    """Test we create an issue when an automation or script is using a deprecated entity."""
+    """Test issue for automation/script using deprecated entity."""
     entity_id = f"switch.{suggested_object_id}"
     issue_id = f"deprecated_switch_{issue_string}_{entity_id}"
 

--- a/tests/components/smarttub/test_config_flow.py
+++ b/tests/components/smarttub/test_config_flow.py
@@ -96,7 +96,7 @@ async def test_reauth_success(hass: HomeAssistant, smarttub_api, config_entry) -
 async def test_reauth_wrong_account(
     hass: HomeAssistant, smarttub_api, account, config_entry
 ) -> None:
-    """Test reauthentication flow if the user enters credentials for a different already-configured account."""
+    """Test reauth flow with credentials for a different account."""
     config_entry.add_to_hass(hass)
 
     mock_entry2 = MockConfigEntry(

--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -98,7 +98,8 @@ HTML = """
                 <h1>Intruder alert at apartment!!</h1>
               </div>
               <div>
-                <img alt="tests/testing_config/notify/test.jpg" src="cid:tests/testing_config/notify/test.jpg"/>
+                <img alt="tests/testing_config/notify/test.jpg"\
+ src="cid:tests/testing_config/notify/test.jpg"/>
               </div>
             </body>
         </html>"""

--- a/tests/components/snapcast/test_media_player.py
+++ b/tests/components/snapcast/test_media_player.py
@@ -112,7 +112,7 @@ async def test_join_non_snapcast_client(
     mock_create_server: AsyncMock,
     mock_group_1: AsyncMock,
 ) -> None:
-    """Test join service throws an exception when trying to add a non-Snapcast client."""
+    """Test join throws when trying to add a non-Snapcast client."""
 
     # Create a dummy media player entity
     entity_registry.async_get_or_create(
@@ -152,7 +152,7 @@ async def test_join_different_server(
     mock_create_server: AsyncMock,
     mock_group_1: AsyncMock,
 ) -> None:
-    """Test join service throws an exception when trying to join a Snapcast client from another server."""
+    """Test join throws when joining a Snapcast client from another server."""
 
     # Create a dummy Snapcast client with a different unique_id prefix
     entity_registry.async_get_or_create(
@@ -196,7 +196,8 @@ async def test_join_client_key_error(
 ) -> None:
     """Test join service throws an exception when a key error is thrown."""
 
-    # add_client will throw a KeyError if the client identifier is not found on the server
+    # add_client will throw a KeyError if the client identifier
+    # is not found on the server
     mock_group_1.add_client = AsyncMock(side_effect=KeyError())
 
     # Setup and verify the integration is loaded
@@ -320,7 +321,7 @@ async def test_select_source_group_is_none(
     mock_client_1: AsyncMock,
     mock_group_1: AsyncMock,
 ) -> None:
-    """Test the select source action throws a service validation error when a client has no group."""
+    """Test select source throws a validation error when client has no group."""
     # Force nonexistent group
     mock_client_1.group = None
 
@@ -378,7 +379,7 @@ async def test_unjoin_group_is_none(
     mock_client_1: AsyncMock,
     mock_group_1: AsyncMock,
 ) -> None:
-    """Test the unjoin action throws a service validation error when a client has no group."""
+    """Test unjoin throws a validation error when client has no group."""
     # Force nonexistent group
     mock_client_1.group = None
 

--- a/tests/components/snoo/test_event.py
+++ b/tests/components/snoo/test_event.py
@@ -30,7 +30,7 @@ async def test_events(hass: HomeAssistant, bypass_api: AsyncMock) -> None:
 async def test_events_data_on_startup(
     hass: HomeAssistant, bypass_api: AsyncMock
 ) -> None:
-    """Test events and check test values are correctly set if data exists on first update."""
+    """Test events are correctly set if data exists on first update."""
 
     def update_status(_):
         find_update_callback(bypass_api, "random_num")(MOCK_SNOO_DATA)

--- a/tests/components/snooz/test_config_flow.py
+++ b/tests/components/snooz/test_config_flow.py
@@ -35,7 +35,7 @@ async def test_async_step_bluetooth_valid_device(hass: HomeAssistant) -> None:
 
 
 async def test_async_step_bluetooth_waits_to_pair(hass: HomeAssistant) -> None:
-    """Test discovery via bluetooth with a device that's not in pairing mode, but enters pairing mode to complete setup."""
+    """Test discovery with a device not in pairing mode that enters it."""
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -50,7 +50,7 @@ async def test_async_step_bluetooth_waits_to_pair(hass: HomeAssistant) -> None:
 
 
 async def test_async_step_bluetooth_retries_pairing(hass: HomeAssistant) -> None:
-    """Test discovery via bluetooth with a device that's not in pairing mode, times out waiting, but eventually complete setup."""
+    """Test discovery retries pairing after timeout and completes setup."""
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -109,7 +109,7 @@ async def test_async_step_user_with_found_devices(hass: HomeAssistant) -> None:
 async def test_async_step_user_with_found_devices_waits_to_pair(
     hass: HomeAssistant,
 ) -> None:
-    """Test setup from service info cache with devices found that require pairing mode."""
+    """Test setup from service info cache with devices requiring pairing."""
     with patch(
         "homeassistant.components.snooz.config_flow.async_discovered_service_info",
         return_value=[SNOOZ_SERVICE_INFO_NOT_PAIRING],
@@ -127,7 +127,7 @@ async def test_async_step_user_with_found_devices_waits_to_pair(
 async def test_async_step_user_with_found_devices_retries_pairing(
     hass: HomeAssistant,
 ) -> None:
-    """Test setup from service info cache with devices found that require pairing mode, times out, then completes."""
+    """Test setup from service info cache retries pairing then completes."""
     with patch(
         "homeassistant.components.snooz.config_flow.async_discovered_service_info",
         return_value=[SNOOZ_SERVICE_INFO_NOT_PAIRING],

--- a/tests/components/snooz/test_init.py
+++ b/tests/components/snooz/test_init.py
@@ -8,7 +8,7 @@ from . import SnoozFixture
 async def test_removing_entry_cleans_up_connections(
     hass: HomeAssistant, mock_connected_snooz: SnoozFixture
 ) -> None:
-    """Tests setup and removal of a config entry, ensuring connections are cleaned up."""
+    """Tests setup and removal of a config entry, cleaning up connections."""
     await hass.config_entries.async_remove(mock_connected_snooz.entry.entry_id)
     await hass.async_block_till_done()
 

--- a/tests/components/solaredge/test_config_flow.py
+++ b/tests/components/solaredge/test_config_flow.py
@@ -173,7 +173,7 @@ async def test_abort_if_already_setup(
 async def test_ignored_entry_does_not_cause_error(
     recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
-    """Test an ignored entry does not cause and error and we can still create an new entry."""
+    """Test an ignored entry does not cause an error on new entry."""
     MockConfigEntry(
         domain="solaredge",
         data={CONF_NAME: DEFAULT_NAME, CONF_API_KEY: API_KEY},

--- a/tests/components/solaredge/test_coordinator.py
+++ b/tests/components/solaredge/test_coordinator.py
@@ -140,7 +140,8 @@ async def _trigger_and_wait_for_refresh(
     """Trigger a coordinator refresh and wait for it to complete."""
     # The coordinator refresh runs in the background.
     # To reliably assert the result, we need to wait for the refresh to complete.
-    # We patch the coordinator's update method to signal completion via an asyncio.Event.
+    # We patch the coordinator's update method to signal completion
+    # via an asyncio.Event.
     refresh_done = asyncio.Event()
     original_update = coordinator._async_update_data
 
@@ -332,7 +333,7 @@ async def test_modules_coordinator_subsequent_run_with_gap(
     freezer: FrozenDateTimeFactory,
     mock_solar_edge_web: AsyncMock,
 ) -> None:
-    """Test the coordinator correctly updates statistics on subsequent runs with a gap in data."""
+    """Test the coordinator updates statistics with a gap in data."""
     mock_solar_edge_web.async_get_equipment.return_value = {
         1001: {"displayName": "1.1"},
     }

--- a/tests/components/solaredge/test_sensor.py
+++ b/tests/components/solaredge/test_sensor.py
@@ -73,7 +73,7 @@ async def test_all_entities(
     mock_config_entry: MockConfigEntry,
     solaredge_api: Mock,
 ) -> None:
-    """Test all sensor entities are created with the correct state and registry entry."""
+    """Test all sensors are created with correct state and registry."""
     with patch("homeassistant.components.solaredge.PLATFORMS", [Platform.SENSOR]):
         await setup_integration(hass, mock_config_entry)
 
@@ -111,7 +111,7 @@ async def test_storage_level_unknown_when_storage_missing(
     mock_config_entry: MockConfigEntry,
     solaredge_api: Mock,
 ) -> None:
-    """Test storage_level returns None (unknown) when site has no storage in flow data."""
+    """Test storage_level returns None when site has no storage."""
     power_flow = solaredge_api.get_current_power_flow.return_value
     power_flow["siteCurrentPowerFlow"].pop("STORAGE")
     # Drop STORAGE from connections too so the data service does not reference it.
@@ -161,7 +161,7 @@ async def test_sensor_unavailable_on_data_service_keyerror(
     api_method: str,
     sensor_id: str,
 ) -> None:
-    """Test sensors become unavailable when a data service refresh raises UpdateFailed."""
+    """Test sensors become unavailable on UpdateFailed."""
     getattr(solaredge_api, api_method).return_value = {}
 
     await setup_integration(hass, mock_config_entry)
@@ -220,7 +220,7 @@ async def test_energy_details_filters_meters(
     mock_config_entry: MockConfigEntry,
     solaredge_api: Mock,
 ) -> None:
-    """Test energy details data service skips meters without type/values and unsupported types."""
+    """Test energy details skips meters without type/values."""
     solaredge_api.get_energy_details.return_value = {
         "energyDetails": {
             "unit": "Wh",
@@ -277,7 +277,7 @@ async def test_power_flow_grid_export_storage_discharge(
     mock_config_entry: MockConfigEntry,
     solaredge_api: Mock,
 ) -> None:
-    """Test power flow sign flipping for grid export and reports for storage discharge."""
+    """Test power flow sign flipping for grid export and storage."""
     solaredge_api.get_current_power_flow.return_value = {
         "siteCurrentPowerFlow": {
             "unit": "W",
@@ -507,7 +507,7 @@ async def test_storage_data_missing_keys_in_response(
     entity_registry: er.EntityRegistry,
     bad_response: dict,
 ) -> None:
-    """Test storage sensors are unavailable when the response is missing required keys."""
+    """Test storage sensors unavailable with missing required keys."""
     solaredge_api.get_storage_data.return_value = bad_response
 
     await setup_integration(hass, mock_config_entry)
@@ -627,7 +627,7 @@ async def test_storage_data_service_handles_malformed_responses(
     storage_response: dict,
     expected_charge_state: str,
 ) -> None:
-    """Test storage data service tolerates batteries without serial / telemetries / single telemetry."""
+    """Test storage tolerates batteries without serial/telemetries."""
     solaredge_api.get_storage_data.return_value = storage_response
 
     await setup_integration(hass, mock_config_entry)
@@ -649,7 +649,7 @@ async def test_inventory_battery_without_serial_skipped(
     solaredge_api: Mock,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test inventory batteries without a serial number are skipped for per-battery sensors."""
+    """Test batteries without serial are skipped for per-battery sensors."""
     inventory = solaredge_api.get_inventory.return_value
     inventory["Inventory"]["batteries"] = [{"name": "Battery without serial"}]
 
@@ -682,7 +682,7 @@ async def test_storage_service_not_retried_after_recovery_with_no_batteries(
     solaredge_api: Mock,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test storage service stays idle when inventory recovers but reports no batteries."""
+    """Test storage stays idle when inventory has no batteries."""
     solaredge_api.get_inventory.side_effect = KeyError("Inventory")
 
     await setup_integration(hass, mock_config_entry)

--- a/tests/components/solarlog/conftest.py
+++ b/tests/components/solarlog/conftest.py
@@ -32,7 +32,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 @pytest.fixture
 def mock_solarlog_connector():
-    """Build a fixture for the SolarLog API that connects successfully and returns one device."""
+    """Build a fixture for the SolarLog API that connects successfully."""
 
     mock_solarlog_api = AsyncMock()
     mock_solarlog_api.device_name = {0: "Inverter 1", 1: "Inverter 2"}.get

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -121,7 +121,8 @@ class SonosMockEvent:
             soco: The mock SoCo device associated with this event.
             service: The Sonos mock service that generated the event.
             variables: A dictionary of event variables and their values.
-            zone_player_uui_ds_in_group: Optional comma-separated string of unique zone IDs in the group.
+            zone_player_uui_ds_in_group: Optional comma-separated string
+                of unique zone IDs in the group.
 
         """
         self.sid = f"{soco.uid}_sub0000000001"
@@ -227,7 +228,7 @@ class MockSoCo(MagicMock):
 
     @property
     def visible_zones(self):
-        """Return visible zones and allow property to be overridden by device classes."""
+        """Return visible zones, overridable by device classes."""
         return {self}
 
     @property
@@ -684,9 +685,12 @@ def alarm_clock_fixture() -> SonosMockAlarmClock:
         {
             "CurrentAlarmListVersion": "RINCON_test:14",
             "CurrentAlarmList": "<Alarms>"
-            '<Alarm ID="14" StartTime="07:00:00" Duration="02:00:00" Recurrence="DAILY" '
-            'Enabled="1" RoomUUID="RINCON_test" ProgramURI="x-rincon-buzzer:0" '
-            'ProgramMetaData="" PlayMode="SHUFFLE_NOREPEAT" Volume="25" '
+            '<Alarm ID="14" StartTime="07:00:00"'
+            ' Duration="02:00:00" Recurrence="DAILY" '
+            'Enabled="1" RoomUUID="RINCON_test"'
+            ' ProgramURI="x-rincon-buzzer:0" '
+            'ProgramMetaData="" PlayMode="SHUFFLE_NOREPEAT"'
+            ' Volume="25" '
             'IncludeLinkedZones="0"/>'
             "</Alarms>",
         }
@@ -700,13 +704,15 @@ def alarm_clock_fixture_extended() -> SonosMockAlarmClock:
         {
             "CurrentAlarmListVersion": "RINCON_test:15",
             "CurrentAlarmList": "<Alarms>"
-            '<Alarm ID="14" StartTime="07:00:00" Duration="02:00:00" Recurrence="DAILY" '
+            '<Alarm ID="14" StartTime="07:00:00" Duration="02:00:00"'
+            ' Recurrence="DAILY" '
             'Enabled="1" RoomUUID="RINCON_test" ProgramURI="x-rincon-buzzer:0" '
             'ProgramMetaData="" PlayMode="SHUFFLE_NOREPEAT" Volume="25" '
             'IncludeLinkedZones="0"/>'
             '<Alarm ID="15" StartTime="07:00:00" Duration="02:00:00" '
             'Recurrence="DAILY" Enabled="1" RoomUUID="RINCON_test" '
-            'ProgramURI="x-rincon-buzzer:0" ProgramMetaData="" PlayMode="SHUFFLE_NOREPEAT" '
+            'ProgramURI="x-rincon-buzzer:0" ProgramMetaData=""'
+            ' PlayMode="SHUFFLE_NOREPEAT" '
             'Volume="25" IncludeLinkedZones="0"/>'
             "</Alarms>",
         }
@@ -793,7 +799,10 @@ def alarm_event_fixture(soco):
     """Create alarm_event fixture."""
     variables = {
         "time_zone": "ffc40a000503000003000502ffc4",
-        "time_server": "0.sonostime.pool.ntp.org,1.sonostime.pool.ntp.org,2.sonostime.pool.ntp.org,3.sonostime.pool.ntp.org",
+        "time_server": (
+            "0.sonostime.pool.ntp.org,1.sonostime.pool.ntp.org,"
+            "2.sonostime.pool.ntp.org,3.sonostime.pool.ntp.org"
+        ),
         "time_generation": "20000001",
         "alarm_list_version": "RINCON_test:1",
         "time_format": "INV",
@@ -959,7 +968,7 @@ def create_zgs_sonos_event(
     soco_2: MockSoCo,
     create_uui_ds_in_group: bool = True,
 ) -> SonosMockEvent:
-    """Create a Sonos Event for zone group state, with the option of creating the uui_ds_in_group."""
+    """Create a Sonos Event for zone group state."""
     zgs = load_fixture(fixture_file, DOMAIN)
     variables = {}
     variables["ZoneGroupState"] = zgs

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -126,7 +126,7 @@ async def test_device_registry_not_portable(
     async_setup_sonos,
     soco,
 ) -> None:
-    """Test non-portable sonos device registered in the device registry to ensure area suggested."""
+    """Test non-portable sonos device has area suggested."""
     soco.get_battery_info.return_value = {}
     await async_setup_sonos()
 
@@ -753,25 +753,73 @@ async def test_select_source_line_in_tv(
                 "play_uri": 1,
                 "play_uri_uri": "x-sonosapi-radio:ST%3aetc",
                 "play_uri_title": "James Taylor Radio",
-                "play_uri_meta": '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"><item id="100c2068ST%3a1683194971234567890" parentID="10fe2064myStations" restricted="true"><dc:title>James Taylor Radio</dc:title><upnp:class>object.item.audioItem.audioBroadcast.#station</upnp:class><desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON60423_X_#Svc60423-99999999-Token</desc></item></DIDL-Lite>',
+                "play_uri_meta": (
+                    '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/"'
+                    ' xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"'
+                    ' xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/"'
+                    ' xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">'
+                    '<item id="100c2068ST%3a1683194971234567890"'
+                    ' parentID="10fe2064myStations" restricted="true">'
+                    "<dc:title>James Taylor Radio</dc:title>"
+                    "<upnp:class>object.item.audioItem.audioBroadcast"
+                    ".#station</upnp:class>"
+                    '<desc id="cdudn"'
+                    ' nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">'
+                    "SA_RINCON60423_X_#Svc60423-99999999-Token"
+                    "</desc></item></DIDL-Lite>"
+                ),
             },
         ),
         (
             "66 - Watercolors",
             {
                 "play_uri": 1,
-                "play_uri_uri": "x-sonosapi-hls:Api%3atune%3aliveAudio%3ajazzcafe%3aetc",
+                "play_uri_uri": (
+                    "x-sonosapi-hls:Api%3atune%3aliveAudio%3ajazzcafe%3aetc"
+                ),
                 "play_uri_title": "66 - Watercolors",
-                "play_uri_meta": '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"><item id="10090120Api%3atune%3aliveAudio%3ajazzcafe%3ae4b5402c-9999-9999-9999-4bc8e2cdccce" parentID="10086064live%3f93b0b9cb-9999-9999-9999-bcf75971fcfe" restricted="false"><dc:title>66 - Watercolors</dc:title><upnp:class>object.item.audioItem.audioBroadcast</upnp:class><desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON9479_X_#Svc9479-99999999-Token</desc></item></DIDL-Lite>',
+                "play_uri_meta": (
+                    '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/"'
+                    ' xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"'
+                    ' xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/"'
+                    ' xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">'
+                    '<item id="10090120Api%3atune%3aliveAudio%3ajazzcafe'
+                    '%3ae4b5402c-9999-9999-9999-4bc8e2cdccce"'
+                    ' parentID="10086064live%3f93b0b9cb-9999-9999-9999'
+                    '-bcf75971fcfe" restricted="false">'
+                    "<dc:title>66 - Watercolors</dc:title>"
+                    "<upnp:class>object.item.audioItem.audioBroadcast"
+                    "</upnp:class>"
+                    '<desc id="cdudn"'
+                    ' nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">'
+                    "SA_RINCON9479_X_#Svc9479-99999999-Token"
+                    "</desc></item></DIDL-Lite>"
+                ),
             },
         ),
         (
             "American Tall Tales",
             {
                 "play_uri": 1,
-                "play_uri_uri": "x-rincon-cpcontainer:101340c8reftitle%C9F27_com?sid=239&flags=16584&sn=5",
+                "play_uri_uri": (
+                    "x-rincon-cpcontainer:101340c8reftitle"
+                    "%C9F27_com?sid=239&flags=16584&sn=5"
+                ),
                 "play_uri_title": "American Tall Tales",
-                "play_uri_meta": '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"><item id="101340c8reftitleC9F27_com" parentID="101340c8reftitleC9F27_com" restricted="true"><dc:title>American Tall Tales</dc:title><upnp:class>object.item.audioItem.audioBook</upnp:class><desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON61191_X_#Svc6-0-Token</desc></item></DIDL-Lite>',
+                "play_uri_meta": (
+                    '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/"'
+                    ' xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"'
+                    ' xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/"'
+                    ' xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">'
+                    '<item id="101340c8reftitleC9F27_com"'
+                    ' parentID="101340c8reftitleC9F27_com" restricted="true">'
+                    "<dc:title>American Tall Tales</dc:title>"
+                    "<upnp:class>object.item.audioItem.audioBook</upnp:class>"
+                    '<desc id="cdudn"'
+                    ' nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">'
+                    "SA_RINCON61191_X_#Svc6-0-Token"
+                    "</desc></item></DIDL-Lite>"
+                ),
             },
         ),
     ],

--- a/tests/components/sonos/test_services.py
+++ b/tests/components/sonos/test_services.py
@@ -54,8 +54,8 @@ async def test_media_player_join(
             blocking=False,
         )
         await join_complete_event.wait()
-        # Fire the ZGS event to update the speaker grouping as the join method is waiting
-        # for the speakers to be regrouped.
+        # Fire the ZGS event to update the speaker grouping as
+        # the join method is waiting for the speakers to be regrouped.
         group_speakers(soco_living_room, soco_bedroom)
         await hass.async_block_till_done(wait_background_tasks=True)
 

--- a/tests/components/sonos/test_speaker.py
+++ b/tests/components/sonos/test_speaker.py
@@ -45,7 +45,8 @@ async def test_fallback_to_polling(
 
     caplog.clear()
 
-    # Ensure subscriptions are cancelled and polling methods are called when subscriptions time out
+    # Ensure subscriptions are cancelled and polling methods are
+    # called when subscriptions time out
     with (
         patch("homeassistant.components.sonos.media.SonosMedia.poll_media"),
         patch(
@@ -105,8 +106,9 @@ async def test_zgs_event_group_speakers(
     hass: HomeAssistant, sonos_setup_two_speakers: list[MockSoCo]
 ) -> None:
     """Tests grouping and ungrouping two speakers."""
-    # When Sonos speakers are grouped; one of the speakers is the coordinator and is in charge
-    # of playback across both speakers. Hence, service calls to play or pause on media_players
+    # When Sonos speakers are grouped; one of the speakers is the coordinator
+    # and is in charge of playback across both speakers. Hence, service calls
+    # to play or pause on media_players
     # that are part of the group are routed to the coordinator.
     soco_lr = sonos_setup_two_speakers[0]
     soco_br = sonos_setup_two_speakers[1]

--- a/tests/components/sonos/test_switch.py
+++ b/tests/components/sonos/test_switch.py
@@ -179,7 +179,7 @@ async def test_switch_speech_enhancement(
     model: str,
     attribute: str,
 ) -> None:
-    """Tests the speech enhancement switch and attribute substitution for different models."""
+    """Tests speech enhancement switch and attribute substitution."""
     entity_id = "switch.zone_a_speech_enhancement"
     speaker_info["model_name"] = model
     soco.get_speaker_info.return_value = speaker_info
@@ -572,7 +572,7 @@ async def test_tv_ungroup_autoplay_unavailable_when_linked_zones_missing(
     soco: MockSoCo,
     speaker_info: dict[str, str],
 ) -> None:
-    """Test ungroup-on-autoplay becomes unavailable when IncludeLinkedZones is absent."""
+    """Test ungroup-on-autoplay unavailable without IncludeLinkedZones."""
     entity_id = f"switch.zone_a_{ATTR_TV_UNGROUP_AUTOPLAY}"
 
     speaker_info["model_name"] = "Sonos Beam"
@@ -634,7 +634,7 @@ async def test_tv_ungroup_autoplay_not_created_for_non_ht(
     async_autosetup_sonos,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test that ungroup-on-autoplay switch is not created when device raises SoCoUPnPException.
+    """Test ungroup-on-autoplay switch not created on SoCoUPnPException.
 
     Non-HT devices don't support the GetAutoplayLinkedZones action and raise
     SoCoUPnPException, which is the capability check we rely on. The conftest
@@ -655,7 +655,8 @@ async def test_alarm_update_exception_logs_warning(
     with patch(
         "homeassistant.components.sonos.alarms.Alarms.update",
         side_effect=SoCoException(
-            "Alarm list UID RINCON_0001234567890:31 does not match RINCON_000E987654321:0"
+            "Alarm list UID RINCON_0001234567890:31"
+            " does not match RINCON_000E987654321:0"
         ),
     ):
         await async_setup_sonos()
@@ -674,7 +675,7 @@ async def test_alarm_setup_for_undiscovered_speaker(
     soco_factory: SoCoMockFactory,
     discover,
 ) -> None:
-    """Test for creation of alarm on a speaker that is discovered after the integration is setup."""
+    """Test alarm creation on a speaker discovered after setup."""
 
     soco_bedroom = soco_factory.cache_mock(MockSoCo(), "10.10.10.2", "Bedroom")
     one_alarm = copy(alarm_clock.ListAlarms.return_value)

--- a/tests/components/splunk/test_init.py
+++ b/tests/components/splunk/test_init.py
@@ -394,7 +394,8 @@ async def test_yaml_import_already_configured_creates_deprecation_issue(
     # Add existing config entry before YAML import
     mock_config_entry.add_to_hass(hass)
 
-    # Set up component with YAML - should see existing entry and abort with single_instance_allowed
+    # Set up component with YAML - should see existing entry and
+    # abort with single_instance_allowed
     assert await async_setup_component(
         hass,
         DOMAIN,

--- a/tests/components/spotify/test_init.py
+++ b/tests/components/spotify/test_init.py
@@ -64,7 +64,8 @@ async def test_setup_free_account_is_failing(
 ) -> None:
     """Test the Spotify setup with a free account is failing."""
     mock_spotify.return_value.get_current_user.side_effect = SpotifyForbiddenError(
-        "Check settings on developer.spotify.com/dashboard, the user may not be registered."
+        "Check settings on developer.spotify.com/dashboard,"
+        " the user may not be registered."
     )
     mock_config_entry.add_to_hass(hass)
 

--- a/tests/components/spotify/test_media_player.py
+++ b/tests/components/spotify/test_media_player.py
@@ -600,7 +600,8 @@ async def test_fallback_show_image(
     assert state
     assert (
         state.attributes[ATTR_ENTITY_PICTURE]
-        == "/api/media_player_proxy/media_player.spotify_spotify_1?token=mock-token&cache=16ff384dbae94fea"
+        == "/api/media_player_proxy/media_player.spotify_spotify_1"
+        "?token=mock-token&cache=16ff384dbae94fea"
     )
 
 

--- a/tests/components/sql/__init__.py
+++ b/tests/components/sql/__init__.py
@@ -63,7 +63,10 @@ ENTRY_CONFIG_WITH_VALUE_TEMPLATE = {
 }
 
 ENTRY_CONFIG_WITH_QUERY_TEMPLATE = {
-    CONF_QUERY: "SELECT {% if states('sensor.input1')=='on' %} 5 {% else %} 6 {% endif %} as value",
+    CONF_QUERY: (
+        "SELECT {% if states('sensor.input1')=='on' %}"
+        " 5 {% else %} 6 {% endif %} as value"
+    ),
     CONF_COLUMN_NAME: "value",
     CONF_ADVANCED_OPTIONS: {
         CONF_UNIT_OF_MEASUREMENT: "MiB",
@@ -144,7 +147,10 @@ ENTRY_CONFIG_INVALID_QUERY_3_OPT = {
 
 
 ENTRY_CONFIG_QUERY_READ_ONLY_CTE = {
-    CONF_QUERY: "WITH test AS (SELECT 1 AS row_num, 10 AS state) SELECT state FROM test WHERE row_num = 1 LIMIT 1;",
+    CONF_QUERY: (
+        "WITH test AS (SELECT 1 AS row_num, 10 AS state)"
+        " SELECT state FROM test WHERE row_num = 1 LIMIT 1;"
+    ),
     CONF_COLUMN_NAME: "state",
     CONF_ADVANCED_OPTIONS: {
         CONF_UNIT_OF_MEASUREMENT: "MiB",
@@ -160,7 +166,10 @@ ENTRY_CONFIG_QUERY_NO_READ_ONLY = {
 }
 
 ENTRY_CONFIG_QUERY_NO_READ_ONLY_CTE = {
-    CONF_QUERY: "WITH test AS (SELECT state FROM states) UPDATE states SET states.state = test.state;",
+    CONF_QUERY: (
+        "WITH test AS (SELECT state FROM states)"
+        " UPDATE states SET states.state = test.state;"
+    ),
     CONF_COLUMN_NAME: "size",
     CONF_ADVANCED_OPTIONS: {
         CONF_UNIT_OF_MEASUREMENT: "MiB",
@@ -168,7 +177,10 @@ ENTRY_CONFIG_QUERY_NO_READ_ONLY_CTE = {
 }
 
 ENTRY_CONFIG_QUERY_READ_ONLY_CTE_OPT = {
-    CONF_QUERY: "WITH test AS (SELECT 1 AS row_num, 10 AS state) SELECT state FROM test WHERE row_num = 1 LIMIT 1;",
+    CONF_QUERY: (
+        "WITH test AS (SELECT 1 AS row_num, 10 AS state)"
+        " SELECT state FROM test WHERE row_num = 1 LIMIT 1;"
+    ),
     CONF_COLUMN_NAME: "state",
     CONF_ADVANCED_OPTIONS: {
         CONF_UNIT_OF_MEASUREMENT: "MiB",
@@ -184,7 +196,10 @@ ENTRY_CONFIG_QUERY_NO_READ_ONLY_OPT = {
 }
 
 ENTRY_CONFIG_QUERY_NO_READ_ONLY_CTE_OPT = {
-    CONF_QUERY: "WITH test AS (SELECT state FROM states) UPDATE states SET states.state = test.state;",
+    CONF_QUERY: (
+        "WITH test AS (SELECT state FROM states)"
+        " UPDATE states SET states.state = test.state;"
+    ),
     CONF_COLUMN_NAME: "size",
     CONF_ADVANCED_OPTIONS: {
         CONF_UNIT_OF_MEASUREMENT: "MiB",
@@ -287,7 +302,10 @@ YAML_CONFIG_BINARY = {
     "sql": {
         CONF_DB_URL: "sqlite://",
         CONF_NAME: "Get Binary Value",
-        CONF_QUERY: "SELECT cast(x'd34324324230392032' as blob) as value, cast(x'd343aa' as blob) as test_attr",
+        CONF_QUERY: (
+            "SELECT cast(x'd34324324230392032' as blob) as value,"
+            " cast(x'd343aa' as blob) as test_attr"
+        ),
         CONF_COLUMN_NAME: "value",
         CONF_UNIQUE_ID: "unique_id_12345",
     }
@@ -319,8 +337,15 @@ YAML_CONFIG_ALL_TEMPLATES = {
         CONF_UNIT_OF_MEASUREMENT: "MiB/s",
         CONF_UNIQUE_ID: "unique_id_123456",
         CONF_VALUE_TEMPLATE: "{{ value }}",
-        CONF_ICON: '{% if states("sensor.input1")=="on" %} mdi:on {% else %} mdi:off {% endif %}',
-        CONF_PICTURE: '{% if states("sensor.input1")=="on" %} /local/picture1.jpg {% else %} /local/picture2.jpg {% endif %}',
+        CONF_ICON: (
+            '{% if states("sensor.input1")=="on" %}'
+            " mdi:on {% else %} mdi:off {% endif %}"
+        ),
+        CONF_PICTURE: (
+            '{% if states("sensor.input1")=="on" %}'
+            " /local/picture1.jpg"
+            " {% else %} /local/picture2.jpg {% endif %}"
+        ),
         CONF_AVAILABILITY: '{{ states("sensor.input2")=="on" }}',
         CONF_DEVICE_CLASS: SensorDeviceClass.DATA_RATE,
         CONF_STATE_CLASS: SensorStateClass.MEASUREMENT,

--- a/tests/components/sql/test_config_flow.py
+++ b/tests/components/sql/test_config_flow.py
@@ -136,7 +136,10 @@ async def test_form_with_query_template(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "Get Value"
     assert result["options"] == {
-        CONF_QUERY: "SELECT {% if states('sensor.input1')=='on' %} 5 {% else %} 6 {% endif %} as value",
+        CONF_QUERY: (
+            "SELECT {% if states('sensor.input1')=='on' %}"
+            " 5 {% else %} 6 {% endif %} as value"
+        ),
         CONF_COLUMN_NAME: "value",
         CONF_ADVANCED_OPTIONS: {
             CONF_UNIT_OF_MEASUREMENT: "MiB",
@@ -180,7 +183,10 @@ async def test_form_with_broken_query_template(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "Get Value"
     assert result["options"] == {
-        CONF_QUERY: "SELECT {% if states('sensor.input1')=='on' %} 5 {% else %} 6 {% endif %} as value",
+        CONF_QUERY: (
+            "SELECT {% if states('sensor.input1')=='on' %}"
+            " 5 {% else %} 6 {% endif %} as value"
+        ),
         CONF_COLUMN_NAME: "value",
         CONF_ADVANCED_OPTIONS: {
             CONF_UNIT_OF_MEASUREMENT: "MiB",

--- a/tests/components/sql/test_init.py
+++ b/tests/components/sql/test_init.py
@@ -95,7 +95,8 @@ async def test_query_no_read_only_cte(hass: HomeAssistant) -> None:
     with pytest.raises(vol.Invalid, match="SQL query must be of type SELECT"):
         validate_sql_select(
             Template(
-                "WITH test AS (SELECT state FROM states) UPDATE states SET states.state = test.state;",
+                "WITH test AS (SELECT state FROM states)"
+                " UPDATE states SET states.state = test.state;",
                 hass,
             )
         )

--- a/tests/components/sql/test_sensor.py
+++ b/tests/components/sql/test_sensor.py
@@ -69,7 +69,10 @@ async def test_query_basic(recorder_mock: Recorder, hass: HomeAssistant) -> None
 async def test_query_cte(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test the SQL sensor with CTE."""
     options = {
-        CONF_QUERY: "WITH test AS (SELECT 1 AS row_num, 10 AS state) SELECT state FROM test WHERE row_num = 1 LIMIT 1;",
+        CONF_QUERY: (
+            "WITH test AS (SELECT 1 AS row_num, 10 AS state)"
+            " SELECT state FROM test WHERE row_num = 1 LIMIT 1;"
+        ),
         CONF_COLUMN_NAME: "state",
     }
     await init_integration(hass, title="Select value SQL query CTE", options=options)
@@ -113,7 +116,10 @@ async def test_template_query(
 ) -> None:
     """Test the SQL sensor with a query template."""
     options = {
-        CONF_QUERY: "SELECT {% if states('sensor.input1')=='on' %} 5 {% else %} 6 {% endif %} as value",
+        CONF_QUERY: (
+            "SELECT {% if states('sensor.input1')=='on' %}"
+            " 5 {% else %} 6 {% endif %} as value"
+        ),
         CONF_COLUMN_NAME: "value",
         CONF_ADVANCED_OPTIONS: {
             CONF_VALUE_TEMPLATE: "{{ value | int }}",
@@ -194,9 +200,13 @@ async def test_broken_template_query_2(
     state = hass.states.get("sensor.count_tables")
     assert state.state == "0.005"
     assert (
-        "Error rendering query SELECT {{ states.sensor.input1.state | int / 1000}} as value"
-        " LIMIT 1;: ValueError: Template error: int got invalid input 'on' when rendering"
-        " template 'SELECT {{ states.sensor.input1.state | int / 1000}} as value LIMIT 1;'"
+        "Error rendering query SELECT"
+        " {{ states.sensor.input1.state | int / 1000}} as value"
+        " LIMIT 1;: ValueError: Template error: int got invalid"
+        " input 'on' when rendering"
+        " template 'SELECT"
+        " {{ states.sensor.input1.state | int / 1000}} as value"
+        " LIMIT 1;'"
         " but no default was specified" in caplog.text
     )
 

--- a/tests/components/sql/test_services.py
+++ b/tests/components/sql/test_services.py
@@ -38,8 +38,10 @@ async def test_query_service_recorder_db(
         {
             "query": (
                 "SELECT states_meta.entity_id, states.state "
-                "FROM states INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id "
-                "WHERE states_meta.entity_id LIKE 'sensor.test%' ORDER BY states_meta.entity_id"
+                "FROM states INNER JOIN states_meta ON"
+                " states.metadata_id = states_meta.metadata_id "
+                "WHERE states_meta.entity_id LIKE 'sensor.test%'"
+                " ORDER BY states_meta.entity_id"
             )
         },
         blocking=True,
@@ -126,7 +128,8 @@ async def test_query_service_data_conversion(
         "CREATE TABLE data (id INTEGER, cost DECIMAL(10, 2), event_date DATE, raw BLOB)"
     )
     conn.execute(
-        "INSERT INTO data (id, cost, event_date, raw) VALUES (1, 199.99, '2023-01-15', X'DEADBEEF')"
+        "INSERT INTO data (id, cost, event_date, raw)"
+        " VALUES (1, 199.99, '2023-01-15', X'DEADBEEF')"
     )
     conn.commit()
     conn.close()
@@ -240,13 +243,16 @@ async def test_query_service_performance_issue_validation(
     recorder_mock: Recorder,
     hass: HomeAssistant,
 ) -> None:
-    """Test the service validates queries against the recorder for performance issues."""
+    """Test the service validates queries against the recorder."""
     await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     with pytest.raises(
         ServiceValidationError,
-        match="The provided query is not allowed: Query contains entity_id but does not reference states_meta",
+        match=(
+            "The provided query is not allowed: Query contains"
+            " entity_id but does not reference states_meta"
+        ),
     ):
         await hass.services.async_call(
             DOMAIN,

--- a/tests/components/sql/test_util.py
+++ b/tests/components/sql/test_util.py
@@ -55,7 +55,8 @@ async def test_resolve_db_url_when_configured(hass: HomeAssistant) -> None:
             "SQL query must be of type SELECT",
         ),
         (
-            "WITH test AS (SELECT state FROM states) UPDATE states SET states.state = test.state;",
+            "WITH test AS (SELECT state FROM states)"
+            " UPDATE states SET states.state = test.state;",
             "SQL query must be of type SELECT",
         ),
         (
@@ -69,7 +70,7 @@ async def test_invalid_sql_queries(
     sql_query: str,
     expected_error_message: str,
 ) -> None:
-    """Test that various invalid or disallowed SQL queries raise the correct exception."""
+    """Test that invalid SQL queries raise the correct exception."""
     with pytest.raises(vol.Invalid, match=expected_error_message):
         validate_sql_select(Template(sql_query, hass))
 

--- a/tests/components/squeezebox/conftest.py
+++ b/tests/components/squeezebox/conftest.py
@@ -84,8 +84,16 @@ FAKE_QUERY_RESPONSE = {
     STATUS_SENSOR_INFO_TOTAL_SONGS: 42,
     STATUS_SENSOR_PLAYER_COUNT: 10,
     STATUS_SENSOR_OTHER_PLAYER_COUNT: 0,
-    STATUS_UPDATE_NEWVERSION: 'A new version of Logitech Media Server is available (8.5.2 - 0). <a href="updateinfo.html?installerFile=/var/lib/squeezeboxserver/cache/updates/logitechmediaserver_8.5.2_amd64.deb" target="update">Click here for further information</a>.',
-    STATUS_UPDATE_NEWPLUGINS: "Plugins have been updated - Restart Required (Big Sounds)",
+    STATUS_UPDATE_NEWVERSION: (
+        "A new version of Logitech Media Server is available"
+        ' (8.5.2 - 0). <a href="updateinfo.html?installerFile='
+        "/var/lib/squeezeboxserver/cache/updates/"
+        'logitechmediaserver_8.5.2_amd64.deb" target="update">'
+        "Click here for further information</a>."
+    ),
+    STATUS_UPDATE_NEWPLUGINS: (
+        "Plugins have been updated - Restart Required (Big Sounds)"
+    ),
     "_can": 1,
     "players_loop": [
         {
@@ -379,7 +387,7 @@ def mock_pysqueezebox_player(uuid: str) -> MagicMock:
 
 @pytest.fixture
 def lms_factory(player_factory: MagicMock) -> MagicMock:
-    """Return a factory for creating mock Lyrion Media Servers with arbitrary number of players."""
+    """Return a factory for creating mock Lyrion Media Servers."""
     return lambda player_count, uuid: mock_pysqueezebox_server(
         player_factory, player_count, uuid
     )
@@ -394,7 +402,7 @@ def lms(player_factory: MagicMock) -> MagicMock:
 def mock_pysqueezebox_server(
     player_factory: MagicMock, player_count: int, uuid: str
 ) -> MagicMock:
-    """Create a mock Lyrion Media Server with the given number of mock players attached."""
+    """Create a mock Lyrion Media Server with mock players."""
     with patch("homeassistant.components.squeezebox.Server", autospec=True) as mock_lms:
         players = [player_factory(TEST_MAC[index]) for index in range(player_count)]
         mock_lms.async_get_players = AsyncMock(return_value=players)
@@ -472,7 +480,7 @@ async def configured_players(
     config_entry: MockConfigEntry,
     lms_factory: MagicMock,
 ) -> list[MagicMock]:
-    """Fixture mocking calls to multiple pysqueezebox Players from a configured squeezebox."""
+    """Fixture mocking calls to multiple pysqueezebox Players."""
     lms = lms_factory(3, uuid=SERVER_UUIDS[0])
 
     with patch("homeassistant.components.squeezebox.Server", return_value=lms):

--- a/tests/components/squeezebox/test_init.py
+++ b/tests/components/squeezebox/test_init.py
@@ -82,7 +82,7 @@ async def test_init_unauthorized(
             return_value=False,  # async_query returns False on auth failure
         ),
         patch(
-            "homeassistant.components.squeezebox.Server",  # Patch the Server class itself
+            "homeassistant.components.squeezebox.Server",
             autospec=True,
         ) as mock_server_instance,
     ):

--- a/tests/components/squeezebox/test_media_player.py
+++ b/tests/components/squeezebox/test_media_player.py
@@ -516,7 +516,10 @@ async def test_squeezebox_play_media_with_announce_volume_invalid(
     """Test play service call with announce and volume zero."""
     with pytest.raises(
         ServiceValidationError,
-        match="announce_volume must be a number greater than 0 and less than or equal to 1",
+        match=(
+            "announce_volume must be a number greater than 0"
+            " and less than or equal to 1"
+        ),
     ):
         await hass.services.async_call(
             MEDIA_PLAYER_DOMAIN,

--- a/tests/components/srp_energy/test_config_flow.py
+++ b/tests/components/srp_energy/test_config_flow.py
@@ -134,7 +134,8 @@ async def test_flow_entry_already_configured(
     assert init_integration.data[CONF_ID] == ACCNT_ID
     assert init_integration.unique_id == ACCNT_ID
 
-    # Attempt a second config using same account id. This is the unique id between configs.
+    # Attempt a second config using same account id.
+    # This is the unique id between configs.
     user_input_second = TEST_CONFIG_HOME
     user_input_second[CONF_ID] = init_integration.data[CONF_ID]
 
@@ -157,7 +158,8 @@ async def test_flow_multiple_configs(
     assert init_integration.data[CONF_ID] == ACCNT_ID
     assert init_integration.unique_id == ACCNT_ID
 
-    # Attempt a second config using different account id. This is the unique id between configs.
+    # Attempt a second config using different account id.
+    # This is the unique id between configs.
     assert TEST_CONFIG_CABIN[CONF_ID] != ACCNT_ID
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/ssdp/test_init.py
+++ b/tests/components/ssdp/test_init.py
@@ -605,7 +605,10 @@ async def test_getting_existing_headers(
         {
             "ST": "mock-st",
             "LOCATION": "http://1.1.1.1",
-            "USN": "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL::urn:mdx-netflix-com:service:target:3",
+            "USN": (
+                "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL"
+                "::urn:mdx-netflix-com:service:target:3"
+            ),
             "SERVER": "mock-server",
             "EXT": "",
             "_source": "search",
@@ -621,8 +624,8 @@ async def test_getting_existing_headers(
     assert discovery_info_by_st.ssdp_server == "mock-server"
     assert discovery_info_by_st.ssdp_st == "mock-st"
     assert (
-        discovery_info_by_st.ssdp_usn
-        == "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL::urn:mdx-netflix-com:service:target:3"
+        discovery_info_by_st.ssdp_usn == "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL"
+        "::urn:mdx-netflix-com:service:target:3"
     )
     assert discovery_info_by_st.ssdp_udn == ANY
     assert discovery_info_by_st.ssdp_headers["_timestamp"] == ANY
@@ -640,8 +643,8 @@ async def test_getting_existing_headers(
     assert discovery_info_by_udn.ssdp_server == "mock-server"
     assert discovery_info_by_udn.ssdp_st == "mock-st"
     assert (
-        discovery_info_by_udn.ssdp_usn
-        == "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL::urn:mdx-netflix-com:service:target:3"
+        discovery_info_by_udn.ssdp_usn == "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL"
+        "::urn:mdx-netflix-com:service:target:3"
     )
     assert discovery_info_by_udn.ssdp_udn == ANY
     assert discovery_info_by_udn.ssdp_headers["_timestamp"] == ANY
@@ -659,7 +662,8 @@ async def test_getting_existing_headers(
     assert discovery_info_by_udn_st.ssdp_st == "mock-st"
     assert (
         discovery_info_by_udn_st.ssdp_usn
-        == "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL::urn:mdx-netflix-com:service:target:3"
+        == "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL"
+        "::urn:mdx-netflix-com:service:target:3"
     )
     assert discovery_info_by_udn_st.ssdp_udn == ANY
     assert discovery_info_by_udn_st.ssdp_headers["_timestamp"] == ANY

--- a/tests/components/starline/test_config_flow.py
+++ b/tests/components/starline/test_config_flow.py
@@ -40,7 +40,17 @@ async def test_flow_works(hass: HomeAssistant) -> None:
         )
         mock.get(
             f"https://developer.starline.ru/json/v2/user/{TEST_APP_UID}/user_info",
-            text='{"code": 200, "devices": [{"device_id": "123", "imei": "123", "alias": "123", "battery": "123", "ctemp": "123", "etemp": "123", "fw_version": "123", "gsm_lvl": "123", "phone": "123", "status": "1", "ts_activity": "123", "typename": "123", "balance": {}, "car_state": {}, "car_alr_state": {}, "functions": [], "position": {}}], "shared_devices": []}',
+            text=(
+                '{"code": 200, "devices": [{"device_id": "123",'
+                ' "imei": "123", "alias": "123", "battery": "123",'
+                ' "ctemp": "123", "etemp": "123",'
+                ' "fw_version": "123", "gsm_lvl": "123",'
+                ' "phone": "123", "status": "1",'
+                ' "ts_activity": "123", "typename": "123",'
+                ' "balance": {}, "car_state": {},'
+                ' "car_alr_state": {}, "functions": [],'
+                ' "position": {}}], "shared_devices": []}'
+            ),
         )
 
         result = await hass.config_entries.flow.async_init(

--- a/tests/components/starlink/test_config_flow.py
+++ b/tests/components/starlink/test_config_flow.py
@@ -13,7 +13,7 @@ from tests.common import MockConfigEntry
 
 
 async def test_flow_user_fails_can_succeed(hass: HomeAssistant) -> None:
-    """Test user initialized flow can still succeed after failure when Starlink is available."""
+    """Test user flow can succeed after failure when Starlink is available."""
     user_input = {CONF_IP_ADDRESS: "192.168.100.1:9200"}
 
     with NO_DEVICE_PATCHER, SETUP_ENTRY_PATCHER:

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -269,8 +269,9 @@ async def test_sensor_state_updated_reported(
 ) -> None:
     """Test the behavior of the sensor with a sequence of identical values.
 
-    Forced updates no longer make a difference, since the statistics are now reacting not
-    only to state change events but also to state report events (EVENT_STATE_REPORTED).
+    Forced updates no longer make a difference, since the statistics are
+    now reacting not only to state change events but also to state report
+    events (EVENT_STATE_REPORTED).
     This means repeating values will be added to the buffer repeatedly in both cases.
     This fixes problems with time based averages and some other functions that behave
     differently when repeating values are reported.
@@ -804,7 +805,8 @@ async def test_device_class(hass: HomeAssistant) -> None:
         {
             "sensor": [
                 {
-                    # Device class is carried over from source sensor for characteristics which retain unit
+                    # Device class carried over from source sensor
+                    # for characteristics which retain unit
                     "platform": "statistics",
                     "name": "test_retain_unit",
                     "entity_id": "sensor.test_monitored",
@@ -812,7 +814,8 @@ async def test_device_class(hass: HomeAssistant) -> None:
                     "sampling_size": 20,
                 },
                 {
-                    # Device class is set to None for characteristics with special meaning
+                    # Device class is set to None for characteristics
+                    # with special meaning
                     "platform": "statistics",
                     "name": "test_none",
                     "entity_id": "sensor.test_monitored",
@@ -828,7 +831,8 @@ async def test_device_class(hass: HomeAssistant) -> None:
                     "sampling_size": 20,
                 },
                 {
-                    # Device class is set to None for any source sensor with TOTAL state class
+                    # Device class is set to None for any source
+                    # sensor with TOTAL state class
                     "platform": "statistics",
                     "name": "test_source_class_total",
                     "entity_id": "sensor.test_monitored_total",
@@ -1345,7 +1349,10 @@ async def test_state_characteristics(hass: HomeAssistant) -> None:
     sensors_config = [
         {
             "platform": "statistics",
-            "name": f"test_{characteristic['source_sensor_domain']}_{characteristic['name']}",
+            "name": (
+                f"test_{characteristic['source_sensor_domain']}"
+                f"_{characteristic['name']}"
+            ),
             "entity_id": f"{characteristic['source_sensor_domain']}.test_monitored",
             "state_characteristic": characteristic["name"],
             "max_age": {"minutes": 8},  # 9 values spaces by one minute
@@ -1714,7 +1721,7 @@ async def test_device_id(
 
 
 async def test_update_before_load(recorder_mock: Recorder, hass: HomeAssistant) -> None:
-    """Verify that updates happening before reloading from the database are handled correctly."""
+    """Verify updates before reloading from database are handled."""
 
     current_time = dt_util.utcnow()
 
@@ -1737,8 +1744,9 @@ async def test_update_before_load(recorder_mock: Recorder, hass: HomeAssistant) 
 
         await async_wait_recording_done(hass)
 
-        # some synchronisation is needed to prevent that loading from the database finishes too soon
-        # we want this to take long enough to be able to try to add a value BEFORE loading is done
+        # some synchronisation is needed to prevent that loading from
+        # the database finishes too soon - we want this to take long
+        # enough to try to add a value BEFORE loading is done
         state_changes_during_period_called_evt = AsyncioEvent()
         state_changes_during_period_stall_evt = ThreadingEvent()
         real_state_changes_during_period = history.state_changes_during_period
@@ -1769,9 +1777,11 @@ async def test_update_before_load(recorder_mock: Recorder, hass: HomeAssistant) 
                     ]
                 },
             )
-            # adding this value is going to be ignored, since loading from the database hasn't finished yet
-            # if this value would be added before loading from the database is done
-            # it would mess up the order of the internal queue which is supposed to be sorted by time
+            # adding this value is going to be ignored, since loading
+            # from the database hasn't finished yet - if this value
+            # would be added before loading from the database is done
+            # it would mess up the order of the internal queue which
+            # is supposed to be sorted by time
             await state_changes_during_period_called_evt.wait()
             hass.states.async_set(
                 "sensor.test_monitored",

--- a/tests/components/steamist/test_config_flow.py
+++ b/tests/components/steamist/test_config_flow.py
@@ -213,7 +213,7 @@ async def test_discovery(hass: HomeAssistant) -> None:
 
 
 async def test_discovered_by_discovery_and_dhcp(hass: HomeAssistant) -> None:
-    """Test we get the form with discovery and abort for dhcp source when we get both."""
+    """Test we get discovery form and abort for dhcp when we get both."""
 
     with _patch_discovery(), _patch_status(MOCK_ASYNC_GET_STATUS_INACTIVE):
         result = await hass.config_entries.flow.async_init(
@@ -313,7 +313,7 @@ async def test_discovered_by_dhcp(hass: HomeAssistant) -> None:
 
 
 async def test_discovered_by_dhcp_discovery_fails(hass: HomeAssistant) -> None:
-    """Test we can setup when discovered from dhcp but then we cannot get the device name."""
+    """Test setup when discovered from dhcp but cannot get device name."""
 
     with (
         _patch_discovery(no_device=True),
@@ -360,7 +360,7 @@ async def test_discovered_by_dhcp_discovery_finds_non_steamist_device(
 async def test_discovered_by_dhcp_or_discovery_adds_missing_unique_id(
     hass: HomeAssistant, source, data
 ) -> None:
-    """Test we can setup when discovered from dhcp or discovery and add a missing unique id."""
+    """Test setup from dhcp/discovery adds a missing unique id."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: DEVICE_IP_ADDRESS})
     config_entry.add_to_hass(hass)
 
@@ -393,7 +393,7 @@ async def test_discovered_by_dhcp_or_discovery_adds_missing_unique_id(
 async def test_discovered_by_dhcp_or_discovery_existing_unique_id_does_not_reload(
     hass: HomeAssistant, source, data
 ) -> None:
-    """Test we can setup when discovered from dhcp or discovery and it does not reload."""
+    """Test setup from dhcp/discovery with existing unique id skips reload."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data=DEFAULT_ENTRY_DATA, unique_id=FORMATTED_MAC_ADDRESS
     )

--- a/tests/components/steamist/test_init.py
+++ b/tests/components/steamist/test_init.py
@@ -72,7 +72,7 @@ async def test_config_entry_fills_unique_id_with_directed_discovery(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
 ) -> None:
-    """Test that the unique id is added if its missing via directed (not broadcast) discovery."""
+    """Test unique id is added if missing via directed discovery."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: DEVICE_IP_ADDRESS}, unique_id=None
     )

--- a/tests/components/steamist/test_sensor.py
+++ b/tests/components/steamist/test_sensor.py
@@ -26,7 +26,7 @@ async def test_steam_active(hass: HomeAssistant) -> None:
 
 @pytest.mark.usefixtures("mock_aio_discovery")
 async def test_steam_inactive(hass: HomeAssistant) -> None:
-    """Test that the sensors are setup with the expected values when steam is not active."""
+    """Test sensors have expected values when steam is not active."""
     await _async_setup_entry_with_status(hass, MOCK_ASYNC_GET_STATUS_INACTIVE)
     state = hass.states.get("sensor.steam_temperature")
     assert round(float(state.state)) == 21

--- a/tests/components/steamist/test_switch.py
+++ b/tests/components/steamist/test_switch.py
@@ -21,7 +21,7 @@ from tests.common import async_fire_time_changed
 
 @pytest.mark.usefixtures("mock_aio_discovery")
 async def test_steam_active(hass: HomeAssistant) -> None:
-    """Test that the switches are setup with the expected values when steam is active."""
+    """Test switches have expected values when steam is active."""
     client, _ = await _async_setup_entry_with_status(hass, MOCK_ASYNC_GET_STATUS_ACTIVE)
     assert len(hass.states.async_all("switch")) == 1
     assert hass.states.get("switch.steam_active").state == STATE_ON
@@ -41,7 +41,7 @@ async def test_steam_active(hass: HomeAssistant) -> None:
 
 @pytest.mark.usefixtures("mock_aio_discovery")
 async def test_steam_inactive(hass: HomeAssistant) -> None:
-    """Test that the switches are setup with the expected values when steam is not active."""
+    """Test switches have expected values when steam is not active."""
     client, _ = await _async_setup_entry_with_status(
         hass, MOCK_ASYNC_GET_STATUS_INACTIVE
     )

--- a/tests/components/stream/conftest.py
+++ b/tests/components/stream/conftest.py
@@ -120,13 +120,13 @@ class HLSSync:
         return False
 
     def bad_request(self):
-        """Intercept the HTTPBadRequest call so we know when the web handler is finished."""
+        """Intercept HTTPBadRequest to detect web handler completion."""
         self._num_finished += 1
         self.check_requests_ready()
         return self._original_bad_request()
 
     def not_found(self):
-        """Intercept the HTTPNotFound call so we know when the web handler is finished."""
+        """Intercept HTTPNotFound to detect web handler completion."""
         self._num_finished += 1
         self.check_requests_ready()
         return self._original_not_found()

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -401,7 +401,7 @@ async def test_hls_playlist_view(
 async def test_hls_max_segments(
     hass: HomeAssistant, setup_component, hls_stream, stream_worker_sync
 ) -> None:
-    """Test rendering the hls playlist with more segments than the segment deque can hold."""
+    """Test hls playlist with more segments than the deque can hold."""
     stream = create_stream(hass, STREAM_SOURCE, {}, dynamic_stream_settings())
     stream_worker_sync.pause()
     hls = stream.add_provider(HLS_PROVIDER)
@@ -438,7 +438,8 @@ async def test_hls_max_segments(
         segment_response = await hls_client.get("/segment/0.m4s")
     assert segment_response.status == HTTPStatus.NOT_FOUND
 
-    # However all segments in the buffer are accessible, even those that were not in the playlist.
+    # However all segments in the buffer are accessible,
+    # even those that were not in the playlist.
     for sequence in range(1, MAX_SEGMENTS + 1):
         segment_response = await hls_client.get(f"/segment/{sequence}.m4s")
         assert segment_response.status == HTTPStatus.OK

--- a/tests/components/stream/test_ll_hls.py
+++ b/tests/components/stream/test_ll_hls.py
@@ -458,14 +458,16 @@ async def test_ll_hls_playlist_bad_msn_part(
     # Current sequence number is 1 and part number is num_completed_parts-1
     # The following two tests should fail immediately:
     # - request with a _HLS_msn of 4
-    # - request with a _HLS_msn of 1 and a _HLS_part of num_completed_parts-1+advance_part_limit
+    # - request with a _HLS_msn of 1 and a _HLS_part of
+    #   num_completed_parts-1+advance_part_limit
     assert (
         await hls_client.get("/playlist.m3u8?_HLS_msn=4")
     ).status == HTTPStatus.BAD_REQUEST
+    part_limit = hass.data[DOMAIN][ATTR_SETTINGS].hls_advance_part_limit
     assert (
         await hls_client.get(
             "/playlist.m3u8?_HLS_msn=1&_HLS_part="
-            f"{num_completed_parts - 1 + hass.data[DOMAIN][ATTR_SETTINGS].hls_advance_part_limit}"
+            f"{num_completed_parts - 1 + part_limit}"
         )
     ).status == HTTPStatus.BAD_REQUEST
     stream_worker_sync.resume()

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -178,7 +178,10 @@ class PacketSequence:
             size = 3
 
             def __str__(self) -> str:
-                return f"FakePacket<stream={self.stream}, pts={self.pts}, key={self.is_keyframe}>"
+                return (
+                    f"FakePacket<stream={self.stream},"
+                    f" pts={self.pts}, key={self.is_keyframe}>"
+                )
 
         return FakePacket()
 
@@ -312,7 +315,7 @@ async def async_decode_stream(
     py_av: MockPyAv | None = None,
     stream_settings: StreamSettings | None = None,
 ) -> FakePyAvBuffer:
-    """Start a stream worker that decodes incoming stream packets into output segments."""
+    """Start a stream worker that decodes packets into segments."""
     stream = Stream(
         hass,
         STREAM_SOURCE,
@@ -336,8 +339,9 @@ async def async_decode_stream(
         try:
             run_worker(hass, stream, STREAM_SOURCE, stream_settings)
         except StreamEndedError:
-            # Tests only use a limited number of packets, then the worker exits as expected. In
-            # production, stream ending would be unexpected.
+            # Tests only use a limited number of packets, then the
+            # worker exits as expected. In production, stream ending
+            # would be unexpected.
             pass
         finally:
             # Wait for all packets to be flushed even when exceptions are thrown
@@ -710,7 +714,8 @@ async def test_stream_stopped_while_decoding(hass: HomeAssistant) -> None:
         worker_wake.set()
         await stream.stop()
 
-    # Stream is still considered available when the worker was still active and asked to stop
+    # Stream is still considered available when the worker was still
+    # active and asked to stop
     assert stream.available
 
 
@@ -727,8 +732,8 @@ async def test_update_stream_source(hass: HomeAssistant) -> None:
         dynamic_stream_settings(),
     )
     stream.add_provider(HLS_PROVIDER)
-    # Note that retries are disabled by default in tests, however the stream is "restarted" when
-    # the stream source is updated.
+    # Note that retries are disabled by default in tests, however
+    # the stream is "restarted" when the stream source is updated.
 
     py_av = MockPyAv()
     py_av.container.packets = PacketSequence(TEST_SEQUENCE_LENGTH)
@@ -917,8 +922,9 @@ async def test_has_keyframe(
             "stream": {
                 CONF_LL_HLS: True,
                 CONF_SEGMENT_DURATION: SEGMENT_DURATION,
-                # Our test video has keyframes every second. Use smaller parts so we have more
-                # part boundaries to better test keyframe logic.
+                # Our test video has keyframes every second. Use
+                # smaller parts so we have more part boundaries to
+                # better test keyframe logic.
                 CONF_PART_DURATION: 0.25,
             }
         },

--- a/tests/components/stt/test_init.py
+++ b/tests/components/stt/test_init.py
@@ -300,11 +300,13 @@ async def test_stream_audio_uses_enum_values(
         ),
         (
             (
-                "format=wav; codec=pcm; sample_rate=16000; bit_rate=16; channel=bad channel;"
+                "format=wav; codec=pcm; sample_rate=16000;"
+                " bit_rate=16; channel=bad channel;"
                 " language=en"
             ),
             400,
-            "Wrong format of X-Speech-Content: invalid literal for int() with base 10: 'bad channel'",
+            "Wrong format of X-Speech-Content: invalid literal"
+            " for int() with base 10: 'bad channel'",
         ),
         (
             "format=wav; codec=pcm; sample_rate=16000",
@@ -615,7 +617,7 @@ async def test_audio_processing_default(
 async def test_audio_processing_entity_default(
     hass: HomeAssistant, tmp_path: Path, mock_provider_entity: MockSTTProviderEntity
 ) -> None:
-    """Test that the default audio_processing property on entity returns correct values."""
+    """Test default audio_processing property returns correct values."""
     await mock_config_entry_setup(hass, tmp_path, mock_provider_entity)
 
     engine = async_get_speech_to_text_engine(hass, f"{DOMAIN}.{TEST_DOMAIN}")

--- a/tests/components/subaru/conftest.py
+++ b/tests/components/subaru/conftest.py
@@ -193,7 +193,7 @@ async def subaru_config_entry(hass: HomeAssistant) -> MockConfigEntry:
 async def ev_entry(
     hass: HomeAssistant, subaru_config_entry: MockConfigEntry
 ) -> MockConfigEntry:
-    """Create a Subaru entry representing an EV vehicle with full STARLINK subscription."""
+    """Create a Subaru entry for an EV with full STARLINK subscription."""
     await setup_subaru_config_entry(hass, subaru_config_entry)
     assert DOMAIN in hass.config_entries.async_domains()
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1

--- a/tests/components/swiss_public_transport/test_config_flow.py
+++ b/tests/components/swiss_public_transport/test_config_flow.py
@@ -90,7 +90,8 @@ MOCK_ADVANCED_DATA_STEP_TIME_OFFSET = {
         (
             MOCK_USER_DATA_STEP_MANY_VIA,
             None,
-            "test_start test_destination via via_station_1, via_station_2, via_station_3",
+            "test_start test_destination via"
+            " via_station_1, via_station_2, via_station_3",
         ),
         (MOCK_USER_DATA_STEP_ARRIVAL, None, "test_start test_destination arrival"),
         (

--- a/tests/components/switch/test_condition.py
+++ b/tests/components/switch/test_condition.py
@@ -257,7 +257,7 @@ async def test_input_boolean_state_condition_behavior_all(
 async def test_switch_condition_evaluates_both_domains(
     hass: HomeAssistant,
 ) -> None:
-    """Test that the switch condition evaluates both switch and input_boolean entities."""
+    """Test switch condition evaluates both switch and input_boolean."""
     entity_id_switch = "switch.test_switch"
     entity_id_input_boolean = "input_boolean.test_input_boolean"
 

--- a/tests/components/switch/test_trigger.py
+++ b/tests/components/switch/test_trigger.py
@@ -108,7 +108,7 @@ async def test_switch_state_trigger_behavior_any(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test that the switch state trigger fires when any switch state changes to a specific state."""
+    """Test switch trigger fires when any switch changes to a state."""
     await assert_trigger_behavior_any(
         hass,
         target_entities=target_switches,
@@ -140,7 +140,7 @@ async def test_switch_state_trigger_behavior_first(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test that the switch state trigger fires when the first switch changes to a specific state."""
+    """Test switch trigger fires when the first switch changes state."""
     await assert_trigger_behavior_first(
         hass,
         target_entities=target_switches,
@@ -172,7 +172,7 @@ async def test_switch_state_trigger_behavior_last(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test that the switch state trigger fires when the last switch changes to a specific state."""
+    """Test switch trigger fires when the last switch changes state."""
     await assert_trigger_behavior_last(
         hass,
         target_entities=target_switches,

--- a/tests/components/switchbot/__init__.py
+++ b/tests/components/switchbot/__init__.py
@@ -1200,7 +1200,10 @@ GARAGE_DOOR_OPENER_SERVICE_INFO = BluetoothServiceInfoBleak(
 CLIMATE_PANEL_SERVICE_INFO = BluetoothServiceInfoBleak(
     name="Climate Panel",
     manufacturer_data={
-        2409: b"\xb0\xe9\xfe\x8e\x98Oi_\x06\x9a,\x00\x00\x00\x00\xe4\x00\x08\x04\x00\x01\x00\x00"
+        2409: (
+            b"\xb0\xe9\xfe\x8e\x98Oi_\x06\x9a,"
+            b"\x00\x00\x00\x00\xe4\x00\x08\x04\x00\x01\x00\x00"
+        )
     },
     service_data={
         "0000fd3d-0000-1000-8000-00805f9b34fb": b"\x00 _\x00\x10\xf3\xd8@",
@@ -1212,7 +1215,10 @@ CLIMATE_PANEL_SERVICE_INFO = BluetoothServiceInfoBleak(
     advertisement=generate_advertisement_data(
         local_name="Climate Panel",
         manufacturer_data={
-            2409: b"\xb0\xe9\xfe\x8e\x98Oi_\x06\x9a,\x00\x00\x00\x00\xe4\x00\x08\x04\x00\x01\x00\x00"
+            2409: (
+                b"\xb0\xe9\xfe\x8e\x98Oi_\x06\x9a,"
+                b"\x00\x00\x00\x00\xe4\x00\x08\x04\x00\x01\x00\x00"
+            )
         },
         service_data={
             "0000fd3d-0000-1000-8000-00805f9b34fb": b"\x00 _\x00\x10\xf3\xd8@"

--- a/tests/components/switchbot/conftest.py
+++ b/tests/components/switchbot/conftest.py
@@ -48,7 +48,7 @@ def mock_entry_factory():
 
 @pytest.fixture
 def mock_entry_encrypted_factory():
-    """Fixture to create a MockConfigEntry with an encryption key and a customizable sensor type."""
+    """Create a MockConfigEntry with encryption key and sensor type."""
 
     def _create_entry(sensor_type: str = "lock") -> MockConfigEntry:
         options: dict[str, int] = {CONF_RETRY_COUNT: DEFAULT_RETRY_COUNT}

--- a/tests/components/switchbot/test_config_flow.py
+++ b/tests/components/switchbot/test_config_flow.py
@@ -1740,7 +1740,7 @@ async def test_user_setup_worelay_switch_1pm_auth(hass: HomeAssistant) -> None:
 async def test_user_setup_worelay_switch_1pm_auth_switchbot_api_down(
     hass: HomeAssistant,
 ) -> None:
-    """Test the user initiated form for a relay switch 1pm when the switchbot api is down."""
+    """Test user form for relay switch 1pm when switchbot api is down."""
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}

--- a/tests/components/switchbot/test_humidifier.py
+++ b/tests/components/switchbot/test_humidifier.py
@@ -160,7 +160,10 @@ async def test_exception_handling_humidifier_service(
     entry.add_to_hass(hass)
     entity_id = "humidifier.test_name"
 
-    patch_target = f"homeassistant.components.switchbot.humidifier.switchbot.SwitchbotHumidifier.{mock_method}"
+    patch_target = (
+        "homeassistant.components.switchbot.humidifier"
+        f".switchbot.SwitchbotHumidifier.{mock_method}"
+    )
 
     with patch(patch_target, new=AsyncMock(side_effect=exception)):
         assert await hass.config_entries.async_setup(entry.entry_id)
@@ -240,7 +243,10 @@ async def test_evaporative_humidifier_services_with_exception(
     entry.add_to_hass(hass)
     entity_id = "humidifier.test_name"
 
-    patch_target = f"homeassistant.components.switchbot.humidifier.switchbot.SwitchbotEvaporativeHumidifier.{mock_method}"
+    patch_target = (
+        "homeassistant.components.switchbot.humidifier"
+        f".switchbot.SwitchbotEvaporativeHumidifier.{mock_method}"
+    )
 
     with patch(
         patch_target,

--- a/tests/components/switchbot/test_init.py
+++ b/tests/components/switchbot/test_init.py
@@ -41,7 +41,8 @@ from tests.components.bluetooth import inject_bluetooth_service_info
     [
         (
             ValueError("wrong model"),
-            "Switchbot device initialization failed because of incorrect configuration parameters: wrong model",
+            "Switchbot device initialization failed because of"
+            " incorrect configuration parameters: wrong model",
         ),
     ],
 )
@@ -279,7 +280,7 @@ async def test_migrate_deprecated_air_purifier_sensor_type(
     service_info: BluetoothServiceInfoBleak,
     expected_sensor_type: str,
 ) -> None:
-    """Test that deprecated air_purifier sensor types are migrated via BLE advertisement."""
+    """Test deprecated air_purifier types are migrated via BLE."""
     inject_bluetooth_service_info(hass, service_info)
 
     entry = MockConfigEntry(
@@ -305,7 +306,7 @@ async def test_migrate_deprecated_air_purifier_sensor_type(
 async def test_migrate_deprecated_air_purifier_sensor_type_device_not_in_range(
     hass: HomeAssistant,
 ) -> None:
-    """Test deprecated air_purifier type entry is not loaded when device is out of range."""
+    """Test deprecated air_purifier entry not loaded when out of range."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={

--- a/tests/components/switchbot/test_number.py
+++ b/tests/components/switchbot/test_number.py
@@ -38,7 +38,7 @@ async def test_meter_pro_co2_display_time_offset_initial_state(
     offset_seconds_on_device: int,
     expected_state: int,
 ) -> None:
-    """Test the display_time_offset entity gets the initial state from a MeterProCO2 device."""
+    """Test display_time_offset gets initial state from MeterProCO2."""
     await async_setup_component(hass, DOMAIN, {})
     inject_bluetooth_service_info(hass, WOMETERTHPC_SERVICE_INFO)
 
@@ -152,7 +152,11 @@ async def test_set_display_time_offset_out_of_range(
 
         with pytest.raises(
             ServiceValidationError,
-            match=r"Value -?\d+\.0 for number\.test_name_display_time_offset is outside valid range",
+            match=(
+                r"Value -?\d+\.0 for"
+                r" number\.test_name_display_time_offset"
+                r" is outside valid range"
+            ),
         ):
             await hass.services.async_call(
                 NUMBER_DOMAIN,

--- a/tests/components/switcher_kis/test_init.py
+++ b/tests/components/switcher_kis/test_init.py
@@ -50,8 +50,8 @@ async def test_update_fail(
 
     for device in DUMMY_SWITCHER_DEVICES:
         assert (
-            f"Device {device.name} did not send update for {MAX_UPDATE_INTERVAL_SEC} seconds"
-            in caplog.text
+            f"Device {device.name} did not send update for"
+            f" {MAX_UPDATE_INTERVAL_SEC} seconds" in caplog.text
         )
 
         entity_id = f"switch.{slugify(device.name)}"
@@ -102,8 +102,8 @@ async def test_update_fail_token_needed(
     await hass.async_block_till_done()
 
     assert (
-        f"Device {device.name} did not send update for {MAX_UPDATE_INTERVAL_SEC} seconds"
-        in caplog.text
+        f"Device {device.name} did not send update for"
+        f" {MAX_UPDATE_INTERVAL_SEC} seconds" in caplog.text
     )
 
     entity_id = f"switch.{slugify(device.name)}"

--- a/tests/components/synology_dsm/test_backup.py
+++ b/tests/components/synology_dsm/test_backup.py
@@ -50,7 +50,8 @@ async def _mock_download_file(path: str, filename: str) -> MockStreamReader:
             b'{"addons":[],"backup_id":"abcd12ef","date":"2025-01-09T20:14:35.457323+01:00",'
             b'"database_included":true,"extra_metadata":{"instance_id":"36b3b7e984da43fc89f7bafb2645fa36",'
             b'"with_automatic_settings":true},"folders":[],"homeassistant_included":true,'
-            b'"homeassistant_version":"2025.2.0.dev0","name":"Automatic backup 2025.2.0.dev0","protected":true,"size":13916160}'
+            b'"homeassistant_version":"2025.2.0.dev0",'
+            b'"name":"Automatic backup 2025.2.0.dev0","protected":true,"size":13916160}'
         )
     if filename == f"{BASE_FILENAME}.tar":
         return MockStreamReaderChunked(b"backup data")
@@ -65,7 +66,8 @@ async def _mock_download_file_meta_ok_tar_missing(
             b'{"addons":[],"backup_id":"abcd12ef","date":"2025-01-09T20:14:35.457323+01:00",'
             b'"database_included":true,"extra_metadata":{"instance_id":"36b3b7e984da43fc89f7bafb2645fa36",'
             b'"with_automatic_settings":true},"folders":[],"homeassistant_included":true,'
-            b'"homeassistant_version":"2025.2.0.dev0","name":"Automatic backup 2025.2.0.dev0","protected":true,"size":13916160}'
+            b'"homeassistant_version":"2025.2.0.dev0",'
+            b'"name":"Automatic backup 2025.2.0.dev0","protected":true,"size":13916160}'
         )
     if filename == f"{BASE_FILENAME}.tar":
         raise SynologyDSMAPIErrorException("api", "900", [{"code": 408}])
@@ -750,15 +752,18 @@ async def test_agents_delete_not_existing(
     [
         (
             SynologyDSMAPIErrorException("api", "100", "Unknown error"),
-            "{'api': 'api', 'code': '100', 'reason': 'Unknown', 'details': 'Unknown error'}",
+            "{'api': 'api', 'code': '100', 'reason': 'Unknown',"
+            " 'details': 'Unknown error'}",
         ),
         (
             SynologyDSMAPIErrorException("api", "900", [{"code": 407}]),
-            "{'api': 'api', 'code': '900', 'reason': 'Unknown', 'details': [{'code': 407}]",
+            "{'api': 'api', 'code': '900', 'reason': 'Unknown',"
+            " 'details': [{'code': 407}]",
         ),
         (
             SynologyDSMAPIErrorException("api", "900", [{"code": 417}]),
-            "{'api': 'api', 'code': '900', 'reason': 'Unknown', 'details': [{'code': 417}]",
+            "{'api': 'api', 'code': '900', 'reason': 'Unknown',"
+            " 'details': [{'code': 417}]",
         ),
     ],
 )

--- a/tests/components/synology_dsm/test_config_flow.py
+++ b/tests/components/synology_dsm/test_config_flow.py
@@ -511,7 +511,8 @@ async def test_form_ssdp(
             ssdp_location="http://192.168.1.5:5000",
             upnp={
                 ATTR_UPNP_FRIENDLY_NAME: "mydsm",
-                ATTR_UPNP_SERIAL: "001132XXXX99",  # MAC address, but SSDP does not have `-`
+                # MAC address, but SSDP does not have `-`
+                ATTR_UPNP_SERIAL: "001132XXXX99",
             },
         ),
     )
@@ -558,7 +559,8 @@ async def test_reconfig_ssdp(hass: HomeAssistant, service: MagicMock) -> None:
             ssdp_location="http://192.168.1.5:5000",
             upnp={
                 ATTR_UPNP_FRIENDLY_NAME: "mydsm",
-                ATTR_UPNP_SERIAL: "001132XXXX59",  # Existing in MACS[0], but SSDP does not have `-`
+                # Existing in MACS[0], but SSDP does not have `-`
+                ATTR_UPNP_SERIAL: "001132XXXX59",
             },
         ),
     )
@@ -601,7 +603,8 @@ async def test_skip_reconfig_ssdp(
             ssdp_location=f"http://{new_host}:5000",
             upnp={
                 ATTR_UPNP_FRIENDLY_NAME: "mydsm",
-                ATTR_UPNP_SERIAL: "001132XXXX59",  # Existing in MACS[0], but SSDP does not have `-`
+                # Existing in MACS[0], but SSDP does not have `-`
+                ATTR_UPNP_SERIAL: "001132XXXX59",
             },
         ),
     )
@@ -634,7 +637,8 @@ async def test_existing_ssdp(hass: HomeAssistant, service: MagicMock) -> None:
             ssdp_location="http://192.168.1.5:5000",
             upnp={
                 ATTR_UPNP_FRIENDLY_NAME: "mydsm",
-                ATTR_UPNP_SERIAL: "001132XXXX59",  # Existing in MACS[0], but SSDP does not have `-`
+                # Existing in MACS[0], but SSDP does not have `-`
+                ATTR_UPNP_SERIAL: "001132XXXX59",
             },
         ),
     )
@@ -707,7 +711,8 @@ async def test_discovered_via_zeroconf(
             type="_http._tcp.local.",
             name="mydsm._http._tcp.local.",
             properties={
-                "mac_address": "00:11:32:XX:XX:99|00:11:22:33:44:55",  # MAC address, but SSDP does not have `-`
+                # MAC address, but SSDP does not have `-`
+                "mac_address": "00:11:32:XX:XX:99|00:11:22:33:44:55",
             },
         ),
     )

--- a/tests/components/synology_dsm/test_media_source.py
+++ b/tests/components/synology_dsm/test_media_source.py
@@ -70,7 +70,7 @@ def dsm_with_photos() -> MagicMock:
 
 @pytest.mark.usefixtures("setup_media_source")
 async def test_get_media_source(hass: HomeAssistant) -> None:
-    """Test the async_get_media_source function and SynologyPhotosMediaSource constructor."""
+    """Test async_get_media_source and SynologyPhotosMediaSource."""
 
     source = await async_get_media_source(hass)
     assert isinstance(source, SynologyPhotosMediaSource)

--- a/tests/components/synology_dsm/test_repairs.py
+++ b/tests/components/synology_dsm/test_repairs.py
@@ -170,7 +170,7 @@ async def test_missing_backup_success(
     hass_client: ClientSessionGenerator,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
-    """Test the missing backup location setup repair flow is fully processed by the user."""
+    """Test missing backup location repair flow is fully processed."""
     ws_client = await hass_ws_client(hass)
     client = await hass_client()
     entries = hass.config_entries.async_entries(DOMAIN)

--- a/tests/components/system_health/test_init.py
+++ b/tests/components/system_health/test_init.py
@@ -145,10 +145,12 @@ async def test_platform_loading(
                         "server_reachable": system_health.async_check_can_reach_url(
                             hass, "http://example.com/status"
                         ),
-                        "server_fail_reachable": system_health.async_check_can_reach_url(
-                            hass,
-                            "http://example.com/status_fail",
-                            more_info="http://more-info-url.com",
+                        "server_fail_reachable": (
+                            system_health.async_check_can_reach_url(
+                                hass,
+                                "http://example.com/status_fail",
+                                more_info="http://more-info-url.com",
+                            )
                         ),
                         "server_timeout": system_health.async_check_can_reach_url(
                             hass,

--- a/tests/components/system_log/test_init.py
+++ b/tests/components/system_log/test_init.py
@@ -143,7 +143,7 @@ async def test_warning(hass: HomeAssistant, hass_ws_client: WebSocketGenerator) 
 async def test_warning_good_format(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
-    """Test that warning with good format arguments are logged and retrieved correctly."""
+    """Test warning with good format arguments are logged correctly."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
     _LOGGER.warning("Warning message: %s", "test")
@@ -156,7 +156,7 @@ async def test_warning_good_format(
 async def test_warning_missing_format_args(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
-    """Test that warning with missing format arguments are logged and retrieved correctly."""
+    """Test warning with missing format args are logged correctly."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
     _LOGGER.warning("Warning message missing a format arg %s")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix all 352 E501 (line too long) violations in `tests/components/` for integrations starting with s.

Part of a series to enforce the 88-character line length limit across the codebase. Changes are purely cosmetic — rewrapped comments, split long strings, shortened docstrings, and reformatted test data. No logic changes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
