### PR TITLE
Bump dsmr-parser to 1.7.0

### DIFF
--- a/homeassistant/components/dsmr/config_flow.py
+++ b/homeassistant/components/dsmr/config_flow.py
@@ -11,7 +11,6 @@ from dsmr_parser.clients.rfxtrx_protocol import (
     create_rfxtrx_tcp_dsmr_reader,
 )
 from dsmr_parser.objects import DSMRObject
-import serial
 import voluptuous as vol
 
 from homeassistant.components import usb
@@ -117,7 +116,7 @@ class DSMRConnection:
 
         try:
             transport, protocol = await asyncio.create_task(reader_factory())
-        except serial.SerialException, OSError:
+        except OSError:
             LOGGER.exception("Error connecting to DSMR")
             return False
 

--- a/homeassistant/components/dsmr/manifest.json
+++ b/homeassistant/components/dsmr/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["dsmr_parser"],
-  "requirements": ["dsmr-parser==1.5.0"]
+  "requirements": ["dsmr-parser==1.7.0"]
 }

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -15,7 +15,6 @@ from dsmr_parser.clients.rfxtrx_protocol import (
     create_rfxtrx_tcp_dsmr_reader,
 )
 from dsmr_parser.objects import DSMRObject, MbusDevice, Telegram
-import serial
 
 from homeassistant.components.sensor import (
     DOMAIN as SENSOR_DOMAIN,
@@ -846,7 +845,7 @@ async def async_setup_entry(
                 # throttle reconnect attempts
                 await asyncio.sleep(DEFAULT_RECONNECT_INTERVAL)
 
-            except serial.SerialException, OSError:
+            except OSError:
                 # Log any error while establishing connection and drop to retry
                 # connection wait
                 LOGGER.exception("Error connecting to DSMR")

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -853,7 +853,7 @@ dremel3dpy==2.1.1
 dropmqttapi==1.0.3
 
 # homeassistant.components.dsmr
-dsmr-parser==1.5.0
+dsmr-parser==1.7.0
 
 # homeassistant.components.dwd_weather_warnings
 dwdwfsapi==1.0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -765,7 +765,7 @@ dremel3dpy==2.1.1
 dropmqttapi==1.0.3
 
 # homeassistant.components.dsmr
-dsmr-parser==1.5.0
+dsmr-parser==1.7.0
 
 # homeassistant.components.dwd_weather_warnings
 dwdwfsapi==1.0.7

--- a/tests/components/dsmr/test_config_flow.py
+++ b/tests/components/dsmr/test_config_flow.py
@@ -5,7 +5,6 @@ from typing import Any
 from unittest.mock import DEFAULT, AsyncMock, MagicMock, patch
 
 import pytest
-import serial
 
 from homeassistant import config_entries
 from homeassistant.components.dsmr.const import DOMAIN
@@ -366,7 +365,7 @@ async def test_setup_serial_fail(
     # override the mock to have it fail the first time and succeed after
     first_fail_connection_factory = AsyncMock(
         return_value=(transport, protocol),
-        side_effect=chain([serial.SerialException], repeat(DEFAULT)),
+        side_effect=chain([OSError], repeat(DEFAULT)),
     )
 
     assert result["type"] is FlowResultType.FORM


### PR DESCRIPTION
## Breaking change


## Proposed change

Bumps `dsmr-parser` from 1.5.0 to 1.7.0 for the `dsmr` integration.

Notable changes across 1.6.0 and 1.7.0:
- 1.6.0: dropped Python 3.8 support; removed the `pytz` dependency in favor of the stdlib `datetime` timezone handling.
- 1.7.0: dropped Python 3.9 support; switched the serial backend from `pyserial`/`pyserial-asyncio-fast` to `serialx`.

Because `dsmr-parser` 1.7.0 no longer pulls in `pyserial`, the integration is updated to no longer import the `serial` module directly:
- Removed `import serial` from `config_flow.py` and `sensor.py`.
- Replaced `except serial.SerialException, OSError:` with `except OSError:`. `serialx` connection failures raise `OSError` subclasses (e.g. `FileNotFoundError`), and `pyserial`'s `SerialException` was itself an `OSError` subclass, so behavior is preserved. This follows the [pyserial-to-serialx migration guidance](https://developers.home-assistant.io/blog/2026/04/27/pyserial-to-serialx/) of catching the broader `OSError` instead of `SerialException`.

The public `dsmr-parser` API used by the integration (`create_dsmr_reader`, `create_tcp_dsmr_reader`, `create_rfxtrx_dsmr_reader`, `create_rfxtrx_tcp_dsmr_reader`, `obis_references`, `Telegram`, `DSMRObject`, `MbusDevice`) is unchanged.

- Changelog / release notes: https://github.com/ndokter/dsmr_parser/releases
- This builds on #171043, which bumped `serialx` to 1.8.0 (the version required by `dsmr-parser` 1.7.0).

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: `https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure`

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtZkDL9UcMvC8K2q834osD)_