### PR TITLE
Fix swallowed exceptions in rest switch action handlers

### DIFF
--- a/homeassistant/components/rest/strings.json
+++ b/homeassistant/components/rest/strings.json
@@ -1,4 +1,15 @@
 {
+  "exceptions": {
+    "error_communicating": {
+      "message": "Error communicating with {resource}"
+    },
+    "turn_off_failed": {
+      "message": "Failed to turn off {resource}"
+    },
+    "turn_on_failed": {
+      "message": "Failed to turn on {resource}"
+    }
+  },
   "services": {
     "reload": {
       "description": "Reloads REST entities from the YAML-configuration.",

--- a/homeassistant/components/rest/switch.py
+++ b/homeassistant/components/rest/switch.py
@@ -27,7 +27,7 @@ from homeassistant.const import (
     CONF_VERIFY_SSL,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import PlatformNotReady
+from homeassistant.exceptions import HomeAssistantError, PlatformNotReady
 from homeassistant.helpers import config_validation as cv, template
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.httpx_client import get_async_client
@@ -39,6 +39,8 @@ from homeassistant.helpers.trigger_template_entity import (
     ValueTemplate,
 )
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 CONF_BODY_OFF = "body_off"
@@ -163,16 +165,21 @@ class RestSwitch(ManualTriggerEntity, SwitchEntity):
 
         try:
             req = await self.set_device_state(body_on_t)
+        except (TimeoutError, httpx.RequestError) as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="error_communicating",
+                translation_placeholders={"resource": self._resource},
+            ) from err
 
-            if HTTPStatus.OK <= req.status_code < HTTPStatus.MULTIPLE_CHOICES:
-                self._attr_is_on = True
-            else:
-                _LOGGER.error(
-                    "Can't turn on %s. Is resource/endpoint offline?", self._resource
-                )
-        # pylint: disable-next=home-assistant-action-swallowed-exception
-        except TimeoutError, httpx.RequestError:
-            _LOGGER.error("Error while switching on %s", self._resource)
+        if not HTTPStatus.OK <= req.status_code < HTTPStatus.MULTIPLE_CHOICES:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="turn_on_failed",
+                translation_placeholders={"resource": self._resource},
+            )
+
+        self._attr_is_on = True
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
@@ -180,15 +187,21 @@ class RestSwitch(ManualTriggerEntity, SwitchEntity):
 
         try:
             req = await self.set_device_state(body_off_t)
-            if HTTPStatus.OK <= req.status_code < HTTPStatus.MULTIPLE_CHOICES:
-                self._attr_is_on = False
-            else:
-                _LOGGER.error(
-                    "Can't turn off %s. Is resource/endpoint offline?", self._resource
-                )
-        # pylint: disable-next=home-assistant-action-swallowed-exception
-        except TimeoutError, httpx.RequestError:
-            _LOGGER.error("Error while switching off %s", self._resource)
+        except (TimeoutError, httpx.RequestError) as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="error_communicating",
+                translation_placeholders={"resource": self._resource},
+            ) from err
+
+        if not HTTPStatus.OK <= req.status_code < HTTPStatus.MULTIPLE_CHOICES:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="turn_off_failed",
+                translation_placeholders={"resource": self._resource},
+            )
+
+        self._attr_is_on = False
 
     async def set_device_state(self, body: Any) -> httpx.Response:
         """Send a state update to the device."""

--- a/tests/components/rest/test_switch.py
+++ b/tests/components/rest/test_switch.py
@@ -41,6 +41,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.trigger_template_entity import CONF_PICTURE
 from homeassistant.setup import async_setup_component
@@ -308,18 +309,20 @@ async def test_turn_on_status_not_ok(hass: HomeAssistant) -> None:
     await _async_setup_test_switch(hass)
 
     route = respx.post(RESOURCE) % HTTPStatus.INTERNAL_SERVER_ERROR
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "switch.foo"},
-        blocking=True,
-    )
-    await hass.async_block_till_done()
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.foo"},
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "turn_on_failed"
 
     last_call = route.calls[-1]
     last_request: httpx.Request = last_call.request
     assert last_request.content.decode() == "ON"
-    assert hass.states.get("switch.foo").state == STATE_UNKNOWN
 
 
 @respx.mock
@@ -328,15 +331,16 @@ async def test_turn_on_timeout(hass: HomeAssistant) -> None:
     await _async_setup_test_switch(hass)
 
     respx.post(RESOURCE).mock(side_effect=httpx.TimeoutException(""))
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "switch.foo"},
-        blocking=True,
-    )
-    await hass.async_block_till_done()
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.foo"},
+            blocking=True,
+        )
 
-    assert hass.states.get("switch.foo").state == STATE_UNKNOWN
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "error_communicating"
 
 
 @respx.mock
@@ -370,19 +374,20 @@ async def test_turn_off_status_not_ok(hass: HomeAssistant) -> None:
     await _async_setup_test_switch(hass)
 
     route = respx.post(RESOURCE) % HTTPStatus.INTERNAL_SERVER_ERROR
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "switch.foo"},
-        blocking=True,
-    )
-    await hass.async_block_till_done()
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "switch.foo"},
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "turn_off_failed"
 
     last_call = route.calls[-1]
     last_request: httpx.Request = last_call.request
     assert last_request.content.decode() == "OFF"
-
-    assert hass.states.get("switch.foo").state == STATE_UNKNOWN
 
 
 @respx.mock
@@ -391,15 +396,16 @@ async def test_turn_off_timeout(hass: HomeAssistant) -> None:
     await _async_setup_test_switch(hass)
 
     respx.post(RESOURCE).mock(side_effect=httpx.TimeoutException(""))
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "switch.foo"},
-        blocking=True,
-    )
-    await hass.async_block_till_done()
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "switch.foo"},
+            blocking=True,
+        )
 
-    assert hass.states.get("switch.foo").state == STATE_UNKNOWN
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "error_communicating"
 
 
 @respx.mock


### PR DESCRIPTION
## Proposed change

Replace swallowed exceptions in the REST switch integration's `async_turn_on` and `async_turn_off` methods with proper `HomeAssistantError` raises. Previously, connection errors and non-success HTTP responses were only logged, giving the user no feedback in the UI and allowing automations to continue as if the action succeeded.

Two distinct translation keys differentiate the failure modes:
- `error_communicating` for connection/timeout errors
- `turn_on_failed` / `turn_off_failed` for non-success HTTP status codes

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #170635
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr