### PR TITLE
Make info/warning alerts in matter update release notes translatable

### DIFF
--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -1,4 +1,8 @@
 {
+  "common": {
+    "release_notes_non_main_net_warning": "Update provided by {update_source}. Installing this update is at your own risk and you may run into unexpected problems such as the need to re-add and factory reset your device.",
+    "release_notes_update_process_info": "The update process can take a while, especially for battery powered devices. Please be patient and wait until the update process is fully completed. Do not remove power from the device while it's updating. The device may restart during the update process and be unavailable for several minutes."
+  },
   "config": {
     "abort": {
       "addon_get_discovery_info_failed": "Failed to get Matter Server app discovery info.",

--- a/homeassistant/components/matter/update.py
+++ b/homeassistant/components/matter/update.py
@@ -21,7 +21,9 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.restore_state import ExtraStoredData
+from homeassistant.helpers.translation import async_get_translations
 
+from .const import DOMAIN
 from .entity import MatterEntity, MatterEntityDescription
 from .helpers import MatterConfigEntry
 from .models import MatterDiscoverySchema
@@ -30,6 +32,13 @@ SCAN_INTERVAL = timedelta(hours=12)
 POLL_AFTER_INSTALL = 10
 
 ATTR_SOFTWARE_UPDATE = "software_update"
+
+TRANSLATION_KEY_RELEASE_NOTES_INFO = (
+    f"component.{DOMAIN}.common.release_notes_update_process_info"
+)
+TRANSLATION_KEY_RELEASE_NOTES_WARNING = (
+    f"component.{DOMAIN}.common.release_notes_non_main_net_warning"
+)
 
 
 @dataclass
@@ -170,30 +179,22 @@ class MatterUpdate(MatterEntity, UpdateEntity):
         if self.state != STATE_ON:
             return None
 
+        translations = await async_get_translations(
+            self.hass, self.hass.config.language, "common", {DOMAIN}
+        )
+
         release_notes = ""
 
         # insert extra heavy warning case the update is not from the main net
         if self._software_update.update_source is not UpdateSource.MAIN_NET_DCL:
-            release_notes += (
-                "\n\n<ha-alert alert-type='warning'>"
-                "Update provided by "
-                f"{self._software_update.update_source.value}. "
-                "Installing this update is at your own risk "
-                "and you may run into unexpected "
-                "problems such as the need to re-add and "
-                "factory reset your device.</ha-alert>\n\n"
+            warning = translations[TRANSLATION_KEY_RELEASE_NOTES_WARNING].format(
+                update_source=self._software_update.update_source.value
             )
-        return release_notes + (
-            "\n\n<ha-alert alert-type='info'>"
-            "The update process can take a while, "
-            "especially for battery powered devices. "
-            "Please be patient and wait until the update "
-            "process is fully completed. Do not remove power "
-            "from the device while it's updating. "
-            "The device may restart during the update process "
-            "and be unavailable for several minutes."
-            "</ha-alert>\n\n"
-        )
+            release_notes += (
+                f"\n\n<ha-alert alert-type='warning'>{warning}</ha-alert>\n\n"
+            )
+        info = translations[TRANSLATION_KEY_RELEASE_NOTES_INFO]
+        return release_notes + f"\n\n<ha-alert alert-type='info'>{info}</ha-alert>\n\n"
 
     async def async_added_to_hass(self) -> None:
         """Call when the entity is added to hass."""

--- a/tests/components/matter/test_update.py
+++ b/tests/components/matter/test_update.py
@@ -1,7 +1,7 @@
 """Test Matter number entities."""
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 from chip.clusters import Objects as clusters
 from chip.clusters.ClusterObjects import ClusterAttributeDescriptor
@@ -15,11 +15,7 @@ from homeassistant.components.homeassistant import (
     DOMAIN as HA_DOMAIN,
     SERVICE_UPDATE_ENTITY,
 )
-from homeassistant.components.matter.update import (
-    SCAN_INTERVAL,
-    TRANSLATION_KEY_RELEASE_NOTES_INFO,
-    TRANSLATION_KEY_RELEASE_NOTES_WARNING,
-)
+from homeassistant.components.matter.update import SCAN_INTERVAL
 from homeassistant.components.update import (
     ATTR_VERSION,
     DOMAIN as UPDATE_DOMAIN,
@@ -275,9 +271,9 @@ async def test_update_check_with_same_numeric_version(
             UpdateSource.LOCAL,
             [
                 "<ha-alert alert-type='warning'>",
-                "Translated warning for local.",
+                "Update provided by local.",
                 "<ha-alert alert-type='info'>",
-                "Translated update process info.",
+                "The update process can take a while",
             ],
             [],
         ),
@@ -285,11 +281,11 @@ async def test_update_check_with_same_numeric_version(
             UpdateSource.MAIN_NET_DCL,
             [
                 "<ha-alert alert-type='info'>",
-                "Translated update process info.",
+                "The update process can take a while",
             ],
             [
                 "<ha-alert alert-type='warning'>",
-                "Translated warning",
+                "Update provided by",
             ],
         ),
     ],
@@ -319,34 +315,23 @@ async def test_update_release_notes(
 
     ws_client = await hass_ws_client(hass)
 
-    with patch(
-        "homeassistant.components.matter.update.async_get_translations",
-        AsyncMock(
-            return_value={
-                TRANSLATION_KEY_RELEASE_NOTES_WARNING: (
-                    "Translated warning for {update_source}."
-                ),
-                TRANSLATION_KEY_RELEASE_NOTES_INFO: "Translated update process info.",
-            }
-        ),
-    ):
-        await hass.services.async_call(
-            HA_DOMAIN,
-            SERVICE_UPDATE_ENTITY,
-            {
-                ATTR_ENTITY_ID: "update.mock_dimmable_light_firmware",
-            },
-            blocking=True,
-        )
+    await hass.services.async_call(
+        HA_DOMAIN,
+        SERVICE_UPDATE_ENTITY,
+        {
+            ATTR_ENTITY_ID: "update.mock_dimmable_light_firmware",
+        },
+        blocking=True,
+    )
 
-        await ws_client.send_json(
-            {
-                "id": 1,
-                "type": "update/release_notes",
-                "entity_id": "update.mock_dimmable_light_firmware",
-            }
-        )
-        result = await ws_client.receive_json()
+    await ws_client.send_json(
+        {
+            "id": 1,
+            "type": "update/release_notes",
+            "entity_id": "update.mock_dimmable_light_firmware",
+        }
+    )
+    result = await ws_client.receive_json()
 
     assert result["success"]
     release_notes = result["result"]

--- a/tests/components/matter/test_update.py
+++ b/tests/components/matter/test_update.py
@@ -1,7 +1,7 @@
 """Test Matter number entities."""
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from chip.clusters import Objects as clusters
 from chip.clusters.ClusterObjects import ClusterAttributeDescriptor
@@ -15,7 +15,11 @@ from homeassistant.components.homeassistant import (
     DOMAIN as HA_DOMAIN,
     SERVICE_UPDATE_ENTITY,
 )
-from homeassistant.components.matter.update import SCAN_INTERVAL
+from homeassistant.components.matter.update import (
+    SCAN_INTERVAL,
+    TRANSLATION_KEY_RELEASE_NOTES_INFO,
+    TRANSLATION_KEY_RELEASE_NOTES_WARNING,
+)
 from homeassistant.components.update import (
     ATTR_VERSION,
     DOMAIN as UPDATE_DOMAIN,
@@ -38,6 +42,7 @@ from tests.common import (
     async_mock_restore_state_shutdown_restart,
     mock_restore_cache_with_extra_data,
 )
+from tests.typing import WebSocketGenerator
 
 TEST_SOFTWARE_VERSION = MatterSoftwareVersion(
     vid=65521,
@@ -260,6 +265,93 @@ async def test_update_check_with_same_numeric_version(
     assert state.state == STATE_OFF
     assert state.attributes.get("installed_version") == "v1.0"
     assert state.attributes.get("latest_version") == "v1.0"
+
+
+@pytest.mark.parametrize("node_fixture", ["mock_dimmable_light"])
+@pytest.mark.parametrize(
+    ("update_source", "expected_fragments", "unexpected_fragments"),
+    [
+        (
+            UpdateSource.LOCAL,
+            [
+                "<ha-alert alert-type='warning'>",
+                "Translated warning for local.",
+                "<ha-alert alert-type='info'>",
+                "Translated update process info.",
+            ],
+            [],
+        ),
+        (
+            UpdateSource.MAIN_NET_DCL,
+            [
+                "<ha-alert alert-type='info'>",
+                "Translated update process info.",
+            ],
+            [
+                "<ha-alert alert-type='warning'>",
+                "Translated warning",
+            ],
+        ),
+    ],
+)
+@pytest.mark.usefixtures("matter_node")
+async def test_update_release_notes(
+    hass: HomeAssistant,
+    check_node_update: AsyncMock,
+    hass_ws_client: WebSocketGenerator,
+    update_source: UpdateSource,
+    expected_fragments: list[str],
+    unexpected_fragments: list[str],
+) -> None:
+    """Test release notes include translated alert content."""
+    await async_setup_component(hass, HA_DOMAIN, {})
+    check_node_update.return_value = MatterSoftwareVersion(
+        vid=65521,
+        pid=32768,
+        software_version=2,
+        software_version_string="v2.0",
+        firmware_information="",
+        min_applicable_software_version=0,
+        max_applicable_software_version=1,
+        release_notes_url="http://home-assistant.io/non-existing-product",
+        update_source=update_source,
+    )
+
+    ws_client = await hass_ws_client(hass)
+
+    with patch(
+        "homeassistant.components.matter.update.async_get_translations",
+        AsyncMock(
+            return_value={
+                TRANSLATION_KEY_RELEASE_NOTES_WARNING: (
+                    "Translated warning for {update_source}."
+                ),
+                TRANSLATION_KEY_RELEASE_NOTES_INFO: "Translated update process info.",
+            }
+        ),
+    ):
+        await hass.services.async_call(
+            HA_DOMAIN,
+            SERVICE_UPDATE_ENTITY,
+            {
+                ATTR_ENTITY_ID: "update.mock_dimmable_light_firmware",
+            },
+            blocking=True,
+        )
+
+        await ws_client.send_json(
+            {
+                "id": 1,
+                "type": "update/release_notes",
+                "entity_id": "update.mock_dimmable_light_firmware",
+            }
+        )
+        result = await ws_client.receive_json()
+
+    assert result["success"]
+    release_notes = result["result"]
+    assert all(fragment in release_notes for fragment in expected_fragments)
+    assert all(fragment not in release_notes for fragment in unexpected_fragments)
 
 
 @pytest.mark.parametrize("node_fixture", ["mock_dimmable_light"])


### PR DESCRIPTION
## Proposed change
Make the info and warning alerts in Matter update release notes translatable instead of hardcoding it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
