### PR TITLE
Bump python-bsblan to version 6.0.1

### DIFF
--- a/homeassistant/components/bsblan/manifest.json
+++ b/homeassistant/components/bsblan/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "local_polling",
   "loggers": ["bsblan"],
   "quality_scale": "silver",
-  "requirements": ["python-bsblan==5.2.1"],
+  "requirements": ["python-bsblan==6.0.1"],
   "zeroconf": [
     {
       "name": "bsb-lan*",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2596,7 +2596,7 @@ python-awair==0.2.5
 python-blockchain-api==0.0.2
 
 # homeassistant.components.bsblan
-python-bsblan==5.2.1
+python-bsblan==6.0.1
 
 # homeassistant.components.citybikes
 python-citybikes==0.3.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2231,7 +2231,7 @@ python-aidot==0.3.53
 python-awair==0.2.5
 
 # homeassistant.components.bsblan
-python-bsblan==5.2.1
+python-bsblan==6.0.1
 
 # homeassistant.components.citybikes
 python-citybikes==0.3.3

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -128,7 +128,6 @@ FORBIDDEN_PACKAGE_EXCEPTIONS: dict[str, dict[str, set[str]]] = {
         # pyblackbird > pyserial-asyncio
         "pyblackbird": {"pyserial-asyncio"}
     },
-    "bsblan": {"python-bsblan": {"backoff"}},
     "coinbase": {"coinbase-advanced-py": {"backoff"}},
     "cmus": {
         # https://github.com/mtreinish/pycmus/issues/4

--- a/tests/components/bsblan/snapshots/test_diagnostics.ambr
+++ b/tests/components/bsblan/snapshots/test_diagnostics.ambr
@@ -6,6 +6,11 @@
     ]),
     'device': dict({
       'MAC': '00:80:41:19:69:90',
+      'bus': 'BSB',
+      'busaddr': 66,
+      'busdest': 0,
+      'busdevices': None,
+      'buswritable': 1,
       'name': 'BSB-LAN',
       'uptime': 969402857,
       'version': '1.0.38-20200730234859',


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Add support in lib for PPS-bus (experimental)
- update dependency backoff to python backoff

https://github.com/liudger/python-bsblan/compare/v5.2.1...v6.0.1

<details>
<summary>Details</summary>

This pull request updates the `bsblan` integration to use the latest `python-bsblan` library (version 6.0.1) and adjusts related requirements and test snapshots. The main focus is on dependency updates and ensuring compatibility, along with enhancing test diagnostics.

Dependency updates:

* Updated the `python-bsblan` dependency to version 6.0.1 in `manifest.json`, `requirements_all.txt`, and `requirements_test_all.txt` to ensure the integration uses the latest library version. [[1]](diffhunk://#diff-fbd49835c369530338a67413a9b235d801f9a0affb21aa1a4645440499c5fef6L11-R11) [[2]](diffhunk://#diff-ae66cd41e5a8644fe0cdd7b9a2f0fee97b5deabe5f3793da15b73fa6353d2128L2599-R2599) [[3]](diffhunk://#diff-f946654c97927cbf41d54a07e10b9f92e95e9a43c0a7e2455d30acc696f08019L2234-R2234)

Testing and diagnostics:

* Added new fields (`bus`, `busaddr`, `busdest`, `busdevices`, `buswritable`) to the device diagnostics snapshot in `tests/components/bsblan/snapshots/test_diagnostics.ambr` to reflect updated or additional device information.

Code cleanup:

* Removed an unnecessary dependency mapping for `bsblan` in `script/hassfest/requirements.py`, as it is no longer needed.

</details>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
