### PR TITLE
Fix swallowed exception in knx event_register action

### DIFF
--- a/homeassistant/components/knx/services.py
+++ b/homeassistant/components/knx/services.py
@@ -132,7 +132,7 @@ async def service_event_register_modify(call: ServiceCall) -> None:
             translation_domain=DOMAIN,
             translation_key="service_event_register_ga_not_found",
             translation_placeholders={
-                "group_addresses": ", ".join(map(str, _error_gas))
+                "group_addresses": ", ".join(map(str, sorted(_error_gas)))
             },
         )
 

--- a/homeassistant/components/knx/services.py
+++ b/homeassistant/components/knx/services.py
@@ -114,7 +114,7 @@ async def service_event_register_modify(call: ServiceCall) -> None:
     knx_module = get_knx_module(call.hass)
 
     attr_address = call.data[KNX_ADDRESS]
-    group_addresses = list(map(parse_device_group_address, attr_address))
+    group_addresses = set(map(parse_device_group_address, attr_address))
 
     if call.data.get(SERVICE_KNX_ATTR_REMOVE):
         _error_gas = set()

--- a/homeassistant/components/knx/services.py
+++ b/homeassistant/components/knx/services.py
@@ -117,18 +117,24 @@ async def service_event_register_modify(call: ServiceCall) -> None:
     group_addresses = list(map(parse_device_group_address, attr_address))
 
     if call.data.get(SERVICE_KNX_ATTR_REMOVE):
+        _error_gas = set()
         for group_address in group_addresses:
             try:
                 knx_module.knx_event_callback.group_addresses.remove(group_address)
-            # pylint: disable-next=home-assistant-action-swallowed-exception
             except ValueError:
-                _LOGGER.warning(
-                    "Service event_register could not remove event for '%s'",
-                    str(group_address),
-                )
+                _error_gas.add(group_address)
             if group_address in knx_module.group_address_transcoder:
                 del knx_module.group_address_transcoder[group_address]
-        return
+
+        if not _error_gas:
+            return
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="service_event_register_ga_not_found",
+            translation_placeholders={
+                "group_addresses": ", ".join(map(str, _error_gas))
+            },
+        )
 
     if (dpt := call.data.get(CONF_TYPE)) and (
         transcoder := DPTBase.parse_transcoder(dpt)

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -1094,6 +1094,9 @@
     "integration_not_loaded": {
       "message": "KNX integration is not loaded."
     },
+    "service_event_register_ga_not_found": {
+      "message": "Could not remove event for `{group_addresses}`"
+    },
     "service_exposure_remove_not_found": {
       "message": "Could not find exposure for `{group_address}` to remove."
     },

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -1095,7 +1095,7 @@
       "message": "KNX integration is not loaded."
     },
     "service_event_register_ga_not_found": {
-      "message": "Could not remove event for `{group_addresses}`"
+      "message": "Could not find registered event for `{group_addresses}` to remove."
     },
     "service_exposure_remove_not_found": {
       "message": "Could not find exposure for `{group_address}` to remove."

--- a/tests/components/knx/test_services.py
+++ b/tests/components/knx/test_services.py
@@ -194,6 +194,18 @@ async def test_event_register(hass: HomeAssistant, knx: KNXTestKit) -> None:
     assert untyped_event_1.data["data"] is True
     assert untyped_event_1.data["value"] is None
 
+    # remove event for non-registered address - raise error
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            "knx",
+            "event_register",
+            {"address": "4/4/4", "remove": True},
+            blocking=True,
+        )
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "service_event_register_ga_not_found"
+    assert exc_info.value.translation_placeholders == {"group_addresses": "4/4/4"}
+
 
 async def test_exposure_register(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test `knx.exposure_register` service."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Raise HomeAssistantError instead of logging a warning.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170618
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
