### PR TITLE
Declare PARALLEL_UPDATES on arcam_fmj platforms

### DIFF
--- a/homeassistant/components/arcam_fmj/binary_sensor.py
+++ b/homeassistant/components/arcam_fmj/binary_sensor.py
@@ -16,6 +16,8 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from .coordinator import ArcamFmjConfigEntry
 from .entity import ArcamFmjEntity
 
+PARALLEL_UPDATES = 0
+
 
 @dataclass(frozen=True, kw_only=True)
 class ArcamFmjBinarySensorEntityDescription(BinarySensorEntityDescription):

--- a/homeassistant/components/arcam_fmj/binary_sensor.py
+++ b/homeassistant/components/arcam_fmj/binary_sensor.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from .coordinator import ArcamFmjConfigEntry
 from .entity import ArcamFmjEntity
 
+# Read-only, coordinator-driven entities; no per-entity I/O to bound.
 PARALLEL_UPDATES = 0
 
 

--- a/homeassistant/components/arcam_fmj/media_player.py
+++ b/homeassistant/components/arcam_fmj/media_player.py
@@ -27,6 +27,8 @@ from .entity import ArcamFmjEntity
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/arcam_fmj/media_player.py
+++ b/homeassistant/components/arcam_fmj/media_player.py
@@ -27,7 +27,9 @@ from .entity import ArcamFmjEntity
 
 _LOGGER = logging.getLogger(__name__)
 
-PARALLEL_UPDATES = 0
+# arcam-fmj serializes commands on a single TCP writer at the library
+# layer; serialize at HA's layer to match the device's contract.
+PARALLEL_UPDATES = 1
 
 
 async def async_setup_entry(

--- a/homeassistant/components/arcam_fmj/sensor.py
+++ b/homeassistant/components/arcam_fmj/sensor.py
@@ -22,6 +22,8 @@ from .entity import ArcamFmjEntity
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 0
+
 
 def _enum_options(value: type[IntOrTypeEnum]) -> list[str]:
     return [

--- a/homeassistant/components/arcam_fmj/sensor.py
+++ b/homeassistant/components/arcam_fmj/sensor.py
@@ -22,6 +22,7 @@ from .entity import ArcamFmjEntity
 
 _LOGGER = logging.getLogger(__name__)
 
+# Read-only, coordinator-driven entities; no per-entity I/O to bound.
 PARALLEL_UPDATES = 0
 
 


### PR DESCRIPTION
## Proposed change

Declare `PARALLEL_UPDATES = 0` as a module-level constant on all three `arcam_fmj` entity platforms (`binary_sensor`, `media_player`, `sensor`).

The integration is coordinator-driven via `ArcamFmjConfigEntry`, so entities don't perform their own I/O during updates and Home Assistant's per-platform update serialization isn't needed. Setting `PARALLEL_UPDATES = 0` declares "unlimited / not applicable" explicitly, satisfying the silver-tier `parallel-updates` rule of the Integration Quality Scale.

No behavior change, no user-facing configuration change, no new dependencies.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr