### PR TITLE
Use CONF_MODEL from homeassistant.const in marantz_infrared

### DIFF
--- a/homeassistant/components/marantz_infrared/button.py
+++ b/homeassistant/components/marantz_infrared/button.py
@@ -9,11 +9,12 @@ from dataclasses import dataclass
 from infrared_protocols.codes.marantz.audio import MarantzAudioCode
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.const import CONF_MODEL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import MarantzIrConfigEntry
-from .const import CONF_INFRARED_EMITTER_ENTITY_ID, CONF_MODEL, MODELS
+from .const import CONF_INFRARED_EMITTER_ENTITY_ID, MODELS
 from .entity import MarantzIrEntity
 
 PARALLEL_UPDATES = 1

--- a/homeassistant/components/marantz_infrared/config_flow.py
+++ b/homeassistant/components/marantz_infrared/config_flow.py
@@ -9,6 +9,7 @@ from homeassistant.components.infrared import (
     async_get_emitters,
 )
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_MODEL
 from homeassistant.helpers.selector import (
     EntitySelector,
     EntitySelectorConfig,
@@ -18,7 +19,7 @@ from homeassistant.helpers.selector import (
     SelectSelectorMode,
 )
 
-from .const import CONF_INFRARED_EMITTER_ENTITY_ID, CONF_MODEL, DOMAIN, MODELS
+from .const import CONF_INFRARED_EMITTER_ENTITY_ID, DOMAIN, MODELS
 
 
 class MarantzIrConfigFlow(ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/marantz_infrared/const.py
+++ b/homeassistant/components/marantz_infrared/const.py
@@ -6,8 +6,6 @@ from homeassistant.util import slugify
 
 DOMAIN = "marantz_infrared"
 CONF_INFRARED_EMITTER_ENTITY_ID = "infrared_emitter_entity_id"
-# pylint: disable-next=home-assistant-duplicate-const
-CONF_MODEL = "model"
 
 MODELS: dict[str, marantz_models.MarantzModel] = {
     slugify(model.name): model for model in marantz_models.ALL_MODELS

--- a/homeassistant/components/marantz_infrared/entity.py
+++ b/homeassistant/components/marantz_infrared/entity.py
@@ -4,10 +4,11 @@ from infrared_protocols.codes.marantz import models as marantz_models
 from infrared_protocols.codes.marantz.audio import MarantzAudioCode
 
 from homeassistant.components.infrared import InfraredEmitterConsumerEntity
+from homeassistant.const import CONF_MODEL
 from homeassistant.helpers.device_registry import DeviceInfo
 
 from . import MarantzIrConfigEntry
-from .const import CONF_MODEL, DOMAIN, MODELS
+from .const import DOMAIN, MODELS
 
 
 class MarantzIrEntity(InfraredEmitterConsumerEntity):

--- a/homeassistant/components/marantz_infrared/media_player.py
+++ b/homeassistant/components/marantz_infrared/media_player.py
@@ -11,12 +11,13 @@ from homeassistant.components.media_player import (
     MediaPlayerEntityFeature,
     MediaPlayerState,
 )
+from homeassistant.const import CONF_MODEL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
 
 from . import MarantzIrConfigEntry
-from .const import CONF_INFRARED_EMITTER_ENTITY_ID, CONF_MODEL, MODELS
+from .const import CONF_INFRARED_EMITTER_ENTITY_ID, MODELS
 from .entity import MarantzIrEntity
 
 PARALLEL_UPDATES = 1

--- a/tests/components/marantz_infrared/conftest.py
+++ b/tests/components/marantz_infrared/conftest.py
@@ -9,11 +9,10 @@ import pytest
 from homeassistant.components.marantz_infrared import PLATFORMS
 from homeassistant.components.marantz_infrared.const import (
     CONF_INFRARED_EMITTER_ENTITY_ID,
-    CONF_MODEL,
     DOMAIN,
     MODELS,
 )
-from homeassistant.const import Platform
+from homeassistant.const import CONF_MODEL, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.util import slugify
 

--- a/tests/components/marantz_infrared/test_config_flow.py
+++ b/tests/components/marantz_infrared/test_config_flow.py
@@ -4,10 +4,10 @@ import pytest
 
 from homeassistant.components.marantz_infrared.const import (
     CONF_INFRARED_EMITTER_ENTITY_ID,
-    CONF_MODEL,
     DOMAIN,
 )
 from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_MODEL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 


### PR DESCRIPTION
## Proposed change

The `marantz_infrared` integration defined `CONF_MODEL` locally even though an identical constant already exists in `homeassistant.const`. This PR removes the local definition, imports `CONF_MODEL` from `homeassistant.const` in all integration and test modules, and drops the `pylint: disable-next=home-assistant-duplicate-const` comment.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #171276
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: `https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure`

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


---
_Generated by [Claude Code](https://claude.ai/code/session_01YDGXj5ZHkiooCgtLct65Ns)_