### PR TITLE
Load template extensions by class to prevent import deadlock

### DIFF
--- a/homeassistant/helpers/template/__init__.py
+++ b/homeassistant/helpers/template/__init__.py
@@ -36,6 +36,27 @@ from .context import (
     template_context_manager,
     template_cv,
 )
+from .extensions import (
+    AreaExtension,
+    Base64Extension,
+    CollectionExtension,
+    ConfigEntryExtension,
+    CryptoExtension,
+    DateTimeExtension,
+    DeviceExtension,
+    EntityExtension,
+    FloorExtension,
+    FunctionalExtension,
+    IssuesExtension,
+    LabelExtension,
+    MathExtension,
+    RegexExtension,
+    SerializationExtension,
+    StateExtension,
+    StringExtension,
+    TypeCastExtension,
+    VersionExtension,
+)
 from .helpers import result_as_boolean as result_as_boolean
 from .render_info import RenderInfo, render_info_cv
 from .states import (
@@ -722,37 +743,25 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         ] = weakref.WeakValueDictionary()
         self.add_extension("jinja2.ext.loopcontrols")
         self.add_extension("jinja2.ext.do")
-        self.add_extension("homeassistant.helpers.template.extensions.AreaExtension")
-        self.add_extension("homeassistant.helpers.template.extensions.Base64Extension")
-        self.add_extension(
-            "homeassistant.helpers.template.extensions.CollectionExtension"
-        )
-        self.add_extension(
-            "homeassistant.helpers.template.extensions.ConfigEntryExtension"
-        )
-        self.add_extension("homeassistant.helpers.template.extensions.CryptoExtension")
-        self.add_extension(
-            "homeassistant.helpers.template.extensions.DateTimeExtension"
-        )
-        self.add_extension("homeassistant.helpers.template.extensions.DeviceExtension")
-        self.add_extension("homeassistant.helpers.template.extensions.EntityExtension")
-        self.add_extension("homeassistant.helpers.template.extensions.FloorExtension")
-        self.add_extension(
-            "homeassistant.helpers.template.extensions.FunctionalExtension"
-        )
-        self.add_extension("homeassistant.helpers.template.extensions.IssuesExtension")
-        self.add_extension("homeassistant.helpers.template.extensions.LabelExtension")
-        self.add_extension("homeassistant.helpers.template.extensions.MathExtension")
-        self.add_extension("homeassistant.helpers.template.extensions.RegexExtension")
-        self.add_extension(
-            "homeassistant.helpers.template.extensions.SerializationExtension"
-        )
-        self.add_extension("homeassistant.helpers.template.extensions.StateExtension")
-        self.add_extension("homeassistant.helpers.template.extensions.StringExtension")
-        self.add_extension(
-            "homeassistant.helpers.template.extensions.TypeCastExtension"
-        )
-        self.add_extension("homeassistant.helpers.template.extensions.VersionExtension")
+        self.add_extension(AreaExtension)
+        self.add_extension(Base64Extension)
+        self.add_extension(CollectionExtension)
+        self.add_extension(ConfigEntryExtension)
+        self.add_extension(CryptoExtension)
+        self.add_extension(DateTimeExtension)
+        self.add_extension(DeviceExtension)
+        self.add_extension(EntityExtension)
+        self.add_extension(FloorExtension)
+        self.add_extension(FunctionalExtension)
+        self.add_extension(IssuesExtension)
+        self.add_extension(LabelExtension)
+        self.add_extension(MathExtension)
+        self.add_extension(RegexExtension)
+        self.add_extension(SerializationExtension)
+        self.add_extension(StateExtension)
+        self.add_extension(StringExtension)
+        self.add_extension(TypeCastExtension)
+        self.add_extension(VersionExtension)
 
         if hass is not None:
             # This environment has access to hass, attach its loader


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The template integration fails to load on startup with a `DeadlockError` in the `MathExtension` Jinja2 extension. This happens because template extensions are registered by import path string (e.g., `"homeassistant.helpers.template.extensions.MathExtension"`), which causes Jinja2 to call `import_module()` at runtime. When multiple threads create a `TemplateEnvironment` simultaneously during startup, the Python import lock deadlocks.

This changes the extension loading to import the classes at module level and pass them directly to `add_extension()`, avoiding runtime imports entirely. The existing `jinja2.ext` extensions remain as strings since those are external and always pre-loaded.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170975
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr