### PR TITLE
Use CONF_CODE in Novy Cooker Hood

### DIFF
--- a/homeassistant/components/novy_cooker_hood/config_flow.py
+++ b/homeassistant/components/novy_cooker_hood/config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.config_entries import (
     ConfigFlow,
     ConfigFlowResult,
 )
+from homeassistant.const import CONF_CODE
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er, selector
 
@@ -22,7 +23,6 @@ from .commands import COMMAND_LIGHT
 from .const import (
     CODE_MAX,
     CODE_MIN,
-    CONF_CODE,
     CONF_TRANSMITTER,
     DEFAULT_CODE,
     DOMAIN,

--- a/homeassistant/components/novy_cooker_hood/const.py
+++ b/homeassistant/components/novy_cooker_hood/const.py
@@ -7,8 +7,6 @@ from rf_protocols import ModulationType
 DOMAIN: Final = "novy_cooker_hood"
 
 CONF_TRANSMITTER: Final = "transmitter"
-# pylint: disable-next=home-assistant-duplicate-const
-CONF_CODE: Final = "code"
 
 CODE_MIN: Final = 1
 CODE_MAX: Final = 10

--- a/homeassistant/components/novy_cooker_hood/fan.py
+++ b/homeassistant/components/novy_cooker_hood/fan.py
@@ -8,6 +8,7 @@ from rf_protocols.codes.novy.cooker_hood import get_codes_for_code
 from homeassistant.components.fan import ATTR_PERCENTAGE, FanEntity, FanEntityFeature
 from homeassistant.components.radio_frequency import async_send_command
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_CODE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -17,7 +18,7 @@ from homeassistant.util.percentage import (
 )
 
 from .commands import COMMAND_MINUS, COMMAND_PLUS
-from .const import CONF_CODE, SPEED_COUNT
+from .const import SPEED_COUNT
 from .entity import NovyCookerHoodEntity
 
 PARALLEL_UPDATES = 1

--- a/homeassistant/components/novy_cooker_hood/light.py
+++ b/homeassistant/components/novy_cooker_hood/light.py
@@ -7,13 +7,12 @@ from rf_protocols.codes.novy.cooker_hood import get_codes_for_code
 from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.components.radio_frequency import async_send_command
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_ON
+from homeassistant.const import CONF_CODE, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from .commands import COMMAND_LIGHT
-from .const import CONF_CODE
 from .entity import NovyCookerHoodEntity
 
 PARALLEL_UPDATES = 1

--- a/tests/components/novy_cooker_hood/conftest.py
+++ b/tests/components/novy_cooker_hood/conftest.py
@@ -6,11 +6,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from rf_protocols.loader import CodeCollection
 
-from homeassistant.components.novy_cooker_hood.const import (
-    CONF_CODE,
-    CONF_TRANSMITTER,
-    DOMAIN,
-)
+from homeassistant.components.novy_cooker_hood.const import CONF_TRANSMITTER, DOMAIN
+from homeassistant.const import CONF_CODE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 

--- a/tests/components/novy_cooker_hood/test_config_flow.py
+++ b/tests/components/novy_cooker_hood/test_config_flow.py
@@ -6,13 +6,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from homeassistant.components.novy_cooker_hood.commands import COMMAND_LIGHT
-from homeassistant.components.novy_cooker_hood.const import (
-    CONF_CODE,
-    CONF_TRANSMITTER,
-    DOMAIN,
-)
+from homeassistant.components.novy_cooker_hood.const import CONF_TRANSMITTER, DOMAIN
 from homeassistant.components.radio_frequency import DATA_COMPONENT, DOMAIN as RF_DOMAIN
 from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_CODE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.exceptions import HomeAssistantError


### PR DESCRIPTION
## Proposed change

Remove the local `CONF_CODE` constant from `novy_cooker_hood` and import it from `homeassistant.const` instead.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #171299
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.
