### PR TITLE
Remove advanced mode dependency from version config flow

### DIFF
--- a/homeassistant/components/version/config_flow.py
+++ b/homeassistant/components/version/config_flow.py
@@ -62,10 +62,7 @@ class VersionConfigFlow(ConfigFlow, domain=DOMAIN):
         user_input[CONF_SOURCE] = VERSION_SOURCE_MAP[user_input[CONF_VERSION_SOURCE]]
         self._entry_data.update(user_input)
 
-        if not self.show_advanced_options or user_input[CONF_SOURCE] in (
-            "local",
-            "haio",
-        ):
+        if user_input[CONF_SOURCE] in ("local", "haio"):
             return self.async_create_entry(
                 title=self._config_entry_name,
                 data=self._entry_data,

--- a/tests/components/version/test_config_flow.py
+++ b/tests/components/version/test_config_flow.py
@@ -12,9 +12,11 @@ from homeassistant.components.version.const import (
     CONF_IMAGE,
     CONF_VERSION_SOURCE,
     DEFAULT_CONFIGURATION,
+    DEFAULT_NAME_CURRENT,
     DOMAIN,
     UPDATE_COORDINATOR_UPDATE_INTERVAL,
     VERSION_SOURCE_DOCKER_HUB,
+    VERSION_SOURCE_LOCAL,
     VERSION_SOURCE_PYPI,
     VERSION_SOURCE_VERSIONS,
 )
@@ -49,10 +51,10 @@ async def test_reload_config_entry(hass: HomeAssistant) -> None:
 
 
 async def test_basic_form(hass: HomeAssistant) -> None:
-    """Test that we get the form."""
+    """Test that local source creates an entry without the version_source step."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        context={"source": config_entries.SOURCE_USER, "show_advanced_options": False},
+        context={"source": config_entries.SOURCE_USER},
     )
     assert result["type"] is FlowResultType.FORM
 
@@ -62,25 +64,25 @@ async def test_basic_form(hass: HomeAssistant) -> None:
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {CONF_VERSION_SOURCE: VERSION_SOURCE_DOCKER_HUB},
+            {CONF_VERSION_SOURCE: VERSION_SOURCE_LOCAL},
         )
         await hass.async_block_till_done()
 
     assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == VERSION_SOURCE_DOCKER_HUB
+    assert result2["title"] == DEFAULT_NAME_CURRENT
     assert result2["data"] == {
         **DEFAULT_CONFIGURATION,
-        CONF_SOURCE: HaVersionSource.CONTAINER,
-        CONF_VERSION_SOURCE: VERSION_SOURCE_DOCKER_HUB,
+        CONF_SOURCE: HaVersionSource.LOCAL,
+        CONF_VERSION_SOURCE: VERSION_SOURCE_LOCAL,
     }
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_advanced_form_pypi(hass: HomeAssistant) -> None:
-    """Show advanced form when pypi is selected."""
+async def test_form_pypi(hass: HomeAssistant) -> None:
+    """Show form when pypi is selected."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        context={"source": config_entries.SOURCE_USER, "show_advanced_options": True},
+        context={"source": config_entries.SOURCE_USER},
     )
     assert result["type"] is FlowResultType.FORM
 
@@ -117,11 +119,11 @@ async def test_advanced_form_pypi(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_advanced_form_container(hass: HomeAssistant) -> None:
-    """Show advanced form when container source is selected."""
+async def test_form_container(hass: HomeAssistant) -> None:
+    """Show form when container source is selected."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        context={"source": config_entries.SOURCE_USER, "show_advanced_options": True},
+        context={"source": config_entries.SOURCE_USER},
     )
     assert result["type"] is FlowResultType.FORM
 
@@ -158,11 +160,11 @@ async def test_advanced_form_container(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_advanced_form_supervisor(hass: HomeAssistant) -> None:
-    """Show advanced form when docker source is selected."""
+async def test_form_supervisor(hass: HomeAssistant) -> None:
+    """Show form when supervisor source is selected."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        context={"source": config_entries.SOURCE_USER, "show_advanced_options": True},
+        context={"source": config_entries.SOURCE_USER},
     )
     assert result["type"] is FlowResultType.FORM
 


### PR DESCRIPTION
## Proposed change

Remove `show_advanced_options` dependency from the `version` integration's config flow. Previously, the second step (`version_source`) — which lets the user pick channel/image/board/beta — was only shown when Home Assistant was running in advanced mode. With this change, the step is shown for any source that has configurable options (supervisor, container, pypi), and sources without options (local, haio) still create the entry directly.

Relates to https://github.com/home-assistant/core/issues/163890
Closes https://github.com/home-assistant/core/issues/169825

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #169825
- This PR is related to issue: #163890
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr