### PR TITLE
Fix bsblan set data error translation

### DIFF
--- a/homeassistant/components/bsblan/climate.py
+++ b/homeassistant/components/bsblan/climate.py
@@ -184,7 +184,6 @@ class BSBLANClimate(BSBLanCircuitEntity, ClimateEntity):
             await self.coordinator.client.thermostat(**data, circuit=self._circuit)
         except BSBLANError as err:
             raise HomeAssistantError(
-                "An error occurred while updating the BSBLAN device",
                 translation_domain=DOMAIN,
                 translation_key="set_data_error",
             ) from err

--- a/tests/components/bsblan/test_button.py
+++ b/tests/components/bsblan/test_button.py
@@ -7,6 +7,7 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.bsblan.const import DOMAIN
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
@@ -111,13 +112,19 @@ async def test_button_press_error_handling(
     mock_bsblan.time.side_effect = BSBLANError("Connection failed")
 
     # Press the button - should raise HomeAssistantError
-    with pytest.raises(HomeAssistantError, match="Failed to sync time"):
+    with pytest.raises(HomeAssistantError) as exc:
         await hass.services.async_call(
             BUTTON_DOMAIN,
             SERVICE_PRESS,
             {ATTR_ENTITY_ID: ENTITY_SYNC_TIME},
             blocking=True,
         )
+    assert exc.value.translation_domain == DOMAIN
+    assert exc.value.translation_key == "sync_time_failed"
+    assert exc.value.translation_placeholders == {
+        "device_name": "BSB-LAN",
+        "error": "Connection failed",
+    }
 
 
 async def test_button_press_set_time_error(
@@ -140,10 +147,16 @@ async def test_button_press_set_time_error(
     mock_bsblan.set_time.side_effect = BSBLANError("Write failed")
 
     # Press the button - should raise HomeAssistantError
-    with pytest.raises(HomeAssistantError, match="Failed to sync time"):
+    with pytest.raises(HomeAssistantError) as exc:
         await hass.services.async_call(
             BUTTON_DOMAIN,
             SERVICE_PRESS,
             {ATTR_ENTITY_ID: ENTITY_SYNC_TIME},
             blocking=True,
         )
+    assert exc.value.translation_domain == DOMAIN
+    assert exc.value.translation_key == "sync_time_failed"
+    assert exc.value.translation_placeholders == {
+        "device_name": "BSB-LAN",
+        "error": "Write failed",
+    }

--- a/tests/components/bsblan/test_climate.py
+++ b/tests/components/bsblan/test_climate.py
@@ -8,6 +8,7 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.bsblan.const import DOMAIN
 from homeassistant.components.climate import (
     ATTR_HVAC_MODE,
     ATTR_PRESET_MODE,
@@ -394,14 +395,15 @@ async def test_async_set_data(
 
     # Test error handling
     mock_bsblan.thermostat.side_effect = BSBLANError("Test error")
-    error_message = "An error occurred while sending the data to the BSB-LAN device"
-    with pytest.raises(HomeAssistantError, match=error_message):
+    with pytest.raises(HomeAssistantError) as exc:
         await hass.services.async_call(
             CLIMATE_DOMAIN,
             SERVICE_SET_TEMPERATURE,
             {ATTR_ENTITY_ID: ENTITY_ID, ATTR_TEMPERATURE: 20},
             blocking=True,
         )
+    assert exc.value.translation_domain == DOMAIN
+    assert exc.value.translation_key == "set_data_error"
 
 
 async def test_dual_circuit_climate_entities(

--- a/tests/components/bsblan/test_climate.py
+++ b/tests/components/bsblan/test_climate.py
@@ -394,7 +394,7 @@ async def test_async_set_data(
 
     # Test error handling
     mock_bsblan.thermostat.side_effect = BSBLANError("Test error")
-    error_message = "An error occurred while updating the BSBLAN device"
+    error_message = "An error occurred while sending the data to the BSB-LAN device"
     with pytest.raises(HomeAssistantError, match=error_message):
         await hass.services.async_call(
             CLIMATE_DOMAIN,

--- a/tests/components/bsblan/test_services.py
+++ b/tests/components/bsblan/test_services.py
@@ -517,13 +517,19 @@ async def test_sync_time_service_error_handling(
     mock_bsblan.time.side_effect = BSBLANError("Connection failed")
 
     # Call the service - should raise HomeAssistantError
-    with pytest.raises(HomeAssistantError, match="Failed to sync time"):
+    with pytest.raises(HomeAssistantError) as exc:
         await hass.services.async_call(
             DOMAIN,
             "sync_time",
             {"device_id": device.id},
             blocking=True,
         )
+    assert exc.value.translation_domain == DOMAIN
+    assert exc.value.translation_key == "sync_time_failed"
+    assert exc.value.translation_placeholders == {
+        "device_name": "BSB-LAN",
+        "error": "Connection failed",
+    }
 
 
 async def test_sync_time_service_set_time_error(
@@ -553,13 +559,19 @@ async def test_sync_time_service_set_time_error(
     mock_bsblan.set_time.side_effect = BSBLANError("Write failed")
 
     # Call the service - should raise HomeAssistantError
-    with pytest.raises(HomeAssistantError, match="Failed to sync time"):
+    with pytest.raises(HomeAssistantError) as exc:
         await hass.services.async_call(
             DOMAIN,
             "sync_time",
             {"device_id": device.id},
             blocking=True,
         )
+    assert exc.value.translation_domain == DOMAIN
+    assert exc.value.translation_key == "sync_time_failed"
+    assert exc.value.translation_placeholders == {
+        "device_name": "BSB-LAN",
+        "error": "Write failed",
+    }
 
 
 async def test_sync_time_service_entry_not_found(

--- a/tests/components/bsblan/test_water_heater.py
+++ b/tests/components/bsblan/test_water_heater.py
@@ -8,6 +8,7 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.bsblan.const import DOMAIN
 from homeassistant.components.water_heater import (
     ATTR_OPERATION_MODE,
     DOMAIN as WATER_HEATER_DOMAIN,
@@ -235,9 +236,7 @@ async def test_set_temperature_failure(
 
     mock_bsblan.set_hot_water.side_effect = BSBLANError("Test error")
 
-    with pytest.raises(
-        HomeAssistantError, match="An error occurred while setting the temperature"
-    ):
+    with pytest.raises(HomeAssistantError) as exc:
         await hass.services.async_call(
             domain=WATER_HEATER_DOMAIN,
             service=SERVICE_SET_TEMPERATURE,
@@ -247,6 +246,8 @@ async def test_set_temperature_failure(
             },
             blocking=True,
         )
+    assert exc.value.translation_domain == DOMAIN
+    assert exc.value.translation_key == "set_temperature_error"
 
 
 async def test_operation_mode_error(
@@ -261,9 +262,7 @@ async def test_operation_mode_error(
 
     mock_bsblan.set_hot_water.side_effect = BSBLANError("Test error")
 
-    with pytest.raises(
-        HomeAssistantError, match="An error occurred while setting the operation mode"
-    ):
+    with pytest.raises(HomeAssistantError) as exc:
         await hass.services.async_call(
             domain=WATER_HEATER_DOMAIN,
             service=SERVICE_SET_OPERATION_MODE,
@@ -273,6 +272,8 @@ async def test_operation_mode_error(
             },
             blocking=True,
         )
+    assert exc.value.translation_domain == DOMAIN
+    assert exc.value.translation_key == "set_operation_mode_error"
 
 
 async def test_water_heater_no_sensors(
@@ -453,9 +454,7 @@ async def test_turn_on_error(
 
     mock_bsblan.set_hot_water.side_effect = BSBLANError("Test error")
 
-    with pytest.raises(
-        HomeAssistantError, match="An error occurred while setting the operation mode"
-    ):
+    with pytest.raises(HomeAssistantError) as exc:
         await hass.services.async_call(
             domain=WATER_HEATER_DOMAIN,
             service=SERVICE_TURN_ON,
@@ -464,6 +463,8 @@ async def test_turn_on_error(
             },
             blocking=True,
         )
+    assert exc.value.translation_domain == DOMAIN
+    assert exc.value.translation_key == "set_operation_mode_error"
 
 
 async def test_turn_off_error(
@@ -478,9 +479,7 @@ async def test_turn_off_error(
 
     mock_bsblan.set_hot_water.side_effect = BSBLANError("Test error")
 
-    with pytest.raises(
-        HomeAssistantError, match="An error occurred while setting the operation mode"
-    ):
+    with pytest.raises(HomeAssistantError) as exc:
         await hass.services.async_call(
             domain=WATER_HEATER_DOMAIN,
             service=SERVICE_TURN_OFF,
@@ -489,3 +488,5 @@ async def test_turn_off_error(
             },
             blocking=True,
         )
+    assert exc.value.translation_domain == DOMAIN
+    assert exc.value.translation_key == "set_operation_mode_error"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- fix to only use translation key #171519 
- also fixes tests to use translation keys

<details>
<summary>Details</summary>

This pull request refines and extends the error handling tests for the BSBLAN integration by updating assertions to check for translated error details rather than just error messages. The changes ensure that raised `HomeAssistantError` exceptions include the correct translation domain, key, and placeholders, making the tests more robust and aligned with the integration's internationalization practices.

Key changes include:

**Test improvements for error handling and translation:**

* Updated all relevant tests in `test_button.py`, `test_climate.py`, `test_services.py`, and `test_water_heater.py` to assert that `HomeAssistantError` exceptions include the expected `translation_domain`, `translation_key`, and, where relevant, `translation_placeholders` for BSBLAN errors. This replaces previous assertions that only matched error strings. [[1]](diffhunk://#diff-2d51362eabe9a4409ad1972c16c3345923a7245be8c4e5ad6bab31374cd4297dL114-R127) [[2]](diffhunk://#diff-2d51362eabe9a4409ad1972c16c3345923a7245be8c4e5ad6bab31374cd4297dL143-R162) [[3]](diffhunk://#diff-e99598f290cd7f09b0b7e7a7af12e01a1f6afe5328bb1375ae81b1b39676abadL397-R406) [[4]](diffhunk://#diff-61a319961c667ac8e7c0ff3e7a42920926de2ddf2d6e509c5a44744834a2a582L520-R532) [[5]](diffhunk://#diff-61a319961c667ac8e7c0ff3e7a42920926de2ddf2d6e509c5a44744834a2a582L556-R574) [[6]](diffhunk://#diff-857292b3ae7ad8dcb3b31c2366d7c66b083121504ed7ec3053bdc8335414d56fL238-R239) [[7]](diffhunk://#diff-857292b3ae7ad8dcb3b31c2366d7c66b083121504ed7ec3053bdc8335414d56fR249-R250) [[8]](diffhunk://#diff-857292b3ae7ad8dcb3b31c2366d7c66b083121504ed7ec3053bdc8335414d56fL264-R265) [[9]](diffhunk://#diff-857292b3ae7ad8dcb3b31c2366d7c66b083121504ed7ec3053bdc8335414d56fR275-R276) [[10]](diffhunk://#diff-857292b3ae7ad8dcb3b31c2366d7c66b083121504ed7ec3053bdc8335414d56fL456-R457) [[11]](diffhunk://#diff-857292b3ae7ad8dcb3b31c2366d7c66b083121504ed7ec3053bdc8335414d56fR466-R467) [[12]](diffhunk://#diff-857292b3ae7ad8dcb3b31c2366d7c66b083121504ed7ec3053bdc8335414d56fL481-R482) [[13]](diffhunk://#diff-857292b3ae7ad8dcb3b31c2366d7c66b083121504ed7ec3053bdc8335414d56fR491-R492)

**Code cleanup and consistency:**

* Removed hardcoded error messages from the exception raising logic in `climate.py`, relying instead on translation keys and domains for error reporting.
* Added explicit imports of the BSBLAN `DOMAIN` constant in all relevant test files to support the new assertions. [[1]](diffhunk://#diff-2d51362eabe9a4409ad1972c16c3345923a7245be8c4e5ad6bab31374cd4297dR10) [[2]](diffhunk://#diff-e99598f290cd7f09b0b7e7a7af12e01a1f6afe5328bb1375ae81b1b39676abadR11) [[3]](diffhunk://#diff-857292b3ae7ad8dcb3b31c2366d7c66b083121504ed7ec3053bdc8335414d56fR11)

These changes improve test accuracy and ensure that error handling aligns with Home Assistant's translation and localization standards.

</details>


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #171519 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
