### PR TITLE
Add TIMEOUT constant to CalDAV integration

### DIFF
--- a/homeassistant/components/caldav/__init__.py
+++ b/homeassistant/components/caldav/__init__.py
@@ -17,6 +17,8 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 
+from .const import TIMEOUT
+
 type CalDavConfigEntry = ConfigEntry[caldav.DAVClient]
 
 _LOGGER = logging.getLogger(__name__)
@@ -32,7 +34,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: CalDavConfigEntry) -> bo
         username=entry.data[CONF_USERNAME],
         password=entry.data[CONF_PASSWORD],
         ssl_verify_cert=entry.data[CONF_VERIFY_SSL],
-        timeout=30,
+        timeout=TIMEOUT,
     )
     try:
         await hass.async_add_executor_job(client.principal)

--- a/homeassistant/components/caldav/config_flow.py
+++ b/homeassistant/components/caldav/config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME, CONF_VERIFY_SSL
 from homeassistant.helpers import config_validation as cv
 
-from .const import DOMAIN
+from .const import DOMAIN, TIMEOUT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -65,6 +65,7 @@ class CalDavConfigFlow(ConfigFlow, domain=DOMAIN):
             username=user_input[CONF_USERNAME],
             password=user_input[CONF_PASSWORD],
             ssl_verify_cert=user_input[CONF_VERIFY_SSL],
+            timeout=TIMEOUT,
         )
         try:
             await self.hass.async_add_executor_job(client.principal)

--- a/homeassistant/components/caldav/config_flow.py
+++ b/homeassistant/components/caldav/config_flow.py
@@ -76,6 +76,9 @@ class CalDavConfigFlow(ConfigFlow, domain=DOMAIN):
             # AuthorizationError can be raised if the url is incorrect or
             # on some other unexpected server response.
             return "cannot_connect"
+        except requests.Timeout as err:
+            _LOGGER.warning("Timeout connecting to CalDAV server: %s", err)
+            return "cannot_connect"
         except requests.ConnectionError as err:
             _LOGGER.warning("Connection Error connecting to CalDAV server: %s", err)
             return "cannot_connect"

--- a/homeassistant/components/caldav/const.py
+++ b/homeassistant/components/caldav/const.py
@@ -3,3 +3,4 @@
 from typing import Final
 
 DOMAIN: Final = "caldav"
+TIMEOUT: Final = 30

--- a/tests/components/caldav/test_config_flow.py
+++ b/tests/components/caldav/test_config_flow.py
@@ -64,6 +64,7 @@ async def test_form(
     ("side_effect", "expected_error"),
     [
         (Exception(), "unknown"),
+        (requests.Timeout(), "cannot_connect"),
         (requests.ConnectionError(), "cannot_connect"),
         (DAVError(), "cannot_connect"),
         (AuthorizationError(reason="Unauthorized"), "invalid_auth"),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

N/A

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Replace the hardcoded `timeout=30` in `__init__.py` with a shared `TIMEOUT` constant in `const.py`, and add the missing `timeout` parameter to the `DAVClient` call in `config_flow.py` so connection tests during setup don't hang indefinitely.

Split from #171417 per reviewer feedback — this is the standalone improvement.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #171416
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code I am submitting and can explain how it works.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr