### PR TITLE
Fix onboarding crash when area translations are missing

### DIFF
--- a/homeassistant/components/onboarding/views.py
+++ b/homeassistant/components/onboarding/views.py
@@ -198,14 +198,18 @@ class UserOnboardingView(_BaseOnboardingStepView):
             if await async_wait_component(hass, "person"):
                 await person.async_create_person(hass, data["name"], user_id=user.id)
 
-            # Create default areas using the users supplied language,
+            # Create default areas using the user-supplied language,
             # falling back to English for any missing keys.
+            language = data["language"]
             english_translations = await async_get_translations(
                 hass, "en", "area", {DOMAIN}
             )
-            translations = await async_get_translations(
-                hass, data["language"], "area", {DOMAIN}
-            )
+            if language == "en":
+                translations = english_translations
+            else:
+                translations = await async_get_translations(
+                    hass, language, "area", {DOMAIN}
+                )
 
             area_registry = ar.async_get(hass)
 

--- a/homeassistant/components/onboarding/views.py
+++ b/homeassistant/components/onboarding/views.py
@@ -198,7 +198,11 @@ class UserOnboardingView(_BaseOnboardingStepView):
             if await async_wait_component(hass, "person"):
                 await person.async_create_person(hass, data["name"], user_id=user.id)
 
-            # Create default areas using the users supplied language.
+            # Create default areas using the users supplied language,
+            # falling back to English for any missing keys.
+            english_translations = await async_get_translations(
+                hass, "en", "area", {DOMAIN}
+            )
             translations = await async_get_translations(
                 hass, data["language"], "area", {DOMAIN}
             )
@@ -206,7 +210,11 @@ class UserOnboardingView(_BaseOnboardingStepView):
             area_registry = ar.async_get(hass)
 
             for area in DEFAULT_AREAS:
-                name = translations[f"component.onboarding.area.{area.key}"]
+                translation_key = f"component.onboarding.area.{area.key}"
+                name = translations.get(
+                    translation_key,
+                    english_translations.get(translation_key, area.key),
+                )
                 # Guard because area might have been created by an automatically
                 # set up integration.
                 if not area_registry.async_get_area_by_name(name):


### PR DESCRIPTION
## Proposed change

Fix a `KeyError` crash during onboarding when area translation keys are not available. This happens when running Home Assistant Core from a development install or when translation files are incomplete for a given language. The onboarding user creation step crashes because it uses direct dict access on translations that may not exist.

Now fetches English translations as a fallback for any missing keys in the user's language, with the area key itself as a last resort.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #170802
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr