### PR TITLE
Fix duplicate unique_id in ecobee sensor setup

### DIFF
--- a/homeassistant/components/ecobee/sensor.py
+++ b/homeassistant/components/ecobee/sensor.py
@@ -69,6 +69,15 @@ SENSOR_TYPES: tuple[EcobeeSensorEntityDescription, ...] = (
 )
 
 
+def _remote_sensor_unique_id(
+    thermostat: dict, sensor: dict, description: EcobeeSensorEntityDescription
+) -> str:
+    """Build the unique_id used by EcobeeSensor for a remote sensor capability."""
+    if "code" in sensor:
+        return f"{sensor['code']}-{description.device_class}"
+    return f"{thermostat['identifier']}-{sensor['id']}-{description.device_class}"
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: EcobeeConfigEntry,
@@ -76,14 +85,29 @@ async def async_setup_entry(
 ) -> None:
     """Set up ecobee sensors."""
     data = config_entry.runtime_data
-    entities = [
-        EcobeeSensor(data, sensor["name"], index, description)
-        for index in range(len(data.ecobee.thermostats))
-        for sensor in data.ecobee.get_remote_sensors(index)
-        for item in sensor["capability"]
-        for description in SENSOR_TYPES
-        if description.key == item["type"]
-    ]
+    entities: list[EcobeeSensor] = []
+    seen_unique_ids: set[str] = set()
+    for index in range(len(data.ecobee.thermostats)):
+        thermostat = data.ecobee.get_thermostat(index)
+        for sensor in data.ecobee.get_remote_sensors(index):
+            for item in sensor["capability"]:
+                for description in SENSOR_TYPES:
+                    if description.key != item["type"]:
+                        continue
+                    # Deduplicate at setup time: some thermostats return the
+                    # same sensor twice in remoteSensors, and SmartSensors
+                    # paired to multiple thermostats share a `code`. Without
+                    # this dedup the later registration is silently dropped
+                    # by entity_platform with an "already exists" ERROR log.
+                    unique_id = _remote_sensor_unique_id(
+                        thermostat, sensor, description
+                    )
+                    if unique_id in seen_unique_ids:
+                        continue
+                    seen_unique_ids.add(unique_id)
+                    entities.append(
+                        EcobeeSensor(data, sensor["name"], index, description)
+                    )
 
     async_add_entities(entities, True)
 
@@ -114,10 +138,10 @@ class EcobeeSensor(SensorEntity):
         """Return a unique identifier for this sensor."""
         for sensor in self.data.ecobee.get_remote_sensors(self.index):
             if sensor["name"] == self.sensor_name:
-                if "code" in sensor:
-                    return f"{sensor['code']}-{self.device_class}"
                 thermostat = self.data.ecobee.get_thermostat(self.index)
-                return f"{thermostat['identifier']}-{sensor['id']}-{self.device_class}"
+                return _remote_sensor_unique_id(
+                    thermostat, sensor, self.entity_description
+                )
         return None
 
     @property

--- a/tests/components/ecobee/test_sensor.py
+++ b/tests/components/ecobee/test_sensor.py
@@ -1,0 +1,99 @@
+"""Tests for the Ecobee sensor platform."""
+
+from unittest.mock import patch
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .common import setup_platform
+
+
+async def test_remote_sensor_unique_id_dedup(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Ensure duplicate entries in remoteSensors do not collide on unique_id.
+
+    Some thermostats return the same sensor twice in the remoteSensors list
+    (observed in the field on an Ecobee3 Lite, where every entry in
+    available_sensors appears in adjacent pairs). Without dedup at setup
+    time, the second registration collides with the first and is dropped
+    by entity_platform with an "already exists" ERROR log on every startup.
+
+    Regression test: when remoteSensors contains a duplicate, only the
+    de-duplicated set of entities should be registered, and no ERROR
+    should be raised by entity_platform.
+    """
+    # Patch the pyecobee instance method to return a remoteSensors list
+    # with a duplicated built-in sensor (same id, same capability set).
+    duplicated_sensors = [
+        {
+            "id": "ei:0",
+            "name": "ecobee",
+            "type": "thermostat",
+            "capability": [
+                {"id": "1", "type": "temperature", "value": "720"},
+                {"id": "2", "type": "humidity", "value": "30"},
+            ],
+        },
+        # Verbatim duplicate of the previous entry — same id, same caps.
+        {
+            "id": "ei:0",
+            "name": "ecobee",
+            "type": "thermostat",
+            "capability": [
+                {"id": "1", "type": "temperature", "value": "720"},
+                {"id": "2", "type": "humidity", "value": "30"},
+            ],
+        },
+    ]
+
+    with patch(
+        "pyecobee.Ecobee.get_remote_sensors",
+        return_value=duplicated_sensors,
+    ):
+        await setup_platform(hass, Platform.SENSOR)
+
+    # One temperature + one humidity entity, NOT two of each.
+    registered = [
+        e
+        for e in entity_registry.entities.values()
+        if e.platform == "ecobee" and e.unique_id.startswith("8675309-ei:0-")
+    ]
+    assert len(registered) == 2
+    assert {e.unique_id for e in registered} == {
+        "8675309-ei:0-temperature",
+        "8675309-ei:0-humidity",
+    }
+
+
+async def test_remote_sensor_no_duplicates_unchanged(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Confirm the dedup does not drop entities in the normal (unique) case.
+
+    With the standard fixture (no duplicated remoteSensors), every distinct
+    sensor capability should still be registered as before.
+    """
+    await setup_platform(hass, Platform.SENSOR)
+
+    # Default fixture (ecobee-data.json) has 3 thermostats with distinct
+    # sensors per the test fixtures. We assert that the dedup did not drop
+    # any of them by checking at least one expected unique_id from each
+    # thermostat shows up in the registry.
+    ecobee_entries = [
+        e for e in entity_registry.entities.values() if e.platform == "ecobee"
+    ]
+    sensor_unique_ids = {e.unique_id for e in ecobee_entries}
+
+    # ecobee-data.json: thermostat 0 has remoteSensor id=ei:0 (no code) and
+    # rs:100 with code=WKRP. Confirm both branches of the unique_id
+    # construction are represented.
+    assert any(uid.endswith("-ei:0-temperature") for uid in sensor_unique_ids), (
+        "expected built-in sensor (id-based unique_id) to survive dedup"
+    )
+    assert any(uid.startswith("WKRP-") for uid in sensor_unique_ids), (
+        "expected paired SmartSensor (code-based unique_id) to survive dedup"
+    )


### PR DESCRIPTION
## Proposed change

The setup comprehension in `ecobee/sensor.py:79-86` registers one entity per `(thermostat, sensor, capability)` tuple but the resulting `unique_id` only encodes `(thermostat_id_or_sensor_code, sensor_id, device_class)`. When the same key appears more than once in that loop, the second registration is dropped by `entity_platform` with an ERROR log on every startup:

```
ERROR [homeassistant.components.sensor] Platform ecobee does not generate unique IDs.
ID 416423719342-ei:0-temperature already exists - ignoring sensor.basement_thermostat_temperature
```

Two real scenarios reach this path:

1. **Duplicated `remoteSensors` entries** — observed in the field on an Ecobee3 Lite where the API returns every sensor twice (verified via the `climate.X` `available_sensors` attribute: "Basement, Basement, Basement Sonos Beam, Basement Sonos Beam, Basement Thermostat, Basement Thermostat").
2. **A SmartSensor paired to multiple thermostats** — the existing fixture (`ecobee-data.json`) already triggers this: same `code=WKRP` appears on three thermostats, so `test_remote_sensors` on `dev` logs `ID WKRP-temperature already exists - ignoring sensor.remote_sensor_1` mid-run.

## Fix

Deduplicate at setup time by reproducing the `unique_id` key construction inline and skipping any entity whose key was already added. No data is lost — the dropped duplicate maps to the same physical capability — but the spurious ERROR disappears and the registered set matches steady-state.

Regression test (`tests/components/ecobee/test_sensor.py`) covers the same-thermostat-duplicate case from (1), plus a positive control confirming the dedup doesn't drop legitimately distinct sensors.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration
- [ ] New feature
- [ ] Deprecation
- [ ] Breaking change
- [ ] Code quality improvements

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] Followed the [development checklist][dev-checklist] and [perfect PR recommendations][perfect-pr].
- [x] Code formatted with Ruff.
- [x] Tests added covering the bug.
- [ ] User-exposed functionality / configuration variables — N/A.
- [ ] Manifest / dependencies / coveragerc changes — N/A.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/development_submitting#perfect-pull-requests