### PR TITLE
Add additional overrides to cover entity in Overkiz

### DIFF
--- a/homeassistant/components/overkiz/cover.py
+++ b/homeassistant/components/overkiz/cover.py
@@ -354,6 +354,9 @@ COVER_DESCRIPTIONS: list[OverkizCoverDescription] = [
         close_command=OverkizCommand.CLOSE,
         is_closed_state=OverkizState.CORE_OPEN_CLOSED,
         stop_command=OverkizCommand.STOP,
+        current_tilt_position_state=OverkizState.CORE_SLATE_ORIENTATION,
+        set_tilt_position_command=OverkizCommand.SET_ORIENTATION,
+        stop_tilt_command=OverkizCommand.STOP,
     ),
     OverkizCoverDescription(
         key=UIClass.SCREEN,

--- a/homeassistant/components/overkiz/cover.py
+++ b/homeassistant/components/overkiz/cover.py
@@ -101,38 +101,6 @@ COVER_DESCRIPTIONS: list[OverkizCoverDescription] = [
         close_tilt_command=OverkizCommand.LOWER_CLOSE,
         stop_tilt_command=OverkizCommand.STOP,
     ),
-    # Needs override since PositionableOrOrientableRollerShutter has orientation
-    # (core:SlateOrientationState + setOrientation) not provided by UIClass.ROLLER_SHUTTER
-    # uiClass is RollerShutter
-    OverkizCoverDescription(
-        key=UIWidget.POSITIONABLE_OR_ORIENTABLE_ROLLER_SHUTTER,
-        device_class=CoverDeviceClass.SHUTTER,
-        current_position_state=OverkizState.CORE_CLOSURE,
-        set_position_command=OverkizCommand.SET_CLOSURE,
-        open_command=OverkizCommand.OPEN,
-        close_command=OverkizCommand.CLOSE,
-        stop_command=OverkizCommand.STOP,
-        is_closed_state=OverkizState.CORE_OPEN_CLOSED,
-        current_tilt_position_state=OverkizState.CORE_SLATE_ORIENTATION,
-        set_tilt_position_command=OverkizCommand.SET_ORIENTATION,
-        stop_tilt_command=OverkizCommand.STOP,
-    ),
-    # Needs override since PositionableOrProgressiveOrientableRollerShutter has orientation
-    # (core:SlateOrientationState + setOrientation) not provided by UIClass.ROLLER_SHUTTER
-    # uiClass is RollerShutter
-    OverkizCoverDescription(
-        key=UIWidget.POSITIONABLE_OR_PROGRESSIVE_ORIENTABLE_ROLLER_SHUTTER,
-        device_class=CoverDeviceClass.SHUTTER,
-        current_position_state=OverkizState.CORE_CLOSURE,
-        set_position_command=OverkizCommand.SET_CLOSURE,
-        open_command=OverkizCommand.OPEN,
-        close_command=OverkizCommand.CLOSE,
-        stop_command=OverkizCommand.STOP,
-        is_closed_state=OverkizState.CORE_OPEN_CLOSED,
-        current_tilt_position_state=OverkizState.CORE_SLATE_ORIENTATION,
-        set_tilt_position_command=OverkizCommand.SET_ORIENTATION,
-        stop_tilt_command=OverkizCommand.STOP,
-    ),
     # Needs override to add support for very specific tilt commands
     # uiClass is VenetianBlind
     OverkizCoverDescription(

--- a/homeassistant/components/overkiz/cover.py
+++ b/homeassistant/components/overkiz/cover.py
@@ -210,6 +210,41 @@ COVER_DESCRIPTIONS: list[OverkizCoverDescription] = [
         is_closed_state=OverkizState.CORE_OPEN_CLOSED_PEDESTRIAN,
         stop_command=OverkizCommand.STOP,
     ),
+    # Needs override since OpenCloseGateWithPedestrianPosition reports
+    # core:OpenClosedPedestrianState instead of core:OpenClosedState
+    # uiClass is Gate
+    OverkizCoverDescription(
+        key=UIWidget.OPEN_CLOSE_GATE_WITH_PEDESTRIAN_POSITION,
+        device_class=CoverDeviceClass.GATE,
+        open_command=OverkizCommand.OPEN,
+        close_command=OverkizCommand.CLOSE,
+        is_closed_state=OverkizState.CORE_OPEN_CLOSED_PEDESTRIAN,
+        stop_command=OverkizCommand.STOP,
+    ),
+    # Needs override since OpenCloseSlidingGateWithPedestrianPosition reports
+    # core:OpenClosedPedestrianState instead of core:OpenClosedState
+    # uiClass is Gate
+    OverkizCoverDescription(
+        key=UIWidget.OPEN_CLOSE_SLIDING_GATE_WITH_PEDESTRIAN_POSITION,
+        device_class=CoverDeviceClass.GATE,
+        open_command=OverkizCommand.OPEN,
+        close_command=OverkizCommand.CLOSE,
+        is_closed_state=OverkizState.CORE_OPEN_CLOSED_PEDESTRIAN,
+        stop_command=OverkizCommand.STOP,
+    ),
+    # Needs override since PositionableGateWithPedestrianPosition reports
+    # core:OpenClosedPedestrianState instead of core:OpenClosedState
+    # uiClass is Gate
+    OverkizCoverDescription(
+        key=UIWidget.POSITIONABLE_GATE_WITH_PEDESTRIAN_POSITION,
+        device_class=CoverDeviceClass.GATE,
+        open_command=OverkizCommand.OPEN,
+        close_command=OverkizCommand.CLOSE,
+        is_closed_state=OverkizState.CORE_OPEN_CLOSED_PEDESTRIAN,
+        current_position_state=OverkizState.CORE_CLOSURE,
+        set_position_command=OverkizCommand.SET_CLOSURE,
+        stop_command=OverkizCommand.STOP,
+    ),
     # Needs override to support this Generic device (rts:GenericRTSComponent)
     # uiClass is Generic (not mapped to cover as this is a Generic device class)
     OverkizCoverDescription(

--- a/homeassistant/components/overkiz/cover.py
+++ b/homeassistant/components/overkiz/cover.py
@@ -101,6 +101,38 @@ COVER_DESCRIPTIONS: list[OverkizCoverDescription] = [
         close_tilt_command=OverkizCommand.LOWER_CLOSE,
         stop_tilt_command=OverkizCommand.STOP,
     ),
+    # Needs override since PositionableOrOrientableRollerShutter has orientation
+    # (core:SlateOrientationState + setOrientation) not provided by UIClass.ROLLER_SHUTTER
+    # uiClass is RollerShutter
+    OverkizCoverDescription(
+        key=UIWidget.POSITIONABLE_OR_ORIENTABLE_ROLLER_SHUTTER,
+        device_class=CoverDeviceClass.SHUTTER,
+        current_position_state=OverkizState.CORE_CLOSURE,
+        set_position_command=OverkizCommand.SET_CLOSURE,
+        open_command=OverkizCommand.OPEN,
+        close_command=OverkizCommand.CLOSE,
+        stop_command=OverkizCommand.STOP,
+        is_closed_state=OverkizState.CORE_OPEN_CLOSED,
+        current_tilt_position_state=OverkizState.CORE_SLATE_ORIENTATION,
+        set_tilt_position_command=OverkizCommand.SET_ORIENTATION,
+        stop_tilt_command=OverkizCommand.STOP,
+    ),
+    # Needs override since PositionableOrProgressiveOrientableRollerShutter has orientation
+    # (core:SlateOrientationState + setOrientation) not provided by UIClass.ROLLER_SHUTTER
+    # uiClass is RollerShutter
+    OverkizCoverDescription(
+        key=UIWidget.POSITIONABLE_OR_PROGRESSIVE_ORIENTABLE_ROLLER_SHUTTER,
+        device_class=CoverDeviceClass.SHUTTER,
+        current_position_state=OverkizState.CORE_CLOSURE,
+        set_position_command=OverkizCommand.SET_CLOSURE,
+        open_command=OverkizCommand.OPEN,
+        close_command=OverkizCommand.CLOSE,
+        stop_command=OverkizCommand.STOP,
+        is_closed_state=OverkizState.CORE_OPEN_CLOSED,
+        current_tilt_position_state=OverkizState.CORE_SLATE_ORIENTATION,
+        set_tilt_position_command=OverkizCommand.SET_ORIENTATION,
+        stop_tilt_command=OverkizCommand.STOP,
+    ),
     # Needs override to add support for very specific tilt commands
     # uiClass is VenetianBlind
     OverkizCoverDescription(


### PR DESCRIPTION
## Proposed change
Based on the available UIWidgets, adding additional overrides for the "withPedestrianPosition" devices. Add tilt support to the Roller Shutter.

Unfortunately I haven't been able to find device fixtures for these specific devices, but they are very similar to previous implementations / bugfixes after the large cover entity rewrite.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
