### PR TITLE
Fix Avea color state refresh

### DIFF
--- a/homeassistant/components/avea/light.py
+++ b/homeassistant/components/avea/light.py
@@ -193,14 +193,14 @@ class AveaLight(LightEntity):
 
     def update(self) -> None:
         """Fetch new state data for this light."""
-        if not self._light.connect():
-            return
+        connected = self._light.connect()
 
         try:
             brightness = self._light.get_brightness()
             rgb_color = self._light.get_rgb()
         finally:
-            self._light.disconnect()
+            if connected:
+                self._light.disconnect()
 
         if brightness is not None:
             self._attr_is_on = brightness != 0

--- a/homeassistant/components/avea/light.py
+++ b/homeassistant/components/avea/light.py
@@ -193,6 +193,16 @@ class AveaLight(LightEntity):
 
     def update(self) -> None:
         """Fetch new state data for this light."""
-        if (brightness := self._light.get_brightness()) is not None:
+        if not self._light.connect():
+            return
+
+        try:
+            brightness = self._light.get_brightness()
+            rgb_color = self._light.get_rgb()
+        finally:
+            self._light.disconnect()
+
+        if brightness is not None:
             self._attr_is_on = brightness != 0
             self._attr_brightness = round(255 * (brightness / 4095))
+        self._attr_hs_color = color_util.color_RGB_to_hs(*rgb_color)

--- a/tests/components/avea/test_light.py
+++ b/tests/components/avea/test_light.py
@@ -2,7 +2,7 @@
 
 from collections.abc import AsyncGenerator
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
@@ -28,7 +28,9 @@ def mock_bulb() -> MagicMock:
     bulb = MagicMock()
     bulb.name = "Bedroom"
     bulb.brightness = 0
+    bulb.connect.return_value = True
     bulb.get_brightness.return_value = 0
+    bulb.get_rgb.return_value = (0, 0, 0)
     return bulb
 
 
@@ -117,13 +119,24 @@ async def test_update_state(
     assert state.attributes[ATTR_BRIGHTNESS] is None
 
     bulb = setup_integration
+    bulb.reset_mock()
+    bulb.connect.return_value = True
     bulb.get_brightness.return_value = 2048
+    bulb.get_rgb.return_value = (0, 255, 0)
 
     freezer.tick(timedelta(seconds=30))
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
+    assert bulb.mock_calls == [
+        call.connect(),
+        call.get_brightness(),
+        call.get_rgb(),
+        call.disconnect(),
+    ]
+
     state = hass.states.get("light.bedroom")
     assert state is not None
     assert state.state == STATE_ON
     assert state.attributes[ATTR_BRIGHTNESS] == 128
+    assert state.attributes[ATTR_HS_COLOR] == (120.0, 100.0)

--- a/tests/components/avea/test_light.py
+++ b/tests/components/avea/test_light.py
@@ -133,14 +133,13 @@ async def test_update_state(
     bulb.get_rgb.assert_called_once()
     bulb.disconnect.assert_called_once()
 
-    assert bulb.mock_calls.index(call.connect()) < bulb.mock_calls.index(
-        call.get_brightness()
-    )
-    assert bulb.mock_calls.index(call.get_brightness()) < bulb.mock_calls.index(
-        call.get_rgb()
-    )
-    assert bulb.mock_calls.index(call.get_rgb()) < bulb.mock_calls.index(
-        call.disconnect()
+    bulb.assert_has_calls(
+        [
+            call.connect(),
+            call.get_brightness(),
+            call.get_rgb(),
+            call.disconnect(),
+        ]
     )
 
     state = hass.states.get("light.bedroom")

--- a/tests/components/avea/test_light.py
+++ b/tests/components/avea/test_light.py
@@ -128,12 +128,20 @@ async def test_update_state(
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert bulb.mock_calls == [
-        call.connect(),
-        call.get_brightness(),
-        call.get_rgb(),
-        call.disconnect(),
-    ]
+    bulb.connect.assert_called_once()
+    bulb.get_brightness.assert_called_once()
+    bulb.get_rgb.assert_called_once()
+    bulb.disconnect.assert_called_once()
+
+    assert bulb.mock_calls.index(call.connect()) < bulb.mock_calls.index(
+        call.get_brightness()
+    )
+    assert bulb.mock_calls.index(call.get_brightness()) < bulb.mock_calls.index(
+        call.get_rgb()
+    )
+    assert bulb.mock_calls.index(call.get_rgb()) < bulb.mock_calls.index(
+        call.disconnect()
+    )
 
     state = hass.states.get("light.bedroom")
     assert state is not None

--- a/tests/components/avea/test_light.py
+++ b/tests/components/avea/test_light.py
@@ -148,3 +148,29 @@ async def test_update_state(
     assert state.state == STATE_ON
     assert state.attributes[ATTR_BRIGHTNESS] == 128
     assert state.attributes[ATTR_HS_COLOR] == (120.0, 100.0)
+
+
+async def test_update_state_uses_cached_values_when_connect_fails(
+    hass: HomeAssistant, setup_integration: MagicMock, freezer: FrozenDateTimeFactory
+) -> None:
+    """Test updating the entity state when the shared connection fails."""
+    bulb = setup_integration
+    bulb.reset_mock()
+    bulb.connect.return_value = False
+    bulb.get_brightness.return_value = 2048
+    bulb.get_rgb.return_value = (0, 255, 0)
+
+    freezer.tick(timedelta(seconds=30))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    bulb.connect.assert_called_once()
+    bulb.get_brightness.assert_called_once()
+    bulb.get_rgb.assert_called_once()
+    bulb.disconnect.assert_not_called()
+
+    state = hass.states.get("light.bedroom")
+    assert state is not None
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 128
+    assert state.attributes[ATTR_HS_COLOR] == (120.0, 100.0)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix Avea light state refresh so color is updated together with brightness during a Home Assistant entity update.

Avea requires separate BLE requests for brightness and color, so this keeps those device-level reads separate. The update now opens one BLE connection, reads brightness and RGB color within the same refresh, then updates the Home Assistant light state with both brightness and `hs_color`.

Previously, Avea only refreshed brightness in `update()`. If the color changed outside Home Assistant, the entity state could report fresh brightness with stale or missing color data.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
