### PR TITLE
Use HA timezone for date in recollect_waste

### DIFF
--- a/homeassistant/components/recollect_waste/calendar.py
+++ b/homeassistant/components/recollect_waste/calendar.py
@@ -7,6 +7,7 @@ from aiorecollect.client import PickupEvent
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util import dt as dt_util
 
 from .coordinator import RecollectWasteConfigEntry, ReCollectWasteDataUpdateCoordinator
 from .entity import ReCollectWasteEntity
@@ -68,7 +69,7 @@ class ReCollectWasteCalendar(ReCollectWasteEntity, CalendarEntity):
             current_event = next(
                 event
                 for event in self.coordinator.data
-                if event.date >= datetime.date.today()  # noqa: DTZ011
+                if event.date >= dt_util.now().date()
             )
         except StopIteration:
             self._event = None

--- a/homeassistant/components/recollect_waste/coordinator.py
+++ b/homeassistant/components/recollect_waste/coordinator.py
@@ -1,6 +1,6 @@
 """Data update coordinator for ReCollect Waste."""
 
-from datetime import date, timedelta
+from datetime import timedelta
 
 from aiorecollect.client import Client, PickupEvent
 from aiorecollect.errors import RecollectError
@@ -9,6 +9,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from .const import CONF_PLACE_ID, CONF_SERVICE_ID, LOGGER
 
@@ -52,7 +53,7 @@ class ReCollectWasteDataUpdateCoordinator(DataUpdateCoordinator[list[PickupEvent
             # This ensures that data about when the next pickup is will be
             # returned when the next pickup is the first day of the next month.
             # Ex: Today is August 31st, tomorrow is a pickup on September 1st.
-            today = date.today()  # noqa: DTZ011
+            today = dt_util.now().date()
             return await self._client.async_get_pickup_events(
                 start_date=today,
                 end_date=today + timedelta(days=35),

--- a/homeassistant/components/recollect_waste/sensor.py
+++ b/homeassistant/components/recollect_waste/sensor.py
@@ -1,7 +1,5 @@
 """Support for ReCollect Waste sensors."""
 
-from datetime import date
-
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -9,6 +7,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util import dt as dt_util
 
 from .const import LOGGER
 from .coordinator import RecollectWasteConfigEntry, ReCollectWasteDataUpdateCoordinator
@@ -70,7 +69,9 @@ class ReCollectWasteSensor(ReCollectWasteEntity, SensorEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        relevant_events = (e for e in self.coordinator.data if e.date >= date.today())  # noqa: DTZ011
+        relevant_events = (
+            e for e in self.coordinator.data if e.date >= dt_util.now().date()
+        )
         pickup_index = self.PICKUP_INDEX_MAP[self.entity_description.key]
 
         try:


### PR DESCRIPTION
## Proposed change

Replace `date.today()` with `dt_util.now().date()` in three places across the recollect_waste integration. `date.today()` returns the date based on the system's local timezone (often UTC), not the Home Assistant configured timezone. This causes incorrect pickup date filtering for users whose HA timezone differs from the server timezone (common with cloud/VM setups running UTC).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #170579
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr