### PR TITLE
Use HA timezone for date in withings

### DIFF
--- a/homeassistant/components/saj/sensor.py
+++ b/homeassistant/components/saj/sensor.py
@@ -34,6 +34,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.start import async_at_start
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -123,7 +124,7 @@ async def async_setup_platform(
             # Sensors with live values like "temperature" or "current_power"
             # will also be reset to None.
             if not success and (
-                (sensor.per_day_basis and date.today() > sensor.date_updated)  # noqa: DTZ011
+                (sensor.per_day_basis and dt_util.now().date() > sensor.date_updated)
                 or (not sensor.per_day_basis and not sensor.per_total_basis)
             ):
                 state_unknown = True

--- a/homeassistant/components/saj/sensor.py
+++ b/homeassistant/components/saj/sensor.py
@@ -34,7 +34,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.start import async_at_start
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -124,7 +123,7 @@ async def async_setup_platform(
             # Sensors with live values like "temperature" or "current_power"
             # will also be reset to None.
             if not success and (
-                (sensor.per_day_basis and dt_util.now().date() > sensor.date_updated)
+                (sensor.per_day_basis and date.today() > sensor.date_updated)  # noqa: DTZ011
                 or (not sensor.per_day_basis and not sensor.per_total_basis)
             ):
                 state_unknown = True

--- a/homeassistant/components/withings/coordinator.py
+++ b/homeassistant/components/withings/coordinator.py
@@ -1,7 +1,7 @@
 """Withings coordinator."""
 
 from abc import abstractmethod
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 from aiowithings import (
@@ -270,7 +270,7 @@ class WithingsActivityDataUpdateCoordinator(
                 self._last_valid_update
             )
 
-        today = date.today()  # noqa: DTZ011
+        today = dt_util.now().date()
         for activity in activities:
             if activity.date == today:
                 self._previous_data = activity


### PR DESCRIPTION
## Proposed change

Replace `date.today()` with `dt_util.now().date()` in the withings integration's activity coordinator. `date.today()` returns the date based on the system's local timezone (often UTC), not the Home Assistant configured timezone. This causes today's activity data to be missed or yesterday's to be shown for users whose HA timezone differs from the server timezone.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #170591
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr