### PR TITLE
Bump opensensemap-api to 0.4.1

### DIFF
--- a/homeassistant/components/opensensemap/manifest.json
+++ b/homeassistant/components/opensensemap/manifest.json
@@ -6,5 +6,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["opensensemap_api"],
   "quality_scale": "legacy",
-  "requirements": ["opensensemap-api==0.2.0"]
+  "requirements": ["opensensemap-api==0.4.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1757,7 +1757,7 @@ openhomedevice==2.2.0
 openrgb-python==0.3.6
 
 # homeassistant.components.opensensemap
-opensensemap-api==0.2.0
+opensensemap-api==0.4.1
 
 # homeassistant.components.enigma2
 openwebifpy==4.3.1

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -202,7 +202,6 @@ FORBIDDEN_PACKAGE_EXCEPTIONS: dict[str, dict[str, set[str]]] = {
     "nibe_heatpump": {"nibe": {"async-timeout"}},
     "norway_air": {"pymetno": {"async-timeout"}},
     "opengarage": {"open-garage": {"async-timeout"}},
-    "opensensemap": {"opensensemap-api": {"async-timeout"}},
     "overkiz": {"pyoverkiz": {"backoff"}},
     "prosegur": {"pyprosegur": {"backoff"}},
     "pvpc_hourly_pricing": {"aiopvpc": {"async-timeout"}},


### PR DESCRIPTION
## Proposed change

Bump `opensensemap-api` from 0.2.0 to 0.4.1.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Library: https://github.com/home-assistant-ecosystem/python-opensensemap-api
Releases: https://github.com/home-assistant-ecosystem/python-opensensemap-api/releases
Diff 0.2.0...0.4.1: https://github.com/home-assistant-ecosystem/python-opensensemap-api/compare/0.2.0...0.4.1

Notable changes (from upstream release notes):
- 0.3.0: Drop Python 3.8; add 3.10/3.11 support.
- 0.3.1: Work with offline stations; station `description` made optional.
- 0.3.2: Fix unhandled exception when sensor missing `lastMeasurement`; expose additional model properties.
- 0.4.0: Build system migrated to `hatchling`; ruff + initial pytest tests added; PyPI metadata declares Python 3.13+.
- 0.4.1: Drop `async-timeout` dependency in favor of stdlib `asyncio.timeout`.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr