### PR TITLE
Fix subscription ID for restored subscriptions

### DIFF
--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -855,10 +855,24 @@ class MQTT:
     ) -> None:
         """Restore tracked subscriptions after reload."""
         for subscription in subscriptions:
-            self._mqtt_data.subscription_id_generator.restore(
-                subscription.subscription_id, subscription.topic
+            subscription_id = (
+                1
+                if subscription.is_simple_match
+                else self._mqtt_data.subscription_id_generator.get_subscription_id(
+                    subscription.topic
+                )
             )
-            self._async_track_subscription(subscription)
+            self._async_track_subscription(
+                Subscription(
+                    subscription.topic,
+                    subscription.is_simple_match,
+                    subscription.complex_matcher,
+                    subscription.job,
+                    subscription.qos,
+                    subscription.encoding,
+                    subscription_id,
+                )
+            )
         self._matching_subscriptions.cache_clear()
 
     @callback

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -68,6 +68,7 @@ class SubscriptionID:
         if self._available_ids:
             subscription_id = self._available_ids.pop()
             self._used_ids.add(subscription_id)
+            self._registered_subscriptions[topic] = subscription_id
             return subscription_id
 
         subscription_id = self._next_id
@@ -108,13 +109,6 @@ class SubscriptionID:
         ):
             self._used_ids.remove(subscription_id)
             self._available_ids.add(subscription_id)
-
-    def restore(self, subscription_id: int | None, topic: str) -> None:
-        """Restore a subscription."""
-        if subscription_id is None:
-            return
-        self._registered_subscriptions[topic] = subscription_id
-        self._used_ids.add(subscription_id)
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/components/mqtt/test_client.py
+++ b/tests/components/mqtt/test_client.py
@@ -2602,6 +2602,8 @@ async def test_subscriptions_id_generation(hass: HomeAssistant) -> None:
     # Mock we are past the last subscriptions
     generator._next_id = mqtt.models.MAX_28BIT - 2
     new_id_1 = generator.get_or_generate("test1/#")
+    assert generator.get_or_generate("test1/#") == new_id_1
+    assert generator.get_subscription_id("test1/#") == new_id_1
     assert new_id_1 == mqtt.models.MAX_28BIT - 2
     new_id_2 = generator.get_or_generate("test2/#")
     assert new_id_2 == mqtt.models.MAX_28BIT - 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes a regression introduced with #169604.

For MQTT v5 subscriptions a Subscription Identifier is attached to the subscription.
When Home Assistant restarts used and released ID will be reused.

This PR will fix that an exiting ID might be restored while it was not available fir use. The new code will always use the SubscriptionID generator for a vailable ID in case of a wildcard description.

When a Subscription Identifier was reused, the topic was not registered again.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
