### PR TITLE
Send Marantz IR power-on command with repeat_count=5

### DIFF
--- a/homeassistant/components/marantz_infrared/entity.py
+++ b/homeassistant/components/marantz_infrared/entity.py
@@ -33,11 +33,15 @@ class MarantzIrEntity(InfraredEmitterConsumerEntity):
             model=None if lib_model is marantz_models.GENERIC else lib_model.name,
         )
 
-    async def _send_marantz_command(self, code: MarantzAudioCode) -> None:
+    async def _send_marantz_command(
+        self, code: MarantzAudioCode, repeat_count: int = 0
+    ) -> None:
         """Send an IR command using the Marantz protocol.
 
         Flips the RC-5 toggle bit before each frame so the receiver
         treats consecutive presses as new presses, not as a held repeat.
         """
         self._runtime_data.toggle ^= 1
-        await self._send_command(code.to_command(toggle=self._runtime_data.toggle))
+        await self._send_command(
+            code.to_command(repeat_count=repeat_count, toggle=self._runtime_data.toggle)
+        )

--- a/homeassistant/components/marantz_infrared/media_player.py
+++ b/homeassistant/components/marantz_infrared/media_player.py
@@ -117,7 +117,7 @@ class MarantzIrAmplifierMediaPlayer(MarantzIrEntity, MediaPlayerEntity, RestoreE
 
     async def async_turn_on(self) -> None:
         """Send discrete power-on command."""
-        await self._send_marantz_command(MarantzAudioCode.POWER_ON)
+        await self._send_marantz_command(MarantzAudioCode.POWER_ON, repeat_count=5)
         self._attr_state = MediaPlayerState.ON
         self.async_write_ha_state()
 

--- a/tests/components/marantz_infrared/test_media_player.py
+++ b/tests/components/marantz_infrared/test_media_player.py
@@ -286,3 +286,20 @@ async def test_toggle_flips_between_commands(
 
     toggles = [call.kwargs["toggle"] for call in mock_marantz_to_command.call_args_list]
     assert toggles == [1, 0, 1, 0]
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_power_on_sends_repeat_count(
+    hass: HomeAssistant,
+    mock_marantz_to_command: MagicMock,
+) -> None:
+    """Power-on sends repeat_count=5 so the receiver reliably wakes up."""
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: MEDIA_PLAYER_ENTITY_ID},
+        blocking=True,
+    )
+
+    assert mock_marantz_to_command.call_count == 1
+    assert mock_marantz_to_command.call_args_list[0].kwargs["repeat_count"] == 5


### PR DESCRIPTION
## Breaking change

N/A

## Proposed change

Send the Marantz IR POWER_ON command with `repeat_count=5` so the emitter transmits the frame 6 times total. Marantz receivers require multiple repetitions of the power-on IR frame to reliably wake up from standby.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)