### PR TITLE
Fix time trigger crash when using entity_id dict format without offset

### DIFF
--- a/homeassistant/components/homeassistant/triggers/time.py
+++ b/homeassistant/components/homeassistant/triggers/time.py
@@ -268,7 +268,7 @@ async def async_attach_trigger(  # noqa: C901
             # entity
             update_entity_trigger(at_time, new_state=hass.states.get(at_time))
             to_track.append(TrackEntity(at_time, update_entity_trigger_event))
-        elif isinstance(at_time, dict) and CONF_OFFSET in at_time:
+        elif isinstance(at_time, dict):
             # entity with offset
             entity_id: str = at_time.get(CONF_ENTITY_ID, "")
             offset: timedelta = at_time.get(CONF_OFFSET, timedelta(0))

--- a/homeassistant/components/homeassistant/triggers/time.py
+++ b/homeassistant/components/homeassistant/triggers/time.py
@@ -269,7 +269,7 @@ async def async_attach_trigger(  # noqa: C901
             update_entity_trigger(at_time, new_state=hass.states.get(at_time))
             to_track.append(TrackEntity(at_time, update_entity_trigger_event))
         elif isinstance(at_time, dict):
-            # entity with offset
+            # entity with optional offset
             entity_id: str = at_time.get(CONF_ENTITY_ID, "")
             offset: timedelta = at_time.get(CONF_OFFSET, timedelta(0))
             update_entity_trigger(

--- a/homeassistant/components/homeassistant/triggers/time.py
+++ b/homeassistant/components/homeassistant/triggers/time.py
@@ -270,7 +270,7 @@ async def async_attach_trigger(  # noqa: C901
             to_track.append(TrackEntity(at_time, update_entity_trigger_event))
         elif isinstance(at_time, dict):
             # entity with optional offset
-            entity_id: str = at_time.get(CONF_ENTITY_ID, "")
+            entity_id: str = at_time[CONF_ENTITY_ID]
             offset: timedelta = at_time.get(CONF_OFFSET, timedelta(0))
             update_entity_trigger(
                 entity_id, new_state=hass.states.get(entity_id), offset=offset

--- a/tests/components/homeassistant/triggers/test_time.py
+++ b/tests/components/homeassistant/triggers/test_time.py
@@ -732,6 +732,52 @@ async def test_if_fires_using_at_sensor_with_offset(
     )
 
 
+async def test_if_fires_using_at_sensor_dict_without_offset(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    service_calls: list[ServiceCall],
+) -> None:
+    """Test for firing at sensor time using dict format without offset."""
+    now = dt_util.now()
+
+    trigger_dt = now.replace(hour=5, minute=0, second=0, microsecond=0) + timedelta(2)
+
+    hass.states.async_set(
+        "sensor.next_alarm",
+        trigger_dt.isoformat(),
+        {ATTR_DEVICE_CLASS: SensorDeviceClass.TIMESTAMP},
+    )
+
+    time_that_will_not_match_right_away = trigger_dt - timedelta(minutes=1)
+
+    freezer.move_to(dt_util.as_utc(time_that_will_not_match_right_away))
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "time",
+                    "at": {
+                        "entity_id": "sensor.next_alarm",
+                    },
+                },
+                "action": {
+                    "service": "test.automation",
+                    "data_template": {"some": "{{ trigger.entity_id }}"},
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    async_fire_time_changed(hass, trigger_dt + timedelta(seconds=1))
+    await hass.async_block_till_done()
+
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "sensor.next_alarm"
+
+
 @pytest.mark.parametrize(
     "conf",
     [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When a time trigger uses the dict format with `entity_id` but without `offset`:

```yaml
trigger:
  - trigger: time
    at:
      - entity_id: sensor.next_alarm
```

The trigger crashes with `AttributeError: 'NodeDictClass' object has no attribute 'hour'`. This happens because the runtime code only handles dicts when `offset` is present (`isinstance(at_time, dict) and CONF_OFFSET in at_time`), even though the schema correctly declares `offset` as optional. When `offset` is missing, the dict falls through to the `datetime.time` branch which tries to access `.hour` on it.

The fix removes the `CONF_OFFSET in at_time` guard so all entity_id dicts are handled correctly. The offset already defaults to `timedelta(0)` via `.get()`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #164697
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr