### PR TITLE
Annotate parametrized arcam_fmj media_player test signatures

### DIFF
--- a/tests/components/arcam_fmj/test_media_player.py
+++ b/tests/components/arcam_fmj/test_media_player.py
@@ -1,5 +1,6 @@
 """Tests for arcam fmj receivers."""
 
+from collections.abc import Generator
 from math import isclose
 from unittest.mock import Mock, PropertyMock, patch
 
@@ -46,7 +47,7 @@ from tests.common import MockConfigEntry, snapshot_platform
 
 
 @pytest.fixture(autouse=True)
-def platform_fixture():
+def platform_fixture() -> Generator[None]:
     """Only test single platform."""
     with patch("homeassistant.components.arcam_fmj.PLATFORMS", [Platform.MEDIA_PLAYER]):
         yield
@@ -355,7 +356,11 @@ async def test_play_media_invalid(hass: HomeAssistant, state_1: State) -> None:
 )
 @pytest.mark.usefixtures("player_setup")
 async def test_sound_mode(
-    hass: HomeAssistant, client: Mock, state_1: State, mode, mode_enum
+    hass: HomeAssistant,
+    client: Mock,
+    state_1: State,
+    mode: str | None,
+    mode_enum: DecodeMode2CH | DecodeModeMCH | None,
 ) -> None:
     """Test selection sound mode."""
     state_1.get_decode_mode.return_value = mode_enum
@@ -373,7 +378,11 @@ async def test_sound_mode(
 )
 @pytest.mark.usefixtures("player_setup")
 async def test_sound_mode_list(
-    hass: HomeAssistant, client: Mock, state_1: State, modes, modes_enum
+    hass: HomeAssistant,
+    client: Mock,
+    state_1: State,
+    modes: list[str] | None,
+    modes_enum: list[DecodeMode2CH] | list[DecodeModeMCH] | None,
 ) -> None:
     """Test sound mode list."""
     state_1.get_decode_modes.return_value = modes_enum
@@ -422,10 +431,9 @@ async def test_volume_level(hass: HomeAssistant, client: Mock, state_1: State) -
 @pytest.mark.parametrize(("volume", "call"), [(0.0, 0), (0.5, 50), (1.0, 99)])
 @pytest.mark.usefixtures("player_setup")
 async def test_set_volume_level(
-    hass: HomeAssistant, state_1: State, volume, call
+    hass: HomeAssistant, state_1: State, volume: float, call: int
 ) -> None:
     """Test setting volume."""
-
     await hass.services.async_call(
         "media_player",
         SERVICE_VOLUME_SET,
@@ -468,7 +476,11 @@ async def test_set_volume_level_lost(hass: HomeAssistant, state_1: State) -> Non
 )
 @pytest.mark.usefixtures("player_setup")
 async def test_media_content_type(
-    hass: HomeAssistant, client: Mock, state_1: State, source, media_content_type
+    hass: HomeAssistant,
+    client: Mock,
+    state_1: State,
+    source: SourceCodes | None,
+    media_content_type: MediaType | None,
 ) -> None:
     """Test content type deduction."""
     state_1.get_source.return_value = source
@@ -488,7 +500,13 @@ async def test_media_content_type(
 )
 @pytest.mark.usefixtures("player_setup")
 async def test_media_channel(
-    hass: HomeAssistant, client: Mock, state_1: State, source, dab, rds, channel
+    hass: HomeAssistant,
+    client: Mock,
+    state_1: State,
+    source: SourceCodes,
+    dab: str | None,
+    rds: str | None,
+    channel: str | None,
 ) -> None:
     """Test media channel."""
     state_1.get_dab_station.return_value = dab
@@ -508,7 +526,12 @@ async def test_media_channel(
 )
 @pytest.mark.usefixtures("player_setup")
 async def test_media_artist(
-    hass: HomeAssistant, client: Mock, state_1: State, source, dls, artist
+    hass: HomeAssistant,
+    client: Mock,
+    state_1: State,
+    source: SourceCodes,
+    dls: str | None,
+    artist: str | None,
 ) -> None:
     """Test media artist."""
     state_1.get_dls_pdt.return_value = dls
@@ -527,17 +550,18 @@ async def test_media_artist(
 )
 @pytest.mark.usefixtures("player_setup")
 async def test_media_title(
-    hass: HomeAssistant, client: Mock, state_1: State, source, channel, title
+    hass: HomeAssistant,
+    client: Mock,
+    state_1: State,
+    source: SourceCodes | None,
+    channel: str | None,
+    title: str | None,
 ) -> None:
     """Test media title."""
-
     state_1.get_source.return_value = source
     with patch.object(
         ArcamFmj, "media_channel", new_callable=PropertyMock
     ) as media_channel:
         media_channel.return_value = channel
         data = await update(hass, client, MOCK_ENTITY_ID)
-        if title is None:
-            assert "media_title" not in data.attributes
-        else:
-            assert data.attributes["media_title"] == title
+        assert data.attributes.get("media_title") == title


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Several parametrized tests in `tests/components/arcam_fmj/test_media_player.py` lacked annotations on the parametrized parameters. Add concrete types (`bool | None`, `SourceCodes | None`, `DecodeMode2CH | DecodeModeMCH`, `MediaType | None`, etc.) as appropriate, and annotate `platform_fixture`'s return type as `Generator[None]` (importing `Generator` from `collections.abc`).

While in `test_media_title`, replace the small `if title is None / else` branch with a single equality assertion via `data.attributes.get(...)`, per the CLAUDE.md guidance to avoid conditions in tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an \`x\` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (\`ruff format homeassistant tests\`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: \`python3 -m script.hassfest\`.
- [ ] New or updated dependencies have been added to \`requirements_all.txt\`.  
      Updated by running \`python3 -m script.gen_requirements_all\`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr