### PR TITLE
Fix ZHA config entries using a URI without a port

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -33,6 +33,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.typing import ConfigType
 
 from . import homeassistant_hardware, repairs, websocket_api
+from .config_flow import ZhaConfigFlowHandler
 from .const import (
     CONF_BAUDRATE,
     CONF_CUSTOM_QUIRKS_PATH,
@@ -308,6 +309,13 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         config_entry.version,
         config_entry.minor_version,
     )
+
+    if (config_entry.version, config_entry.minor_version) > (
+        ZhaConfigFlowHandler.VERSION,
+        ZhaConfigFlowHandler.MINOR_VERSION,
+    ):
+        # This means the user has downgraded from a future version
+        return False
 
     if config_entry.version == 1:
         data = {

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -5,6 +5,7 @@ import logging
 from zoneinfo import ZoneInfo
 
 import voluptuous as vol
+from yarl import URL
 from zha.application.const import BAUD_RATES, RadioType
 from zha.application.gateway import Gateway
 from zha.application.helpers import ZHAData
@@ -43,6 +44,7 @@ from .const import (
     CONF_ZIGPY,
     DATA_ZHA,
     DOMAIN,
+    LEGACY_ZEROCONF_PORT,
 )
 from .helpers import (
     SIGNAL_ADD_ENTITIES,
@@ -301,7 +303,11 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Migrate old entry."""
-    _LOGGER.debug("Migrating from version %s", config_entry.version)
+    _LOGGER.debug(
+        "Migrating from version %s.%s",
+        config_entry.version,
+        config_entry.minor_version,
+    )
 
     if config_entry.version == 1:
         data = {
@@ -361,5 +367,24 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
                 version=5,
             )
 
-    _LOGGER.info("Migration to version %s successful", config_entry.version)
+    if config_entry.version == 5 and config_entry.minor_version < 2:
+        data = {**config_entry.data, CONF_DEVICE: {**config_entry.data[CONF_DEVICE]}}
+        device_path = data[CONF_DEVICE][CONF_DEVICE_PATH]
+
+        if device_path.startswith(("socket://", "tcp://")):
+            url = URL(device_path)
+            if url.explicit_port is None:
+                data[CONF_DEVICE][CONF_DEVICE_PATH] = str(
+                    url.with_port(LEGACY_ZEROCONF_PORT)
+                )
+
+        hass.config_entries.async_update_entry(
+            config_entry, data=data, version=5, minor_version=2
+        )
+
+    _LOGGER.info(
+        "Migration to version %s.%s successful",
+        config_entry.version,
+        config_entry.minor_version,
+    )
     return True

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -45,7 +45,13 @@ from homeassistant.helpers.service_info.usb import UsbServiceInfo
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from homeassistant.util import dt as dt_util
 
-from .const import CONF_BAUDRATE, CONF_FLOW_CONTROL, CONF_RADIO_TYPE, DOMAIN
+from .const import (
+    CONF_BAUDRATE,
+    CONF_FLOW_CONTROL,
+    CONF_RADIO_TYPE,
+    DOMAIN,
+    LEGACY_ZEROCONF_PORT,
+)
 from .helpers import get_config_entry_unique_id, get_zha_gateway
 from .radio_manager import (
     DEVICE_SCHEMA,
@@ -87,7 +93,6 @@ UPLOADED_BACKUP_FILE = "uploaded_backup_file"
 
 REPAIR_MY_URL = "https://my.home-assistant.io/redirect/repairs/"
 
-LEGACY_ZEROCONF_PORT = 6638
 LEGACY_ZEROCONF_ESPHOME_API_PORT = 6053
 
 ZEROCONF_SERVICE_TYPE = "_zigbee-coordinator._tcp.local."

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -763,6 +763,7 @@ class ZhaConfigFlowHandler(BaseZhaFlow, ConfigFlow, domain=DOMAIN):
     """Handle a config flow."""
 
     VERSION = 5
+    MINOR_VERSION = 2
 
     async def _set_unique_id_and_update_ignored_flow(
         self, unique_id: str, device_path: str

--- a/homeassistant/components/zha/const.py
+++ b/homeassistant/components/zha/const.py
@@ -64,6 +64,8 @@ DEVICE_PAIRING_STATUS = "pairing_status"
 
 DOMAIN = "zha"
 
+LEGACY_ZEROCONF_PORT = 6638
+
 GROUP_ID = "group_id"
 
 

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -1263,19 +1263,6 @@ def async_add_entities(
     entities.clear()
 
 
-def _clean_serial_port_path(path: str) -> str:
-    """Clean the serial port path, applying corrections where necessary."""
-
-    if path.startswith("socket://"):
-        path = path.strip()
-
-    # Removes extraneous brackets from IP addresses (they don't parse in CPython 3.11.4)
-    if re.match(r"^socket://\[\d+\.\d+\.\d+\.\d+\]:\d+$", path):
-        path = path.replace("[", "").replace("]", "")
-
-    return path
-
-
 CONF_ZHA_OPTIONS_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_DEFAULT_LIGHT_TRANSITION, default=0): vol.All(
@@ -1313,18 +1300,6 @@ def create_zha_config(hass: HomeAssistant, ha_zha_data: HAZHAData) -> ZHAData:
     # ensure that we have the necessary HA configuration data
     assert ha_zha_data.config_entry is not None
     assert ha_zha_data.yaml_config is not None
-
-    # Remove brackets around IP addresses, this no longer works in CPython 3.11.4
-    # This will be removed in 2023.11.0
-    path = ha_zha_data.config_entry.data[CONF_DEVICE][CONF_DEVICE_PATH]
-    cleaned_path = _clean_serial_port_path(path)
-
-    if path != cleaned_path:
-        _LOGGER.debug("Cleaned serial port path %r -> %r", path, cleaned_path)
-        ha_zha_data.config_entry.data[CONF_DEVICE][CONF_DEVICE_PATH] = cleaned_path
-        hass.config_entries.async_update_entry(
-            ha_zha_data.config_entry, data=ha_zha_data.config_entry.data
-        )
 
     # deep copy the yaml config to avoid modifying the original and to safely
     # pass it to the ZHA library

--- a/tests/components/zha/snapshots/test_diagnostics.ambr
+++ b/tests/components/zha/snapshots/test_diagnostics.ambr
@@ -100,7 +100,7 @@
       'discovery_keys': dict({
       }),
       'domain': 'zha',
-      'minor_version': 1,
+      'minor_version': 2,
       'options': dict({
         'custom_configuration': dict({
           'zha_alarm_options': dict({

--- a/tests/components/zha/test_init.py
+++ b/tests/components/zha/test_init.py
@@ -141,6 +141,47 @@ async def test_config_depreciation(hass: HomeAssistant, zha_config) -> None:
 
 
 @pytest.mark.parametrize(
+    ("old_path", "new_path"),
+    [
+        ("/dev/ttyUSB0", "/dev/ttyUSB0"),
+        ("socket://1.2.3.4:5678", "socket://1.2.3.4:5678"),
+        ("socket://1.2.3.4", "socket://1.2.3.4:6638"),
+        ("tcp://hostname", "tcp://hostname:6638"),
+        ("tcp://hostname:1234", "tcp://hostname:1234"),
+        ("socket://[::1]", "socket://[::1]:6638"),
+    ],
+)
+@patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
+async def test_migration_v5_to_v5_2_explicit_socket_port(
+    old_path: str,
+    new_path: str,
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test that socket:// and tcp:// paths get an explicit default port."""
+    config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        config_entry,
+        data={
+            **config_entry.data,
+            CONF_DEVICE: {
+                **config_entry.data[CONF_DEVICE],
+                CONF_DEVICE_PATH: old_path,
+            },
+        },
+        version=5,
+        minor_version=1,
+    )
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.version == 5
+    assert config_entry.minor_version == 2
+    assert config_entry.data[CONF_DEVICE][CONF_DEVICE_PATH] == new_path
+
+
+@pytest.mark.parametrize(
     (
         "radio_type",
         "old_baudrate",

--- a/tests/components/zha/test_init.py
+++ b/tests/components/zha/test_init.py
@@ -4,7 +4,7 @@ import asyncio
 from collections.abc import Callable
 import logging
 import typing
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, patch
 import zoneinfo
 
 import pytest
@@ -138,55 +138,6 @@ async def test_config_depreciation(hass: HomeAssistant, zha_config) -> None:
     ) as setup_mock:
         assert await async_setup_component(hass, DOMAIN, {DOMAIN: zha_config})
         assert setup_mock.call_count == 1
-
-
-@pytest.mark.parametrize(
-    ("path", "cleaned_path"),
-    [
-        # No corrections
-        ("/dev/path1", "/dev/path1"),
-        ("/dev/path1[asd]", "/dev/path1[asd]"),
-        ("/dev/path1 ", "/dev/path1 "),
-        ("socket://1.2.3.4:5678", "socket://1.2.3.4:5678"),
-        # Brackets around URI
-        ("socket://[1.2.3.4]:5678", "socket://1.2.3.4:5678"),
-        # Spaces
-        ("socket://dev/path1 ", "socket://dev/path1"),
-        # Both
-        ("socket://[1.2.3.4]:5678 ", "socket://1.2.3.4:5678"),
-    ],
-)
-@patch(
-    "homeassistant.components.zha.websocket_api.async_load_api", Mock(return_value=True)
-)
-async def test_setup_with_v3_cleaning_uri(
-    hass: HomeAssistant,
-    path: str,
-    cleaned_path: str,
-    mock_zigpy_connect: ControllerApplication,
-) -> None:
-    """Test migration of config entry from v3, applying corrections to the port path."""
-    config_entry_v4 = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_RADIO_TYPE: DATA_RADIO_TYPE,
-            CONF_DEVICE: {
-                CONF_DEVICE_PATH: path,
-                CONF_BAUDRATE: 115200,
-                CONF_FLOW_CONTROL: None,
-            },
-        },
-        version=5,
-    )
-    config_entry_v4.add_to_hass(hass)
-
-    await hass.config_entries.async_setup(config_entry_v4.entry_id)
-    await hass.async_block_till_done()
-    await hass.config_entries.async_unload(config_entry_v4.entry_id)
-
-    assert config_entry_v4.data[CONF_RADIO_TYPE] == DATA_RADIO_TYPE
-    assert config_entry_v4.data[CONF_DEVICE][CONF_DEVICE_PATH] == cleaned_path
-    assert config_entry_v4.version == 5
 
 
 @pytest.mark.parametrize(

--- a/tests/components/zha/test_init.py
+++ b/tests/components/zha/test_init.py
@@ -152,7 +152,7 @@ async def test_config_depreciation(hass: HomeAssistant, zha_config) -> None:
     ],
 )
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
-async def test_migration_v5_to_v5_2_explicit_socket_port(
+async def test_migration_v5_explicit_socket_port(
     old_path: str,
     new_path: str,
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
ZHA had an undocumented default TCP port for `socket://` URIs. This changed in 2026.5.0 with the new serial library migration and it looks like some people managed to use it by accident, causing startup to fail. This PR does a data migration and automatically adds the correct port number.

There was a cleanup task scheduled for removal in 2023.11.0 that was affecting tests so I've cleaned that up as well.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170938
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
