### PR TITLE
Fix PowerView cover crash when shade position is unavailable

### DIFF
--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -139,8 +139,10 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
         return {STATE_ATTRIBUTE_ROOM_NAME: self._room_name}
 
     @property
-    def is_closed(self) -> bool:
+    def is_closed(self) -> bool | None:
         """Return if the cover is closed."""
+        if self.positions.primary is None:
+            return None
         return self.positions.primary <= CLOSED_POSITION
 
     @property
@@ -527,8 +529,10 @@ class PowerViewShadeTiltOnly(PowerViewShadeWithTiltBase):
         return self.positions.tilt
 
     @property
-    def is_closed(self) -> bool:
+    def is_closed(self) -> bool | None:
         """Return if the cover is closed."""
+        if self.positions.tilt is None:
+            return None
         return self.positions.tilt <= CLOSED_POSITION
 
 
@@ -555,8 +559,10 @@ class PowerViewShadeTopDown(PowerViewShadeBase):
         await self._async_set_cover_position(MAX_POSITION - kwargs[ATTR_POSITION])
 
     @property
-    def is_closed(self) -> bool:
+    def is_closed(self) -> bool | None:
         """Return if the cover is closed."""
+        if self.positions.primary is None:
+            return None
         return (MAX_POSITION - self.positions.primary) <= CLOSED_POSITION
 
 
@@ -643,9 +649,11 @@ class PowerViewShadeTDBUTop(PowerViewShadeDualRailBase):
         return False
 
     @property
-    def is_closed(self) -> bool:
+    def is_closed(self) -> bool | None:
         """Return if the cover is closed."""
         # top shade needs to check other motor
+        if self.positions.secondary is None:
+            return None
         return self.positions.secondary <= CLOSED_POSITION
 
     @property
@@ -742,9 +750,11 @@ class PowerViewShadeDualOverlappedCombined(PowerViewShadeDualOverlappedBase):
         self._attr_unique_id = f"{self._attr_unique_id}_combined"
 
     @property
-    def is_closed(self) -> bool:
+    def is_closed(self) -> bool | None:
         """Return if the cover is closed."""
         # if rear shade is down it is closed
+        if self.positions.secondary is None:
+            return None
         return self.positions.secondary <= CLOSED_POSITION
 
     @property
@@ -873,9 +883,11 @@ class PowerViewShadeDualOverlappedRear(PowerViewShadeDualOverlappedBase):
         return False
 
     @property
-    def is_closed(self) -> bool:
+    def is_closed(self) -> bool | None:
         """Return if the cover is closed."""
         # if rear shade is down it is closed
+        if self.positions.secondary is None:
+            return None
         return self.positions.secondary <= CLOSED_POSITION
 
     @property

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -134,15 +134,18 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
         return self._is_hard_wired
 
     @property
+    def available(self) -> bool:
+        """Return True if shade position data is available."""
+        return super().available and self.positions.primary is not None
+
+    @property
     def extra_state_attributes(self) -> dict[str, str]:
         """Return the state attributes."""
         return {STATE_ATTRIBUTE_ROOM_NAME: self._room_name}
 
     @property
-    def is_closed(self) -> bool | None:
+    def is_closed(self) -> bool:
         """Return if the cover is closed."""
-        if self.positions.primary is None:
-            return None
         return self.positions.primary <= CLOSED_POSITION
 
     @property
@@ -529,10 +532,8 @@ class PowerViewShadeTiltOnly(PowerViewShadeWithTiltBase):
         return self.positions.tilt
 
     @property
-    def is_closed(self) -> bool | None:
+    def is_closed(self) -> bool:
         """Return if the cover is closed."""
-        if self.positions.tilt is None:
-            return None
         return self.positions.tilt <= CLOSED_POSITION
 
 
@@ -559,10 +560,8 @@ class PowerViewShadeTopDown(PowerViewShadeBase):
         await self._async_set_cover_position(MAX_POSITION - kwargs[ATTR_POSITION])
 
     @property
-    def is_closed(self) -> bool | None:
+    def is_closed(self) -> bool:
         """Return if the cover is closed."""
-        if self.positions.primary is None:
-            return None
         return (MAX_POSITION - self.positions.primary) <= CLOSED_POSITION
 
 
@@ -649,11 +648,9 @@ class PowerViewShadeTDBUTop(PowerViewShadeDualRailBase):
         return False
 
     @property
-    def is_closed(self) -> bool | None:
+    def is_closed(self) -> bool:
         """Return if the cover is closed."""
         # top shade needs to check other motor
-        if self.positions.secondary is None:
-            return None
         return self.positions.secondary <= CLOSED_POSITION
 
     @property
@@ -750,11 +747,9 @@ class PowerViewShadeDualOverlappedCombined(PowerViewShadeDualOverlappedBase):
         self._attr_unique_id = f"{self._attr_unique_id}_combined"
 
     @property
-    def is_closed(self) -> bool | None:
+    def is_closed(self) -> bool:
         """Return if the cover is closed."""
         # if rear shade is down it is closed
-        if self.positions.secondary is None:
-            return None
         return self.positions.secondary <= CLOSED_POSITION
 
     @property
@@ -883,11 +878,9 @@ class PowerViewShadeDualOverlappedRear(PowerViewShadeDualOverlappedBase):
         return False
 
     @property
-    def is_closed(self) -> bool | None:
+    def is_closed(self) -> bool:
         """Return if the cover is closed."""
         # if rear shade is down it is closed
-        if self.positions.secondary is None:
-            return None
         return self.positions.secondary <= CLOSED_POSITION
 
     @property


### PR DESCRIPTION
## Proposed change

Mark Hunter Douglas PowerView cover entities as unavailable when shade position data is missing. When a shade times out during polling, the API response omits position data, resulting in `None` values. Previously, the `is_closed` property would crash with `TypeError` when comparing `None <= CLOSED_POSITION`.

The entity now reports itself as unavailable when position data is absent, which is the correct behavior since the hub could not reach the shade via radio. Once the shade responds again on the next poll, the entity automatically becomes available with updated position data.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #159105
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr