### PR TITLE
Use `is`/`is not` for same-enum identity comparisons (source)

### DIFF
--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -134,7 +134,7 @@ class AuthManagerFlowManager(
         """
         flow = cast(LoginFlow, flow)
 
-        if result["type"] != FlowResultType.CREATE_ENTRY:
+        if result["type"] is not FlowResultType.CREATE_ENTRY:
             return result
 
         # we got final result

--- a/homeassistant/components/anthropic/config_flow.py
+++ b/homeassistant/components/anthropic/config_flow.py
@@ -226,7 +226,7 @@ class ConversationSubentryFlowHandler(ConfigSubentryFlow):
     ) -> SubentryFlowResult:
         """Set initial options."""
         # abort if entry is not loaded
-        if self._get_entry().state != ConfigEntryState.LOADED:
+        if self._get_entry().state is not ConfigEntryState.LOADED:
             return self.async_abort(reason="entry_not_loaded")
 
         hass_apis: list[SelectOptionDict] = [

--- a/homeassistant/components/aosmith/water_heater.py
+++ b/homeassistant/components/aosmith/water_heater.py
@@ -89,7 +89,7 @@ class AOSmithWaterHeaterEntity(AOSmithStatusEntity, WaterHeaterEntity):
     def supported_features(self) -> WaterHeaterEntityFeature:
         """Return the list of supported features."""
         supports_vacation_mode = any(
-            supported_mode.mode == AOSmithOperationMode.VACATION
+            supported_mode.mode is AOSmithOperationMode.VACATION
             for supported_mode in self.device.supported_modes
         )
 
@@ -122,7 +122,7 @@ class AOSmithWaterHeaterEntity(AOSmithStatusEntity, WaterHeaterEntity):
     @property
     def is_away_mode_on(self) -> bool:
         """Return True if away mode is on."""
-        return self.device.status.current_mode == AOSmithOperationMode.VACATION
+        return self.device.status.current_mode is AOSmithOperationMode.VACATION
 
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         """Set new target operation mode."""

--- a/homeassistant/components/apple_tv/__init__.py
+++ b/homeassistant/components/apple_tv/__init__.py
@@ -369,7 +369,7 @@ class AppleTVManager(DeviceListener):
 
             attrs[ATTR_MODEL] = (
                 dev_info.raw_model
-                if dev_info.model == DeviceModel.Unknown and dev_info.raw_model
+                if dev_info.model is DeviceModel.Unknown and dev_info.raw_model
                 else model_str(dev_info.model)
             )
             attrs[ATTR_SW_VERSION] = dev_info.version

--- a/homeassistant/components/apple_tv/binary_sensor.py
+++ b/homeassistant/components/apple_tv/binary_sensor.py
@@ -63,7 +63,7 @@ class AppleTVKeyboardFocused(AppleTVEntity, BinarySensorEntity, KeyboardListener
         # Listen to keyboard updates
         atv.keyboard.listener = self
         # Set initial state based on current focus state
-        self._update_state(atv.keyboard.text_focus_state == KeyboardFocusState.Focused)
+        self._update_state(atv.keyboard.text_focus_state is KeyboardFocusState.Focused)
 
     @callback
     def async_device_disconnected(self) -> None:
@@ -78,7 +78,7 @@ class AppleTVKeyboardFocused(AppleTVEntity, BinarySensorEntity, KeyboardListener
 
         This is a callback function from pyatv.interface.KeyboardListener.
         """
-        self._update_state(new_state == KeyboardFocusState.Focused)
+        self._update_state(new_state is KeyboardFocusState.Focused)
 
     def _update_state(self, new_state: bool) -> None:
         """Update and report."""

--- a/homeassistant/components/apple_tv/config_flow.py
+++ b/homeassistant/components/apple_tv/config_flow.py
@@ -354,7 +354,7 @@ class AppleTVConfigFlow(ConfigFlow, domain=DOMAIN):
             "name": self.atv.name,
             "type": (
                 dev_info.raw_model
-                if dev_info.model == DeviceModel.Unknown and dev_info.raw_model
+                if dev_info.model is DeviceModel.Unknown and dev_info.raw_model
                 else model_str(dev_info.model)
             ),
         }
@@ -441,7 +441,7 @@ class AppleTVConfigFlow(ConfigFlow, domain=DOMAIN):
             return await self.async_step_password()
 
         # Figure out, depending on protocol, what kind of pairing is needed
-        if service.pairing == PairingRequirement.Unsupported:
+        if service.pairing is PairingRequirement.Unsupported:
             _LOGGER.debug("%s does not support pairing", self.protocol)
             return await self.async_pair_next_protocol()
         if service.pairing == PairingRequirement.Disabled:
@@ -457,7 +457,7 @@ class AppleTVConfigFlow(ConfigFlow, domain=DOMAIN):
         pair_args: dict[str, Any] = {}
         if self.protocol in {Protocol.AirPlay, Protocol.Companion, Protocol.DMAP}:
             pair_args["name"] = "Home Assistant"
-        if self.protocol == Protocol.DMAP:
+        if self.protocol is Protocol.DMAP:
             pair_args["zeroconf"] = await zeroconf.async_get_instance(self.hass)
 
         # Initiate the pairing process

--- a/homeassistant/components/apple_tv/config_flow.py
+++ b/homeassistant/components/apple_tv/config_flow.py
@@ -444,9 +444,9 @@ class AppleTVConfigFlow(ConfigFlow, domain=DOMAIN):
         if service.pairing is PairingRequirement.Unsupported:
             _LOGGER.debug("%s does not support pairing", self.protocol)
             return await self.async_pair_next_protocol()
-        if service.pairing == PairingRequirement.Disabled:
+        if service.pairing is PairingRequirement.Disabled:
             return await self.async_step_protocol_disabled()
-        if service.pairing == PairingRequirement.NotNeeded:
+        if service.pairing is PairingRequirement.NotNeeded:
             _LOGGER.debug("%s does not require pairing", self.protocol)
             self.credentials[self.protocol.value] = None
             return await self.async_pair_next_protocol()

--- a/homeassistant/components/apple_tv/media_player.py
+++ b/homeassistant/components/apple_tv/media_player.py
@@ -139,7 +139,7 @@ class AppleTvMediaPlayer(
         all_features = atv.features.all_features()
         for feature_name, support_flag in SUPPORT_FEATURE_MAPPING.items():
             feature_info = all_features.get(feature_name)
-            if feature_info and feature_info.state != FeatureState.Unsupported:
+            if feature_info and feature_info.state is not FeatureState.Unsupported:
                 self._attr_supported_features |= support_flag
 
         # No need to schedule state update here as that will happen when the first
@@ -188,14 +188,14 @@ class AppleTvMediaPlayer(
             return MediaPlayerState.OFF
         if (
             self._is_feature_available(FeatureName.PowerState)
-            and self.atv.power.power_state == PowerState.Off
+            and self.atv.power.power_state is PowerState.Off
         ):
             return MediaPlayerState.OFF
         if self._playing:
             state = self._playing.device_state
             if state in (DeviceState.Idle, DeviceState.Loading):
                 return MediaPlayerState.IDLE
-            if state == DeviceState.Playing:
+            if state is DeviceState.Playing:
                 return MediaPlayerState.PLAYING
             if state in (DeviceState.Paused, DeviceState.Seeking, DeviceState.Stopped):
                 return MediaPlayerState.PAUSED
@@ -446,7 +446,7 @@ class AppleTvMediaPlayer(
     def shuffle(self) -> bool | None:
         """Boolean if shuffle is enabled."""
         if self._playing and self._is_feature_available(FeatureName.Shuffle):
-            return self._playing.shuffle != ShuffleState.Off
+            return self._playing.shuffle is not ShuffleState.Off
         return None
 
     def _is_feature_available(self, feature: FeatureName) -> bool:
@@ -506,7 +506,7 @@ class AppleTvMediaPlayer(
             and (self._is_feature_available(FeatureName.TurnOff))
             and (
                 not self._is_feature_available(FeatureName.PowerState)
-                or self.atv.power.power_state == PowerState.On
+                or self.atv.power.power_state is PowerState.On
             )
         ):
             await self.atv.power.turn_off()

--- a/homeassistant/components/apple_tv/services.py
+++ b/homeassistant/components/apple_tv/services.py
@@ -59,7 +59,7 @@ def _check_keyboard_focus(atv: AppleTVInterface) -> None:
             translation_domain=DOMAIN,
             translation_key="keyboard_not_available",
         ) from err
-    if focus_state != KeyboardFocusState.Focused:
+    if focus_state is not KeyboardFocusState.Focused:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="keyboard_not_focused",

--- a/homeassistant/components/arcam_fmj/media_player.py
+++ b/homeassistant/components/arcam_fmj/media_player.py
@@ -265,7 +265,7 @@ class ArcamFmj(ArcamFmjEntity, MediaPlayerEntity):
         source = self._state.get_source()
         if source is SourceCodes.DAB:
             value = self._state.get_dab_station()
-        elif source == SourceCodes.FM:
+        elif source is SourceCodes.FM:
             value = self._state.get_rds_information()
         else:
             value = None

--- a/homeassistant/components/arcam_fmj/media_player.py
+++ b/homeassistant/components/arcam_fmj/media_player.py
@@ -263,7 +263,7 @@ class ArcamFmj(ArcamFmjEntity, MediaPlayerEntity):
     def media_channel(self) -> str | None:
         """Channel currently playing."""
         source = self._state.get_source()
-        if source == SourceCodes.DAB:
+        if source is SourceCodes.DAB:
             value = self._state.get_dab_station()
         elif source == SourceCodes.FM:
             value = self._state.get_rds_information()
@@ -274,7 +274,7 @@ class ArcamFmj(ArcamFmjEntity, MediaPlayerEntity):
     @property
     def media_artist(self) -> str | None:
         """Artist of current playing media, music track only."""
-        if self._state.get_source() == SourceCodes.DAB:
+        if self._state.get_source() is SourceCodes.DAB:
             value = self._state.get_dls_pdt()
         else:
             value = None

--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -1355,7 +1355,7 @@ class PipelineRun:
     ) -> bool:
         """Return true if all targeted entities were in the same area as the device."""
         if (
-            intent_response.response_type != intent.IntentResponseType.ACTION_DONE
+            intent_response.response_type is not intent.IntentResponseType.ACTION_DONE
             or not intent_response.matched_states
         ):
             return False

--- a/homeassistant/components/auth/login_flow.py
+++ b/homeassistant/components/auth/login_flow.py
@@ -256,7 +256,7 @@ def _prepare_result_json(result: AuthFlowResult) -> dict[str, Any]:
             key: val for key, val in result.items() if key not in ("result", "data")
         }
 
-    if result["type"] != data_entry_flow.FlowResultType.FORM:
+    if result["type"] is not data_entry_flow.FlowResultType.FORM:
         return result  # type: ignore[return-value]
 
     data = dict(result)
@@ -293,7 +293,7 @@ class LoginFlowBaseView(HomeAssistantView):
             # @log_invalid_auth does not work here since it returns HTTP 200.
             # We need to manually log failed login attempts.
             if (
-                result["type"] == data_entry_flow.FlowResultType.FORM
+                result["type"] is data_entry_flow.FlowResultType.FORM
                 and (errors := result.get("errors"))
                 and errors.get("base")
                 in (

--- a/homeassistant/components/auth/login_flow.py
+++ b/homeassistant/components/auth/login_flow.py
@@ -251,7 +251,7 @@ class AuthProvidersView(HomeAssistantView):
 
 def _prepare_result_json(result: AuthFlowResult) -> dict[str, Any]:
     """Convert result to JSON serializable dict."""
-    if result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY:
+    if result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY:
         return {
             key: val for key, val in result.items() if key not in ("result", "data")
         }
@@ -289,7 +289,7 @@ class LoginFlowBaseView(HomeAssistantView):
         result: AuthFlowResult,
     ) -> web.Response:
         """Convert the flow result to a response."""
-        if result["type"] != data_entry_flow.FlowResultType.CREATE_ENTRY:
+        if result["type"] is not data_entry_flow.FlowResultType.CREATE_ENTRY:
             # @log_invalid_auth does not work here since it returns HTTP 200.
             # We need to manually log failed login attempts.
             if (

--- a/homeassistant/components/auth/mfa_setup_flow.py
+++ b/homeassistant/components/auth/mfa_setup_flow.py
@@ -142,7 +142,7 @@ def websocket_depose_mfa(
 
 def _prepare_result_json(result: data_entry_flow.FlowResult) -> dict[str, Any]:
     """Convert result to JSON serializable dict."""
-    if result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY:
+    if result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY:
         return dict(result)
     if result["type"] != data_entry_flow.FlowResultType.FORM:
         return result  # type: ignore[return-value]

--- a/homeassistant/components/auth/mfa_setup_flow.py
+++ b/homeassistant/components/auth/mfa_setup_flow.py
@@ -144,7 +144,7 @@ def _prepare_result_json(result: data_entry_flow.FlowResult) -> dict[str, Any]:
     """Convert result to JSON serializable dict."""
     if result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY:
         return dict(result)
-    if result["type"] != data_entry_flow.FlowResultType.FORM:
+    if result["type"] is not data_entry_flow.FlowResultType.FORM:
         return result  # type: ignore[return-value]
 
     data = dict(result)

--- a/homeassistant/components/bluetooth/websocket_api.py
+++ b/homeassistant/components/bluetooth/websocket_api.py
@@ -273,7 +273,7 @@ async def ws_subscribe_scanner_details(
 
     def _async_registration_changed(registration: HaScannerRegistration) -> None:
         added_event = HaScannerRegistrationEvent.ADDED
-        event_type = "add" if registration.event == added_event else "remove"
+        event_type = "add" if registration.event is added_event else "remove"
         _async_event_message({event_type: [registration.scanner.details]})
 
     manager = _get_manager(hass)

--- a/homeassistant/components/bthome/__init__.py
+++ b/homeassistant/components/bthome/__init__.py
@@ -158,7 +158,10 @@ def process_service_info(
             )
 
     # If payload is encrypted and the bindkey is not verified then we need to reauth
-    if data.encryption_scheme != EncryptionScheme.NONE and not data.bindkey_verified:
+    if (
+        data.encryption_scheme is not EncryptionScheme.NONE
+        and not data.bindkey_verified
+    ):
         entry.async_start_reauth(hass, data={"device": data})
 
     return update

--- a/homeassistant/components/bthome/config_flow.py
+++ b/homeassistant/components/bthome/config_flow.py
@@ -59,7 +59,7 @@ class BTHomeConfigFlow(ConfigFlow, domain=DOMAIN):
         self._discovery_info = discovery_info
         self._discovered_device = device
 
-        if device.encryption_scheme == EncryptionScheme.BTHOME_BINDKEY:
+        if device.encryption_scheme is EncryptionScheme.BTHOME_BINDKEY:
             return await self.async_step_get_encryption_key()
         return await self.async_step_bluetooth_confirm()
 
@@ -125,7 +125,7 @@ class BTHomeConfigFlow(ConfigFlow, domain=DOMAIN):
             self._discovery_info = discovery.discovery_info
             self._discovered_device = discovery.device
 
-            if discovery.device.encryption_scheme == EncryptionScheme.BTHOME_BINDKEY:
+            if discovery.device.encryption_scheme is EncryptionScheme.BTHOME_BINDKEY:
                 return await self.async_step_get_encryption_key()
 
             return self._async_get_or_create_entry()
@@ -164,7 +164,7 @@ class BTHomeConfigFlow(ConfigFlow, domain=DOMAIN):
 
         self._discovery_info = device.last_service_info
 
-        if device.encryption_scheme == EncryptionScheme.BTHOME_BINDKEY:
+        if device.encryption_scheme is EncryptionScheme.BTHOME_BINDKEY:
             return await self.async_step_get_encryption_key()
 
         # Otherwise there wasn't actually encryption so abort

--- a/homeassistant/components/comelit/alarm_control_panel.py
+++ b/homeassistant/components/comelit/alarm_control_panel.py
@@ -110,7 +110,7 @@ class ComelitAlarmEntity(
     @property
     def available(self) -> bool:
         """Return True if alarm is available."""
-        if self._area.human_status == AlarmAreaState.UNKNOWN:
+        if self._area.human_status is AlarmAreaState.UNKNOWN:
             return False
         return super().available
 
@@ -124,7 +124,7 @@ class ComelitAlarmEntity(
             self._area.human_status,
             self._area.armed,
         )
-        if self._area.human_status == AlarmAreaState.ARMED:
+        if self._area.human_status is AlarmAreaState.ARMED:
             if self._area.armed == ALARM_AREA_ARMED_STATUS[AWAY]:
                 return AlarmControlPanelState.ARMED_AWAY
             if self._area.armed == ALARM_AREA_ARMED_STATUS[NIGHT]:

--- a/homeassistant/components/comelit/binary_sensor.py
+++ b/homeassistant/components/comelit/binary_sensor.py
@@ -43,7 +43,7 @@ BINARY_SENSOR_TYPES: Final[tuple[ComelitBinarySensorEntityDescription, ...]] = (
         device_class=BinarySensorDeviceClass.PROBLEM,
         is_on_fn=lambda obj: cast(ComelitVedoAreaObject, obj).anomaly,
         available_fn=lambda obj: (
-            cast(ComelitVedoAreaObject, obj).human_status != AlarmAreaState.UNKNOWN
+            cast(ComelitVedoAreaObject, obj).human_status is not AlarmAreaState.UNKNOWN
         ),
     ),
     ComelitBinarySensorEntityDescription(
@@ -67,7 +67,7 @@ BINARY_SENSOR_TYPES: Final[tuple[ComelitBinarySensorEntityDescription, ...]] = (
         object_type=ALARM_ZONE,
         device_class=BinarySensorDeviceClass.PROBLEM,
         is_on_fn=lambda obj: (
-            cast(ComelitVedoZoneObject, obj).human_status == AlarmZoneState.FAULTY
+            cast(ComelitVedoZoneObject, obj).human_status is AlarmZoneState.FAULTY
         ),
         available_fn=lambda obj: (
             cast(ComelitVedoZoneObject, obj).human_status

--- a/homeassistant/components/comelit/sensor.py
+++ b/homeassistant/components/comelit/sensor.py
@@ -166,12 +166,12 @@ class ComelitVedoSensorEntity(
     @property
     def available(self) -> bool:
         """Sensor availability."""
-        return self._zone_object.human_status != AlarmZoneState.UNAVAILABLE
+        return self._zone_object.human_status is not AlarmZoneState.UNAVAILABLE
 
     @property
     def native_value(self) -> StateType:
         """Sensor value."""
-        if (status := self._zone_object.human_status) == AlarmZoneState.UNKNOWN:
+        if (status := self._zone_object.human_status) is AlarmZoneState.UNKNOWN:
             return None
 
         return cast(str, status.value)

--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -148,7 +148,7 @@ def _prepare_config_flow_result_json(
     prepare_result_json: Callable[[data_entry_flow.FlowResult], dict[str, Any]],
 ) -> dict[str, Any]:
     """Convert result to JSON."""
-    if result["type"] != data_entry_flow.FlowResultType.CREATE_ENTRY:
+    if result["type"] is not data_entry_flow.FlowResultType.CREATE_ENTRY:
         return prepare_result_json(result)
 
     data = {key: val for key, val in result.items() if key not in ("data", "context")}

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -1582,26 +1582,26 @@ def _get_match_error_response(
 
         return ErrorKey.DUPLICATE_ENTITIES, {"entity": result.no_match_name}
 
-    if reason == intent.MatchFailedReason.INVALID_AREA:
+    if reason is intent.MatchFailedReason.INVALID_AREA:
         # Invalid area name
         return ErrorKey.NO_AREA, {"area": result.no_match_name}
 
-    if reason == intent.MatchFailedReason.INVALID_FLOOR:
+    if reason is intent.MatchFailedReason.INVALID_FLOOR:
         # Invalid floor name
         return ErrorKey.NO_FLOOR, {"floor": result.no_match_name}
 
-    if reason == intent.MatchFailedReason.FEATURE:
+    if reason is intent.MatchFailedReason.FEATURE:
         # Feature not supported by entity
         return ErrorKey.FEATURE_NOT_SUPPORTED, {}
 
-    if reason == intent.MatchFailedReason.STATE:
+    if reason is intent.MatchFailedReason.STATE:
         # Entity is not in correct state
         assert constraints.states
         state = next(iter(constraints.states))
 
         return ErrorKey.ENTITY_WRONG_STATE, {"state": state}
 
-    if reason == intent.MatchFailedReason.ASSISTANT:
+    if reason is intent.MatchFailedReason.ASSISTANT:
         # Not exposed
         if constraints.name:
             if constraints.area_name:

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -1447,7 +1447,7 @@ class DefaultAgent(ConversationEntity):
 
         response = await self._async_process_intent_result(result, user_input, chat_log)
         if (
-            response.response_type is intent.IntentResponseType.ERROR
+            response.response_type == intent.IntentResponseType.ERROR
             and response.error_code
             not in (
                 intent.IntentResponseErrorCode.FAILED_TO_HANDLE,

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -646,7 +646,7 @@ class DefaultAgent(ConversationEntity):
         cache_value = self._intent_cache.get(cache_key)
         if cache_value is not None:
             if (cache_value.result is not None) and (
-                cache_value.stage == IntentMatchingStage.EXPOSED_ENTITIES_ONLY
+                cache_value.stage is IntentMatchingStage.EXPOSED_ENTITIES_ONLY
             ):
                 _LOGGER.debug("Got cached result for exposed entities")
                 return cache_value.result
@@ -686,7 +686,7 @@ class DefaultAgent(ConversationEntity):
         skip_unexposed_entities_match = False
         if cache_value is not None:
             if (cache_value.result is not None) and (
-                cache_value.stage == IntentMatchingStage.UNEXPOSED_ENTITIES
+                cache_value.stage is IntentMatchingStage.UNEXPOSED_ENTITIES
             ):
                 _LOGGER.debug("Got cached result for all entities")
                 return cache_value.result
@@ -731,7 +731,7 @@ class DefaultAgent(ConversationEntity):
         skip_unknown_names = False
         if cache_value is not None:
             if (cache_value.result is not None) and (
-                cache_value.stage == IntentMatchingStage.UNKNOWN_NAMES
+                cache_value.stage is IntentMatchingStage.UNKNOWN_NAMES
             ):
                 _LOGGER.debug("Got cached result for unknown names")
                 return cache_value.result
@@ -1447,7 +1447,7 @@ class DefaultAgent(ConversationEntity):
 
         response = await self._async_process_intent_result(result, user_input, chat_log)
         if (
-            response.response_type == intent.IntentResponseType.ERROR
+            response.response_type is intent.IntentResponseType.ERROR
             and response.error_code
             not in (
                 intent.IntentResponseErrorCode.FAILED_TO_HANDLE,
@@ -1546,7 +1546,7 @@ def _get_match_error_response(
         # device_class only
         return ErrorKey.NO_DEVICE_CLASS, {"device_class": device_class}
 
-    if (reason == intent.MatchFailedReason.DOMAIN) and constraints.domains:
+    if (reason is intent.MatchFailedReason.DOMAIN) and constraints.domains:
         domain = next(iter(constraints.domains))  # first domain
         if constraints.area_name:
             # domain in area
@@ -1565,7 +1565,7 @@ def _get_match_error_response(
         # domain only
         return ErrorKey.NO_DOMAIN, {"domain": domain}
 
-    if reason == intent.MatchFailedReason.DUPLICATE_NAME:
+    if reason is intent.MatchFailedReason.DUPLICATE_NAME:
         if constraints.floor_name:
             # duplicate on floor
             return ErrorKey.DUPLICATE_ENTITIES_IN_FLOOR, {

--- a/homeassistant/components/device_automation/helpers.py
+++ b/homeassistant/components/device_automation/helpers.py
@@ -80,7 +80,7 @@ async def async_validate_device_automation_config(
     # the checks below which look for a config entry matching the device automation
     # domain
     if (
-        automation_type == DeviceAutomationType.ACTION
+        automation_type is DeviceAutomationType.ACTION
         and validated_config[CONF_DOMAIN] in ENTITY_PLATFORMS
     ):
         # Pass the unvalidated config to avoid mutating the raw config twice

--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -281,7 +281,7 @@ class DlnaDmrEntity(MediaPlayerEntity):
                 await self._device_disconnect()
         self._bootid = bootid
 
-        if change == ssdp.SsdpChange.BYEBYE:
+        if change is ssdp.SsdpChange.BYEBYE:
             # Device is going away
             if self._device:
                 # Disconnect from gone device
@@ -290,7 +290,7 @@ class DlnaDmrEntity(MediaPlayerEntity):
             self._ssdp_connect_failed = False
 
         if (
-            change == ssdp.SsdpChange.ALIVE
+            change is ssdp.SsdpChange.ALIVE
             and not self._device
             and not self._ssdp_connect_failed
         ):
@@ -785,7 +785,7 @@ class DlnaDmrEntity(MediaPlayerEntity):
         if play_mode is PlayMode.VENDOR_DEFINED:
             return None
 
-        if play_mode == PlayMode.REPEAT_ONE:
+        if play_mode is PlayMode.REPEAT_ONE:
             return RepeatMode.ONE
 
         if play_mode in (PlayMode.REPEAT_ALL, PlayMode.RANDOM):

--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -261,7 +261,7 @@ class DlnaDmrEntity(MediaPlayerEntity):
         except KeyError, ValueError:
             bootid = None
 
-        if change == ssdp.SsdpChange.UPDATE:
+        if change is ssdp.SsdpChange.UPDATE:
             # This is an announcement that bootid is about to change
             if self._bootid is not None and self._bootid == bootid:
                 # Store the new value (because our old value matches) so that we
@@ -718,7 +718,7 @@ class DlnaDmrEntity(MediaPlayerEntity):
 
         # If already playing, or don't want to autoplay, no need to call Play
         autoplay = extra.get("autoplay", True)
-        if self._device.transport_state == TransportState.PLAYING or not autoplay:
+        if self._device.transport_state is TransportState.PLAYING or not autoplay:
             return
 
         # Play it
@@ -748,7 +748,7 @@ class DlnaDmrEntity(MediaPlayerEntity):
         if not (play_mode := self._device.play_mode):
             return None
 
-        if play_mode == PlayMode.VENDOR_DEFINED:
+        if play_mode is PlayMode.VENDOR_DEFINED:
             return None
 
         return play_mode in (PlayMode.SHUFFLE, PlayMode.RANDOM)
@@ -782,7 +782,7 @@ class DlnaDmrEntity(MediaPlayerEntity):
         if not (play_mode := self._device.play_mode):
             return None
 
-        if play_mode == PlayMode.VENDOR_DEFINED:
+        if play_mode is PlayMode.VENDOR_DEFINED:
             return None
 
         if play_mode == PlayMode.REPEAT_ONE:

--- a/homeassistant/components/dlna_dms/dms.py
+++ b/homeassistant/components/dlna_dms/dms.py
@@ -258,7 +258,7 @@ class DmsDeviceSource:
                 await self.device_disconnect()
         self._bootid = bootid
 
-        if change == ssdp.SsdpChange.BYEBYE:
+        if change is ssdp.SsdpChange.BYEBYE:
             # Device is going away
             if self._device:
                 # Disconnect from gone device
@@ -267,7 +267,7 @@ class DmsDeviceSource:
             self._ssdp_connect_failed = False
 
         if (
-            change == ssdp.SsdpChange.ALIVE
+            change is ssdp.SsdpChange.ALIVE
             and not self._device
             and not self._ssdp_connect_failed
         ):

--- a/homeassistant/components/dlna_dms/dms.py
+++ b/homeassistant/components/dlna_dms/dms.py
@@ -236,7 +236,7 @@ class DmsDeviceSource:
         except KeyError, ValueError:
             bootid = None
 
-        if change == ssdp.SsdpChange.UPDATE:
+        if change is ssdp.SsdpChange.UPDATE:
             # This is an announcement that bootid is about to change
             if self._bootid is not None and self._bootid == bootid:
                 # Store the new value (because our old value matches) so that we

--- a/homeassistant/components/elevenlabs/stt.py
+++ b/homeassistant/components/elevenlabs/stt.py
@@ -150,9 +150,9 @@ class ElevenLabsSTTEntity(SpeechToTextEntity):
 
         raw_pcm_compatible = (
             metadata.codec == AudioCodecs.PCM
-            and metadata.sample_rate == AudioSampleRates.SAMPLERATE_16000
-            and metadata.channel == AudioChannels.CHANNEL_MONO
-            and metadata.bit_rate == AudioBitRates.BITRATE_16
+            and metadata.sample_rate is AudioSampleRates.SAMPLERATE_16000
+            and metadata.channel is AudioChannels.CHANNEL_MONO
+            and metadata.bit_rate is AudioBitRates.BITRATE_16
         )
         if raw_pcm_compatible:
             file_format = "pcm_s16le_16"

--- a/homeassistant/components/elkm1/binary_sensor.py
+++ b/homeassistant/components/elkm1/binary_sensor.py
@@ -50,5 +50,5 @@ class ElkBinarySensor(ElkAttachedEntity, BinarySensorEntity):
     def _element_changed(self, element: Element, changeset: dict[str, Any]) -> None:
         # Zone in NORMAL state is OFF; any other state is ON
         self._attr_is_on = bool(
-            self._element.logical_status != ZoneLogicalStatus.NORMAL
+            self._element.logical_status is not ZoneLogicalStatus.NORMAL
         )

--- a/homeassistant/components/elkm1/climate.py
+++ b/homeassistant/components/elkm1/climate.py
@@ -104,7 +104,7 @@ class ElkThermostat(ElkEntity, ClimateEntity):
             ThermostatMode.EMERGENCY_HEAT,
         ):
             return self._element.heat_setpoint
-        if self._element.mode == ThermostatMode.COOL:
+        if self._element.mode is ThermostatMode.COOL:
             return self._element.cool_setpoint
         return None
 
@@ -162,6 +162,6 @@ class ElkThermostat(ElkEntity, ClimateEntity):
             self._attr_hvac_mode = ELK_TO_HASS_HVAC_MODES[self._element.mode]
             if (
                 self._attr_hvac_mode == HVACMode.OFF
-                and self._element.fan == ThermostatFan.ON
+                and self._element.fan is ThermostatFan.ON
             ):
                 self._attr_hvac_mode = HVACMode.FAN_ONLY

--- a/homeassistant/components/elkm1/number.py
+++ b/homeassistant/components/elkm1/number.py
@@ -56,7 +56,7 @@ class ElkNumberSetting(ElkAttachedEntity, NumberEntity):
     def __init__(self, element: Setting, elk: Any, elk_data: ELKM1Data) -> None:
         """Initialize the number setting."""
         super().__init__(element, elk, elk_data)
-        if element.value_format == SettingFormat.TIMER:
+        if element.value_format is SettingFormat.TIMER:
             self._attr_device_class = NumberDeviceClass.DURATION
             self._attr_native_unit_of_measurement = UnitOfTime.SECONDS
 

--- a/homeassistant/components/elkm1/sensor.py
+++ b/homeassistant/components/elkm1/sensor.py
@@ -75,7 +75,7 @@ async def async_setup_entry(
     for setting in elk.settings:
         setting = cast(Setting, setting)
         domain = (
-            "time" if setting.value_format == SettingFormat.TIME_OF_DAY else "number"
+            "time" if setting.value_format is SettingFormat.TIME_OF_DAY else "number"
         )
 
         orig_unique_id = generate_unique_id(elk_data.prefix, setting)
@@ -288,7 +288,7 @@ class ElkZone(ElkSensor):
     @property
     def temperature_unit(self) -> str | None:
         """Return the temperature unit."""
-        if self._element.definition == ZoneType.TEMPERATURE:
+        if self._element.definition is ZoneType.TEMPERATURE:
             return self._temperature_unit
         return None
 
@@ -305,14 +305,14 @@ class ElkZone(ElkSensor):
     @property
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit of measurement."""
-        if self._element.definition == ZoneType.TEMPERATURE:
+        if self._element.definition is ZoneType.TEMPERATURE:
             return self._temperature_unit
         if self._element.definition == ZoneType.ANALOG_ZONE:
             return UnitOfElectricPotential.VOLT
         return None
 
     def _element_changed(self, element: Element, changeset: dict[str, Any]) -> None:
-        if self._element.definition == ZoneType.TEMPERATURE:
+        if self._element.definition is ZoneType.TEMPERATURE:
             self._attr_native_value = temperature_to_state(
                 self._element.temperature, UNDEFINED_TEMPERATURE
             )

--- a/homeassistant/components/elkm1/sensor.py
+++ b/homeassistant/components/elkm1/sensor.py
@@ -307,7 +307,7 @@ class ElkZone(ElkSensor):
         """Return the unit of measurement."""
         if self._element.definition is ZoneType.TEMPERATURE:
             return self._temperature_unit
-        if self._element.definition == ZoneType.ANALOG_ZONE:
+        if self._element.definition is ZoneType.ANALOG_ZONE:
             return UnitOfElectricPotential.VOLT
         return None
 
@@ -316,7 +316,7 @@ class ElkZone(ElkSensor):
             self._attr_native_value = temperature_to_state(
                 self._element.temperature, UNDEFINED_TEMPERATURE
             )
-        elif self._element.definition == ZoneType.ANALOG_ZONE:
+        elif self._element.definition is ZoneType.ANALOG_ZONE:
             self._attr_native_value = f"{self._element.voltage}"
         else:
             self._attr_native_value = pretty_const(self._element.logical_status.name)

--- a/homeassistant/components/elkm1/switch.py
+++ b/homeassistant/components/elkm1/switch.py
@@ -66,7 +66,7 @@ class ElkThermostatEMHeat(ElkEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Get the current emergency heat status."""
-        return self._element.mode == ThermostatMode.EMERGENCY_HEAT
+        return self._element.mode is ThermostatMode.EMERGENCY_HEAT
 
     def _elk_set(self, mode: ThermostatMode) -> None:
         """Set the thermostat mode."""

--- a/homeassistant/components/elkm1/time.py
+++ b/homeassistant/components/elkm1/time.py
@@ -30,7 +30,7 @@ async def async_setup_entry(
     time_settings = [
         setting
         for setting in cast(list[Setting], elk.settings)
-        if setting.value_format == SettingFormat.TIME_OF_DAY
+        if setting.value_format is SettingFormat.TIME_OF_DAY
     ]
 
     create_elk_entities(

--- a/homeassistant/components/energyzero/services.py
+++ b/homeassistant/components/energyzero/services.py
@@ -96,7 +96,7 @@ def __get_coordinator(call: ServiceCall) -> EnergyZeroDataUpdateCoordinator:
                 "config_entry": entry_id,
             },
         )
-    if entry.state != ConfigEntryState.LOADED:
+    if entry.state is not ConfigEntryState.LOADED:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="unloaded_config_entry",
@@ -125,7 +125,7 @@ async def __get_prices(
 
     data: Electricity | Gas
 
-    if price_type == PriceType.GAS:
+    if price_type is PriceType.GAS:
         data = await coordinator.energyzero.get_gas_prices_legacy(
             start_date=start,
             end_date=end,

--- a/homeassistant/components/fastdotcom/__init__.py
+++ b/homeassistant/components/fastdotcom/__init__.py
@@ -24,7 +24,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: FastdotcomConfigEntry) -
 
     async def _async_finish_startup(hass: HomeAssistant) -> None:
         """Run this only when HA has finished its startup."""
-        if entry.state == ConfigEntryState.LOADED:
+        if entry.state is ConfigEntryState.LOADED:
             await coordinator.async_refresh()
         else:
             await coordinator.async_config_entry_first_refresh()

--- a/homeassistant/components/fish_audio/config_flow.py
+++ b/homeassistant/components/fish_audio/config_flow.py
@@ -284,7 +284,7 @@ class FishAudioSubentryFlowHandler(ConfigSubentryFlow):
     ) -> SubentryFlowResult:
         """Manage initial options."""
         entry = self._get_entry()
-        if entry.state != ConfigEntryState.LOADED:
+        if entry.state is not ConfigEntryState.LOADED:
             return self.async_abort(reason="entry_not_loaded")
 
         self.client = entry.runtime_data

--- a/homeassistant/components/flume/__init__.py
+++ b/homeassistant/components/flume/__init__.py
@@ -109,7 +109,7 @@ def setup_service(hass: HomeAssistant) -> None:
         entry: FlumeConfigEntry | None = hass.config_entries.async_get_entry(entry_id)
         if not entry:
             raise ValueError(f"Invalid config entry: {entry_id}")
-        if not entry.state == ConfigEntryState.LOADED:
+        if entry.state is not ConfigEntryState.LOADED:
             raise ValueError(f"Config entry not loaded: {entry_id}")
         return {
             "notifications": entry.runtime_data.notifications_coordinator.notifications  # type: ignore[dict-item]

--- a/homeassistant/components/flux_led/config_flow.py
+++ b/homeassistant/components/flux_led/config_flow.py
@@ -136,7 +136,7 @@ class FluxLedConfigFlow(ConfigFlow, domain=DOMAIN):
                     ConfigEntryState.SETUP_IN_PROGRESS,
                     ConfigEntryState.NOT_LOADED,
                 )
-            ) or entry.state == ConfigEntryState.SETUP_RETRY:
+            ) or entry.state is ConfigEntryState.SETUP_RETRY:
                 self.hass.config_entries.async_schedule_reload(entry.entry_id)
             else:
                 async_dispatcher_send(

--- a/homeassistant/components/flux_led/select.py
+++ b/homeassistant/components/flux_led/select.py
@@ -51,7 +51,7 @@ async def async_setup_entry(
     entry.data.get(CONF_NAME, entry.title)
     base_unique_id = entry.unique_id or entry.entry_id
 
-    if device.device_type == DeviceType.Switch:
+    if device.device_type is DeviceType.Switch:
         entities.append(FluxPowerStateSelect(coordinator.device, entry))
     if device.operating_modes:
         entities.append(

--- a/homeassistant/components/flux_led/switch.py
+++ b/homeassistant/components/flux_led/switch.py
@@ -32,7 +32,7 @@ async def async_setup_entry(
     entities: list[FluxSwitch | FluxRemoteAccessSwitch | FluxMusicSwitch] = []
     base_unique_id = entry.unique_id or entry.entry_id
 
-    if coordinator.device.device_type == DeviceType.Switch:
+    if coordinator.device.device_type is DeviceType.Switch:
         entities.append(FluxSwitch(coordinator, base_unique_id, None))
 
     if entry.data.get(CONF_REMOTE_ACCESS_HOST):

--- a/homeassistant/components/fronius/__init__.py
+++ b/homeassistant/components/fronius/__init__.py
@@ -212,7 +212,7 @@ class FroniusSolarNet:
                 inverter_info=_inverter_info,
                 config_entry=self.config_entry,
             )
-            if self.config_entry.state == ConfigEntryState.LOADED:
+            if self.config_entry.state is ConfigEntryState.LOADED:
                 await _coordinator.async_refresh()
             else:
                 await _coordinator.async_config_entry_first_refresh()
@@ -220,7 +220,7 @@ class FroniusSolarNet:
 
             # Only for re-scans. Initial setup adds entities
             # through sensor.async_setup_entry
-            if self.config_entry.state == ConfigEntryState.LOADED:
+            if self.config_entry.state is ConfigEntryState.LOADED:
                 async_dispatcher_send(self.hass, SOLAR_NET_DISCOVERY_NEW, _coordinator)
 
             _LOGGER.debug(
@@ -235,7 +235,7 @@ class FroniusSolarNet:
         try:
             _inverter_info = await self.fronius.inverter_info()
         except FroniusError as err:
-            if self.config_entry.state == ConfigEntryState.LOADED:
+            if self.config_entry.state is ConfigEntryState.LOADED:
                 # During a re-scan we will attempt again as per schedule.
                 _LOGGER.debug("Re-scan failed for %s", self.host)
                 return inverter_infos

--- a/homeassistant/components/fully_kiosk/services.py
+++ b/homeassistant/components/fully_kiosk/services.py
@@ -42,7 +42,7 @@ async def _collect_coordinators(
             raise HomeAssistantError(f"Device '{target}' not found in device registry")
     coordinators = list[FullyKioskDataUpdateCoordinator]()
     for config_entry in config_entries:
-        if config_entry.state != ConfigEntryState.LOADED:
+        if config_entry.state is not ConfigEntryState.LOADED:
             raise HomeAssistantError(f"{config_entry.title} is not loaded")
         coordinators.append(config_entry.runtime_data)
     return coordinators

--- a/homeassistant/components/gardena_bluetooth/__init__.py
+++ b/homeassistant/components/gardena_bluetooth/__init__.py
@@ -75,7 +75,7 @@ async def async_setup_entry(
 
     mfg_data = await async_get_manufacturer_data({address})
     product_type = mfg_data[address].product_type
-    if product_type == ProductType.UNKNOWN:
+    if product_type is ProductType.UNKNOWN:
         raise ConfigEntryNotReady("Unable to find product type")
 
     client = Client(get_connection(hass, address), product_type)

--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -143,7 +143,7 @@ def _get_entity_descriptions(
         local_sync = True
         if (
             search := data.get(CONF_SEARCH)
-        ) or calendar_item.access_role == AccessRole.FREE_BUSY_READER:
+        ) or calendar_item.access_role is AccessRole.FREE_BUSY_READER:
             read_only = True
             local_sync = False
         entity_description = GoogleCalendarEntityDescription(
@@ -386,14 +386,14 @@ class GoogleCalendarEntity(
         """Return True if the event is visible and not declined."""
 
         if any(
-            attendee.is_self and attendee.response_status == ResponseStatus.DECLINED
+            attendee.is_self and attendee.response_status is ResponseStatus.DECLINED
             for attendee in event.attendees
         ):
             return False
         # Calendar enttiy may be limited to a specific event type
         if (
             self.entity_description.event_type is not None
-            and self.entity_description.event_type != event.event_type
+            and self.entity_description.event_type is not event.event_type
         ):
             return False
         # Default calendar entity omits the special types but includes all the others

--- a/homeassistant/components/google_air_quality/config_flow.py
+++ b/homeassistant/components/google_air_quality/config_flow.py
@@ -247,7 +247,7 @@ class LocationSubentryFlowHandler(ConfigSubentryFlow):
         user_input: dict[str, Any] | None = None,
     ) -> SubentryFlowResult:
         """Handle the location step."""
-        if self._get_entry().state != ConfigEntryState.LOADED:
+        if self._get_entry().state is not ConfigEntryState.LOADED:
             return self.async_abort(reason="entry_not_loaded")
 
         errors: dict[str, str] = {}

--- a/homeassistant/components/google_generative_ai_conversation/config_flow.py
+++ b/homeassistant/components/google_generative_ai_conversation/config_flow.py
@@ -225,7 +225,7 @@ class LLMSubentryFlowHandler(ConfigSubentryFlow):
     ) -> SubentryFlowResult:
         """Set conversation options."""
         # abort if entry is not loaded
-        if self._get_entry().state != ConfigEntryState.LOADED:
+        if self._get_entry().state is not ConfigEntryState.LOADED:
             return self.async_abort(reason="entry_not_loaded")
 
         errors: dict[str, str] = {}

--- a/homeassistant/components/google_generative_ai_conversation/entity.py
+++ b/homeassistant/components/google_generative_ai_conversation/entity.py
@@ -754,7 +754,7 @@ async def async_prepare_files_for_prompt(
                 config={"http_options": {"timeout": TIMEOUT_MILLIS}},
             )
 
-        if uploaded_file.state == FileState.FAILED:
+        if uploaded_file.state is FileState.FAILED:
             raise HomeAssistantError(
                 f"File `{uploaded_file.name}` processing"
                 " failed, reason:"
@@ -766,7 +766,7 @@ async def async_prepare_files_for_prompt(
     tasks = [
         asyncio.create_task(wait_for_file_processing(part))
         for part in prompt_parts
-        if part.state != FileState.ACTIVE
+        if part.state is not FileState.ACTIVE
     ]
     async with asyncio.timeout(TIMEOUT_MILLIS / 1000):
         await asyncio.gather(*tasks)

--- a/homeassistant/components/google_weather/config_flow.py
+++ b/homeassistant/components/google_weather/config_flow.py
@@ -237,7 +237,7 @@ class LocationSubentryFlowHandler(ConfigSubentryFlow):
         user_input: dict[str, Any] | None = None,
     ) -> SubentryFlowResult:
         """Handle the location step."""
-        if self._get_entry().state != ConfigEntryState.LOADED:
+        if self._get_entry().state is not ConfigEntryState.LOADED:
             return self.async_abort(reason="entry_not_loaded")
 
         errors: dict[str, str] = {}

--- a/homeassistant/components/growatt_server/services.py
+++ b/homeassistant/components/growatt_server/services.py
@@ -26,7 +26,7 @@ def _get_coordinators(
     coordinators: dict[str, GrowattCoordinator] = {}
 
     for entry in hass.config_entries.async_entries(DOMAIN):
-        if entry.state != ConfigEntryState.LOADED:
+        if entry.state is not ConfigEntryState.LOADED:
             continue
 
         for coord in entry.runtime_data.devices.values():

--- a/homeassistant/components/hassio/update.py
+++ b/homeassistant/components/hassio/update.py
@@ -247,7 +247,7 @@ class SupervisorOSUpdateEntity(HassioOSEntity, UpdateEntity):
     def release_url(self) -> str | None:
         """URL to the full release notes of the latest version available."""
         version = AwesomeVersion(self.latest_version)
-        if version.dev or version.strategy == AwesomeVersionStrategy.UNKNOWN:
+        if version.dev or version.strategy is AwesomeVersionStrategy.UNKNOWN:
             return "https://github.com/home-assistant/operating-system/commits/dev"
         return (
             f"https://github.com/home-assistant/operating-system/releases/tag/{version}"
@@ -304,7 +304,7 @@ class SupervisorSupervisorUpdateEntity(HassioSupervisorEntity, UpdateEntity):
     def release_url(self) -> str | None:
         """URL to the full release notes of the latest version available."""
         version = AwesomeVersion(self.latest_version)
-        if version.dev or version.strategy == AwesomeVersionStrategy.UNKNOWN:
+        if version.dev or version.strategy is AwesomeVersionStrategy.UNKNOWN:
             return "https://github.com/home-assistant/supervisor/commits/main"
         return f"https://github.com/home-assistant/supervisor/releases/tag/{version}"
 

--- a/homeassistant/components/heos/services.py
+++ b/homeassistant/components/heos/services.py
@@ -150,7 +150,7 @@ def _get_controller(hass: HomeAssistant) -> Heos:
         hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, DOMAIN)
     )
 
-    if not entry or not entry.state == ConfigEntryState.LOADED:
+    if not entry or entry.state is not ConfigEntryState.LOADED:
         raise HomeAssistantError(
             translation_domain=DOMAIN, translation_key="integration_not_loaded"
         )

--- a/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
+++ b/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
@@ -418,7 +418,7 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
         otbr_manager = get_otbr_addon_manager(self.hass)
         addon_info = await self._async_get_addon_info(otbr_manager)
 
-        if addon_info.state == AddonState.NOT_INSTALLED:
+        if addon_info.state is AddonState.NOT_INSTALLED:
             return await self.async_step_install_otbr_addon()
 
         if addon_info.state == AddonState.RUNNING:

--- a/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
+++ b/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
@@ -421,7 +421,7 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
         if addon_info.state is AddonState.NOT_INSTALLED:
             return await self.async_step_install_otbr_addon()
 
-        if addon_info.state == AddonState.RUNNING:
+        if addon_info.state is AddonState.RUNNING:
             await otbr_manager.async_stop_addon()
 
         return await self.async_step_start_otbr_addon()

--- a/homeassistant/components/homeassistant_hardware/silabs_multiprotocol_addon.py
+++ b/homeassistant/components/homeassistant_hardware/silabs_multiprotocol_addon.py
@@ -694,7 +694,7 @@ class OptionsFlowHandler(OptionsFlow, ABC):
         if addon_info.state is AddonState.NOT_INSTALLED:
             return await self.async_step_install_flasher_addon()
 
-        if addon_info.state == AddonState.NOT_RUNNING:
+        if addon_info.state is AddonState.NOT_RUNNING:
             return await self.async_step_configure_flasher_addon()
 
         # If the addon is already installed and running, fail

--- a/homeassistant/components/homeassistant_hardware/silabs_multiprotocol_addon.py
+++ b/homeassistant/components/homeassistant_hardware/silabs_multiprotocol_addon.py
@@ -111,7 +111,7 @@ class WaitingAddonManager(AddonManager):
             info = None
 
         # Do not try to uninstall an addon if it is already uninstalled
-        if info is not None and info.state == AddonState.NOT_INSTALLED:
+        if info is not None and info.state is AddonState.NOT_INSTALLED:
             return
 
         await self.async_uninstall_addon()
@@ -383,7 +383,7 @@ class OptionsFlowHandler(OptionsFlow, ABC):
         multipan_manager = await get_multiprotocol_addon_manager(self.hass)
         addon_info = await self._async_get_addon_info(multipan_manager)
 
-        if addon_info.state == AddonState.NOT_INSTALLED:
+        if addon_info.state is AddonState.NOT_INSTALLED:
             return await self.async_step_addon_not_installed()
         return await self.async_step_addon_installed()
 
@@ -691,7 +691,7 @@ class OptionsFlowHandler(OptionsFlow, ABC):
         flasher_manager = get_flasher_addon_manager(self.hass)
         addon_info = await self._async_get_addon_info(flasher_manager)
 
-        if addon_info.state == AddonState.NOT_INSTALLED:
+        if addon_info.state is AddonState.NOT_INSTALLED:
             return await self.async_step_install_flasher_addon()
 
         if addon_info.state == AddonState.NOT_RUNNING:
@@ -907,7 +907,7 @@ async def check_multi_pan_addon(hass: HomeAssistant) -> None:
     # Request the addon to start if it's not started
     # `async_start_addon` returns as soon as the start request has been sent
     # and does not wait for the addon to be started, so we raise below
-    if addon_info.state == AddonState.NOT_RUNNING:
+    if addon_info.state is AddonState.NOT_RUNNING:
         await multipan_manager.async_start_addon()
 
     if addon_info.state not in (AddonState.NOT_INSTALLED, AddonState.RUNNING):
@@ -927,7 +927,7 @@ async def multi_pan_addon_using_device(hass: HomeAssistant, device_path: str) ->
     multipan_manager = await get_multiprotocol_addon_manager(hass)
     addon_info: AddonInfo = await multipan_manager.async_get_addon_info()
 
-    if addon_info.state != AddonState.RUNNING:
+    if addon_info.state is not AddonState.RUNNING:
         return False
 
     if addon_info.options["device"] != device_path:

--- a/homeassistant/components/homeassistant_hardware/util.py
+++ b/homeassistant/components/homeassistant_hardware/util.py
@@ -124,7 +124,7 @@ class OwningAddon:
         except AddonError:
             return False
         else:
-            return addon_info.state == AddonState.RUNNING
+            return addon_info.state is AddonState.RUNNING
 
     @asynccontextmanager
     async def temporarily_stop(self, hass: HomeAssistant) -> AsyncGenerator[None]:
@@ -137,7 +137,7 @@ class OwningAddon:
             yield
             return
 
-        if addon_info.state != AddonState.RUNNING:
+        if addon_info.state is not AddonState.RUNNING:
             yield
             return
 
@@ -173,7 +173,7 @@ class OwningIntegration:
             yield
             return
 
-        if entry.state != ConfigEntryState.LOADED:
+        if entry.state is not ConfigEntryState.LOADED:
             yield
             return
 
@@ -213,7 +213,7 @@ async def get_otbr_addon_firmware_info(
     except AddonError:
         return None
 
-    if otbr_addon_info.state == AddonState.NOT_INSTALLED:
+    if otbr_addon_info.state is AddonState.NOT_INSTALLED:
         return None
 
     if (otbr_path := otbr_addon_info.options.get("device")) is None:
@@ -238,7 +238,7 @@ async def get_z2m_addon_firmware_info(
     except AddonError:
         return None
 
-    if z2m_addon_info.state == AddonState.NOT_INSTALLED:
+    if z2m_addon_info.state is AddonState.NOT_INSTALLED:
         return None
 
     serial = z2m_addon_info.options.get("serial")
@@ -286,7 +286,7 @@ async def guess_hardware_owners(
     except AddonError:
         pass
     else:
-        if multipan_addon_info.state != AddonState.NOT_INSTALLED:
+        if multipan_addon_info.state is not AddonState.NOT_INSTALLED:
             multipan_path = multipan_addon_info.options.get("device")
 
             if multipan_path is not None:

--- a/homeassistant/components/homee/config_flow.py
+++ b/homeassistant/components/homee/config_flow.py
@@ -122,7 +122,7 @@ class HomeeConfigFlow(ConfigFlow, domain=DOMAIN):
         existing_entry = await self.async_set_unique_id(self._name)
         if (
             existing_entry
-            and existing_entry.state == ConfigEntryState.LOADED
+            and existing_entry.state is ConfigEntryState.LOADED
             and existing_entry.runtime_data.connected
             and existing_entry.data[CONF_HOST] != self._host
         ):

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -298,7 +298,7 @@ class HKDevice:
         # yet.
         attempts = None if self.hass.state is CoreState.running else 1
         if (
-            transport == Transport.BLE
+            transport is Transport.BLE
             and pairing.accessories
             and pairing.accessories.has_aid(1)
         ):
@@ -328,7 +328,7 @@ class HKDevice:
         )
         entry.async_on_unload(self._async_cancel_subscription_timer)
 
-        if transport != Transport.BLE:
+        if transport is not Transport.BLE:
             # Although async_populate_accessories_state fetched the accessory database,
             # the /accessories endpoint may return cached values from the accessory's
             # perspective. For example, Ecobee thermostats may report stale temperature
@@ -349,7 +349,7 @@ class HKDevice:
 
         await self.async_process_entity_map()
 
-        if transport != Transport.BLE:
+        if transport is not Transport.BLE:
             # Start regular polling after entity map is processed
             self._async_start_polling()
 
@@ -359,7 +359,7 @@ class HKDevice:
 
         self.async_set_available_state(self.pairing.is_available)
 
-        if transport == Transport.BLE:
+        if transport is Transport.BLE:
             # If we are using BLE, we need to periodically check of the
             # BLE device is available since we won't get callbacks
             # when it goes away since we HomeKit supports disconnected
@@ -420,7 +420,7 @@ class HKDevice:
             identifiers.add((IDENTIFIER_SERIAL_NUMBER, accessory.serial_number))
 
         connections: set[tuple[str, str]] = set()
-        if self.pairing.transport == Transport.BLE and (
+        if self.pairing.transport is Transport.BLE and (
             discovery := self.pairing.controller.discoveries.get(
                 normalize_hkid(self.unique_id)
             )
@@ -622,7 +622,7 @@ class HKDevice:
                 current_unique_id.add((accessory.aid, service.iid, None))
 
                 for char in service.characteristics:
-                    if self.pairing.transport != Transport.BLE:
+                    if self.pairing.transport is not Transport.BLE:
                         if char.type == CharacteristicsTypes.THREAD_CONTROL_POINT:
                             continue
 
@@ -1057,7 +1057,7 @@ class HKDevice:
     @property
     def is_unprovisioned_thread_device(self) -> bool:
         """Is this a thread capable device not connected by CoAP."""
-        if self.pairing.controller.transport_type != TransportType.BLE:
+        if self.pairing.controller.transport_type is not TransportType.BLE:
             return False
 
         if not self.entity_map.aid(1).services.first(
@@ -1069,7 +1069,7 @@ class HKDevice:
 
     async def async_thread_provision(self) -> None:
         """Migrate a HomeKit pairing to CoAP (Thread)."""
-        if self.pairing.controller.transport_type == TransportType.COAP:
+        if self.pairing.controller.transport_type is TransportType.COAP:
             raise HomeAssistantError("Already connected to a thread network")
 
         if not (dataset := await async_get_preferred_dataset(self.hass)):

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -700,7 +700,7 @@ async def async_setup_entry(
 
     @callback
     def async_add_accessory(accessory: Accessory) -> bool:
-        if conn.pairing.transport != Transport.BLE:
+        if conn.pairing.transport is not Transport.BLE:
             return False
 
         accessory_info = accessory.services.first(

--- a/homeassistant/components/husqvarna_automower_ble/config_flow.py
+++ b/homeassistant/components/husqvarna_automower_ble/config_flow.py
@@ -69,7 +69,7 @@ class HusqvarnaAutomowerBleConfigFlow(ConfigFlow, domain=DOMAIN):
             await async_get_manufacturer_data({discovery_info.address})
         )[discovery_info.address]
 
-        if manufacturer_data.product_type != ProductType.MOWER:
+        if manufacturer_data.product_type is not ProductType.MOWER:
             LOGGER.debug(
                 "Unsupported device: %s (%s)", manufacturer_data, discovery_info
             )

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -567,7 +567,7 @@ class IntegrationSensor(RestoreSensor):
             assert old_timestamp is not None
         elapsed_seconds = Decimal(
             (new_timestamp - old_timestamp).total_seconds()
-            if self._last_integration_trigger == _IntegrationTrigger.StateEvent
+            if self._last_integration_trigger is _IntegrationTrigger.StateEvent
             else (new_timestamp - self._last_integration_time).total_seconds()
         )
 

--- a/homeassistant/components/intellifire/__init__.py
+++ b/homeassistant/components/intellifire/__init__.py
@@ -192,11 +192,11 @@ async def async_update_options(
     current_control_mode = fireplace.control_mode
 
     # Only update modes that actually changed
-    if new_read_mode != current_read_mode:
+    if new_read_mode is not current_read_mode:
         LOGGER.debug("Updating read mode: %s -> %s", current_read_mode, new_read_mode)
         await fireplace.set_read_mode(new_read_mode)
 
-    if new_control_mode != current_control_mode:
+    if new_control_mode is not current_control_mode:
         LOGGER.debug(
             "Updating control mode: %s -> %s", current_control_mode, new_control_mode
         )

--- a/homeassistant/components/iotty/cover.py
+++ b/homeassistant/components/iotty/cover.py
@@ -126,19 +126,19 @@ class IottyShutter(IottyEntity, CoverEntity):
             self._iotty_device.percentage,
         )
         return (
-            self._iotty_device.status == ShutterState.STATIONARY
+            self._iotty_device.status is ShutterState.STATIONARY
             and self._iotty_device.percentage == 0
         )
 
     @property
     def is_opening(self) -> bool:
         """Return true if the Shutter is opening."""
-        return self._iotty_device.status == ShutterState.OPENING
+        return self._iotty_device.status is ShutterState.OPENING
 
     @property
     def is_closing(self) -> bool:
         """Return true if the Shutter is closing."""
-        return self._iotty_device.status == ShutterState.CLOSING
+        return self._iotty_device.status is ShutterState.CLOSING
 
     @property
     def supported_features(self) -> CoverEntityFeature:

--- a/homeassistant/components/knx/climate.py
+++ b/homeassistant/components/knx/climate.py
@@ -380,7 +380,7 @@ class _KnxClimate(ClimateEntity, _KnxEntityBase):
                 self._attr_fan_modes = [fan_zero_mode, FAN_LOW, FAN_HIGH]
             elif fan_max_step == 1:
                 self._attr_fan_modes = [fan_zero_mode, FAN_ON]
-            elif device.fan_speed_mode == FanSpeedMode.STEP:
+            elif device.fan_speed_mode is FanSpeedMode.STEP:
                 self._attr_fan_modes = [fan_zero_mode] + [
                     str(i) for i in range(1, fan_max_step + 1)
                 ]
@@ -550,7 +550,7 @@ class _KnxClimate(ClimateEntity, _KnxEntityBase):
         if not fan_speed or self._attr_fan_modes is None:
             return self.fan_zero_mode
 
-        if self._device.fan_speed_mode == FanSpeedMode.STEP:
+        if self._device.fan_speed_mode is FanSpeedMode.STEP:
             return self._attr_fan_modes[fan_speed]
 
         # Find the closest fan mode percentage
@@ -570,7 +570,7 @@ class _KnxClimate(ClimateEntity, _KnxEntityBase):
 
         fan_mode_index = self._attr_fan_modes.index(fan_mode)
 
-        if self._device.fan_speed_mode == FanSpeedMode.STEP:
+        if self._device.fan_speed_mode is FanSpeedMode.STEP:
             await self._device.set_fan_speed(fan_mode_index)
             return
 

--- a/homeassistant/components/knx/knx_module.py
+++ b/homeassistant/components/knx/knx_module.py
@@ -258,7 +258,7 @@ class KNXModule:
 
     def connection_state_changed_cb(self, state: XknxConnectionState) -> None:
         """Call invoked after a KNX connection state change was received."""
-        self.connected = state == XknxConnectionState.CONNECTED
+        self.connected = state is XknxConnectionState.CONNECTED
         for device in self.xknx.devices:
             device.after_update()
 

--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -246,7 +246,7 @@ def async_host_event_received(
     ):
         _LOGGER.info('The connection to host "%s" has been lost', config_entry.title)
         hass.async_create_task(reload_config_entry())
-    elif event == LcnEvent.BUS_DISCONNECTED:
+    elif event is LcnEvent.BUS_DISCONNECTED:
         _LOGGER.info(
             'The connection to the LCN bus via host "%s" has been disconnected',
             config_entry.title,
@@ -296,7 +296,7 @@ def _async_fire_access_control_event(
     if device is not None:
         event_data.update({CONF_DEVICE_ID: device.id})
 
-    if inp.periphery == pypck.lcn_defs.AccessControlPeriphery.TRANSMITTER:
+    if inp.periphery is pypck.lcn_defs.AccessControlPeriphery.TRANSMITTER:
         event_data.update(
             {
                 "level": inp.level,
@@ -317,7 +317,7 @@ def _async_fire_send_keys_event(
 ) -> None:
     """Fire send_keys event."""
     for table, action in enumerate(inp.actions):
-        if action == pypck.lcn_defs.SendKeyCommand.DONTSEND:
+        if action is pypck.lcn_defs.SendKeyCommand.DONTSEND:
             continue
 
         for key, selected in enumerate(inp.keys):

--- a/homeassistant/components/lcn/climate.py
+++ b/homeassistant/components/lcn/climate.py
@@ -116,7 +116,7 @@ class LcnClimate(LcnEntity, ClimateEntity):
         # Config schema only allows for:
         # UnitOfTemperature.CELSIUS and
         # UnitOfTemperature.FAHRENHEIT
-        if self.unit == pypck.lcn_defs.VarUnit.FAHRENHEIT:
+        if self.unit is pypck.lcn_defs.VarUnit.FAHRENHEIT:
             return UnitOfTemperature.FAHRENHEIT
         return UnitOfTemperature.CELSIUS
 
@@ -188,11 +188,11 @@ class LcnClimate(LcnEntity, ClimateEntity):
         if not isinstance(input_obj, pypck.inputs.ModStatusVar):
             return
         self._attr_available = True
-        if input_obj.get_var() == self.variable:
+        if input_obj.get_var() is self.variable:
             self._attr_current_temperature = float(
                 input_obj.get_value().to_var_unit(self.unit)
             )
-        elif input_obj.get_var() == self.setpoint:
+        elif input_obj.get_var() is self.setpoint:
             self._is_on = not input_obj.get_value().is_locked_regulator()
             if self._is_on:
                 self._attr_target_temperature = float(

--- a/homeassistant/components/lcn/cover.py
+++ b/homeassistant/components/lcn/cover.py
@@ -191,7 +191,7 @@ class LcnRelayCover(LcnEntity, CoverEntity):
             )
         )
 
-        if self.positioning_mode != pypck.lcn_defs.MotorPositioningMode.NONE:
+        if self.positioning_mode is not pypck.lcn_defs.MotorPositioningMode.NONE:
             self._attr_supported_features |= CoverEntityFeature.SET_POSITION
 
         self.motor = pypck.lcn_defs.MotorPort[config[CONF_DOMAIN_DATA][CONF_MOTOR]]
@@ -267,7 +267,7 @@ class LcnRelayCover(LcnEntity, CoverEntity):
                 | None,
             ]
         ] = [self.device_connection.request_status_relays(SCAN_INTERVAL.seconds)]
-        if self.positioning_mode == pypck.lcn_defs.MotorPositioningMode.BS4:
+        if self.positioning_mode is pypck.lcn_defs.MotorPositioningMode.BS4:
             coros.append(
                 self.device_connection.request_status_motor_position(
                     self.motor, self.positioning_mode, SCAN_INTERVAL.seconds
@@ -282,7 +282,7 @@ class LcnRelayCover(LcnEntity, CoverEntity):
             self._attr_is_opening = input_obj.is_opening(self.motor.value)
             self._attr_is_closing = input_obj.is_closing(self.motor.value)
 
-            if self.positioning_mode == pypck.lcn_defs.MotorPositioningMode.NONE:
+            if self.positioning_mode is pypck.lcn_defs.MotorPositioningMode.NONE:
                 self._attr_is_closed = input_obj.is_assumed_closed(self.motor.value)
             self.async_write_ha_state()
         elif (

--- a/homeassistant/components/lcn/sensor.py
+++ b/homeassistant/components/lcn/sensor.py
@@ -144,7 +144,7 @@ class LcnVariableSensor(LcnEntity, SensorEntity):
         """Set sensor value when LCN input object (command) is received."""
         if (
             not isinstance(input_obj, pypck.inputs.ModStatusVar)
-            or input_obj.get_var() != self.variable
+            or input_obj.get_var() is not self.variable
         ):
             return
         self._attr_available = True

--- a/homeassistant/components/lcn/services.py
+++ b/homeassistant/components/lcn/services.py
@@ -330,7 +330,7 @@ class SendKeys(LcnServiceCall):
 
         if (delay_time := service.data[CONF_TIME]) != 0:
             hit = pypck.lcn_defs.SendKeyCommand.HIT
-            if pypck.lcn_defs.SendKeyCommand[service.data[CONF_STATE]] != hit:
+            if pypck.lcn_defs.SendKeyCommand[service.data[CONF_STATE]] is not hit:
                 raise ServiceValidationError(
                     translation_domain=DOMAIN,
                     translation_key="invalid_send_keys_action",

--- a/homeassistant/components/lcn/switch.py
+++ b/homeassistant/components/lcn/switch.py
@@ -200,7 +200,7 @@ class LcnRegulatorLockSwitch(LcnEntity, SwitchEntity):
         """Set switch state when LCN input object (command) is received."""
         if (
             not isinstance(input_obj, pypck.inputs.ModStatusVar)
-            or input_obj.get_var() != self.setpoint_variable
+            or input_obj.get_var() is not self.setpoint_variable
         ):
             return
         self._attr_available = True

--- a/homeassistant/components/lutron/binary_sensor.py
+++ b/homeassistant/components/lutron/binary_sensor.py
@@ -54,4 +54,4 @@ class LutronOccupancySensor(LutronDevice, BinarySensorEntity):
 
     def _update_attrs(self) -> None:
         """Update the state attributes."""
-        self._attr_is_on = self._lutron_device.state == OccupancyGroup.State.OCCUPIED
+        self._attr_is_on = self._lutron_device.state is OccupancyGroup.State.OCCUPIED

--- a/homeassistant/components/lutron_caseta/cover.py
+++ b/homeassistant/components/lutron_caseta/cover.py
@@ -79,7 +79,7 @@ class LutronCasetaShade(LutronCasetaUpdatableEntity, CoverEntity):
         """Stop the cover."""
         # Send appropriate directional command before stop to ensure it works correctly
         # Use tracked direction if moving, otherwise use position-based heuristic
-        if self._movement_direction == ShadeMovementDirection.OPENING or (
+        if self._movement_direction is ShadeMovementDirection.OPENING or (
             self._movement_direction in (ShadeMovementDirection.STOPPED, None)
             and self.current_cover_position >= 50
         ):

--- a/homeassistant/components/matter/__init__.py
+++ b/homeassistant/components/matter/__init__.py
@@ -179,13 +179,13 @@ async def _client_listen(
     try:
         await matter_client.start_listening(init_ready)
     except MatterError as err:
-        if entry.state != ConfigEntryState.LOADED:
+        if entry.state is not ConfigEntryState.LOADED:
             raise
         LOGGER.error("Failed to listen: %s", err)
     except Exception as err:
         # We need to guard against unknown exceptions to not crash this task.
         LOGGER.exception("Unexpected exception: %s", err)
-        if entry.state != ConfigEntryState.LOADED:
+        if entry.state is not ConfigEntryState.LOADED:
             raise
 
     if not hass.is_stopping:
@@ -293,7 +293,7 @@ async def _async_ensure_addon_running(
 
     addon_state = addon_info.state
 
-    if addon_state == AddonState.NOT_INSTALLED:
+    if addon_state is AddonState.NOT_INSTALLED:
         addon_manager.async_schedule_install_setup_addon(
             addon_info.options,
             catch_error=True,

--- a/homeassistant/components/matter/__init__.py
+++ b/homeassistant/components/matter/__init__.py
@@ -300,7 +300,7 @@ async def _async_ensure_addon_running(
         )
         raise ConfigEntryNotReady
 
-    if addon_state == AddonState.NOT_RUNNING:
+    if addon_state is AddonState.NOT_RUNNING:
         addon_manager.async_schedule_start_addon(catch_error=True)
         raise ConfigEntryNotReady
 

--- a/homeassistant/components/matter/config_flow.py
+++ b/homeassistant/components/matter/config_flow.py
@@ -291,7 +291,7 @@ class MatterConfigFlow(ConfigFlow, domain=DOMAIN):
         if addon_info.state is AddonState.RUNNING:
             return await self.async_step_finish_addon_setup()
 
-        if addon_info.state == AddonState.NOT_RUNNING:
+        if addon_info.state is AddonState.NOT_RUNNING:
             return await self.async_step_start_addon()
 
         return await self.async_step_install_addon()

--- a/homeassistant/components/matter/config_flow.py
+++ b/homeassistant/components/matter/config_flow.py
@@ -288,7 +288,7 @@ class MatterConfigFlow(ConfigFlow, domain=DOMAIN):
 
         addon_info = await self._async_get_addon_info()
 
-        if addon_info.state == AddonState.RUNNING:
+        if addon_info.state is AddonState.RUNNING:
             return await self.async_step_finish_addon_setup()
 
         if addon_info.state == AddonState.NOT_RUNNING:

--- a/homeassistant/components/matter/update.py
+++ b/homeassistant/components/matter/update.py
@@ -173,7 +173,7 @@ class MatterUpdate(MatterEntity, UpdateEntity):
         release_notes = ""
 
         # insert extra heavy warning case the update is not from the main net
-        if self._software_update.update_source != UpdateSource.MAIN_NET_DCL:
+        if self._software_update.update_source is not UpdateSource.MAIN_NET_DCL:
             release_notes += (
                 "\n\n<ha-alert alert-type='warning'>"
                 "Update provided by "

--- a/homeassistant/components/motioneye/__init__.py
+++ b/homeassistant/components/motioneye/__init__.py
@@ -437,7 +437,7 @@ def _get_media_event_data(
     if (
         not config_entry_id
         or not (entry := hass.config_entries.async_get_entry(config_entry_id))
-        or entry.state != ConfigEntryState.LOADED
+        or entry.state is not ConfigEntryState.LOADED
     ):
         return {}
 

--- a/homeassistant/components/motioneye/media_source.py
+++ b/homeassistant/components/motioneye/media_source.py
@@ -122,7 +122,7 @@ class MotionEyeMediaSource(MediaSource):
     def _get_config_or_raise(self, config_id: str) -> MotionEyeConfigEntry:
         """Get a config entry from a URL."""
         entry = self.hass.config_entries.async_get_entry(config_id)
-        if not entry or entry.state != ConfigEntryState.LOADED:
+        if not entry or entry.state is not ConfigEntryState.LOADED:
             raise MediaSourceError(f"Unable to find config entry with id: {config_id}")
         return entry
 

--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -4158,7 +4158,7 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
             # Finish setup using discovery info
             return await self.async_step_setup_entry_from_discovery()
 
-        if addon_info.state == AddonState.NOT_RUNNING:
+        if addon_info.state is AddonState.NOT_RUNNING:
             return await self.async_step_start_addon()
 
         # Install the add-on and start it

--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -4154,7 +4154,7 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
                 description_placeholders={"addon": self._addon_manager.addon_name},
             ) from err
 
-        if addon_info.state == AddonState.RUNNING:
+        if addon_info.state is AddonState.RUNNING:
             # Finish setup using discovery info
             return await self.async_step_setup_entry_from_discovery()
 

--- a/homeassistant/components/mqtt/util.py
+++ b/homeassistant/components/mqtt/util.py
@@ -219,7 +219,7 @@ async def async_wait_for_mqtt_client(hass: HomeAssistant) -> bool:
         return False
 
     entry = hass.config_entries.async_entries(DOMAIN)[0]
-    if entry.state == ConfigEntryState.LOADED:
+    if entry.state is ConfigEntryState.LOADED:
         return True
 
     state_reached_future: asyncio.Future[bool]

--- a/homeassistant/components/music_assistant/__init__.py
+++ b/homeassistant/components/music_assistant/__init__.py
@@ -265,12 +265,12 @@ async def _client_listen(
     try:
         await mass.start_listening(init_ready)
     except MusicAssistantError as err:
-        if entry.state != ConfigEntryState.LOADED:
+        if entry.state is not ConfigEntryState.LOADED:
             raise
         LOGGER.error("Failed to listen: %s", err)
     except Exception as err:  # pylint: disable=broad-except
         # We need to guard against unknown exceptions to not crash this task.
-        if entry.state != ConfigEntryState.LOADED:
+        if entry.state is not ConfigEntryState.LOADED:
             raise
         LOGGER.exception("Unexpected exception: %s", err)
 

--- a/homeassistant/components/mysensors/cover.py
+++ b/homeassistant/components/mysensors/cover.py
@@ -81,17 +81,17 @@ class MySensorsCover(MySensorsChildEntity, CoverEntity):
     @property
     def is_closed(self) -> bool:
         """Return True if the cover is closed."""
-        return self.get_cover_state() == CoverState.CLOSED
+        return self.get_cover_state() is CoverState.CLOSED
 
     @property
     def is_closing(self) -> bool:
         """Return True if the cover is closing."""
-        return self.get_cover_state() == CoverState.CLOSING
+        return self.get_cover_state() is CoverState.CLOSING
 
     @property
     def is_opening(self) -> bool:
         """Return True if the cover is opening."""
-        return self.get_cover_state() == CoverState.OPENING
+        return self.get_cover_state() is CoverState.OPENING
 
     @property
     def current_cover_position(self) -> int | None:

--- a/homeassistant/components/myuplink/binary_sensor.py
+++ b/homeassistant/components/myuplink/binary_sensor.py
@@ -144,7 +144,7 @@ class MyUplinkDevicePointBinarySensor(MyUplinkEntity, BinarySensorEntity):
         """Return device data availability."""
         return super().available and (
             self.coordinator.data.devices[self.device_id].connectionState
-            == DeviceConnectionState.Connected
+            is DeviceConnectionState.Connected
         )
 
 
@@ -172,7 +172,7 @@ class MyUplinkDeviceBinarySensor(MyUplinkEntity, BinarySensorEntity):
         """Binary sensor state value."""
         return (
             self.coordinator.data.devices[self.device_id].connectionState
-            == DeviceConnectionState.Connected
+            is DeviceConnectionState.Connected
         )
 
 

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -244,7 +244,7 @@ def async_get_client_for_service_call(
     if device_entry := device_registry.async_get(device_id):
         for entry_id in device_entry.config_entries:
             if entry := hass.config_entries.async_get_entry(entry_id):
-                if entry.domain == DOMAIN and entry.state == ConfigEntryState.LOADED:
+                if entry.domain is DOMAIN and entry.state is ConfigEntryState.LOADED:
                     return cast(OctoprintConfigEntry, entry).runtime_data.octoprint
 
     raise ServiceValidationError(

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -244,7 +244,7 @@ def async_get_client_for_service_call(
     if device_entry := device_registry.async_get(device_id):
         for entry_id in device_entry.config_entries:
             if entry := hass.config_entries.async_get_entry(entry_id):
-                if entry.domain is DOMAIN and entry.state is ConfigEntryState.LOADED:
+                if entry.domain == DOMAIN and entry.state is ConfigEntryState.LOADED:
                     return cast(OctoprintConfigEntry, entry).runtime_data.octoprint
 
     raise ServiceValidationError(

--- a/homeassistant/components/ollama/config_flow.py
+++ b/homeassistant/components/ollama/config_flow.py
@@ -259,7 +259,7 @@ class OllamaSubentryFlowHandler(ConfigSubentryFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> SubentryFlowResult:
         """Handle model selection and configuration step."""
-        if self._get_entry().state != ConfigEntryState.LOADED:
+        if self._get_entry().state is not ConfigEntryState.LOADED:
             return self.async_abort(reason="entry_not_loaded")
 
         if user_input is None:

--- a/homeassistant/components/onkyo/coordinator.py
+++ b/homeassistant/components/onkyo/coordinator.py
@@ -160,6 +160,6 @@ class ChannelMutingCoordinator(DataUpdateCoordinator[ChannelMutingData]):
             self._desired = {
                 channel: desired
                 for channel, desired in self._desired.items()
-                if self.data[channel] != desired
+                if self.data[channel] is not desired
             }
             self.async_set_updated_data(self.data)

--- a/homeassistant/components/onkyo/media_player.py
+++ b/homeassistant/components/onkyo/media_player.py
@@ -197,7 +197,7 @@ class OnkyoMediaPlayer(MediaPlayerEntity):
 
         name = manager.info.model_name
         identifier = manager.info.identifier
-        self._attr_name = f"{name}{' ' + ZONES[zone] if zone != Zone.MAIN else ''}"
+        self._attr_name = f"{name}{' ' + ZONES[zone] if zone is not Zone.MAIN else ''}"
         self._attr_unique_id = f"{identifier}_{zone.value}"
 
         self._volume_resolution = volume_resolution
@@ -226,7 +226,7 @@ class OnkyoMediaPlayer(MediaPlayerEntity):
         self._attr_sound_mode_list = list(self._rev_sound_mode_mapping)
 
         self._attr_supported_features = SUPPORTED_FEATURES_BASE
-        if zone == Zone.MAIN:
+        if zone is Zone.MAIN:
             self._attr_supported_features |= SUPPORTED_FEATURES_VOLUME
             self._supports_volume = True
             self._attr_supported_features |= MediaPlayerEntityFeature.SELECT_SOUND_MODE
@@ -259,7 +259,7 @@ class OnkyoMediaPlayer(MediaPlayerEntity):
         await self._manager.write(query.TunerPreset(self._zone))
         if self._supports_sound_mode is not None:
             await self._manager.write(query.ListeningMode(self._zone))
-        if self._zone == Zone.MAIN:
+        if self._zone is Zone.MAIN:
             await self._manager.write(query.HDMIOutput())
             await self._manager.write(query.AudioInformation())
             await self._manager.write(query.VideoInformation())
@@ -386,7 +386,7 @@ class OnkyoMediaPlayer(MediaPlayerEntity):
                 self._attr_volume_level = min(1, volume_level)
 
             case status.Muting(param=muting):
-                self._attr_is_volume_muted = bool(muting == status.Muting.Param.ON)
+                self._attr_is_volume_muted = bool(muting is status.Muting.Param.ON)
 
             case status.InputSource(param=source):
                 if source in self._source_mapping:

--- a/homeassistant/components/onkyo/switch.py
+++ b/homeassistant/components/onkyo/switch.py
@@ -89,6 +89,6 @@ class OnkyoChannelMutingSwitch(
         """Handle updated data from the coordinator."""
         value = self.coordinator.data.get(self._channel)
         self._attr_is_on = (
-            None if value is None else value == status.ChannelMuting.Param.ON
+            None if value is None else value is status.ChannelMuting.Param.ON
         )
         super()._handle_coordinator_update()

--- a/homeassistant/components/onvif/event_manager.py
+++ b/homeassistant/components/onvif/event_manager.py
@@ -127,8 +127,8 @@ class EventManager:
     def started(self) -> bool:
         """Return True if event manager is started."""
         return (
-            self.webhook_manager.state == WebHookManagerState.STARTED
-            or self.pullpoint_manager.state == PullPointManagerState.STARTED
+            self.webhook_manager.state is WebHookManagerState.STARTED
+            or self.pullpoint_manager.state is PullPointManagerState.STARTED
         )
 
     @callback
@@ -260,7 +260,7 @@ class EventManager:
     @callback
     def async_webhook_failed(self) -> None:
         """Mark webhook as failed."""
-        if self.pullpoint_manager.state != PullPointManagerState.PAUSED:
+        if self.pullpoint_manager.state is not PullPointManagerState.PAUSED:
             return
         LOGGER.debug("%s: Switching to PullPoint for events", self.name)
         self.pullpoint_manager.async_resume()
@@ -268,7 +268,7 @@ class EventManager:
     @callback
     def async_webhook_working(self) -> None:
         """Mark webhook as working."""
-        if self.pullpoint_manager.state != PullPointManagerState.STARTED:
+        if self.pullpoint_manager.state is not PullPointManagerState.STARTED:
             return
         LOGGER.debug("%s: Switching to webhook for events", self.name)
         self.pullpoint_manager.async_pause()
@@ -308,7 +308,7 @@ class PullPointManager:
 
     async def async_start(self) -> bool:
         """Start pullpoint subscription."""
-        assert self.state == PullPointManagerState.STOPPED, (
+        assert self.state is PullPointManagerState.STOPPED, (
             "PullPoint manager already started"
         )
         LOGGER.debug("%s: Starting PullPoint manager", self._name)
@@ -462,7 +462,7 @@ class PullPointManager:
         finally:
             self.async_schedule_pull_messages(next_pull_delay)
 
-        if self.state != PullPointManagerState.STARTED:
+        if self.state is not PullPointManagerState.STARTED:
             # If the webhook became started working during the long poll,
             # and we got paused, our data is stale and we should not process it.
             LOGGER.debug(
@@ -507,7 +507,7 @@ class PullPointManager:
         Must not check if the webhook is working.
         """
         self.async_cancel_pull_messages()
-        if self.state != PullPointManagerState.STARTED:
+        if self.state is not PullPointManagerState.STARTED:
             return
         if self._pullpoint_manager:
             when = delay if delay is not None else PULLPOINT_COOLDOWN_TIME
@@ -566,7 +566,7 @@ class WebHookManager:
     async def async_start(self) -> bool:
         """Start polling events."""
         LOGGER.debug("%s: Starting webhook manager", self._name)
-        assert self.state == WebHookManagerState.STOPPED, (
+        assert self.state is WebHookManagerState.STOPPED, (
             "Webhook manager already started"
         )
         assert self._webhook_url is None, "Webhook already registered"

--- a/homeassistant/components/open_router/config_flow.py
+++ b/homeassistant/components/open_router/config_flow.py
@@ -141,7 +141,7 @@ class ConversationFlowHandler(OpenRouterSubentryFlowHandler):
         self, user_input: dict[str, Any] | None = None
     ) -> SubentryFlowResult:
         """Manage conversation agent configuration."""
-        if self._get_entry().state != ConfigEntryState.LOADED:
+        if self._get_entry().state is not ConfigEntryState.LOADED:
             return self.async_abort(reason="entry_not_loaded")
 
         if user_input is not None:
@@ -256,7 +256,7 @@ class AITaskDataFlowHandler(OpenRouterSubentryFlowHandler):
         self, user_input: dict[str, Any] | None = None
     ) -> SubentryFlowResult:
         """Manage AI task configuration."""
-        if self._get_entry().state != ConfigEntryState.LOADED:
+        if self._get_entry().state is not ConfigEntryState.LOADED:
             return self.async_abort(reason="entry_not_loaded")
 
         if user_input is not None:

--- a/homeassistant/components/openai_conversation/config_flow.py
+++ b/homeassistant/components/openai_conversation/config_flow.py
@@ -255,7 +255,7 @@ class OpenAISubentryFlowHandler(ConfigSubentryFlow):
     ) -> SubentryFlowResult:
         """Manage initial options."""
         # abort if entry is not loaded
-        if self._get_entry().state != ConfigEntryState.LOADED:
+        if self._get_entry().state is not ConfigEntryState.LOADED:
             return self.async_abort(reason="entry_not_loaded")
 
         options = self.options
@@ -710,7 +710,7 @@ class OpenAISubentrySTTFlowHandler(ConfigSubentryFlow):
     ) -> SubentryFlowResult:
         """Manage initial options."""
         # abort if entry is not loaded
-        if self._get_entry().state != ConfigEntryState.LOADED:
+        if self._get_entry().state is not ConfigEntryState.LOADED:
             return self.async_abort(reason="entry_not_loaded")
 
         options = self.options
@@ -799,7 +799,7 @@ class OpenAISubentryTTSFlowHandler(ConfigSubentryFlow):
     ) -> SubentryFlowResult:
         """Manage initial options."""
         # abort if entry is not loaded
-        if self._get_entry().state != ConfigEntryState.LOADED:
+        if self._get_entry().state is not ConfigEntryState.LOADED:
             return self.async_abort(reason="entry_not_loaded")
 
         options = self.options

--- a/homeassistant/components/opower/coordinator.py
+++ b/homeassistant/components/opower/coordinator.py
@@ -193,12 +193,12 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, OpowerData]]):
             )
             consumption_unit_class = (
                 EnergyConverter.UNIT_CLASS
-                if account.meter_type == MeterType.ELEC
+                if account.meter_type is MeterType.ELEC
                 else VolumeConverter.UNIT_CLASS
             )
             consumption_unit = (
                 UnitOfEnergy.KILO_WATT_HOUR
-                if account.meter_type == MeterType.ELEC
+                if account.meter_type is MeterType.ELEC
                 else UnitOfVolume.CENTUM_CUBIC_FEET
             )
             consumption_metadata = StatisticMetaData(
@@ -553,7 +553,7 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, OpowerData]]):
             _LOGGER.error("Error getting monthly cost reads: %s", err)
             raise
         _LOGGER.debug("Got %s monthly cost reads", len(cost_reads))
-        if account.read_resolution == ReadResolution.BILLING:
+        if account.read_resolution is ReadResolution.BILLING:
             return cost_reads
 
         if start_time is None:

--- a/homeassistant/components/opower/coordinator.py
+++ b/homeassistant/components/opower/coordinator.py
@@ -573,7 +573,7 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, OpowerData]]):
             raise
         _LOGGER.debug("Got %s daily cost reads", len(daily_cost_reads))
         _update_with_finer_cost_reads(cost_reads, daily_cost_reads)
-        if account.read_resolution == ReadResolution.DAY:
+        if account.read_resolution is ReadResolution.DAY:
             return cost_reads
 
         if start_time is None:

--- a/homeassistant/components/opower/sensor.py
+++ b/homeassistant/components/opower/sensor.py
@@ -233,13 +233,13 @@ async def async_setup_entry(
             )
             sensors: tuple[OpowerEntityDescription, ...] = COMMON_SENSORS
             if (
-                account.meter_type == MeterType.ELEC
+                account.meter_type is MeterType.ELEC
                 and forecast is not None
-                and forecast.unit_of_measure == UnitOfMeasure.KWH
+                and forecast.unit_of_measure is UnitOfMeasure.KWH
             ):
                 sensors += ELEC_SENSORS
             elif (
-                account.meter_type == MeterType.GAS
+                account.meter_type is MeterType.GAS
                 and forecast is not None
                 and forecast.unit_of_measure in [UnitOfMeasure.THERM, UnitOfMeasure.CCF]
             ):

--- a/homeassistant/components/otbr/config_flow.py
+++ b/homeassistant/components/otbr/config_flow.py
@@ -213,7 +213,7 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
                     or current_url.port == config["port"]
                 ):
                     # Reload the entry since OTBR has restarted
-                    if current_entry.state == ConfigEntryState.LOADED:
+                    if current_entry.state is ConfigEntryState.LOADED:
                         assert current_entry.unique_id is not None
                         await self.hass.config_entries.async_reload(
                             current_entry.entry_id

--- a/homeassistant/components/paperless_ngx/sensor.py
+++ b/homeassistant/components/paperless_ngx/sensor.py
@@ -130,7 +130,7 @@ SENSOR_STATUS: tuple[PaperlessEntityDescription[Status], ...] = (
         device_class=SensorDeviceClass.ENUM,
         entity_category=EntityCategory.DIAGNOSTIC,
         options=[
-            item.value.lower() for item in StatusType if item != StatusType.UNKNOWN
+            item.value.lower() for item in StatusType if item is not StatusType.UNKNOWN
         ],
         value_fn=(
             lambda data: (
@@ -138,7 +138,7 @@ SENSOR_STATUS: tuple[PaperlessEntityDescription[Status], ...] = (
                 if (
                     data.database is not None
                     and data.database.status is not None
-                    and data.database.status != StatusType.UNKNOWN
+                    and data.database.status is not StatusType.UNKNOWN
                 )
                 else None
             )
@@ -151,7 +151,7 @@ SENSOR_STATUS: tuple[PaperlessEntityDescription[Status], ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         options=[
-            item.value.lower() for item in StatusType if item != StatusType.UNKNOWN
+            item.value.lower() for item in StatusType if item is not StatusType.UNKNOWN
         ],
         value_fn=(
             lambda data: (
@@ -159,7 +159,7 @@ SENSOR_STATUS: tuple[PaperlessEntityDescription[Status], ...] = (
                 if (
                     data.tasks is not None
                     and data.tasks.index_status is not None
-                    and data.tasks.index_status != StatusType.UNKNOWN
+                    and data.tasks.index_status is not StatusType.UNKNOWN
                 )
                 else None
             )
@@ -172,7 +172,7 @@ SENSOR_STATUS: tuple[PaperlessEntityDescription[Status], ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         options=[
-            item.value.lower() for item in StatusType if item != StatusType.UNKNOWN
+            item.value.lower() for item in StatusType if item is not StatusType.UNKNOWN
         ],
         value_fn=(
             lambda data: (
@@ -180,7 +180,7 @@ SENSOR_STATUS: tuple[PaperlessEntityDescription[Status], ...] = (
                 if (
                     data.tasks is not None
                     and data.tasks.classifier_status is not None
-                    and data.tasks.classifier_status != StatusType.UNKNOWN
+                    and data.tasks.classifier_status is not StatusType.UNKNOWN
                 )
                 else None
             )
@@ -193,7 +193,7 @@ SENSOR_STATUS: tuple[PaperlessEntityDescription[Status], ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         options=[
-            item.value.lower() for item in StatusType if item != StatusType.UNKNOWN
+            item.value.lower() for item in StatusType if item is not StatusType.UNKNOWN
         ],
         value_fn=(
             lambda data: (
@@ -201,7 +201,7 @@ SENSOR_STATUS: tuple[PaperlessEntityDescription[Status], ...] = (
                 if (
                     data.tasks is not None
                     and data.tasks.celery_status is not None
-                    and data.tasks.celery_status != StatusType.UNKNOWN
+                    and data.tasks.celery_status is not StatusType.UNKNOWN
                 )
                 else None
             )
@@ -213,7 +213,7 @@ SENSOR_STATUS: tuple[PaperlessEntityDescription[Status], ...] = (
         device_class=SensorDeviceClass.ENUM,
         entity_category=EntityCategory.DIAGNOSTIC,
         options=[
-            item.value.lower() for item in StatusType if item != StatusType.UNKNOWN
+            item.value.lower() for item in StatusType if item is not StatusType.UNKNOWN
         ],
         value_fn=(
             lambda data: (
@@ -221,7 +221,7 @@ SENSOR_STATUS: tuple[PaperlessEntityDescription[Status], ...] = (
                 if (
                     data.tasks is not None
                     and data.tasks.redis_status is not None
-                    and data.tasks.redis_status != StatusType.UNKNOWN
+                    and data.tasks.redis_status is not StatusType.UNKNOWN
                 )
                 else None
             )
@@ -233,7 +233,7 @@ SENSOR_STATUS: tuple[PaperlessEntityDescription[Status], ...] = (
         device_class=SensorDeviceClass.ENUM,
         entity_category=EntityCategory.DIAGNOSTIC,
         options=[
-            item.value.lower() for item in StatusType if item != StatusType.UNKNOWN
+            item.value.lower() for item in StatusType if item is not StatusType.UNKNOWN
         ],
         value_fn=(
             lambda data: (
@@ -241,7 +241,7 @@ SENSOR_STATUS: tuple[PaperlessEntityDescription[Status], ...] = (
                 if (
                     data.tasks is not None
                     and data.tasks.sanity_check_status is not None
-                    and data.tasks.sanity_check_status != StatusType.UNKNOWN
+                    and data.tasks.sanity_check_status is not StatusType.UNKNOWN
                 )
                 else None
             )

--- a/homeassistant/components/picnic/services.py
+++ b/homeassistant/components/picnic/services.py
@@ -54,7 +54,7 @@ async def get_api_client(hass: HomeAssistant, config_entry_id: str) -> PicnicAPI
     entry: PicnicConfigEntry | None = hass.config_entries.async_get_entry(
         config_entry_id
     )
-    if entry is None or entry.state != ConfigEntryState.LOADED:
+    if entry is None or entry.state is not ConfigEntryState.LOADED:
         raise ValueError(f"Config entry with id {config_entry_id} not found!")
     return entry.runtime_data.picnic_api_client
 

--- a/homeassistant/components/playstation_network/helpers.py
+++ b/homeassistant/components/playstation_network/helpers.py
@@ -182,7 +182,7 @@ class PlaystationNetwork:
                 for title in self.trophy_titles
                 if game_title_info["titleName"]
                 == normalize_title(title.title_name or "")
-                and next(iter(title.title_platform)) == PlatformType.PS_VITA
+                and next(iter(title.title_platform)) is PlatformType.PS_VITA
             ),
             None,
         )

--- a/homeassistant/components/pooldose/__init__.py
+++ b/homeassistant/components/pooldose/__init__.py
@@ -74,7 +74,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: PooldoseConfigEntry) -> 
             f"Failed to connect to PoolDose device: {err}"
         ) from err
 
-    if client_status != RequestStatus.SUCCESS:
+    if client_status is not RequestStatus.SUCCESS:
         # pylint: disable-next=home-assistant-exception-not-translated
         raise ConfigEntryNotReady(
             f"Failed to create PoolDose client while initialization: {client_status}"

--- a/homeassistant/components/pooldose/config_flow.py
+++ b/homeassistant/components/pooldose/config_flow.py
@@ -45,15 +45,15 @@ class PooldoseConfigFlow(ConfigFlow, domain=DOMAIN):
         client_status = await client.connect()
         if client_status is RequestStatus.HOST_UNREACHABLE:
             return None, None, {"base": "cannot_connect"}
-        if client_status == RequestStatus.PARAMS_FETCH_FAILED:
+        if client_status is RequestStatus.PARAMS_FETCH_FAILED:
             return None, None, {"base": "params_fetch_failed"}
-        if client_status != RequestStatus.SUCCESS:
+        if client_status is not RequestStatus.SUCCESS:
             return None, None, {"base": "cannot_connect"}
 
         api_status, api_versions = client.check_apiversion_supported()
         if api_status is RequestStatus.NO_DATA:
             return None, None, {"base": "api_not_set"}
-        if api_status == RequestStatus.API_VERSION_UNSUPPORTED:
+        if api_status is RequestStatus.API_VERSION_UNSUPPORTED:
             return None, api_versions, {"base": "api_not_supported"}
 
         device_info = client.device_info

--- a/homeassistant/components/pooldose/config_flow.py
+++ b/homeassistant/components/pooldose/config_flow.py
@@ -43,7 +43,7 @@ class PooldoseConfigFlow(ConfigFlow, domain=DOMAIN):
         """Validate the host and return (serial_number, api_versions, errors)."""
         client = PooldoseClient(host, websession=async_get_clientsession(self.hass))
         client_status = await client.connect()
-        if client_status == RequestStatus.HOST_UNREACHABLE:
+        if client_status is RequestStatus.HOST_UNREACHABLE:
             return None, None, {"base": "cannot_connect"}
         if client_status == RequestStatus.PARAMS_FETCH_FAILED:
             return None, None, {"base": "params_fetch_failed"}
@@ -51,7 +51,7 @@ class PooldoseConfigFlow(ConfigFlow, domain=DOMAIN):
             return None, None, {"base": "cannot_connect"}
 
         api_status, api_versions = client.check_apiversion_supported()
-        if api_status == RequestStatus.NO_DATA:
+        if api_status is RequestStatus.NO_DATA:
             return None, None, {"base": "api_not_set"}
         if api_status == RequestStatus.API_VERSION_UNSUPPORTED:
             return None, api_versions, {"base": "api_not_supported"}

--- a/homeassistant/components/pooldose/coordinator.py
+++ b/homeassistant/components/pooldose/coordinator.py
@@ -59,7 +59,7 @@ class PooldoseCoordinator(DataUpdateCoordinator[StructuredValuesDict]):
                 f"Failed to connect to PoolDose device while fetching data: {err}"
             ) from err
 
-        if status != RequestStatus.SUCCESS:
+        if status is not RequestStatus.SUCCESS:
             # pylint: disable-next=home-assistant-exception-not-translated
             raise UpdateFailed(f"API returned status: {status}")
 

--- a/homeassistant/components/powerwall/switch.py
+++ b/homeassistant/components/powerwall/switch.py
@@ -62,7 +62,7 @@ class PowerwallOffGridEnabledEntity(PowerWallEntity, SwitchEntity):
                 f"Setting off-grid operation to {island_mode} failed: {ex}"
             ) from ex
 
-        self._attr_is_on = island_mode == IslandMode.OFFGRID
+        self._attr_is_on = island_mode is IslandMode.OFFGRID
         self.async_write_ha_state()
 
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/qbittorrent/__init__.py
+++ b/homeassistant/components/qbittorrent/__init__.py
@@ -71,7 +71,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         entry: QBittorrentConfigEntry | None = hass.config_entries.async_get_entry(
             entry_id
         )
-        if entry is None or entry.state != ConfigEntryState.LOADED:
+        if entry is None or entry.state is not ConfigEntryState.LOADED:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="invalid_entry_id",

--- a/homeassistant/components/qnap_qsw/binary_sensor.py
+++ b/homeassistant/components/qnap_qsw/binary_sensor.py
@@ -140,7 +140,7 @@ class QswBinarySensor(QswSensorEntity, BinarySensorEntity):
     ) -> None:
         """Initialize."""
         super().__init__(coordinator, entry, type_id)
-        if description.name == UNDEFINED:
+        if description.name is UNDEFINED:
             self._attr_has_entity_name = True
         else:
             self._attr_name = f"{self.product} {description.name}"

--- a/homeassistant/components/qnap_qsw/sensor.py
+++ b/homeassistant/components/qnap_qsw/sensor.py
@@ -357,7 +357,7 @@ class QswSensor(QswSensorEntity, SensorEntity):
         """Initialize."""
         super().__init__(coordinator, entry, type_id)
 
-        if description.name == UNDEFINED:
+        if description.name is UNDEFINED:
             self._attr_has_entity_name = True
         else:
             self._attr_name = f"{self.product} {description.name}"

--- a/homeassistant/components/rabbitair/fan.py
+++ b/homeassistant/components/rabbitair/fan.py
@@ -101,7 +101,7 @@ class RabbitAirFanEntity(RabbitAirBaseEntity, FanEntity):
         else:
             # Get key by value in dictionary
             self._attr_preset_mode = next(
-                k for k, v in PRESET_MODES.items() if v == data.mode
+                k for k, v in PRESET_MODES.items() if v is data.mode
             )
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:

--- a/homeassistant/components/radio_browser/media_source.py
+++ b/homeassistant/components/radio_browser/media_source.py
@@ -56,7 +56,7 @@ class RadioMediaSource(MediaSource):
     async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:
         """Resolve selected Radio station to a streaming URL."""
 
-        if self.entry.state != ConfigEntryState.LOADED:
+        if self.entry.state is not ConfigEntryState.LOADED:
             raise Unresolvable(
                 translation_domain=DOMAIN,
                 translation_key="config_entry_not_ready",
@@ -86,7 +86,7 @@ class RadioMediaSource(MediaSource):
     ) -> BrowseMediaSource:
         """Return media."""
 
-        if self.entry.state != ConfigEntryState.LOADED:
+        if self.entry.state is not ConfigEntryState.LOADED:
             raise BrowseError(
                 translation_domain=DOMAIN,
                 translation_key="config_entry_not_ready",

--- a/homeassistant/components/rainforest_raven/config_flow.py
+++ b/homeassistant/components/rainforest_raven/config_flow.py
@@ -59,7 +59,7 @@ class RainforestRavenConfigFlow(ConfigFlow, domain=DOMAIN):
                     meter_info = await raven_device.get_meter_info(meter=meter)
                     if meter_info and (
                         meter_info.meter_type is None
-                        or meter_info.meter_type == MeterType.ELECTRIC
+                        or meter_info.meter_type is MeterType.ELECTRIC
                     ):
                         self._meter_macs.add(meter.hex())
         self._dev_path = dev_path

--- a/homeassistant/components/renault/binary_sensor.py
+++ b/homeassistant/components/renault/binary_sensor.py
@@ -79,7 +79,7 @@ def _plugged_in_value_lambda(
 ) -> bool | None:
     """Return true if the vehicle is plugged in."""
     if (plug_status := self.coordinator.data.get_plug_status()) is not None:
-        return plug_status == PlugState.PLUGGED
+        return plug_status is PlugState.PLUGGED
 
     if (
         charging_status := self.coordinator.data.get_charging_status()

--- a/homeassistant/components/reolink/coordinator.py
+++ b/homeassistant/components/reolink/coordinator.py
@@ -123,7 +123,7 @@ class ReolinkDeviceCoordinator(ReolinkCoordinator):
 
         if (
             self._host.api.new_devices
-            and self.config_entry.state == ConfigEntryState.LOADED
+            and self.config_entry.state is ConfigEntryState.LOADED
         ):
             # There are new cameras/chimes connected, reload to add them.
             _LOGGER.debug(

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -682,7 +682,7 @@ class ReolinkHost:
                 self._api.host,
                 sub_type,
             )
-            if sub_type == SubType.push:
+            if sub_type is SubType.push:
                 await self.subscribe()
                 return
 

--- a/homeassistant/components/reolink/media_source.py
+++ b/homeassistant/components/reolink/media_source.py
@@ -84,7 +84,7 @@ class ReolinkVODMediaSource(MediaSource):
 
         vod_type = get_vod_type()
 
-        if vod_type == VodRequestType.NVR_DOWNLOAD:
+        if vod_type is VodRequestType.NVR_DOWNLOAD:
             filename = f"{start_time}_{end_time}"
 
         if vod_type in {

--- a/homeassistant/components/reolink/services.py
+++ b/homeassistant/components/reolink/services.py
@@ -43,7 +43,7 @@ async def _async_play_chime(service_call: ServiceCall) -> None:
         if (
             config_entry is None
             or device is None
-            or config_entry.state != ConfigEntryState.LOADED
+            or config_entry.state is not ConfigEntryState.LOADED
         ):
             raise ServiceValidationError(
                 translation_domain=DOMAIN,

--- a/homeassistant/components/reolink/util.py
+++ b/homeassistant/components/reolink/util.py
@@ -51,7 +51,7 @@ def is_connected(hass: HomeAssistant, config_entry: config_entries.ConfigEntry) 
     """Check if an existing entry has a proper connection."""
     return (
         hasattr(config_entry, "runtime_data")
-        and config_entry.state == config_entries.ConfigEntryState.LOADED
+        and config_entry.state is config_entries.ConfigEntryState.LOADED
         and config_entry.runtime_data.device_coordinator.last_update_success
     )
 

--- a/homeassistant/components/repairs/issue_handler.py
+++ b/homeassistant/components/repairs/issue_handler.py
@@ -91,7 +91,7 @@ class RepairsFlowManager(
         This method is called when a flow step returns FlowResultType.ABORT or
         FlowResultType.CREATE_ENTRY.
         """
-        if result.get("type") != data_entry_flow.FlowResultType.ABORT:
+        if result.get("type") is not data_entry_flow.FlowResultType.ABORT:
             ir.async_delete_issue(self.hass, flow.handler, flow.init_data["issue_id"])
         return result
 

--- a/homeassistant/components/ridwell/calendar.py
+++ b/homeassistant/components/ridwell/calendar.py
@@ -28,7 +28,7 @@ def async_get_calendar_event_from_pickup_event(
     calendar_preference = config_entry.options.get(CONF_CALENDAR_TITLE, False)
     for pickup in pickup_event.pickups:
         pickup_items.append(f"{pickup.name} (quantity: {pickup.quantity})")
-        if pickup.category == PickupCategory.ROTATING:
+        if pickup.category is PickupCategory.ROTATING:
             rotating_category = pickup.name
             break
 

--- a/homeassistant/components/ridwell/switch.py
+++ b/homeassistant/components/ridwell/switch.py
@@ -51,7 +51,7 @@ class RidwellSwitch(RidwellEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return True if entity is on."""
-        return self.next_pickup_event.state == EventState.SCHEDULED
+        return self.next_pickup_event.state is EventState.SCHEDULED
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -442,7 +442,7 @@ class SamsungTVConfigFlow(ConfigFlow, domain=DOMAIN):
             return None
         LOGGER.debug("Updating existing config entry with %s", entry_kw_args)
         self.hass.config_entries.async_update_entry(entry, **entry_kw_args)
-        if entry.state != ConfigEntryState.LOADED:
+        if entry.state is not ConfigEntryState.LOADED:
             # If its loaded it already has a reload listener in place
             # and we do not want to trigger multiple reloads
             self.hass.async_create_task(

--- a/homeassistant/components/screenlogic/services.py
+++ b/homeassistant/components/screenlogic/services.py
@@ -74,7 +74,7 @@ async def _get_coordinators(
                 f"Failed to call service '{service_call.service}'. Config entry "
                 f"'{entry_id}' is not a {DOMAIN} config"
             )
-        if not config_entry.state == ConfigEntryState.LOADED:
+        if config_entry.state is not ConfigEntryState.LOADED:
             raise ServiceValidationError(
                 f"Failed to call service '{service_call.service}'. Config entry "
                 f"'{entry_id}' not loaded"

--- a/homeassistant/components/sia/hub.py
+++ b/homeassistant/components/sia/hub.py
@@ -145,7 +145,7 @@ class SIAHub:
         underlying platforms, and then setup platforms, this
         reflects any changes in number of zones.
         """
-        if config_entry.state != ConfigEntryState.LOADED:
+        if config_entry.state is not ConfigEntryState.LOADED:
             return
         config_entry.runtime_data.update_accounts()
         await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -228,7 +228,7 @@ def _async_get_system_for_service_call(
         if (
             (entry := hass.config_entries.async_get_entry(entry_id)) is None
             or entry.domain != DOMAIN
-            or entry.state != ConfigEntryState.LOADED
+            or entry.state is not ConfigEntryState.LOADED
         ):
             continue
         return entry.runtime_data.systems[system_id]

--- a/homeassistant/components/simplisafe/lock.py
+++ b/homeassistant/components/simplisafe/lock.py
@@ -92,8 +92,8 @@ class SimpliSafeLock(SimpliSafeEntity, LockEntity):
     @callback
     def async_update_from_rest_api(self) -> None:
         """Update the entity with the provided REST API data."""
-        self._attr_is_jammed = self._device.state == LockStates.JAMMED
-        self._attr_is_locked = self._device.state == LockStates.LOCKED
+        self._attr_is_jammed = self._device.state is LockStates.JAMMED
+        self._attr_is_locked = self._device.state is LockStates.LOCKED
 
         self._attr_extra_state_attributes.update(
             {

--- a/homeassistant/components/simplisafe/sensor.py
+++ b/homeassistant/components/simplisafe/sensor.py
@@ -39,7 +39,7 @@ async def async_setup_entry(
         sensors.extend(
             SimplisafeFreezeSensor(simplisafe, system, cast(SensorV3, sensor))
             for sensor in system.sensors.values()
-            if sensor.type == DeviceTypes.TEMPERATURE
+            if sensor.type is DeviceTypes.TEMPERATURE
         )
 
     async_add_entities(sensors)

--- a/homeassistant/components/sleepiq/number.py
+++ b/homeassistant/components/sleepiq/number.py
@@ -86,7 +86,7 @@ async def _async_set_foot_warmer_time(
     foot_warmer: SleepIQFootWarmer, time: int
 ) -> None:
     temperature = FootWarmingTemps(foot_warmer.temperature)
-    if temperature != FootWarmingTemps.OFF:
+    if temperature is not FootWarmingTemps.OFF:
         await foot_warmer.turn_on(temperature, time)
 
     foot_warmer.timer = time
@@ -105,7 +105,7 @@ async def _async_set_core_climate_time(
     core_climate: SleepIQCoreClimate, time: int
 ) -> None:
     temperature = CoreTemps(core_climate.temperature)
-    if temperature != CoreTemps.OFF:
+    if temperature is not CoreTemps.OFF:
         await core_climate.turn_on(temperature, time)
 
     core_climate.timer = time

--- a/homeassistant/components/sleepiq/select.py
+++ b/homeassistant/components/sleepiq/select.py
@@ -57,7 +57,7 @@ class SleepIQSelectEntity(SleepIQBedEntity[SleepIQDataUpdateCoordinator], Select
 
         self._attr_name = f"SleepNumber {bed.name} Foundation Preset"
         self._attr_unique_id = f"{bed.id}_preset"
-        if preset.side != Side.NONE:
+        if preset.side is not Side.NONE:
             self._attr_name += f" {preset.side_full}"
             self._attr_unique_id += f"_{preset.side.value}"
         self._attr_options = preset.options
@@ -164,7 +164,7 @@ class SleepIQCoreTempSelectEntity(
         temperature = self.HA_TO_SLEEPIQ_CORE_TEMP_MAP[option]
         timer = self.core_climate.timer or 240
 
-        if temperature == CoreTemps.OFF:
+        if temperature is CoreTemps.OFF:
             await self.core_climate.turn_off()
         else:
             await self.core_climate.turn_on(temperature, timer)

--- a/homeassistant/components/snooz/fan.py
+++ b/homeassistant/components/snooz/fan.py
@@ -164,7 +164,7 @@ class SnoozFan(FanEntity, RestoreEntity):
 
         if result.status is SnoozCommandResultStatus.SUCCESSFUL:
             self._async_write_state_changed()
-        elif result.status != SnoozCommandResultStatus.CANCELLED:
+        elif result.status is not SnoozCommandResultStatus.CANCELLED:
             raise HomeAssistantError(
                 f"Command {command} failed with status {result.status.name} after"
                 f" {result.duration}"

--- a/homeassistant/components/snooz/fan.py
+++ b/homeassistant/components/snooz/fan.py
@@ -162,7 +162,7 @@ class SnoozFan(FanEntity, RestoreEntity):
     async def _async_execute_command(self, command: SnoozCommandData) -> None:
         result = await self._device.async_execute_command(command)
 
-        if result.status == SnoozCommandResultStatus.SUCCESSFUL:
+        if result.status is SnoozCommandResultStatus.SUCCESSFUL:
             self._async_write_state_changed()
         elif result.status != SnoozCommandResultStatus.CANCELLED:
             raise HomeAssistantError(

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -556,7 +556,7 @@ class SonosDiscoveryManager:
             return
         uid = uid[5:]
 
-        if change == ssdp.SsdpChange.BYEBYE:
+        if change is ssdp.SsdpChange.BYEBYE:
             _LOGGER.debug(
                 "ssdp:byebye received from %s", info.upnp.get("friendlyName", uid)
             )

--- a/homeassistant/components/ssdp/scanner.py
+++ b/homeassistant/components/ssdp/scanner.py
@@ -367,7 +367,7 @@ class Scanner:
         callbacks = self._async_get_matching_callbacks(combined_headers)
 
         # If there are no changes from a search, do not trigger a config flow
-        if source != SsdpSource.SEARCH_ALIVE:
+        if source is not SsdpSource.SEARCH_ALIVE:
             matching_domains = self.integration_matchers.async_matching_domains(
                 CaseInsensitiveDict(combined_headers.as_dict(), **info_desc)
             )
@@ -375,7 +375,7 @@ class Scanner:
         if (
             not callbacks
             and not matching_domains
-            and source != SsdpSource.ADVERTISEMENT_BYEBYE
+            and source is not SsdpSource.ADVERTISEMENT_BYEBYE
         ):
             return
 
@@ -390,7 +390,7 @@ class Scanner:
 
         # Config flows should only be created for alive/update
         # messages from alive devices
-        if source == SsdpSource.ADVERTISEMENT_BYEBYE:
+        if source is SsdpSource.ADVERTISEMENT_BYEBYE:
             self._async_dismiss_discoveries(discovery_info)
             return
 

--- a/homeassistant/components/sunricher_dali/binary_sensor.py
+++ b/homeassistant/components/sunricher_dali/binary_sensor.py
@@ -79,7 +79,7 @@ class SunricherDaliMotionSensor(DaliDeviceEntity, BinarySensorEntity):
     def _handle_motion_status(self, status: MotionStatus) -> None:
         """Handle motion status updates."""
         motion_state = status["motion_state"]
-        if motion_state == MotionState.MOTION:
+        if motion_state is MotionState.MOTION:
             self._attr_is_on = True
             self.schedule_update_ha_state()
         elif motion_state == MotionState.NO_MOTION:
@@ -124,6 +124,6 @@ class SunricherDaliOccupancySensor(DaliDeviceEntity, BinarySensorEntity):
         if motion_state in _OCCUPANCY_ON_STATES:
             self._attr_is_on = True
             self.schedule_update_ha_state()
-        elif motion_state == MotionState.VACANT:
+        elif motion_state is MotionState.VACANT:
             self._attr_is_on = False
             self.schedule_update_ha_state()

--- a/homeassistant/components/sunricher_dali/binary_sensor.py
+++ b/homeassistant/components/sunricher_dali/binary_sensor.py
@@ -82,7 +82,7 @@ class SunricherDaliMotionSensor(DaliDeviceEntity, BinarySensorEntity):
         if motion_state is MotionState.MOTION:
             self._attr_is_on = True
             self.schedule_update_ha_state()
-        elif motion_state == MotionState.NO_MOTION:
+        elif motion_state is MotionState.NO_MOTION:
             self._attr_is_on = False
             self.schedule_update_ha_state()
 

--- a/homeassistant/components/switchbee/button.py
+++ b/homeassistant/components/switchbee/button.py
@@ -22,7 +22,7 @@ async def async_setup_entry(
     async_add_entities(
         SwitchBeeButton(switchbee_device, coordinator)
         for switchbee_device in coordinator.data.values()
-        if switchbee_device.type == DeviceType.Scenario
+        if switchbee_device.type is DeviceType.Scenario
     )
 
 

--- a/homeassistant/components/switchbee/entity.py
+++ b/homeassistant/components/switchbee/entity.py
@@ -48,7 +48,7 @@ class SwitchBeeDeviceEntity[_DeviceTypeT: SwitchBeeBaseDevice](
         super().__init__(device, coordinator)
         self._is_online: bool = True
         identifier = (
-            device.id if device.type == DeviceType.Thermostat else device.unit_id
+            device.id if device.type is DeviceType.Thermostat else device.unit_id
         )
         self._attr_device_info = DeviceInfo(
             name=device.zone,

--- a/homeassistant/components/switchbee/light.py
+++ b/homeassistant/components/switchbee/light.py
@@ -40,7 +40,7 @@ async def async_setup_entry(
     async_add_entities(
         SwitchBeeLightEntity(cast(SwitchBeeDimmer, switchbee_device), coordinator)
         for switchbee_device in coordinator.data.values()
-        if switchbee_device.type == DeviceType.Dimmer
+        if switchbee_device.type is DeviceType.Dimmer
     )
 
 

--- a/homeassistant/components/switcher_kis/button.py
+++ b/homeassistant/components/switcher_kis/button.py
@@ -70,7 +70,7 @@ async def async_setup_entry(
     async def async_add_buttons(coordinator: SwitcherDataUpdateCoordinator) -> None:
         """Get remote and add button from Switcher device."""
         data = cast(SwitcherBreezeRemote, coordinator.data)
-        if coordinator.data.device_type.category == DeviceCategory.THERMOSTAT:
+        if coordinator.data.device_type.category is DeviceCategory.THERMOSTAT:
             remote: SwitcherBreezeRemote = await hass.async_add_executor_job(
                 get_breeze_remote_manager(hass).get_remote, data.remote_id
             )

--- a/homeassistant/components/switcher_kis/climate.py
+++ b/homeassistant/components/switcher_kis/climate.py
@@ -67,7 +67,7 @@ async def async_setup_entry(
     async def async_add_climate(coordinator: SwitcherDataUpdateCoordinator) -> None:
         """Get remote and add climate from Switcher device."""
         data = cast(SwitcherThermostat, coordinator.data)
-        if coordinator.data.device_type.category == DeviceCategory.THERMOSTAT:
+        if coordinator.data.device_type.category is DeviceCategory.THERMOSTAT:
             remote: SwitcherBreezeRemote = await hass.async_add_executor_job(
                 get_breeze_remote_manager(hass).get_remote, data.remote_id
             )
@@ -130,7 +130,7 @@ class SwitcherClimateEntity(SwitcherEntity, ClimateEntity):
         self._attr_target_temperature = float(data.target_temperature)
 
         self._attr_hvac_mode = HVACMode.OFF
-        if data.device_state == DeviceState.ON:
+        if data.device_state is DeviceState.ON:
             self._attr_hvac_mode = DEVICE_MODE_TO_HA[data.mode]
 
         self._attr_fan_mode = None
@@ -144,7 +144,7 @@ class SwitcherClimateEntity(SwitcherEntity, ClimateEntity):
         if features["swing"]:
             self._attr_swing_mode = SWING_OFF
             self._attr_swing_modes = [SWING_VERTICAL, SWING_OFF]
-            if data.swing == ThermostatSwing.ON:
+            if data.swing is ThermostatSwing.ON:
                 self._attr_swing_mode = SWING_VERTICAL
 
     async def _async_control_breeze_device(self, **kwargs: Any) -> None:

--- a/homeassistant/components/switcher_kis/cover.py
+++ b/homeassistant/components/switcher_kis/cover.py
@@ -75,10 +75,10 @@ class SwitcherBaseCoverEntity(SwitcherEntity, CoverEntity):
         self._attr_current_cover_position = data.position[self._cover_id]
         self._attr_is_closed = data.position[self._cover_id] == 0
         self._attr_is_closing = (
-            data.direction[self._cover_id] == ShutterDirection.SHUTTER_DOWN
+            data.direction[self._cover_id] is ShutterDirection.SHUTTER_DOWN
         )
         self._attr_is_opening = (
-            data.direction[self._cover_id] == ShutterDirection.SHUTTER_UP
+            data.direction[self._cover_id] is ShutterDirection.SHUTTER_UP
         )
 
     async def async_close_cover(self, **kwargs: Any) -> None:

--- a/homeassistant/components/switcher_kis/light.py
+++ b/homeassistant/components/switcher_kis/light.py
@@ -78,7 +78,7 @@ class SwitcherBaseLightEntity(SwitcherEntity, LightEntity):
             return
 
         data = cast(SwitcherLight, self.coordinator.data)
-        self._attr_is_on = bool(data.light[self._light_id] == DeviceState.ON)
+        self._attr_is_on = bool(data.light[self._light_id] is DeviceState.ON)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""

--- a/homeassistant/components/switcher_kis/sensor.py
+++ b/homeassistant/components/switcher_kis/sensor.py
@@ -106,7 +106,7 @@ async def async_setup_entry(
                 SwitcherSensorEntity(coordinator, description)
                 for description in HEATER_SENSORS
             )
-        elif coordinator.data.device_type.category == DeviceCategory.THERMOSTAT:
+        elif coordinator.data.device_type.category is DeviceCategory.THERMOSTAT:
             async_add_entities(
                 SwitcherSensorEntity(coordinator, description)
                 for description in THERMOSTAT_SENSORS

--- a/homeassistant/components/switcher_kis/sensor.py
+++ b/homeassistant/components/switcher_kis/sensor.py
@@ -93,7 +93,7 @@ async def async_setup_entry(
     @callback
     def async_add_sensors(coordinator: SwitcherDataUpdateCoordinator) -> None:
         """Add sensors from Switcher device."""
-        if coordinator.data.device_type.category == DeviceCategory.POWER_PLUG:
+        if coordinator.data.device_type.category is DeviceCategory.POWER_PLUG:
             async_add_entities(
                 SwitcherSensorEntity(coordinator, description)
                 for description in POWER_PLUG_SENSORS

--- a/homeassistant/components/switcher_kis/switch.py
+++ b/homeassistant/components/switcher_kis/switch.py
@@ -75,7 +75,7 @@ async def async_setup_entry(
         """Add switch from Switcher device."""
         entities: list[SwitchEntity] = []
 
-        if coordinator.data.device_type.category == DeviceCategory.POWER_PLUG:
+        if coordinator.data.device_type.category is DeviceCategory.POWER_PLUG:
             entities.append(SwitcherPowerPlugSwitchEntity(coordinator))
         elif coordinator.data.device_type.category in [
             DeviceCategory.WATER_HEATER,
@@ -123,7 +123,7 @@ class SwitcherBaseSwitchEntity(SwitcherEntity, SwitchEntity):
             self.control_result = None
             return
 
-        self._attr_is_on = bool(self.coordinator.data.device_state == DeviceState.ON)
+        self._attr_is_on = bool(self.coordinator.data.device_state is DeviceState.ON)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
@@ -188,7 +188,7 @@ class SwitcherShutterChildLockBaseSwitchEntity(SwitcherEntity, SwitchEntity):
             return
 
         data = cast(SwitcherShutter, self.coordinator.data)
-        self._attr_is_on = bool(data.child_lock[self._cover_id] == ShutterChildLock.ON)
+        self._attr_is_on = bool(data.child_lock[self._cover_id] is ShutterChildLock.ON)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""

--- a/homeassistant/components/system_bridge/sensor.py
+++ b/homeassistant/components/system_bridge/sensor.py
@@ -653,7 +653,7 @@ class SystemBridgeSensor(SystemBridgeEntity, SensorEntity):
             description.key,
         )
         self.entity_description = description
-        if description.name != UNDEFINED:
+        if description.name is not UNDEFINED:
             self._attr_has_entity_name = False
 
     @property

--- a/homeassistant/components/telegram_bot/config_flow.py
+++ b/homeassistant/components/telegram_bot/config_flow.py
@@ -491,7 +491,7 @@ class TelegramBotConfigFlow(ConfigFlow, domain=DOMAIN):
             CONF_API_ENDPOINT
         ]
         if (
-            self._get_reconfigure_entry().state == ConfigEntryState.LOADED
+            self._get_reconfigure_entry().state is ConfigEntryState.LOADED
             and user_input[CONF_API_ENDPOINT] != DEFAULT_API_ENDPOINT
             and existing_api_endpoint == DEFAULT_API_ENDPOINT
         ):
@@ -596,7 +596,7 @@ class AllowedChatIdsSubEntryFlowHandler(ConfigSubentryFlow):
     ) -> SubentryFlowResult:
         """Create allowed chat ID."""
 
-        if self._get_entry().state != ConfigEntryState.LOADED:
+        if self._get_entry().state is not ConfigEntryState.LOADED:
             return self.async_abort(
                 reason="entry_not_loaded",
                 description_placeholders={"telegram_bot": self._get_entry().title},

--- a/homeassistant/components/tesla_fleet/coordinator.py
+++ b/homeassistant/components/tesla_fleet/coordinator.py
@@ -113,7 +113,7 @@ class TeslaFleetVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.endpoints = (
             ENDPOINTS
             if location
-            else [ep for ep in ENDPOINTS if ep != VehicleDataEndpoint.LOCATION_DATA]
+            else [ep for ep in ENDPOINTS if ep is not VehicleDataEndpoint.LOCATION_DATA]
         )
 
     async def _async_update_data(self) -> dict[str, Any]:

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -433,7 +433,7 @@ class CoordinatedTPLinkFeatureEntity(CoordinatedTPLinkEntity, ABC):
                 parent=parent,
             )
             for feat in device.features.values()
-            if feat.type == feature_type
+            if feat.type is feature_type
             and feat.id not in EXCLUDED_FEATURES
             and (
                 feat.category is not Feature.Category.Primary

--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -49,7 +49,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: UpnpConfigEntry) -> bool
     async def device_discovered(
         headers: SsdpServiceInfo, change: ssdp.SsdpChange
     ) -> None:
-        if change == ssdp.SsdpChange.BYEBYE:
+        if change is ssdp.SsdpChange.BYEBYE:
             return
 
         nonlocal discovery_info

--- a/homeassistant/components/victron_gx/hub.py
+++ b/homeassistant/components/victron_gx/hub.py
@@ -170,7 +170,7 @@ class Hub:
                     metric.short_id: {
                         "name": metric.name,
                         "value": "**REDACTED**"
-                        if metric.metric_type == MetricType.LOCATION
+                        if metric.metric_type is MetricType.LOCATION
                         else metric.value
                         if not isinstance(metric.value, VictronEnum)
                         else metric.value.id,

--- a/homeassistant/components/victron_remote_monitoring/energy.py
+++ b/homeassistant/components/victron_remote_monitoring/energy.py
@@ -10,7 +10,7 @@ async def async_get_solar_forecast(
     """Get solar forecast for a config entry ID."""
     if (
         entry := hass.config_entries.async_get_entry(config_entry_id)
-    ) is None or entry.state != ConfigEntryState.LOADED:
+    ) is None or entry.state is not ConfigEntryState.LOADED:
         return None
     data = entry.runtime_data.data.solar
     if data is None:

--- a/homeassistant/components/withings/sensor.py
+++ b/homeassistant/components/withings/sensor.py
@@ -857,7 +857,7 @@ async def async_setup_entry(
                                 config_entry_id
                             )
                         )
-                        and config_entry.state == ConfigEntryState.LOADED
+                        and config_entry.state is ConfigEntryState.LOADED
                         for config_entry_id in device.config_entries
                     ):
                         continue

--- a/homeassistant/components/xiaomi_ble/__init__.py
+++ b/homeassistant/components/xiaomi_ble/__init__.py
@@ -100,7 +100,7 @@ def process_service_info(
     # not verified then we need to reauth
     if (
         not data.pending
-        and data.encryption_scheme != EncryptionScheme.NONE
+        and data.encryption_scheme is not EncryptionScheme.NONE
         and not data.bindkey_verified
     ):
         entry.async_start_reauth(hass, data={"device": data})

--- a/homeassistant/components/xiaomi_ble/config_flow.py
+++ b/homeassistant/components/xiaomi_ble/config_flow.py
@@ -111,7 +111,7 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if device.encryption_scheme is EncryptionScheme.MIBEACON_LEGACY:
             return await self.async_step_get_encryption_key_legacy()
-        if device.encryption_scheme == EncryptionScheme.MIBEACON_4_5:
+        if device.encryption_scheme is EncryptionScheme.MIBEACON_4_5:
             return await self.async_step_get_encryption_key_4_5_choose_method()
         return await self.async_step_bluetooth_confirm()
 
@@ -299,7 +299,7 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
             if discovery.device.encryption_scheme is EncryptionScheme.MIBEACON_LEGACY:
                 return await self.async_step_get_encryption_key_legacy()
 
-            if discovery.device.encryption_scheme == EncryptionScheme.MIBEACON_4_5:
+            if discovery.device.encryption_scheme is EncryptionScheme.MIBEACON_4_5:
                 return await self.async_step_get_encryption_key_4_5_choose_method()
 
             return self._async_get_or_create_entry()
@@ -341,7 +341,7 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
         if device.encryption_scheme is EncryptionScheme.MIBEACON_LEGACY:
             return await self.async_step_get_encryption_key_legacy()
 
-        if device.encryption_scheme == EncryptionScheme.MIBEACON_4_5:
+        if device.encryption_scheme is EncryptionScheme.MIBEACON_4_5:
             return await self.async_step_get_encryption_key_4_5_choose_method()
 
         # Otherwise there wasn't actually encryption so abort

--- a/homeassistant/components/xiaomi_ble/config_flow.py
+++ b/homeassistant/components/xiaomi_ble/config_flow.py
@@ -109,7 +109,7 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
             # encryption later, we can do a reauth
             return await self.async_step_confirm_slow()
 
-        if device.encryption_scheme == EncryptionScheme.MIBEACON_LEGACY:
+        if device.encryption_scheme is EncryptionScheme.MIBEACON_LEGACY:
             return await self.async_step_get_encryption_key_legacy()
         if device.encryption_scheme == EncryptionScheme.MIBEACON_4_5:
             return await self.async_step_get_encryption_key_4_5_choose_method()
@@ -296,7 +296,7 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
 
             self._discovered_device = discovery.device
 
-            if discovery.device.encryption_scheme == EncryptionScheme.MIBEACON_LEGACY:
+            if discovery.device.encryption_scheme is EncryptionScheme.MIBEACON_LEGACY:
                 return await self.async_step_get_encryption_key_legacy()
 
             if discovery.device.encryption_scheme == EncryptionScheme.MIBEACON_4_5:
@@ -338,7 +338,7 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
 
         self._discovery_info = device.last_service_info
 
-        if device.encryption_scheme == EncryptionScheme.MIBEACON_LEGACY:
+        if device.encryption_scheme is EncryptionScheme.MIBEACON_LEGACY:
             return await self.async_step_get_encryption_key_legacy()
 
         if device.encryption_scheme == EncryptionScheme.MIBEACON_4_5:

--- a/homeassistant/components/xiaomi_miio/humidifier.py
+++ b/homeassistant/components/xiaomi_miio/humidifier.py
@@ -253,7 +253,7 @@ class XiaomiAirHumidifier(XiaomiGenericHumidifier, HumidifierEntity):
         if (
             self.supported_features & HumidifierEntityFeature.MODES == 0
             or AirhumidifierOperationMode(self._attributes[ATTR_MODE])
-            == AirhumidifierOperationMode.Auto
+            is AirhumidifierOperationMode.Auto
             or AirhumidifierOperationMode.Auto.name not in self.available_modes
         ):
             self.async_write_ha_state()
@@ -310,7 +310,7 @@ class XiaomiAirHumidifierMiot(XiaomiAirHumidifier):
             return (
                 self._target_humidity
                 if AirhumidifierMiotOperationMode(self._mode)
-                == AirhumidifierMiotOperationMode.Auto
+                is AirhumidifierMiotOperationMode.Auto
                 else None
             )
         return None
@@ -331,7 +331,7 @@ class XiaomiAirHumidifierMiot(XiaomiAirHumidifier):
         if (
             self.supported_features & HumidifierEntityFeature.MODES == 0
             or AirhumidifierMiotOperationMode(self._attributes[ATTR_MODE])
-            == AirhumidifierMiotOperationMode.Auto
+            is AirhumidifierMiotOperationMode.Auto
         ):
             self.async_write_ha_state()
             return
@@ -385,7 +385,7 @@ class XiaomiAirHumidifierMjjsq(XiaomiAirHumidifier):
         if self.is_on:
             if (
                 AirhumidifierMjjsqOperationMode(self._mode)
-                == AirhumidifierMjjsqOperationMode.Humidity
+                is AirhumidifierMjjsqOperationMode.Humidity
             ):
                 return self._target_humidity
         return None
@@ -406,7 +406,7 @@ class XiaomiAirHumidifierMjjsq(XiaomiAirHumidifier):
         if (
             self.supported_features & HumidifierEntityFeature.MODES == 0
             or AirhumidifierMjjsqOperationMode(self._attributes[ATTR_MODE])
-            == AirhumidifierMjjsqOperationMode.Humidity
+            is AirhumidifierMjjsqOperationMode.Humidity
         ):
             self.async_write_ha_state()
             return

--- a/homeassistant/components/yalexs_ble/binary_sensor.py
+++ b/homeassistant/components/yalexs_ble/binary_sensor.py
@@ -35,5 +35,5 @@ class YaleXSBLEDoorSensor(YALEXSBLEEntity, BinarySensorEntity):
         self, new_state: LockState, lock_info: LockInfo, connection_info: ConnectionInfo
     ) -> None:
         """Update the state."""
-        self._attr_is_on = new_state.door == DoorStatus.OPENED
+        self._attr_is_on = new_state.door is DoorStatus.OPENED
         super()._async_update_state(new_state, lock_info, connection_info)

--- a/homeassistant/components/yeelight/config_flow.py
+++ b/homeassistant/components/yeelight/config_flow.py
@@ -106,7 +106,7 @@ class YeelightConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_ID
             ):
                 continue
-            reload = entry.state == ConfigEntryState.SETUP_RETRY
+            reload = entry.state is ConfigEntryState.SETUP_RETRY
             if entry.data.get(CONF_HOST) != self._discovered_ip:
                 self.hass.config_entries.async_update_entry(
                     entry, data={**entry.data, CONF_HOST: self._discovered_ip}

--- a/homeassistant/components/yolink/services.py
+++ b/homeassistant/components/yolink/services.py
@@ -40,7 +40,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
                     continue
                 if entry.domain == DOMAIN:
                     break
-            if entry is None or entry.state != ConfigEntryState.LOADED:
+            if entry is None or entry.state is not ConfigEntryState.LOADED:
                 raise ServiceValidationError(
                     translation_domain=DOMAIN,
                     translation_key="invalid_config_entry",

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -1207,7 +1207,7 @@ async def async_ensure_addon_running(
     if addon_has_esphome and socket_path is not None:
         addon_config[CONF_ADDON_SOCKET] = socket_path
 
-    if addon_state == AddonState.NOT_INSTALLED:
+    if addon_state is AddonState.NOT_INSTALLED:
         addon_manager.async_schedule_install_setup_addon(
             addon_config,
             catch_error=True,

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -1214,7 +1214,7 @@ async def async_ensure_addon_running(
         )
         raise ConfigEntryNotReady
 
-    if addon_state == AddonState.NOT_RUNNING:
+    if addon_state is AddonState.NOT_RUNNING:
         addon_manager.async_schedule_setup_addon(
             addon_config,
             catch_error=True,

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -382,7 +382,7 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
         if new_addon_config == addon_config:
             return
 
-        if addon_info.state == AddonState.RUNNING:
+        if addon_info.state is AddonState.RUNNING:
             self.restart_addon = True
         # Copy the add-on config to keep the objects separate.
         self.original_addon_config = dict(addon_config)
@@ -732,7 +732,7 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
 
         addon_info = await self._async_get_addon_info()
 
-        if addon_info.state == AddonState.RUNNING:
+        if addon_info.state is AddonState.RUNNING:
             addon_config = addon_info.options
             # Use the options set by USB/ESPHome discovery
             if not self._adapter_discovered:
@@ -1230,7 +1230,7 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
 
         addon_info = await self._async_get_addon_info()
 
-        if addon_info.state == AddonState.NOT_INSTALLED:
+        if addon_info.state is AddonState.NOT_INSTALLED:
             return await self.async_step_install_addon()
 
         return await self.async_step_configure_addon_reconfigure()
@@ -1268,7 +1268,7 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
 
             await self._async_set_addon_config(addon_config_updates)
 
-            if addon_info.state == AddonState.RUNNING and not self.restart_addon:
+            if addon_info.state is AddonState.RUNNING and not self.restart_addon:
                 return await self.async_step_finish_addon_setup_reconfigure()
 
             if (
@@ -1719,7 +1719,7 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
         """Get the driver from the config entry."""
         config_entry = self._reconfigure_config_entry
         assert config_entry is not None
-        if config_entry.state != ConfigEntryState.LOADED:
+        if config_entry.state is not ConfigEntryState.LOADED:
             raise AbortFlow("Configuration entry is not loaded")
         client: Client = config_entry.runtime_data.client
         assert client.driver is not None

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -757,7 +757,7 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
             )
             return await self.async_step_finish_addon_setup_user()
 
-        if addon_info.state == AddonState.NOT_RUNNING:
+        if addon_info.state is AddonState.NOT_RUNNING:
             return await self.async_step_configure_addon_user()
 
         return await self.async_step_install_addon()

--- a/homeassistant/components/zwave_js/device_automation_helpers.py
+++ b/homeassistant/components/zwave_js/device_automation_helpers.py
@@ -44,7 +44,7 @@ def async_bypass_dynamic_config_validation(hass: HomeAssistant, device_id: str) 
             config_entry
             for config_entry in hass.config_entries.async_entries(DOMAIN)
             if config_entry.entry_id in device.config_entries
-            and config_entry.state == ConfigEntryState.LOADED
+            and config_entry.state is ConfigEntryState.LOADED
         ),
         None,
     )

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -305,7 +305,7 @@ def async_get_node_from_device_id(
         raise ValueError(
             f"Device {device_id} is not from an existing zwave_js config entry"
         )
-    if entry.state != ConfigEntryState.LOADED:
+    if entry.state is not ConfigEntryState.LOADED:
         raise ValueError(f"Device {device_id} config entry is not loaded")
 
     client = entry.runtime_data.client
@@ -353,7 +353,7 @@ async def async_get_provisioning_entry_from_device_id(
         raise ValueError(
             f"Device {device_id} is not from an existing zwave_js config entry"
         )
-    if entry.state != ConfigEntryState.LOADED:
+    if entry.state is not ConfigEntryState.LOADED:
         raise ValueError(f"Device {device_id} config entry is not loaded")
 
     client = entry.runtime_data.client

--- a/homeassistant/components/zwave_js/triggers/trigger_helpers.py
+++ b/homeassistant/components/zwave_js/triggers/trigger_helpers.py
@@ -21,7 +21,7 @@ def async_bypass_dynamic_config_validation(
     trigger_devices = config.get(ATTR_DEVICE_ID, [])
     trigger_entities = config.get(ATTR_ENTITY_ID, [])
     for entry in hass.config_entries.async_entries(DOMAIN):
-        if entry.state != ConfigEntryState.LOADED and (
+        if entry.state is not ConfigEntryState.LOADED and (
             entry.entry_id == config.get(ATTR_CONFIG_ENTRY_ID)
             or any(
                 device.id in trigger_devices

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -985,7 +985,7 @@ class ConfigEntry[_DataT = Any]:
             self._async_set_state(hass, ConfigEntryState.NOT_LOADED, None)
             return True
 
-        if self.state == ConfigEntryState.NOT_LOADED:
+        if self.state is ConfigEntryState.NOT_LOADED:
             return True
 
         if not integration and (integration := self._integration_for_domain) is None:
@@ -1648,7 +1648,7 @@ class ConfigEntriesFlowManager(
         """
         flow = cast(ConfigFlow, flow)
 
-        if result["type"] != data_entry_flow.FlowResultType.CREATE_ENTRY:
+        if result["type"] is not data_entry_flow.FlowResultType.CREATE_ENTRY:
             # If there's a config entry with a matching unique ID,
             # update the discovery key.
             if (
@@ -2177,7 +2177,7 @@ class ConfigEntries:
         """
         entries = self._entries.get_entries_for_domain(domain)
 
-        return [entry for entry in entries if entry.state == ConfigEntryState.LOADED]
+        return [entry for entry in entries if entry.state is ConfigEntryState.LOADED]
 
     @callback
     def async_entry_for_domain_unique_id(
@@ -3651,7 +3651,7 @@ class ConfigSubentryFlowManager(
         """
         flow = cast(ConfigSubentryFlow, flow)
 
-        if result["type"] != data_entry_flow.FlowResultType.CREATE_ENTRY:
+        if result["type"] is not data_entry_flow.FlowResultType.CREATE_ENTRY:
             return result
 
         entry_id, subentry_type = flow.handler
@@ -3874,7 +3874,7 @@ class OptionsFlowManager(
         """
         flow = cast(OptionsFlow, flow)
 
-        if result["type"] != data_entry_flow.FlowResultType.CREATE_ENTRY:
+        if result["type"] is not data_entry_flow.FlowResultType.CREATE_ENTRY:
             return result
 
         entry = self.hass.config_entries.async_get_known_entry(flow.handler)

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -326,11 +326,11 @@ class FlowManager(abc.ABC, Generic[_FlowContextT, _FlowResultT, _HandlerT]):
         if flow and flow.deprecated_show_progress:
             if (cur_step := flow.cur_step) and cur_step[
                 "type"
-            ] == FlowResultType.SHOW_PROGRESS:
+            ] is FlowResultType.SHOW_PROGRESS:
                 # Allow the progress task to finish before we call the flow handler
                 await asyncio.sleep(0)
 
-        while not result or result["type"] == FlowResultType.SHOW_PROGRESS_DONE:
+        while not result or result["type"] is FlowResultType.SHOW_PROGRESS_DONE:
             result = await self._async_configure(flow_id, user_input)
             flow = self._progress.get(flow_id)
             if flow and flow.deprecated_show_progress:
@@ -374,7 +374,7 @@ class FlowManager(abc.ABC, Generic[_FlowContextT, _FlowResultT, _HandlerT]):
                 ) from ex
 
         # Handle a menu navigation choice
-        if cur_step["type"] == FlowResultType.MENU and user_input:
+        if cur_step["type"] is FlowResultType.MENU and user_input:
             result = await self._async_handle_step(
                 flow, user_input["next_step_id"], None
             )
@@ -414,7 +414,7 @@ class FlowManager(abc.ABC, Generic[_FlowContextT, _FlowResultT, _HandlerT]):
             # - The step is same but result type is SHOW_PROGRESS and progress_action
             #   or description_placeholders has changed
             if cur_step["step_id"] != result.get("step_id") or (
-                result["type"] == FlowResultType.SHOW_PROGRESS
+                result["type"] is FlowResultType.SHOW_PROGRESS
                 and (
                     cur_step["progress_action"] != result.get("progress_action")
                     or cur_step["description_placeholders"]
@@ -491,8 +491,10 @@ class FlowManager(abc.ABC, Generic[_FlowContextT, _FlowResultT, _HandlerT]):
 
         if flow.flow_id not in self._progress:
             # The flow was removed during the step, raise UnknownFlow
-            # unless the result is an abort
-            if result["type"] != FlowResultType.ABORT:
+            # unless the result is an abort. Uses `!=` (not `is not`) because
+            # this runs before the legacy-string normalization below, and
+            # out-of-tree flow handlers may still return raw "abort".
+            if result["type"] != FlowResultType.ABORT:  # type: ignore[ha-enum-identity-compare,unused-ignore]
                 raise UnknownFlow
             return result
 
@@ -509,7 +511,7 @@ class FlowManager(abc.ABC, Generic[_FlowContextT, _FlowResultT, _HandlerT]):
             )
 
         if (
-            result["type"] == FlowResultType.SHOW_PROGRESS
+            result["type"] is FlowResultType.SHOW_PROGRESS
             # Mypy does not agree with using pop on _FlowResultT
             and (progress_task := result.pop("progress_task", None))  # type: ignore[arg-type]
             and progress_task != flow.async_get_progress_task()
@@ -526,7 +528,7 @@ class FlowManager(abc.ABC, Generic[_FlowContextT, _FlowResultT, _HandlerT]):
             progress_task.add_done_callback(schedule_configure)  # type: ignore[attr-defined]
             flow.async_set_progress_task(progress_task)  # type: ignore[arg-type]
 
-        elif result["type"] != FlowResultType.SHOW_PROGRESS:
+        elif result["type"] is not FlowResultType.SHOW_PROGRESS:
             flow.async_cancel_progress_task()
 
         if result["type"] in STEP_ID_OPTIONAL_STEPS:
@@ -551,7 +553,7 @@ class FlowManager(abc.ABC, Generic[_FlowContextT, _FlowResultT, _HandlerT]):
             )
 
         # _async_finish_flow may change result type, check it again
-        if result["type"] == FlowResultType.FORM:
+        if result["type"] is FlowResultType.FORM:
             flow.cur_step = result
             return result
 

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -387,7 +387,7 @@ class FlowManager(abc.ABC, Generic[_FlowContextT, _FlowResultT, _HandlerT]):
             FlowResultType.EXTERNAL_STEP,
             FlowResultType.SHOW_PROGRESS,
         ):
-            if cur_step["type"] == FlowResultType.EXTERNAL_STEP and result[
+            if cur_step["type"] is FlowResultType.EXTERNAL_STEP and result[
                 "type"
             ] not in (
                 FlowResultType.EXTERNAL_STEP,
@@ -397,7 +397,7 @@ class FlowManager(abc.ABC, Generic[_FlowContextT, _FlowResultT, _HandlerT]):
                     "External step can only transition to "
                     "external step or external step done."
                 )
-            if cur_step["type"] == FlowResultType.SHOW_PROGRESS and result[
+            if cur_step["type"] is FlowResultType.SHOW_PROGRESS and result[
                 "type"
             ] not in (
                 FlowResultType.SHOW_PROGRESS,

--- a/homeassistant/helpers/data_entry_flow.py
+++ b/homeassistant/helpers/data_entry_flow.py
@@ -31,7 +31,7 @@ class _BaseFlowManagerView(HomeAssistantView, Generic[_FlowManagerT]):
         self, result: data_entry_flow.FlowResult
     ) -> dict[str, Any]:
         """Convert result to JSON serializable dict."""
-        if result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY:
+        if result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY:
             assert "result" not in result
             return {
                 key: val

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -1957,7 +1957,7 @@ class EntityRegistry(BaseRegistry):
             raise ValueError("Only entities that haven't been loaded can be migrated")
 
         old = self.entities[entity_id]
-        if new_config_entry_id == UNDEFINED and old.config_entry_id is not None:
+        if new_config_entry_id is UNDEFINED and old.config_entry_id is not None:
             raise ValueError(
                 f"new_config_entry_id required because {entity_id} is already linked "
                 "to a config entry"

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -1453,7 +1453,7 @@ class IntentResponse:
 
         response_data: dict[str, Any] = {}
 
-        if self.response_type == IntentResponseType.ERROR:
+        if self.response_type is IntentResponseType.ERROR:
             assert self.error_code is not None, "error code is required"
             response_data["code"] = self.error_code.value
         else:

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -260,7 +260,7 @@ class _GlobalTaskContext:
         await self._wait_zone.wait()
         await asyncio.sleep(self._cool_down)  # Allow context switch
         self._on_wait_task = None
-        if self.state != _State.TIMEOUT:
+        if self.state is not _State.TIMEOUT:
             return
         self._cancel_task()
 


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

<!-- No "Breaking change" section — pure semantic equivalence. -->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Mechanical codemod that replaces `==` with `is` (and `!=` with `is not`)
on every line where both operands statically resolve to the same enum
class — as identified by `mypy_plugins.enum_identity_compare` from
#171551.

**This PR covers `homeassistant/` source files only** (156 files,
289 sites). The corresponding tests-side codemod is in #171689.

```python
# Before:
if self.state == ConfigEntryState.LOADED:  # both sides are ConfigEntryState
# After:
if self.state is ConfigEntryState.LOADED:
```

**Scope is intentionally narrow:**

- **Plain `enum.Enum` subclasses** — 100% safe, because `Enum.__eq__`
  is identity-based: `==` and `is` give the same result.
- **`homeassistant.data_entry_flow.FlowResultType`** — the only
  `StrEnum` on a curated allowlist, because HA's framework controls
  every value-assigning callsite (`async_show_form`, `async_create_entry`,
  etc. all set it to the enum instance).

**What is NOT changed:**

- Other `StrEnum`/`IntEnum`/`ReprEnum` subclasses (`HVACMode`,
  `HTTPStatus`, `Platform`, `EntityCategory`, ...). Their `__eq__`
  delegates to `str`/`int` equality, and callers routinely pass the
  underlying primitive (which is the whole reason those base classes
  exist). Replacing `==` with `is` there would silently break behavior.
- `Flag`/`IntFlag` — bitwise `==` is idiomatic.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #171551 (plugin), #171689 (tests-side codemod)
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

The codemod is independent of #171551 and of the tests-side codemod.
All three can land in any order; CI on the plugin will be fully clean
only once both codemod halves land.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
