### PR TITLE
Enable current/power/voltage sensors by default for Tuya electrical categories

### DIFF
--- a/homeassistant/components/tuya/sensor.py
+++ b/homeassistant/components/tuya/sensor.py
@@ -637,14 +637,12 @@ SENSORS: dict[DeviceCategory, tuple[TuyaSensorEntityDescription, ...]] = {
             device_class=SensorDeviceClass.CURRENT,
             state_class=SensorStateClass.MEASUREMENT,
             suggested_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
-            entity_registry_enabled_default=False,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.CUR_POWER,
             translation_key="power",
             device_class=SensorDeviceClass.POWER,
             state_class=SensorStateClass.MEASUREMENT,
-            entity_registry_enabled_default=False,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.CUR_VOLTAGE,
@@ -652,7 +650,6 @@ SENSORS: dict[DeviceCategory, tuple[TuyaSensorEntityDescription, ...]] = {
             device_class=SensorDeviceClass.VOLTAGE,
             state_class=SensorStateClass.MEASUREMENT,
             suggested_unit_of_measurement=UnitOfElectricPotential.VOLT,
-            entity_registry_enabled_default=False,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.ADD_ELE,
@@ -1167,14 +1164,12 @@ SENSORS: dict[DeviceCategory, tuple[TuyaSensorEntityDescription, ...]] = {
             device_class=SensorDeviceClass.CURRENT,
             state_class=SensorStateClass.MEASUREMENT,
             suggested_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
-            entity_registry_enabled_default=False,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.CUR_POWER,
             translation_key="power",
             device_class=SensorDeviceClass.POWER,
             state_class=SensorStateClass.MEASUREMENT,
-            entity_registry_enabled_default=False,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.CUR_VOLTAGE,
@@ -1182,7 +1177,6 @@ SENSORS: dict[DeviceCategory, tuple[TuyaSensorEntityDescription, ...]] = {
             device_class=SensorDeviceClass.VOLTAGE,
             state_class=SensorStateClass.MEASUREMENT,
             suggested_unit_of_measurement=UnitOfElectricPotential.VOLT,
-            entity_registry_enabled_default=False,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.ADD_ELE,

--- a/homeassistant/components/tuya/sensor.py
+++ b/homeassistant/components/tuya/sensor.py
@@ -110,7 +110,7 @@ BATTERY_SENSORS: tuple[TuyaSensorEntityDescription, ...] = (
 
 # All descriptions can be found here. Mostly the Integer data types in the
 # default status set of each category (that don't have a set instruction)
-# end up being a sensor. test
+# end up being a sensor.
 SENSORS: dict[DeviceCategory, tuple[TuyaSensorEntityDescription, ...]] = {
     DeviceCategory.AQCZ: (
         TuyaSensorEntityDescription(

--- a/homeassistant/components/tuya/sensor.py
+++ b/homeassistant/components/tuya/sensor.py
@@ -110,7 +110,7 @@ BATTERY_SENSORS: tuple[TuyaSensorEntityDescription, ...] = (
 
 # All descriptions can be found here. Mostly the Integer data types in the
 # default status set of each category (that don't have a set instruction)
-# end up being a sensor.
+# end up being a sensor. test
 SENSORS: dict[DeviceCategory, tuple[TuyaSensorEntityDescription, ...]] = {
     DeviceCategory.AQCZ: (
         TuyaSensorEntityDescription(


### PR DESCRIPTION
## Proposed change

  Remove `entity_registry_enabled_default=False` from `cur_current`, `cur_power`, and `cur_voltage` sensor descriptions for Tuya electrical device
  categories (KG, TDQ, and their aliases CZ/PC).

  **Why this change makes sense:**

  1. **Inconsistency with existing behavior**: In the same sensor block, `add_ele` (Total energy) is already enabled by default for these exact categories.
  Users can see cumulative energy but not the live readings (current/power/voltage) that feed into it — this is inconsistent and confusing.

  2. **Fixture data supports the change**: Based on test fixtures in this repository:
     - `cz` (Socket): 32/53 fixtures (60%) report these DPs
     - `pc` (Power strip): 2/4 fixtures (50%) report these DPs
     - `tdq` (Circuit breaker): 1/11 fixtures (9%)
     - `kg` (Switch): 0/3 fixtures (0%)

  3. **No risk for devices without these DPs**: The `get_default_definition` check in `async_setup_entry` ensures that entities are **only created** when a
  device actually exposes the DP. Removing the disabled-by-default flag does not add entities to devices that lack these DPs — it only makes already-created
   entities visible without requiring manual intervention.

  4. **Low fixture coverage ≠ low real-world coverage**: The `kg` and `tdq` fixture samples (3 and 11 respectively) are too small to be statistically
  representative. Regardless, point 3 guarantees that even if a device doesn't have these DPs, no entity is created — so the change is safe for all devices
  in these categories.

  5. **User expectation**: Smart sockets and metering switches are primarily purchased for energy monitoring. Hiding live electrical readings behind a
  manual "enable disabled entity" workflow contradicts the out-of-box experience.

  **Impact scope**: This change only affects entity registration for **newly added** devices. Existing devices retain their current entity registry state —
  HA's entity registry is persistent and does not re-evaluate `entity_registry_enabled_default` for existing entries (see `entity_registry.py` L1312-1313).

  ## Type of change

  - [ ] Dependency upgrade
  - [ ] Bugfix (non-breaking change which fixes an issue)
  - [ ] New integration (thank you!)
  - [x] New feature (which adds functionality to an existing integration)
  - [ ] Deprecation (breaking change to happen in the future)
  - [ ] Breaking change (fix/feature causing existing functionality to break)
  - [ ] Code quality improvements to existing code or addition of tests

  ## Additional information

  - This PR fixes or closes issue: fixes #
  - This PR is related to issue:
  - Link to documentation pull request:
  - Link to developer documentation pull request:
  - Link to frontend pull request:

  ## Checklist

  - [x] I understand the code I am submitting and can explain how it works.
  - [x] The code change is tested and works locally.
  - [x] Local tests pass. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
  - [x] I have followed the [perfect PR recommendations][perfect-pr]
  - [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
  - [x] Tests have been added to verify that the new code works.
  - [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

  If user exposed functionality or configuration variables are added/changed:

  - [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

  If the code communicates with devices, web services, or third-party tools:

  - [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
        Updated and included derived files by running: `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt`.
        Updated by running `python3 -m script.gen_requirements_all`.
  - [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

  To help with the load of incoming pull requests:

  - [ ] I have reviewed two other [open pull requests][prs] in this repository.

  [prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

  [dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
  [manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
  [quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
  [docs-repository]: https://github.com/home-assistant/home-assistant.io
  [perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr