### PR TITLE
Group sequential executor jobs in Backblaze B2 backup agent

### DIFF
--- a/homeassistant/components/backblaze_b2/backup.py
+++ b/homeassistant/components/backblaze_b2/backup.py
@@ -175,12 +175,13 @@ class BackblazeBackupAgent(BackupAgent):
             "Attempting to delete partially uploaded backup file %s",
             filename,
         )
+
+        def _delete_uploaded_file() -> None:
+            """Look up and delete the partially uploaded backup file."""
+            self._bucket.get_file_info_by_name(filename).delete()
+
         try:
-            uploaded_main_file_info = await self._hass.async_add_executor_job(
-                self._bucket.get_file_info_by_name, filename
-            )
-            # pylint: disable-next=home-assistant-sequential-executor-jobs
-            await self._hass.async_add_executor_job(uploaded_main_file_info.delete)
+            await self._hass.async_add_executor_job(_delete_uploaded_file)
         except B2Error:
             _LOGGER.warning(
                 "Failed to clean up partially uploaded backup file %s;"
@@ -386,9 +387,12 @@ class BackblazeBackupAgent(BackupAgent):
             metadata_file.file_name,
         )
 
-        await self._hass.async_add_executor_job(file.delete)
-        # pylint: disable-next=home-assistant-sequential-executor-jobs
-        await self._hass.async_add_executor_job(metadata_file.delete)
+        def _delete_backup_files() -> None:
+            """Delete the backup file and its metadata file."""
+            file.delete()
+            metadata_file.delete()
+
+        await self._hass.async_add_executor_job(_delete_backup_files)
 
         self._invalidate_caches(
             backup_id,


### PR DESCRIPTION
## Proposed change

  The `backblaze_b2` backup agent had two places where multiple sequential blocking calls were each dispatched as their own `async_add_executor_job`, causing unnecessary context switches between the event loop and the executor. Both were
   flagged by the `home-assistant-sequential-executor-jobs` pylint check and suppressed with inline `# pylint: disable-next` comments.

  - `_cleanup_failed_upload` looked up the partially uploaded file and then deleted it in two separate executor jobs.
  - `async_delete_backup` deleted the backup file and its metadata file in two separate executor jobs.

  Each pair is now wrapped in a small helper that performs all the blocking work, so it runs as a single executor job. The `# pylint: disable-next=home-assistant-sequential-executor-jobs` comments are no longer needed and have been
  removed.

  ## Type of change

  <!--
    What type of change does your PR introduce to Home Assistant?
    NOTE: Please, check only 1! box!
    If your PR requires multiple boxes to be checked, you'll most likely need to
    split it into multiple PRs. This makes things easier and faster to code review.
  -->

  - [ ] Dependency upgrade
  - [ ] Bugfix (non-breaking change which fixes an issue)
  - [ ] New integration (thank you!)
  - [ ] New feature (which adds functionality to an existing integration)
  - [ ] Deprecation (breaking change to happen in the future)
  - [ ] Breaking change (fix/feature causing existing functionality to break)
  - [x] Code quality improvements to existing code or addition of tests

  ## Additional information

  <!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
  -->

  - This PR fixes or closes issue: fixes #170814
  - This PR is related to issue:
  - Link to documentation pull request:
  - Link to developer documentation pull request:
  - Link to frontend pull request:

  ## Checklist

  <!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.

    AI tools are welcome, but contributors are responsible for *fully*
    understanding the code before submitting a PR.
  -->

  - [x] I understand the code I am submitting and can explain how it works.
  - [x] The code change is tested and works locally.
  - [x] Local tests pass. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
  - [x] I have followed the [perfect PR recommendations][perfect-pr]
  - [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
  - [ ] Tests have been added to verify that the new code works.
  - [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

  If user exposed functionality or configuration variables are added/changed:

  - [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

  If the code communicates with devices, web services, or third-party tools:

  - [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
        Updated and included derived files by running: `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt`.
        Updated by running `python3 -m script.gen_requirements_all`.
  - [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

  <!--
    This project is very active and we have a high turnover of pull requests.

    Unfortunately, the number of incoming pull requests is higher than what our
    reviewers can review and merge so there is a long backlog of pull requests
    waiting for review. You can help here!

    By reviewing another pull request, you will help raise the code quality of
    that pull request and the final review will be faster. This way the general
    pace of pull request reviews will go up and your wait time will go down.

    When picking a pull request to review, try to choose one that hasn't yet
    been reviewed.

    Thanks for helping out!
  -->

  To help with the load of incoming pull requests:

  - [ ] I have reviewed two other [open pull requests][prs] in this repository.

  [prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

  <!--
    Thank you for contributing <3

    Below, some useful links you could explore:
  -->
  [dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
  [manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
  [quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
  [docs-repository]: https://github.com/home-assistant/home-assistant.io
  [perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

  Title for the PR: Group sequential executor jobs in Backblaze B2 backup agent