### PR TITLE
Fix swallowed exception in cast play_media for unsupported apps

### DIFF
--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -772,9 +772,9 @@ class CastMediaPlayerEntity(CastDevice, MediaPlayerEntity):
                     media_id,
                     err,
                 )
+            # Fallback: if playlist parsing fails, forward the raw URL to the device
             # pylint: disable-next=home-assistant-action-swallowed-exception
             except PlaylistError as err:
-                # Fallback: forward the raw URL to the device
                 _LOGGER.warning(
                     "[%s %s] Failed to parse playlist %s: %s",
                     self.entity_id,

--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -718,9 +718,12 @@ class CastMediaPlayerEntity(CastDevice, MediaPlayerEntity):
                 await self.hass.async_add_executor_job(
                     self._quick_play, app_name, app_data
                 )
-            # pylint: disable-next=home-assistant-action-swallowed-exception
-            except NotImplementedError:
-                _LOGGER.error("App %s not supported", app_name)
+            except NotImplementedError as err:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="app_not_supported",
+                    translation_placeholders={"app_name": app_name},
+                ) from err
             return
 
         # Try the cast platforms
@@ -769,7 +772,9 @@ class CastMediaPlayerEntity(CastDevice, MediaPlayerEntity):
                     media_id,
                     err,
                 )
+            # pylint: disable-next=home-assistant-action-swallowed-exception
             except PlaylistError as err:
+                # Fallback: forward the raw URL to the device
                 _LOGGER.warning(
                     "[%s %s] Failed to parse playlist %s: %s",
                     self.entity_id,

--- a/homeassistant/components/cast/strings.json
+++ b/homeassistant/components/cast/strings.json
@@ -18,6 +18,11 @@
       }
     }
   },
+  "exceptions": {
+    "app_not_supported": {
+      "message": "App {app_name} is not supported"
+    }
+  },
   "options": {
     "error": {
       "invalid_known_hosts": "[%key:component::cast::config::error::invalid_known_hosts%]"

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -1263,9 +1263,14 @@ async def test_entity_play_media_cast_invalid(
 
     # Play_media - media_type cast with unsupported app
     quick_play_mock.side_effect = NotImplementedError()
-    await common.async_play_media(hass, "cast", '{"app_name": "unknown"}', entity_id)
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await common.async_play_media(
+            hass, "cast", '{"app_name": "unknown"}', entity_id
+        )
+    assert exc_info.value.translation_domain == "cast"
+    assert exc_info.value.translation_key == "app_not_supported"
+    assert exc_info.value.translation_placeholders == {"app_name": "unknown"}
     quick_play_mock.assert_called_once_with(ANY, "unknown", {})
-    assert "App unknown not supported" in caplog.text
 
 
 async def test_entity_play_media_sign_URL(hass: HomeAssistant, quick_play_mock) -> None:


### PR DESCRIPTION
## Proposed change

Replace the swallowed exception in the cast integration's `async_play_media` with a proper `HomeAssistantError`. Previously, when an unsupported app was passed to `quick_play`, the `NotImplementedError` was caught and only logged, giving the user no feedback in the UI and allowing automations to continue as if the action succeeded.

Also adds a pylint disable comment for the pre-existing `PlaylistError` fallback, which intentionally forwards the raw URL to the device when playlist parsing fails.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #170604
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr