### PR TITLE
Add has-entity-name pylint quality scale checker

### DIFF
--- a/homeassistant/components/ekeybionyx/event.py
+++ b/homeassistant/components/ekeybionyx/event.py
@@ -26,6 +26,7 @@ async def async_setup_entry(
     async_add_entities(EkeyEvent(data) for data in entry.data["webhooks"])
 
 
+# pylint: disable-next=home-assistant-missing-has-entity-name
 class EkeyEvent(EventEntity):
     """Ekey Event."""
 

--- a/homeassistant/components/fitbit/sensor.py
+++ b/homeassistant/components/fitbit/sensor.py
@@ -649,6 +649,8 @@ class FitbitSensor(SensorEntity):
         self.async_schedule_update_ha_state(force_refresh=True)
 
 
+# has_entity_name=True is supplied by the FITBIT_RESOURCE_BATTERY description
+# pylint: disable-next=home-assistant-missing-has-entity-name
 class FitbitBatterySensor(CoordinatorEntity[FitbitDeviceCoordinator], SensorEntity):
     """Implementation of a Fitbit battery sensor."""
 
@@ -707,6 +709,8 @@ class FitbitBatterySensor(CoordinatorEntity[FitbitDeviceCoordinator], SensorEnti
         self.async_write_ha_state()
 
 
+# has_entity_name=True is supplied by the FITBIT_RESOURCE_BATTERY_LEVEL description
+# pylint: disable-next=home-assistant-missing-has-entity-name
 class FitbitBatteryLevelSensor(
     CoordinatorEntity[FitbitDeviceCoordinator], SensorEntity
 ):

--- a/homeassistant/components/fritz/switch.py
+++ b/homeassistant/components/fritz/switch.py
@@ -438,6 +438,7 @@ class FritzBoxBaseSwitch(FritzBoxBaseEntity, SwitchEntity):
         self._attr_is_on = turn_on
 
 
+# pylint: disable-next=home-assistant-missing-has-entity-name
 class FritzBoxPortSwitch(FritzBoxBaseSwitch):
     """Defines a FRITZ!Box Tools PortForward switch."""
 
@@ -604,6 +605,7 @@ class FritzBoxProfileSwitch(FritzBoxBaseCoordinatorSwitch):
         self.async_write_ha_state()
 
 
+# pylint: disable-next=home-assistant-missing-has-entity-name
 class FritzBoxWifiSwitch(FritzBoxBaseSwitch):
     """Defines a FRITZ!Box Tools Wifi switch."""
 

--- a/homeassistant/components/lunatone/light.py
+++ b/homeassistant/components/lunatone/light.py
@@ -207,6 +207,7 @@ class LunatoneLight(
         await self.coordinator.async_refresh()
 
 
+# pylint: disable-next=home-assistant-missing-has-entity-name
 class LunatoneLineBroadcastLight(
     CoordinatorEntity[LunatoneInfoDataUpdateCoordinator], LightEntity
 ):

--- a/homeassistant/components/ness_alarm/quality_scale.yaml
+++ b/homeassistant/components/ness_alarm/quality_scale.yaml
@@ -13,7 +13,7 @@ rules:
   docs-removal-instructions: done
   entity-event-setup: done
   entity-unique-id: done
-  has-entity-name: done
+  has-entity-name: todo
   runtime-data: done
   test-before-configure: done
   test-before-setup: done

--- a/homeassistant/components/omie/sensor.py
+++ b/homeassistant/components/omie/sensor.py
@@ -33,6 +33,8 @@ SENSOR_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
 }
 
 
+# has_entity_name=True is supplied by every SENSOR_DESCRIPTIONS entry
+# pylint: disable-next=home-assistant-missing-has-entity-name
 class OMIEPriceSensor(CoordinatorEntity[OMIECoordinator], SensorEntity):
     """OMIE price sensor."""
 

--- a/homeassistant/components/rainbird/quality_scale.yaml
+++ b/homeassistant/components/rainbird/quality_scale.yaml
@@ -4,7 +4,7 @@ rules:
   brands: done
   dependency-transparency: done
   common-modules: done
-  has-entity-name: done
+  has-entity-name: todo
   action-setup:
     status: done
     comment: |

--- a/homeassistant/components/smartthings/scene.py
+++ b/homeassistant/components/smartthings/scene.py
@@ -22,6 +22,7 @@ async def async_setup_entry(
     async_add_entities(SmartThingsScene(scene, client) for scene in scenes.values())
 
 
+# pylint: disable-next=home-assistant-missing-has-entity-name
 class SmartThingsScene(Scene):
     """Define a SmartThings scene."""
 

--- a/homeassistant/components/sonos/sensor.py
+++ b/homeassistant/components/sonos/sensor.py
@@ -191,6 +191,7 @@ class SonosAudioInputFormatSensorEntity(SonosPollingEntity, SensorEntity):
         """Provide a stub for required ABC method."""
 
 
+# pylint: disable-next=home-assistant-missing-has-entity-name
 class SonosFavoritesEntity(SensorEntity):
     """Representation of a Sonos favorites info entity."""
 

--- a/homeassistant/components/tplink_omada/device_tracker.py
+++ b/homeassistant/components/tplink_omada/device_tracker.py
@@ -38,6 +38,7 @@ async def async_setup_entry(
     )
 
 
+# pylint: disable-next=home-assistant-missing-has-entity-name
 class OmadaClientScannerEntity(
     CoordinatorEntity[OmadaClientsCoordinator], ScannerEntity
 ):

--- a/pylint/plugins/pylint_home_assistant/checkers/quality_scale/has_entity_name.py
+++ b/pylint/plugins/pylint_home_assistant/checkers/quality_scale/has_entity_name.py
@@ -1,0 +1,344 @@
+"""Checker for missing ``_attr_has_entity_name`` on entity classes.
+
+**Quality-scale-gated** (Bronze): only fires for integrations whose
+``quality_scale.yaml`` marks ``has-entity-name`` as ``done``.
+
+Every entity class instantiated by a platform must *statically guarantee*
+``has_entity_name=True`` for every instance. Patterns that set the flag
+conditionally or per-instance work today but don't enforce the rule, so
+they're rejected; integrations that need them can use
+``# pylint: disable=home-assistant-missing-has-entity-name`` after
+verifying that all instantiations end up True.
+
+Accepted paths (any one, in the class or any ancestor):
+
+1. Class body: ``_attr_has_entity_name = True`` (or
+   ``_attr_has_entity_name: bool = True``).
+2. Top-level statement of a method body: ``self._attr_has_entity_name = True``.
+   Must be the literal value ``True`` and must NOT be nested inside
+   ``if``/``for``/``try``/etc. — that ensures it runs on every instance.
+3. Class-level annotation ``entity_description: SomeDescription`` whose
+   description class (or an ancestor) sets ``has_entity_name = True``
+   as a class-level default.
+Mixin/base classes that are subclassed by another class in the same
+module are exempted on the assumption that the subclass is the runtime
+entity.
+
+Known limitations
+-----------------
+The rule is a high-signal heuristic, not a soundness proof. Two
+intentional scope choices to be aware of:
+
+- **Per-instance override.** When an EntityDescription subclass sets a
+  class-level ``has_entity_name = True`` default, a specific instance
+  can still be constructed with ``has_entity_name=False``. We accept
+  based on the class default and do not scan call sites.
+- **Computed or dynamic assignment.** ``@property has_entity_name``,
+  ``setattr(self, "_attr_has_entity_name", ...)``, and any factory or
+  metaprogrammed path are not detected — static analysis can't follow
+  them.
+
+``# pylint: disable=home-assistant-missing-has-entity-name`` on the
+offending class declaration is the recommended escape hatch.
+
+https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/has-entity-name
+"""
+
+from collections.abc import Iterator
+
+import astroid
+from astroid import nodes
+from pylint.checkers import BaseChecker
+from pylint.lint import PyLinter
+
+from pylint_home_assistant.const import ENTITY_COMPONENTS, QualityScaleRule
+from pylint_home_assistant.helpers.module_info import get_module_platform
+from pylint_home_assistant.helpers.quality_scale import quality_scale_rule_is_done
+
+_ENTITY_QNAME = "homeassistant.helpers.entity.Entity"
+_ENTITY_DESCRIPTION_QNAME = "homeassistant.helpers.entity.EntityDescription"
+_ATTR_NAME = "_attr_has_entity_name"
+_DESCRIPTION_ATTR = "entity_description"
+_DESCRIPTION_FIELD = "has_entity_name"
+
+
+def _safe_ancestors(class_node: nodes.ClassDef) -> list[nodes.ClassDef]:
+    """Return ``class_node.ancestors()`` swallowing inference errors."""
+    try:
+        return list(class_node.ancestors())
+    except astroid.exceptions.InferenceError:
+        return []
+
+
+def _subscript_base_classes(class_node: nodes.ClassDef) -> Iterator[nodes.ClassDef]:
+    """Yield ClassDefs from subscript bases (e.g. ``class B(Base[T])``).
+
+    astroid's ``ancestors()`` drops Subscript bases such as
+    ``VeSyncBaseEntity[VeSyncFanBase | VeSyncPurifier]`` (PEP-695 generic
+    syntax), so this method recovers them by inferring the subscript's
+    value.
+    """
+    for base in class_node.bases:
+        if not isinstance(base, nodes.Subscript):
+            continue
+        try:
+            inferred = list(base.value.infer())
+        except astroid.exceptions.InferenceError:
+            continue
+        for inferred_node in inferred:
+            if isinstance(inferred_node, nodes.ClassDef):
+                yield inferred_node
+
+
+def _extended_ancestors(class_node: nodes.ClassDef) -> Iterator[nodes.ClassDef]:
+    """Yield all ancestors including transitive subscript-based ones."""
+    seen: set[str] = set()
+    stack: list[nodes.ClassDef] = [class_node]
+
+    while stack:
+        current = stack.pop()
+        for ancestor in _safe_ancestors(current):
+            qname = ancestor.qname()
+            if qname in seen:
+                continue
+            seen.add(qname)
+            yield ancestor
+            stack.append(ancestor)
+        for subscript_base in _subscript_base_classes(current):
+            qname = subscript_base.qname()
+            if qname in seen:
+                continue
+            seen.add(qname)
+            yield subscript_base
+            stack.append(subscript_base)
+
+
+def _inherits_from_entity(class_node: nodes.ClassDef) -> bool:
+    """Return True if class inherits from homeassistant.helpers.entity.Entity."""
+    return any(a.qname() == _ENTITY_QNAME for a in _extended_ancestors(class_node))
+
+
+def _class_body_sets_attr_true(class_node: nodes.ClassDef, attr_name: str) -> bool:
+    """Return True if class body assigns ``attr_name = True``.
+
+    Limitation: only literal ``Const(True)`` values are recognised.
+    ``dataclasses.field(default=True)`` and other ``Call``-shaped defaults
+    are not detected even though they evaluate to True at runtime.
+    """
+    for item in class_node.body:
+        if (
+            isinstance(item, nodes.Assign)
+            and any(
+                isinstance(target, nodes.AssignName) and target.name == attr_name
+                for target in item.targets
+            )
+            and isinstance(item.value, nodes.Const)
+            and item.value.value is True
+        ):
+            return True
+        if (
+            isinstance(item, nodes.AnnAssign)
+            and isinstance(item.target, nodes.AssignName)
+            and item.target.name == attr_name
+            and isinstance(item.value, nodes.Const)
+            and item.value.value is True
+        ):
+            return True
+    return False
+
+
+def _method_unconditionally_sets_attr_true(class_node: nodes.ClassDef) -> bool:
+    """Return True if a method has a top-level ``self._attr_has_entity_name = True``.
+
+    Accepts both ``self._attr_has_entity_name = True`` (``Assign``) and
+    ``self._attr_has_entity_name: bool = True`` (``AnnAssign``). The
+    assignment must be the literal ``True`` and a direct statement of
+    the method body — not nested in an ``if``/``for``/``try``/etc. —
+    so that it executes for every instance constructed.
+    """
+    for method in class_node.body:
+        if not isinstance(method, nodes.FunctionDef | nodes.AsyncFunctionDef):
+            continue
+        for stmt in method.body:
+            if isinstance(stmt, nodes.Assign):
+                targets = stmt.targets
+            elif isinstance(stmt, nodes.AnnAssign):
+                targets = [stmt.target]
+            else:
+                continue
+            if not (isinstance(stmt.value, nodes.Const) and stmt.value.value is True):
+                continue
+            for target in targets:
+                if (
+                    isinstance(target, nodes.AssignAttr)
+                    and target.attrname == _ATTR_NAME
+                    and isinstance(target.expr, nodes.Name)
+                    and target.expr.name == "self"
+                ):
+                    return True
+    return False
+
+
+def _is_entity_description(class_node: nodes.ClassDef) -> bool:
+    """Return True if class is or inherits from EntityDescription."""
+    if class_node.qname() == _ENTITY_DESCRIPTION_QNAME:
+        return True
+    return any(
+        ancestor.qname() == _ENTITY_DESCRIPTION_QNAME
+        for ancestor in _safe_ancestors(class_node)
+    )
+
+
+def _description_sets_has_entity_name(description_class: nodes.ClassDef) -> bool:
+    """Return True if the description class or any ancestor sets has_entity_name = True."""
+    if _class_body_sets_attr_true(description_class, _DESCRIPTION_FIELD):
+        return True
+    return any(
+        _class_body_sets_attr_true(ancestor, _DESCRIPTION_FIELD)
+        for ancestor in _safe_ancestors(description_class)
+    )
+
+
+def _entity_description_annotation_satisfies(class_node: nodes.ClassDef) -> bool:
+    """Return True if a typed entity_description supplies has_entity_name=True.
+
+    The class must declare an ``entity_description: SomeDescription``
+    annotation, and that description class (or an ancestor) must set
+    ``has_entity_name = True`` as a class-level default. This detects
+    the ``EntityDescription.has_entity_name`` fallback path used by
+    integrations like unifi, where the entity itself sets neither
+    ``_attr_has_entity_name`` nor ``self._attr_has_entity_name`` but
+    the typed description class supplies a True default.
+    """
+    for item in class_node.body:
+        if not isinstance(item, nodes.AnnAssign):
+            continue
+        if not isinstance(item.target, nodes.AssignName):
+            continue
+        if item.target.name != _DESCRIPTION_ATTR:
+            continue
+        annotation = item.annotation
+        if isinstance(annotation, nodes.Subscript):
+            annotation = annotation.value
+        try:
+            inferred = list(annotation.infer())
+        except astroid.exceptions.InferenceError:
+            continue
+        for inferred_node in inferred:
+            if (
+                isinstance(inferred_node, nodes.ClassDef)
+                and _is_entity_description(inferred_node)
+                and _description_sets_has_entity_name(inferred_node)
+            ):
+                return True
+    return False
+
+
+def _class_satisfies_rule(class_node: nodes.ClassDef) -> bool:
+    """Return True if this single class satisfies the rule on its own.
+
+    Checks the three runtime resolution paths against the class body
+    only — ancestors are checked by the caller.
+    """
+    return (
+        _class_body_sets_attr_true(class_node, _ATTR_NAME)
+        or _method_unconditionally_sets_attr_true(class_node)
+        or _entity_description_annotation_satisfies(class_node)
+    )
+
+
+def _has_entity_name_handled(class_node: nodes.ClassDef) -> bool:
+    """Return True if the rule is satisfied by the class or any ancestor."""
+    if _class_satisfies_rule(class_node):
+        return True
+    return any(
+        _class_satisfies_rule(ancestor) for ancestor in _extended_ancestors(class_node)
+    )
+
+
+def _collect_same_module_ancestor_qnames(module: nodes.Module) -> set[str]:
+    """Return qnames of every class used as an ancestor by any class in *module*.
+
+    Used to exempt mixin/abstract bases from the rule. Three limitations
+    fall out of the "same-module" scoping:
+
+    1. A class that is BOTH a same-module base AND directly instantiated
+       (e.g. both the base and a subclass passed to async_add_entities)
+       is exempted by this filter.
+    2. A base defined here but only subclassed from a *different* module
+       (e.g. base in sensor.py, subclasses in binary_sensor.py) is NOT
+       exempted and would be flagged as if it were a runtime entity.
+    3. An abstract-by-convention class with no same-module subclass at
+       all is flagged. This rule should be disable for those classes
+       after verifying the class is never instantiated.
+    """
+    qnames: set[str] = set()
+    for class_node in module.nodes_of_class(nodes.ClassDef):
+        for ancestor in _extended_ancestors(class_node):
+            qnames.add(ancestor.qname())
+    return qnames
+
+
+class HasEntityNameChecker(BaseChecker):
+    """Checker for missing ``_attr_has_entity_name`` on entity classes."""
+
+    name = "home_assistant_has_entity_name"
+    priority = -1
+    msgs = {
+        "W7416": (
+            (
+                "Entity class `%s` should set `_attr_has_entity_name = True` "
+                "(https://developers.home-assistant.io/docs/core/"
+                "integration-quality-scale/rules/has-entity-name)"
+            ),
+            "home-assistant-missing-has-entity-name",
+            (
+                "Used when an entity class defined in a platform module does "
+                "not statically guarantee has_entity_name=True via a class-"
+                "level _attr_has_entity_name = True, an unconditional "
+                "self._attr_has_entity_name = True at the top of a method, or "
+                "an entity_description annotation whose description class "
+                "sets has_entity_name = True as a default. Conditional and "
+                "per-instance patterns are intentionally rejected."
+            ),
+        ),
+    }
+    options = ()
+
+    _check_module: bool
+    _subclassed_qnames: set[str]
+
+    def visit_module(self, node: nodes.Module) -> None:
+        """Cache per-module gating result."""
+        platform = get_module_platform(node.name)
+        self._check_module = (
+            platform is not None
+            and platform in ENTITY_COMPONENTS
+            and quality_scale_rule_is_done(node, QualityScaleRule.HAS_ENTITY_NAME)
+        )
+        self._subclassed_qnames = (
+            _collect_same_module_ancestor_qnames(node) if self._check_module else set()
+        )
+
+    def visit_classdef(self, node: nodes.ClassDef) -> None:
+        """Flag entity classes missing _attr_has_entity_name."""
+        if not self._check_module:
+            return
+        if not _inherits_from_entity(node):
+            return
+        if _has_entity_name_handled(node):
+            return
+        # Skip mixin / abstract bases: another class in the same module
+        # inherits from this one, so this class is not the runtime entity.
+        if node.qname() in self._subclassed_qnames:
+            return
+        self.add_message(
+            "home-assistant-missing-has-entity-name",
+            node=node,
+            args=(node.name,),
+        )
+
+
+def register(linter: PyLinter) -> None:
+    """Register the checker."""
+    linter.register_checker(HasEntityNameChecker(linter))

--- a/pylint/plugins/pylint_home_assistant/checkers/quality_scale/has_entity_name.py
+++ b/pylint/plugins/pylint_home_assistant/checkers/quality_scale/has_entity_name.py
@@ -148,13 +148,21 @@ def _class_body_sets_attr_true(class_node: nodes.ClassDef, attr_name: str) -> bo
 
 
 def _method_unconditionally_sets_attr_true(class_node: nodes.ClassDef) -> bool:
-    """Return True if a method has a top-level ``self._attr_has_entity_name = True``.
+    """Return True if a method unconditionally sets self._attr_has_entity_name=True.
 
     Accepts both ``self._attr_has_entity_name = True`` (``Assign``) and
     ``self._attr_has_entity_name: bool = True`` (``AnnAssign``). The
-    assignment must be the literal ``True`` and a direct statement of
-    the method body — not nested in an ``if``/``for``/``try``/etc. —
-    so that it executes for every instance constructed.
+    assignment must:
+
+    - have the literal value ``True``,
+    - be a direct statement of the method body (not nested in
+      ``if``/``for``/``try``/etc.), and
+    - be preceded only by flow-safe statements (other assignments,
+      ``super()`` and other expression calls, ``pass``). Any statement
+      that could divert control flow (``return``, ``raise``, ``if``,
+      loops, ``try``, ``assert``, etc.) before the assignment ends the
+      scan, since after that point the assignment is no longer
+      guaranteed to run.
     """
     for method in class_node.body:
         if not isinstance(method, nodes.FunctionDef | nodes.AsyncFunctionDef):
@@ -162,11 +170,19 @@ def _method_unconditionally_sets_attr_true(class_node: nodes.ClassDef) -> bool:
         for stmt in method.body:
             if isinstance(stmt, nodes.Assign):
                 targets = stmt.targets
+                value = stmt.value
             elif isinstance(stmt, nodes.AnnAssign):
                 targets = [stmt.target]
-            else:
+                value = stmt.value
+            elif isinstance(stmt, nodes.Expr | nodes.AugAssign | nodes.Pass):
+                # Flow-safe; keep scanning past it.
                 continue
-            if not (isinstance(stmt.value, nodes.Const) and stmt.value.value is True):
+            else:
+                # Control-flow statement (Return/Raise/If/For/While/Try/
+                # Assert/etc.); the target assignment after this point
+                # is no longer guaranteed to run.
+                break
+            if not (isinstance(value, nodes.Const) and value.value is True):
                 continue
             for target in targets:
                 if (

--- a/tests/pylint/quality_scale/test_has_entity_name.py
+++ b/tests/pylint/quality_scale/test_has_entity_name.py
@@ -110,6 +110,28 @@ class MyEntity(Entity):
 """,
             id="self_annassign_true_in_init",
         ),
+        pytest.param(
+            """
+from homeassistant.helpers.entity import Entity
+
+class MyEntity(Entity):
+    def __init__(self, coordinator):
+        super().__init__(coordinator)
+        self._attr_has_entity_name = True
+""",
+            id="self_assign_true_after_super_call",
+        ),
+        pytest.param(
+            """
+from homeassistant.helpers.entity import Entity
+
+class MyEntity(Entity):
+    def __init__(self, name):
+        self._attr_name = name
+        self._attr_has_entity_name = True
+""",
+            id="self_assign_true_after_other_assign",
+        ),
     ],
 )
 def test_handled(
@@ -265,6 +287,32 @@ class MyEntity(Entity):
 """,
             "MyEntity",
             id="self_assign_true_inside_try",
+        ),
+        pytest.param(
+            """
+from homeassistant.helpers.entity import Entity
+
+class MyEntity(Entity):
+    def __init__(self, valid):
+        if not valid:
+            raise ValueError
+        self._attr_has_entity_name = True
+""",
+            "MyEntity",
+            id="self_assign_true_after_guard_raise",
+        ),
+        pytest.param(
+            """
+from homeassistant.helpers.entity import Entity
+
+class MyEntity(Entity):
+    def __init__(self, skip):
+        if skip:
+            return
+        self._attr_has_entity_name = True
+""",
+            "MyEntity",
+            id="self_assign_true_after_guard_return",
         ),
     ],
 )

--- a/tests/pylint/quality_scale/test_has_entity_name.py
+++ b/tests/pylint/quality_scale/test_has_entity_name.py
@@ -1,0 +1,757 @@
+"""Tests for the has_entity_name quality scale checker."""
+
+from pathlib import Path
+
+import astroid
+from astroid import nodes
+from pylint.testutils import MessageTest, UnittestLinter
+from pylint.utils.ast_walker import ASTWalker
+from pylint_home_assistant.checkers.quality_scale.has_entity_name import (
+    HasEntityNameChecker,
+)
+from pylint_home_assistant.helpers.quality_scale import clear_quality_scale_cache
+import pytest
+import yaml
+
+from tests.pylint import assert_adds_messages, assert_no_messages
+
+
+@pytest.fixture(name="has_entity_name_checker")
+def has_entity_name_checker_fixture(
+    linter: UnittestLinter,
+) -> HasEntityNameChecker:
+    """Fixture to provide a has-entity-name checker."""
+    clear_quality_scale_cache()
+    return HasEntityNameChecker(linter)
+
+
+def _create_quality_scale(integration_dir: Path, rules: dict | None = None) -> None:
+    """Create a quality_scale.yaml in the integration directory."""
+    if rules is not None:
+        (integration_dir / "quality_scale.yaml").write_text(yaml.dump({"rules": rules}))
+
+
+def _make_integration(tmp_path: Path) -> Path:
+    """Create a fake integration directory under components/."""
+    integration_dir = tmp_path / "homeassistant" / "components" / "test_integration"
+    integration_dir.mkdir(parents=True)
+    return integration_dir
+
+
+def _parse(
+    code: str,
+    integration_dir: Path,
+    module_name: str = "homeassistant.components.test_integration.sensor",
+    file_name: str = "sensor.py",
+) -> nodes.Module:
+    """Parse code as a module of the integration with .file set."""
+    root_node = astroid.parse(code, module_name)
+    root_node.file = str(integration_dir / file_name)
+    return root_node
+
+
+def _expect_missing(class_node: nodes.ClassDef) -> MessageTest:
+    """Build the expected MessageTest for a flagged class.
+
+    Pylint uses astroid's ``ClassDef.position`` (the class-name range, not
+    the full body) for the end_line/end_col_offset of messages attached
+    to a class node.
+    """
+    pos = class_node.position
+    return MessageTest(
+        msg_id="home-assistant-missing-has-entity-name",
+        node=class_node,
+        line=pos.lineno,
+        col_offset=pos.col_offset,
+        end_line=pos.end_lineno,
+        end_col_offset=pos.end_col_offset,
+        args=(class_node.name,),
+    )
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        pytest.param(
+            """
+from homeassistant.helpers.entity import Entity
+
+class MyEntity(Entity):
+    _attr_has_entity_name = True
+""",
+            id="class_level_assign_true",
+        ),
+        pytest.param(
+            """
+from homeassistant.helpers.entity import Entity
+
+class MyEntity(Entity):
+    _attr_has_entity_name: bool = True
+""",
+            id="class_level_annassign_true",
+        ),
+        pytest.param(
+            """
+from homeassistant.helpers.entity import Entity
+
+class MyEntity(Entity):
+    def __init__(self):
+        self._attr_has_entity_name = True
+""",
+            id="self_assign_true_in_init",
+        ),
+        pytest.param(
+            """
+from homeassistant.helpers.entity import Entity
+
+class MyEntity(Entity):
+    def __init__(self):
+        self._attr_has_entity_name: bool = True
+""",
+            id="self_annassign_true_in_init",
+        ),
+    ],
+)
+def test_handled(
+    linter: UnittestLinter,
+    has_entity_name_checker: HasEntityNameChecker,
+    tmp_path: Path,
+    code: str,
+) -> None:
+    """No warning when the class handles _attr_has_entity_name."""
+    integration_dir = _make_integration(tmp_path)
+    _create_quality_scale(integration_dir, {"has-entity-name": "done"})
+
+    root_node = _parse(code, integration_dir)
+    walker = ASTWalker(linter)
+    walker.add_checker(has_entity_name_checker)
+    with assert_no_messages(linter):
+        walker.walk(root_node)
+
+
+def test_ancestor_class_level(
+    linter: UnittestLinter,
+    has_entity_name_checker: HasEntityNameChecker,
+    tmp_path: Path,
+) -> None:
+    """Subclass passes when an ancestor sets it at class level."""
+    integration_dir = _make_integration(tmp_path)
+    _create_quality_scale(integration_dir, {"has-entity-name": "done"})
+
+    astroid.parse(
+        """
+from homeassistant.helpers.entity import Entity
+
+class TestIntegrationBaseEntity(Entity):
+    _attr_has_entity_name = True
+""",
+        "homeassistant.components.test_integration.entity",
+    )
+
+    root_node = _parse(
+        """
+from homeassistant.components.test_integration.entity import TestIntegrationBaseEntity
+
+class MySensor(TestIntegrationBaseEntity):
+    pass
+""",
+        integration_dir,
+    )
+
+    walker = ASTWalker(linter)
+    walker.add_checker(has_entity_name_checker)
+    with assert_no_messages(linter):
+        walker.walk(root_node)
+
+
+def test_ancestor_self_assign(
+    linter: UnittestLinter,
+    has_entity_name_checker: HasEntityNameChecker,
+    tmp_path: Path,
+) -> None:
+    """Subclass passes when an ancestor sets it via self in __init__."""
+    integration_dir = _make_integration(tmp_path)
+    _create_quality_scale(integration_dir, {"has-entity-name": "done"})
+
+    astroid.parse(
+        """
+from homeassistant.helpers.entity import Entity
+
+class TestIntegrationBaseEntity(Entity):
+    def __init__(self):
+        self._attr_has_entity_name = True
+""",
+        "homeassistant.components.test_integration.entity",
+    )
+
+    root_node = _parse(
+        """
+from homeassistant.components.test_integration.entity import TestIntegrationBaseEntity
+
+class MySensor(TestIntegrationBaseEntity):
+    pass
+""",
+        integration_dir,
+    )
+
+    walker = ASTWalker(linter)
+    walker.add_checker(has_entity_name_checker)
+    with assert_no_messages(linter):
+        walker.walk(root_node)
+
+
+def test_missing_fires(
+    linter: UnittestLinter,
+    has_entity_name_checker: HasEntityNameChecker,
+    tmp_path: Path,
+) -> None:
+    """Warning when no _attr_has_entity_name is set anywhere."""
+    integration_dir = _make_integration(tmp_path)
+    _create_quality_scale(integration_dir, {"has-entity-name": "done"})
+
+    root_node = _parse(
+        """
+from homeassistant.helpers.entity import Entity
+
+class MySensor(Entity):
+    pass
+""",
+        integration_dir,
+    )
+
+    class_node = next(root_node.nodes_of_class(nodes.ClassDef))
+    walker = ASTWalker(linter)
+    walker.add_checker(has_entity_name_checker)
+    with assert_adds_messages(linter, _expect_missing(class_node)):
+        walker.walk(root_node)
+
+
+@pytest.mark.parametrize(
+    ("code", "class_name"),
+    [
+        pytest.param(
+            """
+from homeassistant.helpers.entity import Entity
+
+class MyEntity(Entity):
+    def __init__(self, has_name):
+        self._attr_has_entity_name = has_name
+""",
+            "MyEntity",
+            id="self_assign_non_constant",
+        ),
+        pytest.param(
+            """
+from homeassistant.helpers.entity import Entity
+
+class MyEntity(Entity):
+    def __init__(self, condition):
+        if condition:
+            self._attr_has_entity_name = True
+""",
+            "MyEntity",
+            id="self_assign_true_inside_if",
+        ),
+        pytest.param(
+            """
+from homeassistant.helpers.entity import Entity
+
+class MyEntity(Entity):
+    def __init__(self):
+        try:
+            self._attr_has_entity_name = True
+        except Exception:
+            pass
+""",
+            "MyEntity",
+            id="self_assign_true_inside_try",
+        ),
+    ],
+)
+def test_conditional_self_assignment_fires(
+    linter: UnittestLinter,
+    has_entity_name_checker: HasEntityNameChecker,
+    tmp_path: Path,
+    code: str,
+    class_name: str,
+) -> None:
+    """Non-literal or nested self assignments don't guarantee True."""
+    integration_dir = _make_integration(tmp_path)
+    _create_quality_scale(integration_dir, {"has-entity-name": "done"})
+
+    root_node = _parse(code, integration_dir)
+    class_node = next(
+        cls
+        for cls in root_node.nodes_of_class(nodes.ClassDef)
+        if cls.name == class_name
+    )
+    walker = ASTWalker(linter)
+    walker.add_checker(has_entity_name_checker)
+    with assert_adds_messages(linter, _expect_missing(class_node)):
+        walker.walk(root_node)
+
+
+def test_explicit_false_fires(
+    linter: UnittestLinter,
+    has_entity_name_checker: HasEntityNameChecker,
+    tmp_path: Path,
+) -> None:
+    """Warning when _attr_has_entity_name = False with no override."""
+    integration_dir = _make_integration(tmp_path)
+    _create_quality_scale(integration_dir, {"has-entity-name": "done"})
+
+    root_node = _parse(
+        """
+from homeassistant.helpers.entity import Entity
+
+class MySensor(Entity):
+    _attr_has_entity_name = False
+""",
+        integration_dir,
+    )
+
+    class_node = next(root_node.nodes_of_class(nodes.ClassDef))
+    walker = ASTWalker(linter)
+    walker.add_checker(has_entity_name_checker)
+    with assert_adds_messages(linter, _expect_missing(class_node)):
+        walker.walk(root_node)
+
+
+def test_generic_subscript_base_sets_flag(
+    linter: UnittestLinter,
+    has_entity_name_checker: HasEntityNameChecker,
+    tmp_path: Path,
+) -> None:
+    """PEP-695-style generic base ``Base[T]`` is recognised as an ancestor."""
+    integration_dir = _make_integration(tmp_path)
+    _create_quality_scale(integration_dir, {"has-entity-name": "done"})
+
+    astroid.parse(
+        """
+from homeassistant.helpers.entity import Entity
+
+class TestIntegrationGenericBase[T](Entity):
+    _attr_has_entity_name = True
+""",
+        "homeassistant.components.test_integration.entity",
+    )
+
+    root_node = _parse(
+        """
+from homeassistant.components.test_integration.entity import TestIntegrationGenericBase
+
+class MySensor(TestIntegrationGenericBase[int]):
+    pass
+""",
+        integration_dir,
+    )
+
+    walker = ASTWalker(linter)
+    walker.add_checker(has_entity_name_checker)
+    with assert_no_messages(linter):
+        walker.walk(root_node)
+
+
+def test_two_level_subscript_chain(
+    linter: UnittestLinter,
+    has_entity_name_checker: HasEntityNameChecker,
+    tmp_path: Path,
+) -> None:
+    """Subscript-base resolution walks transitively through ancestors.
+
+    Mirrors the vesync pattern: a non-subscript ancestor itself uses a
+    subscript base for the class that sets the flag.
+    """
+    integration_dir = _make_integration(tmp_path)
+    _create_quality_scale(integration_dir, {"has-entity-name": "done"})
+
+    astroid.parse(
+        """
+from homeassistant.helpers.entity import Entity
+
+class TestIntegrationBase[T](Entity):
+    _attr_has_entity_name = True
+
+class TestIntegrationLightBase(TestIntegrationBase[int]):
+    _attr_name = None
+""",
+        "homeassistant.components.test_integration.entity",
+    )
+
+    root_node = _parse(
+        """
+from homeassistant.components.test_integration.entity import TestIntegrationLightBase
+
+class MyLight(TestIntegrationLightBase):
+    pass
+""",
+        integration_dir,
+        module_name="homeassistant.components.test_integration.light",
+        file_name="light.py",
+    )
+
+    walker = ASTWalker(linter)
+    walker.add_checker(has_entity_name_checker)
+    with assert_no_messages(linter):
+        walker.walk(root_node)
+
+
+def test_entity_description_fallback(
+    linter: UnittestLinter,
+    has_entity_name_checker: HasEntityNameChecker,
+    tmp_path: Path,
+) -> None:
+    """Entity passes via EntityDescription.has_entity_name = True fallback."""
+    integration_dir = _make_integration(tmp_path)
+    _create_quality_scale(integration_dir, {"has-entity-name": "done"})
+
+    root_node = _parse(
+        """
+from dataclasses import dataclass
+
+from homeassistant.helpers.entity import Entity, EntityDescription
+
+
+@dataclass(frozen=True, kw_only=True)
+class TestIntegrationDescription(EntityDescription):
+    has_entity_name = True
+
+
+class MyEntity(Entity):
+    entity_description: TestIntegrationDescription
+""",
+        integration_dir,
+    )
+
+    walker = ASTWalker(linter)
+    walker.add_checker(has_entity_name_checker)
+    with assert_no_messages(linter):
+        walker.walk(root_node)
+
+
+def test_entity_description_subscripted_annotation(
+    linter: UnittestLinter,
+    has_entity_name_checker: HasEntityNameChecker,
+    tmp_path: Path,
+) -> None:
+    """``entity_description: Desc[T]`` annotation still resolves."""
+    integration_dir = _make_integration(tmp_path)
+    _create_quality_scale(integration_dir, {"has-entity-name": "done"})
+
+    root_node = _parse(
+        """
+from dataclasses import dataclass
+
+from homeassistant.helpers.entity import Entity, EntityDescription
+
+
+@dataclass(frozen=True, kw_only=True)
+class TestIntegrationDescription[T](EntityDescription):
+    has_entity_name = True
+
+
+class MyEntity[T](Entity):
+    entity_description: TestIntegrationDescription[T]
+""",
+        integration_dir,
+    )
+
+    walker = ASTWalker(linter)
+    walker.add_checker(has_entity_name_checker)
+    with assert_no_messages(linter):
+        walker.walk(root_node)
+
+
+def test_entity_description_without_flag_still_fires(
+    linter: UnittestLinter,
+    has_entity_name_checker: HasEntityNameChecker,
+    tmp_path: Path,
+) -> None:
+    """Description annotation that doesn't set has_entity_name doesn't satisfy."""
+    integration_dir = _make_integration(tmp_path)
+    _create_quality_scale(integration_dir, {"has-entity-name": "done"})
+
+    root_node = _parse(
+        """
+from dataclasses import dataclass
+
+from homeassistant.helpers.entity import Entity, EntityDescription
+
+
+@dataclass(frozen=True, kw_only=True)
+class TestIntegrationDescription(EntityDescription):
+    pass
+
+
+class MyEntity(Entity):
+    entity_description: TestIntegrationDescription
+""",
+        integration_dir,
+    )
+
+    class_node = next(
+        cls
+        for cls in root_node.nodes_of_class(nodes.ClassDef)
+        if cls.name == "MyEntity"
+    )
+    walker = ASTWalker(linter)
+    walker.add_checker(has_entity_name_checker)
+    with assert_adds_messages(linter, _expect_missing(class_node)):
+        walker.walk(root_node)
+
+
+def test_entity_description_set_in_ancestor(
+    linter: UnittestLinter,
+    has_entity_name_checker: HasEntityNameChecker,
+    tmp_path: Path,
+) -> None:
+    """Annotation on an ancestor counts for subclass."""
+    integration_dir = _make_integration(tmp_path)
+    _create_quality_scale(integration_dir, {"has-entity-name": "done"})
+
+    astroid.parse(
+        """
+from dataclasses import dataclass
+
+from homeassistant.helpers.entity import Entity, EntityDescription
+
+
+@dataclass(frozen=True, kw_only=True)
+class TestIntegrationDescription(EntityDescription):
+    has_entity_name = True
+
+
+class TestIntegrationBaseEntity(Entity):
+    entity_description: TestIntegrationDescription
+""",
+        "homeassistant.components.test_integration.entity",
+    )
+
+    root_node = _parse(
+        """
+from homeassistant.components.test_integration.entity import TestIntegrationBaseEntity
+
+class MySensor(TestIntegrationBaseEntity):
+    pass
+""",
+        integration_dir,
+    )
+
+    walker = ASTWalker(linter)
+    walker.add_checker(has_entity_name_checker)
+    with assert_no_messages(linter):
+        walker.walk(root_node)
+
+
+def test_mixin_subclassed_in_same_module_ignored(
+    linter: UnittestLinter,
+    has_entity_name_checker: HasEntityNameChecker,
+    tmp_path: Path,
+) -> None:
+    """Mixin base class is skipped if another class in the same module extends it."""
+    integration_dir = _make_integration(tmp_path)
+    _create_quality_scale(integration_dir, {"has-entity-name": "done"})
+
+    root_node = _parse(
+        """
+from homeassistant.helpers.entity import Entity
+
+class MyClimateMixin(Entity):
+    _attr_temperature_unit = "C"
+
+class ActualEntity(MyClimateMixin):
+    _attr_has_entity_name = True
+""",
+        integration_dir,
+    )
+
+    walker = ASTWalker(linter)
+    walker.add_checker(has_entity_name_checker)
+    with assert_no_messages(linter):
+        walker.walk(root_node)
+
+
+def test_subclassed_via_subscript_ignored(
+    linter: UnittestLinter,
+    has_entity_name_checker: HasEntityNameChecker,
+    tmp_path: Path,
+) -> None:
+    """Generic base referenced as ``Base[T]`` in subclass declaration is recognised."""
+    integration_dir = _make_integration(tmp_path)
+    _create_quality_scale(integration_dir, {"has-entity-name": "done"})
+
+    root_node = _parse(
+        """
+from homeassistant.helpers.entity import Entity
+
+class GenericBase[T](Entity):
+    pass
+
+class ConcreteEntity(GenericBase[int]):
+    _attr_has_entity_name = True
+""",
+        integration_dir,
+    )
+
+    walker = ASTWalker(linter)
+    walker.add_checker(has_entity_name_checker)
+    with assert_no_messages(linter):
+        walker.walk(root_node)
+
+
+def test_leaf_class_still_fires(
+    linter: UnittestLinter,
+    has_entity_name_checker: HasEntityNameChecker,
+    tmp_path: Path,
+) -> None:
+    """A class that other module classes don't extend is still flagged."""
+    integration_dir = _make_integration(tmp_path)
+    _create_quality_scale(integration_dir, {"has-entity-name": "done"})
+
+    root_node = _parse(
+        """
+from homeassistant.helpers.entity import Entity
+
+class LonelySensor(Entity):
+    pass
+
+class SomethingUnrelated:
+    pass
+""",
+        integration_dir,
+    )
+
+    class_node = next(
+        cls
+        for cls in root_node.nodes_of_class(nodes.ClassDef)
+        if cls.name == "LonelySensor"
+    )
+    walker = ASTWalker(linter)
+    walker.add_checker(has_entity_name_checker)
+    with assert_adds_messages(linter, _expect_missing(class_node)):
+        walker.walk(root_node)
+
+
+def test_non_entity_class_ignored(
+    linter: UnittestLinter,
+    has_entity_name_checker: HasEntityNameChecker,
+    tmp_path: Path,
+) -> None:
+    """Class that does not inherit from Entity is ignored."""
+    integration_dir = _make_integration(tmp_path)
+    _create_quality_scale(integration_dir, {"has-entity-name": "done"})
+
+    root_node = _parse(
+        """
+class NotAnEntity:
+    pass
+""",
+        integration_dir,
+    )
+
+    walker = ASTWalker(linter)
+    walker.add_checker(has_entity_name_checker)
+    with assert_no_messages(linter):
+        walker.walk(root_node)
+
+
+def test_dict_status_done_fires(
+    linter: UnittestLinter,
+    has_entity_name_checker: HasEntityNameChecker,
+    tmp_path: Path,
+) -> None:
+    """Dict-form {status: done} also gates."""
+    integration_dir = _make_integration(tmp_path)
+    _create_quality_scale(
+        integration_dir,
+        {"has-entity-name": {"status": "done", "comment": "ok"}},
+    )
+
+    root_node = _parse(
+        """
+from homeassistant.helpers.entity import Entity
+
+class MySensor(Entity):
+    pass
+""",
+        integration_dir,
+    )
+
+    class_node = next(root_node.nodes_of_class(nodes.ClassDef))
+    walker = ASTWalker(linter)
+    walker.add_checker(has_entity_name_checker)
+    with assert_adds_messages(linter, _expect_missing(class_node)):
+        walker.walk(root_node)
+
+
+@pytest.mark.parametrize(
+    ("module_name", "file_name", "rules"),
+    [
+        pytest.param(
+            "homeassistant.components.test_integration.sensor",
+            "sensor.py",
+            None,
+            id="no_quality_scale_file",
+        ),
+        pytest.param(
+            "homeassistant.components.test_integration.sensor",
+            "sensor.py",
+            {"has-entity-name": "todo"},
+            id="rule_todo",
+        ),
+        pytest.param(
+            "homeassistant.components.test_integration.sensor",
+            "sensor.py",
+            {"has-entity-name": {"status": "exempt", "comment": "reason"}},
+            id="rule_exempt",
+        ),
+        pytest.param(
+            "homeassistant.components.test_integration.sensor",
+            "sensor.py",
+            {"some-other-rule": "done"},
+            id="rule_absent",
+        ),
+        pytest.param(
+            "homeassistant.components.test_integration.entity",
+            "entity.py",
+            {"has-entity-name": "done"},
+            id="non_platform_module",
+        ),
+        pytest.param(
+            "homeassistant.components.test_integration",
+            "__init__.py",
+            {"has-entity-name": "done"},
+            id="init_module",
+        ),
+        pytest.param(
+            "not_homeassistant.something.sensor",
+            "sensor.py",
+            {"has-entity-name": "done"},
+            id="not_an_integration",
+        ),
+    ],
+)
+def test_not_fired(
+    linter: UnittestLinter,
+    has_entity_name_checker: HasEntityNameChecker,
+    tmp_path: Path,
+    module_name: str,
+    file_name: str,
+    rules: dict | None,
+) -> None:
+    """No warning when rule is not done, module is not a platform, etc."""
+    integration_dir = _make_integration(tmp_path)
+    _create_quality_scale(integration_dir, rules)
+
+    code = """
+from homeassistant.helpers.entity import Entity
+
+class MySensor(Entity):
+    pass
+"""
+    root_node = _parse(code, integration_dir, module_name, file_name)
+
+    walker = ASTWalker(linter)
+    walker.add_checker(has_entity_name_checker)
+    with assert_no_messages(linter):
+        walker.walk(root_node)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a custom pylint checker that enforces the Bronze quality-scale rule `has-entity-name`. Like the other migrated quality-scale checkers (`config-entry-unloading`, `parallel-updates`, `reauthentication-flow`, `diagnostics`), it only fires for integrations whose `quality_scale.yaml` marks the rule as `done`, so it catches regressions without spamming integrations that haven't claimed the rule yet.

The checker accepts three paths that statically guarantee `has_entity_name=True`:

- A class-level `_attr_has_entity_name = True` on the entity class or any ancestor.
- An unconditional `self._attr_has_entity_name = True` at the top of a method body.
- A typed `entity_description` whose description class sets `has_entity_name = True` as a class-level default.

Conditional and per-instance patterns are rejected on purpose, since they don't enforce the rule statically.

A full-codebase audit surfaced 13 existing violations. To keep this PR focused on the rule itself, integrations that are already non-scaled (`ness_alarm`, `rainbird`) have the rule marked `todo`, and the remaining cases (`fitbit`, `omie`, `ekeybionyx`, `fritz`, `lunatone`, `smartthings`, `sonos`, `tplink_omada`) are silenced with targeted `# pylint: disable-next=home-assistant-missing-has-entity-name` comments. This avoids forcing a quality-scale tier downgrade and gives maintainers time to refactor; follow-up issues will track each integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
