### PR TITLE
Fix line length violations in new code since cleanup PRs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,9 +6,7 @@
 
 - Start review comments with a short, one-sentence summary of the suggested fix.
 - Do not comment on code style, formatting or linting issues.
-- A Pull Request with a dependency version bump should only contain
-changes required for the version bump. If the PR includes other
-changes, request that they are removed from the PR.
+- A Pull Request with a dependency version bump should only contain changes required for the version bump. If the PR includes other changes, request that they are removed from the PR.
 
 # GitHub Copilot & Claude Code Instructions
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,9 @@
 
 - Start review comments with a short, one-sentence summary of the suggested fix.
 - Do not comment on code style, formatting or linting issues.
-- A Pull Request with a dependency version bump should only contain changes required for the version bump. If the PR includes other changes, request that they are removed from the PR.
+- A Pull Request with a dependency version bump should only contain
+changes required for the version bump. If the PR includes other
+changes, request that they are removed from the PR.
 
 # GitHub Copilot & Claude Code Instructions
 

--- a/homeassistant/components/blebox/light.py
+++ b/homeassistant/components/blebox/light.py
@@ -80,7 +80,8 @@ class BleBoxLightEntity(BleBoxEntity[blebox_uniapi.light.Light], LightEntity):
     def _color_temp_to_native_scale(self, x: int) -> int:
         """Convert color temperature from Kelvin to native BleBox scale (0-255).
 
-        BleBox native scale is inverted relative to Kelvin: 0=warm (2700K), 255=cold (6500K).
+        BleBox native scale is inverted:
+        0=warm (2700K), 255=cold (6500K).
         """
         scaled = (
             (self._attr_max_color_temp_kelvin - x)
@@ -98,7 +99,8 @@ class BleBoxLightEntity(BleBoxEntity[blebox_uniapi.light.Light], LightEntity):
     def _color_temp_from_native_scale(self, x: int) -> int:
         """Convert color temperature from native BleBox scale (0-255) to Kelvin.
 
-        BleBox native scale is inverted relative to Kelvin: 0=warm (2700K), 255=cold (6500K).
+        BleBox native scale is inverted:
+        0=warm (2700K), 255=cold (6500K).
         """
         scaled = self._attr_max_color_temp_kelvin - (x / 255) * (
             self._attr_max_color_temp_kelvin - self._attr_min_color_temp_kelvin

--- a/homeassistant/components/bluetooth/passive_update_coordinator.py
+++ b/homeassistant/components/bluetooth/passive_update_coordinator.py
@@ -89,7 +89,9 @@ class PassiveBluetoothDataUpdateCoordinator(
 
 
 class PassiveBluetoothCoordinatorEntity[  # pylint: disable=home-assistant-enforce-class-module
-    _PassiveBluetoothDataUpdateCoordinatorT: PassiveBluetoothDataUpdateCoordinator = PassiveBluetoothDataUpdateCoordinator
+    _PassiveBluetoothDataUpdateCoordinatorT: (
+        PassiveBluetoothDataUpdateCoordinator
+    ) = PassiveBluetoothDataUpdateCoordinator
 ](BaseCoordinatorEntity[_PassiveBluetoothDataUpdateCoordinatorT]):
     """A class for entities using DataUpdateCoordinator."""
 

--- a/homeassistant/components/bluetooth/websocket_api.py
+++ b/homeassistant/components/bluetooth/websocket_api.py
@@ -94,8 +94,8 @@ def serialize_service_info(
         "address": service_info.address,
         "rssi": service_info.rssi,
         "manufacturer_data": {
-            str(manufacturer_id): manufacturer_data.hex()
-            for manufacturer_id, manufacturer_data in service_info.manufacturer_data.items()
+            str(manufacturer_id): data.hex()
+            for manufacturer_id, data in service_info.manufacturer_data.items()
         },
         "service_data": {
             service_uuid: service_data.hex()

--- a/homeassistant/components/bthome/binary_sensor.py
+++ b/homeassistant/components/bthome/binary_sensor.py
@@ -151,7 +151,9 @@ def sensor_update_to_bluetooth_data_update(
             device_key_to_bluetooth_entity_key(device_key): BINARY_SENSOR_DESCRIPTIONS[
                 description.device_class
             ]
-            for device_key, description in sensor_update.binary_entity_descriptions.items()
+            for device_key, description in (
+                sensor_update.binary_entity_descriptions.items()
+            )
             if description.device_class
         },
         entity_data={

--- a/homeassistant/components/caldav/api.py
+++ b/homeassistant/components/caldav/api.py
@@ -52,14 +52,16 @@ async def async_get_calendars(
                 warned_calendars.add((url, comp))
                 if comp in ASSUMED_COMPONENTS:
                     _LOGGER.warning(
-                        "CalDAV server does not report supported components for calendar %s, "
+                        "CalDAV server does not report supported"
+                        " components for calendar %s, "
                         "assuming it supports the requested component '%s'",
                         name or url,
                         comp,
                     )
                 else:
                     _LOGGER.warning(
-                        "CalDAV server does not report supported components for calendar %s. "
+                        "CalDAV server does not report supported"
+                        " components for calendar %s. "
                         "Not assuming support for requested component '%s'",
                         name or url,
                         comp,

--- a/homeassistant/components/cloud/client.py
+++ b/homeassistant/components/cloud/client.py
@@ -220,8 +220,11 @@ class CloudClient(Interface):
                 )
                 if is_cloud_ice_servers_enabled:
                     if self._cloud_ice_servers_listener is None:
-                        self._cloud_ice_servers_listener = await self.cloud.ice_servers.async_register_ice_servers_listener(
-                            register_cloud_ice_server
+                        ice_servers = self.cloud.ice_servers
+                        self._cloud_ice_servers_listener = (
+                            await ice_servers.async_register_ice_servers_listener(
+                                register_cloud_ice_server
+                            )
                         )
                 elif self._cloud_ice_servers_listener:
                     self._cloud_ice_servers_listener()

--- a/homeassistant/components/govee_ble/binary_sensor.py
+++ b/homeassistant/components/govee_ble/binary_sensor.py
@@ -57,7 +57,9 @@ def sensor_update_to_bluetooth_data_update(
             device_key_to_bluetooth_entity_key(device_key): BINARY_SENSOR_DESCRIPTIONS[
                 description.device_class
             ]
-            for device_key, description in sensor_update.binary_entity_descriptions.items()
+            for device_key, description in (
+                sensor_update.binary_entity_descriptions.items()
+            )
             if description.device_class
         },
         entity_data={

--- a/homeassistant/components/guardian/diagnostics.py
+++ b/homeassistant/components/guardian/diagnostics.py
@@ -36,7 +36,9 @@ async def async_get_config_entry_diagnostics(
         "data": {
             "valve_controller": {
                 api_category: async_redact_data(coordinator.data, TO_REDACT)
-                for api_category, coordinator in data.valve_controller_coordinators.items()
+                for api_category, coordinator in (
+                    data.valve_controller_coordinators.items()
+                )
             },
             "paired_sensors": [
                 async_redact_data(coordinator.data, TO_REDACT)

--- a/homeassistant/components/home_connect/fan.py
+++ b/homeassistant/components/home_connect/fan.py
@@ -21,6 +21,13 @@ _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 1
 
+_FAN_SPEED_PERCENTAGE_KEY = (
+    OptionKey.HEATING_VENTILATION_AIR_CONDITIONING_AIR_CONDITIONER_FAN_SPEED_PERCENTAGE
+)
+_FAN_SPEED_MODE_KEY = (
+    OptionKey.HEATING_VENTILATION_AIR_CONDITIONING_AIR_CONDITIONER_FAN_SPEED_MODE
+)
+
 FAN_SPEED_MODE_OPTIONS = {
     "auto": (
         "HeatingVentilationAirConditioning"
@@ -116,8 +123,7 @@ class HomeConnectAirConditioningFanEntity(HomeConnectEntity, FanEntity):
     def update_native_value(self) -> None:
         """Set the speed percentage and speed mode values."""
         option_value = None
-        option_key = OptionKey.HEATING_VENTILATION_AIR_CONDITIONING_AIR_CONDITIONER_FAN_SPEED_PERCENTAGE
-        if event := self.appliance.events.get(EventKey(option_key)):
+        if event := self.appliance.events.get(EventKey(_FAN_SPEED_PERCENTAGE_KEY)):
             option_value = event.value
         self._attr_percentage = (
             cast(int, option_value) if option_value is not None else None
@@ -142,8 +148,7 @@ class HomeConnectAirConditioningFanEntity(HomeConnectEntity, FanEntity):
     def update_preset_mode(self) -> None:
         """Set the preset mode value."""
         option_value = None
-        option_key = OptionKey.HEATING_VENTILATION_AIR_CONDITIONING_AIR_CONDITIONER_FAN_SPEED_MODE
-        if event := self.appliance.events.get(EventKey(option_key)):
+        if event := self.appliance.events.get(EventKey(_FAN_SPEED_MODE_KEY)):
             option_value = event.value
         self._attr_preset_mode = (
             FAN_SPEED_MODE_OPTIONS_INVERTED.get(cast(str, option_value))

--- a/homeassistant/components/home_connect/select.py
+++ b/homeassistant/components/home_connect/select.py
@@ -133,7 +133,9 @@ SELECT_ENTITY_DESCRIPTIONS = (
         translation_key_values=FUNCTIONAL_LIGHT_COLOR_TEMPERATURE_ENUM,
         values_translation_key={
             value: translation_key
-            for translation_key, value in FUNCTIONAL_LIGHT_COLOR_TEMPERATURE_ENUM.items()
+            for translation_key, value in (
+                FUNCTIONAL_LIGHT_COLOR_TEMPERATURE_ENUM.items()
+            )
         },
     ),
     HomeConnectSelectEntityDescription(

--- a/homeassistant/components/knx/knx_module.py
+++ b/homeassistant/components/knx/knx_module.py
@@ -280,7 +280,9 @@ class KNXModule:
                 or next(
                     (
                         _transcoder
-                        for _filter, _transcoder in self._address_filter_transcoder.items()
+                        for _filter, _transcoder in (
+                            self._address_filter_transcoder.items()
+                        )
                         if _filter.match(telegram.destination_address)
                     ),
                     None,

--- a/homeassistant/components/lamarzocco/switch.py
+++ b/homeassistant/components/lamarzocco/switch.py
@@ -131,7 +131,9 @@ async def async_setup_entry(
 
     entities.extend(
         LaMarzoccoAutoOnOffSwitchEntity(coordinator, wake_up_sleep_entry)
-        for wake_up_sleep_entry in coordinator.device.schedule.smart_wake_up_sleep.schedules
+        for wake_up_sleep_entry in (
+            coordinator.device.schedule.smart_wake_up_sleep.schedules
+        )
     )
 
     entities.append(

--- a/homeassistant/components/matter/binary_sensor.py
+++ b/homeassistant/components/matter/binary_sensor.py
@@ -58,6 +58,9 @@ class MatterBinarySensor(MatterEntity, BinarySensorEntity):
         self._attr_is_on = value
 
 
+_PUMP_STATUS = clusters.PumpConfigurationAndControl.Bitmaps.PumpStatusBitmap
+_VALVE_FAULT = clusters.ValveConfigurationAndControl.Bitmaps.ValveFaultBitmap
+
 # Discovery schema(s) to map Matter Attributes to HA entities
 DISCOVERY_SCHEMAS = [
     # device specific: translate Hue motion to sensor to HA Motion sensor
@@ -374,11 +377,7 @@ DISCOVERY_SCHEMAS = [
             entity_category=EntityCategory.DIAGNOSTIC,
             # DeviceFault or SupplyFault bit enabled
             device_to_ha=lambda x: bool(
-                x
-                & (
-                    clusters.PumpConfigurationAndControl.Bitmaps.PumpStatusBitmap.kDeviceFault
-                    | clusters.PumpConfigurationAndControl.Bitmaps.PumpStatusBitmap.kSupplyFault
-                )
+                x & (_PUMP_STATUS.kDeviceFault | _PUMP_STATUS.kSupplyFault)
             ),
         ),
         entity_class=MatterBinarySensor,
@@ -393,10 +392,7 @@ DISCOVERY_SCHEMAS = [
             key="PumpStatusRunning",
             translation_key="pump_running",
             device_class=BinarySensorDeviceClass.RUNNING,
-            device_to_ha=lambda x: bool(
-                x
-                & clusters.PumpConfigurationAndControl.Bitmaps.PumpStatusBitmap.kRunning
-            ),
+            device_to_ha=lambda x: bool(x & _PUMP_STATUS.kRunning),
         ),
         entity_class=MatterBinarySensor,
         required_attributes=(
@@ -442,10 +438,7 @@ DISCOVERY_SCHEMAS = [
             device_class=BinarySensorDeviceClass.PROBLEM,
             entity_category=EntityCategory.DIAGNOSTIC,
             # GeneralFault bit from ValveFault attribute
-            device_to_ha=lambda x: bool(
-                x
-                & clusters.ValveConfigurationAndControl.Bitmaps.ValveFaultBitmap.kGeneralFault
-            ),
+            device_to_ha=lambda x: bool(x & _VALVE_FAULT.kGeneralFault),
         ),
         entity_class=MatterBinarySensor,
         required_attributes=(
@@ -461,10 +454,7 @@ DISCOVERY_SCHEMAS = [
             device_class=BinarySensorDeviceClass.PROBLEM,
             entity_category=EntityCategory.DIAGNOSTIC,
             # Blocked bit from ValveFault attribute
-            device_to_ha=lambda x: bool(
-                x
-                & clusters.ValveConfigurationAndControl.Bitmaps.ValveFaultBitmap.kBlocked
-            ),
+            device_to_ha=lambda x: bool(x & _VALVE_FAULT.kBlocked),
         ),
         entity_class=MatterBinarySensor,
         required_attributes=(
@@ -480,10 +470,7 @@ DISCOVERY_SCHEMAS = [
             device_class=BinarySensorDeviceClass.PROBLEM,
             entity_category=EntityCategory.DIAGNOSTIC,
             # Leaking bit from ValveFault attribute
-            device_to_ha=lambda x: bool(
-                x
-                & clusters.ValveConfigurationAndControl.Bitmaps.ValveFaultBitmap.kLeaking
-            ),
+            device_to_ha=lambda x: bool(x & _VALVE_FAULT.kLeaking),
         ),
         entity_class=MatterBinarySensor,
         required_attributes=(

--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -38,10 +38,12 @@ from .util import (
     renormalize,
 )
 
+_CC_COLOR_MODE = clusters.ColorControl.Enums.ColorModeEnum
+
 COLOR_MODE_MAP = {
-    clusters.ColorControl.Enums.ColorModeEnum.kCurrentHueAndCurrentSaturation: ColorMode.HS,
-    clusters.ColorControl.Enums.ColorModeEnum.kCurrentXAndCurrentY: ColorMode.XY,
-    clusters.ColorControl.Enums.ColorModeEnum.kColorTemperatureMireds: ColorMode.COLOR_TEMP,
+    _CC_COLOR_MODE.kCurrentHueAndCurrentSaturation: ColorMode.HS,
+    _CC_COLOR_MODE.kCurrentXAndCurrentY: ColorMode.XY,
+    _CC_COLOR_MODE.kColorTemperatureMireds: ColorMode.COLOR_TEMP,
 }
 
 # Maximum Mireds value per the Matter spec is 65279
@@ -362,24 +364,16 @@ class MatterLight(MatterEntity, LightEntity):
 
                 assert capabilities is not None
 
-                if (
-                    capabilities
-                    & clusters.ColorControl.Bitmaps.ColorCapabilitiesBitmap.kHueSaturation
-                ):
+                color_caps = clusters.ColorControl.Bitmaps.ColorCapabilitiesBitmap
+                if capabilities & color_caps.kHueSaturation:
                     supported_color_modes.add(ColorMode.HS)
                     self._supports_color = True
 
-                if (
-                    capabilities
-                    & clusters.ColorControl.Bitmaps.ColorCapabilitiesBitmap.kXy
-                ):
+                if capabilities & color_caps.kXy:
                     supported_color_modes.add(ColorMode.XY)
                     self._supports_color = True
 
-                if (
-                    capabilities
-                    & clusters.ColorControl.Bitmaps.ColorCapabilitiesBitmap.kColorTemperature
-                ):
+                if capabilities & color_caps.kColorTemperature:
                     supported_color_modes.add(ColorMode.COLOR_TEMP)
                     self._supports_color_temperature = True
                     min_mireds = self.get_matter_attribute_value(

--- a/homeassistant/components/matter/sensor.py
+++ b/homeassistant/components/matter/sensor.py
@@ -162,7 +162,9 @@ ESA_STATE_MAP = {
     clusters.DeviceEnergyManagement.Enums.ESAStateEnum.kOffline: "offline",
     clusters.DeviceEnergyManagement.Enums.ESAStateEnum.kOnline: "online",
     clusters.DeviceEnergyManagement.Enums.ESAStateEnum.kFault: "fault",
-    clusters.DeviceEnergyManagement.Enums.ESAStateEnum.kPowerAdjustActive: "power_adjust_active",
+    clusters.DeviceEnergyManagement.Enums.ESAStateEnum.kPowerAdjustActive: (
+        "power_adjust_active"
+    ),
     clusters.DeviceEnergyManagement.Enums.ESAStateEnum.kPaused: "paused",
 }
 

--- a/homeassistant/components/matter/water_heater.py
+++ b/homeassistant/components/matter/water_heater.py
@@ -88,7 +88,10 @@ class MatterWaterHeater(MatterEntity, WaterHeaterEntity):
         temporary_setpoint: int | None = None,
     ) -> None:
         """Set boost."""
-        boost_info: clusters.WaterHeaterManagement.Structs.WaterHeaterBoostInfoStruct = clusters.WaterHeaterManagement.Structs.WaterHeaterBoostInfoStruct(
+        boost_info_cls = (
+            clusters.WaterHeaterManagement.Structs.WaterHeaterBoostInfoStruct
+        )
+        boost_info = boost_info_cls(
             duration=duration,
             emergencyBoost=emergency_boost,
             temporarySetpoint=(

--- a/homeassistant/components/mill/climate.py
+++ b/homeassistant/components/mill/climate.py
@@ -197,12 +197,13 @@ class LocalMillHeater(CoordinatorEntity[MillDataUpdateCoordinator], ClimateEntit
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
+        conn = self.coordinator.mill_data_connection
         if hvac_mode == HVACMode.HEAT:
-            await self.coordinator.mill_data_connection.set_operation_mode_control_individually()
+            await conn.set_operation_mode_control_individually()
         elif hvac_mode == HVACMode.OFF:
-            await self.coordinator.mill_data_connection.set_operation_mode_off()
+            await conn.set_operation_mode_off()
         elif hvac_mode == HVACMode.AUTO:
-            await self.coordinator.mill_data_connection.set_operation_mode_weekly_program()
+            await conn.set_operation_mode_weekly_program()
         await self.coordinator.async_request_refresh()
 
     @callback

--- a/homeassistant/components/solarlog/__init__.py
+++ b/homeassistant/components/solarlog/__init__.py
@@ -66,15 +66,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: SolarlogConfigEntry) -> 
             new[CONF_TIMEOUT] = timeout
             hass.config_entries.async_update_entry(entry, data=new)
 
-            entry.runtime_data.longtime_data_coordinator = (
-                SolarLogLongtimeDataCoordinator(hass, entry, solarlog, timeout)
+            longtime_coordinator = SolarLogLongtimeDataCoordinator(
+                hass, entry, solarlog, timeout
             )
-            await entry.runtime_data.longtime_data_coordinator.async_config_entry_first_refresh()
+            entry.runtime_data.longtime_data_coordinator = longtime_coordinator
+            await longtime_coordinator.async_config_entry_first_refresh()
 
-        entry.runtime_data.device_data_coordinator = SolarLogDeviceDataCoordinator(
-            hass, entry, solarlog
-        )
-        await entry.runtime_data.device_data_coordinator.async_config_entry_first_refresh()
+        device_coordinator = SolarLogDeviceDataCoordinator(hass, entry, solarlog)
+        entry.runtime_data.device_data_coordinator = device_coordinator
+        await device_coordinator.async_config_entry_first_refresh()
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/solarlog/sensor.py
+++ b/homeassistant/components/solarlog/sensor.py
@@ -428,10 +428,10 @@ class SolarLogBatterySensor(SolarLogBasicCoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> StateType:
         """Return the state for this sensor."""
-        if (
-            battery_data
-            := self.coordinator.config_entry.runtime_data.basic_data_coordinator.data.battery_data
-        ) is None:
+        basic_data = (
+            self.coordinator.config_entry.runtime_data.basic_data_coordinator.data
+        )
+        if (battery_data := basic_data.battery_data) is None:
             return None
         return self.entity_description.value_fn(battery_data)
 

--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -74,7 +74,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TadoConfigEntry) -> bool
     )
 
     def create_tado_instance() -> tuple[Tado, str]:
-        """Create a Tado instance, this time with a previously obtained refresh token."""
+        """Create a Tado instance with a previously obtained refresh token."""
         tado = Tado(
             saved_refresh_token=entry.data[CONF_REFRESH_TOKEN],
             user_agent=f"{APPLICATION_NAME}/{HA_VERSION}",
@@ -97,7 +97,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: TadoConfigEntry) -> bool
     coordinator = TadoDataUpdateCoordinator(hass, entry, tado)
     await coordinator.async_config_entry_first_refresh()
 
-    # Pre-register the bridge device to ensure it exists before other devices reference it
+    # Pre-register the bridge device to ensure it exists
+    # before other devices reference it
     device_registry = dr.async_get(hass)
     for device in coordinator.data["device"].values():
         if device["deviceType"] in TADO_BRIDGE_MODELS:

--- a/homeassistant/components/tado/climate.py
+++ b/homeassistant/components/tado/climate.py
@@ -781,11 +781,11 @@ class TadoClimate(TadoZoneEntity, ClimateEntity):
             duration=duration,
             device_type=self.zone_type,
             mode=self._current_tado_hvac_mode,
-            fan_speed=fan_speed,  # api defaults to not sending fanSpeed if None specified
-            swing=swing,  # api defaults to not sending swing if None specified
-            fan_level=fan_level,  # api defaults to not sending fanLevel if fanSpeend not None
-            vertical_swing=vertical_swing,  # api defaults to not sending verticalSwing if swing not None
-            horizontal_swing=horizontal_swing,  # api defaults to not sending horizontalSwing if swing not None
+            fan_speed=fan_speed,
+            swing=swing,
+            fan_level=fan_level,
+            vertical_swing=vertical_swing,
+            horizontal_swing=horizontal_swing,
         )
 
     def _is_valid_setting_for_hvac_mode(self, setting: str) -> bool:

--- a/homeassistant/components/tado/config_flow.py
+++ b/homeassistant/components/tado/config_flow.py
@@ -84,7 +84,8 @@ class TadoConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
                 if ratelimit.get("remaining") == "0":
                     _LOGGER.error(
-                        "Tado API rate limit reached while waiting for device activation: %s",
+                        "Tado API rate limit reached while"
+                        " waiting for device activation: %s",
                         ex,
                     )
                     raise TadoRateLimitExceeded from ex

--- a/homeassistant/components/tado/coordinator.py
+++ b/homeassistant/components/tado/coordinator.py
@@ -169,7 +169,8 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._time_until_reset = (next_reset - reset_time).total_seconds()
 
         # When any zone is actively heating, we use a shorter minimum
-        # To prevent overshooting in temperature, check if there's heating/cooling activity
+        # To prevent overshooting in temperature,
+        # check if there's heating/cooling activity
         # Accept five minutes to "overshoot", else reset back to 30 minutes
         min_interval = 300 if self._is_any_zone_active else 1800
 
@@ -180,7 +181,8 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self.update_interval = SCAN_INTERVAL
             self._next_update = reset_time + timedelta(seconds=self._current_interval)
             _LOGGER.debug(
-                "Rate limit info unavailable; using default update interval: %s seconds",
+                "Rate limit info unavailable;"
+                " using default update interval: %s seconds",
                 self._current_interval,
             )
             return
@@ -361,7 +363,10 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Set a zone overlay."""
 
         _LOGGER.debug(
-            "Set overlay for zone %s: overlay_mode=%s, temp=%s, duration=%s, type=%s, mode=%s, fan_speed=%s, swing=%s, fan_level=%s, vertical_swing=%s, horizontal_swing=%s",
+            "Set overlay for zone %s: overlay_mode=%s,"
+            " temp=%s, duration=%s, type=%s, mode=%s,"
+            " fan_speed=%s, swing=%s, fan_level=%s,"
+            " vertical_swing=%s, horizontal_swing=%s",
             zone_id,
             overlay_mode,
             temperature,

--- a/homeassistant/components/tado/helper.py
+++ b/homeassistant/components/tado/helper.py
@@ -38,7 +38,7 @@ def decide_duration(
     zone_id: int,
     overlay_mode: str | None = None,
 ) -> None | int:
-    """Return correct duration based on the selected overlay mode/duration and tado config."""
+    """Return correct duration based on overlay mode and tado config."""
 
     # If we ended up with a timer but no duration, set a default duration
     # If we ended up with a timer but no duration, set a default duration

--- a/homeassistant/components/tado/sensor.py
+++ b/homeassistant/components/tado/sensor.py
@@ -56,7 +56,7 @@ def get_tado_mode(data: dict[str, str]) -> str | None:
 
 
 def get_automatic_geofencing(data: dict[str, str]) -> bool:
-    """Return whether Automatic Geofencing is enabled based on Presence Locked attribute."""
+    """Return whether Automatic Geofencing is enabled."""
     if "presenceLocked" in data:
         if data["presenceLocked"]:
             return False

--- a/homeassistant/components/tankerkoenig/coordinator.py
+++ b/homeassistant/components/tankerkoenig/coordinator.py
@@ -117,7 +117,8 @@ class TankerkoenigDataUpdateCoordinator(DataUpdateCoordinator[dict[str, PriceInf
         station_ids = list(self.stations)
 
         prices = {}
-        # The API seems to only return at most 10 results, so split the list in chunks of 10
+        # The API seems to only return at most 10 results,
+        # so split the list in chunks of 10
         # and merge it together.
         for index in range(ceil(len(station_ids) / 10)):
             stations = station_ids[index * 10 : (index + 1) * 10]

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -648,7 +648,8 @@ def _deprecate_timeout(service: ServiceCall) -> None:
     if ATTR_TIMEOUT not in service.data:
         return
 
-    # default: service was called using frontend such as developer tools or automation editor
+    # default: service was called using frontend such as
+    # developer tools or automation editor
     service_call_origin = "call_service"
 
     origin = service.context.origin_event
@@ -785,7 +786,8 @@ def _build_targets(
             )
 
         if not chat_ids and not targets:
-            # no targets from service data, so we default to the first allowed chat IDs of the config entry
+            # no targets from service data, so we default
+            # to the first allowed chat IDs of the config entry
             subentries = list(config_entry.subentries.values())
             if not subentries:
                 raise ServiceValidationError(
@@ -857,7 +859,8 @@ def _warn_chat_id_migration(service: ServiceCall) -> set[int]:
         else service.data[ATTR_TARGET]
     )
 
-    # default: service was called using frontend such as developer tools or automation editor
+    # default: service was called using frontend such as
+    # developer tools or automation editor
     service_call_origin = "call_service"
 
     origin = service.context.origin_event
@@ -883,9 +886,23 @@ def _warn_chat_id_migration(service: ServiceCall) -> set[int]:
             "chat_ids": ", ".join(str(chat_id) for chat_id in chat_ids),
             "action_origin": service_call_origin,
             "telegram_bot_entities_url": "/config/entities?domain=telegram_bot",
-            "example_old": f"```yaml\naction: {service.service}\ndata:\n  target:  # to be updated\n    - 1234567890\n...\n```",
-            "example_new_entity_id": f"```yaml\naction: {service.service}\ndata:\n  entity_id:\n    - notify.telegram_bot_1234567890_1234567890  # replace with your notify entity\n...\n```",
-            "example_new_chat_id": f"```yaml\naction: {service.service}\ndata:\n  chat_id:\n    - 1234567890  # replace with your chat_id\n...\n```",
+            "example_old": (
+                f"```yaml\naction: {service.service}\ndata:\n"
+                "  target:  # to be updated\n"
+                "    - 1234567890\n...\n```"
+            ),
+            "example_new_entity_id": (
+                f"```yaml\naction: {service.service}\ndata:\n"
+                "  entity_id:\n"
+                "    - notify.telegram_bot_1234567890_1234567890"
+                "  # replace with your notify entity\n...\n```"
+            ),
+            "example_new_chat_id": (
+                f"```yaml\naction: {service.service}\ndata:\n"
+                "  chat_id:\n"
+                "    - 1234567890"
+                "  # replace with your chat_id\n...\n```"
+            ),
         },
         learn_more_url="https://github.com/home-assistant/core/pull/154868",
     )

--- a/homeassistant/components/telegram_bot/bot.py
+++ b/homeassistant/components/telegram_bot/bot.py
@@ -158,7 +158,8 @@ class BaseTelegramBot:
 
         # establish event type: text, command or callback_query
         if update.callback_query:
-            # NOTE: Check for callback query first since effective message will be populated with the message
+            # NOTE: Check for callback query first since
+            # effective message will be populated with the message
             # in .callback_query (python-telegram-bot docs are wrong)
             event_type, event_data = self._get_callback_query_event_data(
                 update.callback_query
@@ -202,7 +203,8 @@ class BaseTelegramBot:
             ATTR_MESSAGE_THREAD_ID: message.message_thread_id,
         }
         if filters.COMMAND.filter(message):
-            # This is a command message - set event type to command and split data into command and args
+            # This is a command message - set event type
+            # to command and split data into command and args
             event_type = EVENT_TELEGRAM_COMMAND
             event_data.update(self._get_command_event_data(message.text))
         elif filters.ATTACHMENT.filter(message):
@@ -224,7 +226,7 @@ class BaseTelegramBot:
             photos = cast(Sequence[PhotoSize], message.effective_attachment)
             return {
                 ATTR_FILE_ID: photos[-1].file_id,
-                ATTR_FILE_MIME_TYPE: "image/jpeg",  # telegram always uses jpeg for photos
+                ATTR_FILE_MIME_TYPE: "image/jpeg",
                 ATTR_FILE_SIZE: photos[-1].file_size,
             }
         return {
@@ -544,7 +546,7 @@ class TelegramNotificationService:
     ) -> dict[str, JsonValueType]:
         """Send media group to a chat ID.
 
-        :returns: a dict mapping each chat_id to a list of message_ids for the sent media group.
+        Returns a dict mapping each chat_id to message_ids.
         """
         params = self._get_msg_kwargs(kwargs)
 

--- a/homeassistant/components/telegram_bot/config_flow.py
+++ b/homeassistant/components/telegram_bot/config_flow.py
@@ -408,7 +408,9 @@ class TelegramBotConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "no_url_available"
                 description_placeholders[ERROR_FIELD] = "URL"
                 description_placeholders[ERROR_MESSAGE] = (
-                    "URL is required since you have not configured an external URL in Home Assistant"
+                    "URL is required since you have not"
+                    " configured an external URL"
+                    " in Home Assistant"
                 )
                 return
         elif (
@@ -494,8 +496,10 @@ class TelegramBotConfigFlow(ConfigFlow, domain=DOMAIN):
             and existing_api_endpoint == DEFAULT_API_ENDPOINT
         ):
             # logout existing bot from the official Telegram bot API
-            # logout is only used when changing the API endpoint from official to a custom one
-            # there is a 10-minute lockout period after logout so we only logout if necessary
+            # logout is only used when changing the API
+            # endpoint from official to a custom one
+            # there is a 10-minute lockout period after
+            # logout so we only logout if necessary
             service: TelegramNotificationService = (
                 self._get_reconfigure_entry().runtime_data
             )
@@ -659,8 +663,11 @@ async def _get_most_recent_chat(
 ) -> tuple[int, str | None] | None:
     """Get the most recent chat ID and name.
 
-    For broadcast bot, this is retrieved using get_updates() to find the most recent message received.
-    For polling or webhook bot, this is retrieved from the runtime data which is updated whenever a message is received.
+    For broadcast bot, this is retrieved using
+    get_updates() to find the most recent message received.
+    For polling or webhook bot, this is retrieved from
+    the runtime data which is updated whenever a
+    message is received.
     """
 
     if service.app is not None:

--- a/homeassistant/components/telegram_bot/webhooks.py
+++ b/homeassistant/components/telegram_bot/webhooks.py
@@ -69,7 +69,7 @@ def _get_trusted_networks(config: TelegramBotConfigEntry) -> list[IPv4Network]:
 
 
 class PushBot(BaseTelegramBot):
-    """Handles all the push/webhook logic and passes telegram updates to `self.handle_update`."""
+    """Handles push/webhook logic, passes updates to `self.handle_update`."""
 
     def __init__(
         self,
@@ -82,7 +82,8 @@ class PushBot(BaseTelegramBot):
         self.bot = bot
         self.trusted_networks = _get_trusted_networks(config)
         self.secret_token = secret_token
-        # Dumb Application that just gets our updates to our handler callback (self.handle_update)
+        # Application that gets our updates to our handler
+        # callback (self.handle_update)
         self.application = ApplicationBuilder().bot(bot).updater(None).build()
         self.application.add_handler(TypeHandler(Update, self.handle_update))
         super().__init__(hass, config, bot)

--- a/homeassistant/components/teltonika/config_flow.py
+++ b/homeassistant/components/teltonika/config_flow.py
@@ -198,7 +198,8 @@ class TeltonikaConfigFlow(ConfigFlow, domain=DOMAIN):
         # Store discovered host for later use
         self._discovered_host = host
 
-        # Try to get device info without authentication to get device identifier and name
+        # Try to get device info without authentication
+        # to get device identifier and name
         session = async_get_clientsession(self.hass)
 
         for base_url in get_url_variants(host):
@@ -285,7 +286,8 @@ class TeltonikaConfigFlow(ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception during DHCP confirm")
                 errors["base"] = "unknown"
             else:
-                # Update unique ID to device identifier if we didn't get it during discovery
+                # Update unique ID to device identifier
+                # if we didn't get it during discovery
                 await self.async_set_unique_id(
                     info["device_id"], raise_on_progress=False
                 )

--- a/homeassistant/components/temperature/trigger.py
+++ b/homeassistant/components/temperature/trigger.py
@@ -40,7 +40,7 @@ TEMPERATURE_DOMAIN_SPECS = {
 
 
 class _TemperatureTriggerMixin(EntityNumericalStateTriggerWithUnitBase):
-    """Mixin for temperature triggers providing entity filtering, value extraction, and unit conversion."""
+    """Mixin for temperature triggers with filtering and conversion."""
 
     _base_unit = UnitOfTemperature.CELSIUS
     _domain_specs = TEMPERATURE_DOMAIN_SPECS

--- a/homeassistant/components/template/__init__.py
+++ b/homeassistant/components/template/__init__.py
@@ -233,7 +233,9 @@ async def _process_config(hass: HomeAssistant, hass_config: ConfigType) -> None:
                             "entities": [
                                 {
                                     **entity_conf,
-                                    "raw_blueprint_inputs": conf_section.raw_blueprint_inputs,
+                                    "raw_blueprint_inputs": (
+                                        conf_section.raw_blueprint_inputs
+                                    ),
                                     "raw_configs": conf_section.raw_config,
                                 }
                                 for entity_conf in conf_section[platform_domain]

--- a/homeassistant/components/template/alarm_control_panel.py
+++ b/homeassistant/components/template/alarm_control_panel.py
@@ -172,7 +172,8 @@ class AbstractTemplateAlarmControlPanel(
     _optimistic_entity = True
     _state_option = CONF_STATE
 
-    # The super init is not called because TemplateEntity calls AbstractTemplateEntity.__init__.
+    # The super init is not called because
+    # TemplateEntity calls AbstractTemplateEntity.__init__.
     def __init__(self, name: str) -> None:  # pylint: disable=super-init-not-called
         """Setup the templates and scripts."""
 

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -130,8 +130,11 @@ class AbstractTemplateBinarySensor(
     _entity_id_format = ENTITY_ID_FORMAT
     _state_option = CONF_STATE
 
-    # The super init is not called because TemplateEntity and TriggerEntity will call AbstractTemplateEntity.__init__.
-    # This ensures that the __init__ on AbstractTemplateEntity is not called twice.
+    # The super init is not called because TemplateEntity
+    # and TriggerEntity will call
+    # AbstractTemplateEntity.__init__. This ensures that
+    # the __init__ on AbstractTemplateEntity is not
+    # called twice.
     def __init__(self, config: dict[str, Any]) -> None:  # pylint: disable=super-init-not-called
         """Initialize the features."""
 

--- a/homeassistant/components/template/config.py
+++ b/homeassistant/components/template/config.py
@@ -119,7 +119,10 @@ def ensure_domains_do_not_have_trigger_or_action(*keys: str) -> Callable[[dict],
             invalid = {CONF_TRIGGERS, CONF_ACTIONS}
             if found_invalid := invalid.intersection(set(obj.keys())):
                 raise vol.Invalid(
-                    f"Unsupported option(s) found for domain {found_domains.pop()}, please remove ({', '.join(found_invalid)}) from your configuration",
+                    f"Unsupported option(s) found for domain"
+                    f" {found_domains.pop()}, please remove"
+                    f" ({', '.join(found_invalid)})"
+                    " from your configuration",
                 )
 
         return obj
@@ -154,7 +157,8 @@ def validate_trigger_format(
         [CONF_SENSORS, CONF_BINARY_SENSORS, *PLATFORMS]
     ):
         _LOGGER.warning(
-            "Invalid template configuration found, trigger option is missing matching domain"
+            "Invalid template configuration found,"
+            " trigger option is missing matching domain"
         )
         create_trigger_format_issue(hass, raw_config, CONF_TRIGGERS)
 
@@ -299,8 +303,10 @@ async def _async_resolve_template_config(
     # Trigger based template entities retain CONF_VARIABLES because the variables are
     # always executed between the trigger and action.
     elif CONF_TRIGGERS not in config and CONF_VARIABLES in config:
-        # State based template entities have 2 layers of variables.  Variables at the section level
-        # and variables at the entity level should be merged together at the entity level.
+        # State based template entities have 2 layers of
+        # variables. Variables at the section level and
+        # variables at the entity level should be merged
+        # together at the entity level.
         section_variables = config.pop(CONF_VARIABLES)
         platform_config: list[ConfigType] | ConfigType
         platforms = [platform for platform in PLATFORMS if platform in config]

--- a/homeassistant/components/template/coordinator.py
+++ b/homeassistant/components/template/coordinator.py
@@ -163,7 +163,8 @@ class TriggerUpdateCoordinator(DataUpdateCoordinator):
         condition_result = self._cond_func.async_check(variables=run_variables)
         if condition_result is False:
             _LOGGER.debug(
-                "Conditions not met, aborting template trigger update. Condition summary: %s",
+                "Conditions not met, aborting template"
+                " trigger update. Condition summary: %s",
                 trace_get(clear=False),
             )
         return condition_result

--- a/homeassistant/components/template/cover.py
+++ b/homeassistant/components/template/cover.py
@@ -166,8 +166,11 @@ class AbstractTemplateCover(AbstractTemplateEntity, CoverEntity):
     _extra_optimistic_options = (CONF_POSITION,)
     _state_option = CONF_STATE
 
-    # The super init is not called because TemplateEntity and TriggerEntity will call AbstractTemplateEntity.__init__.
-    # This ensures that the __init__ on AbstractTemplateEntity is not called twice.
+    # The super init is not called because TemplateEntity
+    # and TriggerEntity will call
+    # AbstractTemplateEntity.__init__. This ensures that
+    # the __init__ on AbstractTemplateEntity is not
+    # called twice.
     def __init__(self, name: str, config: dict[str, Any]) -> None:  # pylint: disable=super-init-not-called
         """Initialize the features."""
 

--- a/homeassistant/components/template/entity.py
+++ b/homeassistant/components/template/entity.py
@@ -91,9 +91,11 @@ class AbstractTemplateEntity(Entity):
     ) -> None:
         """Set up a template that manages the main state of the entity.
 
-        Requires _state_option to be set on the inheriting class. _state_option represents
-        the configuration option that derives the state. E.g. Template weather entities main state option
-        is 'condition', where switch is 'state'.
+        Requires _state_option to be set on the inheriting
+        class. _state_option represents the configuration
+        option that derives the state. E.g. Template weather
+        entities main state option is 'condition', where
+        switch is 'state'.
         """
 
     @abstractmethod

--- a/homeassistant/components/template/event.py
+++ b/homeassistant/components/template/event.py
@@ -118,8 +118,11 @@ class AbstractTemplateEvent(AbstractTemplateEntity, EventEntity):
 
     _entity_id_format = ENTITY_ID_FORMAT
 
-    # The super init is not called because TemplateEntity and TriggerEntity will call AbstractTemplateEntity.__init__.
-    # This ensures that the __init__ on AbstractTemplateEntity is not called twice.
+    # The super init is not called because TemplateEntity
+    # and TriggerEntity will call
+    # AbstractTemplateEntity.__init__. This ensures that
+    # the __init__ on AbstractTemplateEntity is not
+    # called twice.
     def __init__(self, config: dict[str, Any]) -> None:  # pylint: disable=super-init-not-called
         """Initialize the features."""
         self._attr_device_class = config.get(CONF_DEVICE_CLASS)

--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -156,8 +156,11 @@ class AbstractTemplateFan(AbstractTemplateEntity, FanEntity):
     _optimistic_entity = True
     _state_option = CONF_STATE
 
-    # The super init is not called because TemplateEntity and TriggerEntity will call AbstractTemplateEntity.__init__.
-    # This ensures that the __init__ on AbstractTemplateEntity is not called twice.
+    # The super init is not called because TemplateEntity
+    # and TriggerEntity will call
+    # AbstractTemplateEntity.__init__. This ensures that
+    # the __init__ on AbstractTemplateEntity is not
+    # called twice.
     def __init__(self, name: str, config: dict[str, Any]) -> None:  # pylint: disable=super-init-not-called
         """Initialize the features."""
         self.setup_state_template(
@@ -165,7 +168,8 @@ class AbstractTemplateFan(AbstractTemplateEntity, FanEntity):
             template_validators.boolean(self, CONF_STATE),
         )
 
-        # Ensure legacy template entity functionality by setting percentage to None instead
+        # Ensure legacy template entity functionality by
+        # setting percentage to None instead
         # of the FanEntity default of 0.
         self._attr_percentage = None
         self.setup_template(

--- a/homeassistant/components/template/helpers.py
+++ b/homeassistant/components/template/helpers.py
@@ -271,7 +271,8 @@ def create_legacy_template_issue(
 
     breadcrumb = _get_config_breadcrumbs(config)
 
-    issue_id = f"{LEGACY_TEMPLATE_DEPRECATION_KEY}_{domain}_{breadcrumb}_{hashlib.md5(','.join(config.keys()).encode()).hexdigest()}"
+    config_hash = hashlib.md5(",".join(config.keys()).encode()).hexdigest()
+    issue_id = f"{LEGACY_TEMPLATE_DEPRECATION_KEY}_{domain}_{breadcrumb}_{config_hash}"
 
     if (deprecation_list := hass.data.get(DATA_DEPRECATION)) is None:
         hass.data[DATA_DEPRECATION] = deprecation_list = []

--- a/homeassistant/components/template/image.py
+++ b/homeassistant/components/template/image.py
@@ -97,8 +97,11 @@ class AbstractTemplateImage(AbstractTemplateEntity, ImageEntity):
     _entity_id_format = ENTITY_ID_FORMAT
     _attr_image_url: str | None = None
 
-    # The super init is not called because TemplateEntity and TriggerEntity will call AbstractTemplateEntity.__init__.
-    # This ensures that the __init__ on AbstractTemplateEntity is not called twice.
+    # The super init is not called because TemplateEntity
+    # and TriggerEntity will call
+    # AbstractTemplateEntity.__init__. This ensures that
+    # the __init__ on AbstractTemplateEntity is not
+    # called twice.
     def __init__(self, hass: HomeAssistant, config: dict[str, Any]) -> None:  # pylint: disable=super-init-not-called
         """Initialize the features."""
         ImageEntity.__init__(self, hass, config[CONF_VERIFY_SSL])

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -268,8 +268,11 @@ class AbstractTemplateLight(AbstractTemplateEntity, LightEntity):
     _attr_min_color_temp_kelvin = DEFAULT_MIN_KELVIN
     _state_option = CONF_STATE
 
-    # The super init is not called because TemplateEntity and TriggerEntity will call AbstractTemplateEntity.__init__.
-    # This ensures that the __init__ on AbstractTemplateEntity is not called twice.
+    # The super init is not called because TemplateEntity
+    # and TriggerEntity will call
+    # AbstractTemplateEntity.__init__. This ensures that
+    # the __init__ on AbstractTemplateEntity is not
+    # called twice.
     def __init__(  # pylint: disable=super-init-not-called
         self, name: str, config: dict[str, Any]
     ) -> None:

--- a/homeassistant/components/template/lock.py
+++ b/homeassistant/components/template/lock.py
@@ -129,8 +129,11 @@ class AbstractTemplateLock(AbstractTemplateEntity, LockEntity):
     _optimistic_entity = True
     _state_option = CONF_STATE
 
-    # The super init is not called because TemplateEntity and TriggerEntity will call AbstractTemplateEntity.__init__.
-    # This ensures that the __init__ on AbstractTemplateEntity is not called twice.
+    # The super init is not called because TemplateEntity
+    # and TriggerEntity will call
+    # AbstractTemplateEntity.__init__. This ensures that
+    # the __init__ on AbstractTemplateEntity is not
+    # called twice.
     def __init__(self, name: str, config: dict[str, Any]) -> None:  # pylint: disable=super-init-not-called
         """Initialize the features."""
         self._code_format_template_error: TemplateError | None = None

--- a/homeassistant/components/template/number.py
+++ b/homeassistant/components/template/number.py
@@ -125,8 +125,11 @@ class AbstractTemplateNumber(AbstractTemplateEntity, NumberEntity):
     _optimistic_entity = True
     _state_option = CONF_STATE
 
-    # The super init is not called because TemplateEntity and TriggerEntity will call AbstractTemplateEntity.__init__.
-    # This ensures that the __init__ on AbstractTemplateEntity is not called twice.
+    # The super init is not called because TemplateEntity
+    # and TriggerEntity will call
+    # AbstractTemplateEntity.__init__. This ensures that
+    # the __init__ on AbstractTemplateEntity is not
+    # called twice.
     def __init__(self, name: str, config: dict[str, Any]) -> None:  # pylint: disable=super-init-not-called
         """Initialize the features."""
         self._attr_device_class = config.get(CONF_DEVICE_CLASS)

--- a/homeassistant/components/template/select.py
+++ b/homeassistant/components/template/select.py
@@ -116,8 +116,11 @@ class AbstractTemplateSelect(AbstractTemplateEntity, SelectEntity):
     _optimistic_entity = True
     _state_option = CONF_STATE
 
-    # The super init is not called because TemplateEntity and TriggerEntity will call AbstractTemplateEntity.__init__.
-    # This ensures that the __init__ on AbstractTemplateEntity is not called twice.
+    # The super init is not called because TemplateEntity
+    # and TriggerEntity will call
+    # AbstractTemplateEntity.__init__. This ensures that
+    # the __init__ on AbstractTemplateEntity is not
+    # called twice.
     def __init__(self, name: str, config: dict[str, Any]) -> None:  # pylint: disable=super-init-not-called
         """Initialize the features."""
         self._attr_options = []

--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -189,8 +189,11 @@ class AbstractTemplateSensor(AbstractTemplateEntity, RestoreSensor):
     _entity_id_format = ENTITY_ID_FORMAT
     _state_option = CONF_STATE
 
-    # The super init is not called because TemplateEntity and TriggerEntity will call AbstractTemplateEntity.__init__.
-    # This ensures that the __init__ on AbstractTemplateEntity is not called twice.
+    # The super init is not called because TemplateEntity
+    # and TriggerEntity will call
+    # AbstractTemplateEntity.__init__. This ensures that
+    # the __init__ on AbstractTemplateEntity is not
+    # called twice.
     def __init__(self, config: ConfigType) -> None:  # pylint: disable=super-init-not-called
         """Initialize the features."""
         self._attr_native_unit_of_measurement = config.get(CONF_UNIT_OF_MEASUREMENT)

--- a/homeassistant/components/template/switch.py
+++ b/homeassistant/components/template/switch.py
@@ -125,8 +125,11 @@ class AbstractTemplateSwitch(AbstractTemplateEntity, SwitchEntity, RestoreEntity
     _optimistic_entity = True
     _state_option = CONF_STATE
 
-    # The super init is not called because TemplateEntity and TriggerEntity will call AbstractTemplateEntity.__init__.
-    # This ensures that the __init__ on AbstractTemplateEntity is not called twice.
+    # The super init is not called because TemplateEntity
+    # and TriggerEntity will call
+    # AbstractTemplateEntity.__init__. This ensures that
+    # the __init__ on AbstractTemplateEntity is not
+    # called twice.
     def __init__(self, name: str, config: dict[str, Any]) -> None:  # pylint: disable=super-init-not-called
         """Initialize the features."""
 

--- a/homeassistant/components/template/template_entity.py
+++ b/homeassistant/components/template/template_entity.py
@@ -207,8 +207,10 @@ class TemplateEntity(AbstractTemplateEntity):
             CONF_AVAILABILITY, "_attr_available", on_update=self._update_available
         )
 
-        # Render name, icon, and picture early. name is rendered early because it influences
-        # the entity_id.  icon and picture are rendered early to ensure they are populated even
+        # Render name, icon, and picture early. name is
+        # rendered early because it influences the
+        # entity_id. icon and picture are rendered early
+        # to ensure they are populated even
         # if the entity renders unavailable.
         self._attr_name = None
         for option, attribute, validator in (
@@ -266,9 +268,11 @@ class TemplateEntity(AbstractTemplateEntity):
         """Create a this variable for the entity."""
         entity_id = self.entity_id
         if self._preview_callback:
-            # During config flow, the registry entry and entity_id will be None. In this scenario,
+            # During config flow, the registry entry and
+            # entity_id will be None. In this scenario,
             # a temporary entity_id is created.
-            # During option flow, the preview entity_id will be None, however the registry entry
+            # During option flow, the preview entity_id
+            # will be None, however the registry entry
             # will contain the target entity_id.
             if self.registry_entry:
                 entity_id = self.registry_entry.entity_id
@@ -296,9 +300,11 @@ class TemplateEntity(AbstractTemplateEntity):
     ) -> None:
         """Set up a template that manages the main state of the entity.
 
-        Requires _state_option to be set on the inheriting class. _state_option represents
-        the configuration option that derives the state. E.g. Template weather entities main state option
-        is 'condition', where switch is 'state'.
+        Requires _state_option to be set on the inheriting
+        class. _state_option represents the configuration
+        option that derives the state. E.g. Template weather
+        entities main state option is 'condition', where
+        switch is 'state'.
         """
 
         @callback
@@ -324,7 +330,8 @@ class TemplateEntity(AbstractTemplateEntity):
 
         if self._state_option is None:
             raise NotImplementedError(
-                f"{self.__class__.__name__} does not implement '_state_option' for 'setup_state_template'."
+                f"{self.__class__.__name__} does not implement"
+                " '_state_option' for 'setup_state_template'."
             )
 
         self.add_template(
@@ -543,7 +550,8 @@ class TemplateEntity(AbstractTemplateEntity):
             """Suppress redundant template render errors.
 
             Preview entities render templates at least 3 times before the preview entity
-            is created. If template contains an error, each render will produce an error.
+            is created. If template contains an error,
+            each render will produce an error.
             Instead of overwhelming the client with errors, suppress them and raise
             a single error through the self._handle_results method.
             """

--- a/homeassistant/components/template/trigger_entity.py
+++ b/homeassistant/components/template/trigger_entity.py
@@ -70,13 +70,16 @@ class TriggerEntity(  # pylint: disable=home-assistant-enforce-class-module
     ) -> None:
         """Set up a template that manages the main state of the entity.
 
-        Requires _state_option to be set on the inheriting class. _state_option represents
-        the configuration option that derives the state. E.g. Template weather entities main state option
-        is 'condition', where switch is 'state'.
+        Requires _state_option to be set on the inheriting
+        class. _state_option represents the configuration
+        option that derives the state. E.g. Template weather
+        entities main state option is 'condition', where
+        switch is 'state'.
         """
         if self._state_option is None:
             raise NotImplementedError(
-                f"{self.__class__.__name__} does not implement '_state_option' for 'setup_state_template'."
+                f"{self.__class__.__name__} does not implement"
+                " '_state_option' for 'setup_state_template'."
             )
 
         if self.add_template(
@@ -180,7 +183,8 @@ class TriggerEntity(  # pylint: disable=home-assistant-enforce-class-module
         rendered = dict(self._static_rendered)
 
         # If state fails to render, the entity should go unavailable. Render the
-        # state as a simple template because the result should always be a string or None.
+        # state as a simple template because the result
+        # should always be a string or None.
         if (
             state_option := self._state_option
         ) is not None and state_option in self._to_render_simple:
@@ -204,7 +208,8 @@ class TriggerEntity(  # pylint: disable=home-assistant-enforce-class-module
         # Handle any templates.
         write_state = False
         if self._state_render_error:
-            # The state errored and the entity is unavailable, do not process any values.
+            # The state errored and the entity is unavailable,
+            # do not process any values.
             return True
 
         for option, entity_template in self._templates.items():

--- a/homeassistant/components/template/update.py
+++ b/homeassistant/components/template/update.py
@@ -144,8 +144,11 @@ class AbstractTemplateUpdate(AbstractTemplateEntity, UpdateEntity):
 
     _entity_id_format = ENTITY_ID_FORMAT
 
-    # The super init is not called because TemplateEntity and TriggerEntity will call AbstractTemplateEntity.__init__.
-    # This ensures that the __init__ on AbstractTemplateEntity is not called twice.
+    # The super init is not called because TemplateEntity
+    # and TriggerEntity will call
+    # AbstractTemplateEntity.__init__. This ensures that
+    # the __init__ on AbstractTemplateEntity is not
+    # called twice.
     def __init__(self, name: str, config: dict[str, Any]) -> None:  # pylint: disable=super-init-not-called
         """Initialize the features."""
 
@@ -265,9 +268,12 @@ class StateUpdateEntity(TemplateEntity, AbstractTemplateUpdate):
         """Return the entity picture to use in the frontend."""
         # This is needed to override the base update entity functionality
         if self._attr_entity_picture is None:
-            # The default picture for update entities would use `self.platform.platform_name` in
-            # place of `template`.  This does not work when creating an entity preview because
-            # the platform does not exist for that entity, therefore this is hardcoded as `template`.
+            # The default picture for update entities would
+            # use `self.platform.platform_name` in place of
+            # `template`. This does not work when creating
+            # an entity preview because the platform does
+            # not exist for that entity, therefore this is
+            # hardcoded as `template`.
             return "/api/brands/integration/template/icon.png"
         return self._attr_entity_picture
 

--- a/homeassistant/components/template/vacuum.py
+++ b/homeassistant/components/template/vacuum.py
@@ -245,8 +245,11 @@ class AbstractTemplateVacuum(AbstractTemplateEntity, StateVacuumEntity):
     _optimistic_entity = True
     _state_option = CONF_STATE
 
-    # The super init is not called because TemplateEntity and TriggerEntity will call AbstractTemplateEntity.__init__.
-    # This ensures that the __init__ on AbstractTemplateEntity is not called twice.
+    # The super init is not called because TemplateEntity
+    # and TriggerEntity will call
+    # AbstractTemplateEntity.__init__. This ensures that
+    # the __init__ on AbstractTemplateEntity is not
+    # called twice.
     def __init__(self, name: str, config: dict[str, Any]) -> None:  # pylint: disable=super-init-not-called
         """Initialize the features."""
 

--- a/homeassistant/components/template/weather.py
+++ b/homeassistant/components/template/weather.py
@@ -328,7 +328,9 @@ def validate_forecast(
                     entity,
                     option,
                     result,
-                    f"expected a list of forecast dictionaries, got {forecast}, {weather_message}",
+                    "expected a list of forecast"
+                    f" dictionaries, got {forecast},"
+                    f" {weather_message}",
                 )
                 continue
 
@@ -339,7 +341,9 @@ def validate_forecast(
                     entity,
                     option,
                     result,
-                    f"expected valid forecast keys, unallowed keys: ({diff_result}) for {forecast}, {weather_message}",
+                    "expected valid forecast keys,"
+                    f" unallowed keys: ({diff_result})"
+                    f" for {forecast}, {weather_message}",
                 )
             if forecast_type == "twice_daily" and "is_daytime" not in forecast:
                 raised = True
@@ -347,7 +351,9 @@ def validate_forecast(
                     entity,
                     option,
                     result,
-                    f"`is_daytime` is missing in twice_daily forecast {forecast}, {weather_message}",
+                    "`is_daytime` is missing in"
+                    f" twice_daily forecast {forecast},"
+                    f" {weather_message}",
                 )
             if "datetime" not in forecast:
                 raised = True
@@ -355,7 +361,8 @@ def validate_forecast(
                     entity,
                     option,
                     result,
-                    f"`datetime` is missing in forecast, got {forecast}, {weather_message}",
+                    "`datetime` is missing in forecast,"
+                    f" got {forecast}, {weather_message}",
                 )
 
         if raised:
@@ -373,8 +380,11 @@ class AbstractTemplateWeather(AbstractTemplateEntity, WeatherEntity):
     _state_option = CONF_CONDITION
     _optimistic_entity = True
 
-    # The super init is not called because TemplateEntity and TriggerEntity will call AbstractTemplateEntity.__init__.
-    # This ensures that the __init__ on AbstractTemplateEntity is not called twice.
+    # The super init is not called because TemplateEntity
+    # and TriggerEntity will call
+    # AbstractTemplateEntity.__init__. This ensures that
+    # the __init__ on AbstractTemplateEntity is not
+    # called twice.
     def __init__(  # pylint: disable=super-init-not-called
         self, config: dict[str, Any]
     ) -> None:

--- a/homeassistant/components/tesla_fleet/__init__.py
+++ b/homeassistant/components/tesla_fleet/__init__.py
@@ -244,7 +244,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
             )
 
             # Create the energy site device regardless of it having entities
-            # This is so users with a Wall Connector but without a Powerwall can still make service calls
+            # This is so users with a Wall Connector but
+            # without a Powerwall can still make service calls
             device_registry.async_get_or_create(
                 config_entry_id=entry.entry_id, **device
             )

--- a/homeassistant/components/tesla_fleet/climate.py
+++ b/homeassistant/components/tesla_fleet/climate.py
@@ -102,7 +102,8 @@ class TeslaFleetClimateEntity(TeslaFleetVehicleEntity, ClimateEntity):
         else:
             self._attr_hvac_mode = HVACMode.OFF
 
-        # If not scoped, prevent the user from changing the HVAC mode by making it the only option
+        # If not scoped, prevent the user from changing the
+        # HVAC mode by making it the only option
         if self._attr_hvac_mode and self.read_only:
             self._attr_hvac_modes = [self._attr_hvac_mode]
 
@@ -243,7 +244,8 @@ class TeslaFleetCabinOverheatProtectionEntity(TeslaFleetVehicleEntity, ClimateEn
         else:
             self._attr_hvac_mode = COP_MODES.get(state)
 
-        # If not scoped, prevent the user from changing the HVAC mode by making it the only option
+        # If not scoped, prevent the user from changing the
+        # HVAC mode by making it the only option
         if self._attr_hvac_mode and self.read_only:
             self._attr_hvac_modes = [self._attr_hvac_mode]
 

--- a/homeassistant/components/tesla_fleet/coordinator.py
+++ b/homeassistant/components/tesla_fleet/coordinator.py
@@ -245,7 +245,7 @@ class TeslaFleetEnergySiteLiveCoordinator(DataUpdateCoordinator[dict[str, Any]])
 
 
 class TeslaFleetEnergySiteHistoryCoordinator(DataUpdateCoordinator[dict[str, Any]]):
-    """Class to manage fetching energy site history import and export from the Tesla Fleet API."""
+    """Manage fetching energy site history from the Tesla Fleet API."""
 
     config_entry: TeslaFleetConfigEntry
 

--- a/homeassistant/components/teslemetry/cover.py
+++ b/homeassistant/components/teslemetry/cover.py
@@ -326,7 +326,8 @@ class TeslemetryFrontTrunkEntity(TeslemetryRootEntity, CoverEntity):
         self._attr_is_closed = False
         self.async_write_ha_state()
 
-    # In the future this could be extended to add aftermarket close support through a option flow
+    # In the future this could be extended to add
+    # aftermarket close support through an option flow
 
 
 class TeslemetryVehiclePollingFrontTrunkEntity(

--- a/homeassistant/components/teslemetry/services.py
+++ b/homeassistant/components/teslemetry/services.py
@@ -345,7 +345,8 @@ def async_setup_services(hass: HomeAssistant) -> None:
 
         # Extract parameters from the service call
         days_of_week = call.data[ATTR_DAYS_OF_WEEK]
-        # If days_of_week is a list (from select with multiple), convert to comma-separated string
+        # If days_of_week is a list (from select with
+        # multiple), convert to comma-separated string
         if isinstance(days_of_week, list):
             days_of_week = ",".join(days_of_week)
         enabled = call.data[ATTR_ENABLE]
@@ -445,7 +446,8 @@ def async_setup_services(hass: HomeAssistant) -> None:
 
         # Extract parameters from the service call
         days_of_week = call.data[ATTR_DAYS_OF_WEEK]
-        # If days_of_week is a list (from select with multiple), convert to comma-separated string
+        # If days_of_week is a list (from select with
+        # multiple), convert to comma-separated string
         if isinstance(days_of_week, list):
             days_of_week = ",".join(days_of_week)
         enabled = call.data[ATTR_ENABLE]

--- a/homeassistant/components/tessie/coordinator.py
+++ b/homeassistant/components/tessie/coordinator.py
@@ -223,7 +223,9 @@ class TessieEnergyHistoryCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             or not data["time_series"]
         ):
             _LOGGER.warning(
-                "Tessie returned no energy history time_series for coordinator %s; skipping update",
+                "Tessie returned no energy history"
+                " time_series for coordinator %s;"
+                " skipping update",
                 self.config_entry.entry_id,
             )
             return self.data

--- a/homeassistant/components/tessie/select.py
+++ b/homeassistant/components/tessie/select.py
@@ -46,15 +46,13 @@ async def async_setup_entry(
                 TessieSeatHeaterSelectEntity(vehicle, key)
                 for vehicle in entry.runtime_data.vehicles
                 for key in SEAT_HEATERS
-                if key
-                in vehicle.data_coordinator.data  # not all vehicles have rear center or third row
+                if key in vehicle.data_coordinator.data
             ),
             (
                 TessieSeatCoolerSelectEntity(vehicle, key)
                 for vehicle in entry.runtime_data.vehicles
                 for key in SEAT_COOLERS
-                if key
-                in vehicle.data_coordinator.data  # not all vehicles have ventilated seats
+                if key in vehicle.data_coordinator.data
             ),
             (
                 TessieOperationSelectEntity(energysite)

--- a/homeassistant/components/text/__init__.py
+++ b/homeassistant/components/text/__init__.py
@@ -70,11 +70,13 @@ async def _async_set_value(entity: TextEntity, service_call: ServiceCall) -> Non
         )
     if len(value) > entity.max:
         raise ValueError(
-            f"Value {value} for {entity.entity_id} is too long (maximum length {entity.max})"
+            f"Value {value} for {entity.entity_id}"
+            f" is too long (maximum length {entity.max})"
         )
     if entity.pattern_cmp and not entity.pattern_cmp.match(value):
         raise ValueError(
-            f"Value {value} for {entity.entity_id} doesn't match pattern {entity.pattern}"
+            f"Value {value} for {entity.entity_id}"
+            f" doesn't match pattern {entity.pattern}"
         )
     await entity.async_set_value(value)
 

--- a/homeassistant/components/thermopro/__init__.py
+++ b/homeassistant/components/thermopro/__init__.py
@@ -33,7 +33,7 @@ def process_service_info(
     data: ThermoProBluetoothDeviceData,
     service_info: BluetoothServiceInfoBleak,
 ) -> SensorUpdate:
-    """Process a BluetoothServiceInfoBleak, running side effects and returning sensor data."""
+    """Process a BluetoothServiceInfoBleak and return sensor data."""
     update = data.update(service_info)
     async_dispatcher_send(
         hass, f"{SIGNAL_DATA_UPDATED}_{entry.entry_id}", data, service_info, update

--- a/homeassistant/components/thread/diagnostics.py
+++ b/homeassistant/components/thread/diagnostics.py
@@ -80,7 +80,7 @@ def _get_possible_thread_routes(
 ) -> tuple[dict[str, dict[str, Route]], dict[str, set[str]]]:
     # Build a list of possible thread routes
     # Right now, this is ipv6 /64's that have a gateway
-    # We cross reference with zerconf data to confirm
+    # We cross reference with zeroconf data to confirm
     # which via's are known border routers
     routes: dict[str, dict[str, Route]] = {}
     reverse_routes: dict[str, set[str]] = {}

--- a/homeassistant/components/thread/diagnostics.py
+++ b/homeassistant/components/thread/diagnostics.py
@@ -1,18 +1,25 @@
 """Diagnostics support for Thread networks.
 
-When triaging Matter and HomeKit issues you often need to check for problems with the Thread network.
+When triaging Matter and HomeKit issues you often need to
+check for problems with the Thread network.
 
 This report helps spot and rule out:
 
 * Is the users border router visible at all?
-* Is the border router actually announcing any routes? The user could have a network boundary like
-  VLANs or WiFi isolation that is blocking the RA packets.
-* Alternatively, if user isn't on HAOS they could have accept_ra_rt_info_max_plen set incorrectly.
-* Are there any bogus routes that could be interfering. If routes don't expire they can build up.
-  When you have 10 routes and only 2 border routers something has gone wrong.
+* Is the border router actually announcing any routes?
+  The user could have a network boundary like VLANs or
+  WiFi isolation that is blocking the RA packets.
+* Alternatively, if user isn't on HAOS they could have
+  accept_ra_rt_info_max_plen set incorrectly.
+* Are there any bogus routes that could be interfering.
+  If routes don't expire they can build up. When you have
+  10 routes and only 2 border routers something has gone
+  wrong.
 
-This does not do any connectivity checks. So user could have all their border routers visible, but
-some of their thread accessories can't be pinged, but it's still a thread problem.
+This does not do any connectivity checks. So user could
+have all their border routers visible, but some of their
+thread accessories can't be pinged, but it's still a
+thread problem.
 """
 
 from ipaddress import IPv6Address
@@ -73,7 +80,8 @@ def _get_possible_thread_routes(
 ) -> tuple[dict[str, dict[str, Route]], dict[str, set[str]]]:
     # Build a list of possible thread routes
     # Right now, this is ipv6 /64's that have a gateway
-    # We cross reference with zerconf data to confirm which via's are known border routers
+    # We cross reference with zerconf data to confirm
+    # which via's are known border routers
     routes: dict[str, dict[str, Route]] = {}
     reverse_routes: dict[str, set[str]] = {}
 
@@ -146,13 +154,17 @@ async def async_get_config_entry_diagnostics(
             },
         )
         if mlp_item := record.dataset.get(MeshcopTLVType.MESHLOCALPREFIX):
-            # We know that it is indeed a /64 mesh-local IPv6 NETWORK because Thread spec;
-            # However, the "prefixes" field contains no /XX (prefix length) in their entries ATM,
-            # so we use an IPv6Address in order to get a "prefixes" entry with no prefix length.
+            # We know that it is indeed a /64 mesh-local
+            # IPv6 NETWORK because Thread spec;
+            # However, the "prefixes" field contains no /XX
+            # (prefix length) in their entries ATM, so we
+            # use an IPv6Address in order to get a "prefixes"
+            # entry with no prefix length.
             prefix_address = IPv6Address(mlp_item.data.ljust(16, b"\x00"))
             network["prefixes"].add(str(prefix_address))
 
-    # Find all routes currently act that might be thread related, so we can match them to
+    # Find all routes currently active that might be
+    # thread related, so we can match them to
     # border routers as we process the zeroconf data.
     #
     # Also find all neighbours

--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -334,7 +334,8 @@ class Timer(collection.CollectionEntity, RestoreEntity):
         """Change duration of a running timer."""
         if self._listener is None or self._end is None:
             raise HomeAssistantError(
-                f"Timer {self.entity_id} is not running, only active timers can be changed"
+                f"Timer {self.entity_id} is not running,"
+                " only active timers can be changed"
             )
         # Check against new remaining time before checking boundaries
         new_remaining = (self._end + duration) - dt_util.utcnow().replace(microsecond=0)
@@ -344,7 +345,8 @@ class Timer(collection.CollectionEntity, RestoreEntity):
             )
         if self._remaining and (self._remaining + duration) < timedelta():
             raise HomeAssistantError(
-                f"Not possible to change timer {self.entity_id} to negative time remaining"
+                f"Not possible to change timer"
+                f" {self.entity_id} to negative time remaining"
             )
 
         self._listener()

--- a/homeassistant/components/tmb/sensor.py
+++ b/homeassistant/components/tmb/sensor.py
@@ -1,4 +1,4 @@
-"""Support for TMB (Transports Metropolitans de Barcelona) Barcelona public transport."""
+"""Support for TMB Barcelona public transport."""
 
 from datetime import timedelta
 import logging

--- a/homeassistant/components/todo/trigger.py
+++ b/homeassistant/components/todo/trigger.py
@@ -78,7 +78,7 @@ class ItemChangeListener(TargetEntityChangeTracker):
     @override
     @callback
     def _handle_entities_update(self, tracked_entities: set[str]) -> None:
-        """Restart the listeners when the list of entities of the tracked targets is updated."""
+        """Restart listeners when tracked target entities change."""
         if self._pending_listener_task:
             self._pending_listener_task.cancel()
         self._pending_listener_task = self._hass.async_create_task(

--- a/homeassistant/components/tplink/camera.py
+++ b/homeassistant/components/tplink/camera.py
@@ -196,7 +196,8 @@ class TPLinkCameraEntity(CoordinatedTPLinkModuleEntity, Camera):
                     _LOGGER.debug(
                         "Empty camera image returned for %s", self._device.host
                     )
-                    # image could be empty if a stream is running so check for explicit auth error
+                    # image could be empty if a stream is
+                    # running so check for explicit auth error
                     await self._async_check_stream_auth(video_url)
                 else:
                     _LOGGER.debug(

--- a/homeassistant/components/tplink/config_flow.py
+++ b/homeassistant/components/tplink/config_flow.py
@@ -129,7 +129,8 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
         if not updates:
             return None
         updates = {**entry.data, **updates}
-        # If the connection parameters have changed the credentials_hash will be invalid.
+        # If the connection parameters have changed the
+        # credentials_hash will be invalid.
         if new_connection_params:
             updates.pop(CONF_CREDENTIALS_HASH, None)
             _LOGGER.debug(
@@ -144,7 +145,7 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
     def _update_config_if_entry_in_setup_error(
         self, entry: ConfigEntry, host: str, device: Device | None
     ) -> ConfigFlowResult | None:
-        """If discovery encounters a device that is in SETUP_ERROR or SETUP_RETRY update the device config."""
+        """Update device config if discovery finds a device in error state."""
         if entry.state not in (
             ConfigEntryState.SETUP_ERROR,
             ConfigEntryState.SETUP_RETRY,
@@ -214,7 +215,7 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
                     self._discovered_device, credentials
                 )
             except AuthenticationError:
-                pass  # Authentication exceptions should continue to the rest of the step
+                pass
             else:
                 self._discovered_device = device
                 return await self.async_step_discovery_confirm()
@@ -551,7 +552,9 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
         self._discovered_devices = await async_discover_devices(self.hass)
         devices_name = {
             formatted_mac: (
-                f"{device.alias or mac_alias(device.mac)} {device.model} ({device.host}) {formatted_mac}"
+                f"{device.alias or mac_alias(device.mac)}"
+                f" {device.model} ({device.host})"
+                f" {formatted_mac}"
             )
             for formatted_mac, device in self._discovered_devices.items()
             if formatted_mac not in configured_devices

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -475,7 +475,7 @@ class CoordinatedTPLinkFeatureEntity(CoordinatedTPLinkEntity, ABC):
     ) -> list[_E]:
         """Create entities for device and its children.
 
-        This is a helper that calls *_entities_for_device* for the device and its children.
+        Calls *_entities_for_device* for the device and its children.
         """
         entities: list[_E] = []
         # Add parent entities before children so via_device id works.
@@ -620,7 +620,7 @@ class CoordinatedTPLinkModuleEntity(CoordinatedTPLinkEntity, ABC):
     ) -> list[_E]:
         """Create entities for device and its children.
 
-        This is a helper that calls *_entities_for_device* for the device and its children.
+        Calls *_entities_for_device* for the device and its children.
         """
         entities: list[_E] = []
 

--- a/homeassistant/components/tplink_omada/config_flow.py
+++ b/homeassistant/components/tplink_omada/config_flow.py
@@ -57,7 +57,8 @@ async def create_omada_client(
         and re.fullmatch(r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}", host_parts.hostname)
         is not None
     ):
-        # TP-Link API uses cookies for login session, so an unsafe cookie jar is required for IP addresses
+        # TP-Link API uses cookies for login session,
+        # so an unsafe cookie jar is required for IPs
         websession = async_create_clientsession(
             hass, cookie_jar=CookieJar(unsafe=True), verify_ssl=verify_ssl
         )

--- a/homeassistant/components/tplink_omada/controller.py
+++ b/homeassistant/components/tplink_omada/controller.py
@@ -69,7 +69,8 @@ class OmadaSiteController:
 
         Args:
             device_filter: Function that returns True if a device should be processed.
-            entity_callback: Given a discovered Omada device, creates entities for that device.
+            entity_callback: Given a discovered Omada device,
+                creates entities for that device.
         """
         # Track which devices have been processed already
         processed_devices: set[str] = set()

--- a/homeassistant/components/tplink_omada/coordinator.py
+++ b/homeassistant/components/tplink_omada/coordinator.py
@@ -158,7 +158,7 @@ class FirmwareUpdateStatus(NamedTuple):
 
 
 class OmadaFirmwareUpdateCoordinator(OmadaCoordinator[FirmwareUpdateStatus]):
-    """Coordinator for getting details about available firmware updates for Omada devices."""
+    """Coordinator for Omada device firmware update details."""
 
     def __init__(
         self,

--- a/homeassistant/components/tplink_omada/sensor.py
+++ b/homeassistant/components/tplink_omada/sensor.py
@@ -84,7 +84,7 @@ async def async_setup_entry(
 
 @dataclass(frozen=True, kw_only=True)
 class OmadaDeviceSensorEntityDescription(SensorEntityDescription):
-    """Entity description for a status derived from an Omada device in the device list."""
+    """Entity description for status from an Omada device."""
 
     exists_func: Callable[[OmadaListDevice], bool] = lambda _: True
     update_func: Callable[[OmadaListDevice], StateType]

--- a/homeassistant/components/tplink_omada/services.py
+++ b/homeassistant/components/tplink_omada/services.py
@@ -27,7 +27,8 @@ def _get_controller(call: ServiceCall) -> OmadaSiteController:
         if not entry:
             raise ServiceValidationError("Specified TP-Link Omada controller not found")
     else:
-        # Assume first loaded entry if none specified (for backward compatibility/99% use case)
+        # Assume first loaded entry if none specified
+        # (for backward compatibility/99% use case)
         entries = call.hass.config_entries.async_entries(DOMAIN)
         if len(entries) == 0:
             raise ServiceValidationError("No active TP-Link Omada controllers found")

--- a/homeassistant/components/tplink_omada/switch.py
+++ b/homeassistant/components/tplink_omada/switch.py
@@ -76,7 +76,8 @@ async def async_setup_entry(
         )
         async_add_entities(entities)
 
-    # Register switch port entities for switches that are connected, such that we can determine the port information
+    # Register switch port entities for switches that are
+    # connected, so we can determine the port information
     await controller.async_register_device_entities(
         device_filter=lambda d: (
             d.type == "switch" and d.status_category == DeviceStatusCategory.CONNECTED
@@ -133,7 +134,7 @@ class OmadaDevicePortSwitchEntityDescription[
     TDevice: OmadaDevice,
     TPort,
 ](SwitchEntityDescription):
-    """Entity description for a toggle switch derived from a network port on an Omada device."""
+    """Entity description for a port toggle on an Omada device."""
 
     exists_func: Callable[[TDevice, TPort], bool] = lambda _, p: True
     coordinator_update_func: Callable[[TCoordinator, TDevice, TPort], TPort | None]
@@ -147,7 +148,7 @@ class OmadaSwitchPortSwitchEntityDescription(
         OmadaSwitchPortCoordinator, OmadaSwitch, OmadaSwitchPortDetails
     ]
 ):
-    """Entity description for a toggle switch for a feature of a Port on an Omada Switch."""
+    """Entity description for a switch port feature toggle."""
 
     coordinator_update_func: Callable[
         [OmadaSwitchPortCoordinator, OmadaSwitch, OmadaSwitchPortDetails],
@@ -161,7 +162,7 @@ class OmadaGatewayPortConfigSwitchEntityDescription(
         OmadaGatewayCoordinator, OmadaGateway, OmadaGatewayPortConfig
     ]
 ):
-    """Entity description for a toggle switch for a configuration of a Port on an Omada Gateway."""
+    """Entity description for a gateway port config toggle."""
 
     coordinator_update_func: Callable[
         [OmadaGatewayCoordinator, OmadaGateway, OmadaGatewayPortConfig],
@@ -179,7 +180,7 @@ class OmadaGatewayPortStatusSwitchEntityDescription(
         OmadaGatewayCoordinator, OmadaGateway, OmadaGatewayPortStatus
     ]
 ):
-    """Entity description for a toggle switch for a status of a Port on an Omada Gateway."""
+    """Entity description for a gateway port status toggle."""
 
     coordinator_update_func: Callable[
         [OmadaGatewayCoordinator, OmadaGateway, OmadaGatewayPortStatus],

--- a/homeassistant/components/tplink_omada/update.py
+++ b/homeassistant/components/tplink_omada/update.py
@@ -86,7 +86,8 @@ class OmadaDeviceUpdate(
             raise HomeAssistantError("Firmware update request rejected") from ex
         except OmadaClientException as ex:
             raise HomeAssistantError(
-                "Unable to send Firmware update request. Check the controller is online."
+                "Unable to send Firmware update request."
+                " Check the controller is online."
             ) from ex
         finally:
             await self.coordinator.async_request_refresh()

--- a/homeassistant/components/traccar_server/coordinator.py
+++ b/homeassistant/components/traccar_server/coordinator.py
@@ -81,6 +81,9 @@ class TraccarServerCoordinator(DataUpdateCoordinator[TraccarServerCoordinatorDat
     async def _async_update_data(self) -> TraccarServerCoordinatorData:
         """Fetch data from Traccar Server."""
         LOGGER.debug("Updating device data")
+        get_custom_attrs = (
+            self._return_custom_attributes_if_not_filtered_by_accuracy_configuration
+        )
         data: TraccarServerCoordinatorData = {}
         try:
             (
@@ -118,12 +121,8 @@ class TraccarServerCoordinator(DataUpdateCoordinator[TraccarServerCoordinatorDat
                 )
                 continue
 
-            if (
-                attr
-                := self._return_custom_attributes_if_not_filtered_by_accuracy_configuration(
-                    device, position
-                )
-            ) is None:
+            attr = get_custom_attrs(device, position)
+            if attr is None:
                 self.logger.debug(
                     "Skipping position update %s for %s due to accuracy filter",
                     position["id"],
@@ -147,18 +146,17 @@ class TraccarServerCoordinator(DataUpdateCoordinator[TraccarServerCoordinatorDat
         """Handle subscription data."""
         self.logger.debug("Received subscription data: %s", data)
         self._should_log_subscription_error = True
+        get_custom_attrs = (
+            self._return_custom_attributes_if_not_filtered_by_accuracy_configuration
+        )
         update_devices = set()
         for device in data.get("devices") or []:
             if (device_id := device["id"]) not in self.data:
                 self.logger.debug("Device %s not found in data", device_id)
                 continue
 
-            if (
-                attr
-                := self._return_custom_attributes_if_not_filtered_by_accuracy_configuration(
-                    device, self.data[device_id]["position"]
-                )
-            ) is None:
+            attr = get_custom_attrs(device, self.data[device_id]["position"])
+            if attr is None:
                 continue
 
             self.data[device_id]["device"] = device
@@ -174,12 +172,8 @@ class TraccarServerCoordinator(DataUpdateCoordinator[TraccarServerCoordinatorDat
                 )
                 continue
 
-            if (
-                attr
-                := self._return_custom_attributes_if_not_filtered_by_accuracy_configuration(
-                    self.data[device_id]["device"], position
-                )
-            ) is None:
+            attr = get_custom_attrs(self.data[device_id]["device"], position)
+            if attr is None:
                 self.logger.debug(
                     "Skipping position update %s for %s due to accuracy filter",
                     position["id"],
@@ -255,7 +249,7 @@ class TraccarServerCoordinator(DataUpdateCoordinator[TraccarServerCoordinatorDat
         device: DeviceModel,
         position: PositionModel,
     ) -> dict[str, Any] | None:
-        """Return a dictionary of custom attributes if not filtered by accuracy configuration."""
+        """Return custom attributes if not filtered by accuracy."""
         attr = {}
         skip_accuracy_filter = False
 

--- a/homeassistant/components/tractive/__init__.py
+++ b/homeassistant/components/tractive/__init__.py
@@ -160,7 +160,8 @@ async def _generate_trackables(
 
     if "details" not in trackable_data:
         _LOGGER.warning(
-            "Tracker %s has no details and will be skipped. This happens for shared trackers",
+            "Tracker %s has no details and will be"
+            " skipped. This happens for shared trackers",
             trackable_data["device_id"],
         )
         return None
@@ -176,7 +177,8 @@ async def _generate_trackables(
 
     if not tracker_details.get("_id"):
         raise ConfigEntryNotReady(
-            f"Tractive API returns incomplete data for tracker {trackable_data['device_id']}",
+            "Tractive API returns incomplete data"
+            f" for tracker {trackable_data['device_id']}",
         )
 
     return Trackables(

--- a/homeassistant/components/tradfri/__init__.py
+++ b/homeassistant/components/tradfri/__init__.py
@@ -165,7 +165,8 @@ def remove_stale_devices(
             continue
 
         if device_id is None or device_id not in all_device_ids:
-            # If device_id is None an invalid device entry was found for this config entry.
+            # If device_id is None an invalid device entry
+            # was found for this config entry.
             # If the device_id is not in existing device ids it's a stale device entry.
             # Remove config entry from this device entry in either case.
             device_registry.async_update_device(
@@ -237,7 +238,8 @@ def migrate_config_entry_and_identifiers(
         # Loop through list of config_entry_ids for device
         config_entry_ids = device.config_entries
         for config_entry_id in config_entry_ids:
-            # Check that the config entry in list is not the device's primary config entry
+            # Check that the config entry in list is not
+            # the device's primary config entry
             if config_entry_id == device.primary_config_entry:
                 continue
 

--- a/homeassistant/components/trafikverket_camera/config_flow.py
+++ b/homeassistant/components/trafikverket_camera/config_flow.py
@@ -201,7 +201,11 @@ class TVCameraConfigFlow(ConfigFlow, domain=DOMAIN):
         camera_choices = [
             SelectOptionDict(
                 value=f"{camera_info.camera_id}",
-                label=f"{camera_info.camera_id} - {camera_info.camera_name} - {camera_info.location}",
+                label=(
+                    f"{camera_info.camera_id}"
+                    f" - {camera_info.camera_name}"
+                    f" - {camera_info.location}"
+                ),
             )
             for camera_info in self.cameras
         ]

--- a/homeassistant/components/trafikverket_ferry/util.py
+++ b/homeassistant/components/trafikverket_ferry/util.py
@@ -8,6 +8,7 @@ def create_unique_id(
 ) -> str:
     """Create unique id."""
     return (
-        f"{ferry_from.casefold().replace(' ', '')}-{ferry_to.casefold().replace(' ', '')}"
+        f"{ferry_from.casefold().replace(' ', '')}"
+        f"-{ferry_to.casefold().replace(' ', '')}"
         f"-{ferry_time!s}-{weekdays!s}"
     )

--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -83,7 +83,8 @@ async def async_setup_entry(
         if CONF_NAME not in config_entry.data:
             return None
         match = re.search(
-            f"{config_entry.data[CONF_HOST]}-{config_entry.data[CONF_NAME]} (?P<name>.+)",
+            f"{config_entry.data[CONF_HOST]}"
+            f"-{config_entry.data[CONF_NAME]} (?P<name>.+)",
             entity_entry.unique_id,
         )
 

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -140,7 +140,7 @@ class TTSCache:
     """If an error occurred while loading, contains the error."""
 
     _consumers: list[asyncio.Queue[bytes | None]] | None = None
-    """A queue for each current consumer to notify of new data while the generator is loading."""
+    """Queue for consumers to receive data while loading."""
 
     def __init__(
         self,

--- a/homeassistant/components/tts/entity.py
+++ b/homeassistant/components/tts/entity.py
@@ -108,13 +108,17 @@ class TextToSpeechEntity(RestoreEntity, cached_properties=CACHED_PROPERTIES_WITH
             _ = self.default_language
         except AttributeError as err:
             raise AttributeError(
-                "TTS entities must either set the '_attr_default_language' attribute or override the 'default_language' property"
+                "TTS entities must either set the"
+                " '_attr_default_language' attribute or override"
+                " the 'default_language' property"
             ) from err
         try:
             _ = self.supported_languages
         except AttributeError as err:
             raise AttributeError(
-                "TTS entities must either set the '_attr_supported_languages' attribute or override the 'supported_languages' property"
+                "TTS entities must either set the"
+                " '_attr_supported_languages' attribute or"
+                " override the 'supported_languages' property"
             ) from err
         state = await self.async_get_last_state()
         if (

--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -61,7 +61,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: TuyaConfigEntry) -> bool
         listener.async_register_device(device_registry, device)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    # If the device does not register any entities, the device does not need to subscribe
+    # If the device does not register any entities,
+    # the device does not need to subscribe
     # So the subscription is here
     await hass.async_add_executor_job(manager.refresh_mq)
     return True

--- a/homeassistant/components/tuya/alarm_control_panel.py
+++ b/homeassistant/components/tuya/alarm_control_panel.py
@@ -41,7 +41,9 @@ _TUYA_TO_HA_STATE_MAPPINGS = {
     TuyaAlarmControlPanelState.ARMED_AWAY: AlarmControlPanelState.ARMED_AWAY,
     TuyaAlarmControlPanelState.ARMED_NIGHT: AlarmControlPanelState.ARMED_NIGHT,
     TuyaAlarmControlPanelState.ARMED_VACATION: AlarmControlPanelState.ARMED_VACATION,
-    TuyaAlarmControlPanelState.ARMED_CUSTOM_BYPASS: AlarmControlPanelState.ARMED_CUSTOM_BYPASS,
+    TuyaAlarmControlPanelState.ARMED_CUSTOM_BYPASS: (
+        AlarmControlPanelState.ARMED_CUSTOM_BYPASS
+    ),
     TuyaAlarmControlPanelState.PENDING: AlarmControlPanelState.PENDING,
     TuyaAlarmControlPanelState.ARMING: AlarmControlPanelState.ARMING,
     TuyaAlarmControlPanelState.DISARMING: AlarmControlPanelState.DISARMING,

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -534,7 +534,8 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
     @property
     def brightness(self) -> int | None:
         """Return the brightness of this light between 0..255."""
-        # If the light is currently in color mode, extract the brightness from the color data
+        # If the light is currently in color mode,
+        # extract the brightness from the color data
         if self.color_mode == ColorMode.HS and self._color_data_wrapper:
             hsv_data = self._read_wrapper(self._color_data_wrapper)
             return None if hsv_data is None else round(hsv_data[2])

--- a/homeassistant/components/tuya/number.py
+++ b/homeassistant/components/tuya/number.py
@@ -543,7 +543,8 @@ class TuyaNumberEntity(TuyaEntity, NumberEntity):
                 or self.device_class not in DEVICE_CLASS_UNITS
             ):
                 LOGGER.debug(
-                    "Device class %s ignored for incompatible unit %s in number entity %s",
+                    "Device class %s ignored for"
+                    " incompatible unit %s in number entity %s",
                     self.device_class,
                     self.native_unit_of_measurement,
                     self.unique_id,

--- a/homeassistant/components/tuya/sensor.py
+++ b/homeassistant/components/tuya/sensor.py
@@ -1070,7 +1070,8 @@ SENSORS: dict[DeviceCategory, tuple[TuyaSensorEntityDescription, ...]] = {
         ),
     ),
     DeviceCategory.SFKZQ: (
-        # Total seconds of irrigation. Read-write value; the device appears to ignore the write action (maybe firmware bug)
+        # Total seconds of irrigation. Read-write value;
+        # the device appears to ignore the write action
         TuyaSensorEntityDescription(
             key=DPCode.TIME_USE,
             translation_key="total_watering_time",
@@ -1774,7 +1775,8 @@ class TuyaSensorEntity(TuyaEntity, SensorEntity):
                 or self.device_class not in DEVICE_CLASS_UNITS
             ):
                 LOGGER.debug(
-                    "Device class %s ignored for incompatible unit %s in sensor entity %s",
+                    "Device class %s ignored for"
+                    " incompatible unit %s in sensor entity %s",
                     self.device_class,
                     self.native_unit_of_measurement,
                     self.unique_id,

--- a/homeassistant/components/twinkly/__init__.py
+++ b/homeassistant/components/twinkly/__init__.py
@@ -20,7 +20,8 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: TwinklyConfigEntry) -> bool:
     """Set up entries from config flow."""
-    # We setup the client here so if at some point we add any other entity for this device,
+    # We setup the client here so if at some point we add
+    # any other entity for this device,
     # we will be able to properly share the connection.
     host = entry.data[CONF_HOST]
 

--- a/homeassistant/components/ukraine_alarm/__init__.py
+++ b/homeassistant/components/ukraine_alarm/__init__.py
@@ -55,7 +55,8 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             regions_data = await Client(websession).get_regions()
         except (aiohttp.ClientError, TimeoutError) as err:
             _LOGGER.warning(
-                "Could not migrate config entry %s: failed to fetch current regions: %s",
+                "Could not migrate config entry %s:"
+                " failed to fetch current regions: %s",
                 config_entry.entry_id,
                 err,
             )

--- a/homeassistant/components/ukraine_alarm/config_flow.py
+++ b/homeassistant/components/ukraine_alarm/config_flow.py
@@ -93,7 +93,8 @@ class UkraineAlarmConfigFlow(ConfigFlow, domain=DOMAIN):
             source = self.states
 
         if user_input is not None:
-            # Only offer to browse subchildren if picked region wasn't the previously picked one
+            # Only offer to browse subchildren if picked
+            # region wasn't the previously picked one
             if (
                 not self.selected_region
                 or user_input[CONF_REGION] != self.selected_region["regionId"]

--- a/homeassistant/components/unifi/hub/hub.py
+++ b/homeassistant/components/unifi/hub/hub.py
@@ -146,7 +146,8 @@ class UnifiHub:
         }
         for key, value in check_keys.items():
             if key == CONF_VERIFY_SSL:
-                # ssl_context is either False or a SSLContext object, so we need to compare it differently
+                # ssl_context is either False or a SSLContext
+                # object, so we need to compare it differently
                 if config_entry.data[CONF_VERIFY_SSL] != bool(
                     getattr(hub.config, value)
                 ):

--- a/homeassistant/components/unifi/light.py
+++ b/homeassistant/components/unifi/light.py
@@ -52,7 +52,7 @@ def convert_brightness_to_ha(
 
 
 def get_device_brightness_or_default(device: Device) -> int:
-    """Get device's current LED brightness. Defaults to 100 (full brightness) if not set."""
+    """Get device LED brightness, default 100 if not set."""
     value = device.led_override_color_brightness
     return value if value is not None else 100
 

--- a/homeassistant/components/unifi/sensor.py
+++ b/homeassistant/components/unifi/sensor.py
@@ -150,7 +150,7 @@ def async_device_clients_value_fn(hub: UnifiHub, device: Device) -> int:
 
 @callback
 def async_device_uptime_value_fn(hub: UnifiHub, device: Device) -> datetime | None:
-    """Calculate the approximate time the device started (based on uptime returned from API, in seconds)."""
+    """Calculate the approximate time the device started."""
     if device.uptime <= 0:
         # Library defaults to 0 if uptime is not provided, e.g. when offline
         return None
@@ -161,7 +161,7 @@ def async_device_uptime_value_fn(hub: UnifiHub, device: Device) -> datetime | No
 def async_uptime_value_changed_fn(
     old: StateType | date | datetime | Decimal, new: datetime | float | str | None
 ) -> bool:
-    """Reject the new uptime value if it's too similar to the old one. Avoids unwanted fluctuation."""
+    """Reject new uptime if too similar to old. Avoids fluctuation."""
     if isinstance(old, datetime) and isinstance(new, datetime):
         return new != old and abs((new - old).total_seconds()) > 120
     return old is None or (new != old)
@@ -726,7 +726,8 @@ class UnifiSensorEntity[HandlerT: APIHandler, ApiItemT: ApiItem](
         """
         description = self.entity_description
         obj = description.object_fn(self.api, self._obj_id)
-        # Update the value only if value is considered to have changed relative to its previous state
+        # Update the value only if value is considered to
+        # have changed relative to its previous state
         if description.value_changed_fn(
             self.native_value, (value := description.value_fn(self.hub, obj))
         ):

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -147,7 +147,7 @@ async def async_firewall_policy_control_fn(
 
 @callback
 def async_firewall_policy_supported_fn(hub: UnifiHub, obj_id: str) -> bool:
-    """Check if firewall policy is able to be controlled. Predefined policies are unable to be turned off."""
+    """Check if firewall policy can be controlled."""
     policy = hub.api.firewall_policies[obj_id]
     return not policy.predefined
 

--- a/homeassistant/components/unifiprotect/config_flow.py
+++ b/homeassistant/components/unifiprotect/config_flow.py
@@ -87,7 +87,7 @@ async def _async_clear_session_if_credentials_changed(
     entry: UFPConfigEntry,
     new_data: Mapping[str, Any],
 ) -> None:
-    """Clear stored session if credentials have changed to force fresh authentication."""
+    """Clear stored session if credentials changed."""
     existing_data = entry.data
     if existing_data.get(CONF_USERNAME) != new_data.get(
         CONF_USERNAME
@@ -296,8 +296,8 @@ class ProtectFlowHandler(ConfigFlow, domain=DOMAIN):
             step_id="discovery_confirm",
             description_placeholders={
                 **placeholders,
-                "local_user_documentation_url": await async_local_user_documentation_url(
-                    self.hass
+                "local_user_documentation_url": (
+                    await async_local_user_documentation_url(self.hass)
                 ),
             },
             data_schema=self.add_suggested_values_to_schema(
@@ -431,8 +431,8 @@ class ProtectFlowHandler(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="reauth_confirm",
             description_placeholders={
-                "local_user_documentation_url": await async_local_user_documentation_url(
-                    self.hass
+                "local_user_documentation_url": (
+                    await async_local_user_documentation_url(self.hass)
                 ),
             },
             data_schema=self.add_suggested_values_to_schema(REAUTH_SCHEMA, form_data),
@@ -481,8 +481,8 @@ class ProtectFlowHandler(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="reconfigure",
             description_placeholders={
-                "local_user_documentation_url": await async_local_user_documentation_url(
-                    self.hass
+                "local_user_documentation_url": (
+                    await async_local_user_documentation_url(self.hass)
                 ),
             },
             data_schema=self.add_suggested_values_to_schema(
@@ -509,8 +509,8 @@ class ProtectFlowHandler(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user",
             description_placeholders={
-                "local_user_documentation_url": await async_local_user_documentation_url(
-                    self.hass
+                "local_user_documentation_url": (
+                    await async_local_user_documentation_url(self.hass)
                 )
             },
             data_schema=self.add_suggested_values_to_schema(CONFIG_SCHEMA, user_input),

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -321,7 +321,8 @@ class ProtectData:
             self._pending_camera_ids.remove(device.id)
             async_dispatcher_send(self._hass, self.channels_signal, device)
 
-        # trigger update for all Cameras with LCD screens when NVR Doorbell settings updates
+        # trigger update for all Cameras with LCD screens
+        # when NVR Doorbell settings updates
         if "doorbell_settings" in changed_data:
             _LOGGER.debug(
                 "Doorbell messages updated. Updating devices with LCD screens"

--- a/homeassistant/components/unifiprotect/media_source.py
+++ b/homeassistant/components/unifiprotect/media_source.py
@@ -266,10 +266,8 @@ class ProtectMediaSource(MediaSource):
             sorted in reverse chronological order
         * {nvr_id}:browse:all|{camera_id}:all|{event_type}:range:{year}:{month}
             List of folders for each day in month + all events for month
-        * {nvr_id}:browse:all|{camera_id}:all|
-          {event_type}:range:{year}:{month}:all|{day}
-            Listing of all events for given
-            {day} + {month} + {year} combination
+        * {nvr_id}:browse:all|{camera_id}:all|{event_type}:range:{year}:{month}:all|{day}
+            All events for given day/month/year
             in chronological order
         """
 

--- a/homeassistant/components/unifiprotect/media_source.py
+++ b/homeassistant/components/unifiprotect/media_source.py
@@ -262,11 +262,15 @@ class ProtectMediaSource(MediaSource):
         * {nvr_id}:browse:all|{camera_id}:all|{event_type}
             Root Camera(s) Event Type(s) browse source
         * {nvr_id}:browse:all|{camera_id}:all|{event_type}:recent:{day_count}
-            Listing of all events in last {day_count}, sorted in reverse chronological order
+            Listing of all events in last {day_count},
+            sorted in reverse chronological order
         * {nvr_id}:browse:all|{camera_id}:all|{event_type}:range:{year}:{month}
             List of folders for each day in month + all events for month
-        * {nvr_id}:browse:all|{camera_id}:all|{event_type}:range:{year}:{month}:all|{day}
-            Listing of all events for give {day} + {month} + {year} combination in chronological order
+        * {nvr_id}:browse:all|{camera_id}:all|
+          {event_type}:range:{year}:{month}:all|{day}
+            Listing of all events for give
+            {day} + {month} + {year} combination
+            in chronological order
         """
 
         if not item.identifier:

--- a/homeassistant/components/unifiprotect/media_source.py
+++ b/homeassistant/components/unifiprotect/media_source.py
@@ -268,7 +268,7 @@ class ProtectMediaSource(MediaSource):
             List of folders for each day in month + all events for month
         * {nvr_id}:browse:all|{camera_id}:all|
           {event_type}:range:{year}:{month}:all|{day}
-            Listing of all events for give
+            Listing of all events for given
             {day} + {month} + {year} combination
             in chronological order
         """

--- a/homeassistant/components/unifiprotect/migrate.py
+++ b/homeassistant/components/unifiprotect/migrate.py
@@ -114,8 +114,10 @@ async def async_migrate_data(
 def async_deprecate_hdr(hass: HomeAssistant, entry: UFPConfigEntry) -> None:
     """Check for usages of hdr_mode switch and raise repair if it is used.
 
-    UniFi Protect v3.0.22 changed how HDR works so it is no longer a simple on/off toggle. There is
-    Always On, Always Off and Auto. So it has been migrated to a select. The old switch is now deprecated.
+    UniFi Protect v3.0.22 changed how HDR works so it is
+    no longer a simple on/off toggle. There is Always On,
+    Always Off and Auto. So it has been migrated to a
+    select. The old switch is now deprecated.
 
     Added in 2024.4.0
     """

--- a/homeassistant/components/upnp/config_flow.py
+++ b/homeassistant/components/upnp/config_flow.py
@@ -91,7 +91,8 @@ class UpnpFlowHandler(ConfigFlow, domain=DOMAIN):
     VERSION = 1
 
     # Paths:
-    # 1: ssdp(discovery_info) --> ssdp_confirm(None) --> ssdp_confirm({}) --> create_entry()
+    # 1: ssdp(discovery_info) --> ssdp_confirm(None)
+    #    --> ssdp_confirm({}) --> create_entry()
     # 2: user(None): scan --> user({...}) --> create_entry()
 
     @staticmethod

--- a/homeassistant/components/upnp/entity.py
+++ b/homeassistant/components/upnp/entity.py
@@ -36,7 +36,10 @@ class UpnpEntity(CoordinatorEntity[UpnpDataUpdateCoordinator]):
         super().__init__(coordinator)
         self._device = coordinator.device
         self.entity_description = entity_description
-        self._attr_unique_id = f"{coordinator.device.original_udn}_{entity_description.unique_id or entity_description.key}"
+        self._attr_unique_id = (
+            f"{coordinator.device.original_udn}"
+            f"_{entity_description.unique_id or entity_description.key}"
+        )
         self._attr_device_info = DeviceInfo(
             connections=coordinator.device_entry.connections,
             name=coordinator.device_entry.name,

--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -60,7 +60,7 @@ def validate_cron_pattern(pattern: str) -> str:
 
 
 def period_or_cron(config: ConfigType) -> ConfigType:
-    """Check that if cron pattern is used, then meter type and offsite must be removed."""
+    """Check cron pattern excludes meter type and offset."""
     if CONF_CRON_PATTERN in config and CONF_METER_TYPE in config:
         raise vol.Invalid(f"Use <{CONF_CRON_PATTERN}> or <{CONF_METER_TYPE}>")
     if (

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -388,7 +388,8 @@ class UtilityMeterSensor(RestoreSensor):
         self._attr_native_unit_of_measurement = None
         self._period = meter_type
         if meter_type is not None:
-            # For backwards compatibility reasons we convert the period and offset into a cron pattern
+            # For backwards compatibility reasons we convert
+            # the period and offset into a cron pattern
             self._cron_pattern = PERIOD2CRON[meter_type].format(
                 minute=meter_offset.seconds % 3600 // 60,
                 hour=meter_offset.seconds // 3600,
@@ -429,7 +430,7 @@ class UtilityMeterSensor(RestoreSensor):
 
     @staticmethod
     def _validate_state(state: State | None) -> Decimal | None:
-        """Parse the state as a Decimal if available. Throws DecimalException if the state is not a number."""
+        """Parse the state as a Decimal if available."""
         try:
             return (
                 None
@@ -455,7 +456,7 @@ class UtilityMeterSensor(RestoreSensor):
         if (
             not self._sensor_periodically_resetting
             and self._last_valid_state is not None
-        ):  # Fallback to old_state if sensor is periodically resetting but last_valid_state is None
+        ):
             return new_state_val - self._last_valid_state
 
         if (old_state_val := self._validate_state(old_state)) is not None:
@@ -542,9 +543,13 @@ class UtilityMeterSensor(RestoreSensor):
                 self._collecting()
             self._collecting = None
 
-        # Reset the last_valid_state during state change because if the last state before the tariff change was invalid,
-        # there is no way to know how much "adjustment" counts for which tariff. Therefore, we set the last_valid_state
-        # to None and let the fallback mechanism handle the case that the old state was valid
+        # Reset the last_valid_state during state change
+        # because if the last state before the tariff
+        # change was invalid, there is no way to know how
+        # much "adjustment" counts for which tariff.
+        # Therefore, we set the last_valid_state to None
+        # and let the fallback mechanism handle the case
+        # that the old state was valid
         self._last_valid_state = None
 
         _LOGGER.debug(

--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -279,7 +279,8 @@ class StateVacuumEntity(
             # Don't report usage until after entity added to hass, after init
             report_usage(
                 f"is setting the battery supported feature which has been deprecated."
-                f" Integration {self.platform.platform_name} should remove this as part of migrating"
+                f" Integration {self.platform.platform_name}"
+                " should remove this as part of migrating"
                 " the battery level and icon to a sensor",
                 core_behavior=ReportBehavior.LOG,
                 core_integration_behavior=ReportBehavior.IGNORE,

--- a/homeassistant/components/vallox/fan.py
+++ b/homeassistant/components/vallox/fan.py
@@ -124,8 +124,9 @@ class ValloxFanEntity(ValloxEntity, FanEntity):
         update_needed = await self._async_set_preset_mode_internal(preset_mode)
 
         if update_needed:
-            # This state change affects other entities like sensors. Force an immediate update that
-            # can be observed by all parties involved.
+            # This state change affects other entities like
+            # sensors. Force an immediate update that can be
+            # observed by all parties involved.
             await self.coordinator.async_request_refresh()
 
     async def async_turn_on(
@@ -149,8 +150,9 @@ class ValloxFanEntity(ValloxEntity, FanEntity):
             )
 
         if update_needed:
-            # This state change affects other entities like sensors. Force an immediate update that
-            # can be observed by all parties involved.
+            # This state change affects other entities like
+            # sensors. Force an immediate update that can be
+            # observed by all parties involved.
             await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:

--- a/homeassistant/components/vallox/sensor.py
+++ b/homeassistant/components/vallox/sensor.py
@@ -78,11 +78,14 @@ class ValloxProfileSensor(ValloxSensorEntity):
         return VALLOX_PROFILE_TO_PRESET_MODE.get(vallox_profile)
 
 
-# There is a quirk with respect to the fan speed reporting. The device keeps on reporting the last
-# valid fan speed from when the device was in regular operation mode, even if it left that state and
-# has been shut off in the meantime.
+# There is a quirk with respect to the fan speed
+# reporting. The device keeps on reporting the last valid
+# fan speed from when the device was in regular operation
+# mode, even if it left that state and has been shut off
+# in the meantime.
 #
-# Therefore, first query the overall state of the device, and report zero percent fan speed in case
+# Therefore, first query the overall state of the device,
+# and report zero percent fan speed in case
 # it is not in regular operation mode.
 class ValloxFanSpeedSensor(ValloxSensorEntity):
     """Child class for fan speed reporting."""

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -141,7 +141,8 @@ async def async_migrate_entry(
         "Migrating from version %s.%s", config_entry.version, config_entry.minor_version
     )
 
-    # This is the config entry migration for swapping the usb unique id to the serial number
+    # This is the config entry migration for swapping the
+    # usb unique id to the serial number
     # migrate from 2.1 to 2.2
     if (
         config_entry.version < 3

--- a/homeassistant/components/velux/__init__.py
+++ b/homeassistant/components/velux/__init__.py
@@ -43,7 +43,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: VeluxConfigEntry) -> boo
         # Since pyvlx raises the same exception for auth and connection errors,
         # we need to check the exception message to distinguish them.
         # Ultimately this should be fixed in pyvlx to raise specialized exceptions,
-        # right now it's been a while since the last pyvlx release, so we do this workaround here.
+        # right now it's been a while since the last pyvlx
+        # release, so we do this workaround here.
         if (
             isinstance(ex, PyVLXException)
             and ex.description == "Login to KLF 200 failed, check credentials"
@@ -99,7 +100,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: VeluxConfigEntry) -> bo
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         # Disconnect from gateway only after platforms are successfully unloaded.
-        # Disconnecting will reboot the gateway in the pyvlx library, which is needed to allow new
+        # Disconnecting will reboot the gateway in the pyvlx
+        # library, which is needed to allow new
         # connections to be made later.
         await entry.runtime_data.disconnect()
     return unload_ok

--- a/homeassistant/components/velux/binary_sensor.py
+++ b/homeassistant/components/velux/binary_sensor.py
@@ -38,7 +38,7 @@ class VeluxRainSensor(VeluxEntity, BinarySensorEntity):
     """Representation of a Velux rain sensor."""
 
     node: Window
-    _attr_should_poll = True  # the rain sensor / opening limitations needs polling unlike the rest of the Velux devices
+    _attr_should_poll = True
     _attr_entity_registry_enabled_default = False
     _attr_device_class = BinarySensorDeviceClass.MOISTURE
     _attr_translation_key = "rain_sensor"
@@ -71,8 +71,10 @@ class VeluxRainSensor(VeluxEntity, BinarySensorEntity):
 
         self._attr_available = True
 
-        # Velux windows with rain sensors report an opening limitation when rain is detected.
-        # So far we've seen 89, 91, 93 (most cases) or 100 (Velux GPU). It probably makes sense to
+        # Velux windows with rain sensors report an opening
+        # limitation when rain is detected. So far we've
+        # seen 89, 91, 93 (most cases) or 100 (Velux GPU).
+        # It probably makes sense to
         # assume that any large enough limitation (we use >=89) means rain is detected.
         # Documentation on this is non-existent AFAIK.
         self._attr_is_on = limitation.position_percent >= 89

--- a/homeassistant/components/venstar/sensor.py
+++ b/homeassistant/components/venstar/sensor.py
@@ -153,7 +153,11 @@ class VenstarSensor(VenstarEntity, SensorEntity):
     @property
     def unique_id(self):
         """Return the unique id."""
-        return f"{self._config.entry_id}_{self.sensor_name.replace(' ', '_')}_{self.entity_description.key}"
+        return (
+            f"{self._config.entry_id}"
+            f"_{self.sensor_name.replace(' ', '_')}"
+            f"_{self.entity_description.key}"
+        )
 
     @property
     def native_value(self) -> int:

--- a/homeassistant/components/vera/common.py
+++ b/homeassistant/components/vera/common.py
@@ -60,7 +60,8 @@ class SubscriptionRegistry(pv.AbstractSubscriptionRegistry):
         delay = 1
 
         # Long poll for changes. The downstream API instructs the endpoint to wait a
-        # a minimum of 200ms before returning data and a maximum of 9s before timing out.
+        # a minimum of 200ms before returning data and a
+        # maximum of 9s before timing out.
         if not self.poll_server_once():
             # If an error was encountered, wait a bit longer before trying again.
             delay = 60

--- a/homeassistant/components/vera/entity.py
+++ b/homeassistant/components/vera/entity.py
@@ -40,7 +40,10 @@ class VeraEntity[_DeviceTypeT: veraApi.VeraDevice](Entity):
         if controller_data.config_entry.data.get(CONF_LEGACY_UNIQUE_ID):
             self._unique_id = str(self.vera_device.vera_device_id)
         else:
-            self._unique_id = f"vera_{controller_data.config_entry.unique_id}_{self.vera_device.vera_device_id}"
+            self._unique_id = (
+                f"vera_{controller_data.config_entry.unique_id}"
+                f"_{self.vera_device.vera_device_id}"
+            )
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to updates."""

--- a/homeassistant/components/versasense/__init__.py
+++ b/homeassistant/components/versasense/__init__.py
@@ -83,7 +83,11 @@ def _add_entity_info(peripheral, device, entity_dict) -> None:
             KEY_PARENT_MAC: device.mac,
         }
 
-        key = f"{entity_info[KEY_PARENT_MAC]}/{entity_info[KEY_IDENTIFIER]}/{entity_info[KEY_MEASUREMENT]}"
+        key = (
+            f"{entity_info[KEY_PARENT_MAC]}"
+            f"/{entity_info[KEY_IDENTIFIER]}"
+            f"/{entity_info[KEY_MEASUREMENT]}"
+        )
         entity_dict[key] = entity_info
 
     return entity_dict

--- a/homeassistant/components/vesync/__init__.py
+++ b/homeassistant/components/vesync/__init__.py
@@ -120,7 +120,8 @@ async def async_migrate_entry(
                 Platform.SWITCH
             ):
                 _LOGGER.debug(
-                    "Migrating switch/outlet entity from unique_id: %s to unique_id: %s",
+                    "Migrating switch/outlet entity"
+                    " from unique_id: %s to unique_id: %s",
                     reg_entry.unique_id,
                     reg_entry.unique_id + "-device_status",
                 )

--- a/homeassistant/components/vesync/common.py
+++ b/homeassistant/components/vesync/common.py
@@ -16,7 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def rgetattr(obj: object, attr: str) -> object | str | None:
-    """Return a string in the form word.1.2.3 and return the item as 3. Note that this last value could be in a dict as well."""
+    """Return nested attribute from a dotted path string."""
     _this_func = rgetattr
     sp = attr.split(".", 1)
     if len(sp) == 1:
@@ -56,7 +56,7 @@ def is_outlet(device: VeSyncBaseDevice) -> TypeGuard[VeSyncOutlet]:
 
 
 def is_wall_switch(device: VeSyncBaseDevice) -> TypeGuard[VeSyncWallSwitch]:
-    """Check if the device represents a wall switch, note this doessn't include dimming switches."""
+    """Check if the device represents a wall switch."""
     if device.product_type != ProductTypes.SWITCH:
         return False
 

--- a/homeassistant/components/vesync/humidifier.py
+++ b/homeassistant/components/vesync/humidifier.py
@@ -95,7 +95,8 @@ def _get_ha_mode(vs_mode: str) -> str | None:
 class VeSyncHumidifierHA(VeSyncBaseEntity[VeSyncHumidifier], HumidifierEntity):
     """Representation of a VeSync humidifier."""
 
-    # The base VeSyncBaseEntity has _attr_has_entity_name and this is to follow the device name
+    # The base VeSyncBaseEntity has _attr_has_entity_name
+    # and this is to follow the device name
     _attr_name = None
 
     _attr_supported_features = HumidifierEntityFeature.MODES
@@ -181,7 +182,8 @@ class VeSyncHumidifierHA(VeSyncBaseEntity[VeSyncHumidifier], HumidifierEntity):
             raise HomeAssistantError("Failed to set mode.")
 
         if mode == MODE_SLEEP:
-            # We successfully changed the mode. Consider it a success even if display operation fails.
+            # We successfully changed the mode. Consider it
+            # a success even if display operation fails.
             await self.device.toggle_display(False)
 
         self.async_write_ha_state()

--- a/homeassistant/components/vesync/light.py
+++ b/homeassistant/components/vesync/light.py
@@ -90,7 +90,8 @@ class VeSyncBaseLightHA(VeSyncBaseEntity[VeSyncSwitch | VeSyncBulb], LightEntity
         """Get light brightness."""
         if self.device.state.brightness is None:
             _LOGGER.debug(
-                "VeSync - received unexpected 'brightness' value from pyvesync api of None"
+                "VeSync - received unexpected 'brightness'"
+                " value from pyvesync api of None"
             )
             return 0
 
@@ -122,7 +123,8 @@ class VeSyncBaseLightHA(VeSyncBaseEntity[VeSyncSwitch | VeSyncBulb], LightEntity
             color_temp = max(0, min(color_temp, 100))
             # call pyvesync library api method to set color_temp
             await self.device.set_color_temp(color_temp)
-            # flag attribute_adjustment_only, so it doesn't turn_on the device redundantly
+            # flag attribute_adjustment_only, so it doesn't
+            # turn_on the device redundantly
             attribute_adjustment_only = True
         # set brightness level
         if (
@@ -177,10 +179,12 @@ class VeSyncTunableWhiteLightHA(VeSyncBaseLightHA, LightEntity):
         if hasattr(self.device.state, "color_temp") is False:
             return None
 
-        # pyvesync v3 provides BulbState.color_temp_kelvin() - possible to use that instead?
+        # pyvesync v3 provides BulbState.color_temp_kelvin()
+        # - possible to use that instead?
         if self.device.state.color_temp is None:
             _LOGGER.debug(
-                "VeSync - received unexpected 'color_temp' value from pyvesync api of None"
+                "VeSync - received unexpected 'color_temp'"
+                " value from pyvesync api of None"
             )
             return 0
 

--- a/homeassistant/components/viaggiatreno/sensor.py
+++ b/homeassistant/components/viaggiatreno/sensor.py
@@ -129,7 +129,8 @@ class ViaggiaTrenoSensor(SensorEntity):
             self._tstatus = self._viaggiatreno.get_line_status(self._line)
             if self._tstatus is None:
                 _LOGGER.error(
-                    "Received status for line %s: None. Check the train and station IDs",
+                    "Received status for line %s: None."
+                    " Check the train and station IDs",
                     self._line,
                 )
                 return

--- a/homeassistant/components/victron_gx/button.py
+++ b/homeassistant/components/victron_gx/button.py
@@ -53,7 +53,8 @@ class VictronButton(VictronBaseEntity, ButtonEntity):
 
     @callback
     def _on_update_cb(self, _value: Any) -> None:
-        # Buttons are stateless in HA; incoming metric updates are intentionally ignored.
+        # Buttons are stateless in HA; incoming metric
+        # updates are intentionally ignored.
         pass
 
     async def async_press(self) -> None:

--- a/homeassistant/components/victron_gx/entity.py
+++ b/homeassistant/components/victron_gx/entity.py
@@ -35,12 +35,14 @@ class VictronBaseEntity(Entity):
         self._attr_device_info = device_info
         self._attr_unique_id = f"{installation_id}_{metric.unique_id}"
         self._attr_suggested_display_precision = metric.precision
-        # Always set translation_key so HA can resolve state/option translations (e.g. select options).
+        # Always set translation_key so HA can resolve
+        # state/option translations (e.g. select options).
         self._attr_translation_key = metric.generic_short_id.replace("{", "").replace(
             "}", ""
         )
         self._attr_translation_placeholders = metric.key_values
-        # When main_topic is set, override name to None so HA uses the device name (via _attr_has_entity_name).
+        # When main_topic is set, override name to None so
+        # HA uses the device name (via _attr_has_entity_name).
         if metric.main_topic:
             self._attr_name = None
 

--- a/homeassistant/components/victron_remote_monitoring/config_flow.py
+++ b/homeassistant/components/victron_remote_monitoring/config_flow.py
@@ -233,7 +233,8 @@ class VictronRemoteMonitoringFlowHandler(ConfigFlow, domain=DOMAIN):
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except SiteNotFound:
-                # Site removed or no longer visible to the account; treat as cannot connect
+                # Site removed or no longer visible to the
+                # account; treat as cannot connect
                 errors["base"] = "site_not_found"
             except Exception:  # pragma: no cover - unexpected
                 _LOGGER.exception("Unexpected exception during reauth")

--- a/homeassistant/components/vilfo/config_flow.py
+++ b/homeassistant/components/vilfo/config_flow.py
@@ -33,7 +33,7 @@ RESULT_INVALID_AUTH = "invalid_auth"
 
 
 def _try_connect_and_fetch_basic_info(host, token):
-    """Attempt to connect and call the ping endpoint and, if successful, fetch basic information."""
+    """Connect, call ping endpoint, and fetch basic info."""
 
     # Perform the ping. This doesn't validate authentication.
     controller = VilfoClient(host=host, token=token)

--- a/homeassistant/components/vizio/const.py
+++ b/homeassistant/components/vizio/const.py
@@ -56,7 +56,8 @@ VIZIO_VOLUME = "volume"
 VIZIO_MUTE = "mute"
 
 # Since Vizio component relies on device class, this dict will ensure that changes to
-# the values of DEVICE_CLASS_SPEAKER or DEVICE_CLASS_TV don't require changes to pyvizio.
+# the values of DEVICE_CLASS_SPEAKER or DEVICE_CLASS_TV
+# don't require changes to pyvizio.
 VIZIO_DEVICE_CLASSES = {
     MediaPlayerDeviceClass.SPEAKER: VIZIO_DEVICE_CLASS_SPEAKER,
     MediaPlayerDeviceClass.TV: VIZIO_DEVICE_CLASS_TV,

--- a/homeassistant/components/vlc_telnet/media_player.py
+++ b/homeassistant/components/vlc_telnet/media_player.py
@@ -164,7 +164,8 @@ class VlcDevice(MediaPlayerEntity):
         self._attr_media_title = _get_str(data.get("data", {}), "title")
         now_playing = _get_str(data.get("data", {}), "now_playing")
 
-        # Many radio streams put artist/title/album in now_playing and title is the station name.
+        # Many radio streams put artist/title/album in
+        # now_playing and title is the station name.
         if now_playing:
             if not self.media_artist:
                 self._attr_media_artist = self._attr_media_title

--- a/homeassistant/components/vodafone_station/coordinator.py
+++ b/homeassistant/components/vodafone_station/coordinator.py
@@ -150,7 +150,9 @@ class VodafoneStationRouter(DataUpdateCoordinator[UpdateCoordinatorDataType]):
             JSONDecodeError,
         ) as err:
             if isinstance(err, JSONDecodeError):
-                # Plain html response (usually occurs after a firmware update), requiring session reinitialization
+                # Plain html response (usually occurs after
+                # a firmware update), requiring session
+                # reinitialization
                 _LOGGER.info("Stale session detected, reinitializing API session")
                 await self.initialize_api()
             raise UpdateFailed(

--- a/homeassistant/components/vodafone_station/helpers.py
+++ b/homeassistant/components/vodafone_station/helpers.py
@@ -31,7 +31,8 @@ async def cleanup_device_tracker(
         entry_host = entry_name.partition(" ")[0] if entry_name else None
         entry_mac = entry.unique_id.partition("_")[0]
 
-        # Some devices, mainly routers, allow to change the hostname of the connected devices.
+        # Some devices, mainly routers, allow to change the
+        # hostname of the connected devices.
         # This can lead to entities no longer aligned to the device UI
         if (
             entry_host

--- a/homeassistant/components/voip/assist_satellite.py
+++ b/homeassistant/components/voip/assist_satellite.py
@@ -148,7 +148,7 @@ class VoipAssistSatellite(VoIPEntity, AssistSatelliteEntity, RtpDatagramProtocol
 
     @property
     def vad_sensitivity_entity_id(self) -> str | None:
-        """Return the entity ID of the VAD sensitivity to use for the next conversation."""
+        """Return the VAD sensitivity entity ID for next conversation."""
         return self.voip_device.get_vad_sensitivity_entity_id(self.hass)
 
     @property
@@ -298,7 +298,8 @@ class VoipAssistSatellite(VoIPEntity, AssistSatelliteEntity, RtpDatagramProtocol
     async def _check_announcement_pickup(self) -> None:
         """Continuously checks if an audio chunk was received within a time limit.
 
-        If not, the caller is presumed to have not picked up the phone and the announcement is ended.
+        If not, the caller is presumed to have not picked
+        up the phone and the announcement is ended.
         """
         while True:
             current_time = time.monotonic()
@@ -452,7 +453,8 @@ class VoipAssistSatellite(VoIPEntity, AssistSatelliteEntity, RtpDatagramProtocol
                 # length of the TTS audio.
                 await self._tts_done.wait()
         except TimeoutError:
-            # This shouldn't happen anymore, we are detecting hang ups with a separate task
+            # This shouldn't happen anymore, we are detecting
+            # hang ups with a separate task
             _LOGGER.exception("Timeout error")
             self.disconnect()  # caller hung up
         except asyncio.CancelledError:
@@ -570,7 +572,8 @@ class VoipAssistSatellite(VoIPEntity, AssistSatelliteEntity, RtpDatagramProtocol
                         or (sample_channels != CHANNELS)
                     ):
                         raise ValueError(
-                            f"Expected rate/width/channels as {RATE}/{WIDTH}/{CHANNELS},"
+                            "Expected rate/width/channels as"
+                            f" {RATE}/{WIDTH}/{CHANNELS},"
                             f" got {sample_rate}/{sample_width}/{sample_channels}"
                         )
 

--- a/homeassistant/components/volvo/entity.py
+++ b/homeassistant/components/volvo/entity.py
@@ -55,7 +55,8 @@ class VolvoBaseEntity(Entity):
         model = (
             f"{vehicle.description.model} ({vehicle.model_year})"
             if vehicle.fuel_type == "NONE"
-            else f"{vehicle.description.model} {vehicle.fuel_type} ({vehicle.model_year})"
+            else f"{vehicle.description.model}"
+            f" {vehicle.fuel_type} ({vehicle.model_year})"
         )
 
         self._attr_device_info = DeviceInfo(

--- a/homeassistant/components/volvo/services.py
+++ b/homeassistant/components/volvo/services.py
@@ -88,7 +88,8 @@ async def _get_image_url(call: ServiceCall) -> dict[str, Any]:
 
         candidates.append((image_type, url))
 
-    # Interior images exist if their URL is populated; exterior images require an HTTP check
+    # Interior images exist if their URL is populated;
+    # exterior images require an HTTP check
     async def _check_exists(image_type: str, url: str) -> bool:
         if image_type == "interior":
             return bool(url)

--- a/homeassistant/components/wake_on_lan/switch.py
+++ b/homeassistant/components/wake_on_lan/switch.py
@@ -143,7 +143,7 @@ class WolSwitch(SwitchEntity):
             self.schedule_update_ha_state()
 
     def update(self) -> None:
-        """Check if device is on and update the state. Only called if assumed state is false."""
+        """Check if device is on and update the state."""
         ping_cmd = [
             "ping",
             "-c",

--- a/homeassistant/components/wallbox/coordinator.py
+++ b/homeassistant/components/wallbox/coordinator.py
@@ -237,7 +237,7 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     @_require_authentication
     async def _async_update_data(self) -> dict[str, Any]:
-        """Get new sensor data for Wallbox component. Set update interval to be UPDATE_INTERVAL * #wallbox chargers configured, this is necessary due to rate limitations."""
+        """Get new sensor data for Wallbox component."""
 
         self.update_interval = timedelta(
             seconds=UPDATE_INTERVAL

--- a/homeassistant/components/wallbox/lock.py
+++ b/homeassistant/components/wallbox/lock.py
@@ -1,4 +1,4 @@
-"""Home Assistant component for accessing the Wallbox Portal API. The lock component creates a lock entity."""
+"""Home Assistant component for accessing the Wallbox Portal API lock."""
 
 from typing import Any
 
@@ -52,7 +52,10 @@ class WallboxLock(WallboxEntity, LockEntity):
 
         super().__init__(coordinator)
         self.entity_description = description
-        self._attr_unique_id = f"{description.key}-{coordinator.data[CHARGER_DATA_KEY][CHARGER_SERIAL_NUMBER_KEY]}"
+        self._attr_unique_id = (
+            f"{description.key}"
+            f"-{coordinator.data[CHARGER_DATA_KEY][CHARGER_SERIAL_NUMBER_KEY]}"
+        )
 
     @property
     def is_locked(self) -> bool:

--- a/homeassistant/components/wallbox/number.py
+++ b/homeassistant/components/wallbox/number.py
@@ -107,7 +107,10 @@ class WallboxNumber(WallboxEntity, NumberEntity):
         super().__init__(coordinator)
         self.entity_description = description
         self._coordinator = coordinator
-        self._attr_unique_id = f"{description.key}-{coordinator.data[CHARGER_DATA_KEY][CHARGER_SERIAL_NUMBER_KEY]}"
+        self._attr_unique_id = (
+            f"{description.key}"
+            f"-{coordinator.data[CHARGER_DATA_KEY][CHARGER_SERIAL_NUMBER_KEY]}"
+        )
 
     @property
     def native_max_value(self) -> float:

--- a/homeassistant/components/wallbox/select.py
+++ b/homeassistant/components/wallbox/select.py
@@ -1,4 +1,4 @@
-"""Home Assistant component for accessing the Wallbox Portal API. The switch component creates a switch entity."""
+"""Home Assistant component for accessing the Wallbox Portal API select."""
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -88,7 +88,10 @@ class WallboxSelect(WallboxEntity, SelectEntity):
         """Initialize a Wallbox select entity."""
         super().__init__(coordinator)
         self.entity_description = description
-        self._attr_unique_id = f"{description.key}-{coordinator.data[CHARGER_DATA_KEY][CHARGER_SERIAL_NUMBER_KEY]}"
+        self._attr_unique_id = (
+            f"{description.key}"
+            f"-{coordinator.data[CHARGER_DATA_KEY][CHARGER_SERIAL_NUMBER_KEY]}"
+        )
 
     @property
     def current_option(self) -> str | None:

--- a/homeassistant/components/wallbox/sensor.py
+++ b/homeassistant/components/wallbox/sensor.py
@@ -1,4 +1,4 @@
-"""Home Assistant component for accessing the Wallbox Portal API. The sensor component creates multiple sensors regarding wallbox performance."""
+"""Home Assistant component for accessing the Wallbox Portal API sensors."""
 
 from dataclasses import dataclass
 from typing import cast
@@ -196,11 +196,14 @@ class WallboxSensor(WallboxEntity, SensorEntity):
         """Initialize a Wallbox sensor."""
         super().__init__(coordinator)
         self.entity_description = description
-        self._attr_unique_id = f"{description.key}-{coordinator.data[CHARGER_DATA_KEY][CHARGER_SERIAL_NUMBER_KEY]}"
+        self._attr_unique_id = (
+            f"{description.key}"
+            f"-{coordinator.data[CHARGER_DATA_KEY][CHARGER_SERIAL_NUMBER_KEY]}"
+        )
 
     @property
     def native_value(self) -> StateType:
-        """Return the state of the sensor. Round the value when it, and the precision property are not None."""
+        """Return the state of the sensor, rounded if applicable."""
         if (
             sensor_round := self.entity_description.precision
         ) is not None and self.coordinator.data[
@@ -214,7 +217,7 @@ class WallboxSensor(WallboxEntity, SensorEntity):
 
     @property
     def native_unit_of_measurement(self) -> str | None:
-        """Return the unit of measurement of the sensor. When monetary, get the value from the api."""
+        """Return the unit of measurement of the sensor."""
         if self.entity_description.key in (
             CHARGER_ENERGY_PRICE_KEY,
             CHARGER_DEPOT_PRICE_KEY,

--- a/homeassistant/components/wallbox/switch.py
+++ b/homeassistant/components/wallbox/switch.py
@@ -1,4 +1,4 @@
-"""Home Assistant component for accessing the Wallbox Portal API. The switch component creates a switch entity."""
+"""Home Assistant component for accessing the Wallbox Portal API switch."""
 
 from typing import Any
 
@@ -51,7 +51,10 @@ class WallboxSwitch(WallboxEntity, SwitchEntity):
         """Initialize a Wallbox switch."""
         super().__init__(coordinator)
         self.entity_description = description
-        self._attr_unique_id = f"{description.key}-{coordinator.data[CHARGER_DATA_KEY][CHARGER_SERIAL_NUMBER_KEY]}"
+        self._attr_unique_id = (
+            f"{description.key}"
+            f"-{coordinator.data[CHARGER_DATA_KEY][CHARGER_SERIAL_NUMBER_KEY]}"
+        )
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/water_heater/trigger.py
+++ b/homeassistant/components/water_heater/trigger.py
@@ -90,7 +90,9 @@ class WaterHeaterTargetTemperatureCrossedThresholdTrigger(
 TRIGGERS: dict[str, type[Trigger]] = {
     "operation_mode_changed": WaterHeaterOperationModeChangedTrigger,
     "target_temperature_changed": WaterHeaterTargetTemperatureChangedTrigger,
-    "target_temperature_crossed_threshold": WaterHeaterTargetTemperatureCrossedThresholdTrigger,
+    "target_temperature_crossed_threshold": (
+        WaterHeaterTargetTemperatureCrossedThresholdTrigger
+    ),
     "turned_off": make_entity_target_state_trigger(DOMAIN, STATE_OFF),
     "turned_on": make_entity_origin_state_trigger(DOMAIN, from_state=STATE_OFF),
 }

--- a/homeassistant/components/waterfurnace/coordinator.py
+++ b/homeassistant/components/waterfurnace/coordinator.py
@@ -367,7 +367,8 @@ class WaterFurnaceEnergyCoordinator(DataUpdateCoordinator[None]):
             self._backfill_task.add_done_callback(self._backfill_done_callback)
             return
 
-        # Normal poll: fetch recent data (up to BACKFILL_GAP_THRESHOLD) and insert any missing hours
+        # Normal poll: fetch recent data (up to
+        # BACKFILL_GAP_THRESHOLD) and insert missing hours
         _LOGGER.debug("Last stat: ts=%s, sum=%s", last_dt.isoformat(), last_sum)
         local_tz = dt_util.DEFAULT_TIME_ZONE
         start_date = last_dt.astimezone(local_tz).strftime("%Y-%m-%d")

--- a/homeassistant/components/waze_travel_time/coordinator.py
+++ b/homeassistant/components/waze_travel_time/coordinator.py
@@ -100,7 +100,8 @@ async def async_get_travel_times(
             )
             if not should_include:
                 _LOGGER.debug(
-                    "Excluding route [%s], because no inclusive filter matched any streetname",
+                    "Excluding route [%s], because no"
+                    " inclusive filter matched any streetname",
                     route.name,
                 )
                 return False
@@ -115,7 +116,9 @@ async def async_get_travel_times(
                 for excl_filter in excl_filters:
                     if excl_filter == street_name:
                         _LOGGER.debug(
-                            "Excluding route, because exclusive filter [%s] matched streetname: %s",
+                            "Excluding route, because"
+                            " exclusive filter [%s]"
+                            " matched streetname: %s",
                             excl_filter,
                             route.name,
                         )

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -986,7 +986,8 @@ class WeatherEntity(Entity, PostInit, cached_properties=CACHED_PROPERTIES_WITH_A
                 for fc_twice_daily in native_forecast_list:
                     if fc_twice_daily.get(ATTR_FORECAST_IS_DAYTIME) is None:
                         raise ValueError(
-                            "is_daytime mandatory attribute for forecast_twice_daily is missing"
+                            "is_daytime mandatory attribute"
+                            " for forecast_twice_daily is missing"
                         )
 
             converted_forecast_list = self._convert_forecast(native_forecast_list)

--- a/homeassistant/components/weatherflow/sensor.py
+++ b/homeassistant/components/weatherflow/sensor.py
@@ -351,7 +351,9 @@ class WeatherFlowSensorEntity(SensorEntity):
 
         self._attr_unique_id = f"{device.serial_number}_{description.key}"
 
-        # In the case of the USA - we may want to have a suggested US unit which differs from the internal suggested units
+        # In the case of the USA - we may want to have a
+        # suggested US unit which differs from the internal
+        # suggested units
         if description.imperial_suggested_unit is not None and not is_metric:
             self._attr_suggested_unit_of_measurement = (
                 description.imperial_suggested_unit

--- a/homeassistant/components/weatherkit/weather.py
+++ b/homeassistant/components/weatherkit/weather.py
@@ -143,7 +143,7 @@ class WeatherKitWeather(
 
     @property
     def supported_features(self) -> WeatherEntityFeature:
-        """Determine supported features based on available data sets reported by WeatherKit."""
+        """Determine supported features based on available data sets."""
         features = WeatherEntityFeature(0)
 
         if not self.coordinator.supported_data_sets:

--- a/homeassistant/components/webhook/__init__.py
+++ b/homeassistant/components/webhook/__init__.py
@@ -77,7 +77,8 @@ def async_register(
         )
 
     if not isinstance(local_only, bool):
-        # Previously it was valid to pass None for local_only and it was treated as False
+        # Previously it was valid to pass None for
+        # local_only and it was treated as False
         # with a deprecation warning. In case a custom component is still passing None,
         # we want to raise an error instead of silently treating it as False as the
         # deprecation period has ended and the message was removed.

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -254,7 +254,7 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
             }
 
     def _update_sources(self) -> None:
-        """Update list of sources from current source, apps, inputs and configured list."""
+        """Update list of sources from current source and apps."""
         tv_state = self._client.tv_state
         source_list = self._source_list
         self._source_list = {}

--- a/homeassistant/components/websocket_api/automation.py
+++ b/homeassistant/components/websocket_api/automation.py
@@ -182,7 +182,7 @@ def _get_automation_component_lookup_table(
     component_type: AutomationComponentType,
     component_descriptions: Mapping[str, Mapping[str, Any] | None],
 ) -> _AutomationComponentLookupTable:
-    """Get a dict of automation components keyed by domain, along with the total number of components.
+    """Get automation components keyed by domain with total count.
 
     Returns a cached object if available.
     """
@@ -229,7 +229,8 @@ def _async_get_automation_components_for_target(
 ) -> set[str]:
     """Get automation components (triggers/conditions/services) for a target.
 
-    Returns all components that can be used on any entity that are currently part of a target.
+    Returns all components that can be used on any entity
+    that are currently part of a target.
     """
     extracted = target_helpers.async_extract_referenced_entity_ids(
         hass,
@@ -252,7 +253,8 @@ def _async_get_automation_components_for_target(
     def _match_components(entities: set[str], check_entity_category: bool) -> None:
         for entity_id in entities:
             if lookup_table.component_count == len(matched_components):
-                # All automation components matched already, so we don't need to iterate further
+                # All automation components matched already,
+                # so we don't need to iterate further
                 break
 
             entity_info = entity_infos.get(entity_id)

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -910,8 +910,8 @@ async def handle_get_triggers_for_target(
 ) -> None:
     """Handle get triggers for target command.
 
-    This command returns all triggers that can be used with any entities that are currently
-    part of a target.
+    This command returns all triggers that can be used
+    with any entities that are currently part of a target.
     """
     triggers = await async_get_triggers_for_target(
         hass, msg["target"], msg["expand_group"]
@@ -933,8 +933,8 @@ async def handle_get_conditions_for_target(
 ) -> None:
     """Handle get conditions for target command.
 
-    This command returns all conditions that can be used with any entities that are currently
-    part of a target.
+    This command returns all conditions that can be used
+    with any entities that are currently part of a target.
     """
     conditions = await async_get_conditions_for_target(
         hass, msg["target"], msg["expand_group"]
@@ -956,8 +956,8 @@ async def handle_get_services_for_target(
 ) -> None:
     """Handle get services for target command.
 
-    This command returns all services that can be used with any entities that are currently
-    part of a target.
+    This command returns all services that can be used
+    with any entities that are currently part of a target.
     """
     services = await async_get_services_for_target(
         hass, msg["target"], msg["expand_group"]

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -214,7 +214,8 @@ class WebSocketHandler:
         if (queue_size_after_add := len(message_queue)) >= MAX_PENDING_MSG:
             self._logger.error(
                 (
-                    "%s: Client unable to keep up with pending messages. Reached %s pending"
+                    "%s: Client unable to keep up with"
+                    " pending messages. Reached %s pending"
                     " messages. The system's load is too high or an integration is"
                     " misbehaving; Last message was: %s"
                 ),
@@ -278,7 +279,8 @@ class WebSocketHandler:
 
         self._logger.error(
             (
-                "%s: Client unable to keep up with pending messages. Stayed over %s for %s"
+                "%s: Client unable to keep up with"
+                " pending messages. Stayed over %s for %s"
                 " seconds. The system's load is too high or an integration is"
                 " misbehaving; Last message was: %s"
             ),
@@ -399,7 +401,8 @@ class WebSocketHandler:
                 msg = await self._wsock.receive(AUTH_MESSAGE_TIMEOUT)
             except TimeoutError as err:
                 raise Disconnect(
-                    f"Did not receive auth message within {AUTH_MESSAGE_TIMEOUT} seconds"
+                    "Did not receive auth message within"
+                    f" {AUTH_MESSAGE_TIMEOUT} seconds"
                 ) from err
 
             if msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSED, WSMsgType.CLOSING):
@@ -549,8 +552,10 @@ class WebSocketHandler:
                 if disconnect_warn is None:
                     logger.debug("%s: Disconnected", self.description)
                 elif connection is None:
-                    # Auth phase disconnects (connection is None) should be logged at debug level
-                    # as they can be from random port scanners or non-legitimate connections
+                    # Auth phase disconnects (connection is
+                    # None) should be logged at debug level
+                    # as they can be from random port scanners
+                    # or non-legitimate connections
                     logger.debug(
                         "%s: Disconnected during auth phase: %s",
                         self.description,

--- a/homeassistant/components/websocket_api/messages.py
+++ b/homeassistant/components/websocket_api/messages.py
@@ -243,7 +243,8 @@ def _state_diff_event(
             additions[COMPRESSED_STATE_ATTRIBUTES] = added
         if removed := old_attributes.keys() - new_attributes:
             # sets are not JSON serializable by default so we convert to list
-            # here if there are any values to avoid jumping into the json_encoder_default
+            # here if there are any values to avoid jumping
+            # into the json_encoder_default
             # for every state diff with a removed attribute
             diff[STATE_DIFF_REMOVALS] = {COMPRESSED_STATE_ATTRIBUTES: list(removed)}
     return {ENTITY_EVENT_CHANGE: {new_state.entity_id: diff}}

--- a/homeassistant/components/weheat/config_flow.py
+++ b/homeassistant/components/weheat/config_flow.py
@@ -32,7 +32,7 @@ class OAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
         }
 
     async def async_oauth_create_entry(self, data: dict) -> ConfigFlowResult:
-        """Override the create entry method to change to the step to find the heat pumps."""
+        """Override create entry to find heat pumps."""
         # get the user id and use that as unique id for this entry
         user_id = await async_get_user_id_from_token(
             API_URL,

--- a/homeassistant/components/weheat/coordinator.py
+++ b/homeassistant/components/weheat/coordinator.py
@@ -42,13 +42,16 @@ class HeatPumpInfo(HeatPumpDiscovery.HeatPumpInfo):
         """Initialize the HeatPump object with the provided pump information.
 
         Args:
-            pump_info (HeatPumpDiscovery.HeatPumpInfo): An object containing the heat pump's discovery information, including:
+            pump_info (HeatPumpDiscovery.HeatPumpInfo):
+                An object containing the heat pump's discovery
+                information, including:
                 - uuid (str): Unique identifier for the heat pump.
                 - uuid (str): Unique identifier for the heat pump.
                 - device_name (str): Name of the heat pump device.
                 - model (str): Model of the heat pump.
                 - sn (str): Serial number of the heat pump.
-                - has_dhw (bool): Indicates if the heat pump has domestic hot water functionality.
+                - has_dhw (bool): Indicates if the heat pump
+                  has domestic hot water functionality.
 
         """
         super().__init__(

--- a/homeassistant/components/wemo/__init__.py
+++ b/homeassistant/components/wemo/__init__.py
@@ -124,7 +124,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         dispatcher=dispatcher,
     )
 
-    # Need to do this at least once in case statistics are defined and discovery is disabled
+    # Need to do this at least once in case statistics
+    # are defined and discovery is disabled
     await discovery.discover_statics()
 
     if wemo_data.discovery_enabled:
@@ -198,7 +199,8 @@ class WemoDispatcher:
             # Three cases:
             # - Platform is loaded, dispatch discovery
             # - Platform is being loaded, add to backlog
-            # - First time we see platform, we need to load it and initialize the backlog
+            # - First time we see platform, we need to load
+            #   it and initialize the backlog
 
             if platform in self._dispatch_callbacks:
                 await self._dispatch_callbacks[platform](coordinator)
@@ -219,7 +221,7 @@ class WemoDispatcher:
     async def async_connect_platform(
         self, platform: Platform, dispatch: DispatchCallback
     ) -> None:
-        """Consider a platform as loaded and dispatch any backlog of discovered devices."""
+        """Mark platform loaded and dispatch backlog of discovered devices."""
         self._dispatch_callbacks[platform] = dispatch
 
         await gather_with_limited_concurrency(

--- a/homeassistant/components/wemo/coordinator.py
+++ b/homeassistant/components/wemo/coordinator.py
@@ -48,7 +48,8 @@ class OptionsValidationError(Exception):
         The field_key and error_key strings must be the same as in strings.json.
 
         Args:
-          field_key: Name of the options.step.init.data key that corresponds to this error.
+          field_key: Name of the options.step.init.data key
+            that corresponds to this error.
             field_key must also match one of the field names inside the Options class.
           error_key: Name of the options.error key that corresponds to this error.
           message: Message for the Exception class.
@@ -79,7 +80,8 @@ class Options:
             raise OptionsValidationError(
                 "enable_subscription",
                 "long_press_requires_subscription",
-                "Local push update subscriptions must be enabled to use long-press events",
+                "Local push update subscriptions must be"
+                " enabled to use long-press events",
             )
 
 
@@ -152,7 +154,8 @@ class DeviceCoordinator(DataUpdateCoordinator[None]):
         if self.options.enable_subscription:
             await self._async_set_enable_subscription(False)
         # Check that the device is available (last_update_success) before disabling long
-        # press. That avoids long shutdown times for devices that are no longer connected.
+        # press. That avoids long shutdown times for devices
+        # that are no longer connected.
         if self.options.enable_long_press and self.last_update_success:
             await self._async_set_enable_long_press(False)
 

--- a/homeassistant/components/whois/sensor.py
+++ b/homeassistant/components/whois/sensor.py
@@ -63,10 +63,9 @@ def _ensure_timezone(timestamp: datetime | None) -> datetime | None:
 def _get_status_type(status: str | None) -> str | None:
     """Get the status type from the status string.
 
-    Returns the status type in snake_case, so it can be
-    used as a key for the translations.
-    E.g: "clientDeleteProhibited
-    https://icann.org/epp#clientDeleteProhibited"
+    Return the status type in snake_case for translations.
+
+    E.g: "clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited"
     -> "client_delete_prohibited".
     """
     if status is None:

--- a/homeassistant/components/whois/sensor.py
+++ b/homeassistant/components/whois/sensor.py
@@ -63,8 +63,11 @@ def _ensure_timezone(timestamp: datetime | None) -> datetime | None:
 def _get_status_type(status: str | None) -> str | None:
     """Get the status type from the status string.
 
-    Returns the status type in snake_case, so it can be used as a key for the translations.
-    E.g: "clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited" -> "client_delete_prohibited".
+    Returns the status type in snake_case, so it can be
+    used as a key for the translations.
+    E.g: "clientDeleteProhibited
+    https://icann.org/epp#clientDeleteProhibited"
+    -> "client_delete_prohibited".
     """
     if status is None:
         return None

--- a/homeassistant/components/wiffi/__init__.py
+++ b/homeassistant/components/wiffi/__init__.py
@@ -25,7 +25,7 @@ type WiffiConfigEntry = ConfigEntry[WiffiIntegrationApi]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: WiffiConfigEntry) -> bool:
-    """Set up wiffi from a config entry, config_entry contains data from config entry database."""
+    """Set up wiffi from a config entry."""
 
     # create api object
     api = WiffiIntegrationApi(hass)

--- a/homeassistant/components/wiim/__init__.py
+++ b/homeassistant/components/wiim/__init__.py
@@ -70,7 +70,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: WiimConfigEntry) -> bool
 
     entry.runtime_data = wiim_device
     LOGGER.info(
-        "WiiM device %s (UDN: %s) linked to HASS. Name: '%s', HTTP: %s, UPnP Location: %s",
+        "WiiM device %s (UDN: %s) linked to HASS."
+        " Name: '%s', HTTP: %s, UPnP Location: %s",
         entry.entry_id,
         wiim_device.udn,
         wiim_device.name,

--- a/homeassistant/components/wiim/media_player.py
+++ b/homeassistant/components/wiim/media_player.py
@@ -217,7 +217,8 @@ class WiimMediaPlayerEntity(WiimBaseEntity, MediaPlayerEntity):
         """Update HA state from SDK's cache/HTTP poll attributes.
 
         This is the main method for updating this entity's HA attributes.
-        Crucially, it also handles propagating metadata to followers if this is a leader.
+        Crucially, it also handles propagating metadata to
+        followers if this is a leader.
         """
         LOGGER.debug(
             "Device %s: Updating HA state from SDK cache/HTTP poll",
@@ -351,7 +352,8 @@ class WiimMediaPlayerEntity(WiimBaseEntity, MediaPlayerEntity):
                 self._device.playing_status = sdk_status
                 if sdk_status == SDKPlayingStatus.STOPPED:
                     LOGGER.debug(
-                        "Device %s: TransportState is STOPPED. Resetting media position and metadata",
+                        "Device %s: TransportState is STOPPED."
+                        " Resetting media position and metadata",
                         self.entity_id,
                     )
                     self._device.current_position = 0
@@ -425,7 +427,8 @@ class WiimMediaPlayerEntity(WiimBaseEntity, MediaPlayerEntity):
         ):
             self._transport_capabilities = None
             LOGGER.debug(
-                "Device %s: Follower transport capabilities unavailable, using base features",
+                "Device %s: Follower transport capabilities"
+                " unavailable, using base features",
                 self.entity_id,
             )
 

--- a/homeassistant/components/wilight/config_flow.py
+++ b/homeassistant/components/wilight/config_flow.py
@@ -82,7 +82,8 @@ class WiLightFlowHandler(ConfigFlow, domain=DOMAIN):
         if not self._wilight_update(host, serial_number, model_name):
             return self.async_abort(reason="not_wilight_device")
 
-        # Check if all components of this WiLight are allowed in this version of the HA integration
+        # Check if all components of this WiLight are
+        # allowed in this version of the HA integration
         component_ok = all(
             wilight_component in ALLOWED_WILIGHT_COMPONENTS
             for wilight_component in self._wilight_components

--- a/homeassistant/components/withings/sensor.py
+++ b/homeassistant/components/withings/sensor.py
@@ -156,13 +156,15 @@ MEASUREMENT_SENSORS: dict[
         suggested_display_precision=2,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    MeasurementType.DIASTOLIC_BLOOD_PRESSURE: WithingsMeasurementSensorEntityDescription(
-        key="diastolic_blood_pressure_mmhg",
-        measurement_type=MeasurementType.DIASTOLIC_BLOOD_PRESSURE,
-        translation_key="diastolic_blood_pressure",
-        native_unit_of_measurement=UnitOfPressure.MMHG,
-        device_class=SensorDeviceClass.PRESSURE,
-        state_class=SensorStateClass.MEASUREMENT,
+    MeasurementType.DIASTOLIC_BLOOD_PRESSURE: (
+        WithingsMeasurementSensorEntityDescription(
+            key="diastolic_blood_pressure_mmhg",
+            measurement_type=MeasurementType.DIASTOLIC_BLOOD_PRESSURE,
+            translation_key="diastolic_blood_pressure",
+            native_unit_of_measurement=UnitOfPressure.MMHG,
+            device_class=SensorDeviceClass.PRESSURE,
+            state_class=SensorStateClass.MEASUREMENT,
+        )
     ),
     MeasurementType.SYSTOLIC_BLOOD_PRESSURE: WithingsMeasurementSensorEntityDescription(
         key="systolic_blood_pressure_mmhg",
@@ -241,26 +243,32 @@ MEASUREMENT_SENSORS: dict[
         translation_key="visceral_fat_index",
         entity_registry_enabled_default=False,
     ),
-    MeasurementType.ELECTRODERMAL_ACTIVITY_FEET: WithingsMeasurementSensorEntityDescription(
-        key="electrodermal_activity_feet",
-        measurement_type=MeasurementType.ELECTRODERMAL_ACTIVITY_FEET,
-        translation_key="electrodermal_activity_feet",
-        native_unit_of_measurement=PERCENTAGE,
-        entity_registry_enabled_default=False,
+    MeasurementType.ELECTRODERMAL_ACTIVITY_FEET: (
+        WithingsMeasurementSensorEntityDescription(
+            key="electrodermal_activity_feet",
+            measurement_type=MeasurementType.ELECTRODERMAL_ACTIVITY_FEET,
+            translation_key="electrodermal_activity_feet",
+            native_unit_of_measurement=PERCENTAGE,
+            entity_registry_enabled_default=False,
+        )
     ),
-    MeasurementType.ELECTRODERMAL_ACTIVITY_LEFT_FOOT: WithingsMeasurementSensorEntityDescription(
-        key="electrodermal_activity_left_foot",
-        measurement_type=MeasurementType.ELECTRODERMAL_ACTIVITY_LEFT_FOOT,
-        translation_key="electrodermal_activity_left_foot",
-        native_unit_of_measurement=PERCENTAGE,
-        entity_registry_enabled_default=False,
+    MeasurementType.ELECTRODERMAL_ACTIVITY_LEFT_FOOT: (
+        WithingsMeasurementSensorEntityDescription(
+            key="electrodermal_activity_left_foot",
+            measurement_type=MeasurementType.ELECTRODERMAL_ACTIVITY_LEFT_FOOT,
+            translation_key="electrodermal_activity_left_foot",
+            native_unit_of_measurement=PERCENTAGE,
+            entity_registry_enabled_default=False,
+        )
     ),
-    MeasurementType.ELECTRODERMAL_ACTIVITY_RIGHT_FOOT: WithingsMeasurementSensorEntityDescription(
-        key="electrodermal_activity_right_foot",
-        measurement_type=MeasurementType.ELECTRODERMAL_ACTIVITY_RIGHT_FOOT,
-        translation_key="electrodermal_activity_right_foot",
-        native_unit_of_measurement=PERCENTAGE,
-        entity_registry_enabled_default=False,
+    MeasurementType.ELECTRODERMAL_ACTIVITY_RIGHT_FOOT: (
+        WithingsMeasurementSensorEntityDescription(
+            key="electrodermal_activity_right_foot",
+            measurement_type=MeasurementType.ELECTRODERMAL_ACTIVITY_RIGHT_FOOT,
+            translation_key="electrodermal_activity_right_foot",
+            native_unit_of_measurement=PERCENTAGE,
+            entity_registry_enabled_default=False,
+        )
     ),
 }
 
@@ -874,7 +882,8 @@ async def async_setup_entry(
 
     if not entities:
         LOGGER.warning(
-            "No data found for Withings entry %s, sensors will be added when new data is available",
+            "No data found for Withings entry %s, sensors"
+            " will be added when new data is available",
             entry.title,
         )
 

--- a/homeassistant/components/wled/__init__.py
+++ b/homeassistant/components/wled/__init__.py
@@ -106,7 +106,8 @@ async def async_migrate_entry(
             ]
             if ignored_entries:
                 _LOGGER.info(
-                    "Found %d ignored WLED config entries with the same MAC address, removing them",
+                    "Found %d ignored WLED config entries"
+                    " with the same MAC address, removing them",
                     len(ignored_entries),
                 )
                 await asyncio.gather(
@@ -117,7 +118,9 @@ async def async_migrate_entry(
                 )
             if len(duplicate_entries) - len(ignored_entries) > 1:
                 _LOGGER.warning(
-                    "Found multiple WLED config entries with the same MAC address, cannot migrate to version 1.2"
+                    "Found multiple WLED config entries with"
+                    " the same MAC address, cannot migrate"
+                    " to version 1.2"
                 )
                 return False
 

--- a/homeassistant/components/wled/const.py
+++ b/homeassistant/components/wled/const.py
@@ -53,7 +53,9 @@ LIGHT_CAPABILITIES_COLOR_MODE_MAPPING: dict[LightCapability, list[ColorMode]] = 
         ColorMode.COLOR_TEMP,
     ],
     LightCapability.RGB_COLOR | LightCapability.COLOR_TEMPERATURE: [
-        # Technically this is RGBWW but wled does not support RGBWW colors (with warm and cold white separately)
+        # Technically this is RGBWW but wled does not
+        # support RGBWW colors (with warm and cold white
+        # separately)
         # but rather RGB + CCT which does not have a direct mapping in HA
         ColorMode.RGB,
     ],

--- a/homeassistant/components/wolflink/__init__.py
+++ b/homeassistant/components/wolflink/__init__.py
@@ -88,7 +88,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def fetch_parameters_init(client: WolfClient, gateway_id: int, device_id: int):
-    """Fetch all available parameters with usage of WolfClient but handles all exceptions and results in ConfigEntryNotReady."""
+    """Fetch all parameters via WolfClient, raising ConfigEntryNotReady on error."""
     try:
         return await fetch_parameters(client, gateway_id, device_id)
     except (FetchFailed, RequestError) as exception:

--- a/homeassistant/components/wolflink/coordinator.py
+++ b/homeassistant/components/wolflink/coordinator.py
@@ -98,7 +98,8 @@ async def fetch_parameters(
 ) -> list[Parameter]:
     """Fetch all available parameters with usage of WolfClient.
 
-    By default Reglertyp entity is removed because API will not provide value for this parameter.
+    By default Reglertyp entity is removed because API
+    will not provide value for this parameter.
     """
     fetched_parameters = await client.fetch_parameters(gateway_id, device_id)
     return [param for param in fetched_parameters if param.name != "Reglertyp"]

--- a/homeassistant/components/wolflink/sensor.py
+++ b/homeassistant/components/wolflink/sensor.py
@@ -173,7 +173,7 @@ class WolfLinkSensor(CoordinatorEntity[WolfLinkCoordinator], SensorEntity):
 
     @property
     def native_value(self) -> str | None:
-        """Return the state. Wolf Client is returning only changed values so we need to store old value here."""
+        """Return the state, storing old values for unchanged parameters."""
         if self.wolf_object.parameter_id in self.coordinator.data:
             new_state = self.coordinator.data[self.wolf_object.parameter_id]
             self.wolf_object.value_id = new_state[0]

--- a/homeassistant/components/wyoming/assist_satellite.py
+++ b/homeassistant/components/wyoming/assist_satellite.py
@@ -140,7 +140,7 @@ class WyomingAssistSatellite(WyomingSatelliteEntity, AssistSatelliteEntity):
 
     @property
     def vad_sensitivity_entity_id(self) -> str | None:
-        """Return the entity ID of the VAD sensitivity to use for the next conversation."""
+        """Return the VAD sensitivity entity ID for next conversation."""
         return self.device.get_vad_sensitivity_entity_id(self.hass)
 
     @property
@@ -299,7 +299,8 @@ class WyomingAssistSatellite(WyomingSatelliteEntity, AssistSatelliteEntity):
                 and not self._is_tts_streaming
                 and (stream := tts.async_get_stream(self.hass, tts_output["token"]))
             ):
-                # Send TTS only if we haven't already started streaming it in INTENT_PROGRESS.
+                # Send TTS only if we haven't already started
+                # streaming it in INTENT_PROGRESS.
                 self.config_entry.async_create_background_task(
                     self.hass,
                     self._stream_tts(stream),

--- a/homeassistant/components/x10/light.py
+++ b/homeassistant/components/x10/light.py
@@ -81,7 +81,8 @@ class X10Light(LightEntity):
         """Instruct the light to turn on."""
         old_brightness = self._attr_brightness
         if old_brightness == 0:
-            # Dim down from max if applicable, also avoids a "dim" command if an "on" is more appropriate
+            # Dim down from max if applicable, also avoids
+            # a "dim" command if an "on" is more appropriate
             old_brightness = 255
         self._attr_brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
         brightness_diff = self.normalize_x10_brightness(

--- a/homeassistant/components/xbox/coordinator.py
+++ b/homeassistant/components/xbox/coordinator.py
@@ -259,7 +259,7 @@ class XboxPresenceCoordinator(XboxBaseCoordinator[XboxData]):
         # The Xbox API constantly fluctuates the "last seen"
         # timestamp between two close values, causing
         # unnecessary updates. We only accept the most
-        # recent one as valild to prevent this.
+        # recent one as valid to prevent this.
 
         prev_dt = (
             prev_data.last_seen_date_time_utc

--- a/homeassistant/components/xbox/coordinator.py
+++ b/homeassistant/components/xbox/coordinator.py
@@ -256,8 +256,10 @@ class XboxPresenceCoordinator(XboxBaseCoordinator[XboxData]):
     def last_seen_timestamp(self, person: Person) -> datetime | None:
         """Returns the most recent of two timestamps."""
 
-        # The Xbox API constantly fluctuates the "last seen" timestamp between two close values,
-        # causing unnecessary updates. We only accept the most recent one as valild to prevent this.
+        # The Xbox API constantly fluctuates the "last seen"
+        # timestamp between two close values, causing
+        # unnecessary updates. We only accept the most
+        # recent one as valild to prevent this.
 
         prev_dt = (
             prev_data.last_seen_date_time_utc

--- a/homeassistant/components/xbox/media_source.py
+++ b/homeassistant/components/xbox/media_source.py
@@ -159,12 +159,10 @@ class XboxSource(MediaSource):
                         )
                     )
                 else:
-                    screenshots = client.screenshots
-                    screenshot_response = (
-                        await screenshots.get_recent_community_screenshots_by_title_id(
-                            identifier.title_id
-                        )
+                    get_community = (
+                        client.screenshots.get_recent_community_screenshots_by_title_id
                     )
+                    screenshot_response = await get_community(identifier.title_id)
             except TimeoutException as e:
                 raise Unresolvable(
                     translation_domain=DOMAIN,

--- a/homeassistant/components/xbox/media_source.py
+++ b/homeassistant/components/xbox/media_source.py
@@ -159,8 +159,11 @@ class XboxSource(MediaSource):
                         )
                     )
                 else:
-                    screenshot_response = await client.screenshots.get_recent_community_screenshots_by_title_id(
-                        identifier.title_id
+                    screenshots = client.screenshots
+                    screenshot_response = (
+                        await screenshots.get_recent_community_screenshots_by_title_id(
+                            identifier.title_id
+                        )
                     )
             except TimeoutException as e:
                 raise Unresolvable(
@@ -421,7 +424,10 @@ class XboxSource(MediaSource):
             identifier=str(identifier),
             media_class=MEDIA_CLASS_MAP[identifier.media_type],
             media_content_type=MediaClass.DIRECTORY,
-            title=f"Xbox / {entry.title} / {game.name} / {MAP_TITLE[identifier.media_type]}",
+            title=(
+                f"Xbox / {entry.title} / {game.name}"
+                f" / {MAP_TITLE[identifier.media_type]}"
+            ),
             can_play=False,
             can_expand=True,
             children=[
@@ -557,7 +563,8 @@ class XboxSource(MediaSource):
                 title=(
                     f"{screenshot.user_caption}"
                     f"{' | ' if screenshot.user_caption else ''}"
-                    f"{dt_util.get_age(screenshot.date_taken)} | {screenshot.resolution_height}p"
+                    f"{dt_util.get_age(screenshot.date_taken)}"
+                    f" | {screenshot.resolution_height}p"
                 ),
                 can_play=True,
                 can_expand=False,
@@ -601,7 +608,8 @@ class XboxSource(MediaSource):
                 title=(
                     f"{screenshot.user_caption}"
                     f"{' | ' if screenshot.user_caption else ''}"
-                    f"{dt_util.get_age(screenshot.date_taken)} | {screenshot.resolution_height}p"
+                    f"{dt_util.get_age(screenshot.date_taken)}"
+                    f" | {screenshot.resolution_height}p"
                 ),
                 can_play=True,
                 can_expand=False,

--- a/homeassistant/components/xbox/sensor.py
+++ b/homeassistant/components/xbox/sensor.py
@@ -152,7 +152,8 @@ def now_playing_attributes(person: Person, title: Title | None) -> dict[str, Any
         attributes.update(
             {
                 "achievements": (
-                    f"{achievement.current_achievements} / {achievement.total_achievements}"
+                    f"{achievement.current_achievements}"
+                    f" / {achievement.total_achievements}"
                 ),
                 "gamerscore": (
                     f"{achievement.current_gamerscore} / {achievement.total_gamerscore}"

--- a/homeassistant/components/xiaomi_ble/__init__.py
+++ b/homeassistant/components/xiaomi_ble/__init__.py
@@ -40,7 +40,7 @@ def process_service_info(
     device_registry: DeviceRegistry,
     service_info: BluetoothServiceInfoBleak,
 ) -> SensorUpdate:
-    """Process a BluetoothServiceInfoBleak, running side effects and returning sensor data."""
+    """Process a BluetoothServiceInfoBleak and return sensor data."""
     coordinator = entry.runtime_data
     data = coordinator.device_data
     update = data.update(service_info)
@@ -96,7 +96,8 @@ def process_service_info(
             )
 
     # If device isn't pending we know it has seen at least one broadcast with a payload
-    # If that payload was encrypted and the bindkey was not verified then we need to reauth
+    # If that payload was encrypted and the bindkey was
+    # not verified then we need to reauth
     if (
         not data.pending
         and data.encryption_scheme != EncryptionScheme.NONE

--- a/homeassistant/components/xiaomi_ble/binary_sensor.py
+++ b/homeassistant/components/xiaomi_ble/binary_sensor.py
@@ -74,9 +74,11 @@ BINARY_SENSOR_DESCRIPTIONS = {
     ExtendedBinarySensorDeviceClass.CHILDLOCK: BinarySensorEntityDescription(
         key=ExtendedBinarySensorDeviceClass.CHILDLOCK,
     ),
-    ExtendedBinarySensorDeviceClass.DEVICE_FORCIBLY_REMOVED: BinarySensorEntityDescription(
-        key=ExtendedBinarySensorDeviceClass.DEVICE_FORCIBLY_REMOVED,
-        device_class=BinarySensorDeviceClass.PROBLEM,
+    ExtendedBinarySensorDeviceClass.DEVICE_FORCIBLY_REMOVED: (
+        BinarySensorEntityDescription(
+            key=ExtendedBinarySensorDeviceClass.DEVICE_FORCIBLY_REMOVED,
+            device_class=BinarySensorDeviceClass.PROBLEM,
+        )
     ),
     ExtendedBinarySensorDeviceClass.DOOR_LEFT_OPEN: BinarySensorEntityDescription(
         key=ExtendedBinarySensorDeviceClass.DOOR_LEFT_OPEN,
@@ -116,7 +118,9 @@ def sensor_update_to_bluetooth_data_update(
             device_key_to_bluetooth_entity_key(device_key): BINARY_SENSOR_DESCRIPTIONS[
                 description.device_class
             ]
-            for device_key, description in sensor_update.binary_entity_descriptions.items()
+            for device_key, description in (
+                sensor_update.binary_entity_descriptions.items()
+            )
             if description.device_class
         },
         entity_data={

--- a/homeassistant/components/xiaomi_miio/__init__.py
+++ b/homeassistant/components/xiaomi_miio/__init__.py
@@ -354,7 +354,7 @@ async def async_create_miio_device_and_coordinator(
     elif model in MODELS_VACUUM or model.startswith(
         (ROBOROCK_GENERIC, ROCKROBO_GENERIC)
     ):
-        # TODO: add lazy_discover as argument when python-miio add support # pylint: disable=fixme
+        # TODO: add lazy_discover as argument  # pylint: disable=fixme
         device = RoborockVacuum(host, token)
         update_method = _async_update_data_vacuum
         coordinator_class = DataUpdateCoordinator[VacuumCoordinatorData]

--- a/homeassistant/components/xiaomi_miio/humidifier.py
+++ b/homeassistant/components/xiaomi_miio/humidifier.py
@@ -1,4 +1,4 @@
-"""Support for Xiaomi Mi Air Purifier and Xiaomi Mi Air Humidifier with humidifier entity."""
+"""Support for Xiaomi Mi Air Purifier and Humidifier."""
 
 import logging
 import math

--- a/homeassistant/components/xiaomi_miio/light.py
+++ b/homeassistant/components/xiaomi_miio/light.py
@@ -476,7 +476,8 @@ class XiaomiPhilipsBulb(XiaomiPhilipsGenericLight):
 
         if ATTR_BRIGHTNESS in kwargs and ATTR_COLOR_TEMP_KELVIN in kwargs:
             _LOGGER.debug(
-                "Setting brightness and color temperature: %s %s%%, %s mireds, %s%% cct",
+                "Setting brightness and color temperature:"
+                " %s %s%%, %s mireds, %s%% cct",
                 brightness,
                 percent_brightness,
                 color_temp,

--- a/homeassistant/components/xiaomi_miio/sensor.py
+++ b/homeassistant/components/xiaomi_miio/sensor.py
@@ -674,15 +674,17 @@ VACUUM_SENSORS = {
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    f"clean_history_{ATTR_CLEAN_HISTORY_DUST_COLLECTION_COUNT}": XiaomiMiioSensorDescription(
-        native_unit_of_measurement="",
-        icon="mdi:counter",
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        key=ATTR_CLEAN_HISTORY_DUST_COLLECTION_COUNT,
-        parent_key=VacuumCoordinatorDataAttributes.clean_history_status,
-        translation_key=ATTR_CLEAN_HISTORY_DUST_COLLECTION_COUNT,
-        entity_registry_enabled_default=False,
-        entity_category=EntityCategory.DIAGNOSTIC,
+    f"clean_history_{ATTR_CLEAN_HISTORY_DUST_COLLECTION_COUNT}": (
+        XiaomiMiioSensorDescription(
+            native_unit_of_measurement="",
+            icon="mdi:counter",
+            state_class=SensorStateClass.TOTAL_INCREASING,
+            key=ATTR_CLEAN_HISTORY_DUST_COLLECTION_COUNT,
+            parent_key=VacuumCoordinatorDataAttributes.clean_history_status,
+            translation_key=ATTR_CLEAN_HISTORY_DUST_COLLECTION_COUNT,
+            entity_registry_enabled_default=False,
+            entity_category=EntityCategory.DIAGNOSTIC,
+        )
     ),
     f"consumable_{ATTR_CONSUMABLE_STATUS_MAIN_BRUSH_LEFT}": XiaomiMiioSensorDescription(
         native_unit_of_measurement=UnitOfTime.SECONDS,
@@ -711,14 +713,16 @@ VACUUM_SENSORS = {
         translation_key=ATTR_CONSUMABLE_STATUS_FILTER_LEFT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    f"consumable_{ATTR_CONSUMABLE_STATUS_SENSOR_DIRTY_LEFT}": XiaomiMiioSensorDescription(
-        native_unit_of_measurement=UnitOfTime.SECONDS,
-        icon="mdi:eye-outline",
-        device_class=SensorDeviceClass.DURATION,
-        key=ATTR_CONSUMABLE_STATUS_SENSOR_DIRTY_LEFT,
-        parent_key=VacuumCoordinatorDataAttributes.consumable_status,
-        translation_key=ATTR_CONSUMABLE_STATUS_SENSOR_DIRTY_LEFT,
-        entity_category=EntityCategory.DIAGNOSTIC,
+    f"consumable_{ATTR_CONSUMABLE_STATUS_SENSOR_DIRTY_LEFT}": (
+        XiaomiMiioSensorDescription(
+            native_unit_of_measurement=UnitOfTime.SECONDS,
+            icon="mdi:eye-outline",
+            device_class=SensorDeviceClass.DURATION,
+            key=ATTR_CONSUMABLE_STATUS_SENSOR_DIRTY_LEFT,
+            parent_key=VacuumCoordinatorDataAttributes.consumable_status,
+            translation_key=ATTR_CONSUMABLE_STATUS_SENSOR_DIRTY_LEFT,
+            entity_category=EntityCategory.DIAGNOSTIC,
+        )
     ),
 }
 

--- a/homeassistant/components/yale/binary_sensor.py
+++ b/homeassistant/components/yale/binary_sensor.py
@@ -164,7 +164,7 @@ class YaleDoorbellBinarySensor(YaleDescriptionEntity, BinarySensorEntity):
             self.async_write_ha_state()
 
     def _schedule_update_to_recheck_turn_off_sensor(self) -> None:
-        """Schedule an update to recheck the sensor to see if it is ready to turn off."""
+        """Schedule an update to recheck if sensor is ready to turn off."""
         # If the sensor is already off there is nothing to do
         if not self.is_on:
             return

--- a/homeassistant/components/yale/lock.py
+++ b/homeassistant/components/yale/lock.py
@@ -129,7 +129,7 @@ class YaleLock(YaleEntity, RestoreEntity, LockEntity):
             )
 
     async def async_added_to_hass(self) -> None:
-        """Restore ATTR_CHANGED_BY on startup since it is likely no longer in the activity log."""
+        """Restore ATTR_CHANGED_BY on startup."""
         await super().async_added_to_hass()
 
         if not (last_state := await self.async_get_last_state()):

--- a/homeassistant/components/yale/sensor.py
+++ b/homeassistant/components/yale/sensor.py
@@ -165,7 +165,7 @@ class YaleOperatorSensor(YaleEntity, RestoreSensor):
         return attributes
 
     async def async_added_to_hass(self) -> None:
-        """Restore ATTR_CHANGED_BY on startup since it is likely no longer in the activity log."""
+        """Restore ATTR_CHANGED_BY on startup."""
         await super().async_added_to_hass()
 
         last_state = await self.async_get_last_state()

--- a/homeassistant/components/yamaha_musiccast/config_flow.py
+++ b/homeassistant/components/yamaha_musiccast/config_flow.py
@@ -95,7 +95,8 @@ class MusicCastFlowHandler(ConfigFlow, domain=DOMAIN):
         self.serial_number = discovery_info.upnp[ATTR_UPNP_SERIAL]
         self.upnp_description = discovery_info.ssdp_location
 
-        # ssdp_location and hostname have been checked in check_yamaha_ssdp so it is safe to ignore type assignment
+        # ssdp_location and hostname have been checked in
+        # check_yamaha_ssdp so it is safe to ignore type
         self.host = urlparse(discovery_info.ssdp_location).hostname  # type: ignore[assignment]
 
         await self.async_set_unique_id(self.serial_number)

--- a/homeassistant/components/yamaha_musiccast/media_player.py
+++ b/homeassistant/components/yamaha_musiccast/media_player.py
@@ -155,7 +155,7 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
 
     @property
     def source_mapping(self):
-        """Return a mapping of the actual source names to their labels configured in the MusicCast App."""
+        """Return a mapping of source names to MusicCast App labels."""
         ret = {}
         for inp in self.coordinator.data.zones[self._zone_id].input_list:
             label = self.coordinator.data.input_names.get(inp, "")
@@ -559,7 +559,7 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
 
     @property
     def is_network_server(self) -> bool:
-        """Return only true if the current entity is a network server and not a main zone with an attached zone2."""
+        """Return true if entity is a network server, not a main zone with zone2."""
         return (
             self.coordinator.data.group_role == "server"
             and self.coordinator.data.group_id != NULL_GROUP
@@ -595,7 +595,7 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
 
     @property
     def is_network_client(self) -> bool:
-        """Return True if the current entity is a network client and not just a main syncing entity."""
+        """Return True if entity is a network client, not just a main sync."""
         return (
             self.coordinator.data.group_role == "client"
             and self.coordinator.data.group_id != NULL_GROUP
@@ -625,12 +625,12 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
         return entities
 
     def get_all_server_entities(self) -> list[MusicCastMediaPlayer]:
-        """Return all media player entities in the musiccast system, which are in server mode."""
+        """Return all media player entities in server mode."""
         entities = self.get_all_mc_entities()
         return [entity for entity in entities if entity.is_server]
 
     def get_distribution_num(self) -> int:
-        """Return the distribution_num (number of clients in the whole musiccast system)."""
+        """Return the distribution_num (number of clients)."""
         return sum(
             len(server.coordinator.data.group_client_list)
             for server in self.get_all_server_entities()
@@ -667,9 +667,10 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
 
     @property
     def musiccast_group(self) -> list[MusicCastMediaPlayer]:
-        """Return all media players of the current group, if the media player is server."""
+        """Return all media players of the current group."""
         if self.is_client:
-            # If we are a client we can still share group information, but we will take them from the server.
+            # If we are a client we can still share group
+            # information, but we will take them from the server.
             if (server := self.group_server) != self:
                 return server.musiccast_group
 
@@ -682,9 +683,11 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
 
     @property
     def musiccast_zone_entity(self) -> MusicCastMediaPlayer:
-        """Return the entity of the zone, which is using MusicCast at the moment, if there is one, self else.
+        """Return the entity of the zone using MusicCast.
 
-        It is possible that multiple zones use MusicCast as client at the same time. In this case the first one is
+        It is possible that multiple zones use MusicCast
+        as client at the same time. In this case the first
+        one is
         returned.
         """
         for entity in self.other_zones:
@@ -695,7 +698,8 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
 
     async def update_all_mc_entities(self, check_clients=False):
         """Update the whole musiccast system when group data change."""
-        # First update all servers as they provide the group information for their clients
+        # First update all servers as they provide the
+        # group information for their clients
         for entity in self.get_all_server_entities():
             if check_clients or self.coordinator.musiccast.group_reduce_by_source:
                 await entity.async_check_client_list()
@@ -729,7 +733,9 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
             await self.async_turn_on()
 
         if not self.is_server and self.musiccast_zone_entity.is_server:
-            # The MusicCast Distribution Module of this device is already in use. To use it as a server, we first
+            # The MusicCast Distribution Module of this
+            # device is already in use. To use it as a server,
+            # we first
             # have to unjoin and wait until the servers are updated.
             await self.musiccast_zone_entity.async_server_close_group()
         elif self.musiccast_zone_entity.is_client:
@@ -847,7 +853,8 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
             and self.coordinator.data.group_id == server.coordinator.data.group_id
             and self.coordinator.data.group_role == "client"
         ):
-            # The device is already part of this group (e.g. main zone is also a client of this group).
+            # The device is already part of this group
+            # (e.g. main zone is also a client of this group).
             # Just select mc_link as source
             await self.coordinator.musiccast.zone_join(self._zone_id)
             return False

--- a/homeassistant/components/youtube/coordinator.py
+++ b/homeassistant/components/youtube/coordinator.py
@@ -66,7 +66,9 @@ class YouTubeDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         ATTR_PUBLISHED_AT: video.snippet.added_at,
                         ATTR_TITLE: video.snippet.title,
                         ATTR_DESCRIPTION: video.snippet.description,
-                        ATTR_THUMBNAIL: video.snippet.thumbnails.get_highest_quality().url,
+                        ATTR_THUMBNAIL: (
+                            video.snippet.thumbnails.get_highest_quality().url
+                        ),
                         ATTR_VIDEO_ID: video.content_details.video_id,
                     }
                 res[channel.channel_id] = {

--- a/homeassistant/components/zeroconf/discovery.py
+++ b/homeassistant/components/zeroconf/discovery.py
@@ -464,7 +464,8 @@ class ZeroconfDiscovery:
         # Conflict detected, create repair issue
         _joined_ips = ", ".join(str(ip_address) for ip_address in discovered_ips)
         _LOGGER.warning(
-            "Discovered another Home Assistant instance with the same instance ID (%s) at %s",
+            "Discovered another Home Assistant instance"
+            " with the same instance ID (%s) at %s",
             discovered_instance_id,
             _joined_ips,
         )

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -62,7 +62,8 @@ DECONZ_DOMAIN = "deconz"
 # The ZHA config flow takes different branches depending on if you are migrating to a
 # new adapter via discovery or setting it up from scratch
 
-# For the fast path, we automatically migrate everything and restore the most recent backup
+# For the fast path, we automatically migrate everything
+# and restore the most recent backup
 MIGRATION_STRATEGY_RECOMMENDED = "migration_strategy_recommended"
 MIGRATION_STRATEGY_ADVANCED = "migration_strategy_advanced"
 

--- a/homeassistant/components/zha/device_action.py
+++ b/homeassistant/components/zha/device_action.py
@@ -217,13 +217,15 @@ async def _execute_cluster_handler_command_based_action(
 
     if action_cluster_handler is None:
         raise InvalidDeviceAutomationConfig(
-            f"Unable to execute cluster handler action - cluster handler: {cluster_handler_name} action:"
+            f"Unable to execute cluster handler action -"
+            f" cluster handler: {cluster_handler_name} action:"
             f" {action_type}"
         )
 
     if not hasattr(action_cluster_handler, action_type):
         raise InvalidDeviceAutomationConfig(
-            f"Unable to execute cluster handler - cluster handler: {cluster_handler_name} action:"
+            f"Unable to execute cluster handler -"
+            f" cluster handler: {cluster_handler_name} action:"
             f" {action_type}"
         )
 
@@ -235,5 +237,7 @@ async def _execute_cluster_handler_command_based_action(
 
 ZHA_ACTION_TYPES = {
     ZHA_ACTION_TYPE_SERVICE_CALL: _execute_service_based_action,
-    ZHA_ACTION_TYPE_CLUSTER_HANDLER_COMMAND: _execute_cluster_handler_command_based_action,
+    ZHA_ACTION_TYPE_CLUSTER_HANDLER_COMMAND: (
+        _execute_cluster_handler_command_based_action
+    ),
 }

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -929,8 +929,9 @@ class ZHAGatewayProxy(EventBase):
     def _cleanup_group_entity_registry_entries(
         self, zha_group_proxy: ZHAGroupProxy
     ) -> None:
-        """Remove entity registry entries for group entities when the groups are removed from HA."""
-        # first we collect the potential unique ids for entities that could be created from this group
+        """Remove entity registry entries for removed group entities."""
+        # first we collect the potential unique ids for
+        # entities that could be created from this group
         possible_entity_unique_ids = [
             f"{domain}_zha_group_0x{zha_group_proxy.group.group_id:04x}"
             for domain in GROUP_ENTITY_DOMAINS
@@ -1249,9 +1250,12 @@ def async_add_entities(
     for entity_data in entities:
         try:
             entities_to_add.append(entity_class(entity_data))
-        # broad exception to prevent a single entity from preventing an entire platform from loading
-        # this can potentially be caused by a misbehaving device or a bad quirk. Not ideal but the
-        # alternative is adding try/catch to each entity class __init__ method with a specific exception
+        # broad exception to prevent a single entity from
+        # preventing an entire platform from loading.
+        # this can potentially be caused by a misbehaving
+        # device or a bad quirk. Not ideal but the
+        # alternative is adding try/catch to each entity
+        # class __init__ method with a specific exception
         except Exception:
             _LOGGER.exception(
                 "Error while adding entity from entity data: %s", entity_data

--- a/homeassistant/components/zha/websocket_api.py
+++ b/homeassistant/components/zha/websocket_api.py
@@ -1501,7 +1501,8 @@ def async_load_api(hass: HomeAssistant) -> None:
                 await cluster_handler.issue_squawk(mode, strobe, level)
             else:
                 _LOGGER.error(
-                    "Squawking IASWD: %s: [%s] is missing the required IASWD cluster handler!",
+                    "Squawking IASWD: %s: [%s] is missing"
+                    " the required IASWD cluster handler!",
                     ATTR_IEEE,
                     str(ieee),
                 )
@@ -1546,7 +1547,8 @@ def async_load_api(hass: HomeAssistant) -> None:
                 )
             else:
                 _LOGGER.error(
-                    "Warning IASWD: %s: [%s] is missing the required IASWD cluster handler!",
+                    "Warning IASWD: %s: [%s] is missing"
+                    " the required IASWD cluster handler!",
                     ATTR_IEEE,
                     str(ieee),
                 )

--- a/homeassistant/components/zimi/entity.py
+++ b/homeassistant/components/zimi/entity.py
@@ -42,7 +42,7 @@ class ZimiEntity(Entity):
 
     @property
     def available(self) -> bool:
-        """Return True if Home Assistant is able to read the state and control the underlying device."""
+        """Return True if HA can read state and control the device."""
         return self._device.is_connected
 
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/zone/trigger.py
+++ b/homeassistant/components/zone/trigger.py
@@ -106,7 +106,10 @@ async def async_attach_trigger(
         if (event == EVENT_ENTER and not from_match and to_match) or (
             event == EVENT_LEAVE and from_match and not to_match
         ):
-            description = f"{entity} {_EVENT_DESCRIPTION[event]} {zone_state.attributes[ATTR_FRIENDLY_NAME]}"
+            description = (
+                f"{entity} {_EVENT_DESCRIPTION[event]}"
+                f" {zone_state.attributes[ATTR_FRIENDLY_NAME]}"
+            )
             hass.async_run_hass_job(
                 job,
                 {

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -669,7 +669,8 @@ async def websocket_node_alerts(
                         "comments": [
                             {
                                 "level": "info",
-                                "text": "This device has been provisioned but is not yet included in the "
+                                "text": "This device has been provisioned"
+                                " but is not yet included in the "
                                 "network.",
                             }
                         ],
@@ -686,7 +687,9 @@ async def websocket_node_alerts(
         comments.append(
             {
                 "level": "warning",
-                "text": "This device is currently being interviewed and may not be fully operational.",
+                "text": "This device is currently being"
+                " interviewed and may not be fully"
+                " operational.",
             }
         )
     connection.send_result(

--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -135,7 +135,7 @@ class NewNotificationZWaveJSEntityDescription(BinarySensorEntityDescription):
 
 @dataclass(frozen=True, kw_only=True)
 class OpeningStateZWaveJSEntityDescription(BinarySensorEntityDescription):
-    """Describe an Access Control binary sensor that derives state from Opening state."""
+    """Describe an Access Control binary sensor from Opening state."""
 
     state_key: int
     parse_opening_state: Callable[[OpeningState], bool]
@@ -1307,7 +1307,8 @@ DISCOVERY_SCHEMAS: list[NewZWaveDiscoverySchema] = [
             entity_category=EntityCategory.DIAGNOSTIC,
             not_states={
                 0,
-                # Lock state values (Lock state schemas consume the value when state 11 is
+                # Lock state values (Lock state schemas
+                # consume the value when state 11 is
                 # available, but may not when state 11 is absent)
                 1,
                 2,
@@ -1326,7 +1327,8 @@ DISCOVERY_SCHEMAS: list[NewZWaveDiscoverySchema] = [
     # -------------------------------------------------------------------
     NewZWaveDiscoverySchema(
         # Hoppe eHandle ConnectSense (0x0313:0x0701:0x0002) - window tilt sensor.
-        # The window tilt state is exposed as a binary sensor that is disabled by default
+        # The window tilt state is exposed as a binary
+        # sensor that is disabled by default
         # instead of a notification sensor. We enable that sensor and give it a name
         # that is more consistent with the other window related entities.
         platform=Platform.BINARY_SENSOR,

--- a/homeassistant/components/zwave_js/climate.py
+++ b/homeassistant/components/zwave_js/climate.py
@@ -565,7 +565,7 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
 
 
 class DynamicCurrentTempClimate(ZWaveClimate):
-    """Representation of a thermostat that can dynamically use a different Zwave Value for current temp."""
+    """Thermostat that dynamically uses a different Zwave Value for current temp."""
 
     def __init__(
         self, config_entry: ZwaveJSConfigEntry, driver: Driver, info: ZwaveDiscoveryInfo

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -268,7 +268,8 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
                 # If the RF region is not set, we need to ask the user to select it.
                 return await self.async_step_rf_region()
         if config_updates := self._addon_config_updates:
-            # If we have updates to the add-on config, set them before starting the add-on.
+            # If we have updates to the add-on config,
+            # set them before starting the add-on.
             self._addon_config_updates = {}
             await self._async_set_addon_config(config_updates)
 
@@ -1409,7 +1410,10 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="restore_failed",
             description_placeholders={
                 "file_path": str(self.backup_filepath),
-                "file_url": f"data:application/octet-stream;base64,{base64.b64encode(self.backup_data).decode('ascii')}",
+                "file_url": (
+                    "data:application/octet-stream;base64,"
+                    f"{base64.b64encode(self.backup_data).decode('ascii')}"
+                ),
                 "file_name": self.backup_filepath.name,
             },
         )
@@ -1556,8 +1560,11 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
                     )
                     return self.async_abort(reason="already_configured")
 
-            # We are not aborting if home ID configured here, we just want to make sure that it's set
-            # We will update a USB based config entry automatically in `async_step_finish_addon_setup_user`
+            # We are not aborting if home ID configured
+            # here, we just want to make sure that it's set
+            # We will update a USB based config entry
+            # automatically in
+            # `async_step_finish_addon_setup_user`
             await self.async_set_unique_id(
                 str(discovery_info.zwave_home_id), raise_on_progress=False
             )

--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -167,7 +167,7 @@ class CoverPositionMixin(ZWaveBaseEntity, CoverEntity):
 
     @property
     def current_cover_position(self) -> int | None:
-        """Return the current position of cover where 0 means closed and 100 is fully open."""
+        """Return current position of cover (0=closed, 100=open)."""
         if (
             self._current_position_value is None
             or self._current_position_value.value is None
@@ -232,7 +232,8 @@ class CoverPositionMixin(ZWaveBaseEntity, CoverEntity):
         assert self._stop_position_value
         # Stop the cover, will stop regardless of the actual direction of travel.
         result = await self._async_set_value(self._stop_position_value, False)
-        # When stopping is successful (or unsupervised), we can assume the cover has stopped moving.
+        # When stopping is successful (or unsupervised),
+        # we can assume the cover has stopped moving.
         if result is not None and result.status in (
             SetValueStatus.SUCCESS,
             SetValueStatus.SUCCESS_UNSUPERVISED,
@@ -501,7 +502,8 @@ class ZWaveWindowCovering(CoverPositionMixin, CoverTiltMixin):
             and tpv.value == cv.value == self._fully_open_position
         )
         result = await self._async_set_value(self._up_value, True)
-        # StartLevelChange: SUCCESS means the device started moving in the desired direction
+        # StartLevelChange: SUCCESS means the device started
+        # moving in the desired direction
         if (
             result is not None
             and result.status in SET_VALUE_SUCCESS
@@ -522,7 +524,8 @@ class ZWaveWindowCovering(CoverPositionMixin, CoverTiltMixin):
             and tpv.value == cv.value == self._fully_closed_position
         )
         result = await self._async_set_value(self._down_value, True)
-        # StartLevelChange: SUCCESS means the device started moving in the desired direction
+        # StartLevelChange: SUCCESS means the device started
+        # moving in the desired direction
         if (
             result is not None
             and result.status in SET_VALUE_SUCCESS
@@ -536,7 +539,8 @@ class ZWaveWindowCovering(CoverPositionMixin, CoverTiltMixin):
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         result = await self._async_set_value(self._up_value, False)
-        # When stopping is successful (or unsupervised), we can assume the cover has stopped moving.
+        # When stopping is successful (or unsupervised),
+        # we can assume the cover has stopped moving.
         if result is not None and result.status in (
             SetValueStatus.SUCCESS,
             SetValueStatus.SUCCESS_UNSUPERVISED,

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -574,7 +574,8 @@ DISCOVERY_SCHEMAS = [
                     command_class=CommandClass.SENSOR_MULTILEVEL,
                     endpoint=3,
                 ),
-                # External sensor (connected to device) with limit by floor sensor (2x sensors)
+                # External sensor (connected to device) with
+                # limit by floor sensor (2x sensors)
                 "External with floor limit": ZwaveValueID(
                     property_=THERMOSTAT_CURRENT_TEMP_PROPERTY,
                     command_class=CommandClass.SENSOR_MULTILEVEL,
@@ -1051,13 +1052,15 @@ DISCOVERY_SCHEMAS = [
         device_class_generic={"Thermostat"},
         primary_value=SWITCH_MULTILEVEL_CURRENT_VALUE_SCHEMA,
     ),
-    # Handle the different combinations of Binary Switch, Multilevel Switch and Color Switch
+    # Handle the different combinations of Binary Switch,
+    # Multilevel Switch and Color Switch
     # to create switches and/or (colored) lights. The goal is to:
     # - couple Color Switch CC with Multilevel Switch CC if possible
     # - couple Color Switch CC with Binary Switch CC as the first fallback
     # - use Color Switch CC standalone as the last fallback
     #
-    # Multilevel Switch CC (+ Color Switch CC) -> Dimmable light with or without color support.
+    # Multilevel Switch CC (+ Color Switch CC) -> Dimmable
+    # light with or without color support.
     ZWaveDiscoverySchema(
         platform=Platform.LIGHT,
         primary_value=SWITCH_MULTILEVEL_CURRENT_VALUE_SCHEMA,

--- a/homeassistant/components/zwave_js/discovery_data_template.py
+++ b/homeassistant/components/zwave_js/discovery_data_template.py
@@ -491,7 +491,7 @@ class FanValueMappingDataTemplate:
 
 @dataclass
 class ConfigurableFanValueMappingValueMix:
-    """Mixin data class for defining fan properties that change based on a device configuration option."""
+    """Mixin for fan properties that change based on device config."""
 
     configuration_option: ZwaveValueID
     configuration_value_to_fan_value_mapping: dict[int, FanValueMapping]

--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -510,7 +510,7 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
 
 
 class ZwaveColorOnOffLight(ZwaveLight):
-    """Representation of a colored Z-Wave light with an optional binary switch to turn on/off.
+    """Colored Z-Wave light with optional binary switch.
 
     Dimming for RGB lights is realized by scaling the color channels.
     """
@@ -580,7 +580,8 @@ class ZwaveColorOnOffLight(ZwaveLight):
                     ColorComponent.BLUE: 255,
                 }
         elif brightness is not None:
-            # If brightness gets set, preserve the color and mix it with the new brightness
+            # If brightness gets set, preserve the color
+            # and mix it with the new brightness
             if self.color_mode == ColorMode.HS:
                 scale = brightness / 255
             if self._last_on_color is not None:

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -629,7 +629,8 @@ async def async_setup_entry(
                 )
             )
         elif info.platform_hint == "notification":
-            # prevent duplicate entities for values that are already represented as binary sensors
+            # prevent duplicate entities for values that are
+            # already represented as binary sensors
             if is_valid_notification_binary_sensor(info):
                 return
             entities.append(

--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -603,11 +603,13 @@ class ZWaveServices:
                 nodes_or_endpoints_list, _results
             ):
                 if value_size is None:
-                    # async_set_config_parameter still returns (Value, SetConfigParameterResult)
+                    # async_set_config_parameter still returns
+                    # (Value, SetConfigParameterResult)
                     zwave_value = result[0]
                     cmd_status = result[1]
                 else:
-                    # async_set_raw_config_parameter_value now returns just SetConfigParameterResult
+                    # async_set_raw_config_parameter_value now
+                    # returns just SetConfigParameterResult
                     cmd_status = result
                     zwave_value = f"parameter {property_or_property_name}"
 
@@ -615,7 +617,8 @@ class ZWaveServices:
                     msg = "Set configuration parameter %s on Node %s with value %s"
                 else:
                     msg = (
-                        "Added command to queue to set configuration parameter %s on %s "
+                        "Added command to queue to set"
+                        " configuration parameter %s on %s "
                         "with value %s. Parameter will be set when the device wakes up"
                     )
                 _LOGGER.info(msg, zwave_value, node_or_endpoint, new_value)

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -257,12 +257,13 @@ class ZWaveFirmwareUpdateEntity(ZWaveNodeBaseEntity, UpdateEntity):
         try:
             # Retrieve all firmware updates including non-stable ones but filter
             # non-stable channels out
-            available_firmware_updates = [
-                update
-                for update in await self.driver.controller.async_get_available_firmware_updates(
+            all_updates = (
+                await self.driver.controller.async_get_available_firmware_updates(
                     self.node, API_KEY_FIRMWARE_UPDATE_SERVICE, True
                 )
-                if update.channel == "stable"
+            )
+            available_firmware_updates = [
+                update for update in all_updates if update.channel == "stable"
             ]
         except FailedZWaveCommand as err:
             LOGGER.debug(

--- a/homeassistant/components/zwave_me/light.py
+++ b/homeassistant/components/zwave_me/light.py
@@ -98,7 +98,10 @@ class ZWaveMeRGB(ZWaveMeEntity, LightEntity):
 
         cmd = command_id
         if command_args:
-            cmd = f"{command_id}?{'&'.join(f'{argId}={argVal}' for argId, argVal in command_args.items())}"
+            args = "&".join(
+                f"{argId}={argVal}" for argId, argVal in command_args.items()
+            )
+            cmd = f"{command_id}?{args}"
         self.controller.zwave_api.send_command(self.device.id, cmd)
 
     @property

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -629,7 +629,9 @@ class ConfigEntry[_DataT = Any]:
                             subentry_flow_handler, "async_step_reconfigure"
                         )
                     }
-                    for subentry_flow_type, subentry_flow_handler in supported_flows.items()
+                    for subentry_flow_type, subentry_flow_handler in (
+                        supported_flows.items()
+                    )
                 },
             )
         return self._supported_subentry_types or {}

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -461,7 +461,9 @@ class DeviceEntry:
                     "config_entries": list(self.config_entries),
                     "config_entries_subentries": {
                         entry_id: list(subentries)
-                        for entry_id, subentries in self.config_entries_subentries.items()
+                        for entry_id, subentries in (
+                            self.config_entries_subentries.items()
+                        )
                     },
                     "configuration_url": self.configuration_url,
                     "connections": list(self.connections),
@@ -560,7 +562,9 @@ class DeletedDeviceEntry:
                     "config_entries": list(self.config_entries),
                     "config_entries_subentries": {
                         entry_id: list(subentries)
-                        for entry_id, subentries in self.config_entries_subentries.items()
+                        for entry_id, subentries in (
+                            self.config_entries_subentries.items()
+                        )
                     },
                     "connections": list(self.connections),
                     "created_at": self.created_at,

--- a/script/gen_copilot_instructions.py
+++ b/script/gen_copilot_instructions.py
@@ -23,7 +23,9 @@ COPILOT_SPECIFIC_INSTRUCTIONS = """
 
 - Start review comments with a short, one-sentence summary of the suggested fix.
 - Do not comment on code style, formatting or linting issues.
-- A Pull Request with a dependency version bump should only contain changes required for the version bump. If the PR includes other changes, request that they are removed from the PR.
+- A Pull Request with a dependency version bump should only contain
+changes required for the version bump. If the PR includes other
+changes, request that they are removed from the PR.
 """
 
 INTEGRATION_PATH_SPECIFIC_INSTRUCTIONS = """---

--- a/script/gen_copilot_instructions.py
+++ b/script/gen_copilot_instructions.py
@@ -23,9 +23,7 @@ COPILOT_SPECIFIC_INSTRUCTIONS = """
 
 - Start review comments with a short, one-sentence summary of the suggested fix.
 - Do not comment on code style, formatting or linting issues.
-- A Pull Request with a dependency version bump should only contain
-changes required for the version bump. If the PR includes other
-changes, request that they are removed from the PR.
+- A Pull Request with a dependency version bump should only contain changes required for the version bump. If the PR includes other changes, request that they are removed from the PR.
 """
 
 INTEGRATION_PATH_SPECIFIC_INSTRUCTIONS = """---

--- a/script/hassfest/docker.py
+++ b/script/hassfest/docker.py
@@ -27,7 +27,8 @@ FROM ${{BUILD_FROM}}
 LABEL \
     io.hass.type="core" \
     org.opencontainers.image.authors="The Home Assistant Authors" \
-    org.opencontainers.image.description="Open-source home automation platform running on Python 3" \
+    org.opencontainers.image.description=\
+    "Open-source home automation platform running on Python 3" \
     org.opencontainers.image.documentation="https://www.home-assistant.io/docs/" \
     org.opencontainers.image.licenses="Apache-2.0" \
     org.opencontainers.image.title="Home Assistant" \
@@ -53,12 +54,14 @@ RUN \
     # Verify go2rtc can be executed
     go2rtc --version \
     # Install uv at the version pinned in the requirements file
-    && pip3 install --no-cache-dir "uv==$(awk -F'==' '/^uv==/{{print $2}}' homeassistant/requirements.txt)" \
+    && pip3 install --no-cache-dir \
+        "uv==$(awk -F'==' '/^uv==/{{print $2}}' homeassistant/requirements.txt)" \
     && uv pip install \
         --no-build \
         -r homeassistant/requirements.txt
 
-COPY requirements_all.txt home_assistant_frontend-* home_assistant_intents-* homeassistant/
+COPY requirements_all.txt home_assistant_frontend-* \
+    home_assistant_intents-* homeassistant/
 RUN \
     if ls homeassistant/home_assistant_*.whl 1> /dev/null 2>&1; then \
         uv pip install homeassistant/home_assistant_*.whl; \
@@ -150,26 +153,35 @@ COPY --parents requirements.txt homeassistant/ script /usr/src/homeassistant/
 
 # Uv creates a lock file in /tmp
 RUN --mount=type=tmpfs,target=/tmp \
-    --mount=type=bind,source=requirements_test.txt,target=/tmp/requirements_test.txt,readonly \
-    --mount=type=bind,source=requirements_test_pre_commit.txt,target=/tmp/requirements_test_pre_commit.txt,readonly \
+    --mount=type=bind,\
+source=requirements_test.txt,\
+target=/tmp/requirements_test.txt,readonly \
+    --mount=type=bind,\
+source=requirements_test_pre_commit.txt,\
+target=/tmp/requirements_test_pre_commit.txt,readonly \
     # Required for PyTurboJPEG
     apk add --no-cache libturbojpeg \
     # Install uv at the version pinned in the requirements file
-    && pip install --no-cache-dir "uv==$(awk -F'==' '/^uv==/{{print $2}}' /usr/src/homeassistant/requirements.txt)" \
+    && pip install --no-cache-dir \
+        "uv==$(awk -F'==' '/^uv==/{{print $2}}' \
+/usr/src/homeassistant/requirements.txt)" \
     && uv pip install \
         --no-build \
         --no-cache \
         -c /usr/src/homeassistant/homeassistant/package_constraints.txt \
         -r /usr/src/homeassistant/requirements.txt \
-        "pipdeptree==$(awk -F'==' '/^pipdeptree==/{{print $2}}' /tmp/requirements_test.txt)" \
+        "pipdeptree==$(awk -F'==' \
+'/^pipdeptree==/{{print $2}}' /tmp/requirements_test.txt)" \
         "tqdm==$(awk -F'==' '/^tqdm==/{{print $2}}' /tmp/requirements_test.txt)" \
-        "ruff==$(awk -F'==' '/^ruff==/{{print $2}}' /tmp/requirements_test_pre_commit.txt)"
+        "ruff==$(awk -F'==' '/^ruff==/{{print $2}}' \
+/tmp/requirements_test_pre_commit.txt)"
 
 LABEL "name"="hassfest"
 LABEL "maintainer"="Home Assistant <hello@home-assistant.io>"
 
 LABEL "com.github.actions.name"="hassfest"
-LABEL "com.github.actions.description"="Run hassfest to validate standalone integration repositories"
+LABEL "com.github.actions.description"=\
+"Run hassfest to validate standalone integration repositories"
 LABEL "com.github.actions.icon"="terminal"
 LABEL "com.github.actions.color"="gray-dark"
 """

--- a/script/hassfest/docker.py
+++ b/script/hassfest/docker.py
@@ -27,8 +27,7 @@ FROM ${{BUILD_FROM}}
 LABEL \
     io.hass.type="core" \
     org.opencontainers.image.authors="The Home Assistant Authors" \
-    org.opencontainers.image.description=\
-    "Open-source home automation platform running on Python 3" \
+    org.opencontainers.image.description="Open-source home automation platform running on Python 3" \
     org.opencontainers.image.documentation="https://www.home-assistant.io/docs/" \
     org.opencontainers.image.licenses="Apache-2.0" \
     org.opencontainers.image.title="Home Assistant" \
@@ -54,14 +53,12 @@ RUN \
     # Verify go2rtc can be executed
     go2rtc --version \
     # Install uv at the version pinned in the requirements file
-    && pip3 install --no-cache-dir \
-        "uv==$(awk -F'==' '/^uv==/{{print $2}}' homeassistant/requirements.txt)" \
+    && pip3 install --no-cache-dir "uv==$(awk -F'==' '/^uv==/{{print $2}}' homeassistant/requirements.txt)" \
     && uv pip install \
         --no-build \
         -r homeassistant/requirements.txt
 
-COPY requirements_all.txt home_assistant_frontend-* \
-    home_assistant_intents-* homeassistant/
+COPY requirements_all.txt home_assistant_frontend-* home_assistant_intents-* homeassistant/
 RUN \
     if ls homeassistant/home_assistant_*.whl 1> /dev/null 2>&1; then \
         uv pip install homeassistant/home_assistant_*.whl; \
@@ -153,35 +150,26 @@ COPY --parents requirements.txt homeassistant/ script /usr/src/homeassistant/
 
 # Uv creates a lock file in /tmp
 RUN --mount=type=tmpfs,target=/tmp \
-    --mount=type=bind,\
-source=requirements_test.txt,\
-target=/tmp/requirements_test.txt,readonly \
-    --mount=type=bind,\
-source=requirements_test_pre_commit.txt,\
-target=/tmp/requirements_test_pre_commit.txt,readonly \
+    --mount=type=bind,source=requirements_test.txt,target=/tmp/requirements_test.txt,readonly \
+    --mount=type=bind,source=requirements_test_pre_commit.txt,target=/tmp/requirements_test_pre_commit.txt,readonly \
     # Required for PyTurboJPEG
     apk add --no-cache libturbojpeg \
     # Install uv at the version pinned in the requirements file
-    && pip install --no-cache-dir \
-        "uv==$(awk -F'==' '/^uv==/{{print $2}}' \
-/usr/src/homeassistant/requirements.txt)" \
+    && pip install --no-cache-dir "uv==$(awk -F'==' '/^uv==/{{print $2}}' /usr/src/homeassistant/requirements.txt)" \
     && uv pip install \
         --no-build \
         --no-cache \
         -c /usr/src/homeassistant/homeassistant/package_constraints.txt \
         -r /usr/src/homeassistant/requirements.txt \
-        "pipdeptree==$(awk -F'==' \
-'/^pipdeptree==/{{print $2}}' /tmp/requirements_test.txt)" \
+        "pipdeptree==$(awk -F'==' '/^pipdeptree==/{{print $2}}' /tmp/requirements_test.txt)" \
         "tqdm==$(awk -F'==' '/^tqdm==/{{print $2}}' /tmp/requirements_test.txt)" \
-        "ruff==$(awk -F'==' '/^ruff==/{{print $2}}' \
-/tmp/requirements_test_pre_commit.txt)"
+        "ruff==$(awk -F'==' '/^ruff==/{{print $2}}' /tmp/requirements_test_pre_commit.txt)"
 
 LABEL "name"="hassfest"
 LABEL "maintainer"="Home Assistant <hello@home-assistant.io>"
 
 LABEL "com.github.actions.name"="hassfest"
-LABEL "com.github.actions.description"=\
-"Run hassfest to validate standalone integration repositories"
+LABEL "com.github.actions.description"="Run hassfest to validate standalone integration repositories"
 LABEL "com.github.actions.icon"="terminal"
 LABEL "com.github.actions.color"="gray-dark"
 """

--- a/script/licenses.py
+++ b/script/licenses.py
@@ -204,7 +204,8 @@ EXCEPTIONS = {
 
 # fmt: off
 TODO = {
-    "TravisPy": AwesomeVersion("0.3.5"),  # None -- GPL -- ['GNU General Public License v3 (GPLv3)']
+    "TravisPy": AwesomeVersion("0.3.5"),
+    # None -- GPL -- ['GNU General Public License v3 (GPLv3)']
     "aiocache": AwesomeVersion(
         "0.12.3"
     ),  # https://github.com/aio-libs/aiocache/blob/master/LICENSE all rights reserved?

--- a/script/licenses.py
+++ b/script/licenses.py
@@ -204,8 +204,7 @@ EXCEPTIONS = {
 
 # fmt: off
 TODO = {
-    "TravisPy": AwesomeVersion("0.3.5"),
-    # None -- GPL -- ['GNU General Public License v3 (GPLv3)']
+    "TravisPy": AwesomeVersion("0.3.5"),  # None -- GPL -- ['GNU General Public License v3 (GPLv3)']
     "aiocache": AwesomeVersion(
         "0.12.3"
     ),  # https://github.com/aio-libs/aiocache/blob/master/LICENSE all rights reserved?

--- a/script/translations/migrate.py
+++ b/script/translations/migrate.py
@@ -383,8 +383,7 @@ def run():
     # rename_keys(
     #     CORE_PROJECT_ID,
     #     {
-    #         "component::blebox::config::step::user::data::host":
-    #             "common::config_flow::data::ip",
+    #         "component::blebox::config::step::user::data::host": "common::config_flow::data::ip",
     #     },
     # )
 

--- a/script/translations/migrate.py
+++ b/script/translations/migrate.py
@@ -383,7 +383,8 @@ def run():
     # rename_keys(
     #     CORE_PROJECT_ID,
     #     {
-    #         "component::blebox::config::step::user::data::host": "common::config_flow::data::ip",
+    #         "component::blebox::config::step::user::data::host":
+    #             "common::config_flow::data::ip",
     #     },
     # )
 

--- a/tests/auth/test_init.py
+++ b/tests/auth/test_init.py
@@ -299,7 +299,8 @@ async def test_linking_user_to_two_auth_providers(
     await manager.async_link_user(user, new_credential)
     assert len(user.credentials) == 2
 
-    # Linking a credential to a user while the credential is already linked to another user should raise
+    # Linking a credential to a user while the credential is
+    # already linked to another user should raise
     user_2 = await manager.async_create_user("User 2")
     with pytest.raises(ValueError):
         await manager.async_link_user(user_2, new_credential)

--- a/tests/common.py
+++ b/tests/common.py
@@ -43,6 +43,9 @@ from homeassistant.auth import (
 )
 from homeassistant.auth.permissions import system_policies
 from homeassistant.components import device_automation, persistent_notification as pn
+from homeassistant.components.device_automation import (
+    _async_get_device_automation_capabilities as async_get_device_automation_capabilities,
+)
 from homeassistant.components.logger import (
     DOMAIN as LOGGER_DOMAIN,
     SERVICE_SET_LEVEL,
@@ -117,10 +120,6 @@ from homeassistant.util.unit_system import METRIC_SYSTEM
 
 from .testing_config.custom_components.test_constant_deprecation import (
     import_deprecated_constant,
-)
-
-async_get_device_automation_capabilities = (
-    device_automation._async_get_device_automation_capabilities
 )
 
 __all__ = [

--- a/tests/common.py
+++ b/tests/common.py
@@ -43,9 +43,6 @@ from homeassistant.auth import (
 )
 from homeassistant.auth.permissions import system_policies
 from homeassistant.components import device_automation, persistent_notification as pn
-from homeassistant.components.device_automation import (
-    _async_get_device_automation_capabilities as async_get_device_automation_capabilities,
-)
 from homeassistant.components.logger import (
     DOMAIN as LOGGER_DOMAIN,
     SERVICE_SET_LEVEL,
@@ -120,6 +117,10 @@ from homeassistant.util.unit_system import METRIC_SYSTEM
 
 from .testing_config.custom_components.test_constant_deprecation import (
     import_deprecated_constant,
+)
+
+async_get_device_automation_capabilities = (
+    device_automation._async_get_device_automation_capabilities
 )
 
 __all__ = [

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -1347,7 +1347,8 @@ async def test_missing_supported_components(
     )
     assert warning_msg in caplog.text
 
-    # Clear caplog and call async_get_calendars again to verify warning is not logged again
+    # Clear caplog and call async_get_calendars again to verify
+    # warning is not logged again
     caplog.clear()
     client = MagicMock()
     client.principal().calendars.return_value = calendars
@@ -1355,8 +1356,9 @@ async def test_missing_supported_components(
     await async_get_calendars(hass, client, "VEVENT")
     assert warning_msg not in caplog.text
 
-    # Verify that querying a *different* component for the same calendar DOES log the warning again
-    # because de-duplication is keyed by (url, component).
+    # Verify that querying a *different* component for the same
+    # calendar DOES log the warning again because de-duplication
+    # is keyed by (url, component).
     vjournal_warning = (
         "CalDAV server does not report supported components for calendar Example. "
         "Not assuming support for requested component 'VJOURNAL'"
@@ -1370,7 +1372,7 @@ async def test_missing_supported_components_not_assumed(
     calendars: list[Mock],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test get_calendars excludes calendars when KeyError is raised for non-assumed components."""
+    """Test get_calendars excludes calendars on KeyError."""
     caplog.set_level(logging.WARNING, logger="homeassistant.components.caldav.api")
     calendars[0].get_supported_components.side_effect = KeyError()
     client = MagicMock()
@@ -1385,7 +1387,8 @@ async def test_missing_supported_components_not_assumed(
     )
     assert warning_msg in caplog.text
 
-    # Clear caplog and call async_get_calendars again to verify warning is not logged again
+    # Clear caplog and call async_get_calendars again to verify
+    # warning is not logged again
     caplog.clear()
     await async_get_calendars(hass, client, "VJOURNAL")
     assert warning_msg not in caplog.text

--- a/tests/components/home_connect/test_fan.py
+++ b/tests/components/home_connect/test_fan.py
@@ -49,6 +49,10 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import MockConfigEntry
 
+_FAN_SPEED_PERCENTAGE_KEY = (
+    OptionKey.HEATING_VENTILATION_AIR_CONDITIONING_AIR_CONDITIONER_FAN_SPEED_PERCENTAGE
+)
+
 
 @pytest.fixture
 def platforms() -> list[str]:
@@ -279,7 +283,7 @@ async def test_speed_percentage_functionality(
 ) -> None:
     """Test speed percentage functionality."""
     entity_id = "fan.air_conditioner"
-    option_key = OptionKey.HEATING_VENTILATION_AIR_CONDITIONING_AIR_CONDITIONER_FAN_SPEED_PERCENTAGE
+    option_key = _FAN_SPEED_PERCENTAGE_KEY
     if set_active_program_options_side_effect:
         client.set_active_program_option.side_effect = (
             set_active_program_options_side_effect

--- a/tests/components/ring/test_binary_sensor.py
+++ b/tests/components/ring/test_binary_sensor.py
@@ -129,9 +129,8 @@ async def test_binary_sensor(
     with patch("homeassistant.components.ring.PLATFORMS", [Platform.BINARY_SENSOR]):
         assert await async_setup_component(hass, DOMAIN, {})
 
-    on_event_cb = mock_ring_event_listener_class.return_value.add_notification_callback.call_args.args[
-        0
-    ]
+    listener = mock_ring_event_listener_class.return_value
+    on_event_cb = listener.add_notification_callback.call_args.args[0]
 
     # Default state is set to off
 

--- a/tests/components/ring/test_event.py
+++ b/tests/components/ring/test_event.py
@@ -90,9 +90,8 @@ async def test_event(
     start_time_str = "2024-09-04T15:32:53.892+00:00"
     start_time = datetime.strptime(start_time_str, "%Y-%m-%dT%H:%M:%S.%f%z")
     freezer.move_to(start_time)
-    on_event_cb = mock_ring_event_listener_class.return_value.add_notification_callback.call_args.args[
-        0
-    ]
+    listener = mock_ring_event_listener_class.return_value
+    on_event_cb = listener.add_notification_callback.call_args.args[0]
 
     # Default state is unknown
     entity_id = f"event.{device_name}_{alert_kind}"

--- a/tests/components/synology_dsm/test_sensor.py
+++ b/tests/components/synology_dsm/test_sensor.py
@@ -273,7 +273,8 @@ async def test_external_usb_new_device(
     # Mock the get_devices method to simulate a USB disk being added
     setup_dsm_with_usb.external_usb.get_devices = mock_dsm_external_usb_devices_usb2()
     # Coordinator refresh
-    await setup_dsm_with_usb.mock_entry.runtime_data.coordinator_central.async_request_refresh()
+    coordinator = setup_dsm_with_usb.mock_entry.runtime_data.coordinator_central
+    await coordinator.async_request_refresh()
     await hass.async_block_till_done()
 
     for sensor_id, (expected_state, expected_attrs) in chain(
@@ -338,7 +339,8 @@ async def test_external_usb_availability(
     # Mock the get_devices method to simulate no USB devices being connected
     setup_dsm_with_usb.external_usb.get_devices = mock_dsm_external_usb_devices_usb0()
     # Coordinator refresh
-    await setup_dsm_with_usb.mock_entry.runtime_data.coordinator_central.async_request_refresh()
+    coordinator = setup_dsm_with_usb.mock_entry.runtime_data.coordinator_central
+    await coordinator.async_request_refresh()
     await hass.async_block_till_done()
 
     for sensor_id, (

--- a/tests/components/zwave_js/scripts/test_convert_device_diagnostics_to_fixture.py
+++ b/tests/components/zwave_js/scripts/test_convert_device_diagnostics_to_fixture.py
@@ -8,16 +8,14 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.zwave_js.scripts import (
-    convert_device_diagnostics_to_fixture,
+from homeassistant.components.zwave_js.scripts.convert_device_diagnostics_to_fixture import (
+    extract_fixture_data,
+    get_fixtures_dir_path,
+    load_file,
+    main,
 )
 
 from tests.common import load_fixture
-
-extract_fixture_data = convert_device_diagnostics_to_fixture.extract_fixture_data
-get_fixtures_dir_path = convert_device_diagnostics_to_fixture.get_fixtures_dir_path
-load_file = convert_device_diagnostics_to_fixture.load_file
-main = convert_device_diagnostics_to_fixture.main
 
 
 def _minify(text: str) -> str:

--- a/tests/components/zwave_js/scripts/test_convert_device_diagnostics_to_fixture.py
+++ b/tests/components/zwave_js/scripts/test_convert_device_diagnostics_to_fixture.py
@@ -8,14 +8,16 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.zwave_js.scripts.convert_device_diagnostics_to_fixture import (
-    extract_fixture_data,
-    get_fixtures_dir_path,
-    load_file,
-    main,
+from homeassistant.components.zwave_js.scripts import (
+    convert_device_diagnostics_to_fixture,
 )
 
 from tests.common import load_fixture
+
+extract_fixture_data = convert_device_diagnostics_to_fixture.extract_fixture_data
+get_fixtures_dir_path = convert_device_diagnostics_to_fixture.get_fixtures_dir_path
+load_file = convert_device_diagnostics_to_fixture.load_file
+main = convert_device_diagnostics_to_fixture.main
 
 
 def _minify(text: str) -> str:

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -5185,7 +5185,9 @@ async def test_entries_for_label(
             "test_device",
             {
                 "en": {
-                    "component.test.device.test_device.name": "{placeholder} English dev"
+                    "component.test.device.test_device.name": (
+                        "{placeholder} English dev"
+                    )
                 },
             },
             {"placeholder": "special"},
@@ -5195,7 +5197,9 @@ async def test_entries_for_label(
             "test_device",
             {
                 "en": {
-                    "component.test.device.test_device.name": "English dev {placeholder}"
+                    "component.test.device.test_device.name": (
+                        "English dev {placeholder}"
+                    )
                 },
             },
             {"placeholder": "special"},
@@ -5253,8 +5257,9 @@ async def test_device_name_translation_placeholders(
             "test_device",
             {
                 "en": {
-                    "component.test.device.test_device.name": "{placeholder} English dev"
-                    " {2ndplaceholder}"
+                    "component.test.device.test_device.name": (
+                        "{placeholder} English dev {2ndplaceholder}"
+                    )
                 },
             },
             {"placeholder": "special"},
@@ -5269,8 +5274,9 @@ async def test_device_name_translation_placeholders(
             "test_device",
             {
                 "en": {
-                    "component.test.device.test_device.name": "{placeholder} English ent"
-                    " {2ndplaceholder}"
+                    "component.test.device.test_device.name": (
+                        "{placeholder} English ent {2ndplaceholder}"
+                    )
                 },
             },
             {"placeholder": "special"},
@@ -5284,7 +5290,9 @@ async def test_device_name_translation_placeholders(
             "test_device",
             {
                 "en": {
-                    "component.test.device.test_device.name": "{placeholder} English dev"
+                    "component.test.device.test_device.name": (
+                        "{placeholder} English dev"
+                    )
                 },
             },
             None,

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -415,9 +415,13 @@ def label_mock(hass: HomeAssistant) -> None:
         {
             config_entity_with_my_label.entity_id: config_entity_with_my_label,
             diag_entity_with_my_label.entity_id: diag_entity_with_my_label,
-            entity_with_label1_and_label2_from_device.entity_id: entity_with_label1_and_label2_from_device,
+            entity_with_label1_and_label2_from_device.entity_id: (
+                entity_with_label1_and_label2_from_device
+            ),
             entity_with_label1_from_device.entity_id: entity_with_label1_from_device,
-            entity_with_label1_from_device_and_different_area.entity_id: entity_with_label1_from_device_and_different_area,
+            entity_with_label1_from_device_and_different_area.entity_id: (
+                entity_with_label1_from_device_and_different_area
+            ),
             entity_with_labels_from_device.entity_id: entity_with_labels_from_device,
             entity_with_my_label.entity_id: entity_with_my_label,
             entity_with_no_labels.entity_id: entity_with_no_labels,

--- a/tests/helpers/test_target.py
+++ b/tests/helpers/test_target.py
@@ -297,9 +297,13 @@ def registries_mock(hass: HomeAssistant) -> None:
             entity_in_area_b.entity_id: entity_in_area_b,
             config_entity_with_my_label.entity_id: config_entity_with_my_label,
             diag_entity_with_my_label.entity_id: diag_entity_with_my_label,
-            entity_with_label1_and_label2_from_device.entity_id: entity_with_label1_and_label2_from_device,
+            entity_with_label1_and_label2_from_device.entity_id: (
+                entity_with_label1_and_label2_from_device
+            ),
             entity_with_label1_from_device.entity_id: entity_with_label1_from_device,
-            entity_with_label1_from_device_and_different_area.entity_id: entity_with_label1_from_device_and_different_area,
+            entity_with_label1_from_device_and_different_area.entity_id: (
+                entity_with_label1_from_device_and_different_area
+            ),
             entity_with_labels_from_device.entity_id: entity_with_labels_from_device,
             entity_with_my_label.entity_id: entity_with_my_label,
             hidden_entity_with_my_label.entity_id: hidden_entity_with_my_label,

--- a/tests/pylint/test_entity_description_defaults.py
+++ b/tests/pylint/test_entity_description_defaults.py
@@ -196,7 +196,7 @@ def test_local_entity_description_name_ignored(
     linter: UnittestLinter,
     defaults_checker: EntityDescriptionDefaultsChecker,
 ) -> None:
-    """Test that a local class named EntityDescription is not confused with the real one."""
+    """Test local EntityDescription class is not confused."""
     root_node = astroid.parse(
         """
 class EntityDescription:

--- a/tests/pylint/tests/test_redundant_usefixtures.py
+++ b/tests/pylint/tests/test_redundant_usefixtures.py
@@ -249,7 +249,7 @@ def test_conftest_autouse_named_fixture_redundant(
     usefixtures_checker: RedundantUsefixtures,
     tmp_path: Path,
 ) -> None:
-    """Test that autouse fixtures with name= override are detected by their public name."""
+    """Test autouse fixtures with name= override detection."""
     test_dir = tmp_path / "tests" / "components" / "test_int"
     test_dir.mkdir(parents=True)
 


### PR DESCRIPTION
## Proposed change

Fix E501 (line too long) violations in code that landed on dev after the line length cleanup PRs were merged. This catches up the codebase so the E501 rule can be enabled.

Changes are purely cosmetic: rewrapped comments, split long strings, shortened docstrings, extracted variables for long expressions. No logic changes.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr