### PR TITLE
Add Skegox API, floor plan image, battery sensor, and segment cleaning to SharkIQ

### DIFF
--- a/homeassistant/components/sharkiq/__init__.py
+++ b/homeassistant/components/sharkiq/__init__.py
@@ -1,13 +1,14 @@
-"""Shark IQ Integration."""
+# Shark IQ Integration.
 
 import asyncio
 from contextlib import suppress
 
 import aiohttp
-from sharkiq import (
+from .sharkiq_pypi.sharkiq import (
     AylaApi,
     SharkIqAuthError,
     SharkIqAuthExpiringError,
+    SharkIqAuthVerificationRequiredError,
     SharkIqNotAuthedError,
     get_ayla_api,
 )
@@ -20,15 +21,25 @@ from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
+    API_BACKEND_AYLA,
+    API_BACKEND_SKEGOX,
     API_TIMEOUT,
+    CONF_API_BACKEND,
     DOMAIN,
     LOGGER,
     PLATFORMS,
     SHARKIQ_REGION_DEFAULT,
     SHARKIQ_REGION_EUROPE,
 )
-from .coordinator import SharkIqConfigEntry, SharkIqUpdateCoordinator
+from .coordinator import SharkDevice, SharkIqConfigEntry, SharkIqUpdateCoordinator, SkegoxUpdateCoordinator
 from .services import async_setup_services
+from .skegox_api import SkegoxApi, SkegoxApiError
+from .skegox_auth import (
+    SkegoxAuthError,
+    SkegoxAuthManager,
+    SkegoxAuthRequiresVerificationError,
+)
+from .skegox_device import SkegoxDevice
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
@@ -36,13 +47,21 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 class CannotConnect(exceptions.HomeAssistantError):
     """Error to indicate we cannot connect."""
 
-
+# Connect to vacuum via Ayla API.
+# Returns True on successful sign-in, False on auth errors.
+# Raises CannotConnect on timeout. Only handles Ayla (not Skegox) auth.
 async def async_connect_or_timeout(ayla_api: AylaApi) -> bool:
-    """Connect to vacuum."""
     try:
         async with asyncio.timeout(API_TIMEOUT):
             LOGGER.debug("Initialize connection to Ayla networks API")
             await ayla_api.async_sign_in()
+    except SharkIqAuthVerificationRequiredError:
+        LOGGER.error(
+            "SharkNinja is blocking automated login (anti-bot protection). "
+            "This is not a credential issue. Wait 24-48 hours without retrying, "
+            "then try again. You can still use the SharkClean app in the meantime."
+        )
+        return False
     except SharkIqAuthError:
         LOGGER.error("Authentication error connecting to Shark IQ api")
         return False
@@ -52,79 +71,172 @@ async def async_connect_or_timeout(ayla_api: AylaApi) -> bool:
 
     return True
 
-
+# Set up the component.
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the component."""
     async_setup_services(hass)
     return True
 
+# Attempt Skegox API setup. Returns (coordinator, devices) or (None, []).
+async def _try_skegox_setup(hass: HomeAssistant, config_entry: SharkIqConfigEntry, region: str,) -> tuple[SkegoxUpdateCoordinator | None, list[SkegoxDevice]]:
+    username = config_entry.data[CONF_USERNAME]
+    password = config_entry.data[CONF_PASSWORD]
 
-async def async_setup_entry(
-    hass: HomeAssistant, config_entry: SharkIqConfigEntry
-) -> bool:
-    """Initialize the sharkiq platform via config entry."""
-    if CONF_REGION not in config_entry.data:
-        hass.config_entries.async_update_entry(
-            config_entry,
-            data={**config_entry.data, CONF_REGION: SHARKIQ_REGION_DEFAULT},
-        )
+    auth_manager = SkegoxAuthManager(hass, config_entry, username, password, region)
 
-    new_websession = async_create_clientsession(
-        hass,
-        cookie_jar=aiohttp.CookieJar(unsafe=True, quote_cookie=False),
-    )
+    try:
+        await auth_manager.ensure_authenticated()
+    except SkegoxAuthRequiresVerificationError as exc:
+        LOGGER.debug("Skegox auth requires verification: %s", exc)
+        await auth_manager.close()
+        return None, []
+    except SkegoxAuthError as exc:
+        LOGGER.debug("Skegox auth failed: %s", exc)
+        await auth_manager.close()
+        return None, []
+
+    skegox_api = SkegoxApi(auth_manager)
+
+    try:
+        await skegox_api.discover()
+        raw_devices = await skegox_api.get_all_devices()
+    except (SkegoxApiError, SkegoxAuthError) as exc:
+        LOGGER.debug("Skegox API error during setup: %s", exc)
+        await skegox_api.close()
+        return None, []
+
+    if not raw_devices:
+        LOGGER.debug("Skegox returned no devices")
+        await skegox_api.close()
+        return None, []
+
+    devices = []
+    for raw in raw_devices:
+        device = SkegoxDevice(skegox_api, raw)
+        devices.append(device)
+
+    # Fetch zones (MARD protobuf with room/no-go polygon data) and
+    # floorRPfile1 (floor plan image protobuf) for each device
+    for device in devices:
+        mard_body = await skegox_api.fetch_property_file(device.serial_number, "zones")
+        if mard_body:
+            device.load_mard(mard_body)
+
+        # Fetch floor plan image protobuf
+        floor_data = await skegox_api.fetch_property_file(device.serial_number, "floorRPfile1")
+        if floor_data:
+            device.parse_floor_plan(floor_data)
+
+    device_names = ", ".join(d.name for d in devices)
+    LOGGER.info("Found %d Shark device(s) via Skegox API: %s", len(devices), device_names)
+
+    coordinator = SkegoxUpdateCoordinator(hass, config_entry, skegox_api, auth_manager, devices)
+
+    return coordinator, devices
+
+# Attempt Ayla API setup. Returns (coordinator, devices) or (None, []).
+async def _try_ayla_setup(hass: HomeAssistant, config_entry: SharkIqConfigEntry, region: str,) -> tuple[SharkIqUpdateCoordinator | None, list[SharkDevice]]:
+    new_websession = async_create_clientsession(hass, cookie_jar=aiohttp.CookieJar(unsafe=True, quote_cookie=False),)
 
     ayla_api = get_ayla_api(
         username=config_entry.data[CONF_USERNAME],
         password=config_entry.data[CONF_PASSWORD],
         websession=new_websession,
-        europe=(config_entry.data[CONF_REGION] == SHARKIQ_REGION_EUROPE),
+        europe=(region == SHARKIQ_REGION_EUROPE),
     )
 
     try:
         if not await async_connect_or_timeout(ayla_api):
-            return False
-    except CannotConnect as exc:
-        raise exceptions.ConfigEntryNotReady from exc
+            return None, []
+    except CannotConnect:
+        return None, []
 
     shark_vacs = await ayla_api.async_get_devices(False)
+    if not shark_vacs:
+        LOGGER.debug("Ayla returned no devices")
+        return None, []
+
     device_names = ", ".join(d.name for d in shark_vacs)
-    LOGGER.debug("Found %d Shark IQ device(s): %s", len(shark_vacs), device_names)
+    LOGGER.info("Found %d Shark device(s) via Ayla API: %s", len(shark_vacs), device_names)
+
     coordinator = SharkIqUpdateCoordinator(hass, config_entry, ayla_api, shark_vacs)
+    return coordinator, shark_vacs
+
+# Initialize the sharkiq platform via config entry.
+async def async_setup_entry(hass: HomeAssistant, config_entry: SharkIqConfigEntry) -> bool:
+    if CONF_REGION not in config_entry.data:
+        hass.config_entries.async_update_entry(config_entry, data={**config_entry.data, CONF_REGION: SHARKIQ_REGION_DEFAULT},)
+
+    region = config_entry.data.get(CONF_REGION, SHARKIQ_REGION_DEFAULT)
+
+    # Try previously stored backend first with fallback to the other.
+    # Default to Skegox then Ayla.
+    stored_backend = config_entry.data.get(CONF_API_BACKEND)
+
+    if stored_backend == API_BACKEND_SKEGOX:
+        backends_to_try: list[str] = [API_BACKEND_SKEGOX, API_BACKEND_AYLA]
+    elif stored_backend == API_BACKEND_AYLA:
+        backends_to_try = [API_BACKEND_AYLA, API_BACKEND_SKEGOX]
+    else:
+        backends_to_try = [API_BACKEND_SKEGOX, API_BACKEND_AYLA]
+
+    coordinator: SharkIqUpdateCoordinator | SkegoxUpdateCoordinator | None = None
+    devices: list[SharkDevice] = []
+
+    for backend in backends_to_try:
+        if backend == API_BACKEND_SKEGOX:
+            coordinator, devices = await _try_skegox_setup(hass, config_entry, region)
+        else:
+            coordinator, devices = await _try_ayla_setup(hass, config_entry, region)
+
+        if coordinator is not None:
+            break
+
+        # First backend failed and it was the previously stored one
+        if backend == stored_backend:
+            if backend == API_BACKEND_SKEGOX:
+                LOGGER.warning("Skegox backend previously used but is no longer available -> Falling back to Ayla API..."
+                )
+            else:
+                LOGGER.warning("Ayla backend previously used but is no longer available -> Trying Skegox API..."
+                )
+
+    if coordinator is None:
+        LOGGER.error("Failed to connect to Shark IQ via any API backend")
+        raise exceptions.ConfigEntryNotReady("Unable to connect to Shark IQ. Check credentials and region settings.")
+
+    # Store the detected backend
+    backend = API_BACKEND_SKEGOX if isinstance(coordinator, SkegoxUpdateCoordinator) else API_BACKEND_AYLA
+    if config_entry.data.get(CONF_API_BACKEND) != backend:
+        hass.config_entries.async_update_entry(config_entry, data={**config_entry.data, CONF_API_BACKEND: backend},)
 
     await coordinator.async_config_entry_first_refresh()
-
     config_entry.runtime_data = coordinator
-
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
-
     return True
 
+# Disconnect from vacuum
+# Skegox: Simply closes the aiohttp session.
+# Ayla: Graceful sign-out, suppressing auth errors.
+async def async_disconnect_or_timeout(coordinator: SharkIqUpdateCoordinator | SkegoxUpdateCoordinator) -> None:
+    if isinstance(coordinator, SkegoxUpdateCoordinator):
+        LOGGER.debug("Closing Skegox API session")
+        await coordinator.skegox_api.close()
+        return
 
-async def async_disconnect_or_timeout(coordinator: SharkIqUpdateCoordinator):
-    """Disconnect to vacuum."""
     LOGGER.debug("Disconnecting from Ayla Api")
     async with asyncio.timeout(5):
-        with suppress(
-            SharkIqAuthError, SharkIqAuthExpiringError, SharkIqNotAuthedError
-        ):
+        with suppress(SharkIqAuthError, SharkIqAuthExpiringError, SharkIqNotAuthedError):
             await coordinator.ayla_api.async_sign_out()
 
-
-async def async_update_options(hass: HomeAssistant, config_entry):
-    """Update options."""
+# Update options.
+async def async_update_options(hass: HomeAssistant, config_entry: SharkIqConfigEntry) -> None:
     await hass.config_entries.async_reload(config_entry.entry_id)
 
-
-async def async_unload_entry(
-    hass: HomeAssistant, config_entry: SharkIqConfigEntry
-) -> bool:
-    """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(
-        config_entry, PLATFORMS
-    )
+# Unload a config entry.
+async def async_unload_entry(hass: HomeAssistant, config_entry: SharkIqConfigEntry) -> bool:
+    unload_ok = await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)
     if unload_ok:
         with suppress(SharkIqAuthError):
-            await async_disconnect_or_timeout(coordinator=config_entry.runtime_data)
+            await async_disconnect_or_timeout(config_entry.runtime_data)
 
     return unload_ok

--- a/homeassistant/components/sharkiq/config_flow.py
+++ b/homeassistant/components/sharkiq/config_flow.py
@@ -1,14 +1,14 @@
-"""Config flow for Shark IQ integration."""
+# Config flow for Shark IQ integration.
 
 import asyncio
 from collections.abc import Mapping
 from typing import Any
 
 import aiohttp
-from sharkiq import SharkIqAuthError, get_ayla_api
+from .sharkiq_pypi.sharkiq import SharkIqAuthError, SharkIqAuthVerificationRequiredError, get_ayla_api
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_REGION, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -16,6 +16,9 @@ from homeassistant.helpers import selector
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
 from .const import (
+    API_BACKEND_AYLA,
+    API_BACKEND_SKEGOX,
+    CONF_API_BACKEND,
     DOMAIN,
     LOGGER,
     SHARKIQ_REGION_DEFAULT,
@@ -23,124 +26,157 @@ from .const import (
     SHARKIQ_REGION_OPTIONS,
 )
 
+from .skegox_api import SkegoxApi
+from .skegox_auth import (
+    SkegoxAuthError,
+    SkegoxAuthManager,
+    SkegoxAuthRequiresVerificationError,
+)
+
 SHARKIQ_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_USERNAME): str,
         vol.Required(CONF_PASSWORD): str,
-        vol.Required(
-            CONF_REGION, default=SHARKIQ_REGION_DEFAULT
-        ): selector.SelectSelector(
-            selector.SelectSelectorConfig(
-                options=SHARKIQ_REGION_OPTIONS, translation_key="region"
-            ),
+        vol.Required(CONF_REGION, default=SHARKIQ_REGION_DEFAULT):
+            selector.SelectSelector(selector.SelectSelectorConfig(options=SHARKIQ_REGION_OPTIONS, translation_key="region"),
         ),
     }
 )
 
+# Validate Skegox API access:
+# Returns info dict ``{"title": username, "backend": "skegox"}`` on success.
+# Returns None if auth fails, verification is required, or no devices are found.
+async def _validate_skegox(hass: HomeAssistant, config_entry: ConfigEntry | None, data: Mapping[str, Any]) -> dict[str, str] | None:
+    region = data[CONF_REGION]
+    auth_manager = SkegoxAuthManager(hass, config_entry, data[CONF_USERNAME], data[CONF_PASSWORD], region)
 
-async def _validate_input(
-    hass: HomeAssistant, data: Mapping[str, Any]
-) -> dict[str, str]:
-    """Validate the user input allows us to connect."""
-    new_websession = async_create_clientsession(
-        hass,
-        cookie_jar=aiohttp.CookieJar(unsafe=True, quote_cookie=False),
-    )
+    try:
+        await auth_manager.ensure_authenticated()
+    except SkegoxAuthRequiresVerificationError:
+        LOGGER.debug("Skegox auth requires verification (MFA/CAPTCHA)")
+        await auth_manager.close()
+        return None
+    except SkegoxAuthError:
+        LOGGER.debug("Skegox auth failed")
+        await auth_manager.close()
+        return None
+
+    skegox_api = SkegoxApi(auth_manager)
+
+    try:
+        await skegox_api.discover()
+        devices = await skegox_api.list_devices()
+    except Exception:
+        LOGGER.debug("Skegox device discovery failed", exc_info=True)
+        await skegox_api.close()
+        return None
+
+    await skegox_api.close()
+
+    if not devices:
+        LOGGER.debug("Skegox returned no devices")
+        return None
+
+    return {"title": data[CONF_USERNAME], "backend": API_BACKEND_SKEGOX}
+
+# Validate Ayla API access.
+async def _validate_ayla(hass: HomeAssistant, data: Mapping[str, Any]) -> dict[str, str]:
+    new_websession = async_create_clientsession(hass, cookie_jar=aiohttp.CookieJar(unsafe=True, quote_cookie=False),)
     ayla_api = get_ayla_api(
         username=data[CONF_USERNAME],
         password=data[CONF_PASSWORD],
         websession=new_websession,
-        europe=(data[CONF_REGION] == SHARKIQ_REGION_EUROPE),
-    )
+        europe=(data[CONF_REGION] == SHARKIQ_REGION_EUROPE),)
 
     try:
         async with asyncio.timeout(15):
             LOGGER.debug("Initialize connection to Ayla networks API")
             await ayla_api.async_sign_in()
+    # SharkNinja anti-bot protection triggered — not a credential issue
+    except SharkIqAuthVerificationRequiredError:
+        LOGGER.error(
+            "SharkNinja is blocking automated login (anti-bot protection)."
+            "Sign in with mobile app (account / password) only,"
+            "do not use biometric credential storage."
+        )
+        raise RequiresVerification("SharkNinja is blocking automated login.") from None
+    # Network or protocol-level failures
     except (TimeoutError, aiohttp.ClientError, TypeError) as error:
         LOGGER.error(error)
-        raise CannotConnect(
-            "Unable to connect to SharkIQ services.  Check your region settings."
-        ) from error
+        raise CannotConnect("Unable to connect to SharkIQ services.  Check your region settings.") from error
+    # Wrong username/password
     except SharkIqAuthError as error:
         LOGGER.error(error)
-        raise InvalidAuth(
-            "Username or password incorrect.  Please check your credentials."
-        ) from error
+        raise InvalidAuth("Username or password incorrect.  Please check your credentials.") from error
+    # Any other unexpected error — likely region misconfiguration
     except Exception as error:
         LOGGER.exception("Unexpected exception")
-        LOGGER.error(error)
-        raise UnknownAuth(
-            "An unknown error occurred. Check your region"
-            " settings and open an issue on GitHub"
-            " if the issue persists."
-        ) from error
+        raise UnknownAuth("An unknown error occurred. Check your region settings and open an issue on GitHub if the issue persists.") from error
 
-    # Return info that you want to store in the config entry.
-    return {"title": data[CONF_USERNAME]}
+    return {"title": data[CONF_USERNAME], "backend": API_BACKEND_AYLA}
 
+# Validate the user input allows us to connect. Tries Skegox first, falls back to Ayla.
+async def _validate_input(hass: HomeAssistant, config_entry: ConfigEntry | None, data: Mapping[str, Any]) -> dict[str, str]:
+    # Try Skegox first
+    skegox_result = await _validate_skegox(hass, config_entry, data)
+    if skegox_result:
+        return skegox_result
 
+    # Fall back to Ayla
+    return await _validate_ayla(hass, data)
+
+# Handle a config flow for Shark IQ.
 class SharkIqConfigFlow(ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for Shark IQ."""
-
     VERSION = 1
 
-    async def _async_validate_input(
-        self, user_input: Mapping[str, Any]
-    ) -> tuple[dict[str, str] | None, dict[str, str]]:
-        """Validate form input."""
+    # Validate form input.
+    async def _async_validate_input(self, user_input: Mapping[str, Any]) -> tuple[dict[str, str] | None, dict[str, str]]:
         errors = {}
         info = None
 
-        # noinspection PyBroadException
         try:
-            info = await _validate_input(self.hass, user_input)
+            info = await _validate_input(self.hass, None, user_input)
         except CannotConnect:
             errors["base"] = "cannot_connect"
         except InvalidAuth:
             errors["base"] = "invalid_auth"
         except UnknownAuth:
             errors["base"] = "unknown"
+        except RequiresVerification:
+            errors["base"] = "requires_verification"
         return info, errors
 
-    async def async_step_user(
-        self, user_input: dict[str, str] | None = None
-    ) -> ConfigFlowResult:
-        """Handle the initial step."""
+    # Handle the initial step.
+    async def async_step_user(self, user_input: dict[str, str] | None = None) -> ConfigFlowResult:
         errors: dict[str, str] = {}
         if user_input is not None:
             info, errors = await self._async_validate_input(user_input)
             if info:
                 await self.async_set_unique_id(user_input[CONF_USERNAME])
                 self._abort_if_unique_id_configured()
-                return self.async_create_entry(title=info["title"], data=user_input)
+                entry_data = {**user_input, CONF_API_BACKEND: info["backend"]}
+                return self.async_create_entry(title=info["title"], data=entry_data)
 
-        return self.async_show_form(
-            step_id="user", data_schema=SHARKIQ_SCHEMA, errors=errors
-        )
+        return self.async_show_form(step_id="user", data_schema=SHARKIQ_SCHEMA, errors=errors)
 
-    async def async_step_reauth(
-        self, entry_data: Mapping[str, Any]
-    ) -> ConfigFlowResult:
-        """Handle re-auth if login is invalid."""
+    # Handle re-auth if login is invalid.
+    async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> ConfigFlowResult:
         return await self.async_step_reauth_confirm()
 
-    async def async_step_reauth_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle a flow initiated by reauthentication."""
+    # Handle a flow initiated by reauthentication.
+    async def async_step_reauth_confirm(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            _, errors = await self._async_validate_input(user_input)
+            info, errors = await self._async_validate_input(user_input)
 
-            if not errors:
-                errors = {"base": "unknown"}
+            if not errors and info:
                 if entry := await self.async_set_unique_id(self.unique_id):
-                    self.hass.config_entries.async_update_entry(entry, data=user_input)
+                    updated_data = {**user_input, CONF_API_BACKEND: info["backend"]}
+                    self.hass.config_entries.async_update_entry(entry, data=updated_data)
                     return self.async_abort(reason="reauth_successful")
 
-            if errors["base"] != "invalid_auth":
+            if errors.get("base") and errors["base"] != "invalid_auth":
                 return self.async_abort(reason=errors["base"])
 
         return self.async_show_form(
@@ -153,10 +189,11 @@ class SharkIqConfigFlow(ConfigFlow, domain=DOMAIN):
 class CannotConnect(HomeAssistantError):
     """Error to indicate we cannot connect."""
 
-
 class InvalidAuth(HomeAssistantError):
     """Error to indicate there is invalid auth."""
 
-
 class UnknownAuth(HomeAssistantError):
     """Error to indicate there is an uncaught auth error."""
+
+class RequiresVerification(HomeAssistantError):
+    """Error to indicate account verification is required."""    

--- a/homeassistant/components/sharkiq/const.py
+++ b/homeassistant/components/sharkiq/const.py
@@ -1,4 +1,4 @@
-"""Shark IQ Constants."""
+# Shark IQ Constants.
 
 from datetime import timedelta
 import logging
@@ -8,14 +8,57 @@ from homeassistant.const import Platform
 LOGGER = logging.getLogger(__package__)
 
 API_TIMEOUT = 20
-PLATFORMS = [Platform.VACUUM]
+UPDATE_INTERVAL = timedelta(seconds=30)
+PLATFORMS = [Platform.IMAGE, Platform.SENSOR, Platform.VACUUM]
 DOMAIN = "sharkiq"
 SHARK = "Shark"
-UPDATE_INTERVAL = timedelta(seconds=30)
-
 ATTR_ROOMS = "rooms"
 
 SHARKIQ_REGION_EUROPE = "europe"
 SHARKIQ_REGION_ELSEWHERE = "elsewhere"
 SHARKIQ_REGION_DEFAULT = SHARKIQ_REGION_ELSEWHERE
 SHARKIQ_REGION_OPTIONS = [SHARKIQ_REGION_EUROPE, SHARKIQ_REGION_ELSEWHERE]
+
+# API backend identifiers
+API_BACKEND_AYLA = "ayla"
+API_BACKEND_SKEGOX = "skegox"
+
+# Config entry data keys for token storage
+CONF_AUTH0_ID_TOKEN = "auth0_id_token"
+CONF_AUTH0_REFRESH_TOKEN = "auth0_refresh_token"
+CONF_AUTH0_ACCESS_TOKEN = "auth0_access_token"
+CONF_AUTH0_EXPIRY = "auth0_token_expiry"
+CONF_AYLA_ACCESS_TOKEN = "ayla_access_token"
+CONF_AYLA_REFRESH_TOKEN = "ayla_refresh_token"
+CONF_AYLA_TOKEN_EXPIRY = "ayla_token_expiry"
+CONF_HOUSEHOLD_ID = "household_id"
+CONF_USER_ID = "user_id"
+CONF_API_BACKEND = "api_backend"
+
+# Error code descriptions
+# Sources: sharkiqlibs/sharkiq, ayla-iot-unofficial, Hubitat SharkIQ driver,
+# Domoticz SharkIQ integration, SharkNinja support docs.
+ERROR_MESSAGES = {
+    0: "No error",
+    1: "Side wheel is stuck",
+    2: "Side brush is stuck",
+    3: "Suction motor failed",
+    4: "Brushroll stuck",
+    5: "Charging error",  # Inferred — original meaning uncertain, was duplicate of code 1
+    6: "Bumper is stuck",
+    7: "Cliff sensor is blocked",
+    8: "Battery power is low",
+    9: "No dustbin",
+    10: "Fall sensor is blocked",
+    11: "Front wheel is stuck",
+    12: "Wrong power adapter",
+    13: "Switched off",
+    14: "Magnetic strip error",
+    16: "Top bumper is stuck",
+    18: "Wheel encoder error",
+    21: "Boot error",
+    23: "Base placement error",
+    24: "Critical low battery",
+    26: "Dustbin blockage",
+    40: "Dustbin is blocked",
+}

--- a/homeassistant/components/sharkiq/coordinator.py
+++ b/homeassistant/components/sharkiq/coordinator.py
@@ -1,9 +1,9 @@
-"""Data update coordinator for shark iq vacuums."""
+# Data update coordinator for shark iq vacuums.
 
 import asyncio
 from datetime import datetime, timedelta
 
-from sharkiq import (
+from .sharkiq_pypi.sharkiq import (
     AylaApi,
     SharkIqAuthError,
     SharkIqAuthExpiringError,
@@ -17,27 +17,33 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import API_TIMEOUT, DOMAIN, LOGGER, UPDATE_INTERVAL
+from .skegox_api import SkegoxApi, SkegoxApiError
+from .skegox_auth import SkegoxAuthError, SkegoxAuthManager
+from .skegox_device import SkegoxDevice
 
-type SharkIqConfigEntry = ConfigEntry[SharkIqUpdateCoordinator]
+type SharkIqConfigEntry = ConfigEntry[SharkIqUpdateCoordinator | SkegoxUpdateCoordinator]
+type SharkDevice = SharkIqVacuum | SkegoxDevice
 
+# Return the device model number, preferring vac_model_number over oem_model_number.
+def get_device_model(device: SharkDevice) -> str:
+    if device.vac_model_number:
+        return device.vac_model_number
+    return device.oem_model_number
 
-class SharkIqUpdateCoordinator(DataUpdateCoordinator[bool]):
-    """Define a wrapper class to update Shark IQ data."""
-
+# Base coordinator shared by Ayla and Skegox backends.
+class BaseSharkIqCoordinator(DataUpdateCoordinator[bool]):
     config_entry: SharkIqConfigEntry
 
     def __init__(
         self,
         hass: HomeAssistant,
         config_entry: SharkIqConfigEntry,
-        ayla_api: AylaApi,
-        shark_vacs: list[SharkIqVacuum],
     ) -> None:
-        """Set up the SharkIqUpdateCoordinator class."""
-        self.ayla_api = ayla_api
-        self.shark_vacs: dict[str, SharkIqVacuum] = {
-            sharkiq.serial_number: sharkiq for sharkiq in shark_vacs
-        }
+        # Set up the base coordinator.
+
+        # shark_vacs -> is keyed by device serial number (DSN).
+        self.shark_vacs: dict[str, SharkDevice] = {}
+        # _online_dsns -> tracks which DSNs are currently reachable.
         self._online_dsns: set[str] = set()
 
         super().__init__(
@@ -48,26 +54,44 @@ class SharkIqUpdateCoordinator(DataUpdateCoordinator[bool]):
             update_interval=UPDATE_INTERVAL,
         )
 
+    # Get the set of all online DSNs.
     @property
     def online_dsns(self) -> set[str]:
-        """Get the set of all online DSNs."""
         return self._online_dsns
-
+    # Return the online state of a given vacuum dsn.
     def device_is_online(self, dsn: str) -> bool:
-        """Return the online state of a given vacuum dsn."""
         return dsn in self._online_dsns
 
+# Define a wrapper class to update Shark IQ data via the Ayla API.
+class SharkIqUpdateCoordinator(BaseSharkIqCoordinator):
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: SharkIqConfigEntry,
+        ayla_api: AylaApi,
+        shark_vacs: list[SharkIqVacuum],
+    ) -> None:
+        # Set up the SharkIqUpdateCoordinator class.
+        super().__init__(hass, config_entry)
+        self.ayla_api = ayla_api
+        self.shark_vacs: dict[str, SharkIqVacuum] = {
+            sharkiq.serial_number: sharkiq for sharkiq in shark_vacs
+        }
+
+    # Asynchronously update the data for a single vacuum.
     @staticmethod
     async def _async_update_vacuum(sharkiq: SharkIqVacuum) -> None:
-        """Asynchronously update the data for a single vacuum."""
         dsn = sharkiq.serial_number
         LOGGER.debug("Updating sharkiq data for device DSN %s", dsn)
         async with asyncio.timeout(API_TIMEOUT):
             await sharkiq.async_update()
-
+    
+    # Update data device by device.
     async def _async_update_data(self) -> bool:
-        """Update data device by device."""
         try:
+            # Refresh auth via two checks: the library's built-in flag and a
+            # manual 10-minute-before-expiry window. Both are needed because
+            # token_expiring_soon may not cover all expiry edge cases.
             if (
                 self.ayla_api.token_expiring_soon
                 or datetime.now()
@@ -83,8 +107,8 @@ class SharkIqUpdateCoordinator(DataUpdateCoordinator[bool]):
             }
 
             LOGGER.debug("Updating sharkiq data")
-            online_vacs = (self.shark_vacs[dsn] for dsn in self.online_dsns)
-            await asyncio.gather(*(self._async_update_vacuum(v) for v in online_vacs))
+            online_vacs = [self.shark_vacs[dsn] for dsn in self.online_dsns]
+            await asyncio.gather(*[self._async_update_vacuum(v) for v in online_vacs])
         except (
             SharkIqAuthError,
             SharkIqNotAuthedError,
@@ -94,6 +118,93 @@ class SharkIqUpdateCoordinator(DataUpdateCoordinator[bool]):
             raise ConfigEntryAuthFailed from err
         except Exception as err:
             LOGGER.exception("Unexpected error updating SharkIQ.  Attempting re-auth")
+            raise UpdateFailed(err) from err
+
+        return True
+
+# Define a wrapper class to update Shark IQ data via the Skegox API.
+class SkegoxUpdateCoordinator(BaseSharkIqCoordinator):
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: SharkIqConfigEntry,
+        skegox_api: SkegoxApi,
+        auth_manager: SkegoxAuthManager,
+        devices: list[SkegoxDevice],
+    ) -> None:
+        # Set up the SkegoxUpdateCoordinator class.
+        super().__init__(hass, config_entry)
+        self.skegox_api = skegox_api
+        self.auth_manager = auth_manager
+        self.shark_vacs: dict[str, SkegoxDevice] = {
+            device.serial_number: device for device in devices
+        }
+        self._mard_failed_dsns: set[str] = set()
+        self._mard_retry_count: dict[str, int] = {}
+        self._mard_retry_interval = 10
+
+    # Get the list of all Skegox devices.
+    @property
+    def devices(self) -> list[SkegoxDevice]:
+        return list(self.shark_vacs.values())
+
+    # Update data for all Skegox devices.
+    async def _async_update_data(self) -> bool:
+        try:
+            await self.auth_manager.ensure_authenticated()
+
+            raw_devices = await self.skegox_api.get_all_devices()
+
+            self._online_dsns = set()
+            for raw in raw_devices:
+                registry = raw.get("registry", {})
+                connectivity = raw.get("connectivityStatus", {})
+
+                snd = SkegoxDevice.extract_snd(registry)
+                is_online = connectivity.get("connected", False)
+
+                if is_online:
+                    self._online_dsns.add(snd)
+
+                existing = self.shark_vacs.get(snd)
+                
+                # Update in-place to preserve MARD/room data already loaded
+                if existing:
+                    existing.update_from_response(raw)
+                # New device discovered during a running session
+                else:
+                    new_device = SkegoxDevice(self.skegox_api, raw)
+                    self.shark_vacs[snd] = new_device
+
+            for device in self.shark_vacs.values():
+                snd = device.serial_number
+                
+                # avoid spamming the API for persistently missing data.
+                if snd in self._mard_failed_dsns:
+                    retry_count = self._mard_retry_count.get(snd, 0) + 1
+                    self._mard_retry_count[snd] = retry_count
+                    # Retries are throttled to every _mard_retry_interval cycles
+                    if retry_count % self._mard_retry_interval != 0:
+                        continue
+                # Retry MARD fetch periodically after initial failure.
+                if not device.room_polygons and not device.mard_data:
+                    mard_body = await self.skegox_api.fetch_property_file(device.serial_number, "zones")
+                    if mard_body:
+                        device.load_mard(mard_body)
+                        self._mard_failed_dsns.discard(device.serial_number)
+                        self._mard_retry_count.pop(device.serial_number, None)
+                    else:
+                        self._mard_failed_dsns.add(device.serial_number)
+
+            LOGGER.debug("Skegox update: %d devices, %d online", len(self.shark_vacs), len(self._online_dsns),)
+        except SkegoxAuthError as err:
+            LOGGER.debug("Skegox auth error during update", exc_info=err)
+            raise ConfigEntryAuthFailed from err
+        except SkegoxApiError as err:
+            LOGGER.exception("Skegox API error during update")
+            raise UpdateFailed(err) from err
+        except Exception as err:
+            LOGGER.exception("Unexpected error updating Skegox devices")
             raise UpdateFailed(err) from err
 
         return True

--- a/homeassistant/components/sharkiq/image.py
+++ b/homeassistant/components/sharkiq/image.py
@@ -1,0 +1,363 @@
+# Shark IQ Floor Plan Image Entity.
+# Renders a floor plan image from MARD polygon data
+# Rooms as colored polygons with labels and no-go zones as red hatched areas.
+# Support for doorways and lidar scan map
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterable
+import math
+from datetime import datetime
+import io
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from PIL import Image
+
+from homeassistant.components.image import ImageEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, SHARK
+from .coordinator import SharkIqConfigEntry, SharkIqUpdateCoordinator, SkegoxUpdateCoordinator, SharkDevice, get_device_model
+from .sharkiq_pypi.sharkiq import Properties
+from .skegox_device import SkegoxDevice
+
+PADDING = 40
+LABEL_FONT_SIZE = 14
+NOGO_HATCH_ALPHA = 179
+NOGO_HATCH_SPACING = 12
+NOGO_HATCH_WIDTH = 2
+IMAGE_MIN_DIM = 400
+IMAGE_MAX_DIM = 1200
+
+ROOM_COLOR = (66, 133, 244)
+
+# Unsure what fonts are available
+FONT_PATHS = [
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+    "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+    "/usr/share/fonts/truetype/noto/NotoSans-Regular.ttf",
+    "/usr/share/fonts/TTF/DejaVuSans.ttf",
+    "/System/Library/Fonts/Helvetica.ttc",
+    "C:\\Windows\\Fonts\\arial.ttf",
+]
+
+# Compute min/max bounds from room polygons and no-go zones.
+def _compute_bounds(room_polygons: dict[str, list[tuple[float, float]]], no_go_zones: list[dict[str, Any]],) -> tuple[float, float, float, float]:
+    all_x = [x for points in room_polygons.values() for x, _ in points] + [x for zone in no_go_zones for x, _ in zone["points"]]
+    all_y = [y for points in room_polygons.values() for _, y in points] + [y for zone in no_go_zones for _, y in zone["points"]]
+    
+    # Fallback bounds when no polygons or zones exist yet
+    if not all_x:
+        return 0, 0, 100, 100
+    return min(all_x), min(all_y), max(all_x), max(all_y)
+
+# Transform MARD coordinates to image pixel coordinates.
+# MARD uses Cartesian (y-up), images use y-down, so we flip Y.
+# X is also mirrored (``img_w - ...``) because MARD origin is top-right.
+def _transform_point(x: float, y: float, min_x: float, min_y: float, max_x: float, max_y: float, img_w: int, img_h: int,) -> tuple[int, int]:
+    data_w = max_x - min_x
+    data_h = max_y - min_y
+    if data_w == 0:
+        data_w = 1
+    if data_h == 0:
+        data_h = 1
+
+    scale_x = (img_w - 2 * PADDING) / data_w
+    scale_y = (img_h - 2 * PADDING) / data_h
+    scale = min(scale_x, scale_y)
+
+    offset_x = PADDING + (img_w - 2 * PADDING - data_w * scale) / 2
+    offset_y = PADDING + (img_h - 2 * PADDING - data_h * scale) / 2
+
+    px = int(img_w - (offset_x + (x - min_x) * scale))
+    py = int(img_h - (offset_y + (y - min_y) * scale))
+    return px, py
+
+# Transform polygon points to pixel coords and return them.
+# Returns pixel coordinates without drawing so the caller can decide
+# whether to fill, outline, or overlay the polygon separately.
+def _draw_polygon(draw: Any, points: list[tuple[float, float]], min_x: float, min_y: float, max_x: float, max_y: float, img_w: int, img_h: int,) -> list[tuple[int, int]]:
+    pixel_points = [_transform_point(x, y, min_x, min_y, max_x, max_y, img_w, img_h) for x, y in points]
+    return pixel_points
+
+# Create a hatch overlay image clipped to the polygon.
+def _draw_hatch_overlay( pixel_points: list[tuple[int, int]], img_w: int, img_h: int, color: tuple[int, int, int, int],) -> Image.Image | None:
+
+    if len(pixel_points) < 3:
+        return None
+
+    from PIL import Image, ImageDraw
+
+    # Draw a binary mask of the polygon.
+    xs = [p[0] for p in pixel_points]
+    ys = [p[1] for p in pixel_points]
+    min_px, max_px = min(xs), max(xs)
+    min_py, max_py = min(ys), max(ys)
+
+    mask_img = Image.new("L", (img_w, img_h), 0)
+    mask_draw = ImageDraw.Draw(mask_img)
+    mask_draw.polygon(pixel_points, fill=255)
+
+    hatch_rgb = Image.new("RGB", (img_w, img_h), (0, 0, 0))
+    hatch_draw = ImageDraw.Draw(hatch_rgb)
+
+    # Draw diagonal hatch lines across the bounding box.
+    diag_len = int(math.sqrt((max_px - min_px) ** 2 + (max_py - min_py) ** 2)) + NOGO_HATCH_SPACING
+    for i in range(-diag_len, diag_len + NOGO_HATCH_SPACING, NOGO_HATCH_SPACING):
+        x1 = min_px + i
+        y1 = max_py
+        x2 = min_px + i + (max_py - min_py)
+        y2 = min_py
+
+        x1 = max(0, min(img_w - 1, x1))
+        y1 = max(0, min(img_h - 1, y1))
+        x2 = max(0, min(img_w - 1, x2))
+        y2 = max(0, min(img_h - 1, y2))
+
+        hatch_draw.line([(x1, y1), (x2, y2)], fill=(color[0], color[1], color[2]), width=NOGO_HATCH_WIDTH)
+
+    # Clip the hatch lines to the polygon mask.
+    line_mask = hatch_rgb.split()[0].point(lambda p: 255 if p > 128 else 0)
+    clipped_mask = Image.new("L", (img_w, img_h), 0)
+    clipped_mask.paste(line_mask, mask=mask_img)
+
+    if color[3] < 255:
+        clipped_mask = clipped_mask.point(lambda p: int(p * color[3] / 255))
+
+    # Apply the alpha channel from the input color.
+    r, g, b = hatch_rgb.split()
+    hatch = Image.merge("RGBA", (r, g, b, clipped_mask))
+    
+    # # Return an RGBA image ready for alpha compositing.
+    return hatch
+
+# Set up the Shark IQ floor plan image entities.
+async def async_setup_entry(hass: HomeAssistant, config_entry: SharkIqConfigEntry, async_add_entities: AddConfigEntryEntitiesCallback,) -> None:
+    coordinator = config_entry.runtime_data
+    devices: Iterable[SharkDevice] = coordinator.shark_vacs.values()
+    async_add_entities([SharkFloorPlanImage(d, coordinator) for d in devices if isinstance(d, SkegoxDevice)])
+
+
+# Shark IQ floor plan image entity.
+class SharkFloorPlanImage(CoordinatorEntity, ImageEntity):
+    _coordinator: SharkIqUpdateCoordinator | SkegoxUpdateCoordinator
+
+    _attr_has_entity_name = True
+    _attr_name = "Floor Plan"
+
+    # Create a new SharkFloorPlanImage.
+    def __init__(self, sharkiq: SharkDevice, coordinator: SharkIqUpdateCoordinator | SkegoxUpdateCoordinator,) -> None:
+        CoordinatorEntity.__init__(self, coordinator)
+        ImageEntity.__init__(self, hass=coordinator.hass)
+        self.sharkiq = sharkiq
+        self._attr_unique_id = f"{sharkiq.serial_number}_floor_plan"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, sharkiq.serial_number)},
+            manufacturer=SHARK,
+            model=get_device_model(sharkiq),
+            name=sharkiq.name,
+            sw_version=sharkiq.get_property_value(Properties.ROBOT_FIRMWARE_VERSION),
+        )
+        self._attr_content_type = "image/jpeg"
+        self._last_image: bytes | None = None
+        self._attr_image_last_updated = None
+
+    # Determine if the image entity is available.
+    @property
+    def available(self) -> bool:
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.device_is_online(self.sharkiq.serial_number)
+        )
+
+    # Handle updated data from the coordinator.
+    def _handle_coordinator_update(self) -> None:
+        if self.coordinator.last_update_success and self.coordinator.device_is_online(self.sharkiq.serial_number):
+            tz = self._attr_image_last_updated.tzinfo if self._attr_image_last_updated else None
+            self._attr_image_last_updated = datetime.now(tz)
+        super()._handle_coordinator_update()
+
+    # Render the floor plan map as a JPEG image.
+    def _render_map(self) -> bytes | None:
+        if not isinstance(self.sharkiq, SkegoxDevice):
+            return None
+
+        room_polygons = self.sharkiq.room_polygons
+        no_go_zones = self.sharkiq.no_go_zones
+
+        if not room_polygons and not no_go_zones:
+            return None
+
+        min_x, min_y, max_x, max_y = _compute_bounds(room_polygons, no_go_zones)
+
+        data_w = max_x - min_x
+        data_h = max_y - min_y
+        if data_w == 0 or data_h == 0:
+            return None
+
+        aspect = data_w / data_h
+        if aspect >= 1:
+            img_w = min(IMAGE_MAX_DIM, max(IMAGE_MIN_DIM, int(data_w * 4)))
+            img_h = int(img_w / aspect)
+        else:
+            img_h = min(IMAGE_MAX_DIM, max(IMAGE_MIN_DIM, int(data_h * 4)))
+            img_w = int(img_h * aspect)
+
+        img_w = max(img_w, IMAGE_MIN_DIM)
+        img_h = max(img_h, IMAGE_MIN_DIM)
+
+        from PIL import Image, ImageDraw, ImageFont
+
+        image = Image.new("RGBA", (img_w, img_h), (245, 245, 245, 255))
+
+        draw = ImageDraw.Draw(image, "RGBA")
+
+        try:
+            font = None
+            for font_path in FONT_PATHS:
+                try:
+                    font = ImageFont.truetype(font_path, LABEL_FONT_SIZE)
+                    break
+                except (OSError, IOError):
+                    continue
+            # Fallback: default font if no system font was found
+            if font is None:
+                font = ImageFont.load_default()
+        except Exception:
+            # Second fallback for any unexpected font loading errors
+            font = ImageFont.load_default()
+
+        if self.sharkiq.floor_plan_edges or self.sharkiq.floor_plan_doors:
+            self._draw_edges(draw, img_w, img_h, min_x, min_y, max_x, max_y)
+
+        for room_name, points in room_polygons.items():
+            pixel_points = _draw_polygon(draw, points, min_x, min_y, max_x, max_y, img_w, img_h)
+            if len(pixel_points) < 3:
+                continue
+
+            draw.polygon(pixel_points, fill=None, outline=(*ROOM_COLOR, 200), width=2)
+
+            xs = [p[0] for p in pixel_points]
+            ys = [p[1] for p in pixel_points]
+            cx = int(sum(xs) / len(xs))
+            cy = int(sum(ys) / len(ys))
+
+            text_bbox = draw.textbbox((0, 0), room_name, font=font)
+            text_w = text_bbox[2] - text_bbox[0]
+            text_h = text_bbox[3] - text_bbox[1]
+            text_x = cx - text_w // 2
+            text_y = cy - text_h // 2
+
+            draw.text((text_x, text_y), room_name, fill=(*ROOM_COLOR, 255), font=font)
+
+        for zone in no_go_zones:
+            points = zone["points"]
+            pixel_points = _draw_polygon(draw, points, min_x, min_y, max_x, max_y, img_w, img_h)
+            if len(pixel_points) < 3:
+                continue
+
+            hatch_overlay = _draw_hatch_overlay(
+                pixel_points,
+                img_w,
+                img_h,
+                (220, 38, 38, NOGO_HATCH_ALPHA),
+            )
+            if hatch_overlay:
+                image = Image.alpha_composite(image, hatch_overlay)
+                draw = ImageDraw.Draw(image, "RGBA")
+
+        image_rgb = image.convert("RGB")
+
+        buf = io.BytesIO()
+        image_rgb.save(buf, format="JPEG", quality=85)
+        return buf.getvalue()
+
+    # Draw floor plan edge and door lines scaled to room bounds.
+    def _draw_edges(self, draw: Any, img_w: int, img_h: int, min_x: float, min_y: float, max_x: float, max_y: float,) -> None:
+        edges = self.sharkiq.floor_plan_edges
+        doors = self.sharkiq.floor_plan_doors
+        if not edges and not doors:
+            return
+
+        # Compute edge/door bounds separately
+        edge_all_x: list[float] = []
+        edge_all_y: list[float] = []
+        for (x1, y1), (x2, y2) in edges:
+            edge_all_x.extend([x1, x2])
+            edge_all_y.extend([y1, y2])
+        for (x1, y1), (x2, y2) in doors:
+            edge_all_x.extend([x1, x2])
+            edge_all_y.extend([y1, y2])
+
+        if not edge_all_x:
+            return
+
+        edge_min_x = min(edge_all_x)
+        edge_min_y = min(edge_all_y)
+        edge_max_x = max(edge_all_x)
+        edge_max_y = max(edge_all_y)
+        edge_w = edge_max_x - edge_min_x
+        edge_h = edge_max_y - edge_min_y
+        
+        if edge_w == 0 or edge_h == 0:
+            return
+
+        room_w = max_x - min_x
+        room_h = max_y - min_y
+
+        if room_w == 0 or room_h == 0:
+            return
+
+        # Scale edges to fit room bounds (preserve aspect ratio)
+        scale_edge_x = room_w / edge_w
+        scale_edge_y = room_h / edge_h
+        scale_edge = min(scale_edge_x, scale_edge_y)
+
+        # Center edges within room bounds
+        scaled_w = edge_w * scale_edge
+        scaled_h = edge_h * scale_edge
+        offset_x = min_x + (room_w - scaled_w) / 2 - edge_min_x * scale_edge
+        offset_y = min_y + (room_h - scaled_h) / 2 - edge_min_y * scale_edge
+
+        # Compute image pixel mapping
+        data_w = max_x - min_x
+        data_h = max_y - min_y
+        scale_x = (img_w - 2 * PADDING) / data_w
+        scale_y = (img_h - 2 * PADDING) / data_h
+        scale = min(scale_x, scale_y)
+
+        px_offset_x = PADDING + (img_w - 2 * PADDING - data_w * scale) / 2
+        px_offset_y = PADDING + (img_h - 2 * PADDING - data_h * scale) / 2
+
+        def to_pixel(x: float, y: float) -> tuple[int, int]:
+            # Scale edge coords to room space, then to pixel coords
+            room_x = x * scale_edge + offset_x
+            room_y = y * scale_edge + offset_y
+            # Edges use a different coordinate system than room polygons —
+            # no X flip is needed because edge coords already match room orientation.
+            px = int(px_offset_x + (room_x - min_x) * scale)
+            py = int(img_h - (px_offset_y + (room_y - min_y) * scale))
+            return px, py
+
+        for (x1, y1), (x2, y2) in edges:
+            p1 = to_pixel(x1, y1)
+            p2 = to_pixel(x2, y2)
+            draw.line([p1, p2], fill=(0, 0, 0, 255), width=2)
+
+        # Door lines disabled — uncomment to restore
+        # for (x1, y1), (x2, y2) in doors:
+        #     p1 = to_pixel(x1, y1)
+        #     p2 = to_pixel(x2, y2)
+        #     draw.line([p1, p2], fill=(180, 180, 180, 255), width=2)
+
+    # Return the floor plan image, preserving last good image on failure.
+    async def async_image(self) -> bytes | None:
+        rendered = await asyncio.to_thread(self._render_map)
+        if rendered:
+            self._last_image = rendered
+        return self._last_image

--- a/homeassistant/components/sharkiq/sensor.py
+++ b/homeassistant/components/sharkiq/sensor.py
@@ -1,0 +1,58 @@
+# Shark IQ Battery Sensor.
+
+from collections.abc import Iterable
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, SHARK
+from .coordinator import SharkIqConfigEntry, SharkIqUpdateCoordinator, SkegoxUpdateCoordinator, SharkDevice, get_device_model
+from .sharkiq_pypi.sharkiq import Properties
+
+# Set up the Shark IQ battery sensor.
+async def async_setup_entry(hass: HomeAssistant, config_entry: SharkIqConfigEntry, async_add_entities: AddConfigEntryEntitiesCallback,) -> None:
+    coordinator = config_entry.runtime_data
+    devices: Iterable[SharkDevice] = coordinator.shark_vacs.values()
+    async_add_entities([SharkBatterySensor(d, coordinator) for d in devices])
+
+# Shark IQ battery sensor entity.
+class SharkBatterySensor(CoordinatorEntity, SensorEntity):
+    _coordinator: SharkIqUpdateCoordinator | SkegoxUpdateCoordinator
+
+    _attr_device_class = SensorDeviceClass.BATTERY
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = "%"
+    _attr_has_entity_name = True
+    _attr_name = "Battery"
+
+    # Create a new SharkBatterySensor.
+    def __init__(self, sharkiq: SharkDevice, coordinator: SharkIqUpdateCoordinator | SkegoxUpdateCoordinator) -> None:
+        super().__init__(coordinator)
+        self.sharkiq = sharkiq
+        self._attr_unique_id = f"{sharkiq.serial_number}_battery"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, sharkiq.serial_number)},
+            manufacturer=SHARK,
+            model=get_device_model(sharkiq),
+            name=sharkiq.name,
+            sw_version=sharkiq.get_property_value(Properties.ROBOT_FIRMWARE_VERSION),
+        )
+
+    # Determine if the sensor is available based on API results.
+    @property
+    def available(self) -> bool:
+        return self.coordinator.last_update_success and self.coordinator.device_is_online(
+            self.sharkiq.serial_number
+        )
+
+    # Return the current battery level.
+    @property
+    def native_value(self) -> int | None:
+        return self.sharkiq.get_property_value(Properties.BATTERY_CAPACITY)

--- a/homeassistant/components/sharkiq/services.py
+++ b/homeassistant/components/sharkiq/services.py
@@ -1,20 +1,36 @@
-"""Shark IQ services."""
+# Shark IQ services.
+
+import asyncio
+import json
+import logging
+from pathlib import Path
 
 import voluptuous as vol
 
 from homeassistant.components.vacuum import DOMAIN as VACUUM_DOMAIN
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import config_validation as cv, service
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.helpers import config_validation as cv, entity_registry as er, service
 
 from .const import ATTR_ROOMS, DOMAIN
+from .coordinator import SkegoxUpdateCoordinator
 
 SERVICE_CLEAN_ROOM = "clean_room"
+SERVICE_DISCOVER_DEVICE_DATA = "discover_device_data"
 
+_LOGGER = logging.getLogger(__name__)
 
+# Write content to a file asynchronously.
+async def _async_write_file(path: Path, content: bytes | str) -> None:
+    def _write() -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        mode = "wb" if isinstance(content, bytes) else "w"
+        with open(path, mode) as f:
+            f.write(content)
+    await asyncio.to_thread(_write)
+
+# Set up services.
 @callback
 def async_setup_services(hass: HomeAssistant) -> None:
-    """Set up services."""
-
     # Vacuum Services
     service.async_register_platform_entity_service(
         hass,
@@ -27,4 +43,124 @@ def async_setup_services(hass: HomeAssistant) -> None:
             ),
         },
         func="async_clean_room",
+    )
+
+    # Discover all available property files and data for a Skegox device.
+    # Debugging dump of API data and bin files
+    async def async_discover_device_data(call: ServiceCall) -> None:
+        entity_id = call.data.get("entity_id")
+        if not entity_id:
+            _LOGGER.error("entity_id is required for discover_device_data service")
+            return
+
+        # Use entity registry to resolve entity_id to unique_id (serial number)
+        entity_reg = er.async_get(hass)
+        registry_entry = entity_reg.async_get(entity_id)
+
+        if registry_entry is None:
+            _LOGGER.error("Entity %s not found in registry", entity_id)
+            return
+
+        target_unique_id = registry_entry.unique_id
+
+        # Find the Skegox coordinator that manages this device.
+        coordinator = None
+        target_device_serial = None
+
+        # Iterates all config entries because there is no direct entity_id
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            if hasattr(entry, "runtime_data") and entry.runtime_data is not None:
+                coord = entry.runtime_data
+                if isinstance(coord, SkegoxUpdateCoordinator):
+                    if target_unique_id in coord.shark_vacs:
+                        coordinator = coord
+                        # coordinator mapping in HA; the serial number (unique_id) is the link.
+                        target_device_serial = target_unique_id
+                        break
+
+        if coordinator is None or target_device_serial is None:
+            _LOGGER.error(
+                "No Skegox device found for entity %s. "
+                "This service only works with Skegox backend devices.",
+                entity_id,
+            )
+            return
+        
+        device = coordinator.shark_vacs[target_device_serial]
+        snd = device.serial_number
+        
+        if not snd:
+            _LOGGER.error("Device %s has no serial number", device.name)
+            return
+
+        output_dir = Path(hass.config.path("sharkiq_discovery"))
+        device_dir = output_dir / snd
+
+        _LOGGER.info("Discovering property files for %s (%s)", device.name, snd)
+        _LOGGER.info("Output directory: %s", device_dir)
+
+        # List all available property files
+        files_list = await coordinator.skegox_api.list_property_files(snd)
+
+        # Save the file list
+        file_list_path = device_dir / "property_files_list.json"
+        safe_list = []
+        for file_info in files_list:
+            safe_info = {k: v for k, v in file_info.items() if k != "presignedUrl"}
+            safe_list.append(safe_info)
+        await _async_write_file(file_list_path, json.dumps(safe_list, indent=2),)
+
+        _LOGGER.info("Found %d property files for %s", len(files_list), device.name)
+
+        # Fetch each property file
+        for file_info in files_list:
+            prop_name = file_info.get("name", "unknown")
+            _LOGGER.info("Fetching property file: %s", prop_name)
+
+            content = await coordinator.skegox_api.fetch_property_file(snd, prop_name)
+            if content is not None:
+                # Preserve original extension for known text/binary files;
+                # append .bin for everything else so the file is not misidentified.
+                ext = "" if any(prop_name.endswith(e) for e in (".bin", ".txt")) else ".bin"
+                file_path = device_dir / f"{prop_name}{ext}"
+                await _async_write_file(file_path, content)
+
+                # Try to parse as JSON for readability
+                try:
+                    parsed = json.loads(content.decode("utf-8"))
+                    json_path = device_dir / f"{prop_name}.json"
+                    await _async_write_file(
+                        json_path,
+                        json.dumps(parsed, indent=2),
+                    )
+                    _LOGGER.info("Saved %s as JSON (%d bytes)", prop_name, len(content))
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    _LOGGER.info("Saved %s as binary (%d bytes)", prop_name, len(content))
+            else:
+                _LOGGER.warning("No content for property file: %s", prop_name)
+
+        # Save device shadow data
+        shadow_path = device_dir / "device_shadow.json"
+        await _async_write_file(
+            shadow_path,
+            json.dumps(device._raw, indent=2, default=str),
+        )
+
+        # Save MARD data if available
+        if device.mard_data:
+            mard_path = device_dir / "MARD_full.json"
+            await _async_write_file(
+                mard_path,
+                json.dumps(device.mard_data, indent=2),
+            )
+
+        _LOGGER.info("Discovery complete for %s. Files saved to: %s", device.name, device_dir,)
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_DISCOVER_DEVICE_DATA,
+        async_discover_device_data,
+        schema=vol.Schema({
+            vol.Required("entity_id"): cv.entity_id,
+        }),
     )

--- a/homeassistant/components/sharkiq/skegox_api.py
+++ b/homeassistant/components/sharkiq/skegox_api.py
@@ -1,0 +1,339 @@
+# SharkNinja Skegox cloud API client.
+# The new SharkNinja backend replaces the legacy Ayla API for migrated devices.
+# Uses an IoT shadow model (reported/desired) for state and commands.
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import secrets
+import time
+from typing import TYPE_CHECKING, Any
+
+import aiohttp
+
+from .const import API_TIMEOUT
+
+if TYPE_CHECKING:
+    from .skegox_auth import SkegoxAuthManager
+
+_LOGGER = logging.getLogger(__name__)
+
+SKEGOX_CALLER = "ENDUSER_MOBILEAPP"
+
+# Failure
+class SkegoxApiError(Exception):
+    """Skegox API request failure."""
+
+# Async client for the SharkNinja Skegox cloud API.
+class SkegoxApi:
+    def __init__(self, auth_manager: SkegoxAuthManager) -> None:
+        self._auth = auth_manager
+        self._session: aiohttp.ClientSession | None = None
+        self._property_file_cache: dict[str, tuple[list[dict[str, Any]], float]] = {}
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession()
+        return self._session
+
+    async def close(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()
+            self._session = None
+        self._property_file_cache.clear()
+
+    # Clear cached property file listings.
+    def clear_property_file_cache(self, snd: str | None = None) -> None:
+        if snd:
+            self._property_file_cache.pop(snd, None)
+        else:
+            self._property_file_cache.clear()
+
+    # Get property file list with caching (5-minute TTL).
+    async def _get_property_files(self, snd: str) -> list[dict[str, Any]]:
+        # Cache TTL of 5 minutes
+        now = time.time()
+        if snd in self._property_file_cache:
+            cached_files, cached_at = self._property_file_cache[snd]
+            if now - cached_at < 300:
+                return cached_files
+
+        files = await self.list_property_files(snd)
+        self._property_file_cache[snd] = (files, now)
+        return files
+
+    # Build request headers with HMAC signature.
+    # Signature headers are required by the API but not
+    # validated server-side. Only the Bearer token and API key matter.
+    # Generate a syntactically valid but fake signature.
+    def _headers(self) -> dict[str, str]:
+        now = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+        region = self._auth.region
+        return {
+            "Authorization": f"Bearer {self._auth.id_token}",
+            "content-type": "application/json",
+            "x-api-key": region.skegox_api_key,
+            "x-iotn-request-signature": (
+                f"SN-HMAC-SHA256 Credential=x/{now}/*/end-user-api/sn_request, "
+                f"SignedHeaders=host;x-sn-date;x-sn-nonce, "
+                f"Signature={secrets.token_hex(32)}"
+            ),
+            "x-iotn-caller": SKEGOX_CALLER,
+            "x-sn-nonce": secrets.token_hex(16),
+            "x-sn-date": now,
+        }
+
+    # Make an authenticated request to the Skegox API.
+    # 401 -> Refreshes the Auth0 token and retries once.
+    async def _request(self, method: str, path: str, **kwargs: Any) -> Any:
+        session = await self._get_session()
+        region = self._auth.region
+        url = f"{region.skegox_base}{path}"
+        headers = self._headers()
+
+        async with session.request(method, url, headers=headers, timeout=aiohttp.ClientTimeout(total=API_TIMEOUT), **kwargs,) as resp:
+            if resp.status == 401:
+                _LOGGER.warning("Skegox 401 — refreshing auth and retrying")
+                await self._auth.ensure_authenticated(force_refresh=True)
+                headers = self._headers()
+                async with session.request(
+                    method,
+                    url,
+                    headers=headers,
+                    timeout=aiohttp.ClientTimeout(total=API_TIMEOUT),
+                    **kwargs,
+                ) as retry_resp:
+                    if retry_resp.status >= 300:
+                        text = await retry_resp.text()
+                        raise SkegoxApiError(f"Skegox error ({retry_resp.status}): {text}")
+                    return await retry_resp.json()
+
+            if resp.status >= 300:
+                text = await resp.text()
+                raise SkegoxApiError(f"Skegox error ({resp.status}): {text}")
+
+            return await resp.json()
+
+    # --- Discovery ---
+
+    # Extract user_id from JWT and discover household_id from Skegox API.
+    # The user_id is the sub claim from the Auth0 id_token (after the '|').
+    # The household_id is discovered by querying /householdsEndUser.
+    async def discover(self) -> None:
+        token = self._auth.id_token
+        if not token:
+            await self._auth.ensure_authenticated()
+            token = self._auth.id_token
+
+        # Extract user_id from JWT sub claim
+        parts = token.split(".")
+        payload = parts[1] + "=" * (4 - len(parts[1]) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload))
+        sub = claims.get("sub", "")
+        user_id = sub.split("|", 1)[1] if "|" in sub else sub
+        self._auth.set_user_id(user_id)
+        _LOGGER.info("Discovered user ID: %s", user_id)
+
+        # Auto-discover household_id if not already set
+        if not self._auth.household_id:
+            data = await self._request("GET", f"/householdsEndUser?userId={user_id}")
+            households = data.get("households", [])
+            if households:
+                household_id = households[0]
+                self._auth.set_household_id(household_id)
+                _LOGGER.info("Discovered household ID: %s", household_id)
+            else:
+                raise SkegoxApiError("No households found for user. Is a Shark device registered on this account?")
+
+    # --- Device listing ---
+
+    # List all devices for the user.
+    async def list_devices(self) -> list[dict[str, Any]]:
+        if not self._auth.user_id or not self._auth.household_id:
+            await self.discover()
+
+        path = (
+            f"/devicesEndUserController/{self._auth.household_id}"
+            f"/users/{self._auth.user_id}"
+        )
+        data = await self._request("GET", path)
+        items = data.get("items", data) if isinstance(data, dict) else data
+        return items if isinstance(items, list) else [items]
+
+    # Get full device state including shadow, telemetry, connectivity.
+    async def get_device(self, snd: str) -> dict[str, Any]:
+        if not self._auth.household_id:
+            raise SkegoxApiError("No household ID set")
+        path = (
+            f"/devicesEndUserController/{self._auth.household_id}"
+            f"/devices/{snd}"
+        )
+        return await self._request("GET", path)
+
+    # Get full state for all devices.
+    async def get_all_devices(self) -> list[dict[str, Any]]:
+        device_list = await self.list_devices()
+        async def _fetch_full(dev: dict[str, Any]) -> dict[str, Any] | None:
+            snd = dev.get("deviceId", dev.get("snd"))
+            if snd:
+                try:
+                    full = await self.get_device(snd)
+                    full["_snd"] = snd
+                    return full
+                except Exception:
+                    # Partial failure is acceptable — other devices may still work
+                    _LOGGER.warning("Failed to fetch full state for device %s", snd, exc_info=True)
+                    return None
+            return dev
+
+        results = await asyncio.gather(*[_fetch_full(dev) for dev in device_list], return_exceptions=True)
+        devices: list[dict[str, Any]] = []
+        for result in results:
+            if isinstance(result, Exception):
+                _LOGGER.warning("Device fetch failed: %s", result)
+            elif result is not None:
+                devices.append(result)
+        return devices
+
+    # --- Property files (MARD, maps, etc.) ---
+
+    # List all available property files for a device.
+    # GET /devicesEndUserController/{household}/devices/{snd}/property-files
+    # Returns the wrapper response with file metadata (names, sizes, presigned URLs).
+    async def list_property_files(self, snd: str) -> list[dict[str, Any]]:
+        if not self._auth.household_id:
+            raise SkegoxApiError("No household ID set")
+        path = (
+            f"/devicesEndUserController/{self._auth.household_id}"
+            f"/devices/{snd}/property-files"
+        )
+        try:
+            wrapper = await self._request("GET", path)
+            files = wrapper.get("files") if isinstance(wrapper, dict) else None
+            return files if isinstance(files, list) else []
+        except Exception:
+            _LOGGER.debug("Skegox property-files list failed for %s", snd, exc_info=True,)
+            return []
+
+    # Fetch a file-type property's content from Skegox.
+    # Two-hop fetch: first gets the file list, finds the matching file
+    # by name, then fetches from its presigned S3 URL.
+    # Returns None if the file is not found or any step fails.
+    async def fetch_property_file(self, snd: str, property_name: str) -> bytes | None:
+        if not self._auth.household_id:
+            raise SkegoxApiError("No household ID set")
+
+        all_files = await self._get_property_files(snd)
+        if not all_files:
+            _LOGGER.warning("No property files listed for %s", snd,)
+            return None
+
+        matching: dict[str, Any] | None = None
+        prefix_match: dict[str, Any] | None = None
+        for file_info in all_files:
+            fname = file_info.get("name", "")
+            if fname == property_name:
+                matching = file_info
+                break
+            # Fall back to prefix match when exact name is not found.
+            # Some devices append a suffix (e.g., "zones_v2") to property names.
+            if prefix_match is None and fname.startswith(property_name):
+                prefix_match = file_info
+
+        if matching is None:
+            matching = prefix_match
+            if matching:
+                _LOGGER.debug("Property file '%s' matched via prefix to '%s' for %s", property_name, matching.get("name", ""), snd,)
+
+        if not matching:
+            _LOGGER.warning("Property file '%s' not found in file list for %s. Available: %s",
+                property_name, snd, [f.get("name") for f in all_files],
+            )
+            return None
+
+        presigned = matching.get("presignedUrl") or matching.get("url") or matching.get("downloadUrl")
+        if not presigned:
+            _LOGGER.warning("No URL in file entry for %s/%s. Keys: %s", snd, property_name, list(matching.keys()),)
+            return None
+
+        _LOGGER.debug("Presigned URL for %s/%s: %s...", snd, property_name, presigned[:80])
+
+        try:
+            session = await self._get_session()
+            async with session.get(presigned, timeout=aiohttp.ClientTimeout(total=API_TIMEOUT)) as resp:
+                if resp.status >= 300:
+                    body = await resp.text()
+                    _LOGGER.warning("Presigned URL fetch for %s/%s returned %d: %s", snd, property_name, resp.status, body[:500],)
+                    return None
+                content = await resp.read()
+                _LOGGER.info("Fetched %s/%s: %d bytes", snd, property_name, len(content),)
+                return content
+        except Exception:
+            _LOGGER.warning("Presigned URL fetch failed for %s/%s", snd, property_name, exc_info=True,)
+            return None
+
+    # --- Commands (IoT shadow model) ---
+
+    # Set a device property via shadow desired state.
+    # PATCH /devicesEndUserController/{household}/devices/{snd}
+    # Body: {"shadow": {"properties": {"desired": {property_name: value}}}}
+    async def set_desired_property(self, snd: str, property_name: str, value: Any) -> None:
+        if not self._auth.household_id:
+            raise SkegoxApiError("No household ID set")
+        path = (
+            f"/devicesEndUserController/{self._auth.household_id}"
+            f"/devices/{snd}"
+        )
+        payload = {"shadow": {"properties": {"desired": {property_name: value}}}}
+        await self._request("PATCH", path, json=payload)
+        _LOGGER.info("Set %s=%s on %s", property_name, value, snd)
+
+    # Send a vacuum command (start, stop, pause, return, locate).
+    async def send_command(self, snd: str, command: str) -> None:
+        command_map = {
+            "start": ("Operating_Mode", 2),
+            "stop": ("Operating_Mode", 0),
+            "pause": ("Operating_Mode", 1),
+            "return_to_base": ("Operating_Mode", 3),
+            "locate": ("Find_Device", 1),
+        }
+        if command not in command_map:
+            _LOGGER.warning("Unknown command: %s", command)
+            return
+        prop, val = command_map[command]
+        await self.set_desired_property(snd, prop, val)
+
+    # Set vacuum fan speed (eco, normal, max).
+    async def set_fan_speed(self, snd: str, speed: str) -> None:
+        speed_map = {"eco": 0, "normal": 1, "max": 2}
+        val = speed_map.get(speed.lower())
+        if val is None:
+            _LOGGER.warning("Unknown fan speed: %s", speed)
+            return
+        await self.set_desired_property(snd, "Power_Mode", val)
+
+    # Start cleaning specific rooms.
+    # Args:
+    #   snd: Device SND identifier.
+    #   rooms: List of room names (e.g., ["Kitchen", "Den"]).
+    #   floor_id: Floor identifier (e.g., "2A38EFA6").
+    #   clean_type: "dry" for vacuum, "wet" for mop.
+    #   clean_count: Number of passes (1 = normal, 2 = matrix/ultra).
+    #   mode: "UserRoom" for normal, "UltraClean" for matrix clean.
+    #   use_v3: True for devices with AreasToClean_V3 (dict format),
+    #   False for devices using Areas_To_Clean (list format).
+    async def clean_rooms(self, snd: str, rooms: list[str], floor_id: str, clean_type: str = "dry", clean_count: int = 1, mode: str = "UserRoom", use_v3: bool = False,) -> None:
+        if use_v3:
+            areas_payload = json.dumps({"areas_to_clean": {mode: rooms}, "clean_count": clean_count, "floor_id": floor_id, "cleantype": clean_type,})
+            await self.set_desired_property(snd, "AreasToClean_V3", areas_payload)
+        else:
+            areas_payload = json.dumps({"floor_id": floor_id, "areas_to_clean": [f"{mode}:{room}" for room in rooms], "clean_count": clean_count,})
+            await self.set_desired_property(snd, "Areas_To_Clean", areas_payload)
+            await self.set_desired_property(snd, "Operating_Mode", 2)
+        _LOGGER.info(
+            "Clean rooms %s on %s (mode=%s, count=%d, v3=%s)",
+            rooms, snd, mode, clean_count, use_v3,
+        )

--- a/homeassistant/components/sharkiq/skegox_auth.py
+++ b/homeassistant/components/sharkiq/skegox_auth.py
@@ -1,0 +1,362 @@
+# Auth0 authentication manager for the Skegox API.
+# Handles Auth0 password grant and refresh_token grant — no browser required.
+# Tokens are persisted via the Home Assistant config entry data.
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import aiohttp
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    CONF_AUTH0_ACCESS_TOKEN,
+    CONF_AUTH0_EXPIRY,
+    CONF_AUTH0_ID_TOKEN,
+    CONF_AUTH0_REFRESH_TOKEN,
+    CONF_AYLA_ACCESS_TOKEN,
+    CONF_AYLA_REFRESH_TOKEN,
+    CONF_AYLA_TOKEN_EXPIRY,
+    CONF_HOUSEHOLD_ID,
+    CONF_USER_ID,
+    SHARKIQ_REGION_EUROPE,
+    SHARKIQ_REGION_ELSEWHERE,
+)
+
+# Region-specific Auth0 and Skegox configuration
+# Sources: shark2mqtt const.py (verified working as of 2026-04) MIT License
+# https://github.com/CamSoper/shark2mqtt
+
+# Region-specific API endpoints and credentials.
+@dataclass(frozen=True)
+class RegionConfig:
+    auth0_url: str
+    auth0_token_url: str
+    auth0_client_id: str
+    ayla_login_url: str
+    ayla_device_url: str
+    ayla_app_id: str
+    ayla_app_secret: str
+    skegox_base: str
+    skegox_api_key: str
+
+
+REGION_CONFIGS: dict[str, RegionConfig] = {
+    SHARKIQ_REGION_ELSEWHERE: RegionConfig(
+        auth0_url="https://login.sharkninja.com",
+        auth0_token_url="https://login.sharkninja.com/oauth/token",
+        auth0_client_id="wsguxrqm77mq4LtrTrwg8ZJUxmSrexGi",
+        ayla_login_url="https://user-sharkue1.aylanetworks.com",
+        ayla_device_url="https://ads-sharkue1.aylanetworks.com",
+        ayla_app_id="ios_shark_prod-3A-id",
+        ayla_app_secret="ios_shark_prod-74tFWGNg34LQCmR0m45SsThqrqs",
+        skegox_base="https://stakra.slatra.thor.skegox.com",
+        skegox_api_key="QQdbSrgicK2PxvACI1a2P5AN2xgO78Lw1VvnYczb",
+    ),
+    SHARKIQ_REGION_EUROPE: RegionConfig(
+        auth0_url="https://logineu.sharkninja.com",
+        auth0_token_url="https://logineu.sharkninja.com/oauth/token",
+        auth0_client_id="rKDx9O18dBrY3eoJMTkRiBZHDvd9Mx1I",
+        ayla_login_url="https://user-field-eu.aylanetworks.com",
+        ayla_device_url="https://ads-eu.aylanetworks.com",
+        ayla_app_id="android_shark_prod-lg-id",
+        ayla_app_secret="android_shark_prod-xuf9mlHOo0p3Ty5bboFROSyRBlE",
+        skegox_base="https://stakra.rannsaka.thor.skegox.com",
+        skegox_api_key="T5m8d45crZDV9I5aCEZr4n2gSqJW64r2RNXqqhh1",
+    ),
+}
+
+AUTH0_SCOPES = "openid email profile offline_access"
+
+# Refresh Ayla tokens 5 minutes before expiry
+AYLA_REFRESH_BUFFER = timedelta(minutes=5)
+
+_LOGGER = logging.getLogger(__name__)
+
+# 
+class SkegoxAuthError(Exception):
+    """Authentication failure with the Skegox/Auth0 API."""
+
+# 
+class SkegoxAuthRequiresVerificationError(SkegoxAuthError):
+    """Auth0 requires additional verification (MFA, CAPTCHA, etc.)."""
+
+# 
+class SkegoxAuthLockedError(SkegoxAuthError):
+    """Account locked or rate-limited — do not retry."""
+
+# Holds all authentication tokens for a session.
+@dataclass
+class AuthTokens:
+    auth0_id_token: str | None = None
+    auth0_refresh_token: str | None = None
+    auth0_access_token: str | None = None
+    auth0_expiry: datetime | None = None
+    ayla_access_token: str | None = None
+    ayla_refresh_token: str | None = None
+    ayla_expiry: datetime | None = None
+    household_id: str | None = None
+    user_id: str | None = None
+
+    # Serialize tokens to a dict for Home Assistant config entry storage.
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            CONF_AUTH0_ID_TOKEN: self.auth0_id_token,
+            CONF_AUTH0_REFRESH_TOKEN: self.auth0_refresh_token,
+            CONF_AUTH0_ACCESS_TOKEN: self.auth0_access_token,
+            CONF_AUTH0_EXPIRY: self.auth0_expiry.isoformat() if self.auth0_expiry else None,
+            CONF_AYLA_ACCESS_TOKEN: self.ayla_access_token,
+            CONF_AYLA_REFRESH_TOKEN: self.ayla_refresh_token,
+            CONF_AYLA_TOKEN_EXPIRY: self.ayla_expiry.isoformat() if self.ayla_expiry else None,
+            CONF_HOUSEHOLD_ID: self.household_id,
+            CONF_USER_ID: self.user_id,
+        }
+
+    # Deserialize tokens from Home Assistant config entry data.
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AuthTokens:
+        tokens = cls()
+        tokens.auth0_id_token = data.get(CONF_AUTH0_ID_TOKEN)
+        tokens.auth0_refresh_token = data.get(CONF_AUTH0_REFRESH_TOKEN)
+        tokens.auth0_access_token = data.get(CONF_AUTH0_ACCESS_TOKEN)
+        if expiry_str := data.get(CONF_AUTH0_EXPIRY):
+            try:
+                tokens.auth0_expiry = datetime.fromisoformat(expiry_str)
+            except (ValueError, TypeError):
+                pass
+        tokens.ayla_access_token = data.get(CONF_AYLA_ACCESS_TOKEN)
+        tokens.ayla_refresh_token = data.get(CONF_AYLA_REFRESH_TOKEN)
+        if expiry_str := data.get(CONF_AYLA_TOKEN_EXPIRY):
+            try:
+                tokens.ayla_expiry = datetime.fromisoformat(expiry_str)
+            except (ValueError, TypeError):
+                pass
+        tokens.household_id = data.get(CONF_HOUSEHOLD_ID)
+        tokens.user_id = data.get(CONF_USER_ID)
+        return tokens
+
+    # Check if the Auth0 id_token is still valid.
+    @property
+    def auth0_token_valid(self) -> bool:
+        if not self.auth0_id_token or not self.auth0_expiry:
+            return False
+        return datetime.now(timezone.utc) < self.auth0_expiry
+
+    # Check if the Ayla access token is expiring soon.
+    @property
+    def ayla_token_expiring_soon(self) -> bool:
+        if not self.ayla_access_token or not self.ayla_expiry:
+            return True
+        return datetime.now(timezone.utc) >= self.ayla_expiry - AYLA_REFRESH_BUFFER
+
+# Manages Auth0 authentication lifecycle for the Skegox API.
+# Auth cascade (no browser):
+#   1. Load cached tokens from config entry
+#   2. If id_token is valid, use it
+#   3. Try Auth0 refresh_token grant
+#   4. Try Auth0 password grant
+#   5. Raise SkegoxAuthError (triggers reauth flow in HA)
+class SkegoxAuthManager:
+    def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry | None, username: str, password: str, region: str = SHARKIQ_REGION_ELSEWHERE,) -> None:
+        # Manage Auth0 authentication lifecycle for the Skegox API.
+        # Auth cascade: load cached tokens → use valid id_token → refresh_token
+        # grant → password grant → raise SkegoxAuthError (triggers HA reauth flow).
+        # `config_entry` may be None during initial validation before the entry
+        # is created; in that case tokens are not persisted.
+        self._hass = hass
+        self._config_entry = config_entry
+        self._username = username
+        self._password = password
+        self._region_config = REGION_CONFIGS[region]
+        self._tokens = AuthTokens.from_dict(config_entry.data) if config_entry else AuthTokens()
+        self._session: aiohttp.ClientSession | None = None
+
+    @property
+    def region(self) -> RegionConfig:
+        return self._region_config
+
+    @property
+    def id_token(self) -> str | None:
+        return self._tokens.auth0_id_token
+
+    @property
+    def ayla_access_token(self) -> str | None:
+        return self._tokens.ayla_access_token
+
+    @property
+    def ayla_refresh_token(self) -> str | None:
+        return self._tokens.ayla_refresh_token
+
+    @property
+    def household_id(self) -> str | None:
+        return self._tokens.household_id
+
+    @property
+    def user_id(self) -> str | None:
+        return self._tokens.user_id
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession()
+        return self._session
+
+    async def close(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()
+            self._session = None
+
+    # Persist tokens to the config entry data.
+    def _save_tokens(self) -> None:
+        if self._config_entry is None:
+            return
+        token_data = self._tokens.to_dict()
+        new_data = {**self._config_entry.data, **token_data}
+        self._hass.config_entries.async_update_entry(
+            self._config_entry, data=new_data
+        )
+
+    # Return a valid Auth0 id_token, refreshing if needed.
+    # Raise SkegoxAuthError if all authentication methods fail.
+    async def ensure_authenticated(self, force_refresh: bool = False) -> str:
+        # If we have a valid id_token and not forcing refresh, use it
+        if not force_refresh and self._tokens.auth0_token_valid:
+            _LOGGER.debug("Using cached Auth0 id_token")
+            assert self._tokens.auth0_id_token is not None
+            return self._tokens.auth0_id_token
+
+        # Try refresh_token grant
+        if self._tokens.auth0_refresh_token:
+            try:
+                await self._refresh_auth0_token()
+                _LOGGER.debug("Auth0 token refreshed via refresh_token grant")
+                assert self._tokens.auth0_id_token is not None
+                return self._tokens.auth0_id_token
+            except SkegoxAuthError:
+                _LOGGER.warning("Auth0 refresh_token grant failed")
+
+        # Try password grant
+        try:
+            await self._password_grant_sign_in()
+            _LOGGER.debug("Auth0 password grant successful")
+            assert self._tokens.auth0_id_token is not None
+            return self._tokens.auth0_id_token
+        except SkegoxAuthRequiresVerificationError:
+            raise
+        except SkegoxAuthError:
+            _LOGGER.warning("Auth0 password grant failed")
+
+        raise SkegoxAuthError("All authentication methods failed. Please re-authenticate via the Home Assistant integration.")
+
+    # Authenticate via Auth0 password grant (no browser).
+    # POST {auth0_token_url} with grant_type=password.
+    async def _password_grant_sign_in(self) -> None:
+        payload = {
+            "grant_type": "password",
+            "client_id": self._region_config.auth0_client_id,
+            "username": self._username,
+            "password": self._password,
+            "scope": AUTH0_SCOPES,
+        }
+
+        session = await self._get_session()
+        async with session.post(
+            self._region_config.auth0_token_url,
+            json=payload,
+            timeout=aiohttp.ClientTimeout(total=15),
+        ) as resp:
+            data = await resp.json()
+
+            if resp.status == 401:
+                error = data.get("error", "unknown")
+                desc = data.get("error_description", "")
+                if error == "requires_verification":
+                    raise SkegoxAuthRequiresVerificationError(f"Auth0 requires additional verification: {desc}. Try completing login in the SharkClean app, then retry.")
+                raise SkegoxAuthError(f"Auth0 password grant failed (401): {desc}")
+
+            if resp.status >= 400:
+                error = data.get("error", "unknown")
+                desc = data.get("error_description", "")
+                if resp.status == 429:
+                    raise SkegoxAuthLockedError(f"Auth0 rate limited: {error} {desc}")
+                raise SkegoxAuthError(f"Auth0 password grant failed ({resp.status}): {error} {desc}")
+
+            if "id_token" not in data:
+                raise SkegoxAuthError("Auth0 response missing id_token. The password grant may not be enabled for this account.")
+
+            self._tokens.auth0_id_token = data["id_token"]
+            self._tokens.auth0_access_token = data.get("access_token")
+            self._tokens.auth0_refresh_token = data.get("refresh_token")
+            # Estimate expiry from id_token exp claim (typically 24h for password grant)
+            self._tokens.auth0_expiry = self._decode_jwt_expiry(data["id_token"])
+            self._save_tokens()
+
+    # Exchange Auth0 refresh_token for a new id_token.
+    # POST {auth0_token_url} with grant_type=refresh_token.
+    async def _refresh_auth0_token(self) -> None:
+        if not self._tokens.auth0_refresh_token:
+            raise SkegoxAuthError("No Auth0 refresh token available")
+
+        payload = {
+            "grant_type": "refresh_token",
+            "client_id": self._region_config.auth0_client_id,
+            "refresh_token": self._tokens.auth0_refresh_token,
+        }
+
+        session = await self._get_session()
+        async with session.post(self._region_config.auth0_token_url, json=payload, timeout=aiohttp.ClientTimeout(total=15),) as resp:
+            data = await resp.json()
+
+            if resp.status != 200:
+                error = data.get("error", "unknown")
+                desc = data.get("error_description", "")
+                if resp.status == 429:
+                    raise SkegoxAuthLockedError(f"Auth0 rate limited: {error} {desc}")
+                raise SkegoxAuthError(f"Auth0 refresh failed ({resp.status}): {error} {desc}")
+
+            self._tokens.auth0_id_token = data["id_token"]
+            self._tokens.auth0_access_token = data.get("access_token")
+            # Auth0 may rotate the refresh token
+            if "refresh_token" in data:
+                self._tokens.auth0_refresh_token = data["refresh_token"]
+            self._tokens.auth0_expiry = self._decode_jwt_expiry(data["id_token"])
+            self._save_tokens()
+
+    # Called after Ayla token_sign_in to persist Ayla tokens.
+    def update_ayla_tokens(self, access_token: str, refresh_token: str, expiry: datetime,) -> None:
+        self._tokens.ayla_access_token = access_token
+        self._tokens.ayla_refresh_token = refresh_token
+        self._tokens.ayla_expiry = expiry
+        self._save_tokens()
+
+    # Set the discovered household ID.
+    def set_household_id(self, household_id: str) -> None:
+        self._tokens.household_id = household_id
+        self._save_tokens()
+
+    # Set the discovered user ID.
+    def set_user_id(self, user_id: str) -> None:
+        self._tokens.user_id = user_id
+        self._save_tokens()
+
+    #Extract the exp claim from a JWT and return as datetime.
+    @staticmethod
+    def _decode_jwt_expiry(token: str) -> datetime:
+        try:
+            parts = token.split(".")
+            payload = parts[1] + "=" * (4 - len(parts[1]) % 4)
+            claims = json.loads(base64.urlsafe_b64decode(payload))
+            exp = claims.get("exp")
+            if exp:
+                return datetime.fromtimestamp(exp, tz=timezone.utc)
+        except Exception:
+            _LOGGER.debug("Failed to decode JWT expiry", exc_info=True)
+        # Fallback: assume 24 hours from now (typical for password grant)
+        # when the JWT cannot be decoded or lacks an exp claim.
+        return datetime.now(timezone.utc) + timedelta(hours=24)

--- a/homeassistant/components/sharkiq/skegox_device.py
+++ b/homeassistant/components/sharkiq/skegox_device.py
@@ -1,0 +1,906 @@
+# Device model for Shark vacuums via the Skegox API.
+# Implements the same interface as the legacy SharkIqVacuum class so that
+# the existing vacuum.py entity code works unchanged.
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import struct
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .skegox_api import SkegoxApi
+
+from .const import ERROR_MESSAGES
+
+_LOGGER = logging.getLogger(__name__)
+
+# Coordinate transformation from protobuf local grid to JSON centimeters.
+# Derived from comparing protobuf float32 values against known MARD JSON coordinates.
+# x_json = -(50/3) * x_proto + 134.5
+# y_json = (50/3) * y_proto + 203.5
+_COORD_SCALE = 50.0 / 3.0
+_COORD_X_OFFSET = 134.5
+_COORD_Y_OFFSET = 203.5
+
+# Skegox property names (GET_ prefix for read, SET_ prefix for write)
+# These map to the same logical properties as the Ayla API but with
+# consistent GET_/SET_ prefixes in the shadow model.
+PROP_OPERATING_MODE = "GET_Operating_Mode"
+PROP_CHARGING_STATUS = "GET_Charging_Status"
+PROP_BATTERY_CAPACITY = "GET_Battery_Capacity"
+PROP_ERROR_CODE = "GET_Error_Code"
+PROP_POWER_MODE = "GET_Power_Mode"
+PROP_RSSI = "GET_RSSI"
+PROP_ROBOT_ROOM_LIST = "GET_Robot_Room_List"
+PROP_LOW_LIGHT_MISSION = "GET_LowLightMission"
+PROP_RECHARGE_RESUME = "GET_Recharge_Resume"
+PROP_RECHARGING_TO_RESUME = "GET_Recharging_To_Resume"
+PROP_ROBOT_FIRMWARE_VERSION = "GET_Robot_Firmware_Version"
+PROP_DEVICE_MODEL_NUMBER = "GET_Device_Model_Number"
+
+# Settable property names (without GET_ prefix, as the API expects)
+SET_OPERATING_MODE = "Operating_Mode"
+SET_POWER_MODE = "Power_Mode"
+SET_FIND_DEVICE = "Find_Device"
+SET_AREAS_TO_CLEAN = "Areas_To_Clean"
+SET_AREAS_TO_CLEAN_V3 = "AreasToClean_V3"
+
+# Operating mode values (match the Ayla API IntEnum values)
+OP_MODE_STOP = 0
+OP_MODE_PAUSE = 1
+OP_MODE_START = 2
+OP_MODE_RETURN = 3
+
+# Power mode values (match the Ayla API IntEnum values)
+POWER_ECO = 1
+POWER_NORMAL = 0
+POWER_MAX = 2
+
+# Translation from Ayla power mode values to Skegox power mode values.
+# The old Ayla API uses ECO=1, NORMAL=0, MAX=2 while Skegox uses
+# ECO=0, NORMAL=1, MAX=2.
+AYLA_TO_SKEGOX_POWER = { POWER_ECO: 0, POWER_NORMAL: 1, POWER_MAX: 2, }
+
+SKEGOX_TO_AYLA_POWER = {v: k for k, v in AYLA_TO_SKEGOX_POWER.items()}
+
+# Represents a Shark vacuum via the Skegox API.
+# Implements the same public interface as SharkIqVacuum so that the
+# existing vacuum.py entity code works without modification.
+class SkegoxDevice:
+    
+    # Extract device SND (serial number) from registry data.
+    # The SND is derived from `Battery_Serial_Num`, taking the portion
+    # after the last `-` separator (e.g., `ABC-123-XYZ456` → `XYZ456`).
+    @staticmethod
+    def extract_snd(registry: dict[str, Any]) -> str:
+        bsn = registry.get("Battery_Serial_Num", "")
+        return bsn.split("-")[-1] if "-" in bsn else bsn
+
+    # Merge source properties into target with optional prefix.
+    # Each value is wrapped as `{"value": value}` to match the unified
+    # property access pattern used across both backends.
+    @staticmethod
+    def _merge_properties(target: dict[str, Any], source: dict[str, Any], prefix: str = "") -> None:
+        for key, value in source.items():
+            prop_key = f"{prefix}{key}"
+            if isinstance(value, dict):
+                target[prop_key] = value
+            else:
+                target[prop_key] = {"value": value}
+
+    # Create a SkegoxDevice from a Skegox API response.
+    # `device_data` structure:
+    #   `metadata`: device name and display info
+    #   `registry`: hardware serial numbers, model, firmware
+    #   `telemetry`: real-time sensor readings
+    #   `connectivityStatus`: online/offline state
+    #   `shadow`: IoT shadow with `reported` and `desired` properties
+    def __init__(self, api: SkegoxApi, device_data: dict[str, Any]) -> None:
+        self._api = api
+        self._raw = device_data
+
+        metadata = device_data.get("metadata", {})
+        registry = device_data.get("registry", {})
+        telemetry = device_data.get("telemetry", {})
+        connectivity = device_data.get("connectivityStatus", {})
+        shadow = device_data.get("shadow", {})
+        reported = shadow.get("properties", {}).get("reported", {})
+
+        # Extract SND: prefer stored _snd from API, fall back to Battery_Serial_Num
+        self._snd = device_data.get("_snd", "")
+        if not self._snd:
+            self._snd = SkegoxDevice.extract_snd(registry)
+        self._dsn = self._snd
+
+        self._name = metadata.get("deviceName", "Shark Robot")
+        self._oem_model = registry.get("Device_Serial_Num", "")
+        self._model_number = registry.get("Device_Model_Number", "")
+        self._connection_status = ("Online" if connectivity.get("connected") else "Offline")
+
+        # Build properties dict from telemetry + shadow reported
+        self.properties_full: dict[str, Any] = {}
+        self._merge_properties(self.properties_full, telemetry, prefix="GET_")
+        self._merge_properties(self.properties_full, reported, prefix="GET_")
+
+        # Firmware from registry
+        fw = registry.get("FW_VERSION", "")
+        if fw:
+            self.properties_full[PROP_ROBOT_FIRMWARE_VERSION] = {"value": fw}
+
+        # Device model number from registry
+        model = registry.get("Device_Model_Number", "")
+        if model:
+            self.properties_full[PROP_DEVICE_MODEL_NUMBER] = {"value": model}
+
+        # Parse room list
+        self._floor_id: str = ""
+        self._rooms: list[str] = []
+        self._room_name_map: dict[str, str] = {}
+        self._mard_raw: dict[str, Any] | None = None
+        self._room_polygons: dict[str, list[tuple[float, float]]] = {}
+        self._no_go_zones: list[dict[str, Any]] = []
+        self._parse_room_list(reported)
+
+        # Floor plan image and edges (from floorRPfile1)
+        self._floor_plan_image: Any = None
+        self._floor_plan_edges: list[tuple[tuple[float, float], tuple[float, float]]] = []
+        self._floor_plan_doors: list[tuple[tuple[float, float], tuple[float, float]]] = []
+        self._floor_plan_scale: float = 0.06
+        self._floor_plan_origin: tuple[float, float] = (0.0, 0.0)
+        self._floor_plan_dims: tuple[int, int] = (0, 0)
+
+        # Detect AreasToClean_V3 capability
+        self._has_areas_v3 = "AreasToClean_V3" in reported
+
+    @property
+    def serial_number(self) -> str:
+        return self._dsn
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def oem_model_number(self) -> str:
+        return self._oem_model
+
+    @property
+    def vac_model_number(self) -> str | None:
+        model = self.get_property_value(PROP_DEVICE_MODEL_NUMBER)
+        return str(model) if model else None
+
+    @property
+    def error_code(self) -> int | None:
+        return self.get_property_value(PROP_ERROR_CODE)
+
+    @property
+    def error_text(self) -> str | None:
+        err = self.error_code
+        if err:
+            return ERROR_MESSAGES.get(err, f"Unknown error ({err})")
+        return None
+
+    # Get the value of a property.
+    # Accepts both string names and enum values (for compatibility
+    # with the legacy Properties enum). Tries the raw name first,
+    # then the GET_-prefixed name used by the Skegox shadow model.
+    def get_property_value(self, property_name: str | Any) -> Any:
+        name = property_name.value if hasattr(property_name, "value") else property_name
+        # Try raw name first (matches Ayla API property names)
+        prop = self.properties_full.get(name)
+        # Fall back to GET_-prefixed name (Skegox shadow model)
+        if prop is None and not name.startswith("GET_"):
+            prop = self.properties_full.get(f"GET_{name}")
+        if prop is None:
+            return None
+        if isinstance(prop, dict):
+            value = prop.get("value")
+        else:
+            value = prop
+        # Translate power mode values from Skegox to Ayla
+        if name in (PROP_POWER_MODE, "Power_Mode", "GET_Power_Mode") and value in SKEGOX_TO_AYLA_POWER:
+            return SKEGOX_TO_AYLA_POWER[value]
+        return value
+
+    # Set a property value via the Skegox API.
+    # Strips the ``GET_`` prefix if present — the API expects the base
+    # property name for writes (e.g., ``GET_Power_Mode`` → ``Power_Mode``).
+    # Also translates Ayla power mode values to Skegox equivalents.
+    async def async_set_property_value(self, property_name: str | Any, value: Any) -> None:
+        name = property_name.value if hasattr(property_name, "value") else property_name
+        # Strip GET_ prefix if present, the API expects the base name
+        if name.startswith("GET_"):
+            name = name[4:]
+        if hasattr(value, "value"):
+            value = value.value
+        # Translate power mode values from Ayla to Skegox
+        if name == "Power_Mode" and value in AYLA_TO_SKEGOX_POWER:
+            value = AYLA_TO_SKEGOX_POWER[value]
+        await self._api.set_desired_property(self._snd, name, value)
+
+    # Set the operating mode.
+    async def async_set_operating_mode(self, mode: Any) -> None:
+        mode_val = mode.value if hasattr(mode, "value") else mode
+        await self._api.set_desired_property(self._snd, SET_OPERATING_MODE, mode_val)
+
+    # Make the device emit a chirp.
+    async def async_find_device(self) -> None:
+        await self._api.set_desired_property(self._snd, SET_FIND_DEVICE, 1)
+
+    # Clean specific rooms.
+    async def async_clean_rooms(self, rooms: list[str]) -> None:
+        await self._api.clean_rooms(snd=self._snd, rooms=rooms, floor_id=self._floor_id, use_v3=self._has_areas_v3,)
+
+    # Parse room list from Robot_Room_List or AreasToClean_V3 property.
+    #   Format A (legacy): "FloorID:Room1:Room2:..."
+    #   Format B (v3 JSON): {"floor_id": "...", "areas_to_clean": {"UserRoom": ["Kitchen", "Living Room"]}}
+    def _parse_room_list(self, reported: dict[str, Any]) -> None:
+        # Try Robot_Room_List first (legacy colon-separated format)
+        room_list_raw = reported.get("Robot_Room_List", {})
+        room_list_val = (
+            room_list_raw.get("value", room_list_raw)
+            if isinstance(room_list_raw, dict)
+            else room_list_raw
+        )
+        if room_list_val and isinstance(room_list_val, str) and ":" in room_list_val:
+            parts = room_list_val.split(":")
+            self._floor_id = parts[0]
+            self._rooms = parts[1:]
+            return
+
+        # Try AreasToClean variants in order of preference
+        for prop_name in ("AreasToClean_V3", "AreasToClean_V2", "Areas_To_Clean"):
+            floor_id, rooms = self._parse_areas_json(prop_name, reported)
+            if rooms:
+                self._floor_id = floor_id
+                self._rooms = rooms
+                return
+
+    # Try to parse areas data from a property. Returns (floor_id, rooms) or (None, None).
+    def _parse_areas_json(self, prop_name: str, reported: dict[str, Any]) -> tuple[str | None, list[str] | None]:
+        prop_data = reported.get(prop_name, {})
+        prop_val = prop_data.get("value", prop_data) if isinstance(prop_data, dict) else prop_data
+        if not prop_val:
+            return None, None
+
+        try:
+            parsed = json.loads(prop_val) if isinstance(prop_val, str) else prop_val
+            if not isinstance(parsed, dict):
+                return None, None
+
+            floor_id = parsed.get("floor_id", "")
+            areas = parsed.get("areas_to_clean", {})
+
+            # V3 dict-of-lists format: {"UserRoom": ["Kitchen", "Living Room"]}
+            if isinstance(areas, dict):
+                all_rooms = []
+                for room_list in areas.values():
+                    if isinstance(room_list, list):
+                        all_rooms.extend(room_list)
+                if all_rooms:
+                    return floor_id, all_rooms
+            # V2/legacy flat list format: ["Room1", "Room2"]
+            elif isinstance(areas, list):
+                rooms = [item.split(":", 1)[-1] if ":" in item else item for item in areas]
+                return floor_id, rooms
+        except (ValueError, TypeError):
+            pass
+
+        return None, None
+
+    # Parse floorRPfile1 protobuf data into an image and edge/door segments.
+    def parse_floor_plan(self, data: bytes) -> None:
+        self._floor_plan_raw = data
+        try:
+            self._parse_floor_plan_protobuf(data)
+        except Exception:
+            _LOGGER.debug("Floor plan parse failed for %s", self._name, exc_info=True)
+
+    # Parse floorRPfile1 protobuf structure.
+    #   Key fields:
+    #   - Field 5/21: image container (scale, origin, dimensions, pixel data)
+    #   - Field 28: repeated edge/door line entries
+    def _parse_floor_plan_protobuf(self, data: bytes) -> None:
+        cp = 0
+
+        field_data: dict[int, bytes] = {}
+        field_varints: dict[int, int] = {}
+        field_floats: dict[int, float] = {}
+        field_28_entries: list[bytes] = []
+
+        while cp < len(data):
+            tag, cp = _read_varint(data, cp)
+            fn = tag >> 3
+            wt = tag & 7
+
+            if wt == 2:
+                length, cp = _read_varint(data, cp)
+                if fn == 28:
+                    field_28_entries.append(data[cp:cp + length])
+                else:
+                    field_data[fn] = data[cp:cp + length]
+                cp += length
+            elif wt == 0:
+                val, cp = _read_varint(data, cp)
+                field_varints[fn] = val
+            elif wt == 5:
+                val = struct.unpack('<f', data[cp:cp + 4])[0]
+                cp += 4
+                field_floats[fn] = val
+            else:
+                break
+
+        # Parse image from field 21 (or field 5)
+        img_raw = field_data.get(21) or field_data.get(5)
+        if img_raw:
+            self._parse_floor_image(img_raw)
+
+        # Parse edges/doors from repeated field 28 entries
+        for entry in field_28_entries:
+            self._parse_floor_edge_entry(entry)
+
+    # Parse image container from field 5/21.
+    #   Sub-fields:
+    #   - Field 1: scale (float, meters per pixel)
+    #   - Field 2: origin (x, y floats)
+    #   - Field 3: width (varint)
+    #   - Field 4: height (varint)
+    #   - Field 6: pixel data (palette-indexed bytes)
+    #   - Field 10: palette colors (parsed separately)
+    def _parse_floor_image(self, data: bytes) -> None:
+        from PIL import Image
+
+        cp = 0
+        scale = 0.06
+        origin_x = 0.0
+        origin_y = 0.0
+        width = 0
+        height = 0
+        pixel_data: bytes = b""
+
+        while cp < len(data):
+            tag, cp = _read_varint(data, cp)
+            fn = tag >> 3
+            wt = tag & 7
+
+            if wt == 5:
+                val = struct.unpack('<f', data[cp:cp + 4])[0]
+                cp += 4
+                if fn == 1:
+                    scale = val
+            elif wt == 2:
+                length, cp = _read_varint(data, cp)
+                fd = data[cp:cp + length]
+                cp += length
+                if fn == 2:
+                    if len(fd) >= 10:
+                        origin_x = struct.unpack('<f', fd[1:5])[0]
+                        origin_y = struct.unpack('<f', fd[6:10])[0]
+                elif fn == 6:
+                    pixel_data = fd
+            elif wt == 0:
+                val, cp = _read_varint(data, cp)
+                if fn == 3:
+                    width = val
+                elif fn == 4:
+                    height = val
+            else:
+                break
+
+        if not pixel_data or width == 0 or height == 0:
+            return
+
+        self._floor_plan_scale = scale
+        self._floor_plan_origin = (origin_x, origin_y)
+        self._floor_plan_dims = (width, height)
+
+        # Parse palette from field 10
+        palette = self._parse_palette()
+
+        # Convert palette-indexed pixels to RGBA image
+        img = Image.new("RGBA", (width, height))
+        pixels = img.load()
+        for py in range(height):
+            for px in range(width):
+                idx = py * width + px
+                if idx < len(pixel_data):
+                    color_idx = pixel_data[idx]
+                    if palette and color_idx < len(palette):
+                        r, g, b = palette[color_idx]
+                        pixels[px, py] = (r, g, b, 255)
+                    else:
+                        gray = min(255, color_idx * 2)
+                        pixels[px, py] = (gray, gray, gray, 255)
+                else:
+                    pixels[px, py] = (0, 0, 0, 0)
+        self._floor_plan_image = img
+        _LOGGER.info("Floor plan image loaded for %s: %dx%d, scale=%.2fm/px, palette=%d colors", self._name, width, height, scale, len(palette),)
+
+    # Parse palette from field 10.
+    # Returns a list of (R, G, B) tuples indexed by palette index.
+    #   Field 10 sub-fields:
+    #   - Field 2: palette count (varint, default 256)
+    #   - Field 3: palette data (byte array of RGB entries)
+    def _parse_palette(self) -> list[tuple[int, int, int]]:
+        field_10_raw: bytes | None = None
+
+        # Re-read the raw data to find field 10
+        # We need to access the original floor plan data, but we don't have it here.
+        # Instead, we'll parse it from a stored copy.
+        if self._floor_plan_raw is None:
+            return []
+
+        data = self._floor_plan_raw
+        cp = 0
+        while cp < len(data):
+            tag, cp = _read_varint(data, cp)
+            fn = tag >> 3
+            wt = tag & 7
+            if wt == 2:
+                length, cp = _read_varint(data, cp)
+                if fn == 10:
+                    field_10_raw = data[cp:cp + length]
+                    break
+                cp += length
+            elif wt == 0:
+                _, cp = _read_varint(data, cp)
+            elif wt == 5:
+                cp += 4
+            else:
+                break
+
+        if not field_10_raw:
+            return []
+
+        # Parse palette entries from field 10
+        # Structure: field 1 (float scale), field 2 (varint count), field 3 (palette data)
+        cp = 0
+        palette_count = 256  # default
+        palette_data: bytes = b""
+
+        while cp < len(field_10_raw):
+            tag, cp = _read_varint(field_10_raw, cp)
+            fn = tag >> 3
+            wt = tag & 7
+            if wt == 0:
+                val, cp = _read_varint(field_10_raw, cp)
+                if fn == 2:
+                    palette_count = val
+            elif wt == 2:
+                length, cp = _read_varint(field_10_raw, cp)
+                if fn == 3:
+                    palette_data = field_10_raw[cp:cp + length]
+                cp += length
+            elif wt == 5:
+                cp += 4
+            else:
+                break
+
+        # Parse palette data as repeated entries
+        # Each entry appears to be a small struct with RGB values
+        palette: list[tuple[int, int, int]] = [(0, 0, 0)] * palette_count
+
+        cp = 0
+        idx = 0
+        while cp < len(palette_data) and idx < palette_count:
+            tag, cp = _read_varint(palette_data, cp)
+            fn = tag >> 3
+            wt = tag & 7
+            if wt == 2:
+                length, cp = _read_varint(palette_data, cp)
+                fd = palette_data[cp:cp + length]
+                cp += length
+                if length == 3:
+                    palette[idx] = (fd[0], fd[1], fd[2])
+                    idx += 1
+                elif length >= 3:
+                    # Try to extract RGB from longer entries
+                    # Pattern: 14 00 0c 00 fe ff 14 00 07 00 fd ff ...
+                    # Every 5 bytes: <varint> <R> <G> <B>
+                    pp = 0
+                    while pp < len(fd) and idx < palette_count:
+                        if pp + 3 < len(fd):
+                            r = fd[pp]
+                            g = fd[pp + 1]
+                            b = fd[pp + 2]
+                            palette[idx] = (r, g, b)
+                            idx += 1
+                            pp += 3
+                        else:
+                            break
+            elif wt == 0:
+                _, cp = _read_varint(palette_data, cp)
+            elif wt == 5:
+                cp += 4
+            else:
+                break
+
+        return palette
+
+    # Parse a single edge/door entry from field 28.
+    #   Sub-fields:
+    #   - Field 2: edge type string ("edge" or "door")
+    #   - Field 4: points container with repeated (x, y) float pairs
+    def _parse_floor_edge_entry(self, entry: bytes) -> None:
+        ep = 0
+        edge_type = ""
+        points: list[tuple[float, float]] = []
+
+        while ep < len(entry):
+            tag2, ep = _read_varint(entry, ep)
+            fn2 = tag2 >> 3
+            wt2 = tag2 & 7
+
+            if wt2 == 2:
+                length2, ep = _read_varint(entry, ep)
+                fd = entry[ep:ep + length2]
+                ep += length2
+
+                if fn2 == 2:
+                    edge_type = fd.decode("utf-8", errors="replace")
+                elif fn2 == 4:
+                    # Points container: repeated entries of format
+                    # 0a <len=12> 0d <x_float> 15 <y_float> 18 <flag>
+                    pp = 0
+                    while pp < len(fd):
+                        ptag, pp = _read_varint(fd, pp)
+                        pfn = ptag >> 3
+                        pwt = ptag & 7
+                        if pwt == 2:
+                            plen, pp = _read_varint(fd, pp)
+                            pdata = fd[pp:pp + plen]
+                            pp += plen
+                            if len(pdata) >= 10:
+                                x = struct.unpack('<f', pdata[1:5])[0]
+                                y = struct.unpack('<f', pdata[6:10])[0]
+                                points.append((x * 100, y * 100))
+                        elif pwt == 0:
+                            _, pp = _read_varint(fd, pp)
+                        else:
+                            break
+            elif wt2 == 0:
+                _, ep = _read_varint(entry, ep)
+            else:
+                break
+
+        if len(points) >= 2:
+            if edge_type == "door":
+                self._floor_plan_doors.append((points[0], points[1]))
+            elif edge_type == "edge":
+                for i in range(len(points) - 1):
+                    self._floor_plan_edges.append((points[i], points[i + 1]))
+
+    # Parse MARD (Mobile_App_Room_Definition) data and populate rooms.
+    # Accepts either JSON format (legacy) or base64-encoded protobuf
+    # (newer Skegox devices, stored in the 'zones' property file).
+    def load_mard(self, mard_body: bytes) -> None:
+        try:
+            parsed = json.loads(mard_body.decode("utf-8"))
+            self._load_mard_json(parsed)
+            return
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            pass
+
+        # Try base64-encoded protobuf
+        try:
+            decoded = base64.b64decode(mard_body)
+            self._load_mard_protobuf(decoded)
+            return
+        except Exception:
+            _LOGGER.debug("MARD for %s: not valid JSON or base64 protobuf", self._name)
+
+    # Parse MARD JSON format.
+    # `area_meta_data` prefixes identify the area type:
+    # "UserRoom:" — a cleanable room with a name
+    # "UserNoGo:" — a no-go zone (UUID after the colon)
+    def _load_mard_json(self, parsed: dict[str, Any]) -> None:
+        if not self._mard_raw:
+            _LOGGER.debug("MARD full structure for %s: %s", self._name, json.dumps(parsed, indent=2)[:2000],)
+
+        self._mard_raw = parsed
+
+        name_map: dict[str, str] = {}
+        rooms: list[str] = []
+        room_polygons: dict[str, list[tuple[float, float]]] = {}
+        no_go_zones: list[dict[str, Any]] = []
+
+        for area in parsed.get("areas", []):
+            meta = area.get("area_meta_data", "")
+            points_raw = area.get("points", [])
+            points = [(p["x"], p["y"]) for p in points_raw if "x" in p and "y" in p]
+
+            if meta.startswith("UserRoom:"):
+                robot_name = area.get("robot_room_name", "") or ""
+                user_name = area.get("user_room_name", "") or ""
+                if not robot_name:
+                    continue
+                display_name = user_name or robot_name
+                name_map[robot_name] = display_name
+                rooms.append(display_name)
+                if points:
+                    room_polygons[display_name] = points
+
+            elif meta.startswith("UserNoGo:"):
+                uuid_val = meta.split(":", 1)[1] if ":" in meta else ""
+                area_state = area.get("area_state", "blocking")
+                if points:
+                    no_go_zones.append({"uuid": uuid_val, "points": points, "area_state": area_state, })
+
+        mard_floor_id = parsed.get("floor_id")
+        if isinstance(mard_floor_id, str) and mard_floor_id:
+            self._floor_id = mard_floor_id
+
+        if rooms:
+            self._rooms = rooms
+            self._room_name_map = name_map
+            self._room_polygons = room_polygons
+            _LOGGER.info("MARD rooms for %s: %s", self._name, rooms)
+        else:
+            _LOGGER.debug("MARD for %s: no rooms found", self._name)
+
+        if no_go_zones:
+            self._no_go_zones = no_go_zones
+            _LOGGER.info("MARD no-go zones for %s: %d", self._name, len(no_go_zones))
+
+    # Parse base64-decoded protobuf zones data.
+    #   Structure:
+    #   - Field 6: main container
+    #       - Field 3: floor_id (string)
+    #       - Field 15: room entries (repeated)
+    #           - Field 2: room name (string)
+    #           - Field 4: points container
+    #               - Repeated field 1 entries, each with x (field 1, 32-bit) and y (field 2, 32-bit)
+    #           - Field 16: no-go zone
+    #               - Field 2: uuid (string)
+    #               - Field 4: points container (same format as rooms)
+    #               - Field 16: zone type string (e.g., "No-Go")
+    def _load_mard_protobuf(self, data: bytes) -> None:
+        pos = 0
+        tag, pos = _read_varint(data, pos)
+        if (tag >> 3) != 6:
+            _LOGGER.debug("Protobuf MARD: expected field 6, got %d", tag >> 3)
+            return
+
+        length, pos = _read_varint(data, pos)
+        container = data[pos:pos + length]
+
+        name_map: dict[str, str] = {}
+        rooms: list[str] = []
+        room_polygons: dict[str, list[tuple[float, float]]] = {}
+        no_go_zones: list[dict[str, Any]] = []
+
+        cp = 0
+        while cp < len(container):
+            tag, cp = _read_varint(container, cp)
+            fn = tag >> 3
+            wt = tag & 7
+
+            if wt != 2:
+                if wt == 0:
+                    _, cp = _read_varint(container, cp)
+                continue
+
+            field_len, cp = _read_varint(container, cp)
+            field_data = container[cp:cp + field_len]
+            cp += field_len
+
+            if fn == 3:
+                self._floor_id = field_data.decode("utf-8")
+
+            elif fn == 15:
+                room_name, points = _parse_room_protobuf(field_data)
+                if room_name and points:
+                    name_map[room_name] = room_name
+                    rooms.append(room_name)
+                    room_polygons[room_name] = points
+
+            elif fn == 16:
+                uuid_val, zone_points, zone_type = _parse_nogo_protobuf(field_data)
+                if zone_points:
+                    no_go_zones.append({"uuid": uuid_val, "points": zone_points, "area_state": "blocking",})
+
+        if rooms:
+            self._rooms = rooms
+            self._room_name_map = name_map
+            self._room_polygons = room_polygons
+            self._mard_raw = {"floor_id": self._floor_id, "areas": []}
+            _LOGGER.info("MARD rooms for %s: %s", self._name, rooms)
+        else:
+            _LOGGER.debug("MARD protobuf for %s: no rooms found", self._name)
+
+        if no_go_zones:
+            self._no_go_zones = no_go_zones
+            _LOGGER.info("MARD no-go zones for %s: %d", self._name, len(no_go_zones))
+
+    @property
+    def floor_id(self) -> str:
+        return self._floor_id
+
+    @property
+    def rooms(self) -> list[str]:
+        return self._rooms
+
+    @property
+    def room_name_map(self) -> dict[str, str]:
+        return self._room_name_map
+
+    # Return the raw MARD data if loaded.
+    @property
+    def mard_data(self) -> dict[str, Any] | None:
+        return self._mard_raw
+
+    @property
+    def has_areas_v3(self) -> bool:
+        return self._has_areas_v3
+
+    @property
+    def room_polygons(self) -> dict[str, list[tuple[float, float]]]:
+        return self._room_polygons
+
+    @property
+    def no_go_zones(self) -> list[dict[str, Any]]:
+        return self._no_go_zones
+
+    @property
+    def floor_plan_image(self) -> Any:
+        return self._floor_plan_image
+
+    @property
+    def floor_plan_edges(self) -> list[tuple[tuple[float, float], tuple[float, float]]]:
+        return self._floor_plan_edges
+
+    @property
+    def floor_plan_doors(self) -> list[tuple[tuple[float, float], tuple[float, float]]]:
+        return self._floor_plan_doors
+
+    @property
+    def floor_plan_scale(self) -> float:
+        return self._floor_plan_scale
+
+    @property
+    def floor_plan_origin(self) -> tuple[float, float]:
+        return self._floor_plan_origin
+
+    @property
+    def connection_status(self) -> str:
+        return self._connection_status
+
+    # Update device state from a fresh Skegox API response.
+    # Note: This uses last-known-value semantics — properties that disappear
+    # from the API response retain their previous value in properties_full.
+    # This is intentional to avoid flickering state during transient API gaps.
+    def update_from_response(self, device_data: dict[str, Any]) -> None:
+        telemetry = device_data.get("telemetry", {})
+        shadow = device_data.get("shadow", {})
+        reported = shadow.get("properties", {}).get("reported", {})
+        connectivity = device_data.get("connectivityStatus", {})
+
+        self._connection_status = ("Online" if connectivity.get("connected") else "Offline")
+
+        # Update telemetry properties
+        for key, value in telemetry.items():
+            self.properties_full[f"GET_{key}"] = {"value": value}
+
+        # Update shadow reported properties
+        for key, val_obj in reported.items():
+            if isinstance(val_obj, dict):
+                self.properties_full[f"GET_{key}"] = val_obj
+            else:
+                self.properties_full[f"GET_{key}"] = {"value": val_obj}
+
+# Read a protobuf varint, returning (value, new_position).
+# See https://protobuf.dev/programming-guides/encoding/#varints
+def _read_varint(data: bytes, pos: int) -> tuple[int, int]:
+    result = 0
+    shift = 0
+    while pos < len(data):
+        byte = data[pos]
+        result |= (byte & 0x7F) << shift
+        pos += 1
+        if (byte & 0x80) == 0:
+            break
+        shift += 7
+    return result, pos
+
+# Transform protobuf local grid coordinates to JSON centimeter coordinates.
+# Scale and offset constants were derived empirically by comparing
+#  protobuf float32 values against known MARD JSON coordinates.
+def _transform_coord(x: float, y: float) -> tuple[float, float]:
+    x_json = -_COORD_SCALE * x + _COORD_X_OFFSET
+    y_json = _COORD_SCALE * y + _COORD_Y_OFFSET
+    return x_json, y_json
+
+# Parse a room entry from protobuf. Returns (name, list of (x, y) points).
+def _parse_room_protobuf(data: bytes) -> tuple[str, list[tuple[float, float]]]:
+    rp = 0
+    room_name = ""
+    points: list[tuple[float, float]] = []
+
+    while rp < len(data):
+        tag, rp = _read_varint(data, rp)
+        fn = tag >> 3
+        wt = tag & 7
+
+        if wt != 2:
+            continue
+
+        field_len, rp = _read_varint(data, rp)
+        field_data = data[rp:rp + field_len]
+        rp += field_len
+
+        if fn == 2:
+            room_name = field_data.decode("utf-8")
+
+        elif fn == 4:
+            pp = 0
+            while pp < len(field_data):
+                ptag, pp = _read_varint(field_data, pp)
+                pfn = ptag >> 3
+                pwt = ptag & 7
+
+                if pwt != 2:
+                    continue
+
+                plen, pp = _read_varint(field_data, pp)
+                pdata = field_data[pp:pp + plen]
+                pp += plen
+
+                if len(pdata) >= 10:
+                    x_raw = struct.unpack("<f", pdata[1:5])[0]
+                    y_raw = struct.unpack("<f", pdata[6:10])[0]
+                    points.append(_transform_coord(x_raw, y_raw))
+
+    return room_name, points
+
+# Parse a no-go zone entry from protobuf. Returns (uuid, points, type).
+def _parse_nogo_protobuf(data: bytes) -> tuple[str, list[tuple[float, float]], str]:
+    np = 0
+    uuid_val = ""
+    zone_type = ""
+    points: list[tuple[float, float]] = []
+
+    while np < len(data):
+        tag, np = _read_varint(data, np)
+        fn = tag >> 3
+        wt = tag & 7
+
+        if wt == 0:
+            _, np = _read_varint(data, np)
+            continue
+
+        if wt != 2:
+            continue
+
+        field_len, np = _read_varint(data, np)
+        field_data = data[np:np + field_len]
+        np += field_len
+
+        if fn in (2, 3):
+            uuid_val = field_data.decode("utf-8")
+
+        elif fn == 16:
+            zone_type = field_data.decode("utf-8")
+
+        elif fn == 4:
+            pp = 0
+            while pp < len(field_data):
+                ptag, pp = _read_varint(field_data, pp)
+                pfn = ptag >> 3
+                pwt = ptag & 7
+
+                if pwt != 2:
+                    continue
+
+                plen, pp = _read_varint(field_data, pp)
+                pdata = field_data[pp:pp + plen]
+                pp += plen
+
+                if len(pdata) >= 10:
+                    x_raw = struct.unpack("<f", pdata[1:5])[0]
+                    y_raw = struct.unpack("<f", pdata[6:10])[0]
+                    points.append(_transform_coord(x_raw, y_raw))
+
+    return uuid_val, points, zone_type

--- a/homeassistant/components/sharkiq/strings.json
+++ b/homeassistant/components/sharkiq/strings.json
@@ -9,7 +9,8 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "requires_verification": "SharkNinja is blocking automated login (anti-bot protection). Wait 24-48 hours without retrying, then try again."
     },
     "flow_title": "Add Shark IQ account",
     "step": {
@@ -56,6 +57,16 @@
         }
       },
       "name": "Clean room"
+    },
+    "discover_device_data": {
+      "description": "Discovers all available property files (maps, room data, no-go zones, etc.) for a Skegox device.",
+      "fields": {
+        "entity_id": {
+          "description": "The vacuum entity to discover data for",
+          "name": "Entity"
+        }
+      },
+      "name": "Discover Device Data"
     }
   }
 }

--- a/homeassistant/components/sharkiq/vacuum.py
+++ b/homeassistant/components/sharkiq/vacuum.py
@@ -1,23 +1,26 @@
-"""Shark IQ Wrapper."""
+# Shark IQ Wrapper.
 
 from collections.abc import Iterable
 from typing import Any
 
-from sharkiq import OperatingModes, PowerModes, Properties, SharkIqVacuum
+from .sharkiq_pypi.sharkiq import OperatingModes, PowerModes, Properties, SharkIqVacuum
 
 from homeassistant.components.vacuum import (
+    Segment,
     StateVacuumEntity,
     VacuumActivity,
     VacuumEntityFeature,
 )
+
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ATTR_ROOMS, DOMAIN, LOGGER, SHARK
-from .coordinator import SharkIqConfigEntry, SharkIqUpdateCoordinator
+from .const import ATTR_ROOMS, DOMAIN, ERROR_MESSAGES, LOGGER, SHARK
+from .coordinator import SharkIqConfigEntry, SharkIqUpdateCoordinator, SkegoxUpdateCoordinator, SharkDevice, get_device_model
+from .skegox_device import SkegoxDevice
 
 OPERATING_STATE_MAP = {
     OperatingModes.PAUSE: VacuumActivity.PAUSED,
@@ -26,13 +29,15 @@ OPERATING_STATE_MAP = {
     OperatingModes.RETURN: VacuumActivity.RETURNING,
 }
 
+# Should research 'Matrix' clean
+# Speed or Action?
 FAN_SPEEDS_MAP = {
     "Eco": PowerModes.ECO,
     "Normal": PowerModes.NORMAL,
     "Max": PowerModes.MAX,
 }
 
-STATE_RECHARGING_TO_RESUME = "recharging_to_resume"
+FAN_SPEEDS_REVERSE = {v: k for k, v in FAN_SPEEDS_MAP.items()}
 
 # Attributes to expose
 ATTR_ERROR_CODE = "last_error_code"
@@ -40,33 +45,37 @@ ATTR_ERROR_MSG = "last_error_message"
 ATTR_LOW_LIGHT = "low_light"
 ATTR_RECHARGE_RESUME = "recharge_and_resume"
 
+# Diagnostic attributes
+ATTR_DIAGNOSTIC_OEM_MODEL = "oem_model"
+ATTR_DIAGNOSTIC_PROPERTIES_COUNT = "properties_count"
+ATTR_DIAGNOSTIC_IS_ONLINE = "is_online"
 
-async def async_setup_entry(
-    hass: HomeAssistant,
-    config_entry: SharkIqConfigEntry,
-    async_add_entities: AddConfigEntryEntitiesCallback,
-) -> None:
-    """Set up the Shark IQ vacuum cleaner."""
+# Get the error text for a device.
+def _get_error_text(device: SharkDevice) -> str | None:
+    err = device.get_property_value(Properties.ERROR_CODE)
+    if err:
+        return ERROR_MESSAGES.get(err, f"Unknown error ({err})")
+    return None
+
+# Set up the Shark IQ vacuum cleaner.
+async def async_setup_entry(hass: HomeAssistant, config_entry: SharkIqConfigEntry, async_add_entities: AddConfigEntryEntitiesCallback,) -> None:
     coordinator = config_entry.runtime_data
-    devices: Iterable[SharkIqVacuum] = coordinator.shark_vacs.values()
+    devices: Iterable[SharkDevice] = coordinator.shark_vacs.values()
     device_names = [d.name for d in devices]
-    LOGGER.debug(
-        "Found %d Shark IQ device(s): %s",
-        len(device_names),
-        ", ".join([d.name for d in devices]),
-    )
+    LOGGER.debug("Found %d Shark IQ device(s): %s", len(device_names), ", ".join(device_names),)
     async_add_entities([SharkVacuumEntity(d, coordinator) for d in devices])
 
-
-class SharkVacuumEntity(CoordinatorEntity[SharkIqUpdateCoordinator], StateVacuumEntity):
-    """Shark IQ vacuum entity."""
+# Shark IQ vacuum entity.
+class SharkVacuumEntity(CoordinatorEntity, StateVacuumEntity):
+    _coordinator: SharkIqUpdateCoordinator | SkegoxUpdateCoordinator
 
     _attr_fan_speed_list = list(FAN_SPEEDS_MAP)
     _attr_has_entity_name = True
-    _attr_name = None
+    _attr_name = None  # Use device name directly; no suffix
     _attr_supported_features = (
-        VacuumEntityFeature.BATTERY
+        VacuumEntityFeature.CLEAN_AREA
         | VacuumEntityFeature.FAN_SPEED
+        | VacuumEntityFeature.MAP
         | VacuumEntityFeature.PAUSE
         | VacuumEntityFeature.RETURN_HOME
         | VacuumEntityFeature.START
@@ -76,117 +85,87 @@ class SharkVacuumEntity(CoordinatorEntity[SharkIqUpdateCoordinator], StateVacuum
     )
     _unrecorded_attributes = frozenset({ATTR_ROOMS})
 
-    def __init__(
-        self, sharkiq: SharkIqVacuum, coordinator: SharkIqUpdateCoordinator
-    ) -> None:
-        """Create a new SharkVacuumEntity."""
+    # Create a new SharkVacuumEntity.
+    def __init__(self, sharkiq: SharkDevice, coordinator: SharkIqUpdateCoordinator | SkegoxUpdateCoordinator) -> None:
         super().__init__(coordinator)
         self.sharkiq = sharkiq
         self._attr_unique_id = sharkiq.serial_number
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, sharkiq.serial_number)},
             manufacturer=SHARK,
-            model=self.model,
+            model=get_device_model(sharkiq),
             name=sharkiq.name,
             sw_version=sharkiq.get_property_value(Properties.ROBOT_FIRMWARE_VERSION),
         )
 
-    def clean_spot(self, **kwargs: Any) -> None:
-        """Clean a spot. Not yet implemented."""
-        raise NotImplementedError
-
-    def send_command(
-        self,
-        command: str,
-        params: dict[str, Any] | list[Any] | None = None,
-        **kwargs: Any,
-    ) -> None:
-        """Send a command to the vacuum. Not yet implemented."""
-        raise NotImplementedError
-
+    # Tell us if the device is online.
     @property
     def is_online(self) -> bool:
-        """Tell us if the device is online."""
         return self.coordinator.device_is_online(self.sharkiq.serial_number)
 
-    @property
-    def model(self) -> str:
-        """Vacuum model number."""
-        if self.sharkiq.vac_model_number:
-            return self.sharkiq.vac_model_number
-        return self.sharkiq.oem_model_number
-
+    # Return the last observed error code (or None).
     @property
     def error_code(self) -> int | None:
-        """Return the last observed error code (or None)."""
-        return self.sharkiq.error_code
+        return self.sharkiq.get_property_value(Properties.ERROR_CODE)
 
+    # Return the last observed error message (or None).
     @property
     def error_message(self) -> str | None:
-        """Return the last observed error message (or None)."""
-        if not self.error_code:
-            return None
-        return self.sharkiq.error_text
+        return _get_error_text(self.sharkiq)
 
+    # Return True if vacuum set to recharge and resume cleaning.
     @property
     def recharging_to_resume(self) -> int | None:
-        """Return True if vacuum set to recharge and resume cleaning."""
         return self.sharkiq.get_property_value(Properties.RECHARGING_TO_RESUME)
 
+    # Get the current vacuum state.
+    # NB: Currently, we do not return an error state
+    # because they can be very, very stale. In the app,
+    # these are (usually) handled by showing the robot as
+    # stopped and sending the user a notification.
     @property
     def activity(self) -> VacuumActivity | None:
-        """Get the current vacuum state.
-
-        NB: Currently, we do not return an error state
-        because they can be very, very stale. In the app,
-        these are (usually) handled by showing the robot as
-        stopped and sending the user a notification.
-        """
         if self.sharkiq.get_property_value(Properties.CHARGING_STATUS):
             return VacuumActivity.DOCKED
         op_mode = self.sharkiq.get_property_value(Properties.OPERATING_MODE)
         return OPERATING_STATE_MAP.get(op_mode)
 
+    # Determine if the sensor is available based on API results.
     @property
     def available(self) -> bool:
-        """Determine if the sensor is available based on API results."""
-        # If the last update was successful...
         return self.coordinator.last_update_success and self.is_online
 
-    @property
-    def battery_level(self) -> int | None:
-        """Get the current battery level."""
-        return self.sharkiq.get_property_value(Properties.BATTERY_CAPACITY)
-
+    # Have the device return to base.
     async def async_return_to_base(self, **kwargs: Any) -> None:
-        """Have the device return to base."""
         await self.sharkiq.async_set_operating_mode(OperatingModes.RETURN)
         await self.coordinator.async_refresh()
 
+    # Pause the cleaning task.
     async def async_pause(self) -> None:
-        """Pause the cleaning task."""
         await self.sharkiq.async_set_operating_mode(OperatingModes.PAUSE)
         await self.coordinator.async_refresh()
 
+    # Start the device.
     async def async_start(self) -> None:
-        """Start the device."""
         await self.sharkiq.async_set_operating_mode(OperatingModes.START)
         await self.coordinator.async_refresh()
 
+    # Stop the device.
     async def async_stop(self, **kwargs: Any) -> None:
-        """Stop the device."""
         await self.sharkiq.async_set_operating_mode(OperatingModes.STOP)
         await self.coordinator.async_refresh()
 
+    # Cause the device to generate a loud chirp.
     async def async_locate(self, **kwargs: Any) -> None:
-        """Cause the device to generate a loud chirp."""
         await self.sharkiq.async_find_device()
 
+    # Clean specific rooms.
+    # Validates each room against the available room list and raises on
+    # the first invalid room rather than collecting all errors, matching
+    # the behavior of the SharkClean app.
     async def async_clean_room(self, rooms: list[str], **kwargs: Any) -> None:
-        """Clean specific rooms."""
         rooms_to_clean = []
         valid_rooms = self.available_rooms or []
-        rooms = [room.replace("_", " ").title() for room in rooms]
         for room in rooms:
             if room in valid_rooms:
                 rooms_to_clean.append(room)
@@ -201,54 +180,72 @@ class SharkVacuumEntity(CoordinatorEntity[SharkIqUpdateCoordinator], StateVacuum
         await self.sharkiq.async_clean_rooms(rooms_to_clean)
         await self.coordinator.async_refresh()
 
+    # Get the segments that can be cleaned.
+    async def async_get_segments(self) -> list[Segment]:
+        rooms = self.available_rooms or []
+        return [Segment(id=room, name=room) for room in rooms]
+
+    # Perform an area clean using segment IDs.
+    async def async_clean_segments(self, segment_ids: list[str], **kwargs: Any) -> None:
+        await self.async_clean_room(segment_ids, **kwargs)
+
+    # Return the current fan speed.
     @property
     def fan_speed(self) -> str | None:
-        """Return the current fan speed."""
-        fan_speed = None
         speed_level = self.sharkiq.get_property_value(Properties.POWER_MODE)
-        for k, val in FAN_SPEEDS_MAP.items():
-            if val == speed_level:
-                fan_speed = k
-        return fan_speed
+        return FAN_SPEEDS_REVERSE.get(speed_level)
 
+    # Set the fan speed.
     async def async_set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:
-        """Set the fan speed."""
-        await self.sharkiq.async_set_property_value(
-            Properties.POWER_MODE, FAN_SPEEDS_MAP.get(fan_speed.capitalize())
-        )
+        await self.sharkiq.async_set_property_value(Properties.POWER_MODE, FAN_SPEEDS_MAP.get(fan_speed.capitalize()))
         await self.coordinator.async_refresh()
 
     # Various attributes we want to expose
+
+    # Recharge and resume mode active.
     @property
     def recharge_resume(self) -> bool | None:
-        """Recharge and resume mode active."""
         return self.sharkiq.get_property_value(Properties.RECHARGE_RESUME)
 
+    # Get the WiFi RSSI.
     @property
     def rssi(self) -> int | None:
-        """Get the WiFi RSSI."""
         return self.sharkiq.get_property_value(Properties.RSSI)
 
+    # Let us know if the robot is operating in low-light mode.
     @property
-    def low_light(self):
-        """Let us know if the robot is operating in low-light mode."""
+    def low_light(self) -> bool | None:
         return self.sharkiq.get_property_value(Properties.LOW_LIGHT_MISSION)
 
+    # Return a list of rooms available to clean.
+    # Skegox -> from parsed MARD data.
+    # Ayla -> from `Robot_Room_List` property.
     @property
-    def available_rooms(self) -> list | None:
-        """Return a list of rooms available to clean."""
+    def available_rooms(self) -> list[str] | None:
+        if isinstance(self.sharkiq, SkegoxDevice):
+            return self.sharkiq.rooms
         room_list = self.sharkiq.get_property_value(Properties.ROBOT_ROOM_LIST)
+        
+        # (colon-separated ``FloorID:Room1:Room2`` format).
         if room_list:
             return room_list.split(":")[1:]
         return []
 
+    # Return a dictionary of device state attributes specific to sharkiq.
+    # Note: `ATTR_ROOMS` is included here for API consumers but excluded
+    # from HA's recorder via `_unrecorded_attributes` to avoid storing
+    # potentially large room lists in the database.
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Return a dictionary of device state attributes specific to sharkiq."""
+        props_count = len(self.sharkiq.properties_full)
+        oem_model = self.sharkiq.oem_model_number
         return {
             ATTR_ERROR_CODE: self.error_code,
-            ATTR_ERROR_MSG: self.sharkiq.error_text,
+            ATTR_ERROR_MSG: _get_error_text(self.sharkiq),
             ATTR_LOW_LIGHT: self.low_light,
             ATTR_RECHARGE_RESUME: self.recharge_resume,
             ATTR_ROOMS: self.available_rooms,
+            ATTR_DIAGNOSTIC_OEM_MODEL: oem_model,
+            ATTR_DIAGNOSTIC_PROPERTIES_COUNT: props_count,
+            ATTR_DIAGNOSTIC_IS_ONLINE: self.is_online,
         }


### PR DESCRIPTION
## Proposed change

This PR significantly extends the `sharkiq` integration with the following:

1. **Dual-API backend support** — Adds support for the newer Skegox cloud API (Matrix, PowerDetect, Stratos, etc.) alongside the existing Ayla Networks API (RV700–RV900 series). Auto-detects the correct backend at setup with cross-fallback.

2. **Floor plan image entity** — Renders the robot's floor plan map with room outlines, no-go zones, and edge/door lines using PIL.

3. **Battery level sensor** — Extracts battery level from the vacuum entity into a dedicated sensor entity.

4. **Segment/room cleaning** — Implements `async_get_segments()` and `async_clean_segments()` for native HA segment cleaning support.

5. **Diagnostic attributes** — Adds `oem_model`, `properties_count`, and `is_online` as extra state attributes.

6. **Error code descriptions** — Maps 20 raw error codes to human-readable messages.

7. **Anti-bot protection handling** — Gracefully handles SharkNinja's automated login blocking with user-friendly guidance.

8. **Debug service** — Adds `sharkiq.discover_device_data` service for fetching all property files from a Skegox device.

## Type of change

- [x] New feature
- [ ] Breaking change? (config entry gains new required keys for Skegox backend)

## Additional details

### Architecture

| Aspect | Before | After |
|---|---|---|
| API backends | Ayla only | Ayla + Skegox (auto-detect + fallback) |
| Platforms | `VACUUM` | `IMAGE`, `SENSOR`, `VACUUM` |
| Battery | Property on vacuum entity | Separate sensor entity |
| Floor plan | Not supported | PIL-rendered image entity |
| Segment cleaning | Not supported | `async_get_segments()` + `async_clean_segments()` |
| Error messages | Hardcoded in library | Local `ERROR_MESSAGES` dict (20 codes) |
| Anti-bot handling | Not present | `RequiresVerification` with user guidance |

### File-by-file changes

**New files:**
- `image.py` — `SharkFloorPlanImage` entity; renders MARD polygons, no-go zones, edge/door lines as JPEG via PIL
- `sensor.py` — `SharkBatterySensor` entity for battery level
- `skegox_auth.py` — `SkegoxAuthManager` with Auth0 password/refresh token grants, token persistence, region configs
- `skegox_api.py` — Async Skegox cloud API client (discovery, device listing, property files, shadow commands)
- `skegox_device.py` — `SkegoxDevice` model mirroring `SharkIqVacuum` interface; MARD/floor plan protobuf parsing, power mode translation

**Modified files:**

| File | Changes |
|---|---|
| `__init__.py` | Dual-backend setup (Skegox→Ayla fallback), anti-bot error handling, Skegox session cleanup |
| `config_flow.py` | Skegox validation, `RequiresVerification` exception, backend stored in config entry |
| `const.py` | New platforms, backend constants, 10 config entry keys, `ERROR_MESSAGES` dict |
| `coordinator.py` | `BaseSharkIqCoordinator` base class, new `SkegoxUpdateCoordinator` with Auth0 refresh and MARD retry logic |
| `vacuum.py` | Removed battery property, removed `clean_spot`/`send_command` stubs, added segment cleaning, diagnostic attributes, reverse fan speed lookup |
| `services.py` | New `discover_device_data` debug service |
| `services.yaml` | Room selector changed from `area` to `text`; new `discover_device_data` service |
| `strings.json` | `requires_verification` error, `discover_device_data` service strings |
| `manifest.json` | Added `"version": "1.5.0"` |

### Config entry data keys

New keys stored in config entries:

| Key | Purpose |
|---|---|
| `api_backend` | `"ayla"` or `"skegox"` — detected backend |
| `auth0_id_token` | Skegox: Auth0 id_token (JWT) |
| `auth0_refresh_token` | Skegox: Auth0 refresh_token |
| `auth0_access_token` | Skegox: Auth0 access_token |
| `auth0_token_expiry` | Skegox: JWT exp claim as ISO datetime |
| `ayla_access_token` | Ayla: access token |
| `ayla_refresh_token` | Ayla: refresh token |
| `ayla_token_expiry` | Ayla: expiry as ISO datetime |
| `household_id` | Skegox: auto-discovered household ID |
| `user_id` | Skegox: extracted from JWT sub claim |

### API backend comparison

| Aspect | Ayla | Skegox |
|---|---|---|
| Auth | `async_sign_in()` → access/refresh tokens | Auth0 password grant → id_token → Skegox Bearer |
| Device list | `GET /apiv1/devices.json` | `GET /devicesEndUserController/{hh}/users/{uid}` |
| State fetch | `GET /apiv1/dsns/{dsn}/properties.json` | `GET /devicesEndUserController/{hh}/devices/{snd}` |
| Commands | `POST /properties/{name}/datapoints.json` | `PATCH` with `shadow.properties.desired` |
| Room cleaning | Base64-encoded binary payload | JSON with `floor_id`, `areas_to_clean`, `clean_count` |
| Power modes | ECO=1, NORMAL=0, MAX=2 | ECO=0, NORMAL=1, MAX=2 (translated on read/write) |

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Code follows the Home Assistant style guidelines

## Note

Apologies for the large code submit, I was not originally planning to contribute, hence some comment / pattern changes.