### PR TITLE
Fix Verisure alarm crash when cloud rejects arm/disarm command

### DIFF
--- a/homeassistant/components/verisure/alarm_control_panel.py
+++ b/homeassistant/components/verisure/alarm_control_panel.py
@@ -65,6 +65,7 @@ class VerisureAlarm(
         )
         LOGGER.debug("Verisure set arm state %s", state)
         if arm_state is None or "data" not in arm_state:
+            await self.coordinator.async_refresh()
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="arm_state_failed",
@@ -83,6 +84,8 @@ class VerisureAlarm(
                     list(arm_state["data"].values())[0], state
                 ),
             )
+            if transaction is None:
+                continue
             result = (
                 transaction.get("data", {})
                 .get("installation", {})

--- a/homeassistant/components/verisure/alarm_control_panel.py
+++ b/homeassistant/components/verisure/alarm_control_panel.py
@@ -9,6 +9,7 @@ from homeassistant.components.alarm_control_panel import (
     CodeFormat,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -63,6 +64,11 @@ class VerisureAlarm(
             self.coordinator.verisure.request, command_data
         )
         LOGGER.debug("Verisure set arm state %s", state)
+        if arm_state is None or "data" not in arm_state:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="arm_state_failed",
+            )
         result = None
         attempts = 0
         while result is None:

--- a/homeassistant/components/verisure/strings.json
+++ b/homeassistant/components/verisure/strings.json
@@ -51,6 +51,11 @@
       }
     }
   },
+  "exceptions": {
+    "arm_state_failed": {
+      "message": "Failed to change alarm state. Check your code and try again."
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/homeassistant/components/verisure/strings.json
+++ b/homeassistant/components/verisure/strings.json
@@ -53,7 +53,7 @@
   },
   "exceptions": {
     "arm_state_failed": {
-      "message": "Failed to change alarm state. Check your code and try again."
+      "message": "Failed to change alarm state. Verify your code is correct and that your account is not temporarily locked."
     }
   },
   "options": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When the Verisure cloud rejects an `alarm_arm_*` or `alarm_disarm` call (wrong PIN, wrong PIN length, rate-limited account), the API returns `None`. The code then tries `arm_state["data"]` on the `None` return value, crashing with:

```
AttributeError: 'NoneType' object has no attribute 'get'
```

This makes ordinary user mistakes (mistyped PIN, too few digits) appear as an integration crash rather than clear feedback.

The fix checks for `None` before accessing the response and raises a translated `HomeAssistantError` so the user sees a proper error message in the UI.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170063
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr