### PR TITLE
Remove useless input validation from cast options flow

### DIFF
--- a/homeassistant/components/cast/config_flow.py
+++ b/homeassistant/components/cast/config_flow.py
@@ -19,7 +19,6 @@ if TYPE_CHECKING:
     from . import CastConfigEntry
 
 CONF_MORE_OPTIONS = "more_options"
-IGNORE_CEC_SCHEMA = vol.Schema(vol.All(cv.ensure_list, [cv.string]))
 KNOWN_HOSTS_SCHEMA = vol.Schema(
     {
         vol.Optional(
@@ -113,35 +112,32 @@ class CastOptionsFlowHandler(OptionsFlow):
         """Manage the Google Cast options."""
         errors: dict[str, str] = {}
         if user_input is not None:
-            bad_cec, ignore_cec = _string_to_list(
-                user_input[CONF_MORE_OPTIONS].get(CONF_IGNORE_CEC, ""),
-                IGNORE_CEC_SCHEMA,
+            ignore_cec = _string_to_list(
+                user_input[CONF_MORE_OPTIONS].get(CONF_IGNORE_CEC, "")
             )
-            bad_uuid, wanted_uuid = _string_to_list(
-                user_input[CONF_MORE_OPTIONS].get(CONF_UUID, ""), WANTED_UUID_SCHEMA
+            known_hosts = _trim_items(user_input.get(CONF_KNOWN_HOSTS, []))
+            wanted_uuid = _string_to_list(
+                user_input[CONF_MORE_OPTIONS].get(CONF_UUID, "")
             )
-            if not bad_cec and not bad_uuid:
-                known_hosts = _trim_items(user_input.get(CONF_KNOWN_HOSTS, []))
-                updated_config = dict(self.config_entry.data)
-                updated_config[CONF_IGNORE_CEC] = ignore_cec
-                updated_config[CONF_KNOWN_HOSTS] = known_hosts
-                updated_config[CONF_UUID] = wanted_uuid
+            updated_config = dict(self.config_entry.data)
+            updated_config[CONF_IGNORE_CEC] = ignore_cec
+            updated_config[CONF_KNOWN_HOSTS] = known_hosts
+            updated_config[CONF_UUID] = wanted_uuid
 
-                self.hass.config_entries.async_update_entry(
-                    self.config_entry, data=updated_config
-                )
-                return self.async_create_entry(title="", data={})
-            suggested: dict[str, Any] = user_input
-        else:
-            suggested = {CONF_MORE_OPTIONS: {}}
-            if CONF_KNOWN_HOSTS in self.config_entry.data:
-                suggested[CONF_KNOWN_HOSTS] = self.config_entry.data[CONF_KNOWN_HOSTS]
-            for key in (CONF_UUID, CONF_IGNORE_CEC):
-                if key not in self.config_entry.data:
-                    continue
-                suggested[CONF_MORE_OPTIONS][key] = _list_to_string(
-                    self.config_entry.data[key]
-                )
+            self.hass.config_entries.async_update_entry(
+                self.config_entry, data=updated_config
+            )
+            return self.async_create_entry(title="", data={})
+
+        suggested: dict[str, Any] = {CONF_MORE_OPTIONS: {}}
+        if CONF_KNOWN_HOSTS in self.config_entry.data:
+            suggested[CONF_KNOWN_HOSTS] = self.config_entry.data[CONF_KNOWN_HOSTS]
+        for key in (CONF_UUID, CONF_IGNORE_CEC):
+            if key not in self.config_entry.data:
+                continue
+            suggested[CONF_MORE_OPTIONS][key] = _list_to_string(
+                self.config_entry.data[key]
+            )
 
         return self.async_show_form(
             step_id="init",
@@ -151,22 +147,15 @@ class CastOptionsFlowHandler(OptionsFlow):
         )
 
 
-def _list_to_string(items):
+def _list_to_string(items: list[str]) -> str:
     comma_separated_string = ""
     if items:
         comma_separated_string = ",".join(items)
     return comma_separated_string
 
 
-def _string_to_list(string, schema):
-    invalid = False
-    items = [x.strip() for x in string.split(",") if x.strip()]
-    try:
-        items = schema(items)
-    except vol.Invalid:
-        invalid = True
-
-    return invalid, items
+def _string_to_list(string: str) -> list[str]:
+    return [x.strip() for x in string.split(",") if x.strip()]
 
 
 def _trim_items(items: list[str]) -> list[str]:

--- a/homeassistant/components/cast/config_flow.py
+++ b/homeassistant/components/cast/config_flow.py
@@ -9,7 +9,6 @@ from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFl
 from homeassistant.const import CONF_UUID
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import SectionConfig, section
-from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
@@ -41,7 +40,6 @@ OPTIONS_SCHEMA = KNOWN_HOSTS_SCHEMA.extend(
         )
     }
 )
-WANTED_UUID_SCHEMA = vol.Schema(vol.All(cv.ensure_list, [cv.string]))
 
 
 class FlowHandler(ConfigFlow, domain=DOMAIN):
@@ -110,7 +108,6 @@ class CastOptionsFlowHandler(OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Manage the Google Cast options."""
-        errors: dict[str, str] = {}
         if user_input is not None:
             ignore_cec = _string_to_list(
                 user_input[CONF_MORE_OPTIONS].get(CONF_IGNORE_CEC, "")
@@ -142,7 +139,6 @@ class CastOptionsFlowHandler(OptionsFlow):
         return self.async_show_form(
             step_id="init",
             data_schema=self.add_suggested_values_to_schema(OPTIONS_SCHEMA, suggested),
-            errors=errors,
             last_step=True,
         )
 

--- a/homeassistant/components/cast/strings.json
+++ b/homeassistant/components/cast/strings.json
@@ -24,9 +24,6 @@
     }
   },
   "options": {
-    "error": {
-      "invalid_known_hosts": "[%key:component::cast::config::error::invalid_known_hosts%]"
-    },
     "step": {
       "init": {
         "data": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove useless input validation and unused translation from cast options flow

The ignore_cec and uuid are options are entered as a comma separated list. The validators checked that the items - which are obviously strings - were not `None`, `list` or `dict`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
