### PR TITLE
Fix Avea stale brightness restore

### DIFF
--- a/homeassistant/components/avea/light.py
+++ b/homeassistant/components/avea/light.py
@@ -206,6 +206,8 @@ class AveaLight(LightEntity):
     def turn_off(self, **kwargs: Any) -> None:
         """Instruct the light to turn off."""
         self._light.set_brightness(0)
+        self._attr_is_on = False
+        self._attr_brightness = 0
 
     def update(self) -> None:
         """Fetch new state data for this light."""

--- a/homeassistant/components/avea/light.py
+++ b/homeassistant/components/avea/light.py
@@ -205,8 +205,6 @@ class AveaLight(LightEntity):
 
     def turn_off(self, **kwargs: Any) -> None:
         """Instruct the light to turn off."""
-        if self._attr_brightness:
-            self._last_brightness = self._attr_brightness
         self._light.set_brightness(0)
 
     def update(self) -> None:

--- a/tests/components/avea/test_light.py
+++ b/tests/components/avea/test_light.py
@@ -144,6 +144,11 @@ async def test_turn_on_restores_last_brightness(
     )
     bulb.set_brightness.assert_called_with(0)
 
+    state = hass.states.get("light.bedroom")
+    assert state is not None
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_BRIGHTNESS] is None
+
     bulb.set_brightness.reset_mock()
     await hass.services.async_call(
         "light",

--- a/tests/components/avea/test_light.py
+++ b/tests/components/avea/test_light.py
@@ -111,17 +111,29 @@ async def test_turn_on_and_off(
 async def test_turn_on_restores_last_brightness(
     hass: HomeAssistant,
     setup_integration: MagicMock,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test turning the light on restores the last brightness."""
     bulb = setup_integration
 
+    bulb.get_brightness.side_effect = [3212, None, None, None]
+
+    freezer.tick(timedelta(seconds=30))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get("light.bedroom")
+    assert state is not None
+    assert state.attributes[ATTR_BRIGHTNESS] == 200
+
+    bulb.set_brightness.reset_mock()
     await hass.services.async_call(
         "light",
         "turn_on",
-        {ATTR_ENTITY_ID: "light.bedroom", ATTR_BRIGHTNESS: 128},
+        {ATTR_ENTITY_ID: "light.bedroom", ATTR_BRIGHTNESS: 10},
         blocking=True,
     )
-    bulb.set_brightness.assert_called_with(2056)
+    bulb.set_brightness.assert_called_with(161)
 
     bulb.set_brightness.reset_mock()
     await hass.services.async_call(
@@ -139,7 +151,7 @@ async def test_turn_on_restores_last_brightness(
         {ATTR_ENTITY_ID: "light.bedroom"},
         blocking=True,
     )
-    bulb.set_brightness.assert_called_with(2056)
+    bulb.set_brightness.assert_called_with(161)
 
 
 async def test_update_state(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is a follow-up to #171120.

Avea now remembers the last non-zero brightness so a plain `light.turn_on` restores the previous brightness instead of sending full brightness. However, `turn_off()` still updated the cached brightness from `_attr_brightness`. Since Avea is polled, `_attr_brightness` can be stale immediately after an explicit brightness service call.

This removes the cache update from `turn_off()` so `_last_brightness` is only updated from explicit brightness service calls or successful device polling. A regression test covers a stale polled brightness followed by an explicit lower brightness, immediate off, and plain on.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #171120
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
