### PR TITLE
Send update_type of 'updated' when a persistent notification already exists

### DIFF
--- a/homeassistant/components/persistent_notification/__init__.py
+++ b/homeassistant/components/persistent_notification/__init__.py
@@ -98,7 +98,9 @@ def async_create(
     notifications = _async_get_or_create_notifications(hass)
     if notification_id is None:
         notification_id = random_uuid_hex()
-    update_type = UpdateType.UPDATED if notification_id in notifications else UpdateType.ADDED
+    update_type = (
+        UpdateType.UPDATED if notification_id in notifications else UpdateType.ADDED
+    )
     notifications[notification_id] = {
         ATTR_MESSAGE: message,
         ATTR_NOTIFICATION_ID: notification_id,

--- a/homeassistant/components/persistent_notification/__init__.py
+++ b/homeassistant/components/persistent_notification/__init__.py
@@ -98,6 +98,7 @@ def async_create(
     notifications = _async_get_or_create_notifications(hass)
     if notification_id is None:
         notification_id = random_uuid_hex()
+    update_type = UpdateType.UPDATED if notification_id in notifications else UpdateType.ADDED
     notifications[notification_id] = {
         ATTR_MESSAGE: message,
         ATTR_NOTIFICATION_ID: notification_id,
@@ -108,7 +109,7 @@ def async_create(
     async_dispatcher_send(
         hass,
         SIGNAL_PERSISTENT_NOTIFICATIONS_UPDATED,
-        UpdateType.ADDED,
+        update_type,
         {notification_id: notifications[notification_id]},
     )
 

--- a/tests/components/persistent_notification/test_trigger.py
+++ b/tests/components/persistent_notification/test_trigger.py
@@ -100,3 +100,17 @@ async def test_automation_with_pn_trigger(hass: HomeAssistant) -> None:
     assert result["notification"]["notification_id"] == "42"
     assert result["notification"]["message"] == "Forty Two"
     assert result_any[2] == result_id[0]
+
+    await hass.services.async_call(
+        pn.DOMAIN,
+        "create",
+        {"notification_id": "42", "message": "Is the answer to the ultimate question"},
+        blocking=True,
+    )
+
+    result = result_any[3].get("trigger")
+    assert result["platform"] == "persistent_notification"
+    assert result["update_type"] == pn.UpdateType.UPDATED
+    assert result["notification"]["notification_id"] == "42"
+    assert result["notification"]["message"] == "Is the answer to the ultimate question"
+    assert result_any[3] == result_id[0]

--- a/tests/components/persistent_notification/test_trigger.py
+++ b/tests/components/persistent_notification/test_trigger.py
@@ -113,4 +113,4 @@ async def test_automation_with_pn_trigger(hass: HomeAssistant) -> None:
     assert result["update_type"] == pn.UpdateType.UPDATED
     assert result["notification"]["notification_id"] == "42"
     assert result["notification"]["message"] == "Is the answer to the ultimate question"
-    assert result_any[3] == result_id[0]
+    assert result_any[3] == result_id[1]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
This is a breaking change for anyone with existing automations relying on an `update_type` of `added` only. If wanting to capture *any* new notifications (including those which overwrite existing notifications of the same id) then automations should now trigger on an `update_type` of `added` or `updated`.

An example of an automation trigger before this change:
```
automation:
  - triggers:
      - trigger: persistent_notification
        update_type:
          - added
```

Which, after this change, should be changed to:
```
automation:
  - triggers:
      - trigger: persistent_notification
        update_type:
          - added
          - updated
```

## Proposed change
Before this change, creating or updating a persistent notification sends a trigger of `UpdateType.ADDED`, and *nothing* sends an `UpdateType.UPDATED`. This fix means that `UpdateType.UPDATED` will be triggered when updating a persistent notification that already exists. New notifications will continue to trigger `UpdateType.ADDED`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes and closes issue: [170315](https://github.com/home-assistant/core/issues/170315)
- Link to documentation pull request: N/A (documentation already implies this behaviour)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] ~~Any generated code has been carefully reviewed for correctness and compliance with project standards.~~

If user exposed functionality or configuration variables are added/changed:

- [x] ~~Documentation added/updated for [www.home-assistant.io][docs-repository]~~

If the code communicates with devices, web services, or third-party tools:

- [x] ~~The [manifest file][manifest-docs] has all fields filled out correctly.~~  
      ~~Updated and included derived files by running: `python3 -m script.hassfest`.~~
- [x] ~~New or updated dependencies have been added to `requirements_all.txt`.~~  
      ~~Updated by running `python3 -m script.gen_requirements_all`.~~
- [x] ~~For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.~~

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
