### PR TITLE
Revert "Bump `py-opendisplay` to 7.0.0"

### DIFF
--- a/homeassistant/components/opendisplay/manifest.json
+++ b/homeassistant/components/opendisplay/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "local_push",
   "loggers": ["opendisplay"],
   "quality_scale": "silver",
-  "requirements": ["py-opendisplay==7.0.0"]
+  "requirements": ["py-opendisplay==5.9.0"]
 }

--- a/homeassistant/components/opendisplay/services.py
+++ b/homeassistant/components/opendisplay/services.py
@@ -218,7 +218,7 @@ async def _async_upload_image(call: ServiceCall) -> None:
                 pil_image,
                 refresh_mode=refresh_mode,
                 dither_mode=dither_mode,
-                tone=tone_compression,
+                tone_compression=tone_compression,
                 fit=fit_mode,
                 rotate=rotation,
             )

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1923,7 +1923,7 @@ py-nightscout==1.2.2
 py-nymta==0.4.0
 
 # homeassistant.components.opendisplay
-py-opendisplay==7.0.0
+py-opendisplay==5.9.0
 
 # homeassistant.components.schluter
 py-schluter==0.1.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1681,7 +1681,7 @@ py-nightscout==1.2.2
 py-nymta==0.4.0
 
 # homeassistant.components.opendisplay
-py-opendisplay==7.0.0
+py-opendisplay==5.9.0
 
 # homeassistant.components.ecovacs
 py-sucks==0.9.11


### PR DESCRIPTION
Reverts home-assistant/core#171088 as subdependencies require a higher rust version as we currently have available in the alpine version we use.
CC @zweckj @g4bri3lDev

See https://github.com/home-assistant/core/actions/runs/26143081226/job/76892562035
As we cannot build wheels, we cannot build any nightlies, so we need to revert it to unblock builder