### PR TITLE
Restore Avea brightness on turn on

### DIFF
--- a/homeassistant/components/avea/light.py
+++ b/homeassistant/components/avea/light.py
@@ -32,6 +32,7 @@ from .const import DOMAIN, INTEGRATION_TITLE, UNKNOWN_NAME
 _LOGGER = logging.getLogger(__name__)
 UPDATE_EXCEPTIONS = (BleakError, OSError, RuntimeError)
 BREAKS_IN_HA_VERSION = "2026.12.0"
+AVEA_MAX_BRIGHTNESS = 4095
 
 
 def _normalize_name(name: str | None) -> str | None:
@@ -39,6 +40,16 @@ def _normalize_name(name: str | None) -> str | None:
     if not name or name == UNKNOWN_NAME:
         return None
     return name
+
+
+def _ha_brightness_to_avea(brightness: int) -> int:
+    """Convert Home Assistant brightness to Avea brightness."""
+    return round((brightness / 255) * AVEA_MAX_BRIGHTNESS)
+
+
+def _avea_brightness_to_ha(brightness: int) -> int:
+    """Convert Avea brightness to Home Assistant brightness."""
+    return round(255 * (brightness / AVEA_MAX_BRIGHTNESS))
 
 
 def _create_deprecated_yaml_issue(hass: HomeAssistant) -> None:
@@ -176,21 +187,26 @@ class AveaLight(LightEntity):
         self._light = light
         self._attr_name = entry_title
         self._attr_brightness = light.brightness
+        self._last_brightness = 255
 
     def turn_on(self, **kwargs: Any) -> None:
         """Instruct the light to turn on."""
         if not kwargs:
-            self._light.set_brightness(4095)
+            self._light.set_brightness(_ha_brightness_to_avea(self._last_brightness))
         else:
             if ATTR_BRIGHTNESS in kwargs:
-                bright = round((kwargs[ATTR_BRIGHTNESS] / 255) * 4095)
-                self._light.set_brightness(bright)
+                brightness = kwargs[ATTR_BRIGHTNESS]
+                if brightness:
+                    self._last_brightness = brightness
+                self._light.set_brightness(_ha_brightness_to_avea(brightness))
             if ATTR_HS_COLOR in kwargs:
                 rgb = color_util.color_hs_to_RGB(*kwargs[ATTR_HS_COLOR])
                 self._light.set_rgb(rgb[0], rgb[1], rgb[2])
 
     def turn_off(self, **kwargs: Any) -> None:
         """Instruct the light to turn off."""
+        if self._attr_brightness:
+            self._last_brightness = self._attr_brightness
         self._light.set_brightness(0)
 
     def update(self) -> None:
@@ -206,5 +222,7 @@ class AveaLight(LightEntity):
 
         if brightness is not None:
             self._attr_is_on = brightness != 0
-            self._attr_brightness = round(255 * (brightness / 4095))
+            self._attr_brightness = _avea_brightness_to_ha(brightness)
+            if self._attr_brightness:
+                self._last_brightness = self._attr_brightness
         self._attr_hs_color = color_util.color_RGB_to_hs(*rgb_color)

--- a/tests/components/avea/test_light.py
+++ b/tests/components/avea/test_light.py
@@ -108,6 +108,40 @@ async def test_turn_on_and_off(
     bulb.set_brightness.assert_called_with(0)
 
 
+async def test_turn_on_restores_last_brightness(
+    hass: HomeAssistant,
+    setup_integration: MagicMock,
+) -> None:
+    """Test turning the light on restores the last brightness."""
+    bulb = setup_integration
+
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {ATTR_ENTITY_ID: "light.bedroom", ATTR_BRIGHTNESS: 128},
+        blocking=True,
+    )
+    bulb.set_brightness.assert_called_with(2056)
+
+    bulb.set_brightness.reset_mock()
+    await hass.services.async_call(
+        "light",
+        "turn_off",
+        {ATTR_ENTITY_ID: "light.bedroom"},
+        blocking=True,
+    )
+    bulb.set_brightness.assert_called_with(0)
+
+    bulb.set_brightness.reset_mock()
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {ATTR_ENTITY_ID: "light.bedroom"},
+        blocking=True,
+    )
+    bulb.set_brightness.assert_called_with(2056)
+
+
 async def test_update_state(
     hass: HomeAssistant, setup_integration: MagicMock, freezer: FrozenDateTimeFactory
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When an Avea light is turned on without an explicit brightness value, Home Assistant currently sends the maximum Avea brightness value. This means a light set to a lower brightness, turned off, and then turned on again from Home Assistant comes back at 100% instead of the previous brightness.

This changes the Avea light entity to remember the last non-zero Home Assistant brightness during the current runtime and reuse it when `light.turn_on` is called without a brightness value. Explicit brightness service calls still take precedence.

The brightness conversion between Home Assistant's 0-255 scale and Avea's 0-4095 scale was moved into small local helpers to make the behavior easier to follow.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
