### PR TITLE
Populate braviatv source_list when TV starts in standby

### DIFF
--- a/homeassistant/components/braviatv/coordinator.py
+++ b/homeassistant/components/braviatv/coordinator.py
@@ -168,6 +168,7 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
                 except BraviaAuthError as err:
                     raise ConfigEntryAuthFailed from err
 
+            was_on = self.is_on
             power_status = await self.client.get_power_status()
             self.is_on = power_status == "active"
             self.skipped_updates = 0
@@ -178,11 +179,12 @@ class BraviaTVCoordinator(DataUpdateCoordinator[None]):
             if not self.system_info:
                 self.system_info = await self.client.get_system_info()
 
+            if not self.source_map or (self.is_on and not was_on):
+                await self.async_update_sources()
+
             if self.is_on is False:
                 return
 
-            if not self.source_map:
-                await self.async_update_sources()
             await self.async_update_volume()
             await self.async_update_playing()
         except BraviaNotFound as err:

--- a/tests/components/braviatv/test_coordinator.py
+++ b/tests/components/braviatv/test_coordinator.py
@@ -1,0 +1,205 @@
+"""Tests for the Bravia TV coordinator."""
+
+from unittest.mock import AsyncMock
+
+from pybravia import BraviaConnectionError
+import pytest
+
+from homeassistant.components.braviatv.const import DOMAIN
+from homeassistant.components.braviatv.coordinator import BraviaTVCoordinator
+from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PIN
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+MOCK_CONFIG_DATA = {
+    CONF_HOST: "192.168.1.100",
+    CONF_MAC: "AA:BB:CC:DD:EE:FF",
+    CONF_PIN: "1234",
+}
+
+MOCK_SYSTEM_INFO = {
+    "product": "TV",
+    "model": "XR-55A95K",
+    "macAddr": "AA:BB:CC:DD:EE:FF",
+}
+
+MOCK_INPUTS = [
+    {"title": "HDMI 1", "uri": "extInput:hdmi?port=1"},
+    {"title": "HDMI 2", "uri": "extInput:hdmi?port=2"},
+    {"title": "AV/Component", "uri": "extInput:component?port=1"},
+]
+
+MOCK_APPS = [
+    {"title": "Netflix", "uri": "com.sony.dtv.com.netflix.ninja"},
+    {"title": "YouTube", "uri": "com.sony.dtv.com.google.android.youtube.tv"},
+]
+
+MOCK_CHANNELS = [
+    {"title": "BBC One", "uri": "tv:dvbt?trip=1.2.3&srvName=BBC+One", "dispNum": "1"},
+]
+
+
+@pytest.fixture
+def mock_bravia_client() -> AsyncMock:
+    """Return a configured mock BraviaClient instance."""
+    client = AsyncMock()
+    client.connect = AsyncMock()
+    client.get_power_status = AsyncMock(return_value="active")
+    client.get_system_info = AsyncMock(return_value=MOCK_SYSTEM_INFO)
+    client.get_external_status = AsyncMock(return_value=MOCK_INPUTS)
+    client.get_app_list = AsyncMock(return_value=MOCK_APPS)
+    client.get_content_list_all = AsyncMock(return_value=MOCK_CHANNELS)
+    client.get_volume_info = AsyncMock(
+        return_value={"volume": 50, "mute": False, "target": "speaker"}
+    )
+    client.get_playing_info = AsyncMock(return_value={})
+    return client
+
+
+@pytest.fixture
+def coordinator(
+    hass: HomeAssistant, mock_bravia_client: AsyncMock
+) -> BraviaTVCoordinator:
+    """Create a coordinator backed by the mock client."""
+    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA)
+    config_entry.add_to_hass(hass)
+    coord = BraviaTVCoordinator(
+        hass=hass,
+        config_entry=config_entry,
+        client=mock_bravia_client,
+    )
+    coord.connected = True  # skip connect step
+    return coord
+
+
+async def test_sources_populated_when_tv_on(
+    coordinator: BraviaTVCoordinator,
+) -> None:
+    """Source list is populated on the first update when TV is on."""
+    await coordinator.async_refresh()
+
+    assert coordinator.is_on is True
+    assert coordinator.source_list == ["HDMI 1", "HDMI 2", "AV/Component"]
+    assert len(coordinator.source_map) == len(MOCK_INPUTS) + len(MOCK_APPS) + len(
+        MOCK_CHANNELS
+    )
+
+
+async def test_sources_populated_when_tv_off(
+    coordinator: BraviaTVCoordinator,
+    mock_bravia_client: AsyncMock,
+) -> None:
+    """Source list is populated even when the TV is in standby."""
+    mock_bravia_client.get_power_status.return_value = "standby"
+    mock_bravia_client.get_content_list_all.return_value = []
+
+    await coordinator.async_refresh()
+
+    assert coordinator.is_on is False
+    assert coordinator.source_list == ["HDMI 1", "HDMI 2", "AV/Component"]
+
+
+async def test_sources_not_populated_on_connection_error(
+    coordinator: BraviaTVCoordinator,
+    mock_bravia_client: AsyncMock,
+) -> None:
+    """A connection error during source fetch is handled by the outer error handler."""
+    mock_bravia_client.get_power_status.return_value = "standby"
+    mock_bravia_client.get_external_status.side_effect = BraviaConnectionError()
+
+    await coordinator.async_refresh()
+
+    assert coordinator.is_on is False
+    assert coordinator.source_list == []
+
+
+async def test_volume_and_playing_not_fetched_when_off(
+    coordinator: BraviaTVCoordinator,
+    mock_bravia_client: AsyncMock,
+) -> None:
+    """Volume and playing info are not fetched when TV is off."""
+    mock_bravia_client.get_power_status.return_value = "standby"
+
+    await coordinator.async_refresh()
+
+    mock_bravia_client.get_volume_info.assert_not_called()
+    mock_bravia_client.get_playing_info.assert_not_called()
+
+
+async def test_sources_fetched_only_once_while_on(
+    coordinator: BraviaTVCoordinator,
+    mock_bravia_client: AsyncMock,
+) -> None:
+    """Sources are not re-fetched on consecutive updates while TV remains on."""
+    await coordinator.async_refresh()
+    await coordinator.async_refresh()
+
+    mock_bravia_client.get_external_status.assert_called_once()
+
+
+async def test_sources_repopulated_when_tv_turns_on(
+    coordinator: BraviaTVCoordinator,
+    mock_bravia_client: AsyncMock,
+) -> None:
+    """Sources are re-fetched with real device names when TV transitions from standby to on.
+
+    In standby the TV returns generic names ("HDMI 1"). When it powers on it reads
+    device names via EDID ("PlayStation 5"). Without re-fetching on this transition,
+    the source list would be permanently stuck with the generic standby names.
+    """
+    mock_bravia_client.get_power_status.side_effect = ["standby", "active"]
+    mock_bravia_client.get_content_list_all.side_effect = [[], MOCK_CHANNELS]
+    mock_bravia_client.get_external_status.side_effect = [
+        MOCK_INPUTS,
+        [
+            {"title": "PlayStation 5", "uri": "extInput:hdmi?port=1"},
+            {"title": "Apple TV", "uri": "extInput:hdmi?port=2"},
+            {"title": "AV/Component", "uri": "extInput:component?port=1"},
+        ],
+    ]
+
+    await coordinator.async_refresh()
+    assert coordinator.source_list == ["HDMI 1", "HDMI 2", "AV/Component"]
+
+    await coordinator.async_refresh()
+    assert coordinator.source_list == ["PlayStation 5", "Apple TV", "AV/Component"]
+    assert mock_bravia_client.get_external_status.call_count == 2
+
+
+async def test_sources_not_overwritten_when_tv_turns_off(
+    coordinator: BraviaTVCoordinator,
+    mock_bravia_client: AsyncMock,
+) -> None:
+    """Sources are not re-fetched when TV transitions from on to standby.
+
+    When the TV is on, real device names are populated ("PlayStation 5"). When it
+    enters standby those names should be preserved, not overwritten with the generic
+    standby names the TV would return.
+    """
+    mock_bravia_client.get_power_status.side_effect = ["active", "standby"]
+    mock_bravia_client.get_external_status.return_value = [
+        {"title": "PlayStation 5", "uri": "extInput:hdmi?port=1"},
+        {"title": "Apple TV", "uri": "extInput:hdmi?port=2"},
+        {"title": "AV/Component", "uri": "extInput:component?port=1"},
+    ]
+
+    await coordinator.async_refresh()
+    assert coordinator.source_list == ["PlayStation 5", "Apple TV", "AV/Component"]
+
+    await coordinator.async_refresh()
+    assert coordinator.source_list == ["PlayStation 5", "Apple TV", "AV/Component"]
+    mock_bravia_client.get_external_status.assert_called_once()
+
+
+async def test_sources_repopulated_after_explicit_refresh(
+    coordinator: BraviaTVCoordinator,
+    mock_bravia_client: AsyncMock,
+) -> None:
+    """async_update_sources resets and fully repopulates source_list."""
+    await coordinator.async_refresh()
+
+    await coordinator.async_update_sources()
+
+    assert coordinator.source_list == ["HDMI 1", "HDMI 2", "AV/Component"]
+    assert mock_bravia_client.get_external_status.call_count == 2


### PR DESCRIPTION
This is my first HA core PR, so apologies if anything isn't perfect! Please feel free to nit-pick this PR.

I did use Claude Code Sonnet 4.7 (the commit is co-authored as such) to help with this, but I edited the code manually to make the minimal change.

## Proposed change

Update `braviatv` to fetch the source list even when the device is off.

There were no existing tests for the `braviatv` coordinator, so I added them. I confirmed they passed with:

```
% ./venv/bin/pytest -v tests/components/braviatv/test_coordinator.py 
Test session starts (platform: darwin, Python 3.14.4, pytest 9.0.3, pytest-sugar 1.1.1)
cachedir: .pytest_cache
rootdir: /Users/benhamilton/Developer/Source/home-assistant-core
configfile: pyproject.toml
plugins: pytest_freezer-0.4.9, unordered-0.7.0, cov-7.1.0, syrupy-5.1.0, socket-0.7.0, xdist-3.8.0, timeout-2.4.0, github-actions-annotate-failures-0.4.0, anyio-4.10.0, asyncio-1.3.0, sugar-1.1.1, aiohttp-1.1.0, respx-0.23.1, picked-0.5.1, requests-mock-1.12.1
asyncio: mode=Mode.AUTO, debug=True, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 7 items                                                                                                                             

 tests/components/braviatv/test_coordinator.py::test_sources_populated_when_tv_on ✓                                              14% █▌        
 tests/components/braviatv/test_coordinator.py::test_sources_populated_when_tv_off ✓                                             29% ██▉       
 tests/components/braviatv/test_coordinator.py::test_sources_silently_skipped_on_connection_error ✓                              43% ████▍     
 tests/components/braviatv/test_coordinator.py::test_channel_error_does_not_discard_inputs ✓                                     57% █████▊    
 tests/components/braviatv/test_coordinator.py::test_volume_and_playing_not_fetched_when_off ✓                                   71% ███████▎  
 tests/components/braviatv/test_coordinator.py::test_sources_fetched_only_once ✓                                                 86% ████████▋ 
 tests/components/braviatv/test_coordinator.py::test_sources_repopulated_after_explicit_refresh ✓                               100% ██████████
```

Confirmed `media-player-source` appeared as expected even when TV was in standby (off) when HA started:

<img width="414" height="449" alt="Screenshot 2026-05-17 at 7 39 53 PM" src="https://github.com/user-attachments/assets/4244a4ba-2255-45e8-ac6f-d04572cebfdc" />

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

https://www.home-assistant.io/blog/2026/05/06/release-20265/#new-tile-card-features-for-media-players

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

Done:

* https://github.com/home-assistant/core/pull/171045
* https://github.com/home-assistant/core/pull/170907

