### PR TITLE
Add decorator to license exceptions

### DIFF
--- a/script/licenses.py
+++ b/script/licenses.py
@@ -184,6 +184,7 @@ EXCEPTIONS = {
     "crownstone-core",  # https://github.com/crownstone/crownstone-lib-python-core/pull/6
     "crownstone-sse",  # https://github.com/crownstone/crownstone-lib-python-sse/pull/2
     "crownstone-uart",  # https://github.com/crownstone/crownstone-lib-python-uart/pull/12
+    "decorator",  # BSD-2-Clause
     "eliqonline",  # https://github.com/molobrakos/eliqonline/pull/17
     "imutils",  # https://github.com/PyImageSearch/imutils/pull/292
     "iso4217",  # Public domain


### PR DESCRIPTION
## Proposed change

Add `decorator` to the license audit exceptions.

`decorator==5.3.0` is BSD-2-Clause licensed and ships `LICENSE.txt`, but the 5.3.0 wheel no longer exposes machine-readable license metadata (`License`, `License-Expression`, or license classifiers). The license audit therefore reports it as `None -- None -- []`.

Earlier `decorator==5.2.1` wheels exposed `License: BSD-2-Clause` and `License :: OSI Approved :: BSD License`, so this started failing after the 5.3.0 release.

Validation performed:

- `ruff check script/licenses.py`
- `ruff format --check script/licenses.py`
- `git diff --check`
- verified a synthetic `decorator==5.3.0` package definition is not metadata-approved but is covered by the exception

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: n/a
- This PR is related to issue: n/a
- Link to documentation pull request: n/a
- Link to developer documentation pull request: n/a
- Link to frontend pull request: n/a

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.