### PR TITLE
Make info alert in zha update release notes translatable

### DIFF
--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -1,4 +1,8 @@
 {
+  "common": {
+    "release_notes_battery_powered": "Battery powered devices can sometimes take multiple hours to update and you may need to wake the device for the update to begin.",
+    "release_notes_reliability": "If you are having issues updating a specific device, make sure that you've eliminated [common environmental issues]({zha_docs_network_reliability}) that could be affecting network reliability. OTA updates require a reliable network."
+  },
   "config": {
     "abort": {
       "cannot_form_network": "Could not form a new Zigbee network.\n\nError: {error}",

--- a/homeassistant/components/zha/update.py
+++ b/homeassistant/components/zha/update.py
@@ -18,11 +18,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.translation import async_get_translations
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
 )
 
+from .const import DOMAIN
 from .entity import ZHAEntity
 from .helpers import (
     SIGNAL_ADD_ENTITIES,
@@ -34,16 +36,12 @@ from .helpers import (
 
 _LOGGER = logging.getLogger(__name__)
 
-OTA_MESSAGE_BATTERY_POWERED = (
-    "Battery powered devices can sometimes take multiple hours to update and you may"
-    " need to wake the device for the update to begin."
+TRANSLATION_KEY_RELEASE_NOTES_BATTERY_POWERED = (
+    f"component.{DOMAIN}.common.release_notes_battery_powered"
 )
-
 ZHA_DOCS_NETWORK_RELIABILITY = "https://www.home-assistant.io/integrations/zha/#zigbee-interference-avoidance-and-network-rangecoverage-optimization"
-OTA_MESSAGE_RELIABILITY = (
-    "If you are having issues updating a specific device, make sure that you've"
-    f" eliminated [common environmental issues]({ZHA_DOCS_NETWORK_RELIABILITY}) that"
-    " could be affecting network reliability. OTA updates require a reliable network."
+TRANSLATION_KEY_RELEASE_NOTES_RELIABILITY = (
+    f"component.{DOMAIN}.common.release_notes_reliability"
 )
 
 
@@ -163,13 +161,22 @@ class ZHAFirmwareUpdateEntity(
         This is suitable for a long changelog that does not fit in the release_summary
         property. The returned string can contain markdown.
         """
+        translations = await async_get_translations(
+            self.hass, self.hass.config.language, "common", {DOMAIN}
+        )
+        reliability = translations[TRANSLATION_KEY_RELEASE_NOTES_RELIABILITY].format(
+            zha_docs_network_reliability=ZHA_DOCS_NETWORK_RELIABILITY
+        )
 
         if self.entity_data.device_proxy.device.is_mains_powered:
-            header = f"<ha-alert alert-type='info'>{OTA_MESSAGE_RELIABILITY}</ha-alert>"
+            header = f"<ha-alert alert-type='info'>{reliability}</ha-alert>"
         else:
+            battery_powered = translations[
+                TRANSLATION_KEY_RELEASE_NOTES_BATTERY_POWERED
+            ]
             header = (
                 "<ha-alert alert-type='info'>"
-                f"{OTA_MESSAGE_BATTERY_POWERED} {OTA_MESSAGE_RELIABILITY}"
+                f"{battery_powered} {reliability}"
                 "</ha-alert>"
             )
 

--- a/tests/components/zha/test_update.py
+++ b/tests/components/zha/test_update.py
@@ -37,10 +37,6 @@ from homeassistant.components.zha.helpers import (
     get_zha_gateway,
     get_zha_gateway_proxy,
 )
-from homeassistant.components.zha.update import (
-    OTA_MESSAGE_BATTERY_POWERED,
-    OTA_MESSAGE_RELIABILITY,
-)
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     STATE_OFF,
@@ -643,11 +639,42 @@ async def test_firmware_update_raises(
         )
 
 
+@pytest.mark.parametrize(
+    ("is_mains_powered", "expected_fragments", "unexpected_fragments"),
+    [
+        (
+            True,
+            [
+                "<ha-alert alert-type='info'>",
+                "common environmental issues",
+                "OTA updates require a reliable network.",
+                "Some lengthy release notes",
+            ],
+            [
+                "Battery powered devices",
+            ],
+        ),
+        (
+            False,
+            [
+                "<ha-alert alert-type='info'>",
+                "Battery powered devices",
+                "common environmental issues",
+                "OTA updates require a reliable network.",
+                "Some lengthy release notes",
+            ],
+            [],
+        ),
+    ],
+)
 async def test_update_release_notes(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     setup_zha: Callable[..., Coroutine[None]],
     zigpy_device_mock: Callable[..., Device],
+    is_mains_powered: bool,
+    expected_fragments: list[str],
+    unexpected_fragments: list[str],
 ) -> None:
     """Test ZHA update platform release notes."""
     await setup_zha()
@@ -667,9 +694,9 @@ async def test_update_release_notes(
 
     ws_client = await hass_ws_client(hass)
 
-    # Mains-powered devices
     with patch(
-        "zha.zigbee.device.Device.is_mains_powered", PropertyMock(return_value=True)
+        "zha.zigbee.device.Device.is_mains_powered",
+        PropertyMock(return_value=is_mains_powered),
     ):
         await ws_client.send_json(
             {
@@ -680,28 +707,11 @@ async def test_update_release_notes(
         )
 
         result = await ws_client.receive_json()
-        assert result["success"] is True
-        assert "Some lengthy release notes" in result["result"]
-        assert OTA_MESSAGE_RELIABILITY in result["result"]
-        assert OTA_MESSAGE_BATTERY_POWERED not in result["result"]
 
-    # Battery-powered devices
-    with patch(
-        "zha.zigbee.device.Device.is_mains_powered", PropertyMock(return_value=False)
-    ):
-        await ws_client.send_json(
-            {
-                "id": 2,
-                "type": "update/release_notes",
-                "entity_id": entity_id,
-            }
-        )
-
-        result = await ws_client.receive_json()
-        assert result["success"] is True
-        assert "Some lengthy release notes" in result["result"]
-        assert OTA_MESSAGE_RELIABILITY in result["result"]
-        assert OTA_MESSAGE_BATTERY_POWERED in result["result"]
+    assert result["success"] is True
+    release_notes = result["result"]
+    assert all(fragment in release_notes for fragment in expected_fragments)
+    assert all(fragment not in release_notes for fragment in unexpected_fragments)
 
 
 async def test_update_version_sync_device_registry(


### PR DESCRIPTION
## Proposed change
Make the info alert in zha update release notes translatable instead of hardcoding it

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
