### PR TITLE
Add fan minimum on time number entity to ecobee

### DIFF
--- a/homeassistant/components/ecobee/entity.py
+++ b/homeassistant/components/ecobee/entity.py
@@ -15,6 +15,8 @@ _LOGGER = logging.getLogger(__name__)
 class EcobeeBaseEntity(Entity):
     """Base methods for Ecobee entities."""
 
+    _attr_has_entity_name = True
+
     def __init__(self, data: EcobeeData, thermostat_index: int) -> None:
         """Initiate base methods for Ecobee entities."""
         self.data = data

--- a/homeassistant/components/ecobee/icons.json
+++ b/homeassistant/components/ecobee/icons.json
@@ -1,4 +1,11 @@
 {
+  "entity": {
+    "number": {
+      "fan_min_on_time": {
+        "default": "mdi:fan-clock"
+      }
+    }
+  },
   "services": {
     "create_vacation": {
       "service": "mdi:umbrella-beach"

--- a/homeassistant/components/ecobee/notify.py
+++ b/homeassistant/components/ecobee/notify.py
@@ -24,7 +24,6 @@ class EcobeeNotifyEntity(EcobeeBaseEntity, NotifyEntity):
     """Implement the notification entity for the Ecobee thermostat."""
 
     _attr_name = None
-    _attr_has_entity_name = True
 
     def __init__(self, data: EcobeeData, thermostat_index: int) -> None:
         """Initialize the thermostat."""

--- a/homeassistant/components/ecobee/number.py
+++ b/homeassistant/components/ecobee/number.py
@@ -90,7 +90,6 @@ class EcobeeVentilatorMinTime(EcobeeBaseEntity, NumberEntity):
     _attr_native_max_value = 60
     _attr_native_step = 5
     _attr_native_unit_of_measurement = UnitOfTime.MINUTES
-    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -134,7 +133,6 @@ class EcobeeCompressorMinTemp(EcobeeBaseEntity, NumberEntity):
     """
 
     _attr_device_class = NumberDeviceClass.TEMPERATURE
-    _attr_has_entity_name = True
     _attr_icon = "mdi:thermometer-off"
     _attr_mode = NumberMode.BOX
     _attr_native_min_value = -25
@@ -174,7 +172,6 @@ class EcobeeCompressorMinTemp(EcobeeBaseEntity, NumberEntity):
 class EcobeeFanMinOnTime(EcobeeBaseEntity, NumberEntity):
     """Minimum minutes per hour that the fan must run on an ecobee thermostat."""
 
-    _attr_has_entity_name = True
     _attr_native_min_value = 0
     _attr_native_max_value = 60
     _attr_native_step = 5
@@ -204,7 +201,5 @@ class EcobeeFanMinOnTime(EcobeeBaseEntity, NumberEntity):
         """Set new fan minimum on time value."""
         step = self._attr_native_step
         aligned_value = int(round(value / step) * step)
-        self.data.ecobee.set_fan_min_on_time(
-            self.thermostat_index, aligned_value
-        )
+        self.data.ecobee.set_fan_min_on_time(self.thermostat_index, aligned_value)
         self.update_without_throttle = True

--- a/homeassistant/components/ecobee/number.py
+++ b/homeassistant/components/ecobee/number.py
@@ -74,6 +74,10 @@ async def async_setup_entry(
         )
     )
 
+    entities.extend(
+        EcobeeFanMinOnTime(data, index) for index in range(len(data.ecobee.thermostats))
+    )
+
     async_add_entities(entities, True)
 
 
@@ -164,4 +168,39 @@ class EcobeeCompressorMinTemp(EcobeeBaseEntity, NumberEntity):
     def set_native_value(self, value: float) -> None:
         """Set new compressor minimum temperature."""
         self.data.ecobee.set_aux_cutover_threshold(self.thermostat_index, value)
+        self.update_without_throttle = True
+
+
+class EcobeeFanMinOnTime(EcobeeBaseEntity, NumberEntity):
+    """Minimum minutes per hour that the fan must run on an ecobee thermostat."""
+
+    _attr_has_entity_name = True
+    _attr_native_min_value = 0
+    _attr_native_max_value = 60
+    _attr_native_step = 5
+    _attr_native_unit_of_measurement = UnitOfTime.MINUTES
+    _attr_translation_key = "fan_min_on_time"
+
+    def __init__(
+        self,
+        data: EcobeeData,
+        thermostat_index: int,
+    ) -> None:
+        """Initialize ecobee fan minimum on time."""
+        super().__init__(data, thermostat_index)
+        self._attr_unique_id = f"{self.base_unique_id}_fan_min_on_time"
+        self.update_without_throttle = False
+
+    async def async_update(self) -> None:
+        """Get the latest state from the thermostat."""
+        if self.update_without_throttle:
+            await self.data.update(no_throttle=True)
+            self.update_without_throttle = False
+        else:
+            await self.data.update()
+        self._attr_native_value = self.thermostat["settings"]["fanMinOnTime"]
+
+    def set_native_value(self, value: float) -> None:
+        """Set new fan minimum on time value."""
+        self.data.ecobee.set_fan_min_on_time(self.thermostat_index, int(value))
         self.update_without_throttle = True

--- a/homeassistant/components/ecobee/number.py
+++ b/homeassistant/components/ecobee/number.py
@@ -202,5 +202,9 @@ class EcobeeFanMinOnTime(EcobeeBaseEntity, NumberEntity):
 
     def set_native_value(self, value: float) -> None:
         """Set new fan minimum on time value."""
-        self.data.ecobee.set_fan_min_on_time(self.thermostat_index, int(value))
+        step = self._attr_native_step
+        aligned_value = int(round(value / step) * step)
+        self.data.ecobee.set_fan_min_on_time(
+            self.thermostat_index, aligned_value
+        )
         self.update_without_throttle = True

--- a/homeassistant/components/ecobee/strings.json
+++ b/homeassistant/components/ecobee/strings.json
@@ -37,6 +37,9 @@
       "compressor_protection_min_temp": {
         "name": "Compressor minimum temperature"
       },
+      "fan_min_on_time": {
+        "name": "Fan minimum on time"
+      },
       "ventilator_min_type_away": {
         "name": "Ventilator minimum time away"
       },

--- a/homeassistant/components/ecobee/switch.py
+++ b/homeassistant/components/ecobee/switch.py
@@ -53,7 +53,6 @@ async def async_setup_entry(
 class EcobeeVentilator20MinSwitch(EcobeeBaseEntity, SwitchEntity):
     """Represent 20 min timer for an ecobee thermostat with ventilator."""
 
-    _attr_has_entity_name = True
     _attr_name = "Ventilator 20m Timer"
 
     def __init__(
@@ -104,7 +103,6 @@ class EcobeeVentilator20MinSwitch(EcobeeBaseEntity, SwitchEntity):
 class EcobeeSwitchAuxHeatOnly(EcobeeBaseEntity, SwitchEntity):
     """Representation of a aux_heat_only ecobee switch."""
 
-    _attr_has_entity_name = True
     _attr_translation_key = "aux_heat_only"
 
     def __init__(

--- a/tests/components/ecobee/snapshots/test_number.ambr
+++ b/tests/components/ecobee/snapshots/test_number.ambr
@@ -1,0 +1,363 @@
+# serializer version: 1
+# name: test_all_entities[number.ecobee2_compressor_minimum_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 19.0,
+      'min': -32.0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 5,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': None,
+    'entity_id': 'number.ecobee2_compressor_minimum_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Compressor minimum temperature',
+    'options': dict({
+    }),
+    'original_device_class': <NumberDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': 'mdi:thermometer-off',
+    'original_name': 'Compressor minimum temperature',
+    'platform': 'ecobee',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'compressor_protection_min_temp',
+    'unique_id': '8675308_compressor_protection_min_temp',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_all_entities[number.ecobee2_compressor_minimum_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'ecobee2 Compressor minimum temperature',
+      'icon': 'mdi:thermometer-off',
+      'max': 19.0,
+      'min': -32.0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 5,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.ecobee2_compressor_minimum_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-12.2',
+  })
+# ---
+# name: test_all_entities[number.ecobee2_fan_minimum_on_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 60,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 5,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': None,
+    'entity_id': 'number.ecobee2_fan_minimum_on_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Fan minimum on time',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Fan minimum on time',
+    'platform': 'ecobee',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'fan_min_on_time',
+    'unique_id': '8675308_fan_min_on_time',
+    'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+  })
+# ---
+# name: test_all_entities[number.ecobee2_fan_minimum_on_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'ecobee2 Fan minimum on time',
+      'max': 60,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 5,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.ecobee2_fan_minimum_on_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10',
+  })
+# ---
+# name: test_all_entities[number.ecobee_fan_minimum_on_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 60,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 5,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': None,
+    'entity_id': 'number.ecobee_fan_minimum_on_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Fan minimum on time',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Fan minimum on time',
+    'platform': 'ecobee',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'fan_min_on_time',
+    'unique_id': '8675309_fan_min_on_time',
+    'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+  })
+# ---
+# name: test_all_entities[number.ecobee_fan_minimum_on_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'ecobee Fan minimum on time',
+      'max': 60,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 5,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.ecobee_fan_minimum_on_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10',
+  })
+# ---
+# name: test_all_entities[number.ecobee_ventilator_minimum_time_away-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 60,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 5,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': None,
+    'entity_id': 'number.ecobee_ventilator_minimum_time_away',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Ventilator minimum time away',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Ventilator minimum time away',
+    'platform': 'ecobee',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ventilator_min_type_away',
+    'unique_id': '8675309_ventilator_away',
+    'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+  })
+# ---
+# name: test_all_entities[number.ecobee_ventilator_minimum_time_away-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'ecobee Ventilator minimum time away',
+      'max': 60,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 5,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.ecobee_ventilator_minimum_time_away',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10',
+  })
+# ---
+# name: test_all_entities[number.ecobee_ventilator_minimum_time_home-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 60,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 5,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': None,
+    'entity_id': 'number.ecobee_ventilator_minimum_time_home',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Ventilator minimum time home',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Ventilator minimum time home',
+    'platform': 'ecobee',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ventilator_min_type_home',
+    'unique_id': '8675309_ventilator_home',
+    'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+  })
+# ---
+# name: test_all_entities[number.ecobee_ventilator_minimum_time_home-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'ecobee Ventilator minimum time home',
+      'max': 60,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 5,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.ecobee_ventilator_minimum_time_home',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '20',
+  })
+# ---
+# name: test_all_entities[number.unknownecobeename_fan_minimum_on_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 60,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 5,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': None,
+    'entity_id': 'number.unknownecobeename_fan_minimum_on_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Fan minimum on time',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Fan minimum on time',
+    'platform': 'ecobee',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'fan_min_on_time',
+    'unique_id': '8675307_fan_min_on_time',
+    'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+  })
+# ---
+# name: test_all_entities[number.unknownecobeename_fan_minimum_on_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'unknownEcobeeName Fan minimum on time',
+      'max': 60,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 5,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.unknownecobeename_fan_minimum_on_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10',
+  })
+# ---

--- a/tests/components/ecobee/test_number.py
+++ b/tests/components/ecobee/test_number.py
@@ -120,3 +120,37 @@ async def test_set_compressor_protection_min_temp(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
         mock_set_compressor_min_temp.assert_called_once_with(1, 32)
+
+
+FAN_MIN_ON_TIME_ID = "number.ecobee_fan_minimum_on_time"
+
+
+async def test_fan_min_on_time_attributes(hass: HomeAssistant) -> None:
+    """Test the fan minimum on time number attributes are correct."""
+    await setup_platform(hass, NUMBER_DOMAIN)
+
+    state = hass.states.get(FAN_MIN_ON_TIME_ID)
+    assert state.state == "10"
+    assert state.attributes.get("min") == 0
+    assert state.attributes.get("max") == 60
+    assert state.attributes.get("step") == 5
+    assert state.attributes.get("friendly_name") == "ecobee Fan minimum on time"
+    assert state.attributes.get("unit_of_measurement") == UnitOfTime.MINUTES
+
+
+async def test_set_fan_min_on_time(hass: HomeAssistant) -> None:
+    """Test the number can set fan minimum on time."""
+    target_value = 25
+    with patch(
+        "homeassistant.components.ecobee.Ecobee.set_fan_min_on_time"
+    ) as mock_set_fan_min_on_time:
+        await setup_platform(hass, NUMBER_DOMAIN)
+
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: FAN_MIN_ON_TIME_ID, ATTR_VALUE: target_value},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        mock_set_fan_min_on_time.assert_called_once_with(THERMOSTAT_ID, target_value)

--- a/tests/components/ecobee/test_number.py
+++ b/tests/components/ecobee/test_number.py
@@ -2,49 +2,38 @@
 
 from unittest.mock import patch
 
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
 from homeassistant.components.number import (
     ATTR_VALUE,
     DOMAIN as NUMBER_DOMAIN,
     SERVICE_SET_VALUE,
 )
-from homeassistant.const import ATTR_ENTITY_ID, UnitOfTime
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
 
+from tests.common import snapshot_platform
+
 VENTILATOR_MIN_HOME_ID = "number.ecobee_ventilator_minimum_time_home"
 VENTILATOR_MIN_AWAY_ID = "number.ecobee_ventilator_minimum_time_away"
+COMPRESSOR_MIN_TEMP_ID = "number.ecobee2_compressor_minimum_temperature"
+FAN_MIN_ON_TIME_ID = "number.ecobee_fan_minimum_on_time"
 THERMOSTAT_ID = 0
 
 
-async def test_ventilator_min_on_home_attributes(hass: HomeAssistant) -> None:
-    """Test the ventilator number on home attributes are correct."""
-    await setup_platform(hass, NUMBER_DOMAIN)
-
-    state = hass.states.get(VENTILATOR_MIN_HOME_ID)
-    assert state.state == "20"
-    assert state.attributes.get("min") == 0
-    assert state.attributes.get("max") == 60
-    assert state.attributes.get("step") == 5
-    assert (
-        state.attributes.get("friendly_name") == "ecobee Ventilator minimum time home"
-    )
-    assert state.attributes.get("unit_of_measurement") == UnitOfTime.MINUTES
-
-
-async def test_ventilator_min_on_away_attributes(hass: HomeAssistant) -> None:
-    """Test the ventilator number on away attributes are correct."""
-    await setup_platform(hass, NUMBER_DOMAIN)
-
-    state = hass.states.get(VENTILATOR_MIN_AWAY_ID)
-    assert state.state == "10"
-    assert state.attributes.get("min") == 0
-    assert state.attributes.get("max") == 60
-    assert state.attributes.get("step") == 5
-    assert (
-        state.attributes.get("friendly_name") == "ecobee Ventilator minimum time away"
-    )
-    assert state.attributes.get("unit_of_measurement") == UnitOfTime.MINUTES
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_all_entities(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test all number entities."""
+    config_entry = await setup_platform(hass, NUMBER_DOMAIN)
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
 
 
 async def test_set_min_time_home(hass: HomeAssistant) -> None:
@@ -83,24 +72,6 @@ async def test_set_min_time_away(hass: HomeAssistant) -> None:
         mock_set_min_away_time.assert_called_once_with(THERMOSTAT_ID, target_value)
 
 
-COMPRESSOR_MIN_TEMP_ID = "number.ecobee2_compressor_minimum_temperature"
-
-
-async def test_compressor_protection_min_temp_attributes(hass: HomeAssistant) -> None:
-    """Test the compressor min temp value is correct.
-
-    Ecobee runs in Fahrenheit; the test rig runs in Celsius. Conversions are necessary.
-    """
-    await setup_platform(hass, NUMBER_DOMAIN)
-
-    state = hass.states.get(COMPRESSOR_MIN_TEMP_ID)
-    assert state.state == "-12.2"
-    assert (
-        state.attributes.get("friendly_name")
-        == "ecobee2 Compressor minimum temperature"
-    )
-
-
 async def test_set_compressor_protection_min_temp(hass: HomeAssistant) -> None:
     """Test the number can set minimum compressor operating temp.
 
@@ -120,22 +91,6 @@ async def test_set_compressor_protection_min_temp(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
         mock_set_compressor_min_temp.assert_called_once_with(1, 32)
-
-
-FAN_MIN_ON_TIME_ID = "number.ecobee_fan_minimum_on_time"
-
-
-async def test_fan_min_on_time_attributes(hass: HomeAssistant) -> None:
-    """Test the fan minimum on time number attributes are correct."""
-    await setup_platform(hass, NUMBER_DOMAIN)
-
-    state = hass.states.get(FAN_MIN_ON_TIME_ID)
-    assert state.state == "10"
-    assert state.attributes.get("min") == 0
-    assert state.attributes.get("max") == 60
-    assert state.attributes.get("step") == 5
-    assert state.attributes.get("friendly_name") == "ecobee Fan minimum on time"
-    assert state.attributes.get("unit_of_measurement") == UnitOfTime.MINUTES
 
 
 async def test_set_fan_min_on_time(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change

Adds a `number.<thermostat>_fan_minimum_on_time` entity to each ecobee thermostat exposing the existing `fan_min_on_time` setting (minimum minutes per hour the fan must run).

Today this value is only accessible:
- read-only, as the `fan_min_on_time` extra state attribute on the climate entity, or
- write-only, via the `ecobee.set_fan_min_on_time` action.

Neither is convenient: reading the attribute requires templating; writing requires custom service calls. Exposing it as a number entity makes it directly read/write from the UI, automations, and scripts.

The new entity mirrors the existing `EcobeeVentilatorMinTime`/`EcobeeCompressorMinTemp` pattern in `number.py`:
- Range 0–60 minutes, step 5 (matches the action's validation schema and ventilator UX).
- `has_entity_name=True` with translation key `fan_min_on_time`.
- Available on every thermostat (no conditional gating — all ecobees expose `fanMinOnTime`).
- Reuses the same `update_without_throttle` flow as the existing ventilator entity so the new value reflects immediately after a write rather than waiting up to the 180 s poll interval.
- Calls the same `pyecobee.Ecobee.set_fan_min_on_time(thermostat_index, value)` method already used by the existing service handler — no dependency change.

The existing `ecobee.set_fan_min_on_time` action and the climate entity's `fan_min_on_time` extra state attribute are intentionally left in place; this change is purely additive.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.