### PR TITLE
Group sequential executor jobs in soma setup

### DIFF
--- a/homeassistant/components/soma/__init__.py
+++ b/homeassistant/components/soma/__init__.py
@@ -59,9 +59,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: SomaConfigEntry) -> bool:
     """Set up Soma from a config entry."""
-    api = await hass.async_add_executor_job(SomaApi, entry.data[HOST], entry.data[PORT])
-    # pylint: disable-next=home-assistant-sequential-executor-jobs
-    devices = await hass.async_add_executor_job(api.list_devices)
+
+    def _setup_api() -> tuple[SomaApi, dict[str, Any]]:
+        api = SomaApi(entry.data[HOST], entry.data[PORT])
+        return api, api.list_devices()
+
+    api, devices = await hass.async_add_executor_job(_setup_api)
     entry.runtime_data = SomaData(api, devices["shades"])
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)


### PR DESCRIPTION
## Proposed change

Group sequential `async_add_executor_job` calls into a single executor job in the soma integration's `async_setup_entry`. The `SomaApi` constructor and `list_devices` calls are now combined to avoid an unnecessary context switch between the event loop and the executor thread.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #170821
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr