### PR TITLE
Remove advanced mode from music_assistant service actions

### DIFF
--- a/homeassistant/components/music_assistant/services.yaml
+++ b/homeassistant/components/music_assistant/services.yaml
@@ -46,7 +46,6 @@ play_media:
             - "add"
           translation_key: enqueue
     radio_mode:
-      advanced: true
       selector:
         boolean:
 
@@ -138,20 +137,21 @@ search:
       example: "News of the world"
       selector:
         text:
-    limit:
-      advanced: true
-      example: 25
-      default: 5
-      selector:
-        number:
-          min: 1
-          max: 100
-          step: 1
-    library_only:
-      example: "true"
-      default: false
-      selector:
-        boolean:
+    search_options:
+      fields:
+        limit:
+          example: 25
+          default: 5
+          selector:
+            number:
+              min: 1
+              max: 100
+              step: 1
+        library_only:
+          example: "true"
+          default: false
+          selector:
+            boolean:
 
 get_library:
   fields:
@@ -183,24 +183,24 @@ get_library:
       example: "We Are The Champions"
       selector:
         text:
-    limit:
-      advanced: true
-      example: 25
-      default: 25
-      selector:
-        number:
-          min: 1
-          max: 500
-          step: 1
-    offset:
-      advanced: true
-      example: 25
-      default: 0
-      selector:
-        number:
-          min: 1
-          max: 1000000
-          step: 1
+    pagination:
+      fields:
+        limit:
+          example: 25
+          default: 25
+          selector:
+            number:
+              min: 1
+              max: 500
+              step: 1
+        offset:
+          example: 25
+          default: 0
+          selector:
+            number:
+              min: 1
+              max: 1000000
+              step: 1
     order_by:
       example: "random"
       selector:

--- a/homeassistant/components/music_assistant/strings.json
+++ b/homeassistant/components/music_assistant/strings.json
@@ -360,7 +360,12 @@
           "name": "Search"
         }
       },
-      "name": "Get library items"
+      "name": "Get library items",
+      "sections": {
+        "pagination": {
+          "name": "Pagination"
+        }
+      }
     },
     "get_queue": {
       "description": "Retrieves the details of the currently active queue of a Music Assistant player.",
@@ -450,7 +455,12 @@
           "name": "Search name"
         }
       },
-      "name": "Search Music Assistant"
+      "name": "Search Music Assistant",
+      "sections": {
+        "search_options": {
+          "name": "Search options"
+        }
+      }
     },
     "transfer_queue": {
       "description": "Transfers a player's queue to another player.",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove advanced mode from music_assistant service actions

The following services no longer gates fields by advanced mode:
- `music_assistant.play_media`: The radio_mode field is promoted to a regular field
- `music_assistant.search`: The limit and library_only fields are now grouped in a "search options" section instead of being gated by advanced mode
- `music_assistant.get_library`: The limit and offset fields are now grouped in a "pagination" section instead of being gated by advanced mode

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/170565
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
