### PR TITLE
Fix Vimar lights stuck at 100% brightness in homekit_controller

### DIFF
--- a/homeassistant/components/homekit_controller/light.py
+++ b/homeassistant/components/homekit_controller/light.py
@@ -204,7 +204,14 @@ class HomeKitLight(HomeKitEntity, LightEntity):
             characteristics[CharacteristicsTypes.HUE] = hs_color[0]
             characteristics[CharacteristicsTypes.SATURATION] = hs_color[1]
 
-        characteristics[CharacteristicsTypes.ON] = True
+        # Extract the manufacturer from the accessory associated with the service
+        manufacturer = getattr(self.service.accessory, "manufacturer", "") if self.service and self.service.accessory else ""
+
+        # VIMAR WORKAROUND: Vimar firmware turns the light on at 100% brightness for a
+        # fraction of a second if it receives ON and BRIGHTNESS in the same payload.
+        # We omit the ON command if we are already sending other parameters.
+        if not characteristics or manufacturer != "Vimar":
+            characteristics[CharacteristicsTypes.ON] = True
 
         await self.async_put_characteristics(characteristics)
 

--- a/homeassistant/components/homekit_controller/light.py
+++ b/homeassistant/components/homekit_controller/light.py
@@ -205,12 +205,17 @@ class HomeKitLight(HomeKitEntity, LightEntity):
             characteristics[CharacteristicsTypes.SATURATION] = hs_color[1]
 
         # Extract the manufacturer from the accessory associated with the service
-        manufacturer = getattr(self.service.accessory, "manufacturer", "") if self.service and self.service.accessory else ""
+        manufacturer = (
+            getattr(self.service.accessory, "manufacturer", "")
+            if self.service and self.service.accessory
+            else ""
+        ).strip().casefold()
+        vimar_manufacturer = "vimar"
 
         # VIMAR WORKAROUND: Vimar firmware turns the light on at 100% brightness for a
         # fraction of a second if it receives ON and BRIGHTNESS in the same payload.
         # We omit the ON command if we are already sending other parameters.
-        if not characteristics or manufacturer != "Vimar":
+        if not characteristics or manufacturer != vimar_manufacturer:
             characteristics[CharacteristicsTypes.ON] = True
 
         await self.async_put_characteristics(characteristics)


### PR DESCRIPTION
## Proposed change
This resolves a long-standing, unresolved issue with Vimar HomeKit lights where the dimming functionality is completely broken.

Due to a firmware bug, if a Vimar light receives `ON: True` and `BRIGHTNESS` in the same payload, it ignores the brightness target and always defaults to 100%. Adjusting the brightness slider from the UI causes the value to update momentarily before shooting right back up to 100%. 

By omitting the explicit `ON: True` command when other characteristics (like `BRIGHTNESS` or color) are present in the payload, the Vimar firmware correctly performs an implicit turn-on and successfully applies the requested dimming level. This fix finally restores full dimming control.

To guarantee this does not negatively impact other HomeKit accessories—which might strictly require the explicit `ON` command to operate correctly—this workaround is scoped to apply **only** when the accessory's manufacturer string is exactly `"Vimar"`.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #101554
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Diagnostic JSON snippet confirming the manufacturer string is exactly `"Vimar"`:

<details>
<summary>Diagnostic JSON</summary>

{
  "aid": 162,
  "services": [
    {
      "iid": 1,
      "type": "0000003E-0000-1000-8000-0026BB765291",
      "characteristics": [
        {
          "type": "00000014-0000-1000-8000-0026BB765291",
          "iid": 2,
          "perms": [
            "pw"
          ],
          "format": "bool",
          "description": "Identify"
        },
        {
          "type": "00000020-0000-1000-8000-0026BB765291",
          "iid": 3,
          "perms": [
            "pr"
          ],
          "format": "string",
          "value": "Vimar",
          "description": "Manufacturer",
          "maxLen": 64
        },
        {
          "type": "00000021-0000-1000-8000-0026BB765291",
          "iid": 4,
          "perms": [
            "pr"
          ],
          "format": "string",
          "value": "Lightbulb",
          "description": "Model",
          "maxLen": 64
        },
        {
          "type": "00000023-0000-1000-8000-0026BB765291",
          "iid": 5,
          "perms": [
            "pr"
          ],
          "format": "string",
          "value": "Luci Perimetrali",
          "description": "Name",
          "maxLen": 64
        },
        {
          "type": "00000030-0000-1000-8000-0026BB765291",
          "iid": 6,
          "perms": [
            "pr"
          ],
          "format": "string",
          "value": "**REDACTED**",
          "description": "Serial Number",
          "maxLen": 64
        },
        {
          "type": "00000052-0000-1000-8000-0026BB765291",
          "iid": 7,
          "perms": [
            "pr"
          ],
          "format": "string",
          "value": "1.0.0",
          "description": "Firmware Revision",
          "maxLen": 64
        }
      ]
    },
    {
      "iid": 8,
      "type": "00000043-0000-1000-8000-0026BB765291",
      "characteristics": [
        {
          "type": "00000025-0000-1000-8000-0026BB765291",
          "iid": 9,
          "perms": [
            "pr",
            "pw",
            "ev"
          ],
          "format": "bool",
          "value": true,
          "description": "On"
        },
        {
          "type": "00000008-0000-1000-8000-0026BB765291",
          "iid": 10,
          "perms": [
            "pr",
            "pw",
            "ev"
          ],
          "format": "int",
          "value": 25,
          "description": "Brightness",
          "unit": "percentage",
          "minValue": 0,
          "maxValue": 100,
          "minStep": 1
        },
        {
          "type": "00000023-0000-1000-8000-0026BB765291",
          "iid": 11,
          "perms": [
            "pr"
          ],
          "format": "string",
          "value": "Luci Perimetrali",
          "description": "Name",
          "maxLen": 64
        }
      ]
    }
  ]
}

</details>

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr