### PR TITLE
Add Russian language support to Fish Audio TTS

### DIFF
--- a/homeassistant/components/fish_audio/const.py
+++ b/homeassistant/components/fish_audio/const.py
@@ -28,6 +28,7 @@ TTS_SUPPORTED_LANGUAGES = [
     "fr",
     "es",
     "ko",
+    "ru",
 ]
 
 


### PR DESCRIPTION
The Fish Audio TTS integration does not declare "ru" in TTS_SUPPORTED_LANGUAGES. Because Home Assistant filters TTS engines by language in voice-assistant pipelines, Fish Audio voices are invisible in Russian-language pipelines — even though the Fish Audio API itself is language-agnostic.

This PR adds "ru" to TTS_SUPPORTED_LANGUAGES so that Russian assist pipelines (e.g., using faster_whisper + Qwen) can select Fish Audio voices such as J.A.R.V.I.S.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- Link to documentation pull request: N/A
- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] I have followed the development checklist.