### PR TITLE
Fix language handling in jewish_calendar tests

### DIFF
--- a/tests/components/jewish_calendar/conftest.py
+++ b/tests/components/jewish_calendar/conftest.py
@@ -99,24 +99,24 @@ def results(
     # If results are generated, by using the HDate library, we need to set the language
     set_language(language)
 
-    if isinstance(request.param, dict):
-        result = {
-            key: value.replace(tzinfo=tz_info)
-            if isinstance(value, dt.datetime)
-            else value
-            for key, value in request.param.items()
-        }
-        if "attr" in result and isinstance(result["attr"], dict):
-            result["attr"] = {
-                key: value() if callable(value) else value
-                for key, value in result["attr"].items()
+    try:
+        if isinstance(request.param, dict):
+            result = {
+                key: value.replace(tzinfo=tz_info)
+                if isinstance(value, dt.datetime)
+                else value
+                for key, value in request.param.items()
             }
-        return result
+            if "attr" in result and isinstance(result["attr"], dict):
+                result["attr"] = {
+                    key: value() if callable(value) else value
+                    for key, value in result["attr"].items()
+                }
+            return result
 
-    # Reset language
-    set_language(previous_language)
-
-    return request.param
+        return request.param
+    finally:
+        set_language(previous_language)
 
 
 @pytest.fixture

--- a/tests/components/jewish_calendar/conftest.py
+++ b/tests/components/jewish_calendar/conftest.py
@@ -89,34 +89,34 @@ def _test_time(
 @pytest.fixture
 def results(
     request: pytest.FixtureRequest, tz_info: dt.tzinfo, language: str
-) -> Iterable:
+) -> Generator[Iterable | None]:
     """Return localized results."""
     if not hasattr(request, "param"):
-        return None
+        yield None
+        return
 
     previous_language = get_language()
 
     # If results are generated, by using the HDate library, we need to set the language
     set_language(language)
 
-    try:
-        if isinstance(request.param, dict):
-            result = {
-                key: value.replace(tzinfo=tz_info)
-                if isinstance(value, dt.datetime)
-                else value
-                for key, value in request.param.items()
+    if isinstance(request.param, dict):
+        result = {
+            key: value.replace(tzinfo=tz_info)
+            if isinstance(value, dt.datetime)
+            else value
+            for key, value in request.param.items()
+        }
+        if "attr" in result and isinstance(result["attr"], dict):
+            result["attr"] = {
+                key: value() if callable(value) else value
+                for key, value in result["attr"].items()
             }
-            if "attr" in result and isinstance(result["attr"], dict):
-                result["attr"] = {
-                    key: value() if callable(value) else value
-                    for key, value in result["attr"].items()
-                }
-            return result
+        yield result
+    else:
+        yield request.param
 
-        return request.param
-    finally:
-        set_language(previous_language)
+    set_language(previous_language)
 
 
 @pytest.fixture

--- a/tests/components/jewish_calendar/conftest.py
+++ b/tests/components/jewish_calendar/conftest.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, patch
 
 from freezegun import freeze_time
 from freezegun.api import FrozenDateTimeFactory
-from hdate.translator import set_language
+from hdate.translator import get_language, set_language
 import pytest
 
 from homeassistant.components.calendar import (
@@ -94,6 +94,8 @@ def results(
     if not hasattr(request, "param"):
         return None
 
+    previous_language = get_language()
+
     # If results are generated, by using the HDate library, we need to set the language
     set_language(language)
 
@@ -110,6 +112,10 @@ def results(
                 for key, value in result["attr"].items()
             }
         return result
+
+    # Reset language
+    set_language(previous_language)
+
     return request.param
 
 


### PR DESCRIPTION
## Proposed change
Fix the language handling in jewish_calendar tests The jewish_calendar dependency uses a ContextVar which leaks the changed language to other tests, this is now fixed by restoring the prev. language.

See https://github.com/home-assistant/core/actions/runs/26111238853/job/76790269096

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
