### PR TITLE
Fix Netatmo valve KeyError when hvac_action state is unavailable in Overkiz

### DIFF
--- a/homeassistant/components/overkiz/climate/valve_heating_temperature_interface.py
+++ b/homeassistant/components/overkiz/climate/valve_heating_temperature_interface.py
@@ -72,11 +72,13 @@ class ValveHeatingTemperatureInterface(OverkizEntity, ClimateEntity):
         )
 
     @property
-    def hvac_action(self) -> HVACAction:
+    def hvac_action(self) -> HVACAction | None:
         """Return the current running hvac operation."""
-        return OVERKIZ_TO_HVAC_ACTION[
-            cast(str, self.executor.select_state(OverkizState.CORE_OPEN_CLOSED_VALVE))
-        ]
+        if (
+            state := self.executor.select_state(OverkizState.CORE_OPEN_CLOSED_VALVE)
+        ) is None:
+            return None
+        return OVERKIZ_TO_HVAC_ACTION[cast(str, state)]
 
     @property
     def target_temperature(self) -> float:

--- a/tests/components/overkiz/test_climate.py
+++ b/tests/components/overkiz/test_climate.py
@@ -1,0 +1,67 @@
+"""Tests for the Overkiz climate platform."""
+
+from collections.abc import Generator
+from unittest.mock import patch
+
+from freezegun.api import FrozenDateTimeFactory
+from pyoverkiz.enums import EventName, OverkizState
+import pytest
+
+from homeassistant.components.climate import ATTR_HVAC_ACTION, HVACAction
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .conftest import FixtureDevice, MockOverkizClient, SetupOverkizIntegration
+from .helpers import async_deliver_events, build_event
+
+VALVE = FixtureDevice(
+    "setup/cloud_nexity_rail_din_europe.json",
+    "io://1234-5678-1698/15702199#1",
+    "climate.garden_radiator",
+)
+
+
+@pytest.fixture(autouse=True)
+def fixture_platforms() -> Generator[None]:
+    """Limit platforms to climate only."""
+    with patch("homeassistant.components.overkiz.PLATFORMS", [Platform.CLIMATE]):
+        yield
+
+
+async def test_valve_hvac_action_none_state(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_client: MockOverkizClient,
+    setup_overkiz_integration: SetupOverkizIntegration,
+) -> None:
+    """Test that hvac_action handles None valve state without crashing."""
+    await setup_overkiz_integration(fixture=VALVE.fixture)
+
+    state = hass.states.get(VALVE.entity_id)
+    assert state is not None
+    assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.IDLE
+
+    # Deliver an event that clears the valve state
+    await async_deliver_events(
+        hass,
+        freezer,
+        mock_client,
+        [
+            build_event(
+                EventName.DEVICE_STATE_CHANGED,
+                device_url=VALVE.device_url,
+                device_states=[
+                    {
+                        "name": OverkizState.CORE_OPEN_CLOSED_VALVE,
+                        "type": 3,
+                        "value": None,
+                    }
+                ],
+            )
+        ],
+    )
+
+    # hvac_action should be None (unknown) rather than raising KeyError
+    state = hass.states.get(VALVE.entity_id)
+    assert state is not None
+    assert state.attributes.get(ATTR_HVAC_ACTION) is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Overkiz `ValveHeatingTemperatureInterface` climate entity (used by Netatmo Smart Valves via Overkiz/TaHoma) crashes with a `KeyError` every ~30 seconds when the valve's open/closed state is unavailable. This happens because `executor.select_state(CORE_OPEN_CLOSED_VALVE)` returns `None` when the state doesn't exist on the device, and `None` is not a key in the `OVERKIZ_TO_HVAC_ACTION` dict.

The resulting exception loop causes heavy logspam and can make the UI near-unusable.

The fix checks for `None` before the dict lookup and returns `None` (unknown action) when the valve state is unavailable. Unexpected state values still raise `KeyError` so they get detected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170423
- This PR is related to issue: #135665, #91213, #140461
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr