### PR TITLE
Fix habitica ignoring zero values for interval and streak

### DIFF
--- a/homeassistant/components/habitica/services.py
+++ b/homeassistant/components/habitica/services.py
@@ -806,10 +806,10 @@ async def _create_or_update_task(call: ServiceCall) -> ServiceResponse:  # noqa:
             data["daysOfMonth"] = [start_date.day]
             data["weeksOfMonth"] = []
 
-    if interval := call.data.get(ATTR_INTERVAL):
+    if (interval := call.data.get(ATTR_INTERVAL)) is not None:
         data["everyX"] = interval
 
-    if streak := call.data.get(ATTR_STREAK):
+    if (streak := call.data.get(ATTR_STREAK)) is not None:
         data["streak"] = streak
 
     try:

--- a/tests/components/habitica/test_services.py
+++ b/tests/components/habitica/test_services.py
@@ -1776,6 +1776,12 @@ async def test_create_todo(
         ),
         (
             {
+                ATTR_INTERVAL: 0,
+            },
+            Task(everyX=0),
+        ),
+        (
+            {
                 ATTR_FREQUENCY: "weekly",
                 ATTR_REPEAT: ["m", "t", "w", "th"],
             },


### PR DESCRIPTION
## Proposed change

Fix the habitica integration's daily task create/update actions ignoring `every_x: 0` and `streak: 0` values. The walrus operator pattern `if interval := call.data.get(...)` treats `0` as falsy, skipping it entirely. Changed to `is not None` checks so that zero values are correctly passed to the Habitica API.

A value of `0` for `every_x` is valid and creates a "grey daily" in Habitica.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #171353
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr