### PR TITLE
Fix swallowed exceptions in lyric climate action handlers

### DIFF
--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -504,19 +504,19 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         """Set fan mode."""
         _LOGGER.debug("Set fan mode: %s", fan_mode)
         try:
-            _LOGGER.debug("Fan mode passed to lyric: %s", LYRIC_FAN_MODES[fan_mode])
-            await self._update_fan(
-                self.location, self.device, mode=LYRIC_FAN_MODES[fan_mode]
-            )
-        except LYRIC_EXCEPTIONS as err:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key="failed_to_set_fan_mode",
-            ) from err
+            mode = LYRIC_FAN_MODES[fan_mode]
         except KeyError as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="invalid_fan_mode",
                 translation_placeholders={"fan_mode": fan_mode},
+            ) from err
+        _LOGGER.debug("Fan mode passed to lyric: %s", mode)
+        try:
+            await self._update_fan(self.location, self.device, mode=mode)
+        except LYRIC_EXCEPTIONS as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="failed_to_set_fan_mode",
             ) from err
         await self.coordinator.async_refresh()

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -29,7 +29,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import VolDictType
@@ -509,7 +509,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         """Set fan mode."""
         _LOGGER.debug("Set fan mode: %s", fan_mode)
         if fan_mode not in LYRIC_FAN_MODES:
-            raise HomeAssistantError(
+            raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="invalid_fan_mode",
                 translation_placeholders={"fan_mode": fan_mode},

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -366,7 +366,8 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                     translation_domain=DOMAIN,
                     translation_key="failed_to_set_temperature",
                 ) from err
-            await self.coordinator.async_refresh()
+            finally:
+                await self.coordinator.async_refresh()
         else:
             temp = kwargs.get(ATTR_TEMPERATURE)
             _LOGGER.debug("Set temperature: %s", temp)
@@ -384,7 +385,8 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                     translation_domain=DOMAIN,
                     translation_key="failed_to_set_temperature",
                 ) from err
-            await self.coordinator.async_refresh()
+            finally:
+                await self.coordinator.async_refresh()
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set hvac mode."""
@@ -400,7 +402,8 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                 translation_domain=DOMAIN,
                 translation_key="failed_to_set_hvac_mode",
             ) from err
-        await self.coordinator.async_refresh()
+        finally:
+            await self.coordinator.async_refresh()
 
     async def _async_set_hvac_mode_tcc(self, hvac_mode: HVACMode) -> None:
         """Set hvac mode for TCC devices (e.g., Lyric round)."""
@@ -481,7 +484,8 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                 translation_domain=DOMAIN,
                 translation_key="failed_to_set_preset_mode",
             ) from err
-        await self.coordinator.async_refresh()
+        finally:
+            await self.coordinator.async_refresh()
 
     async def async_set_hold_time(self, time_period: str) -> None:
         """Set the time to hold until."""
@@ -498,7 +502,8 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                 translation_domain=DOMAIN,
                 translation_key="failed_to_set_hold_time",
             ) from err
-        await self.coordinator.async_refresh()
+        finally:
+            await self.coordinator.async_refresh()
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set fan mode."""
@@ -519,4 +524,5 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                 translation_domain=DOMAIN,
                 translation_key="failed_to_set_fan_mode",
             ) from err
-        await self.coordinator.async_refresh()
+        finally:
+            await self.coordinator.async_refresh()

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -508,14 +508,13 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set fan mode."""
         _LOGGER.debug("Set fan mode: %s", fan_mode)
-        try:
-            mode = LYRIC_FAN_MODES[fan_mode]
-        except KeyError as err:
+        if fan_mode not in LYRIC_FAN_MODES:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="invalid_fan_mode",
                 translation_placeholders={"fan_mode": fan_mode},
-            ) from err
+            )
+        mode = LYRIC_FAN_MODES[fan_mode]
         _LOGGER.debug("Fan mode passed to lyric: %s", mode)
         try:
             await self._update_fan(self.location, self.device, mode=mode)

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -35,6 +35,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import VolDictType
 
 from .const import (
+    DOMAIN,
     LYRIC_EXCEPTIONS,
     PRESET_HOLD_UNTIL,
     PRESET_NO_HOLD,
@@ -360,9 +361,11 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                     heat_setpoint=target_temp_low,
                     mode=mode,
                 )
-            # pylint: disable-next=home-assistant-action-swallowed-exception
-            except LYRIC_EXCEPTIONS as exception:
-                _LOGGER.error(exception)
+            except LYRIC_EXCEPTIONS as err:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="failed_to_set_temperature",
+                ) from err
             await self.coordinator.async_refresh()
         else:
             temp = kwargs.get(ATTR_TEMPERATURE)
@@ -376,8 +379,11 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                     await self._update_thermostat(
                         self.location, device, heat_setpoint=temp
                     )
-            except LYRIC_EXCEPTIONS as exception:
-                _LOGGER.error(exception)
+            except LYRIC_EXCEPTIONS as err:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="failed_to_set_temperature",
+                ) from err
             await self.coordinator.async_refresh()
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
@@ -389,9 +395,11 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                     await self._async_set_hvac_mode_tcc(hvac_mode)
                 case LyricThermostatType.LCC:
                     await self._async_set_hvac_mode_lcc(hvac_mode)
-        # pylint: disable-next=home-assistant-action-swallowed-exception
-        except LYRIC_EXCEPTIONS as exception:
-            _LOGGER.error(exception)
+        except LYRIC_EXCEPTIONS as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="failed_to_set_hvac_mode",
+            ) from err
         await self.coordinator.async_refresh()
 
     async def _async_set_hvac_mode_tcc(self, hvac_mode: HVACMode) -> None:
@@ -468,9 +476,11 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
             await self._update_thermostat(
                 self.location, self.device, thermostat_setpoint_status=preset_mode
             )
-        # pylint: disable-next=home-assistant-action-swallowed-exception
-        except LYRIC_EXCEPTIONS as exception:
-            _LOGGER.error(exception)
+        except LYRIC_EXCEPTIONS as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="failed_to_set_preset_mode",
+            ) from err
         await self.coordinator.async_refresh()
 
     async def async_set_hold_time(self, time_period: str) -> None:
@@ -483,9 +493,11 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                 thermostat_setpoint_status=PRESET_HOLD_UNTIL,
                 next_period_time=time_period,
             )
-        # pylint: disable-next=home-assistant-action-swallowed-exception
-        except LYRIC_EXCEPTIONS as exception:
-            _LOGGER.error(exception)
+        except LYRIC_EXCEPTIONS as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="failed_to_set_hold_time",
+            ) from err
         await self.coordinator.async_refresh()
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
@@ -496,13 +508,15 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
             await self._update_fan(
                 self.location, self.device, mode=LYRIC_FAN_MODES[fan_mode]
             )
-        # pylint: disable-next=home-assistant-action-swallowed-exception
-        except LYRIC_EXCEPTIONS as exception:
-            _LOGGER.error(exception)
-        except KeyError:
-            _LOGGER.error(
-                "The fan mode requested does not have a"
-                " corresponding mode in lyric: %s",
-                fan_mode,
-            )
+        except LYRIC_EXCEPTIONS as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="failed_to_set_fan_mode",
+            ) from err
+        except KeyError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_fan_mode",
+                translation_placeholders={"fan_mode": fan_mode},
+            ) from err
         await self.coordinator.async_refresh()

--- a/homeassistant/components/lyric/strings.json
+++ b/homeassistant/components/lyric/strings.json
@@ -65,6 +65,24 @@
     }
   },
   "exceptions": {
+    "failed_to_set_fan_mode": {
+      "message": "Failed to set fan mode"
+    },
+    "failed_to_set_hold_time": {
+      "message": "Failed to set hold time"
+    },
+    "failed_to_set_hvac_mode": {
+      "message": "Failed to set HVAC mode"
+    },
+    "failed_to_set_preset_mode": {
+      "message": "Failed to set preset mode"
+    },
+    "failed_to_set_temperature": {
+      "message": "Failed to set temperature"
+    },
+    "invalid_fan_mode": {
+      "message": "The fan mode {fan_mode} is not supported by this device"
+    },
     "oauth2_implementation_unavailable": {
       "message": "[%key:common::exceptions::oauth2_implementation_unavailable::message%]"
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
#170623

Generated with cursor (see co-author). Changes look accurate

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: closes #170623
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
