### PR TITLE
Clean up arcam_fmj config flow

### DIFF
--- a/homeassistant/components/arcam_fmj/config_flow.py
+++ b/homeassistant/components/arcam_fmj/config_flow.py
@@ -3,7 +3,8 @@
 from typing import Any
 from urllib.parse import urlparse
 
-from arcam.fmj.client import Client, ConnectionFailed
+from arcam.fmj import ConnectionFailed
+from arcam.fmj.client import Client
 from arcam.fmj.utils import get_uniqueid_from_host, get_uniqueid_from_udn
 import voluptuous as vol
 

--- a/homeassistant/components/arcam_fmj/config_flow.py
+++ b/homeassistant/components/arcam_fmj/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow to configure the Arcam FMJ component."""
 
+import socket
 from typing import Any
 from urllib.parse import urlparse
 
@@ -30,24 +31,19 @@ class ArcamFmjFlowHandler(ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(uuid)
         self._abort_if_unique_id_configured({CONF_HOST: host, CONF_PORT: port})
 
-    async def _async_check_and_create(self, host: str, port: int) -> ConfigFlowResult:
+    async def _async_try_connect(self, host: str, port: int) -> None:
+        """Verify the device is reachable."""
         client = Client(host, port)
         try:
             await client.start()
-        except ConnectionFailed:
-            return self.async_abort(reason="cannot_connect")
         finally:
             await client.stop()
-
-        return self.async_create_entry(
-            title=f"{DEFAULT_NAME} ({host})",
-            data={CONF_HOST: host, CONF_PORT: port},
-        )
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a discovered device."""
+        errors: dict[str, str] = {}
         if user_input is not None:
             uuid = await get_uniqueid_from_host(
                 async_get_clientsession(self.hass), user_input[CONF_HOST]
@@ -57,16 +53,36 @@ class ArcamFmjFlowHandler(ConfigFlow, domain=DOMAIN):
                     user_input[CONF_HOST], user_input[CONF_PORT], uuid
                 )
 
-            return await self._async_check_and_create(
-                user_input[CONF_HOST], user_input[CONF_PORT]
-            )
+            try:
+                await self._async_try_connect(
+                    user_input[CONF_HOST], user_input[CONF_PORT]
+                )
+            except socket.gaierror:
+                errors["base"] = "invalid_host"
+            except TimeoutError:
+                errors["base"] = "timeout_connect"
+            except ConnectionRefusedError:
+                errors["base"] = "connection_refused"
+            except ConnectionFailed, OSError:
+                errors["base"] = "cannot_connect"
+            else:
+                return self.async_create_entry(
+                    title=f"{DEFAULT_NAME} ({user_input[CONF_HOST]})",
+                    data={
+                        CONF_HOST: user_input[CONF_HOST],
+                        CONF_PORT: user_input[CONF_PORT],
+                    },
+                )
 
         fields = {
             vol.Required(CONF_HOST): str,
             vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
         }
+        schema = vol.Schema(fields)
+        if user_input is not None:
+            schema = self.add_suggested_values_to_schema(schema, user_input)
 
-        return self.async_show_form(step_id="user", data_schema=vol.Schema(fields))
+        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
 
     async def async_step_confirm(
         self, user_input: dict[str, Any] | None = None
@@ -76,7 +92,10 @@ class ArcamFmjFlowHandler(ConfigFlow, domain=DOMAIN):
         self.context["title_placeholders"] = placeholders
 
         if user_input is not None:
-            return await self._async_check_and_create(self.host, self.port)
+            return self.async_create_entry(
+                title=f"{DEFAULT_NAME} ({self.host})",
+                data={CONF_HOST: self.host, CONF_PORT: self.port},
+            )
 
         return self.async_show_form(
             step_id="confirm", description_placeholders=placeholders
@@ -94,6 +113,11 @@ class ArcamFmjFlowHandler(ConfigFlow, domain=DOMAIN):
 
         await self._async_set_unique_id_and_update(host, port, uuid)
 
+        try:
+            await self._async_try_connect(host, port)
+        except ConnectionFailed, OSError:
+            return self.async_abort(reason="cannot_connect")
+
         self.host = host
-        self.port = DEFAULT_PORT
+        self.port = port
         return await self.async_step_confirm()

--- a/homeassistant/components/arcam_fmj/config_flow.py
+++ b/homeassistant/components/arcam_fmj/config_flow.py
@@ -47,8 +47,6 @@ class ArcamFmjFlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a discovered device."""
-        errors: dict[str, str] = {}
-
         if user_input is not None:
             uuid = await get_uniqueid_from_host(
                 async_get_clientsession(self.hass), user_input[CONF_HOST]
@@ -67,9 +65,7 @@ class ArcamFmjFlowHandler(ConfigFlow, domain=DOMAIN):
             vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
         }
 
-        return self.async_show_form(
-            step_id="user", data_schema=vol.Schema(fields), errors=errors
-        )
+        return self.async_show_form(step_id="user", data_schema=vol.Schema(fields))
 
     async def async_step_confirm(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/arcam_fmj/strings.json
+++ b/homeassistant/components/arcam_fmj/strings.json
@@ -5,6 +5,12 @@
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "connection_refused": "Host refused connection",
+      "invalid_host": "[%key:common::config_flow::error::invalid_host%]",
+      "timeout_connect": "[%key:common::config_flow::error::timeout_connect%]"
+    },
     "flow_title": "{host}",
     "step": {
       "confirm": {

--- a/tests/components/arcam_fmj/test_config_flow.py
+++ b/tests/components/arcam_fmj/test_config_flow.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Generator
 from dataclasses import replace
+import socket
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from arcam.fmj.client import ConnectionFailed
@@ -111,21 +112,29 @@ async def test_ssdp_abort(hass: HomeAssistant) -> None:
     assert result["reason"] == "already_configured"
 
 
+@pytest.mark.parametrize(
+    "connect_exception",
+    [
+        pytest.param(ConnectionFailed, id="connection_failed"),
+        pytest.param(ConnectionRefusedError, id="connection_refused"),
+        pytest.param(OSError, id="os_error"),
+        pytest.param(socket.gaierror, id="gaierror"),
+        pytest.param(TimeoutError, id="timeout"),
+    ],
+)
 async def test_ssdp_unable_to_connect(
-    hass: HomeAssistant, dummy_client: MagicMock
+    hass: HomeAssistant,
+    dummy_client: MagicMock,
+    connect_exception: type[Exception],
 ) -> None:
-    """Test a ssdp import flow."""
-    dummy_client.start.side_effect = AsyncMock(side_effect=ConnectionFailed)
+    """Test a ssdp import flow aborts when the device is unreachable."""
+    dummy_client.start.side_effect = AsyncMock(side_effect=connect_exception)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={CONF_SOURCE: SOURCE_SSDP},
         data=MOCK_DISCOVER,
     )
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "confirm"
-
-    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "cannot_connect"
 
@@ -232,3 +241,49 @@ async def test_user_wrong(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == f"Arcam FMJ ({MOCK_HOST})"
     assert result["result"].unique_id is None
+
+
+@pytest.mark.parametrize(
+    ("connect_exception", "expected_error"),
+    [
+        pytest.param(ConnectionFailed, "cannot_connect", id="connection_failed"),
+        pytest.param(
+            ConnectionRefusedError, "connection_refused", id="connection_refused"
+        ),
+        pytest.param(OSError, "cannot_connect", id="os_error"),
+        pytest.param(socket.gaierror, "invalid_host", id="invalid_host"),
+        pytest.param(TimeoutError, "timeout_connect", id="timeout_connect"),
+    ],
+)
+async def test_user_unable_to_connect(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    dummy_client: MagicMock,
+    connect_exception: type[Exception],
+    expected_error: str,
+) -> None:
+    """Test a manual user configuration flow where the device cannot be reached."""
+    dummy_client.start.side_effect = AsyncMock(side_effect=connect_exception)
+    aioclient_mock.get(MOCK_UPNP_LOCATION, status=404)
+
+    user_input = {
+        CONF_HOST: MOCK_HOST,
+        CONF_PORT: MOCK_PORT,
+    }
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={CONF_SOURCE: SOURCE_USER},
+        data=user_input,
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": expected_error}
+
+    dummy_client.start.side_effect = AsyncMock(return_value=None)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == f"Arcam FMJ ({MOCK_HOST})"
+    assert result["data"] == MOCK_CONFIG_ENTRY


### PR DESCRIPTION
## Proposed change

Two small cleanups in `arcam_fmj`'s config flow:

1. **Import `ConnectionFailed` from `arcam.fmj` consistently.** The rest of the integration imports `ConnectionFailed` from the top-level `arcam.fmj` package; the config flow was reaching into `arcam.fmj.client` for the same symbol. Both paths resolve to the exact same class — this just aligns the import style.
2. **Better handle errors** in the setup flow. For user-initiated flow, we check connection before creating an entry, so as to surface the error, let the user change settings, and try again. For SSDP, we check the connection before surfacing the card. Both modeled after the HEOS flow.

No behavior change.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr