### PR TITLE
Fix shorthand template conditions in choose blocks crashing all automations

### DIFF
--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -1748,9 +1748,15 @@ def state_validate_config(hass: HomeAssistant, config: ConfigType) -> ConfigType
 
 
 async def async_validate_condition_config(
-    hass: HomeAssistant, config: ConfigType
+    hass: HomeAssistant, config: ConfigType | str
 ) -> ConfigType:
     """Validate config."""
+    if isinstance(config, str):
+        # Shorthand template condition not yet converted by schema
+        config = {
+            CONF_CONDITION: "template",
+            CONF_VALUE_TEMPLATE: config,
+        }
     condition_key: str = config[CONF_CONDITION]
 
     if condition_key in ("and", "not", "or"):

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -1752,10 +1752,9 @@ async def async_validate_condition_config(
 ) -> ConfigType:
     """Validate config."""
     if isinstance(config, str):
-        # Shorthand template condition not yet converted by schema
         config = {
             CONF_CONDITION: "template",
-            CONF_VALUE_TEMPLATE: config,
+            CONF_VALUE_TEMPLATE: cv.dynamic_template(config),
         }
     condition_key: str = config[CONF_CONDITION]
 

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -760,6 +760,12 @@ async def test_shorthand_template_condition_in_or(hass: HomeAssistant) -> None:
     config = await condition.async_validate_condition_config(hass, config)
     assert config["conditions"][0]["condition"] == "template"
 
+    # Verify the condition can actually be evaluated at runtime
+    test = await condition.async_from_config(hass, config)
+    hass.states.async_set("sensor.test", "on")
+    hass.states.async_set("sensor.other", "off")
+    assert test.async_check()
+
 
 async def test_not_condition(hass: HomeAssistant) -> None:
     """Test the 'not' condition."""

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -748,6 +748,19 @@ async def test_or_condition_shorthand(hass: HomeAssistant) -> None:
     assert test.async_check()
 
 
+async def test_shorthand_template_condition_in_or(hass: HomeAssistant) -> None:
+    """Test shorthand template condition inside or block doesn't crash."""
+    config = {
+        "condition": "or",
+        "conditions": [
+            '{{ states("sensor.test") == "on" }}',
+            {"condition": "state", "entity_id": "sensor.other", "state": "on"},
+        ],
+    }
+    config = await condition.async_validate_condition_config(hass, config)
+    assert config["conditions"][0]["condition"] == "template"
+
+
 async def test_not_condition(hass: HomeAssistant) -> None:
     """Test the 'not' condition."""
     config = {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When a shorthand template condition (bare Jinja2 string) is used inside a `choose`, `or`, `and`, or `not` block, `async_validate_condition_config` crashes with `TypeError: string indices must be integers, not 'str'` because it expects a dict but receives a raw string.

The schema's `dynamic_template_condition` normally converts bare template strings to `{condition: "template", value_template: "..."}` dicts, but this conversion doesn't run when `async_validate_condition_config` recurses into nested condition lists. One malformed condition in one automation takes down all automations globally.

The fix handles the bare string case defensively in `async_validate_condition_config` by converting it to the proper template condition dict before accessing dict keys.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170266
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr