### PR TITLE
Fix swallowed exceptions in VLC Telnet actions

### DIFF
--- a/homeassistant/components/vlc_telnet/media_player.py
+++ b/homeassistant/components/vlc_telnet/media_player.py
@@ -75,6 +75,7 @@ def catch_vlc_errors[_VlcDeviceT: VlcDevice, **_P](
                     raise HomeAssistantError(
                         translation_domain=DOMAIN,
                         translation_key="command_error",
+                        translation_placeholders={"error": str(err)},
                     ) from err
             except ConnectError as err:
                 if self._attr_available:
@@ -85,6 +86,7 @@ def catch_vlc_errors[_VlcDeviceT: VlcDevice, **_P](
                     raise HomeAssistantError(
                         translation_domain=DOMAIN,
                         translation_key="connect_error",
+                        translation_placeholders={"error": str(err)},
                     ) from err
 
         return wrapper

--- a/homeassistant/components/vlc_telnet/media_player.py
+++ b/homeassistant/components/vlc_telnet/media_player.py
@@ -78,11 +78,13 @@ def catch_vlc_errors[_VlcDeviceT: VlcDevice, **_P](
                         translation_placeholders={"error": str(err)},
                     ) from err
             except ConnectError as err:
-                if self._attr_available:
-                    if log:
+                if log:
+                    if self._attr_available:
                         LOGGER.error("Connection error: %s", err)
+                        self._attr_available = False
+                else:
                     self._attr_available = False
-                if not log:
+                    self.async_write_ha_state()
                     raise HomeAssistantError(
                         translation_domain=DOMAIN,
                         translation_key="connect_error",

--- a/homeassistant/components/vlc_telnet/media_player.py
+++ b/homeassistant/components/vlc_telnet/media_player.py
@@ -19,6 +19,7 @@ from homeassistant.components.media_player import (
 from homeassistant.config_entries import SOURCE_HASSIO, ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import dt as dt_util
@@ -51,23 +52,44 @@ async def async_setup_entry(
 
 
 def catch_vlc_errors[_VlcDeviceT: VlcDevice, **_P](
-    func: Callable[Concatenate[_VlcDeviceT, _P], Awaitable[None]],
-) -> Callable[Concatenate[_VlcDeviceT, _P], Coroutine[Any, Any, None]]:
+    *, log: bool = False
+) -> Callable[
+    [Callable[Concatenate[_VlcDeviceT, _P], Awaitable[None]]],
+    Callable[Concatenate[_VlcDeviceT, _P], Coroutine[Any, Any, None]],
+]:
     """Catch VLC errors."""
 
-    @wraps(func)
-    async def wrapper(self: _VlcDeviceT, *args: _P.args, **kwargs: _P.kwargs) -> None:
-        """Catch VLC errors and modify availability."""
-        try:
-            await func(self, *args, **kwargs)
-        except CommandError as err:
-            LOGGER.error("Command error: %s", err)
-        except ConnectError as err:
-            if self._attr_available:
-                LOGGER.error("Connection error: %s", err)
-                self._attr_available = False
+    def decorator(
+        func: Callable[Concatenate[_VlcDeviceT, _P], Awaitable[None]],
+    ) -> Callable[Concatenate[_VlcDeviceT, _P], Coroutine[Any, Any, None]]:
+        @wraps(func)
+        async def wrapper(
+            self: _VlcDeviceT, *args: _P.args, **kwargs: _P.kwargs
+        ) -> None:
+            try:
+                await func(self, *args, **kwargs)
+            except CommandError as err:
+                if log:
+                    LOGGER.error("Command error: %s", err)
+                else:
+                    raise HomeAssistantError(
+                        translation_domain=DOMAIN,
+                        translation_key="command_error",
+                    ) from err
+            except ConnectError as err:
+                if self._attr_available:
+                    if log:
+                        LOGGER.error("Connection error: %s", err)
+                    self._attr_available = False
+                if not log:
+                    raise HomeAssistantError(
+                        translation_domain=DOMAIN,
+                        translation_key="connect_error",
+                    ) from err
 
-    return wrapper
+        return wrapper
+
+    return decorator
 
 
 class VlcDevice(MediaPlayerEntity):
@@ -110,7 +132,7 @@ class VlcDevice(MediaPlayerEntity):
         )
         self._using_addon = config_entry.source == SOURCE_HASSIO
 
-    @catch_vlc_errors
+    @catch_vlc_errors(log=True)
     async def async_update(self) -> None:
         """Get the latest details from the device."""
         if not self.available:
@@ -183,14 +205,12 @@ class VlcDevice(MediaPlayerEntity):
             else:
                 self._attr_media_title = media_title
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
-    @catch_vlc_errors
+    @catch_vlc_errors()
     async def async_media_seek(self, position: float) -> None:
         """Seek the media to a specific location."""
         await self._vlc.seek(round(position))
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
-    @catch_vlc_errors
+    @catch_vlc_errors()
     async def async_mute_volume(self, mute: bool) -> None:
         """Mute the volume."""
         assert self._attr_volume_level is not None
@@ -202,8 +222,7 @@ class VlcDevice(MediaPlayerEntity):
 
         self._attr_is_volume_muted = mute
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
-    @catch_vlc_errors
+    @catch_vlc_errors()
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         await self._vlc.set_volume(round(volume * MAX_VOLUME))
@@ -213,8 +232,7 @@ class VlcDevice(MediaPlayerEntity):
             # This can happen if we were muted and then see a volume_up.
             self._attr_is_volume_muted = False
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
-    @catch_vlc_errors
+    @catch_vlc_errors()
     async def async_media_play(self) -> None:
         """Send play command."""
         status = await self._vlc.status()
@@ -225,8 +243,7 @@ class VlcDevice(MediaPlayerEntity):
             await self._vlc.play()
         self._attr_state = MediaPlayerState.PLAYING
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
-    @catch_vlc_errors
+    @catch_vlc_errors()
     async def async_media_pause(self) -> None:
         """Send pause command."""
         status = await self._vlc.status()
@@ -236,15 +253,13 @@ class VlcDevice(MediaPlayerEntity):
 
         self._attr_state = MediaPlayerState.PAUSED
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
-    @catch_vlc_errors
+    @catch_vlc_errors()
     async def async_media_stop(self) -> None:
         """Send stop command."""
         await self._vlc.stop()
         self._attr_state = MediaPlayerState.IDLE
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
-    @catch_vlc_errors
+    @catch_vlc_errors()
     async def async_play_media(
         self, media_type: MediaType | str, media_id: str, **kwargs: Any
     ) -> None:
@@ -264,26 +279,22 @@ class VlcDevice(MediaPlayerEntity):
         await self._vlc.add(media_id)
         self._attr_state = MediaPlayerState.PLAYING
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
-    @catch_vlc_errors
+    @catch_vlc_errors()
     async def async_media_previous_track(self) -> None:
         """Send previous track command."""
         await self._vlc.prev()
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
-    @catch_vlc_errors
+    @catch_vlc_errors()
     async def async_media_next_track(self) -> None:
         """Send next track command."""
         await self._vlc.next()
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
-    @catch_vlc_errors
+    @catch_vlc_errors()
     async def async_clear_playlist(self) -> None:
         """Clear players playlist."""
         await self._vlc.clear()
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
-    @catch_vlc_errors
+    @catch_vlc_errors()
     async def async_set_shuffle(self, shuffle: bool) -> None:
         """Enable/disable shuffle mode."""
         shuffle_command: Literal["on", "off"] = "on" if shuffle else "off"

--- a/homeassistant/components/vlc_telnet/strings.json
+++ b/homeassistant/components/vlc_telnet/strings.json
@@ -35,5 +35,13 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "command_error": {
+      "message": "Command error"
+    },
+    "connect_error": {
+      "message": "Connection error"
+    }
   }
 }

--- a/homeassistant/components/vlc_telnet/strings.json
+++ b/homeassistant/components/vlc_telnet/strings.json
@@ -38,10 +38,10 @@
   },
   "exceptions": {
     "command_error": {
-      "message": "Command error"
+      "message": "Command error: {error}"
     },
     "connect_error": {
-      "message": "Connection error"
+      "message": "Connection error: {error}"
     }
   }
 }

--- a/tests/components/vlc_telnet/conftest.py
+++ b/tests/components/vlc_telnet/conftest.py
@@ -1,0 +1,57 @@
+"""Fixtures for vlc_telnet tests."""
+
+from collections.abc import AsyncGenerator
+from unittest.mock import MagicMock, create_autospec, patch
+
+from aiovlc.client import Client
+import pytest
+
+from homeassistant.components.vlc_telnet.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+ENTRY_CONFIG = {
+    CONF_HOST: "1.1.1.1",
+    CONF_PORT: 4212,
+    CONF_PASSWORD: "test-password",
+}
+
+
+@pytest.fixture
+def config_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Return the default mocked config entry."""
+    entry = MockConfigEntry(domain=DOMAIN, data=ENTRY_CONFIG)
+    entry.add_to_hass(hass)
+    return entry
+
+
+@pytest.fixture
+def vlc_mock() -> MagicMock:
+    """Return a mocked VLC client."""
+    mock = create_autospec(Client, instance=True)
+    status_result = MagicMock()
+    status_result.audio_volume = 100
+    status_result.state = "idle"
+    mock.status.return_value = status_result
+    mock.get_length.return_value = MagicMock(length=0)
+    mock.get_time.return_value = MagicMock(time=0)
+    mock.info.return_value = MagicMock(data={})
+    return mock
+
+
+@pytest.fixture
+async def setup_integration(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    vlc_mock: MagicMock,
+) -> AsyncGenerator[None]:
+    """Set up the VLC integration."""
+    with patch(
+        "homeassistant.components.vlc_telnet.Client",
+        return_value=vlc_mock,
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+        yield

--- a/tests/components/vlc_telnet/test_media_player.py
+++ b/tests/components/vlc_telnet/test_media_player.py
@@ -146,10 +146,17 @@ async def test_action_handler_raises_homeassistant_error(
 
 
 @pytest.mark.parametrize(
-    ("error_class", "expected_state"),
+    ("error_class", "expected_state", "expected_log"),
     [
-        pytest.param(CommandError, "idle", id="command_error"),
-        pytest.param(ConnectError, STATE_UNAVAILABLE, id="connect_error"),
+        pytest.param(
+            CommandError, "idle", "Command error: test error", id="command_error"
+        ),
+        pytest.param(
+            ConnectError,
+            STATE_UNAVAILABLE,
+            "Connection error: test error",
+            id="connect_error",
+        ),
     ],
 )
 @pytest.mark.usefixtures("setup_integration")
@@ -157,8 +164,10 @@ async def test_update_logs_error_instead_of_raising(
     hass: HomeAssistant,
     vlc_mock: MagicMock,
     freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
     error_class: type[Exception],
     expected_state: str,
+    expected_log: str,
 ) -> None:
     """Test that async_update logs VLC errors instead of raising."""
     vlc_mock.status.side_effect = error_class("test error")
@@ -170,3 +179,4 @@ async def test_update_logs_error_instead_of_raising(
     state = hass.states.get(ENTITY_ID)
     assert state
     assert state.state == expected_state
+    assert expected_log in caplog.text

--- a/tests/components/vlc_telnet/test_media_player.py
+++ b/tests/components/vlc_telnet/test_media_player.py
@@ -1,0 +1,172 @@
+"""Test the VLC media player Telnet integration."""
+
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+from aiovlc.exceptions import CommandError, ConnectError
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+
+from homeassistant.components.media_player import (
+    ATTR_MEDIA_CONTENT_ID,
+    ATTR_MEDIA_CONTENT_TYPE,
+    ATTR_MEDIA_SEEK_POSITION,
+    ATTR_MEDIA_SHUFFLE,
+    ATTR_MEDIA_VOLUME_LEVEL,
+    ATTR_MEDIA_VOLUME_MUTED,
+    DOMAIN as MEDIA_PLAYER_DOMAIN,
+    SCAN_INTERVAL,
+    SERVICE_CLEAR_PLAYLIST,
+    SERVICE_PLAY_MEDIA,
+    MediaType,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_MEDIA_NEXT_TRACK,
+    SERVICE_MEDIA_PAUSE,
+    SERVICE_MEDIA_PLAY,
+    SERVICE_MEDIA_PREVIOUS_TRACK,
+    SERVICE_MEDIA_SEEK,
+    SERVICE_MEDIA_STOP,
+    SERVICE_SHUFFLE_SET,
+    SERVICE_VOLUME_MUTE,
+    SERVICE_VOLUME_SET,
+    STATE_UNAVAILABLE,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from tests.common import async_fire_time_changed
+
+ENTITY_ID = "media_player.vlc_telnet"
+
+
+@pytest.mark.parametrize(
+    ("service", "service_data", "vlc_method"),
+    [
+        pytest.param(
+            SERVICE_MEDIA_SEEK,
+            {ATTR_MEDIA_SEEK_POSITION: 100.0},
+            "seek",
+            id="media_seek",
+        ),
+        pytest.param(
+            SERVICE_VOLUME_MUTE,
+            {ATTR_MEDIA_VOLUME_MUTED: True},
+            "set_volume",
+            id="volume_mute",
+        ),
+        pytest.param(
+            SERVICE_VOLUME_SET,
+            {ATTR_MEDIA_VOLUME_LEVEL: 0.5},
+            "set_volume",
+            id="volume_set",
+        ),
+        pytest.param(
+            SERVICE_MEDIA_PLAY,
+            {},
+            "status",
+            id="media_play",
+        ),
+        pytest.param(
+            SERVICE_MEDIA_PAUSE,
+            {},
+            "status",
+            id="media_pause",
+        ),
+        pytest.param(
+            SERVICE_MEDIA_STOP,
+            {},
+            "stop",
+            id="media_stop",
+        ),
+        pytest.param(
+            SERVICE_PLAY_MEDIA,
+            {
+                ATTR_MEDIA_CONTENT_ID: "test.mp3",
+                ATTR_MEDIA_CONTENT_TYPE: MediaType.MUSIC,
+            },
+            "add",
+            id="play_media",
+        ),
+        pytest.param(
+            SERVICE_MEDIA_PREVIOUS_TRACK,
+            {},
+            "prev",
+            id="media_previous_track",
+        ),
+        pytest.param(
+            SERVICE_MEDIA_NEXT_TRACK,
+            {},
+            "next",
+            id="media_next_track",
+        ),
+        pytest.param(
+            SERVICE_CLEAR_PLAYLIST,
+            {},
+            "clear",
+            id="clear_playlist",
+        ),
+        pytest.param(
+            SERVICE_SHUFFLE_SET,
+            {ATTR_MEDIA_SHUFFLE: True},
+            "random",
+            id="shuffle_set",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    ("error_class", "translation_key"),
+    [
+        pytest.param(CommandError, "command_error", id="command_error"),
+        pytest.param(ConnectError, "connect_error", id="connect_error"),
+    ],
+)
+@pytest.mark.usefixtures("setup_integration")
+async def test_action_handler_raises_homeassistant_error(
+    hass: HomeAssistant,
+    vlc_mock: MagicMock,
+    service: str,
+    service_data: dict,
+    vlc_method: str,
+    error_class: type[Exception],
+    translation_key: str,
+) -> None:
+    """Test that action handlers raise HomeAssistantError on VLC errors."""
+    getattr(vlc_mock, vlc_method).side_effect = error_class("test error")
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            MEDIA_PLAYER_DOMAIN,
+            service,
+            {ATTR_ENTITY_ID: ENTITY_ID, **service_data},
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == translation_key
+
+
+@pytest.mark.parametrize(
+    ("error_class", "expected_state"),
+    [
+        pytest.param(CommandError, "idle", id="command_error"),
+        pytest.param(ConnectError, STATE_UNAVAILABLE, id="connect_error"),
+    ],
+)
+@pytest.mark.usefixtures("setup_integration")
+async def test_update_logs_error_instead_of_raising(
+    hass: HomeAssistant,
+    vlc_mock: MagicMock,
+    freezer: FrozenDateTimeFactory,
+    error_class: type[Exception],
+    expected_state: str,
+) -> None:
+    """Test that async_update logs VLC errors instead of raising."""
+    vlc_mock.status.side_effect = error_class("test error")
+
+    freezer.tick(SCAN_INTERVAL + timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state
+    assert state.state == expected_state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Raise HomeAssistantError instead of just logging the error in service action handlers.
- Keep logging in async_update.
- Add tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170646
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
