### PR TITLE
Share arcam_fmj convert_exception decorator from entity module

### DIFF
--- a/homeassistant/components/arcam_fmj/entity.py
+++ b/homeassistant/components/arcam_fmj/entity.py
@@ -1,9 +1,34 @@
 """Base entity for Arcam FMJ integration."""
 
+from collections.abc import Callable, Coroutine
+import functools
+from typing import Any
+
+from arcam.fmj import ConnectionFailed
+
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .const import DOMAIN
 from .coordinator import ArcamFmjCoordinator
+
+
+def convert_exception[**_P, _R](
+    func: Callable[_P, Coroutine[Any, Any, _R]],
+) -> Callable[_P, Coroutine[Any, Any, _R]]:
+    """Convert a connection failure into a translated HomeAssistantError."""
+
+    @functools.wraps(func)
+    async def _convert_exception(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+        try:
+            return await func(*args, **kwargs)
+        except ConnectionFailed as exception:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="connection_failed"
+            ) from exception
+
+    return _convert_exception
 
 
 class ArcamFmjEntity(CoordinatorEntity[ArcamFmjCoordinator]):

--- a/homeassistant/components/arcam_fmj/media_player.py
+++ b/homeassistant/components/arcam_fmj/media_player.py
@@ -1,11 +1,9 @@
 """Arcam media player."""
 
-from collections.abc import Callable, Coroutine
-import functools
 import logging
 from typing import Any
 
-from arcam.fmj import ConnectionFailed, SourceCodes
+from arcam.fmj import SourceCodes
 
 from homeassistant.components.media_player import (
     BrowseError,
@@ -18,12 +16,12 @@ from homeassistant.components.media_player import (
 )
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN, EVENT_TURN_ON
 from .coordinator import ArcamFmjConfigEntry, ArcamFmjCoordinator
-from .entity import ArcamFmjEntity
+from .entity import ArcamFmjEntity, convert_exception
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,23 +37,6 @@ async def async_setup_entry(
     async_add_entities(
         [ArcamFmj(coordinators[zone]) for zone in (1, 2)],
     )
-
-
-def convert_exception[**_P, _R](
-    func: Callable[_P, Coroutine[Any, Any, _R]],
-) -> Callable[_P, Coroutine[Any, Any, _R]]:
-    """Return decorator to convert a connection error into a home assistant error."""
-
-    @functools.wraps(func)
-    async def _convert_exception(*args: _P.args, **kwargs: _P.kwargs) -> _R:
-        try:
-            return await func(*args, **kwargs)
-        except ConnectionFailed as exception:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN, translation_key="connection_failed"
-            ) from exception
-
-    return _convert_exception
 
 
 class ArcamFmj(ArcamFmjEntity, MediaPlayerEntity):


### PR DESCRIPTION
## Proposed change

Hoists the `convert_exception` decorator out of `media_player.py` into `entity.py`, so other platforms in the `arcam_fmj` integration can apply the same `ConnectionFailed` → `HomeAssistantError` translation without duplicating the decorator. Pure refactor, no behavior change — `media_player.py` keeps using it via `from .entity import ArcamFmjEntity, convert_exception`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr