### PR TITLE
Bump pyenvisalink to 4.9

### DIFF
--- a/homeassistant/components/envisalink/manifest.json
+++ b/homeassistant/components/envisalink/manifest.json
@@ -6,5 +6,5 @@
   "iot_class": "local_push",
   "loggers": ["pyenvisalink"],
   "quality_scale": "legacy",
-  "requirements": ["pyenvisalink==4.7"]
+  "requirements": ["pyenvisalink==4.9"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2135,7 +2135,7 @@ pyemoncms==0.1.3
 pyenphase==2.4.8
 
 # homeassistant.components.envisalink
-pyenvisalink==4.7
+pyenvisalink==4.9
 
 # homeassistant.components.ephember
 pyephember2==0.4.12


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps `pyenvisalink` from 4.7 to 4.9 to pull in an upstream fix for DSC alarm panel keypad blanking.

When keypad blanking is enabled on a DSC panel, the panel enters a low-power display-off state after inactivity and stops broadcasting partition state to the Envisalink (EVL). The EVL then silently rejects TPI arm/disarm commands (030/031/032/040) because it pre-validates against a stale "not ready" partition state, so Home Assistant arm/disarm requests appear to do nothing.

`pyenvisalink` 4.9 detects this condition via a 35-second partition-event timeout and sends a `#` keypress to wake the panel before issuing arm/disarm commands. `_cachedCode` handling ensures the wake keypress does not consume the user's code. A `#` is also sent after login to force a fresh state broadcast, so Home Assistant shows accurate state on startup. The behavior is a no-op for users without keypad blanking enabled.

- Upstream PR: https://github.com/ufodone/pyenvisalink/pull/37 (merged into the `v4` branch, which is the branch Home Assistant core consumes)
- Release on PyPI: https://pypi.org/project/pyenvisalink/4.9/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

Supersedes #165286, an earlier attempt that fixed this at the integration layer in `alarm_control_panel.py`. Reviewers (@elupus, @joostlek) correctly redirected the fix upstream into `pyenvisalink`; this PR is the result.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
