### PR TITLE
Group sequential executor jobs in roomba vacuum

### DIFF
--- a/homeassistant/components/roomba/vacuum.py
+++ b/homeassistant/components/roomba/vacuum.py
@@ -304,14 +304,13 @@ class RoombaVacuumCarpetBoost(RoombaVacuum):
         else:
             _LOGGER.error("No such fan speed available: %s", fan_speed)
             return
+
         # The set_preference method does only accept string values
-        await self.hass.async_add_executor_job(
-            self.vacuum.set_preference, "carpetBoost", str(carpet_boost)
-        )
-        # pylint: disable-next=home-assistant-sequential-executor-jobs
-        await self.hass.async_add_executor_job(
-            self.vacuum.set_preference, "vacHigh", str(high_perf)
-        )
+        def _set_fan_speed_preferences() -> None:
+            self.vacuum.set_preference("carpetBoost", str(carpet_boost))
+            self.vacuum.set_preference("vacHigh", str(high_perf))
+
+        await self.hass.async_add_executor_job(_set_fan_speed_preferences)
 
 
 class BraavaJet(IRobotVacuum):
@@ -387,15 +386,14 @@ class BraavaJet(IRobotVacuum):
             overlap = OVERLAP_DEEP
         else:
             overlap = OVERLAP_EXTENDED
-        await self.hass.async_add_executor_job(
-            self.vacuum.set_preference, "rankOverlap", overlap
-        )
-        # pylint: disable-next=home-assistant-sequential-executor-jobs
-        await self.hass.async_add_executor_job(
-            self.vacuum.set_preference,
-            "padWetness",
-            {"disposable": spray, "reusable": spray},
-        )
+
+        def _set_mop_preferences() -> None:
+            self.vacuum.set_preference("rankOverlap", overlap)
+            self.vacuum.set_preference(
+                "padWetness", {"disposable": spray, "reusable": spray}
+            )
+
+        await self.hass.async_add_executor_job(_set_mop_preferences)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:


### PR DESCRIPTION
## Proposed change

Group sequential `async_add_executor_job` calls into single executor jobs in the roomba vacuum integration. This avoids unnecessary context switches between the event loop and the executor thread.

Two methods are affected:
- `async_set_fan_speed` in `RoombaVacuum`: groups `carpetBoost` and `vacHigh` preference calls
- `async_set_fan_speed` in `BraavaJet`: groups `rankOverlap` and `padWetness` preference calls

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #170819
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr