### PR TITLE
Skip foreign metadata files in backblaze_b2 backup listing

### DIFF
--- a/homeassistant/components/backblaze_b2/backup.py
+++ b/homeassistant/components/backblaze_b2/backup.py
@@ -54,7 +54,7 @@ def suggested_filenames(backup: AgentBackup) -> tuple[str, str]:
 
 # Other tools may write unrelated files ending in `.metadata.json` into the
 # bucket; such files must be skipped rather than crashing the backup listing.
-REQUIRED_METADATA_KEYS = {"metadata_version", "backup_id", "backup_metadata"}
+REQUIRED_METADATA_KEYS = frozenset({"metadata_version", "backup_id", "backup_metadata"})
 
 
 def _parse_metadata(raw_content: str) -> dict[str, Any]:
@@ -64,7 +64,7 @@ def _parse_metadata(raw_content: str) -> dict[str, Any]:
     except json.JSONDecodeError as err:
         raise ValueError(f"Invalid JSON format: {err}") from err
     if not isinstance(data, dict):
-        raise ValueError("JSON content is not a dictionary")
+        raise TypeError("JSON content is not a dictionary")
     missing = REQUIRED_METADATA_KEYS - data.keys()
     if missing:
         raise ValueError(f"Missing required metadata keys: {sorted(missing)}")

--- a/homeassistant/components/backblaze_b2/backup.py
+++ b/homeassistant/components/backblaze_b2/backup.py
@@ -64,7 +64,7 @@ def _parse_metadata(raw_content: str) -> dict[str, Any]:
     except json.JSONDecodeError as err:
         raise ValueError(f"Invalid JSON format: {err}") from err
     if not isinstance(data, dict):
-        raise TypeError("JSON content is not a dictionary")
+        raise ValueError("JSON content is not a dictionary")
     missing = REQUIRED_METADATA_KEYS - data.keys()
     if missing:
         raise ValueError(f"Missing required metadata keys: {sorted(missing)}")

--- a/homeassistant/components/backblaze_b2/backup.py
+++ b/homeassistant/components/backblaze_b2/backup.py
@@ -67,7 +67,9 @@ def _parse_metadata(raw_content: str) -> dict[str, Any]:
         raise TypeError("JSON content is not a dictionary")
     missing = REQUIRED_METADATA_KEYS - data.keys()
     if missing:
-        raise ValueError(f"Missing required metadata keys: {sorted(missing)}")
+        raise ValueError(
+            f"Missing required metadata keys: {', '.join(sorted(missing))}"
+        )
     return data
 
 

--- a/homeassistant/components/backblaze_b2/backup.py
+++ b/homeassistant/components/backblaze_b2/backup.py
@@ -52,16 +52,23 @@ def suggested_filenames(backup: AgentBackup) -> tuple[str, str]:
     return f"{base_name}.tar", f"{base_name}.metadata.json"
 
 
+# Other tools may write unrelated files ending in `.metadata.json` into the
+# bucket; such files must be skipped rather than crashing the backup listing.
+REQUIRED_METADATA_KEYS = {"metadata_version", "backup_id", "backup_metadata"}
+
+
 def _parse_metadata(raw_content: str) -> dict[str, Any]:
-    """Parse metadata content from JSON."""
+    """Parse metadata content from JSON and validate its schema."""
     try:
         data = json.loads(raw_content)
     except json.JSONDecodeError as err:
         raise ValueError(f"Invalid JSON format: {err}") from err
-    else:
-        if not isinstance(data, dict):
-            raise TypeError("JSON content is not a dictionary")
-        return data
+    if not isinstance(data, dict):
+        raise TypeError("JSON content is not a dictionary")
+    missing = REQUIRED_METADATA_KEYS - data.keys()
+    if missing:
+        raise ValueError(f"Missing required metadata keys: {sorted(missing)}")
+    return data
 
 
 def _find_backup_file_for_metadata(
@@ -557,7 +564,13 @@ class BackblazeBackupAgent(BackupAgent):
             metadata_content = _parse_metadata(
                 download_response.content.decode("utf-8")
             )
-        except ValueError:
+        except (TypeError, ValueError) as err:
+            _LOGGER.warning(
+                "Skipping metadata file %s: not a valid Backblaze B2 backup "
+                "metadata file (%s)",
+                file_name,
+                err,
+            )
             return None, None
 
         if metadata_content["backup_id"] != target_backup_id:
@@ -633,7 +646,13 @@ class BackblazeBackupAgent(BackupAgent):
             metadata_content = _parse_metadata(
                 download_response.content.decode("utf-8")
             )
-        except ValueError:
+        except (TypeError, ValueError) as err:
+            _LOGGER.warning(
+                "Skipping metadata file %s: not a valid Backblaze B2 backup "
+                "metadata file (%s)",
+                file_name,
+                err,
+            )
             return None
 
         found_backup_file = _find_backup_file_for_metadata(

--- a/tests/components/backblaze_b2/test_backup.py
+++ b/tests/components/backblaze_b2/test_backup.py
@@ -254,7 +254,7 @@ async def test_listeners_get_cleaned_up(hass: HomeAssistant) -> None:
             "invalid json", ValueError, "Invalid JSON format", id="invalid_json"
         ),
         pytest.param(
-            '["not", "a", "dict"]',
+            ValueError,
             TypeError,
             "JSON content is not a dictionary",
             id="not_a_dict",

--- a/tests/components/backblaze_b2/test_backup.py
+++ b/tests/components/backblaze_b2/test_backup.py
@@ -262,26 +262,26 @@ async def test_listeners_get_cleaned_up(hass: HomeAssistant) -> None:
         pytest.param(
             '{"backup_id": "abc", "backup_metadata": {}}',
             ValueError,
-            "Missing required metadata keys: \\['metadata_version'\\]",
+            "Missing required metadata keys: metadata_version",
             id="missing_metadata_version",
         ),
         pytest.param(
             '{"metadata_version": "1", "backup_metadata": {}}',
             ValueError,
-            "Missing required metadata keys: \\['backup_id'\\]",
+            "Missing required metadata keys: backup_id",
             id="missing_backup_id",
         ),
         pytest.param(
             '{"metadata_version": "1", "backup_id": "abc"}',
             ValueError,
-            "Missing required metadata keys: \\['backup_metadata'\\]",
+            "Missing required metadata keys: backup_metadata",
             id="missing_backup_metadata",
         ),
         pytest.param(
             "{}",
             ValueError,
             "Missing required metadata keys: "
-            "\\['backup_id', 'backup_metadata', 'metadata_version'\\]",
+            "backup_id, backup_metadata, metadata_version",
             id="empty_dict",
         ),
     ],

--- a/tests/components/backblaze_b2/test_backup.py
+++ b/tests/components/backblaze_b2/test_backup.py
@@ -254,7 +254,7 @@ async def test_listeners_get_cleaned_up(hass: HomeAssistant) -> None:
             "invalid json", ValueError, "Invalid JSON format", id="invalid_json"
         ),
         pytest.param(
-            ValueError,
+            '["not", "a", "dict"]',
             TypeError,
             "JSON content is not a dictionary",
             id="not_a_dict",
@@ -301,7 +301,7 @@ async def test_agents_list_skips_foreign_metadata_files(
     mock_backup_files: tuple[Mock, Mock],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Foreign .metadata.json files in the bucket are skipped, not crash listing."""
+    """Foreign .metadata.json files in the bucket are skipped, not crash the listing."""
     mock_main, mock_metadata = mock_backup_files
 
     # An unrelated `.metadata.json` from another tool: valid JSON object, but

--- a/tests/components/backblaze_b2/test_backup.py
+++ b/tests/components/backblaze_b2/test_backup.py
@@ -304,9 +304,7 @@ async def test_agents_list_skips_foreign_metadata_files(
     """Foreign .metadata.json files in the bucket are skipped, not crash the listing."""
     mock_main, mock_metadata = mock_backup_files
 
-    # An unrelated `.metadata.json` from another tool: valid JSON object, but
-    # missing the keys this integration expects. Previously this crashed
-    # async_list_backups with KeyError, hiding all backups from the user.
+    # Simulate metadata left behind by another bucket-based backup integration.
     foreign_metadata = Mock()
     foreign_metadata.file_name = "testprefix/foreign.metadata.json"
     foreign_download = Mock()

--- a/tests/components/backblaze_b2/test_backup.py
+++ b/tests/components/backblaze_b2/test_backup.py
@@ -247,13 +247,93 @@ async def test_listeners_get_cleaned_up(hass: HomeAssistant) -> None:
     assert DATA_BACKUP_AGENT_LISTENERS not in hass.data
 
 
-async def test_parse_metadata_invalid_json() -> None:
-    """Test metadata parsing."""
-    with pytest.raises(ValueError, match="Invalid JSON format"):
-        _parse_metadata("invalid json")
+@pytest.mark.parametrize(
+    ("raw_content", "exception", "match"),
+    [
+        pytest.param(
+            "invalid json", ValueError, "Invalid JSON format", id="invalid_json"
+        ),
+        pytest.param(
+            '["not", "a", "dict"]',
+            TypeError,
+            "JSON content is not a dictionary",
+            id="not_a_dict",
+        ),
+        pytest.param(
+            '{"backup_id": "abc", "backup_metadata": {}}',
+            ValueError,
+            "Missing required metadata keys: \\['metadata_version'\\]",
+            id="missing_metadata_version",
+        ),
+        pytest.param(
+            '{"metadata_version": "1", "backup_metadata": {}}',
+            ValueError,
+            "Missing required metadata keys: \\['backup_id'\\]",
+            id="missing_backup_id",
+        ),
+        pytest.param(
+            '{"metadata_version": "1", "backup_id": "abc"}',
+            ValueError,
+            "Missing required metadata keys: \\['backup_metadata'\\]",
+            id="missing_backup_metadata",
+        ),
+        pytest.param(
+            "{}",
+            ValueError,
+            "Missing required metadata keys: "
+            "\\['backup_id', 'backup_metadata', 'metadata_version'\\]",
+            id="empty_dict",
+        ),
+    ],
+)
+async def test_parse_metadata_invalid(
+    raw_content: str, exception: type[Exception], match: str
+) -> None:
+    """Test metadata parsing rejects malformed or foreign metadata files."""
+    with pytest.raises(exception, match=match):
+        _parse_metadata(raw_content)
 
-    with pytest.raises(TypeError, match="JSON content is not a dictionary"):
-        _parse_metadata('["not", "a", "dict"]')
+
+async def test_agents_list_skips_foreign_metadata_files(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    mock_config_entry: MockConfigEntry,
+    mock_backup_files: tuple[Mock, Mock],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Foreign .metadata.json files in the bucket are skipped, not crash listing."""
+    mock_main, mock_metadata = mock_backup_files
+
+    # An unrelated `.metadata.json` from another tool: valid JSON object, but
+    # missing the keys this integration expects. Previously this crashed
+    # async_list_backups with KeyError, hiding all backups from the user.
+    foreign_metadata = Mock()
+    foreign_metadata.file_name = "testprefix/foreign.metadata.json"
+    foreign_download = Mock()
+    foreign_response = Mock()
+    foreign_response.content = json.dumps({"unrelated": "payload"}).encode()
+    foreign_download.response = foreign_response
+    foreign_metadata.download = Mock(return_value=foreign_download)
+
+    def mock_ls(_self, _prefix=""):
+        return iter(
+            [(mock_main, None), (mock_metadata, None), (foreign_metadata, None)]
+        )
+
+    client = await hass_ws_client(hass)
+    with (
+        patch.object(BucketSimulator, "ls", mock_ls),
+        caplog.at_level(logging.WARNING),
+    ):
+        await client.send_json_auto_id({"type": "backup/info"})
+        response = await client.receive_json()
+
+    assert response["success"]
+    assert response["result"]["agent_errors"] == {}
+    backups = response["result"]["backups"]
+    assert len(backups) == 1
+    assert backups[0]["backup_id"] == TEST_BACKUP.backup_id
+    assert "Skipping metadata file testprefix/foreign.metadata.json" in caplog.text
 
 
 async def test_error_during_list_backups(


### PR DESCRIPTION
## Breaking change


## Proposed change

The `backblaze_b2` backup agent walks every file in the bucket prefix and
treats any name ending in `.metadata.json` as a backup metadata file
produced by this integration. If the bucket contains a `.metadata.json`
file from another tool, an older format, or a partial/corrupted write,
`_create_backup_from_metadata` does an unguarded
`metadata_content["backup_metadata"]` access and raises
`KeyError: 'backup_metadata'`. `@handle_b2_errors` only catches `B2Error`,
so the `KeyError` propagates as an "Unexpected error" and breaks the
entire backups page (as well as manual backup runs as a knock-on effect).

This change validates the metadata schema inside `_parse_metadata`,
requiring `metadata_version`, `backup_id`, and `backup_metadata` keys. The
two callers (`_process_metadata_file_sync` and
`_process_metadata_file_for_id_sync`) already had `except` handlers that
silently returned `None` on parse failure; those handlers now log a
warning naming the offending file and skip it, so the listing succeeds
for the real backups and the user can see what got skipped.

The repro from the linked issue (a foreign `.metadata.json` alongside a
real backup) is covered by a new end-to-end test that asserts the real
backup is listed, no agent error is raised, and the warning is logged.

The reporter [confirmed](https://github.com/home-assistant/core/issues/171469#issuecomment-4499485400)
that the foreign `.metadata.json` files in their bucket were left
behind by the "S3 Compatible" backup add-on — a realistic scenario
that will affect anyone migrating between bucket-based backup
integrations on the same bucket.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #171469
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

