### PR TITLE
Add support for ZHA group devices

### DIFF
--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -123,6 +123,11 @@ class ZHAEntity(LogMixin, RestoreEntity, Entity):
     @property
     def device_info(self) -> DeviceInfo:
         """Return a device description for device registry."""
+        if self.entity_data.is_group_entity:
+            group_proxy = self.entity_data.group_proxy
+            assert group_proxy is not None
+            return group_proxy.device_info
+
         zha_device_info = self.entity_data.device_proxy.device_info
         ieee = zha_device_info["ieee"]
         zha_gateway = self.entity_data.device_proxy.gateway_proxy.gateway

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -208,6 +208,7 @@ ZHA_GW_MSG_LOG_OUTPUT = "log_output"
 SIGNAL_REMOVE_ENTITIES = "zha_remove_entities"
 SIGNAL_REMOVE_ENTITY = "zha_remove_entity"
 GROUP_ENTITY_DOMAINS = [Platform.LIGHT, Platform.SWITCH, Platform.FAN]
+GROUP_DEVICE_IDENTIFIER_SUFFIX = "_group_0x"
 SIGNAL_ADD_ENTITIES = "zha_add_entities"
 ENTITIES = "entities"
 
@@ -227,6 +228,33 @@ NEXT_HOP = "next_hop"
 USER_GIVEN_NAME = "user_given_name"
 DEVICE_REG_ID = "device_reg_id"
 
+type EntityRef = EUI64 | str
+
+
+def _entity_reference_key(entity_data: EntityData) -> EntityRef:
+    """Return the key used to store an entity reference."""
+    if entity_data.is_group_entity:
+        assert entity_data.group_proxy is not None
+        return entity_data.group_proxy.device_identifier
+    return entity_data.device_proxy.device.ieee
+
+
+def _group_device_identifier(config_entry_id: str, group_id: int) -> str:
+    """Return the ZHA group device identifier."""
+    return f"{config_entry_id}{GROUP_DEVICE_IDENTIFIER_SUFFIX}{group_id:04x}"
+
+
+def _group_id_from_device_identifier(identifier: str) -> int | None:
+    """Return the ZHA group id from a group device identifier."""
+    if GROUP_DEVICE_IDENTIFIER_SUFFIX not in identifier:
+        return None
+
+    _, group_id = identifier.rsplit(GROUP_DEVICE_IDENTIFIER_SUFFIX, 1)
+    try:
+        return int(group_id, 16)
+    except ValueError:
+        return None
+
 
 class GroupEntityReference(NamedTuple):
     """Reference to a group entity."""
@@ -239,10 +267,47 @@ class GroupEntityReference(NamedTuple):
 class ZHAGroupProxy(LogMixin):
     """Proxy class to interact with the ZHA group instances."""
 
+    _ha_device_id: str | None = None
+
     def __init__(self, group: Group, gateway_proxy: ZHAGatewayProxy) -> None:
         """Initialize the gateway proxy."""
         self.group: Group = group
         self.gateway_proxy: ZHAGatewayProxy = gateway_proxy
+
+    @property
+    def device_id(self) -> str | None:
+        """Return the HA device registry device id."""
+        if self._ha_device_id is None:
+            device_registry = dr.async_get(self.gateway_proxy.hass)
+            if device := device_registry.async_get_device(
+                identifiers={(DOMAIN, self.device_identifier)}
+            ):
+                self._ha_device_id = device.id
+        return self._ha_device_id
+
+    @device_id.setter
+    def device_id(self, device_id: str) -> None:
+        """Set the HA device registry device id."""
+        self._ha_device_id = device_id
+
+    @property
+    def device_identifier(self) -> str:
+        """Return the ZHA group device identifier."""
+        return _group_device_identifier(
+            self.gateway_proxy.config_entry.entry_id, self.group.group_id
+        )
+
+    @property
+    def device_info(self) -> dr.DeviceInfo:
+        """Return a device description for the group device registry entry."""
+        coordinator_ieee = str(self.gateway_proxy.gateway.state.node_info.ieee)
+        return dr.DeviceInfo(
+            identifiers={(DOMAIN, self.device_identifier)},
+            manufacturer="ZHA",
+            model="Zigbee group",
+            name=self.group.name,
+            via_device=(DOMAIN, coordinator_ieee),
+        )
 
     @property
     def group_info(self) -> dict[str, Any]:
@@ -265,7 +330,7 @@ class ZHAGroupProxy(LogMixin):
     def associated_entities(self, member: GroupMember) -> list[GroupEntityReference]:
         """Return the list of entities that were derived from this endpoint."""
         entity_registry = er.async_get(self.gateway_proxy.hass)
-        entity_refs: collections.defaultdict[EUI64, list[EntityReference]] = (
+        entity_refs: collections.defaultdict[EntityRef, list[EntityReference]] = (
             self.gateway_proxy.ha_entity_refs
         )
 
@@ -554,9 +619,9 @@ class ZHAGatewayProxy(EventBase):
         self.gateway = gateway
         self.device_proxies: dict[EUI64, ZHADeviceProxy] = {}
         self.group_proxies: dict[int, ZHAGroupProxy] = {}
-        self._ha_entity_refs: collections.defaultdict[EUI64, list[EntityReference]] = (
-            collections.defaultdict(list)
-        )
+        self._ha_entity_refs: collections.defaultdict[
+            EntityRef, list[EntityReference]
+        ] = collections.defaultdict(list)
         self._log_levels: dict[str, dict[str, int]] = {
             DEBUG_LEVEL_ORIGINAL: async_capture_log_levels(),
             DEBUG_LEVEL_CURRENT: async_capture_log_levels(),
@@ -581,8 +646,10 @@ class ZHAGatewayProxy(EventBase):
         )
 
     @property
-    def ha_entity_refs(self) -> collections.defaultdict[EUI64, list[EntityReference]]:
-        """Return entities by ieee."""
+    def ha_entity_refs(
+        self,
+    ) -> collections.defaultdict[EntityRef, list[EntityReference]]:
+        """Return entities by device or group key."""
         return self._ha_entity_refs
 
     def register_entity_reference(
@@ -593,7 +660,7 @@ class ZHAGatewayProxy(EventBase):
         remove_future: asyncio.Future[Any],
     ) -> None:
         """Record the creation of a hass entity associated with ieee."""
-        self._ha_entity_refs[entity_data.device_proxy.device.ieee].append(
+        self._ha_entity_refs[_entity_reference_key(entity_data)].append(
             EntityReference(
                 ha_entity_id=ha_entity_id,
                 entity_data=entity_data,
@@ -601,6 +668,13 @@ class ZHAGatewayProxy(EventBase):
                 remove_future=remove_future,
             )
         )
+        if entity_data.is_group_entity:
+            assert entity_data.group_proxy is not None
+            device_registry = dr.async_get(self.hass)
+            if device := device_registry.async_get_device(
+                identifiers={(DOMAIN, entity_data.group_proxy.device_identifier)}
+            ):
+                entity_data.group_proxy.device_id = device.id
 
     async def _handle_entity_registry_updated(
         self, event: Event[er.EventEntityRegistryUpdatedData]
@@ -621,22 +695,33 @@ class ZHAGatewayProxy(EventBase):
         )
         assert device_entry
 
-        ieee_address = next(
-            identifier
-            for domain, identifier in device_entry.identifiers
-            if domain == DOMAIN
+        zha_identifier = next(
+            (
+                identifier
+                for domain, identifier in device_entry.identifiers
+                if domain == DOMAIN
+            ),
+            None,
         )
-        assert ieee_address
-
-        ieee = EUI64.convert(ieee_address)
-
-        assert ieee in self.device_proxies
-
-        zha_device_proxy = self.device_proxies[ieee]
-        entity_key = (entity_entry.domain, entity_entry.unique_id)
-        if entity_key not in zha_device_proxy.device.platform_entities:
+        if zha_identifier is None:
             return
-        platform_entity = zha_device_proxy.device.platform_entities[entity_key]
+
+        if (group_id := _group_id_from_device_identifier(zha_identifier)) is not None:
+            if (zha_group_proxy := self.group_proxies.get(group_id)) is None:
+                return
+            platform_entities = zha_group_proxy.group.group_entities
+        else:
+            ieee = EUI64.convert(zha_identifier)
+
+            assert ieee in self.device_proxies
+
+            zha_device_proxy = self.device_proxies[ieee]
+            platform_entities = zha_device_proxy.device.platform_entities
+
+        entity_key = (entity_entry.domain, entity_entry.unique_id)
+        if entity_key not in platform_entities:
+            return
+        platform_entity = platform_entities[entity_key]
         if entity_entry.disabled:
             platform_entity.disable()
         else:
@@ -850,10 +935,10 @@ class ZHAGatewayProxy(EventBase):
 
     def remove_entity_reference(self, entity: ZHAEntity) -> None:
         """Remove entity reference for given entity_id if found."""
-        ieee = entity.entity_data.device_proxy.device.ieee
-        if (entity_refs := self._ha_entity_refs.get(ieee)) is None:
+        key = _entity_reference_key(entity.entity_data)
+        if (entity_refs := self._ha_entity_refs.get(key)) is None:
             return
-        self._ha_entity_refs[ieee] = [
+        self._ha_entity_refs[key] = [
             e for e in entity_refs if e.ha_entity_id != entity.entity_id
         ]
 
@@ -937,16 +1022,30 @@ class ZHAGatewayProxy(EventBase):
             for domain in GROUP_ENTITY_DOMAINS
         ]
 
-        # then we get all group entity entries tied to the coordinator
+        # Get group entity entries tied to this group device.
         entity_registry = er.async_get(self.hass)
+        device_registry = dr.async_get(self.hass)
+        all_group_entity_entries: list[er.RegistryEntry] = []
+        if (group_device_id := zha_group_proxy.device_id) is not None:
+            all_group_entity_entries.extend(
+                er.async_entries_for_device(
+                    entity_registry,
+                    group_device_id,
+                    include_disabled_entities=True,
+                )
+            )
+
+        # Also clean up legacy group entities that were tied to the coordinator.
         assert self.gateway.coordinator_zha_device
         coordinator_proxy = self.device_proxies[
             self.gateway.coordinator_zha_device.ieee
         ]
-        all_group_entity_entries = er.async_entries_for_device(
-            entity_registry,
-            coordinator_proxy.device_id,
-            include_disabled_entities=True,
+        all_group_entity_entries.extend(
+            er.async_entries_for_device(
+                entity_registry,
+                coordinator_proxy.device_id,
+                include_disabled_entities=True,
+            )
         )
 
         # then we get the entity entries for this specific group
@@ -963,6 +1062,12 @@ class ZHAGatewayProxy(EventBase):
                 "cleaning up entity registry entry for entity: %s", entry.entity_id
             )
             entity_registry.async_remove(entry.entity_id)
+
+        # then remove the group device
+        if group_device_id is not None and (
+            group_device := device_registry.async_get(group_device_id)
+        ):
+            device_registry.async_remove_device(group_device.id)
 
     def _update_group_entities(self, group_event: GroupEvent) -> None:
         """Update group entities when a group event is received."""

--- a/tests/components/zha/test_entity.py
+++ b/tests/components/zha/test_entity.py
@@ -1,16 +1,31 @@
 """Test ZHA entities."""
 
 from collections.abc import Callable, Coroutine
+from unittest.mock import MagicMock
 
+from zha.application.platforms import GroupEntity
 from zigpy.device import Device
 from zigpy.profiles import zha
 from zigpy.zcl.clusters import general
 
-from homeassistant.components.zha.helpers import get_zha_gateway
+from homeassistant.components.zha.entity import ZHAEntity
+from homeassistant.components.zha.helpers import (
+    EntityData,
+    get_zha_gateway,
+    get_zha_gateway_proxy,
+)
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
+from .conftest import (
+    FIXTURE_GRP_ID,
+    FIXTURE_GRP_NAME,
+    SIG_EP_INPUT,
+    SIG_EP_OUTPUT,
+    SIG_EP_PROFILE,
+    SIG_EP_TYPE,
+)
 
 
 async def test_device_registry_via_device(
@@ -48,3 +63,79 @@ async def test_device_registry_via_device(
     )
 
     assert reg_device.via_device_id == reg_coordinator_device.id
+
+
+async def test_group_without_entities_has_no_separate_device(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test ZHA group without entities does not create an empty device."""
+
+    await setup_zha()
+    gateway_proxy = get_zha_gateway_proxy(hass)
+    group_proxy = gateway_proxy.group_proxies[FIXTURE_GRP_ID]
+
+    assert group_proxy.device_id is None
+    assert (
+        device_registry.async_get_device(
+            identifiers={("zha", group_proxy.device_identifier)}
+        )
+        is None
+    )
+
+
+async def test_group_entity_uses_group_device_info(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test ZHA group entity is associated with the group device."""
+
+    await setup_zha()
+    gateway = get_zha_gateway(hass)
+    gateway_proxy = get_zha_gateway_proxy(hass)
+    group_proxy = gateway_proxy.group_proxies[FIXTURE_GRP_ID]
+    coordinator_proxy = gateway_proxy.device_proxies[
+        gateway_proxy.gateway.coordinator_zha_device.ieee
+    ]
+
+    group_entity = MagicMock(spec=GroupEntity)
+    group_entity.PLATFORM = Platform.SWITCH
+    group_entity.icon = None
+    group_entity.info_object.unique_id = "switch_zha_group_0x1001"
+    group_entity.info_object.entity_category = None
+    group_entity.info_object.entity_registry_enabled_default = True
+    group_entity.info_object.translation_key = None
+    group_entity.info_object.translation_placeholders = None
+
+    entity = ZHAEntity(
+        EntityData(
+            entity=group_entity,
+            device_proxy=coordinator_proxy,
+            group_proxy=group_proxy,
+        )
+    )
+
+    assert entity.device_info == group_proxy.device_info
+
+    reg_coordinator_device = device_registry.async_get_device(
+        identifiers={("zha", str(gateway.state.node_info.ieee))}
+    )
+    reg_group_device = device_registry.async_get_or_create(
+        config_entry_id=gateway_proxy.config_entry.entry_id,
+        **entity.device_info,
+    )
+    remove_future = hass.loop.create_future()
+    gateway_proxy.register_entity_reference(
+        "switch.test_group",
+        entity.entity_data,
+        entity.device_info,
+        remove_future,
+    )
+
+    assert reg_coordinator_device is not None
+    assert reg_group_device.name == FIXTURE_GRP_NAME
+    assert reg_group_device.identifiers == {("zha", group_proxy.device_identifier)}
+    assert reg_group_device.via_device_id == reg_coordinator_device.id
+    assert group_proxy.device_id == reg_group_device.id


### PR DESCRIPTION
## Proposed change
Add support for ZHA group devices. Instead of adding the Zigbee group entities to the coordinator device this PR creates now a own group device for every Zigbee group. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
