### PR TITLE
Use `is`/`is not` for same-enum identity comparisons (2/3)

### DIFF
--- a/homeassistant/components/matter/__init__.py
+++ b/homeassistant/components/matter/__init__.py
@@ -179,13 +179,13 @@ async def _client_listen(
     try:
         await matter_client.start_listening(init_ready)
     except MatterError as err:
-        if entry.state != ConfigEntryState.LOADED:
+        if entry.state is not ConfigEntryState.LOADED:
             raise
         LOGGER.error("Failed to listen: %s", err)
     except Exception as err:
         # We need to guard against unknown exceptions to not crash this task.
         LOGGER.exception("Unexpected exception: %s", err)
-        if entry.state != ConfigEntryState.LOADED:
+        if entry.state is not ConfigEntryState.LOADED:
             raise
 
     if not hass.is_stopping:
@@ -293,7 +293,7 @@ async def _async_ensure_addon_running(
 
     addon_state = addon_info.state
 
-    if addon_state == AddonState.NOT_INSTALLED:
+    if addon_state is AddonState.NOT_INSTALLED:
         addon_manager.async_schedule_install_setup_addon(
             addon_info.options,
             catch_error=True,

--- a/homeassistant/components/matter/climate.py
+++ b/homeassistant/components/matter/climate.py
@@ -241,7 +241,7 @@ class MatterClimate(MatterEntity, ClimateEntity):
         if target_temperature is not None:
             # single setpoint control
             if self.target_temperature != target_temperature:
-                if current_mode == HVACMode.COOL:
+                if current_mode is HVACMode.COOL:
                     matter_attribute = (
                         clusters.Thermostat.Attributes.OccupiedCoolingSetpoint
                     )
@@ -475,7 +475,7 @@ class MatterClimate(MatterEntity, ClimateEntity):
             self._attr_supported_features
             & ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
         )
-        if supports_range and self._attr_hvac_mode == HVACMode.HEAT_COOL:
+        if supports_range and self._attr_hvac_mode is HVACMode.HEAT_COOL:
             self._attr_target_temperature = None
             self._attr_target_temperature_high = self._get_temperature_in_degrees(
                 clusters.Thermostat.Attributes.OccupiedCoolingSetpoint
@@ -487,7 +487,7 @@ class MatterClimate(MatterEntity, ClimateEntity):
             self._attr_target_temperature_high = None
             self._attr_target_temperature_low = None
             # update target_temperature
-            if self._attr_hvac_mode == HVACMode.COOL:
+            if self._attr_hvac_mode is HVACMode.COOL:
                 self._attr_target_temperature = self._get_temperature_in_degrees(
                     clusters.Thermostat.Attributes.OccupiedCoolingSetpoint
                 )
@@ -500,7 +500,7 @@ class MatterClimate(MatterEntity, ClimateEntity):
     def _update_temperature_limits(self) -> None:
         """Update min and max temperature limits."""
         # update min_temp
-        if self._attr_hvac_mode == HVACMode.COOL:
+        if self._attr_hvac_mode is HVACMode.COOL:
             attribute = clusters.Thermostat.Attributes.AbsMinCoolSetpointLimit
         else:
             attribute = clusters.Thermostat.Attributes.AbsMinHeatSetpointLimit
@@ -557,7 +557,7 @@ class MatterClimate(MatterEntity, ClimateEntity):
                 self._attr_supported_features |= (
                     ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
                 )
-        if any(mode for mode in self.hvac_modes if mode != HVACMode.OFF):
+        if any(mode for mode in self.hvac_modes if mode is not HVACMode.OFF):
             self._attr_supported_features |= ClimateEntityFeature.TURN_ON
 
     @callback

--- a/homeassistant/components/matter/config_flow.py
+++ b/homeassistant/components/matter/config_flow.py
@@ -288,7 +288,7 @@ class MatterConfigFlow(ConfigFlow, domain=DOMAIN):
 
         addon_info = await self._async_get_addon_info()
 
-        if addon_info.state == AddonState.RUNNING:
+        if addon_info.state is AddonState.RUNNING:
             return await self.async_step_finish_addon_setup()
 
         if addon_info.state == AddonState.NOT_RUNNING:

--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -428,12 +428,12 @@ class MatterLight(MatterEntity, LightEntity):
             self._attr_color_mode = color_mode = self._get_color_mode()
             if (
                 ColorMode.HS in self._attr_supported_color_modes
-                and color_mode == ColorMode.HS
+                and color_mode is ColorMode.HS
             ):
                 self._attr_hs_color = self._get_hs_color()
             elif (
                 ColorMode.XY in self._attr_supported_color_modes
-                and color_mode == ColorMode.XY
+                and color_mode is ColorMode.XY
             ):
                 self._attr_xy_color = self._get_xy_color()
         elif self._supports_color_temperature:

--- a/homeassistant/components/matter/update.py
+++ b/homeassistant/components/matter/update.py
@@ -173,7 +173,7 @@ class MatterUpdate(MatterEntity, UpdateEntity):
         release_notes = ""
 
         # insert extra heavy warning case the update is not from the main net
-        if self._software_update.update_source != UpdateSource.MAIN_NET_DCL:
+        if self._software_update.update_source is not UpdateSource.MAIN_NET_DCL:
             release_notes += (
                 "\n\n<ha-alert alert-type='warning'>"
                 "Update provided by "

--- a/homeassistant/components/maxcube/climate.py
+++ b/homeassistant/components/maxcube/climate.py
@@ -124,7 +124,7 @@ class MaxCubeClimate(ClimateEntity):
 
     def set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             self._set_target(MAX_DEVICE_MODE_MANUAL, OFF_TEMPERATURE)
         elif hvac_mode == HVACMode.HEAT:
             temp = max(self._device.target_temperature, self.min_temp)
@@ -171,7 +171,7 @@ class MaxCubeClimate(ClimateEntity):
         if valve:
             return HVACAction.HEATING
 
-        return HVACAction.OFF if self.hvac_mode == HVACMode.OFF else HVACAction.IDLE
+        return HVACAction.OFF if self.hvac_mode is HVACMode.OFF else HVACAction.IDLE
 
     @property
     def target_temperature(self) -> float | None:

--- a/homeassistant/components/mealie/todo.py
+++ b/homeassistant/components/mealie/todo.py
@@ -166,7 +166,7 @@ class MealieShoppingListTodoListEntity(MealieEntity, TodoListEntity):
             list_id=list_item.list_id,
             note=list_item.note,
             display=list_item.display,
-            checked=item.status == TodoItemStatus.COMPLETED,
+            checked=item.status is TodoItemStatus.COMPLETED,
             position=position,
             is_food=list_item.is_food,
             disable_amount=list_item.disable_amount,
@@ -185,7 +185,7 @@ class MealieShoppingListTodoListEntity(MealieEntity, TodoListEntity):
                 update_shopping_item.is_food = False
             update_shopping_item.food_id = None
             update_shopping_item.quantity = 0.0
-            update_shopping_item.checked = item.status == TodoItemStatus.COMPLETED
+            update_shopping_item.checked = item.status is TodoItemStatus.COMPLETED
 
         try:
             await self.coordinator.client.update_shopping_item(

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -1073,7 +1073,7 @@ class MediaPlayerEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
             await self.hass.async_add_executor_job(self.media_play_pause)
             return
 
-        if self.state == MediaPlayerState.PLAYING:
+        if self.state is MediaPlayerState.PLAYING:
             await self.async_media_pause()
         else:
             await self.async_media_play()
@@ -1081,7 +1081,7 @@ class MediaPlayerEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     @property
     def entity_picture(self) -> str | None:
         """Return image of the media playing."""
-        if self.state == MediaPlayerState.OFF:
+        if self.state is MediaPlayerState.OFF:
             return None
 
         if self.media_image_remotely_accessible:
@@ -1127,7 +1127,7 @@ class MediaPlayerEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         if self.support_grouping:
             state_attr[ATTR_GROUP_MEMBERS] = self.group_members
 
-        if self.state == MediaPlayerState.OFF:
+        if self.state is MediaPlayerState.OFF:
             return state_attr
 
         for attr in ATTR_TO_PROPERTY:

--- a/homeassistant/components/mediaroom/media_player.py
+++ b/homeassistant/components/mediaroom/media_player.py
@@ -196,7 +196,7 @@ class MediaroomDevice(MediaPlayerEntity):
             "STB(%s) Play media: %s (%s)", self.stb.stb_ip, media_id, media_type
         )
         command: str | int
-        if media_type == MediaType.CHANNEL:
+        if media_type is MediaType.CHANNEL:
             if not media_id.isdigit():
                 _LOGGER.error("Invalid media_id %s: Must be a channel number", media_id)
                 return

--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -187,7 +187,7 @@ class AtaDeviceClimate(MelCloudClimate):
         self, hvac_mode: HVACMode, set_dict: dict[str, Any]
     ) -> None:
         """Apply hvac mode changes to a dict used to call _device.set."""
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             set_dict["power"] = False
             return
 
@@ -196,7 +196,7 @@ class AtaDeviceClimate(MelCloudClimate):
             raise ValueError(f"Invalid hvac_mode [{hvac_mode}]")
 
         set_dict["operation_mode"] = operation_mode
-        if self.hvac_mode == HVACMode.OFF:
+        if self.hvac_mode is HVACMode.OFF:
             set_dict["power"] = True
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
@@ -366,7 +366,7 @@ class AtwDeviceZoneClimate(MelCloudClimate):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             await self.coordinator.async_set({"power": False})
             return
 
@@ -378,7 +378,7 @@ class AtwDeviceZoneClimate(MelCloudClimate):
             props = {PROPERTY_ZONE_1_OPERATION_MODE: operation_mode}
         else:
             props = {PROPERTY_ZONE_2_OPERATION_MODE: operation_mode}
-        if self.hvac_mode == HVACMode.OFF:
+        if self.hvac_mode is HVACMode.OFF:
             props["power"] = True
         await self.coordinator.async_set(props)
 

--- a/homeassistant/components/melissa/climate.py
+++ b/homeassistant/components/melissa/climate.py
@@ -133,7 +133,7 @@ class MelissaClimate(ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set operation mode."""
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             await self.async_send({self._api.STATE: self._api.STATE_OFF})
             return
 

--- a/homeassistant/components/microbees/climate.py
+++ b/homeassistant/components/microbees/climate.py
@@ -111,7 +111,7 @@ class MBClimate(MicroBeesActuatorEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode, **kwargs: Any) -> None:
         """Set new target hvac mode."""
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             return await self.async_turn_off()
         return await self.async_turn_on()
 

--- a/homeassistant/components/miele/sensor.py
+++ b/homeassistant/components/miele/sensor.py
@@ -843,7 +843,7 @@ async def async_setup_entry(
     ) -> bool:
         """Check if the sensor is enabled."""
         if (
-            definition.description.device_class == SensorDeviceClass.TEMPERATURE
+            definition.description.device_class is SensorDeviceClass.TEMPERATURE
             and definition.description.value_fn(device) is None
             and definition.description.zone != 1
         ):

--- a/homeassistant/components/mill/climate.py
+++ b/homeassistant/components/mill/climate.py
@@ -117,7 +117,7 @@ class MillHeater(MillBaseEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
-        if hvac_mode == HVACMode.HEAT:
+        if hvac_mode is HVACMode.HEAT:
             await self.coordinator.mill_data_connection.heater_control(
                 self._id, power_status=True
             )
@@ -198,7 +198,7 @@ class LocalMillHeater(CoordinatorEntity[MillDataUpdateCoordinator], ClimateEntit
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         conn = self.coordinator.mill_data_connection
-        if hvac_mode == HVACMode.HEAT:
+        if hvac_mode is HVACMode.HEAT:
             await conn.set_operation_mode_control_individually()
         elif hvac_mode == HVACMode.OFF:
             await conn.set_operation_mode_off()

--- a/homeassistant/components/minecraft_server/__init__.py
+++ b/homeassistant/components/minecraft_server/__init__.py
@@ -26,7 +26,7 @@ def prevent_dnspython_blocking_operations() -> None:
 
     # Blocking import: https://github.com/rthalley/dnspython/issues/1083
     for rdtype in dns.rdatatype.RdataType:
-        if not dns.rdatatype.is_metatype(rdtype) or rdtype == dns.rdatatype.OPT:
+        if not dns.rdatatype.is_metatype(rdtype) or rdtype is dns.rdatatype.OPT:
             dns.rdata.get_rdata_class(dns.rdataclass.IN, rdtype)  # type: ignore[no-untyped-call]
 
     # Blocking open: https://github.com/rthalley/dnspython/issues/1200

--- a/homeassistant/components/minecraft_server/api.py
+++ b/homeassistant/components/minecraft_server/api.py
@@ -79,7 +79,7 @@ class MinecraftServer:
     async def async_initialize(self) -> None:
         """Perform async initialization of server instance."""
         try:
-            if self._server_type == MinecraftServerType.JAVA_EDITION:
+            if self._server_type is MinecraftServerType.JAVA_EDITION:
                 self._server = await JavaServer.async_lookup(self._address)
             elif self._server_type == MinecraftServerType.BEDROCK_EDITION:
                 self._server = await self._hass.async_add_executor_job(

--- a/homeassistant/components/mobile_app/sensor.py
+++ b/homeassistant/components/mobile_app/sensor.py
@@ -97,7 +97,7 @@ class MobileAppSensor(MobileAppEntity, RestoreSensor):
                     assert self.unique_id is not None
                 sensor_unique_id = _extract_sensor_unique_id(webhook_id, self.unique_id)
                 if (
-                    self.device_class == SensorDeviceClass.TEMPERATURE
+                    self.device_class is SensorDeviceClass.TEMPERATURE
                     and sensor_unique_id == "battery_temperature"
                 ):
                     config[ATTR_SENSOR_UOM] = UnitOfTemperature.CELSIUS
@@ -121,7 +121,7 @@ class MobileAppSensor(MobileAppEntity, RestoreSensor):
             and isinstance(state, str)
             and (timestamp := dt_util.parse_datetime(state)) is not None
         ):
-            if device_class == SensorDeviceClass.DATE:
+            if device_class is SensorDeviceClass.DATE:
                 return timestamp.date()
             return timestamp
 

--- a/homeassistant/components/mobile_app/timers.py
+++ b/homeassistant/components/mobile_app/timers.py
@@ -19,7 +19,7 @@ def async_handle_timer_event(
     timer_info: TimerInfo,
 ) -> None:
     """Handle timer events."""
-    if event_type != TimerEventType.FINISHED:
+    if event_type is not TimerEventType.FINISHED:
         return
 
     if timer_info.name:

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -327,7 +327,7 @@ class ModbusThermostat(ModbusStructEntity, RestoreEntity, ClimateEntity):
                     self._hvac_onoff_register,
                     [
                         self._hvac_off_value
-                        if hvac_mode == HVACMode.OFF
+                        if hvac_mode is HVACMode.OFF
                         else self._hvac_on_value
                     ],
                     CALL_TYPE_WRITE_REGISTERS,
@@ -337,7 +337,7 @@ class ModbusThermostat(ModbusStructEntity, RestoreEntity, ClimateEntity):
                     self._device_address,
                     self._hvac_onoff_register,
                     self._hvac_off_value
-                    if hvac_mode == HVACMode.OFF
+                    if hvac_mode is HVACMode.OFF
                     else self._hvac_on_value,
                     CALL_TYPE_WRITE_REGISTER,
                 )
@@ -347,14 +347,14 @@ class ModbusThermostat(ModbusStructEntity, RestoreEntity, ClimateEntity):
             await self._hub.async_pb_call(
                 self._device_address,
                 self._hvac_onoff_coil,
-                0 if hvac_mode == HVACMode.OFF else 1,
+                0 if hvac_mode is HVACMode.OFF else 1,
                 CALL_TYPE_WRITE_COIL,
             )
 
         if self._hvac_mode_register is not None:
             # Write a value to the mode register for the desired mode.
             for value, mode in self._hvac_mode_mapping:
-                if mode == hvac_mode:
+                if mode is hvac_mode:
                     if self._hvac_mode_write_registers:
                         await self._hub.async_pb_call(
                             self._device_address,

--- a/homeassistant/components/modbus/light.py
+++ b/homeassistant/components/modbus/light.py
@@ -64,7 +64,7 @@ class ModbusLight(ModbusToggleEntity, LightEntity):
 
         self._attr_min_color_temp_kelvin: int = LIGHT_DEFAULT_MIN_KELVIN
         self._attr_max_color_temp_kelvin: int = LIGHT_DEFAULT_MAX_KELVIN
-        if self._attr_color_mode == ColorMode.COLOR_TEMP:
+        if self._attr_color_mode is ColorMode.COLOR_TEMP:
             self._attr_min_color_temp_kelvin = config.get(
                 CONF_MIN_TEMP, LIGHT_DEFAULT_MIN_KELVIN
             )

--- a/homeassistant/components/moehlenhoff_alpha2/climate.py
+++ b/homeassistant/components/moehlenhoff_alpha2/climate.py
@@ -80,7 +80,7 @@ class Alpha2Climate(CoordinatorEntity[Alpha2BaseCoordinator], ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
-        await self.coordinator.async_set_cooling(hvac_mode == HVACMode.COOL)
+        await self.coordinator.async_set_cooling(hvac_mode is HVACMode.COOL)
 
     @property
     def hvac_action(self) -> HVACAction:

--- a/homeassistant/components/motioneye/__init__.py
+++ b/homeassistant/components/motioneye/__init__.py
@@ -437,7 +437,7 @@ def _get_media_event_data(
     if (
         not config_entry_id
         or not (entry := hass.config_entries.async_get_entry(config_entry_id))
-        or entry.state != ConfigEntryState.LOADED
+        or entry.state is not ConfigEntryState.LOADED
     ):
         return {}
 

--- a/homeassistant/components/motioneye/media_source.py
+++ b/homeassistant/components/motioneye/media_source.py
@@ -122,7 +122,7 @@ class MotionEyeMediaSource(MediaSource):
     def _get_config_or_raise(self, config_id: str) -> MotionEyeConfigEntry:
         """Get a config entry from a URL."""
         entry = self.hass.config_entries.async_get_entry(config_id)
-        if not entry or entry.state != ConfigEntryState.LOADED:
+        if not entry or entry.state is not ConfigEntryState.LOADED:
             raise MediaSourceError(f"Unable to find config entry with id: {config_id}")
         return entry
 

--- a/homeassistant/components/mpd/media_player.py
+++ b/homeassistant/components/mpd/media_player.py
@@ -444,7 +444,7 @@ class MpdDevice(MediaPlayerEntity):
                 )
                 media_id = async_process_play_media_url(self.hass, play_item.url)
 
-            if media_type == MediaType.PLAYLIST:
+            if media_type is MediaType.PLAYLIST:
                 LOGGER.debug("Playing playlist: %s", media_id)
                 if self._attr_source_list and media_id in self._attr_source_list:
                     self._current_playlist = media_id
@@ -472,7 +472,7 @@ class MpdDevice(MediaPlayerEntity):
     async def async_set_repeat(self, repeat: RepeatMode) -> None:
         """Set repeat mode."""
         async with self.connection():
-            if repeat == RepeatMode.OFF:
+            if repeat is RepeatMode.OFF:
                 await self._client.repeat(0)
                 await self._client.single(0)
             else:

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -593,7 +593,7 @@ class MQTT:
         @callback
         def _async_misc() -> None:
             """Start the MQTT client misc loop."""
-            if self._mqttc.loop_misc() == mqtt.MQTT_ERR_SUCCESS:
+            if self._mqttc.loop_misc() is mqtt.MQTT_ERR_SUCCESS:
                 self._misc_timer = self.loop.call_at(self.loop.time() + 1, _async_misc)
 
         self._misc_timer = self.loop.call_at(self.loop.time() + 1, _async_misc)

--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -4154,7 +4154,7 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
                 description_placeholders={"addon": self._addon_manager.addon_name},
             ) from err
 
-        if addon_info.state == AddonState.RUNNING:
+        if addon_info.state is AddonState.RUNNING:
             # Finish setup using discovery info
             return await self.async_step_setup_entry_from_discovery()
 
@@ -5116,7 +5116,7 @@ def async_convert_to_pem(
                 .decode(DEFAULT_ENCODING)
             )
         # Convert from DER encoding to PEM
-        if pem_type == PEMType.CERTIFICATE:
+        if pem_type is PEMType.CERTIFICATE:
             return (
                 load_der_x509_certificate(data)
                 .public_bytes(

--- a/homeassistant/components/mqtt/light/schema_basic.py
+++ b/homeassistant/components/mqtt/light/schema_basic.py
@@ -683,7 +683,7 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
             """Render RGBx payload."""
             rgb_color_str = ",".join(str(channel) for channel in color)
             keys = ["red", "green", "blue"]
-            if color_mode == ColorMode.RGBW:
+            if color_mode is ColorMode.RGBW:
                 keys.append("white")
             elif color_mode == ColorMode.RGBWW:
                 keys.extend(["cold_white", "warm_white"])

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -340,7 +340,7 @@ class MqttSensor(MqttEntity, RestoreSensor):
             _LOGGER.warning("Invalid state message '%s' from '%s'", payload, msg.topic)
             self._attr_native_value = None
             return
-        if self.device_class == SensorDeviceClass.DATE:
+        if self.device_class is SensorDeviceClass.DATE:
             self._attr_native_value = payload_datetime.date()
             return
         self._attr_native_value = payload_datetime

--- a/homeassistant/components/mqtt/util.py
+++ b/homeassistant/components/mqtt/util.py
@@ -219,7 +219,7 @@ async def async_wait_for_mqtt_client(hass: HomeAssistant) -> bool:
         return False
 
     entry = hass.config_entries.async_entries(DOMAIN)[0]
-    if entry.state == ConfigEntryState.LOADED:
+    if entry.state is ConfigEntryState.LOADED:
         return True
 
     state_reached_future: asyncio.Future[bool]

--- a/homeassistant/components/music_assistant/__init__.py
+++ b/homeassistant/components/music_assistant/__init__.py
@@ -265,12 +265,12 @@ async def _client_listen(
     try:
         await mass.start_listening(init_ready)
     except MusicAssistantError as err:
-        if entry.state != ConfigEntryState.LOADED:
+        if entry.state is not ConfigEntryState.LOADED:
             raise
         LOGGER.error("Failed to listen: %s", err)
     except Exception as err:  # pylint: disable=broad-except
         # We need to guard against unknown exceptions to not crash this task.
-        if entry.state != ConfigEntryState.LOADED:
+        if entry.state is not ConfigEntryState.LOADED:
             raise
         LOGGER.exception("Unexpected exception: %s", err)
 

--- a/homeassistant/components/music_assistant/entity.py
+++ b/homeassistant/components/music_assistant/entity.py
@@ -72,7 +72,7 @@ class MusicAssistantEntity(Entity):
 
     async def __on_mass_update(self, event: MassEvent) -> None:
         """Call when we receive an event from MusicAssistant."""
-        if event.event == EventType.QUEUE_UPDATED and event.object_id not in (
+        if event.event is EventType.QUEUE_UPDATED and event.object_id not in (
             self.player.active_source,
             self.player.active_group,
             self.player.player_id,

--- a/homeassistant/components/music_assistant/media_player.py
+++ b/homeassistant/components/music_assistant/media_player.py
@@ -254,7 +254,7 @@ class MusicAssistantPlayer(MusicAssistantEntity, MediaPlayerEntity):
         ]
 
         self._attr_group_members = group_members_entity_ids
-        if player.type == PlayerType.GROUP:
+        if player.type is PlayerType.GROUP:
             volume: int | None = player.group_volume
         else:
             volume = player.volume_level
@@ -512,7 +512,7 @@ class MusicAssistantPlayer(MusicAssistantEntity, MediaPlayerEntity):
         if not source_player:
             # no source player given; try to find a playing player(queue)
             for queue in self.mass.player_queues:
-                if queue.state == MassPlayerState.PLAYING:
+                if queue.state is MassPlayerState.PLAYING:
                     source_queue_id = queue.queue_id
                     break
             else:
@@ -674,7 +674,7 @@ class MusicAssistantPlayer(MusicAssistantEntity, MediaPlayerEntity):
         # queue is playing regular media item
         self._attr_media_title = media_item.name
         # for tracks we can extract more info
-        if media_item.media_type == MediaType.TRACK:
+        if media_item.media_type is MediaType.TRACK:
             if TYPE_CHECKING:
                 assert isinstance(media_item, Track)
             self._attr_media_artist = media_item.artist_str

--- a/homeassistant/components/music_assistant/number.py
+++ b/homeassistant/components/music_assistant/number.py
@@ -94,7 +94,7 @@ class MusicAssistantPlayerConfigNumber(MusicAssistantPlayerOptionEntity, NumberE
     @catch_musicassistant_error
     async def async_set_native_value(self, value: float) -> None:
         """Set a new value."""
-        _value = round(value) if self.mass_type == PlayerOptionType.INTEGER else value
+        _value = round(value) if self.mass_type is PlayerOptionType.INTEGER else value
         await self.mass.players.set_option(
             self.player_id,
             self.mass_option_key,

--- a/homeassistant/components/music_assistant/select.py
+++ b/homeassistant/components/music_assistant/select.py
@@ -45,7 +45,7 @@ async def async_setup_entry(
             if (
                 not player_option.read_only
                 and player_option.type
-                != PlayerOptionType.BOOLEAN  # these always go to switch
+                is not PlayerOptionType.BOOLEAN  # these always go to switch
                 and player_option.options
             ):
                 # We ignore entities with unknown

--- a/homeassistant/components/music_assistant/switch.py
+++ b/homeassistant/components/music_assistant/switch.py
@@ -46,7 +46,7 @@ async def async_setup_entry(
         for player_option in player.options:
             if (
                 not player_option.read_only
-                and player_option.type == PlayerOptionType.BOOLEAN
+                and player_option.type is PlayerOptionType.BOOLEAN
             ):
                 # we ignore entities with unknown translation keys.
                 if player_option.translation_key not in PLAYER_OPTIONS_SWITCH:

--- a/homeassistant/components/music_assistant/text.py
+++ b/homeassistant/components/music_assistant/text.py
@@ -37,7 +37,7 @@ async def async_setup_entry(
         for player_option in player.options:
             if (
                 not player_option.read_only
-                and player_option.type == PlayerOptionType.STRING
+                and player_option.type is PlayerOptionType.STRING
                 and not player_option.options  # these we map to select
             ):
                 # we ignore entities with unknown translation keys.

--- a/homeassistant/components/myneomitis/climate.py
+++ b/homeassistant/components/myneomitis/climate.py
@@ -174,7 +174,7 @@ class MyNeoClimate(ClimateEntity):
                 self._last_preset_mode = self._attr_preset_mode
             if self._attr_preset_mode == "standby":
                 self._attr_hvac_mode = HVACMode.OFF
-            elif self._attr_hvac_mode == HVACMode.OFF:
+            elif self._attr_hvac_mode is HVACMode.OFF:
                 self._attr_hvac_mode = next(
                     (
                         mode
@@ -188,7 +188,7 @@ class MyNeoClimate(ClimateEntity):
                 self._attr_hvac_modes = [HVACMode.COOL, HVACMode.OFF]
 
                 if (
-                    self._attr_hvac_mode != HVACMode.OFF
+                    self._attr_hvac_mode is not HVACMode.OFF
                     and self._attr_preset_mode != "standby"
                 ):
                     self._attr_hvac_mode = HVACMode.COOL
@@ -196,7 +196,7 @@ class MyNeoClimate(ClimateEntity):
                 self._attr_hvac_modes = [HVACMode.HEAT, HVACMode.OFF]
 
                 if (
-                    self._attr_hvac_mode != HVACMode.OFF
+                    self._attr_hvac_mode is not HVACMode.OFF
                     and self._attr_preset_mode != "standby"
                 ):
                     self._attr_hvac_mode = HVACMode.HEAT
@@ -215,7 +215,7 @@ class MyNeoClimate(ClimateEntity):
                     f"Failed to set preset mode 'setpoint' for {self.entity_id}"
                 )
             self._attr_preset_mode = "setpoint"
-            if self._attr_hvac_mode == HVACMode.OFF:
+            if self._attr_hvac_mode is HVACMode.OFF:
                 self._attr_hvac_mode = next(
                     (
                         mode
@@ -243,7 +243,7 @@ class MyNeoClimate(ClimateEntity):
         new_hvac_mode = self._attr_hvac_mode
         if preset_mode == "standby":
             new_hvac_mode = HVACMode.OFF
-        elif self._attr_hvac_mode == HVACMode.OFF:
+        elif self._attr_hvac_mode is HVACMode.OFF:
             new_hvac_mode = next(
                 (
                     mode
@@ -267,7 +267,7 @@ class MyNeoClimate(ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the HVAC mode for the climate entity."""
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             if self._attr_preset_mode and self._attr_preset_mode != "standby":
                 self._last_preset_mode = self._attr_preset_mode
 

--- a/homeassistant/components/mysensors/cover.py
+++ b/homeassistant/components/mysensors/cover.py
@@ -81,17 +81,17 @@ class MySensorsCover(MySensorsChildEntity, CoverEntity):
     @property
     def is_closed(self) -> bool:
         """Return True if the cover is closed."""
-        return self.get_cover_state() == CoverState.CLOSED
+        return self.get_cover_state() is CoverState.CLOSED
 
     @property
     def is_closing(self) -> bool:
         """Return True if the cover is closing."""
-        return self.get_cover_state() == CoverState.CLOSING
+        return self.get_cover_state() is CoverState.CLOSING
 
     @property
     def is_opening(self) -> bool:
         """Return True if the cover is opening."""
-        return self.get_cover_state() == CoverState.OPENING
+        return self.get_cover_state() is CoverState.OPENING
 
     @property
     def current_cover_position(self) -> int | None:

--- a/homeassistant/components/myuplink/binary_sensor.py
+++ b/homeassistant/components/myuplink/binary_sensor.py
@@ -67,7 +67,7 @@ async def async_setup_entry(
     # Setup device point bound sensors
     for device_id, point_data in coordinator.data.points.items():
         for point_id, device_point in point_data.items():
-            if find_matching_platform(device_point) == Platform.BINARY_SENSOR:
+            if find_matching_platform(device_point) is Platform.BINARY_SENSOR:
                 description = get_description(device_point)
 
                 entities.append(
@@ -144,7 +144,7 @@ class MyUplinkDevicePointBinarySensor(MyUplinkEntity, BinarySensorEntity):
         """Return device data availability."""
         return super().available and (
             self.coordinator.data.devices[self.device_id].connectionState
-            == DeviceConnectionState.Connected
+            is DeviceConnectionState.Connected
         )
 
 
@@ -172,7 +172,7 @@ class MyUplinkDeviceBinarySensor(MyUplinkEntity, BinarySensorEntity):
         """Binary sensor state value."""
         return (
             self.coordinator.data.devices[self.device_id].connectionState
-            == DeviceConnectionState.Connected
+            is DeviceConnectionState.Connected
         )
 
 

--- a/homeassistant/components/myuplink/number.py
+++ b/homeassistant/components/myuplink/number.py
@@ -75,7 +75,7 @@ async def async_setup_entry(
             if skip_entity(device_point.category, device_point):
                 continue
             description = get_description(device_point)
-            if find_matching_platform(device_point, description) == Platform.NUMBER:
+            if find_matching_platform(device_point, description) is Platform.NUMBER:
                 entities.append(
                     MyUplinkNumber(
                         coordinator=coordinator,

--- a/homeassistant/components/myuplink/select.py
+++ b/homeassistant/components/myuplink/select.py
@@ -31,7 +31,7 @@ async def async_setup_entry(
         for point_id, device_point in point_data.items():
             if skip_entity(device_point.category, device_point):
                 continue
-            if find_matching_platform(device_point, None) == Platform.SELECT:
+            if find_matching_platform(device_point, None) is Platform.SELECT:
                 entities.append(
                     MyUplinkSelect(
                         coordinator=coordinator,

--- a/homeassistant/components/myuplink/sensor.py
+++ b/homeassistant/components/myuplink/sensor.py
@@ -226,7 +226,7 @@ async def async_setup_entry(
         for point_id, device_point in point_data.items():
             if skip_entity(device_point.category, device_point):
                 continue
-            if find_matching_platform(device_point) == Platform.SENSOR:
+            if find_matching_platform(device_point) is Platform.SENSOR:
                 description = get_description(device_point)
                 entity_class = MyUplinkDevicePointSensor
                 # Ignore sensors without a description that provide non-numeric values
@@ -236,7 +236,7 @@ async def async_setup_entry(
                     continue
                 if (
                     description is not None
-                    and description.device_class == SensorDeviceClass.ENUM
+                    and description.device_class is SensorDeviceClass.ENUM
                 ):
                     entities.append(
                         MyUplinkEnumRawSensor(

--- a/homeassistant/components/myuplink/switch.py
+++ b/homeassistant/components/myuplink/switch.py
@@ -66,7 +66,7 @@ async def async_setup_entry(
         for point_id, device_point in point_data.items():
             if skip_entity(device_point.category, device_point):
                 continue
-            if find_matching_platform(device_point) == Platform.SWITCH:
+            if find_matching_platform(device_point) is Platform.SWITCH:
                 description = get_description(device_point)
 
                 entities.append(

--- a/homeassistant/components/nad/media_player.py
+++ b/homeassistant/components/nad/media_player.py
@@ -154,7 +154,7 @@ class NAD(MediaPlayerEntity):
             else MediaPlayerState.OFF
         )
 
-        if self.state == MediaPlayerState.ON:
+        if self.state is MediaPlayerState.ON:
             self._attr_is_volume_muted = self._nad_receiver.main_mute("?") == "On"
             volume = self._nad_receiver.main_volume("?")
             # Some receivers cannot report the volume, e.g. C 356BEE,

--- a/homeassistant/components/neato/vacuum.py
+++ b/homeassistant/components/neato/vacuum.py
@@ -294,7 +294,7 @@ class NeatoConnectedVacuum(NeatoEntity, StateVacuumEntity):
     def return_to_base(self, **kwargs: Any) -> None:
         """Set the vacuum cleaner to return to the dock."""
         try:
-            if self._attr_activity == VacuumActivity.CLEANING:
+            if self._attr_activity is VacuumActivity.CLEANING:
                 self.robot.pause_cleaning()
             self._attr_activity = VacuumActivity.RETURNING
             self.robot.send_to_base()

--- a/homeassistant/components/nest/climate.py
+++ b/homeassistant/components/nest/climate.py
@@ -150,7 +150,7 @@ class ThermostatEntity(ClimateEntity):
         """Return the temperature currently set to be reached."""
         if not (trait := self._target_temperature_trait):
             return None
-        if self.hvac_mode == HVACMode.HEAT:
+        if self.hvac_mode is HVACMode.HEAT:
             return trait.heat_celsius
         if self.hvac_mode == HVACMode.COOL:
             return trait.cool_celsius
@@ -159,7 +159,7 @@ class ThermostatEntity(ClimateEntity):
     @property
     def target_temperature_high(self) -> float | None:
         """Return the upper bound target temperature."""
-        if self.hvac_mode != HVACMode.HEAT_COOL:
+        if self.hvac_mode is not HVACMode.HEAT_COOL:
             return None
         if not (trait := self._target_temperature_trait):
             return None
@@ -168,7 +168,7 @@ class ThermostatEntity(ClimateEntity):
     @property
     def target_temperature_low(self) -> float | None:
         """Return the lower bound target temperature."""
-        if self.hvac_mode != HVACMode.HEAT_COOL:
+        if self.hvac_mode is not HVACMode.HEAT_COOL:
             return None
         if not (trait := self._target_temperature_trait):
             return None
@@ -207,7 +207,7 @@ class ThermostatEntity(ClimateEntity):
     def hvac_action(self) -> HVACAction | None:
         """Return the current HVAC action (heating, cooling)."""
         trait = self._device.traits[ThermostatHvacTrait.NAME]
-        if trait.status == "OFF" and self.hvac_mode != HVACMode.OFF:
+        if trait.status == "OFF" and self.hvac_mode is not HVACMode.OFF:
             return HVACAction.IDLE
         return THERMOSTAT_HVAC_STATUS_MAP.get(trait.status)
 
@@ -294,7 +294,7 @@ class ThermostatEntity(ClimateEntity):
             )
         trait = self._device.traits[ThermostatTemperatureSetpointTrait.NAME]
         try:
-            if self.preset_mode == PRESET_ECO or hvac_mode == HVACMode.HEAT_COOL:
+            if self.preset_mode == PRESET_ECO or hvac_mode is HVACMode.HEAT_COOL:
                 if low_temp and high_temp:
                     if high_temp - low_temp < MIN_TEMP_RANGE:
                         # Ensure there is a minimum gap from the new temp. Pick
@@ -331,7 +331,7 @@ class ThermostatEntity(ClimateEntity):
         """Set new target fan mode."""
         if fan_mode not in self.fan_modes:
             raise ValueError(f"Unsupported fan_mode '{fan_mode}'")
-        if fan_mode == FAN_ON and self.hvac_mode == HVACMode.OFF:
+        if fan_mode == FAN_ON and self.hvac_mode is HVACMode.OFF:
             raise ValueError(
                 "Cannot turn on fan, please set an HVAC mode (e.g. heat/cool) first"
             )
@@ -351,7 +351,7 @@ class ThermostatEntity(ClimateEntity):
         if not self.supported_features & ClimateEntityFeature.FAN_MODE:
             raise HomeAssistantError(f"Entity {self.entity_id} does not support fan")
 
-        if self.hvac_mode == HVACMode.OFF:
+        if self.hvac_mode is HVACMode.OFF:
             raise HomeAssistantError(
                 f"Cannot turn on fan for {self.entity_id},"
                 " please set an HVAC mode (e.g. heat/cool) first"

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -319,7 +319,7 @@ class NetatmoThermostat(NetatmoRoomEntity, ClimateEntity):
                 data["event_type"] == EVENT_TYPE_CANCEL_SET_POINT
                 and self.device.entity_id == room["id"]
             ):
-                if self._attr_hvac_mode == HVACMode.OFF:
+                if self._attr_hvac_mode is HVACMode.OFF:
                     self._attr_hvac_mode = HVACMode.AUTO
                     self._attr_preset_mode = PRESET_MAP_NETATMO[PRESET_SCHEDULE]
 
@@ -330,7 +330,7 @@ class NetatmoThermostat(NetatmoRoomEntity, ClimateEntity):
     @property
     def hvac_action(self) -> HVACAction:
         """Return the current running hvac operation if supported."""
-        if self.device_type != NA_VALVE and self._boilerstatus is not None:
+        if self.device_type is not NA_VALVE and self._boilerstatus is not None:
             return CURRENT_HVAC_MAP_NETATMO[self._boilerstatus]
         # Maybe it is a valve
         if (
@@ -341,7 +341,7 @@ class NetatmoThermostat(NetatmoRoomEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             await self.async_turn_off()
         elif hvac_mode == HVACMode.AUTO:
             await self.async_set_preset_mode(PRESET_SCHEDULE)
@@ -352,15 +352,15 @@ class NetatmoThermostat(NetatmoRoomEntity, ClimateEntity):
         """Set new preset mode."""
         if (
             preset_mode in (PRESET_BOOST, STATE_NETATMO_MAX)
-            and self.device_type == NA_VALVE
-            and self._attr_hvac_mode == HVACMode.HEAT
+            and self.device_type is NA_VALVE
+            and self._attr_hvac_mode is HVACMode.HEAT
         ):
             await self.device.async_therm_set(
                 STATE_NETATMO_HOME,
             )
         elif (
             preset_mode in (PRESET_BOOST, STATE_NETATMO_MAX)
-            and self.device_type == NA_VALVE
+            and self.device_type is NA_VALVE
         ):
             await self.device.async_therm_set(
                 STATE_NETATMO_MANUAL,
@@ -368,7 +368,7 @@ class NetatmoThermostat(NetatmoRoomEntity, ClimateEntity):
             )
         elif (
             preset_mode in (PRESET_BOOST, STATE_NETATMO_MAX)
-            and self._attr_hvac_mode == HVACMode.HEAT
+            and self._attr_hvac_mode is HVACMode.HEAT
         ):
             await self.device.async_therm_set(STATE_NETATMO_HOME)
         elif preset_mode in (PRESET_BOOST, STATE_NETATMO_MAX):
@@ -389,12 +389,12 @@ class NetatmoThermostat(NetatmoRoomEntity, ClimateEntity):
 
     async def async_turn_off(self) -> None:
         """Turn the entity off."""
-        if self.device_type == NA_VALVE:
+        if self.device_type is NA_VALVE:
             await self.device.async_therm_set(
                 STATE_NETATMO_MANUAL,
                 DEFAULT_MIN_TEMP,
             )
-        elif self._attr_hvac_mode != HVACMode.OFF:
+        elif self._attr_hvac_mode is not HVACMode.OFF:
             await self.device.async_therm_set(STATE_NETATMO_OFF)
         self.async_write_ha_state()
 
@@ -426,7 +426,7 @@ class NetatmoThermostat(NetatmoRoomEntity, ClimateEntity):
             getattr(self.device, "therm_setpoint_mode", STATE_NETATMO_SCHEDULE)
         ]
         self._attr_hvac_mode = HVAC_MAP_NETATMO[self._attr_preset_mode]
-        self._away = self._attr_hvac_mode == HVAC_MAP_NETATMO[STATE_NETATMO_AWAY]
+        self._away = self._attr_hvac_mode is HVAC_MAP_NETATMO[STATE_NETATMO_AWAY]
 
         selected_schedule = self.home.get_selected_schedule()
         self._selected_schedule = getattr(selected_schedule, "name", None)
@@ -437,7 +437,7 @@ class NetatmoThermostat(NetatmoRoomEntity, ClimateEntity):
             selected_schedule, "entity_id", None
         )
 
-        if self.device_type == NA_VALVE:
+        if self.device_type is NA_VALVE:
             self._attr_extra_state_attributes[ATTR_HEATING_POWER_REQUEST] = (
                 self.device.heating_power_request
             )

--- a/homeassistant/components/nexia/climate.py
+++ b/homeassistant/components/nexia/climate.py
@@ -415,7 +415,7 @@ class NexiaZone(NexiaThermostatZoneEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the system mode (Auto, Heat_Cool, Cool, Heat, etc)."""
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             await self._zone.call_permanent_off()
         elif hvac_mode == HVACMode.AUTO:
             await self._zone.call_return_to_schedule()

--- a/homeassistant/components/nibe_heatpump/climate.py
+++ b/homeassistant/components/nibe_heatpump/climate.py
@@ -152,7 +152,7 @@ class NibeClimateEntity(CoordinatorEntity[CoilCoordinator], ClimateEntity):
             setpoint_cool = _get_float(self._coil_setpoint_cool)
         else:
             setpoint_cool = None
-        if mode == HVACMode.HEAT_COOL:
+        if mode is HVACMode.HEAT_COOL:
             self._attr_target_temperature = None
             self._attr_target_temperature_low = setpoint_heat
             self._attr_target_temperature_high = setpoint_cool
@@ -238,7 +238,7 @@ class NibeClimateEntity(CoordinatorEntity[CoilCoordinator], ClimateEntity):
         """Set new target hvac mode."""
         coordinator = self.coordinator
 
-        if hvac_mode == HVACMode.HEAT_COOL:
+        if hvac_mode is HVACMode.HEAT_COOL:
             await coordinator.async_write_coil(
                 self._coil_cooling_with_room_sensor, "ON"
             )

--- a/homeassistant/components/nobo_hub/climate.py
+++ b/homeassistant/components/nobo_hub/climate.py
@@ -106,7 +106,7 @@ class NoboZone(NoboBaseEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target HVAC mode."""
-        preset = PRESET_COMFORT if hvac_mode == HVACMode.HEAT else PRESET_NONE
+        preset = PRESET_COMFORT if hvac_mode is HVACMode.HEAT else PRESET_NONE
         await self._apply_preset(preset, "set_hvac_mode_failed")
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:

--- a/homeassistant/components/nuheat/climate.py
+++ b/homeassistant/components/nuheat/climate.py
@@ -113,7 +113,7 @@ class NuHeatThermostat(CoordinatorEntity[NuHeatCoordinator], ClimateEntity):
 
     def set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the system mode."""
-        if hvac_mode == HVACMode.AUTO:
+        if hvac_mode is HVACMode.AUTO:
             self._set_schedule_mode(SCHEDULE_RUN)
         elif hvac_mode == HVACMode.HEAT:
             self._set_schedule_mode(SCHEDULE_HOLD)

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -392,7 +392,7 @@ class NumberEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         if (
             native_unit_of_measurement
             in (UnitOfTemperature.CELSIUS, UnitOfTemperature.FAHRENHEIT)
-            and self.device_class == NumberDeviceClass.TEMPERATURE
+            and self.device_class is NumberDeviceClass.TEMPERATURE
         ):
             return self.hass.config.units.temperature_unit
 

--- a/homeassistant/components/nws/sensor.py
+++ b/homeassistant/components/nws/sensor.py
@@ -232,6 +232,6 @@ class NWSSensor(CoordinatorEntity[TimestampDataUpdateCoordinator[None]], SensorE
             return round(value, 1)
         if unit_of_measurement == PERCENTAGE:
             return round(value)
-        if self.device_class == SensorDeviceClass.TIMESTAMP:
+        if self.device_class is SensorDeviceClass.TIMESTAMP:
             return parse_datetime(value)
         return value

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -244,7 +244,7 @@ def async_get_client_for_service_call(
     if device_entry := device_registry.async_get(device_id):
         for entry_id in device_entry.config_entries:
             if entry := hass.config_entries.async_get_entry(entry_id):
-                if entry.domain == DOMAIN and entry.state == ConfigEntryState.LOADED:
+                if entry.domain == DOMAIN and entry.state is ConfigEntryState.LOADED:
                     return cast(OctoprintConfigEntry, entry).runtime_data.octoprint
 
     raise ServiceValidationError(

--- a/homeassistant/components/oem/climate.py
+++ b/homeassistant/components/oem/climate.py
@@ -104,9 +104,9 @@ class ThermostatDevice(ClimateEntity):
 
     def set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
-        if hvac_mode == HVACMode.AUTO:
+        if hvac_mode is HVACMode.AUTO:
             self.thermostat.mode = 1
-        elif hvac_mode == HVACMode.HEAT:
+        elif hvac_mode is HVACMode.HEAT:
             self.thermostat.mode = 2
         elif hvac_mode == HVACMode.OFF:
             self.thermostat.mode = 0

--- a/homeassistant/components/ollama/config_flow.py
+++ b/homeassistant/components/ollama/config_flow.py
@@ -259,7 +259,7 @@ class OllamaSubentryFlowHandler(ConfigSubentryFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> SubentryFlowResult:
         """Handle model selection and configuration step."""
-        if self._get_entry().state != ConfigEntryState.LOADED:
+        if self._get_entry().state is not ConfigEntryState.LOADED:
             return self.async_abort(reason="entry_not_loaded")
 
         if user_input is None:

--- a/homeassistant/components/onkyo/coordinator.py
+++ b/homeassistant/components/onkyo/coordinator.py
@@ -160,6 +160,6 @@ class ChannelMutingCoordinator(DataUpdateCoordinator[ChannelMutingData]):
             self._desired = {
                 channel: desired
                 for channel, desired in self._desired.items()
-                if self.data[channel] != desired
+                if self.data[channel] is not desired
             }
             self.async_set_updated_data(self.data)

--- a/homeassistant/components/onkyo/media_player.py
+++ b/homeassistant/components/onkyo/media_player.py
@@ -197,7 +197,7 @@ class OnkyoMediaPlayer(MediaPlayerEntity):
 
         name = manager.info.model_name
         identifier = manager.info.identifier
-        self._attr_name = f"{name}{' ' + ZONES[zone] if zone != Zone.MAIN else ''}"
+        self._attr_name = f"{name}{' ' + ZONES[zone] if zone is not Zone.MAIN else ''}"
         self._attr_unique_id = f"{identifier}_{zone.value}"
 
         self._volume_resolution = volume_resolution
@@ -226,7 +226,7 @@ class OnkyoMediaPlayer(MediaPlayerEntity):
         self._attr_sound_mode_list = list(self._rev_sound_mode_mapping)
 
         self._attr_supported_features = SUPPORTED_FEATURES_BASE
-        if zone == Zone.MAIN:
+        if zone is Zone.MAIN:
             self._attr_supported_features |= SUPPORTED_FEATURES_VOLUME
             self._supports_volume = True
             self._attr_supported_features |= MediaPlayerEntityFeature.SELECT_SOUND_MODE
@@ -259,7 +259,7 @@ class OnkyoMediaPlayer(MediaPlayerEntity):
         await self._manager.write(query.TunerPreset(self._zone))
         if self._supports_sound_mode is not None:
             await self._manager.write(query.ListeningMode(self._zone))
-        if self._zone == Zone.MAIN:
+        if self._zone is Zone.MAIN:
             await self._manager.write(query.HDMIOutput())
             await self._manager.write(query.AudioInformation())
             await self._manager.write(query.VideoInformation())
@@ -369,7 +369,7 @@ class OnkyoMediaPlayer(MediaPlayerEntity):
         """Process update."""
         match message:
             case status.Power(param=status.Power.Param.ON):
-                if self.state != MediaPlayerState.ON:
+                if self.state is not MediaPlayerState.ON:
                     self._query_state_delayed()
                 self._attr_state = MediaPlayerState.ON
             case status.Power(param=status.Power.Param.STANDBY):
@@ -386,7 +386,7 @@ class OnkyoMediaPlayer(MediaPlayerEntity):
                 self._attr_volume_level = min(1, volume_level)
 
             case status.Muting(param=muting):
-                self._attr_is_volume_muted = bool(muting == status.Muting.Param.ON)
+                self._attr_is_volume_muted = bool(muting is status.Muting.Param.ON)
 
             case status.InputSource(param=source):
                 if source in self._source_mapping:

--- a/homeassistant/components/onkyo/switch.py
+++ b/homeassistant/components/onkyo/switch.py
@@ -89,6 +89,6 @@ class OnkyoChannelMutingSwitch(
         """Handle updated data from the coordinator."""
         value = self.coordinator.data.get(self._channel)
         self._attr_is_on = (
-            None if value is None else value == status.ChannelMuting.Param.ON
+            None if value is None else value is status.ChannelMuting.Param.ON
         )
         super()._handle_coordinator_update()

--- a/homeassistant/components/onvif/event_manager.py
+++ b/homeassistant/components/onvif/event_manager.py
@@ -127,8 +127,8 @@ class EventManager:
     def started(self) -> bool:
         """Return True if event manager is started."""
         return (
-            self.webhook_manager.state == WebHookManagerState.STARTED
-            or self.pullpoint_manager.state == PullPointManagerState.STARTED
+            self.webhook_manager.state is WebHookManagerState.STARTED
+            or self.pullpoint_manager.state is PullPointManagerState.STARTED
         )
 
     @callback
@@ -260,7 +260,7 @@ class EventManager:
     @callback
     def async_webhook_failed(self) -> None:
         """Mark webhook as failed."""
-        if self.pullpoint_manager.state != PullPointManagerState.PAUSED:
+        if self.pullpoint_manager.state is not PullPointManagerState.PAUSED:
             return
         LOGGER.debug("%s: Switching to PullPoint for events", self.name)
         self.pullpoint_manager.async_resume()
@@ -268,7 +268,7 @@ class EventManager:
     @callback
     def async_webhook_working(self) -> None:
         """Mark webhook as working."""
-        if self.pullpoint_manager.state != PullPointManagerState.STARTED:
+        if self.pullpoint_manager.state is not PullPointManagerState.STARTED:
             return
         LOGGER.debug("%s: Switching to webhook for events", self.name)
         self.pullpoint_manager.async_pause()
@@ -308,7 +308,7 @@ class PullPointManager:
 
     async def async_start(self) -> bool:
         """Start pullpoint subscription."""
-        assert self.state == PullPointManagerState.STOPPED, (
+        assert self.state is PullPointManagerState.STOPPED, (
             "PullPoint manager already started"
         )
         LOGGER.debug("%s: Starting PullPoint manager", self._name)
@@ -462,7 +462,7 @@ class PullPointManager:
         finally:
             self.async_schedule_pull_messages(next_pull_delay)
 
-        if self.state != PullPointManagerState.STARTED:
+        if self.state is not PullPointManagerState.STARTED:
             # If the webhook became started working during the long poll,
             # and we got paused, our data is stale and we should not process it.
             LOGGER.debug(
@@ -507,7 +507,7 @@ class PullPointManager:
         Must not check if the webhook is working.
         """
         self.async_cancel_pull_messages()
-        if self.state != PullPointManagerState.STARTED:
+        if self.state is not PullPointManagerState.STARTED:
             return
         if self._pullpoint_manager:
             when = delay if delay is not None else PULLPOINT_COOLDOWN_TIME
@@ -566,7 +566,7 @@ class WebHookManager:
     async def async_start(self) -> bool:
         """Start polling events."""
         LOGGER.debug("%s: Starting webhook manager", self._name)
-        assert self.state == WebHookManagerState.STOPPED, (
+        assert self.state is WebHookManagerState.STOPPED, (
             "Webhook manager already started"
         )
         assert self._webhook_url is None, "Webhook already registered"

--- a/homeassistant/components/open_router/config_flow.py
+++ b/homeassistant/components/open_router/config_flow.py
@@ -141,7 +141,7 @@ class ConversationFlowHandler(OpenRouterSubentryFlowHandler):
         self, user_input: dict[str, Any] | None = None
     ) -> SubentryFlowResult:
         """Manage conversation agent configuration."""
-        if self._get_entry().state != ConfigEntryState.LOADED:
+        if self._get_entry().state is not ConfigEntryState.LOADED:
             return self.async_abort(reason="entry_not_loaded")
 
         if user_input is not None:
@@ -256,7 +256,7 @@ class AITaskDataFlowHandler(OpenRouterSubentryFlowHandler):
         self, user_input: dict[str, Any] | None = None
     ) -> SubentryFlowResult:
         """Manage AI task configuration."""
-        if self._get_entry().state != ConfigEntryState.LOADED:
+        if self._get_entry().state is not ConfigEntryState.LOADED:
             return self.async_abort(reason="entry_not_loaded")
 
         if user_input is not None:

--- a/homeassistant/components/openai_conversation/config_flow.py
+++ b/homeassistant/components/openai_conversation/config_flow.py
@@ -255,7 +255,7 @@ class OpenAISubentryFlowHandler(ConfigSubentryFlow):
     ) -> SubentryFlowResult:
         """Manage initial options."""
         # abort if entry is not loaded
-        if self._get_entry().state != ConfigEntryState.LOADED:
+        if self._get_entry().state is not ConfigEntryState.LOADED:
             return self.async_abort(reason="entry_not_loaded")
 
         options = self.options
@@ -710,7 +710,7 @@ class OpenAISubentrySTTFlowHandler(ConfigSubentryFlow):
     ) -> SubentryFlowResult:
         """Manage initial options."""
         # abort if entry is not loaded
-        if self._get_entry().state != ConfigEntryState.LOADED:
+        if self._get_entry().state is not ConfigEntryState.LOADED:
             return self.async_abort(reason="entry_not_loaded")
 
         options = self.options
@@ -799,7 +799,7 @@ class OpenAISubentryTTSFlowHandler(ConfigSubentryFlow):
     ) -> SubentryFlowResult:
         """Manage initial options."""
         # abort if entry is not loaded
-        if self._get_entry().state != ConfigEntryState.LOADED:
+        if self._get_entry().state is not ConfigEntryState.LOADED:
             return self.async_abort(reason="entry_not_loaded")
 
         options = self.options

--- a/homeassistant/components/openai_conversation/stt.py
+++ b/homeassistant/components/openai_conversation/stt.py
@@ -156,7 +156,7 @@ class OpenAISTTEntity(stt.SpeechToTextEntity, OpenAIBaseLLMEntity):
         async for chunk in stream:
             audio_bytes.extend(chunk)
         audio_data = bytes(audio_bytes)
-        if metadata.format == stt.AudioFormats.WAV:
+        if metadata.format is stt.AudioFormats.WAV:
             # Add missing wav header
             wav_buffer = io.BytesIO()
 

--- a/homeassistant/components/openhome/media_player.py
+++ b/homeassistant/components/openhome/media_player.py
@@ -195,7 +195,7 @@ class OpenhomeDevice(MediaPlayerEntity):
             )
             media_id = play_item.url
 
-        if media_type != MediaType.MUSIC:
+        if media_type is not MediaType.MUSIC:
             _LOGGER.error(
                 "Invalid media type %s. Only %s is supported",
                 media_type,

--- a/homeassistant/components/opentherm_gw/select.py
+++ b/homeassistant/components/opentherm_gw/select.py
@@ -152,7 +152,7 @@ SELECT_DESCRIPTIONS: tuple[OpenThermSelectEntityDescription, ...] = (
         options=[
             mode
             for mode in OpenThermSelectGPIOMode
-            if mode != OpenThermSelectGPIOMode.DS1820
+            if mode is not OpenThermSelectGPIOMode.DS1820
         ],
         select_action=partial(set_gpio_mode, "A"),
         convert_pyotgw_state_to_ha_state=(

--- a/homeassistant/components/opower/coordinator.py
+++ b/homeassistant/components/opower/coordinator.py
@@ -192,12 +192,12 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, OpowerData]]):
             )
             consumption_unit_class = (
                 EnergyConverter.UNIT_CLASS
-                if account.meter_type == MeterType.ELEC
+                if account.meter_type is MeterType.ELEC
                 else VolumeConverter.UNIT_CLASS
             )
             consumption_unit = (
                 UnitOfEnergy.KILO_WATT_HOUR
-                if account.meter_type == MeterType.ELEC
+                if account.meter_type is MeterType.ELEC
                 else UnitOfVolume.CENTUM_CUBIC_FEET
             )
             consumption_metadata = StatisticMetaData(
@@ -552,7 +552,7 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, OpowerData]]):
             _LOGGER.error("Error getting monthly cost reads: %s", err)
             raise
         _LOGGER.debug("Got %s monthly cost reads", len(cost_reads))
-        if account.read_resolution == ReadResolution.BILLING:
+        if account.read_resolution is ReadResolution.BILLING:
             return cost_reads
 
         if start_time is None:

--- a/homeassistant/components/opower/sensor.py
+++ b/homeassistant/components/opower/sensor.py
@@ -233,13 +233,13 @@ async def async_setup_entry(
             )
             sensors: tuple[OpowerEntityDescription, ...] = COMMON_SENSORS
             if (
-                account.meter_type == MeterType.ELEC
+                account.meter_type is MeterType.ELEC
                 and forecast is not None
-                and forecast.unit_of_measure == UnitOfMeasure.KWH
+                and forecast.unit_of_measure is UnitOfMeasure.KWH
             ):
                 sensors += ELEC_SENSORS
             elif (
-                account.meter_type == MeterType.GAS
+                account.meter_type is MeterType.GAS
                 and forecast is not None
                 and forecast.unit_of_measure in [UnitOfMeasure.THERM, UnitOfMeasure.CCF]
             ):

--- a/homeassistant/components/otbr/config_flow.py
+++ b/homeassistant/components/otbr/config_flow.py
@@ -213,7 +213,7 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
                     or current_url.port == config["port"]
                 ):
                     # Reload the entry since OTBR has restarted
-                    if current_entry.state == ConfigEntryState.LOADED:
+                    if current_entry.state is ConfigEntryState.LOADED:
                         assert current_entry.unique_id is not None
                         await self.hass.config_entries.async_reload(
                             current_entry.entry_id

--- a/homeassistant/components/ourgroceries/todo.py
+++ b/homeassistant/components/ourgroceries/todo.py
@@ -77,7 +77,7 @@ class OurGroceriesTodoListEntity(
 
     async def async_create_todo_item(self, item: TodoItem) -> None:
         """Create a To-do item."""
-        if item.status != TodoItemStatus.NEEDS_ACTION:
+        if item.status is not TodoItemStatus.NEEDS_ACTION:
             raise ValueError("Only active tasks may be created.")
         await self.coordinator.og.add_item_to_list(
             self._list_id, item.summary, auto_category=True
@@ -97,7 +97,7 @@ class OurGroceriesTodoListEntity(
                 self._list_id, item.uid, category, item.summary
             )
         if item.status is not None:
-            cross_off = item.status == TodoItemStatus.COMPLETED
+            cross_off = item.status is TodoItemStatus.COMPLETED
             await self.coordinator.og.toggle_item_crossed_off(
                 self._list_id, item.uid, cross_off=cross_off
             )

--- a/homeassistant/components/overkiz/climate/atlantic_electrical_towel_dryer.py
+++ b/homeassistant/components/overkiz/climate/atlantic_electrical_towel_dryer.py
@@ -94,7 +94,7 @@ class AtlanticElectricalTowelDryer(OverkizEntity, ClimateEntity):
         """Return the target temperature."""
         state = (
             OverkizState.IO_EFFECTIVE_TEMPERATURE_SETPOINT
-            if self.hvac_mode == HVACMode.AUTO
+            if self.hvac_mode is HVACMode.AUTO
             else OverkizState.CORE_TARGET_TEMPERATURE
         )
 
@@ -114,7 +114,7 @@ class AtlanticElectricalTowelDryer(OverkizEntity, ClimateEntity):
         """Set new temperature."""
         temperature = kwargs[ATTR_TEMPERATURE]
 
-        if self.hvac_mode == HVACMode.AUTO:
+        if self.hvac_mode is HVACMode.AUTO:
             await self.executor.async_execute_command(
                 OverkizCommand.SET_DEROGATED_TARGET_TEMPERATURE, temperature
             )

--- a/homeassistant/components/overkiz/climate/atlantic_pass_apc_heating_zone.py
+++ b/homeassistant/components/overkiz/climate/atlantic_pass_apc_heating_zone.py
@@ -194,7 +194,7 @@ class AtlanticPassAPCHeatingZone(OverkizEntity, ClimateEntity):
         """Set new temperature."""
         temperature = kwargs[ATTR_TEMPERATURE]
 
-        if self.hvac_mode == HVACMode.AUTO:
+        if self.hvac_mode is HVACMode.AUTO:
             await self.executor.async_execute_command(
                 OverkizCommand.SET_COMFORT_HEATING_TARGET_TEMPERATURE,
                 temperature,

--- a/homeassistant/components/overkiz/climate/atlantic_pass_apc_zone_control.py
+++ b/homeassistant/components/overkiz/climate/atlantic_pass_apc_zone_control.py
@@ -81,11 +81,11 @@ class AtlanticPassAPCZoneControl(OverkizEntity, ClimateEntity):
             await self.executor.async_execute_command(
                 OverkizCommand.SET_HEATING_COOLING_AUTO_SWITCH,
                 OverkizCommandParam.ON
-                if hvac_mode == HVACMode.AUTO
+                if hvac_mode is HVACMode.AUTO
                 else OverkizCommandParam.OFF,
             )
 
-        if hvac_mode == HVACMode.AUTO:
+        if hvac_mode is HVACMode.AUTO:
             return
 
         await self.executor.async_execute_command(

--- a/homeassistant/components/overkiz/climate/atlantic_pass_apc_zone_control_zone.py
+++ b/homeassistant/components/overkiz/climate/atlantic_pass_apc_zone_control_zone.py
@@ -221,10 +221,10 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
         # Device is Stopped, it means the air flux is flowing
         # but its venting door is closed.
         if (
-            (device_hvac_mode == HVACMode.COOL and cooling_is_off)
-            or (device_hvac_mode == HVACMode.HEAT and heating_is_off)
+            (device_hvac_mode is HVACMode.COOL and cooling_is_off)
+            or (device_hvac_mode is HVACMode.HEAT and heating_is_off)
             or (
-                device_hvac_mode == HVACMode.HEAT_COOL
+                device_hvac_mode is HVACMode.HEAT_COOL
                 and cooling_is_off
                 and heating_is_off
             )
@@ -245,7 +245,7 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
 
         on_off_target_command_param = (
             OverkizCommandParam.OFF
-            if hvac_mode == HVACMode.OFF
+            if hvac_mode is HVACMode.OFF
             else OverkizCommandParam.ON
         )
 
@@ -315,7 +315,7 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
 
         device_hvac_mode = self.device_hvac_mode
 
-        if device_hvac_mode == HVACMode.HEAT_COOL:
+        if device_hvac_mode is HVACMode.HEAT_COOL:
             return None
 
         if device_hvac_mode == HVACMode.COOL:
@@ -342,7 +342,7 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
     def target_temperature_high(self) -> float | None:
         """Return the highbound target temperature we try to reach (cooling)."""
 
-        if self.device_hvac_mode != HVACMode.HEAT_COOL:
+        if self.device_hvac_mode is not HVACMode.HEAT_COOL:
             return None
 
         return cast(
@@ -354,7 +354,7 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
     def target_temperature_low(self) -> float | None:
         """Return the lowbound target temperature we try to reach (heating)."""
 
-        if self.device_hvac_mode != HVACMode.HEAT_COOL:
+        if self.device_hvac_mode is not HVACMode.HEAT_COOL:
             return None
 
         return cast(
@@ -374,7 +374,7 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
         target_temp_high = kwargs.get(ATTR_TARGET_TEMP_HIGH)
         hvac_mode = self.hvac_mode
 
-        if hvac_mode == HVACMode.HEAT_COOL:
+        if hvac_mode is HVACMode.HEAT_COOL:
             if target_temp_low is not None:
                 await self.executor.async_execute_command(
                     OverkizCommand.SET_HEATING_TARGET_TEMPERATURE,
@@ -447,7 +447,7 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
                 ),
             )
 
-        if device_hvac_mode == HVACMode.COOL:
+        if device_hvac_mode is HVACMode.COOL:
             return cast(
                 float,
                 self.executor.select_state(
@@ -463,7 +463,7 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
 
         device_hvac_mode = self.device_hvac_mode
 
-        if device_hvac_mode == HVACMode.HEAT:
+        if device_hvac_mode is HVACMode.HEAT:
             return cast(
                 float,
                 self.executor.select_state(

--- a/homeassistant/components/overkiz/climate/hitachi_air_to_air_heat_pump_hlrrwifi.py
+++ b/homeassistant/components/overkiz/climate/hitachi_air_to_air_heat_pump_hlrrwifi.py
@@ -129,7 +129,7 @@ class HitachiAirToAirHeatPumpHLRRWIFI(OverkizEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             await self._global_control(main_operation=OverkizCommandParam.OFF)
         else:
             await self._global_control(

--- a/homeassistant/components/overkiz/climate/hitachi_air_to_air_heat_pump_ovp.py
+++ b/homeassistant/components/overkiz/climate/hitachi_air_to_air_heat_pump_ovp.py
@@ -135,7 +135,7 @@ class HitachiAirToAirHeatPumpOVP(OverkizEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             await self._global_control(main_operation=OverkizCommandParam.OFF)
         else:
             await self._global_control(
@@ -244,14 +244,14 @@ class HitachiAirToAirHeatPumpOVP(OverkizEntity, ClimateEntity):
     @property
     def min_temp(self) -> float:
         """Return the minimum temperature."""
-        if self.hvac_mode == HVACMode.AUTO:
+        if self.hvac_mode is HVACMode.AUTO:
             return TEMP_AUTO_MIN
         return TEMP_MIN
 
     @property
     def max_temp(self) -> float:
         """Return the maximum temperature."""
-        if self.hvac_mode == HVACMode.AUTO:
+        if self.hvac_mode is HVACMode.AUTO:
             return TEMP_AUTO_MAX
         return TEMP_MAX
 

--- a/homeassistant/components/overkiz/climate/somfy_thermostat.py
+++ b/homeassistant/components/overkiz/climate/somfy_thermostat.py
@@ -87,7 +87,7 @@ class SomfyThermostat(OverkizEntity, ClimateEntity):
     @property
     def preset_mode(self) -> str:
         """Return the current preset mode, e.g., home, away, temp."""
-        if self.hvac_mode == HVACMode.AUTO:
+        if self.hvac_mode is HVACMode.AUTO:
             state_key = OverkizState.SOMFY_THERMOSTAT_HEATING_MODE
         else:
             state_key = OverkizState.SOMFY_THERMOSTAT_DEROGATION_HEATING_MODE
@@ -109,7 +109,7 @@ class SomfyThermostat(OverkizEntity, ClimateEntity):
     @property
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
-        if self.hvac_mode == HVACMode.AUTO:
+        if self.hvac_mode is HVACMode.AUTO:
             if self.preset_mode == PRESET_NONE:
                 return None
             return cast(
@@ -139,7 +139,7 @@ class SomfyThermostat(OverkizEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
-        if hvac_mode == HVACMode.AUTO:
+        if hvac_mode is HVACMode.AUTO:
             await self.executor.async_execute_command(OverkizCommand.EXIT_DEROGATION)
             await self.executor.async_execute_command(OverkizCommand.REFRESH_STATE)
         else:

--- a/homeassistant/components/overkiz/config_flow.py
+++ b/homeassistant/components/overkiz/config_flow.py
@@ -51,7 +51,7 @@ class OverkizConfigFlow(ConfigFlow, domain=DOMAIN):
         """Validate user credentials."""
         user_input[CONF_API_TYPE] = self._api_type
 
-        if self._api_type == APIType.LOCAL:
+        if self._api_type is APIType.LOCAL:
             user_input[CONF_VERIFY_SSL] = self._verify_ssl
             session = async_create_clientsession(
                 self.hass, verify_ssl=user_input[CONF_VERIFY_SSL]
@@ -116,7 +116,7 @@ class OverkizConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input:
             self._api_type = user_input[CONF_API_TYPE]
 
-            if self._api_type == APIType.LOCAL:
+            if self._api_type is APIType.LOCAL:
                 return await self.async_step_local()
 
             return await self.async_step_cloud()
@@ -344,7 +344,7 @@ class OverkizConfigFlow(ConfigFlow, domain=DOMAIN):
         self._api_type = entry_data.get(CONF_API_TYPE, APIType.CLOUD)
         self._server = entry_data[CONF_HUB]
 
-        if self._api_type == APIType.LOCAL:
+        if self._api_type is APIType.LOCAL:
             self._host = entry_data[CONF_HOST]
             self._verify_ssl = entry_data[CONF_VERIFY_SSL]
         else:

--- a/homeassistant/components/overkiz/diagnostics.py
+++ b/homeassistant/components/overkiz/diagnostics.py
@@ -25,7 +25,7 @@ async def async_get_config_entry_diagnostics(
     }
 
     # Only Overkiz cloud servers expose an endpoint with execution history
-    if client.api_type == APIType.CLOUD:
+    if client.api_type is APIType.CLOUD:
         execution_history = [
             repr(execution) for execution in await client.get_execution_history()
         ]
@@ -55,7 +55,7 @@ async def async_get_device_diagnostics(
     }
 
     # Only Overkiz cloud servers expose an endpoint with execution history
-    if client.api_type == APIType.CLOUD:
+    if client.api_type is APIType.CLOUD:
         data["execution_history"] = [
             repr(execution)
             for execution in await client.get_execution_history()

--- a/homeassistant/components/overkiz/entity.py
+++ b/homeassistant/components/overkiz/entity.py
@@ -49,7 +49,7 @@ class OverkizEntity(CoordinatorEntity[OverkizDataUpdateCoordinator]):
 
         # Workaround: local API may incorrectly report
         # available=False (Somfy-TaHoma-Developer-Mode#217)
-        if self.coordinator.client.api_type != APIType.LOCAL:
+        if self.coordinator.client.api_type is not APIType.LOCAL:
             return False
 
         if status_state := self.device.states.get(OverkizState.CORE_STATUS):

--- a/homeassistant/components/overkiz/executor.py
+++ b/homeassistant/components/overkiz/executor.py
@@ -94,7 +94,7 @@ class OverkizExecutor:
         # Set the execution duration to 0 seconds for RTS devices on supported commands
         # Default execution duration is 30 seconds and will block consecutive commands
         if (
-            self.device.protocol == Protocol.RTS
+            self.device.protocol is Protocol.RTS
             and command_name not in COMMANDS_WITHOUT_DELAY
         ):
             parameters.append(0)

--- a/homeassistant/components/overkiz/sensor.py
+++ b/homeassistant/components/overkiz/sensor.py
@@ -529,7 +529,7 @@ async def async_setup_entry(
     entities: list[SensorEntity] = []
 
     for device in data.coordinator.data.values():
-        if device.widget == UIWidget.HOMEKIT_STACK:
+        if device.widget is UIWidget.HOMEKIT_STACK:
             entities.append(
                 OverkizHomeKitSetupCodeSensor(
                     device.device_url,
@@ -573,7 +573,9 @@ class OverkizStateSensor(OverkizDescriptiveEntity, SensorEntity):
             # This is probably incorrect and should be fixed in a follow up PR.
             # To ensure measurement sensors do not get an `unknown` state on
             # a falsy value (e.g. 0 or 0.0) we also check the state_class.
-            or (self.state_class != SensorStateClass.MEASUREMENT and not state.value)
+            or (
+                self.state_class is not SensorStateClass.MEASUREMENT and not state.value
+            )
         ):
             return None
 

--- a/homeassistant/components/palazzetti/climate.py
+++ b/homeassistant/components/palazzetti/climate.py
@@ -78,7 +78,7 @@ class PalazzettiClimateEntity(PalazzettiEntity, ClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         try:
-            await self.coordinator.client.set_on(hvac_mode != HVACMode.OFF)
+            await self.coordinator.client.set_on(hvac_mode is not HVACMode.OFF)
         except CommunicationError as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN, translation_key="cannot_connect"

--- a/homeassistant/components/panasonic_bluray/media_player.py
+++ b/homeassistant/components/panasonic_bluray/media_player.py
@@ -97,14 +97,14 @@ class PanasonicBluRay(MediaPlayerEntity):
         our favour as it means the device is still accepting commands and we
         can thus turn it back on when desired.
         """
-        if self.state != MediaPlayerState.OFF:
+        if self.state is not MediaPlayerState.OFF:
             self._device.send_key("POWER")
 
         self._attr_state = MediaPlayerState.OFF
 
     def turn_on(self) -> None:
         """Wake the device back up from standby."""
-        if self.state == MediaPlayerState.OFF:
+        if self.state is MediaPlayerState.OFF:
             self._device.send_key("POWER")
 
         self._attr_state = MediaPlayerState.IDLE

--- a/homeassistant/components/panasonic_viera/media_player.py
+++ b/homeassistant/components/panasonic_viera/media_player.py
@@ -176,7 +176,7 @@ class PanasonicVieraTVEntity(MediaPlayerEntity):
             )
             media_id = play_item.url
 
-        if media_type != MediaType.URL:
+        if media_type is not MediaType.URL:
             _LOGGER.warning("Unsupported media_type: %s", media_type)
             return
 

--- a/homeassistant/components/paperless_ngx/sensor.py
+++ b/homeassistant/components/paperless_ngx/sensor.py
@@ -130,7 +130,7 @@ SENSOR_STATUS: tuple[PaperlessEntityDescription[Status], ...] = (
         device_class=SensorDeviceClass.ENUM,
         entity_category=EntityCategory.DIAGNOSTIC,
         options=[
-            item.value.lower() for item in StatusType if item != StatusType.UNKNOWN
+            item.value.lower() for item in StatusType if item is not StatusType.UNKNOWN
         ],
         value_fn=(
             lambda data: (
@@ -138,7 +138,7 @@ SENSOR_STATUS: tuple[PaperlessEntityDescription[Status], ...] = (
                 if (
                     data.database is not None
                     and data.database.status is not None
-                    and data.database.status != StatusType.UNKNOWN
+                    and data.database.status is not StatusType.UNKNOWN
                 )
                 else None
             )
@@ -151,7 +151,7 @@ SENSOR_STATUS: tuple[PaperlessEntityDescription[Status], ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         options=[
-            item.value.lower() for item in StatusType if item != StatusType.UNKNOWN
+            item.value.lower() for item in StatusType if item is not StatusType.UNKNOWN
         ],
         value_fn=(
             lambda data: (
@@ -159,7 +159,7 @@ SENSOR_STATUS: tuple[PaperlessEntityDescription[Status], ...] = (
                 if (
                     data.tasks is not None
                     and data.tasks.index_status is not None
-                    and data.tasks.index_status != StatusType.UNKNOWN
+                    and data.tasks.index_status is not StatusType.UNKNOWN
                 )
                 else None
             )
@@ -172,7 +172,7 @@ SENSOR_STATUS: tuple[PaperlessEntityDescription[Status], ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         options=[
-            item.value.lower() for item in StatusType if item != StatusType.UNKNOWN
+            item.value.lower() for item in StatusType if item is not StatusType.UNKNOWN
         ],
         value_fn=(
             lambda data: (
@@ -180,7 +180,7 @@ SENSOR_STATUS: tuple[PaperlessEntityDescription[Status], ...] = (
                 if (
                     data.tasks is not None
                     and data.tasks.classifier_status is not None
-                    and data.tasks.classifier_status != StatusType.UNKNOWN
+                    and data.tasks.classifier_status is not StatusType.UNKNOWN
                 )
                 else None
             )
@@ -193,7 +193,7 @@ SENSOR_STATUS: tuple[PaperlessEntityDescription[Status], ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         options=[
-            item.value.lower() for item in StatusType if item != StatusType.UNKNOWN
+            item.value.lower() for item in StatusType if item is not StatusType.UNKNOWN
         ],
         value_fn=(
             lambda data: (
@@ -201,7 +201,7 @@ SENSOR_STATUS: tuple[PaperlessEntityDescription[Status], ...] = (
                 if (
                     data.tasks is not None
                     and data.tasks.celery_status is not None
-                    and data.tasks.celery_status != StatusType.UNKNOWN
+                    and data.tasks.celery_status is not StatusType.UNKNOWN
                 )
                 else None
             )
@@ -213,7 +213,7 @@ SENSOR_STATUS: tuple[PaperlessEntityDescription[Status], ...] = (
         device_class=SensorDeviceClass.ENUM,
         entity_category=EntityCategory.DIAGNOSTIC,
         options=[
-            item.value.lower() for item in StatusType if item != StatusType.UNKNOWN
+            item.value.lower() for item in StatusType if item is not StatusType.UNKNOWN
         ],
         value_fn=(
             lambda data: (
@@ -221,7 +221,7 @@ SENSOR_STATUS: tuple[PaperlessEntityDescription[Status], ...] = (
                 if (
                     data.tasks is not None
                     and data.tasks.redis_status is not None
-                    and data.tasks.redis_status != StatusType.UNKNOWN
+                    and data.tasks.redis_status is not StatusType.UNKNOWN
                 )
                 else None
             )
@@ -233,7 +233,7 @@ SENSOR_STATUS: tuple[PaperlessEntityDescription[Status], ...] = (
         device_class=SensorDeviceClass.ENUM,
         entity_category=EntityCategory.DIAGNOSTIC,
         options=[
-            item.value.lower() for item in StatusType if item != StatusType.UNKNOWN
+            item.value.lower() for item in StatusType if item is not StatusType.UNKNOWN
         ],
         value_fn=(
             lambda data: (
@@ -241,7 +241,7 @@ SENSOR_STATUS: tuple[PaperlessEntityDescription[Status], ...] = (
                 if (
                     data.tasks is not None
                     and data.tasks.sanity_check_status is not None
-                    and data.tasks.sanity_check_status != StatusType.UNKNOWN
+                    and data.tasks.sanity_check_status is not StatusType.UNKNOWN
                 )
                 else None
             )

--- a/homeassistant/components/pegel_online/sensor.py
+++ b/homeassistant/components/pegel_online/sensor.py
@@ -124,7 +124,7 @@ class PegelOnlineSensor(PegelOnlineEntity, SensorEntity):
         self.entity_description = description
         self._attr_unique_id = f"{self.station.uuid}_{description.key}"
 
-        if description.device_class != SensorDeviceClass.PH:
+        if description.device_class is not SensorDeviceClass.PH:
             self._attr_native_unit_of_measurement = self.measurement.uom
 
         if self.station.latitude and self.station.longitude:

--- a/homeassistant/components/philips_js/media_player.py
+++ b/homeassistant/components/philips_js/media_player.py
@@ -121,7 +121,7 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
 
     async def async_turn_off(self) -> None:
         """Turn off the device."""
-        if self._attr_state == MediaPlayerState.ON:
+        if self._attr_state is MediaPlayerState.ON:
             await self._tv.sendKey("Standby")
             self._attr_state = MediaPlayerState.OFF
             await self._async_update_soon()
@@ -226,7 +226,7 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
         """Play a piece of media."""
         _LOGGER.debug("Call play media type <%s>, Id <%s>", media_type, media_id)
 
-        if media_type == MediaType.CHANNEL:
+        if media_type is MediaType.CHANNEL:
             await self.async_play_media_channel(media_id)
         elif media_type == MediaType.APP:
             if app := self._tv.applications.get(media_id):
@@ -415,9 +415,9 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
     ) -> tuple[bytes | None, str | None]:
         """Serve album art. Returns (content, content_type)."""
         try:
-            if media_content_type == MediaType.APP and media_content_id:
+            if media_content_type is MediaType.APP and media_content_id:
                 return await self._tv.getApplicationIcon(media_content_id)
-            if media_content_type == MediaType.CHANNEL and media_content_id:
+            if media_content_type is MediaType.CHANNEL and media_content_id:
                 list_id, _, channel_id = media_content_id.partition("/")
                 if not channel_id:
                     channel_id = list_id

--- a/homeassistant/components/picnic/services.py
+++ b/homeassistant/components/picnic/services.py
@@ -54,7 +54,7 @@ async def get_api_client(hass: HomeAssistant, config_entry_id: str) -> PicnicAPI
     entry: PicnicConfigEntry | None = hass.config_entries.async_get_entry(
         config_entry_id
     )
-    if entry is None or entry.state != ConfigEntryState.LOADED:
+    if entry is None or entry.state is not ConfigEntryState.LOADED:
         raise ValueError(f"Config entry with id {config_entry_id} not found!")
     return entry.runtime_data.picnic_api_client
 

--- a/homeassistant/components/playstation_network/helpers.py
+++ b/homeassistant/components/playstation_network/helpers.py
@@ -182,7 +182,7 @@ class PlaystationNetwork:
                 for title in self.trophy_titles
                 if game_title_info["titleName"]
                 == normalize_title(title.title_name or "")
-                and next(iter(title.title_platform)) == PlatformType.PS_VITA
+                and next(iter(title.title_platform)) is PlatformType.PS_VITA
             ),
             None,
         )

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -251,7 +251,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
 
     def _regulation_mode_for_hvac(self, hvac_mode: HVACMode) -> str | None:
         """Return the API regulation value for a manual HVAC mode, or None."""
-        if hvac_mode == HVACMode.HEAT:
+        if hvac_mode is HVACMode.HEAT:
             return HVACAction.HEATING.value
         if hvac_mode == HVACMode.COOL:
             return HVACAction.COOLING.value
@@ -260,14 +260,14 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
     @plugwise_command
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the HVAC mode (off, heat, cool, heat_cool, or auto/schedule)."""
-        if hvac_mode == self.hvac_mode:
+        if hvac_mode is self.hvac_mode:
             return
 
         api = self.coordinator.api
         current_schedule = self.device.get("select_schedule")
 
         # OFF: single API call
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             await api.set_regulation_mode(hvac_mode.value)
             return
 
@@ -294,8 +294,8 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
                 await api.set_regulation_mode(regulation)
 
             if (
-                self.hvac_mode == HVACMode.OFF and current_schedule not in (None, "off")
-            ) or (self.hvac_mode == HVACMode.AUTO and current_schedule is not None):
+                self.hvac_mode is HVACMode.OFF and current_schedule not in (None, "off")
+            ) or (self.hvac_mode is HVACMode.AUTO and current_schedule is not None):
                 await api.set_schedule_state(
                     self._location, STATE_OFF, current_schedule
                 )
@@ -315,7 +315,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
             )
 
         if self._previous_action_mode:
-            if self.hvac_mode == HVACMode.OFF:
+            if self.hvac_mode is HVACMode.OFF:
                 await api.set_regulation_mode(self._previous_action_mode)
             await api.set_schedule_state(self._location, STATE_ON, desired_schedule)
 

--- a/homeassistant/components/point/binary_sensor.py
+++ b/homeassistant/components/point/binary_sensor.py
@@ -88,7 +88,7 @@ class MinutPointBinarySensor(MinutPointEntity, BinarySensorEntity):
 
     def _handle_coordinator_update(self) -> None:
         """Update the value of the sensor."""
-        if self.device_class == BinarySensorDeviceClass.CONNECTIVITY:
+        if self.device_class is BinarySensorDeviceClass.CONNECTIVITY:
             # connectivity is the other way around.
             self._attr_is_on = self._events[0] not in self.device.ongoing_events
         else:

--- a/homeassistant/components/pooldose/__init__.py
+++ b/homeassistant/components/pooldose/__init__.py
@@ -72,7 +72,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: PooldoseConfigEntry) -> 
             f"Failed to connect to PoolDose device: {err}"
         ) from err
 
-    if client_status != RequestStatus.SUCCESS:
+    if client_status is not RequestStatus.SUCCESS:
         raise ConfigEntryNotReady(
             f"Failed to create PoolDose client while initialization: {client_status}"
         )

--- a/homeassistant/components/pooldose/config_flow.py
+++ b/homeassistant/components/pooldose/config_flow.py
@@ -43,7 +43,7 @@ class PooldoseConfigFlow(ConfigFlow, domain=DOMAIN):
         """Validate the host and return (serial_number, api_versions, errors)."""
         client = PooldoseClient(host, websession=async_get_clientsession(self.hass))
         client_status = await client.connect()
-        if client_status == RequestStatus.HOST_UNREACHABLE:
+        if client_status is RequestStatus.HOST_UNREACHABLE:
             return None, None, {"base": "cannot_connect"}
         if client_status == RequestStatus.PARAMS_FETCH_FAILED:
             return None, None, {"base": "params_fetch_failed"}
@@ -51,7 +51,7 @@ class PooldoseConfigFlow(ConfigFlow, domain=DOMAIN):
             return None, None, {"base": "cannot_connect"}
 
         api_status, api_versions = client.check_apiversion_supported()
-        if api_status == RequestStatus.NO_DATA:
+        if api_status is RequestStatus.NO_DATA:
             return None, None, {"base": "api_not_set"}
         if api_status == RequestStatus.API_VERSION_UNSUPPORTED:
             return None, api_versions, {"base": "api_not_supported"}

--- a/homeassistant/components/pooldose/coordinator.py
+++ b/homeassistant/components/pooldose/coordinator.py
@@ -57,7 +57,7 @@ class PooldoseCoordinator(DataUpdateCoordinator[StructuredValuesDict]):
                 f"Failed to connect to PoolDose device while fetching data: {err}"
             ) from err
 
-        if status != RequestStatus.SUCCESS:
+        if status is not RequestStatus.SUCCESS:
             raise UpdateFailed(f"API returned status: {status}")
 
         if not instant_values:

--- a/homeassistant/components/powerfox/__init__.py
+++ b/homeassistant/components/powerfox/__init__.py
@@ -51,7 +51,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: PowerfoxConfigEntry) -> 
         PowerfoxDataUpdateCoordinator | PowerfoxReportDataUpdateCoordinator
     ] = []
     for device in devices:
-        if device.type == DeviceType.GAS_METER:
+        if device.type is DeviceType.GAS_METER:
             coordinators.append(
                 PowerfoxReportDataUpdateCoordinator(hass, entry, client, device)
             )

--- a/homeassistant/components/powerwall/switch.py
+++ b/homeassistant/components/powerwall/switch.py
@@ -62,7 +62,7 @@ class PowerwallOffGridEnabledEntity(PowerWallEntity, SwitchEntity):
                 f"Setting off-grid operation to {island_mode} failed: {ex}"
             ) from ex
 
-        self._attr_is_on = island_mode == IslandMode.OFFGRID
+        self._attr_is_on = island_mode is IslandMode.OFFGRID
         self.async_write_ha_state()
 
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -658,7 +658,7 @@ class PrometheusMetrics:
         if (temp := state.attributes.get(attr)) is None:
             return
 
-        if self._climate_units == UnitOfTemperature.FAHRENHEIT:
+        if self._climate_units is UnitOfTemperature.FAHRENHEIT:
             temp = TemperatureConverter.convert(
                 temp, UnitOfTemperature.FAHRENHEIT, UnitOfTemperature.CELSIUS
             )

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -189,9 +189,9 @@ class PS4Device(MediaPlayerEntity):
                             self.async_get_title_data(title_id, name),
                             "ps4.media_player-get_title_data",
                         )
-                elif self.state != MediaPlayerState.IDLE:
+                elif self.state is not MediaPlayerState.IDLE:
                     self.idle()
-            elif self.state != MediaPlayerState.OFF:
+            elif self.state is not MediaPlayerState.OFF:
                 self.state_standby()
 
         elif self._retry > DEFAULT_RETRIES:
@@ -387,7 +387,7 @@ class PS4Device(MediaPlayerEntity):
     def entity_picture(self) -> str | None:
         """Return picture."""
         if (
-            self.state == MediaPlayerState.PLAYING
+            self.state is MediaPlayerState.PLAYING
             and self.media_content_id is not None
             and (image_hash := self.media_image_hash) is not None
         ):

--- a/homeassistant/components/qbittorrent/__init__.py
+++ b/homeassistant/components/qbittorrent/__init__.py
@@ -71,7 +71,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         entry: QBittorrentConfigEntry | None = hass.config_entries.async_get_entry(
             entry_id
         )
-        if entry is None or entry.state != ConfigEntryState.LOADED:
+        if entry is None or entry.state is not ConfigEntryState.LOADED:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="invalid_entry_id",

--- a/homeassistant/components/qnap_qsw/binary_sensor.py
+++ b/homeassistant/components/qnap_qsw/binary_sensor.py
@@ -140,7 +140,7 @@ class QswBinarySensor(QswSensorEntity, BinarySensorEntity):
     ) -> None:
         """Initialize."""
         super().__init__(coordinator, entry, type_id)
-        if description.name == UNDEFINED:
+        if description.name is UNDEFINED:
             self._attr_has_entity_name = True
         else:
             self._attr_name = f"{self.product} {description.name}"

--- a/homeassistant/components/qnap_qsw/sensor.py
+++ b/homeassistant/components/qnap_qsw/sensor.py
@@ -357,7 +357,7 @@ class QswSensor(QswSensorEntity, SensorEntity):
         """Initialize."""
         super().__init__(coordinator, entry, type_id)
 
-        if description.name == UNDEFINED:
+        if description.name is UNDEFINED:
             self._attr_has_entity_name = True
         else:
             self._attr_name = f"{self.product} {description.name}"

--- a/homeassistant/components/rabbitair/fan.py
+++ b/homeassistant/components/rabbitair/fan.py
@@ -101,7 +101,7 @@ class RabbitAirFanEntity(RabbitAirBaseEntity, FanEntity):
         else:
             # Get key by value in dictionary
             self._attr_preset_mode = next(
-                k for k, v in PRESET_MODES.items() if v == data.mode
+                k for k, v in PRESET_MODES.items() if v is data.mode
             )
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:

--- a/homeassistant/components/radio_browser/media_source.py
+++ b/homeassistant/components/radio_browser/media_source.py
@@ -56,7 +56,7 @@ class RadioMediaSource(MediaSource):
     async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:
         """Resolve selected Radio station to a streaming URL."""
 
-        if self.entry.state != ConfigEntryState.LOADED:
+        if self.entry.state is not ConfigEntryState.LOADED:
             raise Unresolvable(
                 translation_domain=DOMAIN,
                 translation_key="config_entry_not_ready",
@@ -86,7 +86,7 @@ class RadioMediaSource(MediaSource):
     ) -> BrowseMediaSource:
         """Return media."""
 
-        if self.entry.state != ConfigEntryState.LOADED:
+        if self.entry.state is not ConfigEntryState.LOADED:
             raise BrowseError(
                 translation_domain=DOMAIN,
                 translation_key="config_entry_not_ready",

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -156,11 +156,11 @@ class RadioThermostat(RadioThermostatEntity, ClimateEntity):
             ATTR_FAN_ACTION: CODE_TO_FAN_STATE[data["fstate"]]
         }
         self._attr_hvac_mode = CODE_TO_TEMP_MODE[data["tmode"]]
-        if self.hvac_mode == HVACMode.OFF:
+        if self.hvac_mode is HVACMode.OFF:
             self._attr_hvac_action = None
         else:
             self._attr_hvac_action = CODE_TO_TEMP_STATE[data["tstate"]]
-        if self.hvac_mode == HVACMode.COOL:
+        if self.hvac_mode is HVACMode.COOL:
             self._attr_target_temperature = data["t_cool"]
         elif self.hvac_mode == HVACMode.HEAT:
             self._attr_target_temperature = data["t_heat"]
@@ -168,7 +168,7 @@ class RadioThermostat(RadioThermostatEntity, ClimateEntity):
             # This doesn't really work - tstate is only set if the HVAC is
             # active. If it's idle, we don't know what to do with the target
             # temperature.
-            if self.hvac_action == HVACAction.COOLING:
+            if self.hvac_action is HVACAction.COOLING:
                 self._attr_target_temperature = data["t_cool"]
             elif self.hvac_action == HVACAction.HEATING:
                 self._attr_target_temperature = data["t_heat"]
@@ -185,12 +185,12 @@ class RadioThermostat(RadioThermostatEntity, ClimateEntity):
     def _set_temperature(self, temperature: int) -> None:
         """Set new target temperature."""
         temperature = round_temp(temperature)
-        if self.hvac_mode == HVACMode.COOL:
+        if self.hvac_mode is HVACMode.COOL:
             self.device.t_cool = temperature
         elif self.hvac_mode == HVACMode.HEAT:
             self.device.t_heat = temperature
         elif self.hvac_mode == HVACMode.AUTO:
-            if self.hvac_action == HVACAction.COOLING:
+            if self.hvac_action is HVACAction.COOLING:
                 self.device.t_cool = temperature
             elif self.hvac_action == HVACAction.HEATING:
                 self.device.t_heat = temperature
@@ -207,7 +207,7 @@ class RadioThermostat(RadioThermostatEntity, ClimateEntity):
         if hvac_mode in (HVACMode.OFF, HVACMode.AUTO):
             self.device.tmode = TEMP_MODE_TO_CODE[hvac_mode]
         # Setting t_cool or t_heat automatically changes tmode.
-        elif hvac_mode == HVACMode.COOL:
+        elif hvac_mode is HVACMode.COOL:
             self.device.t_cool = self.target_temperature
         elif hvac_mode == HVACMode.HEAT:
             self.device.t_heat = self.target_temperature

--- a/homeassistant/components/rainforest_raven/config_flow.py
+++ b/homeassistant/components/rainforest_raven/config_flow.py
@@ -59,7 +59,7 @@ class RainforestRavenConfigFlow(ConfigFlow, domain=DOMAIN):
                     meter_info = await raven_device.get_meter_info(meter=meter)
                     if meter_info and (
                         meter_info.meter_type is None
-                        or meter_info.meter_type == MeterType.ELECTRIC
+                        or meter_info.meter_type is MeterType.ELECTRIC
                     ):
                         self._meter_macs.add(meter.hex())
         self._dev_path = dev_path

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -268,13 +268,13 @@ class TimeRemainingSensor(RainMachineEntity, RestoreSensor):
         now = utcnow()
 
         if (
-            self._current_run_state == RunStates.NOT_RUNNING
+            self._current_run_state is RunStates.NOT_RUNNING
             and self._previous_run_state in (RunStates.QUEUED, RunStates.RUNNING)
         ):
             # If the activity goes from queued/running to not running, update the
             # state to be right now (i.e., the time the zone stopped running):
             self._attr_native_value = now
-        elif self._current_run_state == RunStates.RUNNING:
+        elif self._current_run_state is RunStates.RUNNING:
             seconds_remaining = self.calculate_seconds_remaining()
             new_timestamp = now + timedelta(seconds=seconds_remaining)
 

--- a/homeassistant/components/random/config_flow.py
+++ b/homeassistant/components/random/config_flow.py
@@ -44,7 +44,7 @@ def _generate_schema(domain: str, flow_type: _FlowType) -> vol.Schema:
     """Generate schema."""
     schema: dict[vol.Marker, Any] = {}
 
-    if flow_type == _FlowType.CONFIG:
+    if flow_type is _FlowType.CONFIG:
         schema[vol.Required(CONF_NAME)] = TextSelector()
 
         if domain == Platform.BINARY_SENSOR:
@@ -67,7 +67,7 @@ def _generate_schema(domain: str, flow_type: _FlowType) -> vol.Schema:
                         options=[
                             cls.value
                             for cls in SensorDeviceClass
-                            if cls != SensorDeviceClass.ENUM
+                            if cls is not SensorDeviceClass.ENUM
                         ],
                         sort=True,
                         mode=SelectSelectorMode.DROPDOWN,

--- a/homeassistant/components/recorder/auto_repairs/schema.py
+++ b/homeassistant/components/recorder/auto_repairs/schema.py
@@ -46,7 +46,7 @@ def validate_table_schema_supports_utf8(
     """Do some basic checks for common schema errors caused by manual migration."""
     schema_errors: set[str] = set()
     # Lack of full utf8 support is only an issue for MySQL / MariaDB
-    if instance.dialect_name != SupportedDialect.MYSQL:
+    if instance.dialect_name is not SupportedDialect.MYSQL:
         return schema_errors
 
     try:
@@ -67,7 +67,7 @@ def validate_table_schema_has_correct_collation(
     """Verify the table has the correct collation."""
     schema_errors: set[str] = set()
     # Lack of full utf8 support is only an issue for MySQL / MariaDB
-    if instance.dialect_name != SupportedDialect.MYSQL:
+    if instance.dialect_name is not SupportedDialect.MYSQL:
         return schema_errors
 
     try:

--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -624,7 +624,7 @@ class Recorder(threading.Thread):
 
         # If the db is using a socket connection, we need to keep alive
         # to prevent errors from unexpected disconnects
-        if self.dialect_name != SupportedDialect.SQLITE:
+        if self.dialect_name is not SupportedDialect.SQLITE:
             self._keep_alive_listener = async_track_time_interval(
                 self.hass,
                 self._async_keep_alive,
@@ -1329,7 +1329,7 @@ class Recorder(threading.Thread):
 
     async def lock_database(self) -> bool:
         """Lock database so it can be backed up safely."""
-        if self.dialect_name != SupportedDialect.SQLITE:
+        if self.dialect_name is not SupportedDialect.SQLITE:
             _LOGGER.debug(
                 "Not a SQLite database or not connected, locking not necessary"
             )
@@ -1359,7 +1359,7 @@ class Recorder(threading.Thread):
 
         Returns true if database lock has been held throughout the process.
         """
-        if self.dialect_name != SupportedDialect.SQLITE:
+        if self.dialect_name is not SupportedDialect.SQLITE:
             _LOGGER.debug(
                 "Not a SQLite database or not connected, unlocking not necessary"
             )

--- a/homeassistant/components/recorder/db_schema.py
+++ b/homeassistant/components/recorder/db_schema.py
@@ -359,7 +359,7 @@ class EventData(Base):
         event: Event, dialect: SupportedDialect | None
     ) -> bytes:
         """Create shared_data from an event."""
-        encoder = json_bytes_strip_null if dialect == PSQL_DIALECT else json_bytes
+        encoder = json_bytes_strip_null if dialect is PSQL_DIALECT else json_bytes
         bytes_result = encoder(event.data)
         if len(bytes_result) > MAX_EVENT_DATA_BYTES:
             _LOGGER.warning(
@@ -573,7 +573,7 @@ class StateAttributes(Base):
                 exclude_attrs -= _MATCH_ALL_KEEP
         else:
             exclude_attrs = ALL_DOMAIN_EXCLUDE_ATTRS
-        encoder = json_bytes_strip_null if dialect == PSQL_DIALECT else json_bytes
+        encoder = json_bytes_strip_null if dialect is PSQL_DIALECT else json_bytes
         bytes_result = encoder(
             {k: v for k, v in state.attributes.items() if k not in exclude_attrs}
         )

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -3109,7 +3109,7 @@ class EventIDPostMigration(BaseRunTimeMigration):
             # Only drop the index if there are no more event_ids in the states table
             # ex all NULL
             assert instance.engine is not None, "engine should never be None"
-            if instance.dialect_name == SupportedDialect.SQLITE:
+            if instance.dialect_name is SupportedDialect.SQLITE:
                 # SQLite does not support dropping foreign key constraints
                 # so we have to rebuild the table
                 fk_remove_ok = rebuild_sqlite_table(

--- a/homeassistant/components/recorder/table_managers/statistics_meta.py
+++ b/homeassistant/components/recorder/table_managers/statistics_meta.py
@@ -218,7 +218,7 @@ class StatisticsMetaManager:
             )
         metadata_id, old_metadata = old_metadata_dict[statistic_id]
         if not (
-            old_metadata["mean_type"] != new_metadata["mean_type"]
+            old_metadata["mean_type"] is not new_metadata["mean_type"]
             or old_metadata["has_sum"] != new_metadata["has_sum"]
             or old_metadata["name"] != new_metadata["name"]
             or old_metadata["unit_class"] != new_metadata["unit_class"]

--- a/homeassistant/components/renault/binary_sensor.py
+++ b/homeassistant/components/renault/binary_sensor.py
@@ -79,7 +79,7 @@ def _plugged_in_value_lambda(
 ) -> bool | None:
     """Return true if the vehicle is plugged in."""
     if (plug_status := self.coordinator.data.get_plug_status()) is not None:
-        return plug_status == PlugState.PLUGGED
+        return plug_status is PlugState.PLUGGED
 
     if (
         charging_status := self.coordinator.data.get_charging_status()

--- a/homeassistant/components/renson/sensor.py
+++ b/homeassistant/components/renson/sensor.py
@@ -254,7 +254,7 @@ class RensonSensor(RensonEntity, SensorEntity):
 
         if self.raw_format:
             self._attr_native_value = value
-        elif self.entity_description.device_class == SensorDeviceClass.ENUM:
+        elif self.entity_description.device_class is SensorDeviceClass.ENUM:
             self._attr_native_value = self.api.parse_value(
                 value, self.data_type
             ).lower()

--- a/homeassistant/components/reolink/coordinator.py
+++ b/homeassistant/components/reolink/coordinator.py
@@ -120,7 +120,7 @@ class ReolinkDeviceCoordinator(ReolinkCoordinator):
 
         if (
             self._host.api.new_devices
-            and self.config_entry.state == ConfigEntryState.LOADED
+            and self.config_entry.state is ConfigEntryState.LOADED
         ):
             # There are new cameras/chimes connected, reload to add them.
             _LOGGER.debug(

--- a/homeassistant/components/reolink/media_source.py
+++ b/homeassistant/components/reolink/media_source.py
@@ -83,7 +83,7 @@ class ReolinkVODMediaSource(MediaSource):
 
         vod_type = get_vod_type()
 
-        if vod_type == VodRequestType.NVR_DOWNLOAD:
+        if vod_type is VodRequestType.NVR_DOWNLOAD:
             filename = f"{start_time}_{end_time}"
 
         if vod_type in {

--- a/homeassistant/components/reolink/services.py
+++ b/homeassistant/components/reolink/services.py
@@ -43,7 +43,7 @@ async def _async_play_chime(service_call: ServiceCall) -> None:
         if (
             config_entry is None
             or device is None
-            or config_entry.state != ConfigEntryState.LOADED
+            or config_entry.state is not ConfigEntryState.LOADED
         ):
             raise ServiceValidationError(
                 translation_domain=DOMAIN,

--- a/homeassistant/components/reolink/util.py
+++ b/homeassistant/components/reolink/util.py
@@ -51,7 +51,7 @@ def is_connected(hass: HomeAssistant, config_entry: config_entries.ConfigEntry) 
     """Check if an existing entry has a proper connection."""
     return (
         hasattr(config_entry, "runtime_data")
-        and config_entry.state == config_entries.ConfigEntryState.LOADED
+        and config_entry.state is config_entries.ConfigEntryState.LOADED
         and config_entry.runtime_data.device_coordinator.last_update_success
     )
 

--- a/homeassistant/components/repairs/issue_handler.py
+++ b/homeassistant/components/repairs/issue_handler.py
@@ -91,7 +91,7 @@ class RepairsFlowManager(
         This method is called when a flow step returns FlowResultType.ABORT or
         FlowResultType.CREATE_ENTRY.
         """
-        if result.get("type") != data_entry_flow.FlowResultType.ABORT:
+        if result.get("type") is not data_entry_flow.FlowResultType.ABORT:
             ir.async_delete_issue(self.hass, flow.handler, flow.init_data["issue_id"])
         return result
 

--- a/homeassistant/components/ridwell/calendar.py
+++ b/homeassistant/components/ridwell/calendar.py
@@ -28,7 +28,7 @@ def async_get_calendar_event_from_pickup_event(
     calendar_preference = config_entry.options.get(CONF_CALENDAR_TITLE, False)
     for pickup in pickup_event.pickups:
         pickup_items.append(f"{pickup.name} (quantity: {pickup.quantity})")
-        if pickup.category == PickupCategory.ROTATING:
+        if pickup.category is PickupCategory.ROTATING:
             rotating_category = pickup.name
             break
 

--- a/homeassistant/components/ridwell/switch.py
+++ b/homeassistant/components/ridwell/switch.py
@@ -51,7 +51,7 @@ class RidwellSwitch(RidwellEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return True if entity is on."""
-        return self.next_pickup_event.state == EventState.SCHEDULED
+        return self.next_pickup_event.state is EventState.SCHEDULED
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""

--- a/homeassistant/components/ring/light.py
+++ b/homeassistant/components/ring/light.py
@@ -85,7 +85,7 @@ class RingLight(RingEntity[RingStickUpCam], LightEntity):
         """Update light state, and causes Home Assistant to correctly update."""
         await self._device.async_set_lights(new_state)
 
-        self._attr_is_on = new_state == OnOffState.ON
+        self._attr_is_on = new_state is OnOffState.ON
         self._no_updates_until = dt_util.utcnow() + SKIP_UPDATES_DELAY
         self.async_write_ha_state()
 

--- a/homeassistant/components/roborock/binary_sensor.py
+++ b/homeassistant/components/roborock/binary_sensor.py
@@ -99,7 +99,7 @@ BINARY_SENSOR_DESCRIPTIONS = [
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: (
-            data.status.clean_fluid_status == CleanFluidStatus.empty_not_installed
+            data.status.clean_fluid_status is CleanFluidStatus.empty_not_installed
             if data.status.clean_fluid_status is not None
             else None
         ),

--- a/homeassistant/components/roborock/select.py
+++ b/homeassistant/components/roborock/select.py
@@ -513,13 +513,13 @@ class RoborockQ10CleanModeSelectEntity(RoborockCoordinatedEntityB01Q10, SelectEn
     @property
     def options(self) -> list[str]:
         """Return available cleaning modes."""
-        return [mode.value for mode in YXCleanType if mode != YXCleanType.UNKNOWN]
+        return [mode.value for mode in YXCleanType if mode is not YXCleanType.UNKNOWN]
 
     @property
     def current_option(self) -> str | None:
         """Get the current cleaning mode."""
         clean_mode = self.coordinator.api.status.clean_mode
-        if clean_mode is None or clean_mode == YXCleanType.UNKNOWN:
+        if clean_mode is None or clean_mode is YXCleanType.UNKNOWN:
             return None
         return clean_mode.value
 

--- a/homeassistant/components/roborock/sensor.py
+++ b/homeassistant/components/roborock/sensor.py
@@ -89,7 +89,7 @@ class RoborockSensorDescriptionQ10(SensorEntityDescription):
 def _dock_error_value_fn(state: DeviceState) -> str | None:
     if (
         status := state.status.dock_error_status
-    ) is not None and state.status.dock_type != RoborockDockTypeCode.no_dock:
+    ) is not None and state.status.dock_type is not RoborockDockTypeCode.no_dock:
         return status.name
 
     return None

--- a/homeassistant/components/roborock/vacuum.py
+++ b/homeassistant/components/roborock/vacuum.py
@@ -527,7 +527,9 @@ class RoborockQ10Vacuum(RoborockCoordinatedEntityB01Q10, StateVacuumEntity):
     _attr_translation_key = DOMAIN
     _attr_name = None
     _attr_fan_speed_list = [
-        fan_level.value for fan_level in YXFanLevel if fan_level != YXFanLevel.UNKNOWN
+        fan_level.value
+        for fan_level in YXFanLevel
+        if fan_level is not YXFanLevel.UNKNOWN
     ]
 
     def __init__(

--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -256,7 +256,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         media_image_id: str | None = None,
     ) -> tuple[bytes | None, str | None]:
         """Fetch media browser image to serve via proxy."""
-        if media_content_type == MediaType.APP and media_content_id:
+        if media_content_type is MediaType.APP and media_content_id:
             image_url = self.coordinator.roku.app_icon_url(media_content_id)
             return await self._async_fetch_image(image_url)
 
@@ -305,7 +305,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
     @roku_exception_handler()
     async def async_media_play_pause(self) -> None:
         """Send play/pause command."""
-        if self.state != MediaPlayerState.OFF:
+        if self.state is not MediaPlayerState.OFF:
             await self.coordinator.roku.remote("play")
             await self.coordinator.async_request_refresh()
 
@@ -392,7 +392,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
 
             if (
                 media_type == MediaType.URL
-                and STREAM_FORMAT_TO_MEDIA_TYPE[extra[ATTR_FORMAT]] == MediaType.MUSIC
+                and STREAM_FORMAT_TO_MEDIA_TYPE[extra[ATTR_FORMAT]] is MediaType.MUSIC
             ):
                 media_type = MediaType.MUSIC
 
@@ -407,7 +407,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
             if extra.get(ATTR_NAME) is None:
                 extra[ATTR_NAME] = stream_name
 
-        if media_type == MediaType.APP:
+        if media_type is MediaType.APP:
             params = {
                 param: extra[attr]
                 for attr, param in ATTRS_TO_LAUNCH_PARAMS.items()

--- a/homeassistant/components/russound_rio/__init__.py
+++ b/homeassistant/components/russound_rio/__init__.py
@@ -43,7 +43,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: RussoundConfigEntry) -> 
         _client: RussoundRIOClient, _callback_type: CallbackType
     ) -> None:
         """Call when the device is notified of changes."""
-        if _callback_type == CallbackType.CONNECTION:
+        if _callback_type is CallbackType.CONNECTION:
             if _client.is_connected():
                 _LOGGER.warning("Reconnected to device at %s", entry.data[CONF_HOST])
             else:

--- a/homeassistant/components/russound_rio/entity.py
+++ b/homeassistant/components/russound_rio/entity.py
@@ -85,7 +85,7 @@ class RussoundBaseEntity(Entity):
         self, _client: RussoundRIOClient, _callback_type: CallbackType
     ) -> None:
         """Call when the device is notified of changes."""
-        if _callback_type == CallbackType.CONNECTION:
+        if _callback_type is CallbackType.CONNECTION:
             self._attr_available = _client.is_connected()
         self._controller = _client.controllers[self._controller.controller_id]
         self.async_write_ha_state()

--- a/homeassistant/components/russound_rio/media_player.py
+++ b/homeassistant/components/russound_rio/media_player.py
@@ -96,7 +96,7 @@ class RussoundZoneDevice(RussoundBaseEntity, MediaPlayerEntity):
         play_status = self._source.play_status
         if not status:
             return MediaPlayerState.OFF
-        if play_status == PlayStatus.PLAYING:
+        if play_status is PlayStatus.PLAYING:
             return MediaPlayerState.PLAYING
         if play_status == PlayStatus.PAUSED:
             return MediaPlayerState.PAUSED

--- a/homeassistant/components/saj/sensor.py
+++ b/homeassistant/components/saj/sensor.py
@@ -205,9 +205,9 @@ class SAJsensor(SensorEntity):
             self._attr_name = f"saj_{self._inverter_name}_{pysaj_sensor.name}"
         else:
             self._attr_name = f"saj_{pysaj_sensor.name}"
-        if native_uom == UnitOfPower.WATT:
+        if native_uom is UnitOfPower.WATT:
             self._attr_device_class = SensorDeviceClass.POWER
-        if native_uom == UnitOfEnergy.KILO_WATT_HOUR:
+        if native_uom is UnitOfEnergy.KILO_WATT_HOUR:
             self._attr_device_class = SensorDeviceClass.ENERGY
         if native_uom in (
             UnitOfTemperature.CELSIUS,

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -442,7 +442,7 @@ class SamsungTVConfigFlow(ConfigFlow, domain=DOMAIN):
             return None
         LOGGER.debug("Updating existing config entry with %s", entry_kw_args)
         self.hass.config_entries.async_update_entry(entry, **entry_kw_args)
-        if entry.state != ConfigEntryState.LOADED:
+        if entry.state is not ConfigEntryState.LOADED:
             # If its loaded it already has a reload listener in place
             # and we do not want to trigger multiple reloads
             self.hass.async_create_task(

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -355,7 +355,7 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         self, media_type: MediaType | str, media_id: str, **kwargs: Any
     ) -> None:
         """Support changing a channel."""
-        if media_type == MediaType.APP:
+        if media_type is MediaType.APP:
             await self._async_launch_app(media_id)
             return
 

--- a/homeassistant/components/satel_integra/alarm_control_panel.py
+++ b/homeassistant/components/satel_integra/alarm_control_panel.py
@@ -119,7 +119,7 @@ class SatelIntegraAlarmPanel(
             return
 
         clear_alarm_necessary = (
-            self._attr_alarm_state == AlarmControlPanelState.TRIGGERED
+            self._attr_alarm_state is AlarmControlPanelState.TRIGGERED
         )
 
         await self._controller.disarm(code, [self._device_number])

--- a/homeassistant/components/saunum/climate.py
+++ b/homeassistant/components/saunum/climate.py
@@ -160,14 +160,14 @@ class LeilSaunaClimate(LeilSaunaEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new HVAC mode."""
-        if hvac_mode == HVACMode.HEAT and self.coordinator.data.door_open:
+        if hvac_mode is HVACMode.HEAT and self.coordinator.data.door_open:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="door_open",
             )
 
         try:
-            if hvac_mode == HVACMode.HEAT:
+            if hvac_mode is HVACMode.HEAT:
                 await self.coordinator.client.async_start_session()
             else:
                 await self.coordinator.client.async_stop_session()

--- a/homeassistant/components/scrape/config_flow.py
+++ b/homeassistant/components/scrape/config_flow.py
@@ -158,7 +158,7 @@ SENSOR_SETTINGS = vol.Schema(
                             options=[
                                 cls.value
                                 for cls in SensorDeviceClass
-                                if cls != SensorDeviceClass.ENUM
+                                if cls is not SensorDeviceClass.ENUM
                             ],
                             mode=SelectSelectorMode.DROPDOWN,
                             translation_key="device_class",

--- a/homeassistant/components/screenlogic/climate.py
+++ b/homeassistant/components/screenlogic/climate.py
@@ -129,14 +129,14 @@ class ScreenLogicClimate(ScreenLogicPushEntity, ClimateEntity, RestoreEntity):
         """Return the current action of the heater."""
         if self.entity_data[VALUE.HEAT_STATE][ATTR.VALUE] > 0:
             return HVACAction.HEATING
-        if self.hvac_mode == HVACMode.HEAT:
+        if self.hvac_mode is HVACMode.HEAT:
             return HVACAction.IDLE
         return HVACAction.OFF
 
     @property
     def preset_mode(self) -> str:
         """Return current/last preset mode."""
-        if self.hvac_mode == HVACMode.OFF:
+        if self.hvac_mode is HVACMode.OFF:
             return HEAT_MODE(self._last_preset).name.lower()
         return HEAT_MODE(self.entity_data[VALUE.HEAT_MODE][ATTR.VALUE]).name.lower()
 
@@ -159,7 +159,7 @@ class ScreenLogicClimate(ScreenLogicPushEntity, ClimateEntity, RestoreEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the operation mode."""
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             mode = HEAT_MODE.OFF
         else:
             mode = HEAT_MODE.parse(self.preset_mode)
@@ -179,7 +179,7 @@ class ScreenLogicClimate(ScreenLogicPushEntity, ClimateEntity, RestoreEntity):
         mode = HEAT_MODE.parse(preset_mode)
         _LOGGER.debug("Setting last_preset to %s", mode.name)
         self._last_preset = mode.value
-        if self.hvac_mode == HVACMode.OFF:
+        if self.hvac_mode is HVACMode.OFF:
             return
 
         try:

--- a/homeassistant/components/screenlogic/services.py
+++ b/homeassistant/components/screenlogic/services.py
@@ -74,7 +74,7 @@ async def _get_coordinators(
                 f"Failed to call service '{service_call.service}'. Config entry "
                 f"'{entry_id}' is not a {DOMAIN} config"
             )
-        if not config_entry.state == ConfigEntryState.LOADED:
+        if config_entry.state is not ConfigEntryState.LOADED:
             raise ServiceValidationError(
                 f"Failed to call service '{service_call.service}'. Config entry "
                 f"'{entry_id}' not loaded"

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -346,7 +346,7 @@ async def _create_script_entities(
     entities: list[BaseScriptEntity] = []
 
     for script_config in script_configs:
-        if script_config.validation_status != ValidationStatus.OK:
+        if script_config.validation_status is not ValidationStatus.OK:
             entities.append(
                 UnavailableScriptEntity(
                     script_config.key,

--- a/homeassistant/components/sense/sensor.py
+++ b/homeassistant/components/sense/sensor.py
@@ -221,7 +221,7 @@ class SenseTrendsSensor(SenseEntity, SensorEntity):
     @property
     def last_reset(self) -> datetime | None:
         """Return the time when the sensor was last reset, if any."""
-        if self._attr_state_class == SensorStateClass.TOTAL:
+        if self._attr_state_class is SensorStateClass.TOTAL:
             return self._gateway.trend_start(self._scale)
         return None
 

--- a/homeassistant/components/sensibo/climate.py
+++ b/homeassistant/components/sensibo/climate.py
@@ -276,7 +276,7 @@ class SensiboClimate(SensiboDeviceBaseEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target operation mode."""
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             await self.async_send_api_call(
                 key=AC_STATE_TO_DATA["on"],
                 value=False,

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -298,7 +298,7 @@ class SensorEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     async def async_internal_added_to_hass(self) -> None:
         """Call when the sensor entity is added to hass."""
         await super().async_internal_added_to_hass()
-        if self.entity_category == EntityCategory.CONFIG:
+        if self.entity_category is EntityCategory.CONFIG:
             raise HomeAssistantError(
                 f"Entity {self.entity_id} cannot be added as"
                 " the entity category is set to config"
@@ -459,7 +459,7 @@ class SensorEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         """Return state attributes."""
         if last_reset := self.last_reset:
             state_class = self.state_class
-            if state_class != SensorStateClass.TOTAL:
+            if state_class is not SensorStateClass.TOTAL:
                 raise ValueError(
                     f"Entity {self.entity_id} ({type(self)})"
                     f" with state_class {state_class}"

--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -939,7 +939,7 @@ def _update_issues(
                 (metadata_mean_type := metadata[1]["mean_type"]) is not None
                 and state_class
                 and (state_mean_type := DEFAULT_STATISTICS[state_class].mean_type)
-                != metadata_mean_type
+                is not metadata_mean_type
             ):
                 # The mean type has changed and the old statistics are not valid anymore
                 report_issue(

--- a/homeassistant/components/senz/climate.py
+++ b/homeassistant/components/senz/climate.py
@@ -98,7 +98,7 @@ class SENZClimate(CoordinatorEntity[SENZDataUpdateCoordinator], ClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         try:
-            if hvac_mode == HVACMode.AUTO:
+            if hvac_mode is HVACMode.AUTO:
                 await self._thermostat.auto()
             else:
                 await self._thermostat.manual()

--- a/homeassistant/components/shelly/bluetooth/__init__.py
+++ b/homeassistant/components/shelly/bluetooth/__init__.py
@@ -52,7 +52,7 @@ async def async_connect_scanner(
     ]
     await async_start_scanner(
         device=device,
-        active=scanner_mode == BLEScannerMode.ACTIVE,
+        active=scanner_mode is BLEScannerMode.ACTIVE,
         event_type=BLE_SCAN_RESULT_EVENT,
         data_version=BLE_SCAN_RESULT_VERSION,
     )

--- a/homeassistant/components/shelly/climate.py
+++ b/homeassistant/components/shelly/climate.py
@@ -234,10 +234,10 @@ class RpcLinkedgoThermostatClimate(ShellyRpcAttributeEntity, ClimateEntity):
             assert self._thermostat_enable_key is not None
 
         await self.coordinator.device.boolean_set(
-            get_rpc_key_id(self._thermostat_enable_key), hvac_mode != HVACMode.OFF
+            get_rpc_key_id(self._thermostat_enable_key), hvac_mode is not HVACMode.OFF
         )
 
-        if self._working_mode_key is None or hvac_mode == HVACMode.OFF:
+        if self._working_mode_key is None or hvac_mode is HVACMode.OFF:
             return
 
         await self.coordinator.device.enum_set(
@@ -584,13 +584,13 @@ class BlockSleepingClimate(
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set hvac mode."""
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             if isinstance(self.target_temperature, float):
                 self._last_target_temp = self.target_temperature
             await self.set_state_full_path(
                 target_t_enabled=1, target_t=self._attr_min_temp
             )
-        if hvac_mode == HVACMode.HEAT:
+        if hvac_mode is HVACMode.HEAT:
             await self.set_state_full_path(
                 target_t_enabled=1, target_t=self._last_target_temp
             )

--- a/homeassistant/components/shelly/media_player.py
+++ b/homeassistant/components/shelly/media_player.py
@@ -248,13 +248,13 @@ class ShellyRpcMediaPlayer(ShellyRpcAttributeEntity, MediaPlayerEntity):
     @rpc_call
     async def async_media_play(self) -> None:
         """Send play command."""
-        if self.state != MediaPlayerState.PLAYING:
+        if self.state is not MediaPlayerState.PLAYING:
             await self.coordinator.device.media_play_or_pause()
 
     @rpc_call
     async def async_media_pause(self) -> None:
         """Send pause command."""
-        if self.state == MediaPlayerState.PLAYING:
+        if self.state is MediaPlayerState.PLAYING:
             await self.coordinator.device.media_play_or_pause()
 
     @rpc_call

--- a/homeassistant/components/shopping_list/todo.py
+++ b/homeassistant/components/shopping_list/todo.py
@@ -47,14 +47,14 @@ class ShoppingTodoListEntity(TodoListEntity):
     async def async_create_todo_item(self, item: TodoItem) -> None:
         """Add an item to the To-do list."""
         await self._data.async_add(
-            item.summary, complete=(item.status == TodoItemStatus.COMPLETED)
+            item.summary, complete=(item.status is TodoItemStatus.COMPLETED)
         )
 
     async def async_update_todo_item(self, item: TodoItem) -> None:
         """Update an item to the To-do list."""
         data = {
             "name": item.summary,
-            "complete": item.status == TodoItemStatus.COMPLETED,
+            "complete": item.status is TodoItemStatus.COMPLETED,
         }
         try:
             await self._data.async_update(item.uid, data)

--- a/homeassistant/components/sia/hub.py
+++ b/homeassistant/components/sia/hub.py
@@ -145,7 +145,7 @@ class SIAHub:
         underlying platforms, and then setup platforms, this
         reflects any changes in number of zones.
         """
-        if config_entry.state != ConfigEntryState.LOADED:
+        if config_entry.state is not ConfigEntryState.LOADED:
             return
         config_entry.runtime_data.update_accounts()
         await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -228,7 +228,7 @@ def _async_get_system_for_service_call(
         if (
             (entry := hass.config_entries.async_get_entry(entry_id)) is None
             or entry.domain != DOMAIN
-            or entry.state != ConfigEntryState.LOADED
+            or entry.state is not ConfigEntryState.LOADED
         ):
             continue
         return entry.runtime_data.systems[system_id]

--- a/homeassistant/components/simplisafe/lock.py
+++ b/homeassistant/components/simplisafe/lock.py
@@ -92,8 +92,8 @@ class SimpliSafeLock(SimpliSafeEntity, LockEntity):
     @callback
     def async_update_from_rest_api(self) -> None:
         """Update the entity with the provided REST API data."""
-        self._attr_is_jammed = self._device.state == LockStates.JAMMED
-        self._attr_is_locked = self._device.state == LockStates.LOCKED
+        self._attr_is_jammed = self._device.state is LockStates.JAMMED
+        self._attr_is_locked = self._device.state is LockStates.LOCKED
 
         self._attr_extra_state_attributes.update(
             {

--- a/homeassistant/components/simplisafe/sensor.py
+++ b/homeassistant/components/simplisafe/sensor.py
@@ -39,7 +39,7 @@ async def async_setup_entry(
         sensors.extend(
             SimplisafeFreezeSensor(simplisafe, system, cast(SensorV3, sensor))
             for sensor in system.sensors.values()
-            if sensor.type == DeviceTypes.TEMPERATURE
+            if sensor.type is DeviceTypes.TEMPERATURE
         )
 
     async_add_entities(sensors)

--- a/homeassistant/components/slack/__init__.py
+++ b/homeassistant/components/slack/__init__.py
@@ -86,7 +86,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SlackConfigEntry) -> boo
     )
 
     await hass.config_entries.async_forward_entry_setups(
-        entry, [platform for platform in PLATFORMS if platform != Platform.NOTIFY]
+        entry, [platform for platform in PLATFORMS if platform is not Platform.NOTIFY]
     )
 
     return True

--- a/homeassistant/components/sleepiq/number.py
+++ b/homeassistant/components/sleepiq/number.py
@@ -86,7 +86,7 @@ async def _async_set_foot_warmer_time(
     foot_warmer: SleepIQFootWarmer, time: int
 ) -> None:
     temperature = FootWarmingTemps(foot_warmer.temperature)
-    if temperature != FootWarmingTemps.OFF:
+    if temperature is not FootWarmingTemps.OFF:
         await foot_warmer.turn_on(temperature, time)
 
     foot_warmer.timer = time
@@ -105,7 +105,7 @@ async def _async_set_core_climate_time(
     core_climate: SleepIQCoreClimate, time: int
 ) -> None:
     temperature = CoreTemps(core_climate.temperature)
-    if temperature != CoreTemps.OFF:
+    if temperature is not CoreTemps.OFF:
         await core_climate.turn_on(temperature, time)
 
     core_climate.timer = time

--- a/homeassistant/components/sleepiq/select.py
+++ b/homeassistant/components/sleepiq/select.py
@@ -57,7 +57,7 @@ class SleepIQSelectEntity(SleepIQBedEntity[SleepIQDataUpdateCoordinator], Select
 
         self._attr_name = f"SleepNumber {bed.name} Foundation Preset"
         self._attr_unique_id = f"{bed.id}_preset"
-        if preset.side != Side.NONE:
+        if preset.side is not Side.NONE:
             self._attr_name += f" {preset.side_full}"
             self._attr_unique_id += f"_{preset.side.value}"
         self._attr_options = preset.options
@@ -164,7 +164,7 @@ class SleepIQCoreTempSelectEntity(
         temperature = self.HA_TO_SLEEPIQ_CORE_TEMP_MAP[option]
         timer = self.core_climate.timer or 240
 
-        if temperature == CoreTemps.OFF:
+        if temperature is CoreTemps.OFF:
             await self.core_climate.turn_off()
         else:
             await self.core_climate.turn_on(temperature, timer)

--- a/homeassistant/components/smartthings/__init__.py
+++ b/homeassistant/components/smartthings/__init__.py
@@ -229,7 +229,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SmartThingsConfigEntry) 
             status = process_status(await client.get_device_status(device.device_id))
             online = await client.get_device_health(device.device_id)
             device_status[device.device_id] = FullDevice(
-                device=device, status=status, online=online.state == HealthStatus.ONLINE
+                device=device, status=status, online=online.state is HealthStatus.ONLINE
             )
     except SmartThingsAuthenticationFailedError as err:
         raise ConfigEntryAuthFailed from err

--- a/homeassistant/components/smartthings/button.py
+++ b/homeassistant/components/smartthings/button.py
@@ -138,7 +138,7 @@ async def async_setup_entry(
         )
         for device in entry_data.devices.values()
         if (
-            device.device.components[MAIN].manufacturer_category == Category.DISHWASHER
+            device.device.components[MAIN].manufacturer_category is Category.DISHWASHER
             and Capability.CUSTOM_SUPPORTED_OPTIONS in device.status[MAIN]
         )
     )

--- a/homeassistant/components/smartthings/climate.py
+++ b/homeassistant/components/smartthings/climate.py
@@ -237,7 +237,7 @@ class SmartThingsThermostat(SmartThingsEntity, ClimateEntity):
         # Heat/cool setpoint
         heating_setpoint = None
         cooling_setpoint = None
-        if hvac_mode == HVACMode.HEAT:
+        if hvac_mode is HVACMode.HEAT:
             heating_setpoint = kwargs.get(ATTR_TEMPERATURE)
         elif hvac_mode == HVACMode.COOL:
             cooling_setpoint = kwargs.get(ATTR_TEMPERATURE)
@@ -332,7 +332,7 @@ class SmartThingsThermostat(SmartThingsEntity, ClimateEntity):
     @property
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
-        if self.hvac_mode == HVACMode.COOL:
+        if self.hvac_mode is HVACMode.COOL:
             return self.get_attribute_value(
                 Capability.THERMOSTAT_COOLING_SETPOINT, Attribute.COOLING_SETPOINT
             )
@@ -345,7 +345,7 @@ class SmartThingsThermostat(SmartThingsEntity, ClimateEntity):
     @property
     def target_temperature_high(self) -> float | None:
         """Return the highbound target temperature we try to reach."""
-        if self.hvac_mode == HVACMode.HEAT_COOL:
+        if self.hvac_mode is HVACMode.HEAT_COOL:
             return self.get_attribute_value(
                 Capability.THERMOSTAT_COOLING_SETPOINT, Attribute.COOLING_SETPOINT
             )
@@ -354,7 +354,7 @@ class SmartThingsThermostat(SmartThingsEntity, ClimateEntity):
     @property
     def target_temperature_low(self) -> float | None:
         """Return the lowbound target temperature we try to reach."""
-        if self.hvac_mode == HVACMode.HEAT_COOL:
+        if self.hvac_mode is HVACMode.HEAT_COOL:
             return self.get_attribute_value(
                 Capability.THERMOSTAT_HEATING_SETPOINT, Attribute.HEATING_SETPOINT
             )
@@ -425,7 +425,7 @@ class SmartThingsAirConditioner(SmartThingsEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target operation mode."""
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             await self.async_turn_off()
             return
         tasks = []
@@ -708,7 +708,7 @@ class SmartThingsHeatPumpZone(SmartThingsEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target operation mode."""
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             await self.async_turn_off()
             return
         if self.get_attribute_value(Capability.SWITCH, Attribute.SWITCH) == "off":

--- a/homeassistant/components/smartthings/cover.py
+++ b/homeassistant/components/smartthings/cover.py
@@ -134,16 +134,16 @@ class SmartThingsCover(SmartThingsEntity, CoverEntity):
     @property
     def is_opening(self) -> bool:
         """Return if the cover is opening or not."""
-        return self._state == CoverState.OPENING
+        return self._state is CoverState.OPENING
 
     @property
     def is_closing(self) -> bool:
         """Return if the cover is closing or not."""
-        return self._state == CoverState.CLOSING
+        return self._state is CoverState.CLOSING
 
     @property
     def is_closed(self) -> bool | None:
         """Return if the cover is closed or not."""
-        if self._state == CoverState.CLOSED:
+        if self._state is CoverState.CLOSED:
             return True
         return None if self._state is None else False

--- a/homeassistant/components/smartthings/entity.py
+++ b/homeassistant/components/smartthings/entity.py
@@ -70,7 +70,7 @@ class SmartThingsEntity(Entity):
         self._update_attr()
 
     def _availability_handler(self, event: DeviceHealthEvent) -> None:
-        self._attr_available = event.status != HealthStatus.OFFLINE
+        self._attr_available = event.status is not HealthStatus.OFFLINE
         self.async_write_ha_state()
 
     def _update_handler(self, event: DeviceEvent) -> None:

--- a/homeassistant/components/smarttub/climate.py
+++ b/homeassistant/components/smarttub/climate.py
@@ -90,7 +90,7 @@ class SmartTubThermostat(SmartTubEntity, ClimateEntity):
 
         As with hvac_mode, we don't really have an option here.
         """
-        if hvac_mode == HVACMode.HEAT:
+        if hvac_mode is HVACMode.HEAT:
             return
         raise NotImplementedError(hvac_mode)
 

--- a/homeassistant/components/snooz/fan.py
+++ b/homeassistant/components/snooz/fan.py
@@ -162,7 +162,7 @@ class SnoozFan(FanEntity, RestoreEntity):
     async def _async_execute_command(self, command: SnoozCommandData) -> None:
         result = await self._device.async_execute_command(command)
 
-        if result.status == SnoozCommandResultStatus.SUCCESSFUL:
+        if result.status is SnoozCommandResultStatus.SUCCESSFUL:
             self._async_write_state_changed()
         elif result.status != SnoozCommandResultStatus.CANCELLED:
             raise HomeAssistantError(

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -556,7 +556,7 @@ class SonosDiscoveryManager:
             return
         uid = uid[5:]
 
-        if change == ssdp.SsdpChange.BYEBYE:
+        if change is ssdp.SsdpChange.BYEBYE:
             _LOGGER.debug(
                 "ssdp:byebye received from %s", info.upnp.get("friendlyName", uid)
             )

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -573,7 +573,7 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
                     soco.play_from_queue(new_pos - 1)
             elif enqueue == MediaPlayerEnqueue.REPLACE:
                 soco.play_uri(media_id, force_radio=is_radio)
-        elif media_type == MediaType.PLAYLIST:
+        elif media_type is MediaType.PLAYLIST:
             if media_id.startswith("S:"):
                 playlist = media_browser.get_media(
                     self.media.library, media_id, media_type
@@ -622,7 +622,7 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
             item.title,
             enqueue,
         )
-        if enqueue == MediaPlayerEnqueue.REPLACE:
+        if enqueue is MediaPlayerEnqueue.REPLACE:
             soco.clear_queue()
 
         if enqueue in (MediaPlayerEnqueue.ADD, MediaPlayerEnqueue.REPLACE):
@@ -634,7 +634,7 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
             new_pos = soco.add_to_queue(
                 item, position=pos, timeout=LONG_SERVICE_TIMEOUT
             )
-            if enqueue == MediaPlayerEnqueue.PLAY:
+            if enqueue is MediaPlayerEnqueue.PLAY:
                 soco.play_from_queue(new_pos - 1)
 
     def _play_media_directory(
@@ -669,7 +669,7 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
         kwargs = {}
         if title:
             kwargs["dc_title"] = title
-        if enqueue == MediaPlayerEnqueue.ADD:
+        if enqueue is MediaPlayerEnqueue.ADD:
             share_link.add_share_link_to_queue(
                 media_id, timeout=LONG_SERVICE_TIMEOUT, **kwargs
             )

--- a/homeassistant/components/spotify/coordinator.py
+++ b/homeassistant/components/spotify/coordinator.py
@@ -139,7 +139,7 @@ class SpotifyCoordinator(DataUpdateCoordinator[SpotifyCoordinatorData]):
             ):
                 self._checked_playlist_id = context.uri
                 self._playlist = None
-                if context.context_type == ContextType.PLAYLIST:
+                if context.context_type is ContextType.PLAYLIST:
                     # Make sure any playlist lookups don't break the current
                     # playback state update
                     try:

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -137,7 +137,7 @@ class SpotifyMediaPlayer(SpotifyEntity, MediaPlayerEntity):
     @property
     def supported_features(self) -> MediaPlayerEntityFeature:
         """Return the supported features."""
-        if self.coordinator.current_user.product != ProductType.PREMIUM:
+        if self.coordinator.current_user.product is not ProductType.PREMIUM:
             return MediaPlayerEntityFeature(0)
         if not self.currently_playing or self.currently_playing.device.is_restricted:
             return MediaPlayerEntityFeature.SELECT_SOURCE
@@ -169,7 +169,7 @@ class SpotifyMediaPlayer(SpotifyEntity, MediaPlayerEntity):
     @ensure_item
     def media_content_type(self, item: Item) -> str:  # noqa: PLR0206
         """Return the media type."""
-        return MediaType.PODCAST if item.type == ItemType.EPISODE else MediaType.MUSIC
+        return MediaType.PODCAST if item.type is ItemType.EPISODE else MediaType.MUSIC
 
     @property
     @ensure_item
@@ -195,7 +195,7 @@ class SpotifyMediaPlayer(SpotifyEntity, MediaPlayerEntity):
     @ensure_item
     def media_image_url(self, item: Item) -> str | None:  # noqa: PLR0206
         """Return the media image URL."""
-        if item.type == ItemType.EPISODE:
+        if item.type is ItemType.EPISODE:
             if TYPE_CHECKING:
                 assert isinstance(item, Episode)
             if item.images:
@@ -219,7 +219,7 @@ class SpotifyMediaPlayer(SpotifyEntity, MediaPlayerEntity):
     @ensure_item
     def media_artist(self, item: Item) -> str:  # noqa: PLR0206
         """Return the media artist."""
-        if item.type == ItemType.EPISODE:
+        if item.type is ItemType.EPISODE:
             if TYPE_CHECKING:
                 assert isinstance(item, Episode)
             return item.show.name
@@ -232,7 +232,7 @@ class SpotifyMediaPlayer(SpotifyEntity, MediaPlayerEntity):
     @ensure_item
     def media_album_name(self, item: Item) -> str | None:  # noqa: PLR0206
         """Return the media album."""
-        if item.type == ItemType.EPISODE:
+        if item.type is ItemType.EPISODE:
             return None
 
         if TYPE_CHECKING:
@@ -243,7 +243,7 @@ class SpotifyMediaPlayer(SpotifyEntity, MediaPlayerEntity):
     @ensure_item
     def media_track(self, item: Item) -> int | None:  # noqa: PLR0206
         """Track number of current playing media, music track only."""
-        if item.type == ItemType.EPISODE:
+        if item.type is ItemType.EPISODE:
             return None
         if TYPE_CHECKING:
             assert isinstance(item, Track)
@@ -348,7 +348,7 @@ class SpotifyMediaPlayer(SpotifyEntity, MediaPlayerEntity):
         if not self.currently_playing and self.devices.data:
             kwargs["device_id"] = self.devices.data[0].device_id
 
-        if enqueue == MediaPlayerEnqueue.ADD:
+        if enqueue is MediaPlayerEnqueue.ADD:
             if media_type not in {
                 MediaType.TRACK,
                 MediaType.EPISODE,

--- a/homeassistant/components/sql/config_flow.py
+++ b/homeassistant/components/sql/config_flow.py
@@ -60,7 +60,7 @@ OPTIONS_SCHEMA: vol.Schema = vol.Schema(
                             options=[
                                 cls.value
                                 for cls in SensorDeviceClass
-                                if cls != SensorDeviceClass.ENUM
+                                if cls is not SensorDeviceClass.ENUM
                             ],
                             mode=selector.SelectSelectorMode.DROPDOWN,
                             translation_key="device_class",

--- a/homeassistant/components/sql/util.py
+++ b/homeassistant/components/sql/util.py
@@ -88,7 +88,7 @@ async def async_create_sessionmaker(
     sessmaker: scoped_session | None
     sql_data = _async_get_or_init_domain_data(hass)
     use_database_executor = False
-    if uses_recorder_db and instance.dialect_name == SupportedDialect.SQLITE:
+    if uses_recorder_db and instance.dialect_name is SupportedDialect.SQLITE:
         use_database_executor = True
         assert instance.engine is not None
         sessmaker = scoped_session(sessionmaker(bind=instance.engine, future=True))

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -519,7 +519,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
 
         enqueue: MediaPlayerEnqueue | None = kwargs.get(ATTR_MEDIA_ENQUEUE)
 
-        if enqueue == MediaPlayerEnqueue.ADD:
+        if enqueue is MediaPlayerEnqueue.ADD:
             cmd = "add"
         elif enqueue == MediaPlayerEnqueue.NEXT:
             cmd = "insert"
@@ -688,7 +688,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
 
     async def async_set_repeat(self, repeat: RepeatMode) -> None:
         """Set the repeat mode."""
-        if repeat == RepeatMode.ALL:
+        if repeat is RepeatMode.ALL:
             repeat_mode = "playlist"
         elif repeat == RepeatMode.ONE:
             repeat_mode = "song"

--- a/homeassistant/components/ssdp/scanner.py
+++ b/homeassistant/components/ssdp/scanner.py
@@ -367,7 +367,7 @@ class Scanner:
         callbacks = self._async_get_matching_callbacks(combined_headers)
 
         # If there are no changes from a search, do not trigger a config flow
-        if source != SsdpSource.SEARCH_ALIVE:
+        if source is not SsdpSource.SEARCH_ALIVE:
             matching_domains = self.integration_matchers.async_matching_domains(
                 CaseInsensitiveDict(combined_headers.as_dict(), **info_desc)
             )
@@ -375,7 +375,7 @@ class Scanner:
         if (
             not callbacks
             and not matching_domains
-            and source != SsdpSource.ADVERTISEMENT_BYEBYE
+            and source is not SsdpSource.ADVERTISEMENT_BYEBYE
         ):
             return
 
@@ -390,7 +390,7 @@ class Scanner:
 
         # Config flows should only be created for alive/update
         # messages from alive devices
-        if source == SsdpSource.ADVERTISEMENT_BYEBYE:
+        if source is SsdpSource.ADVERTISEMENT_BYEBYE:
             self._async_dismiss_discoveries(discovery_info)
             return
 

--- a/homeassistant/components/stream/fmp4utils.py
+++ b/homeassistant/components/stream/fmp4utils.py
@@ -198,7 +198,7 @@ TRANSFORM_MATRIX_TOP = (
 
 def transform_init(init: bytes, orientation: Orientation) -> bytes:
     """Change the transformation matrix in the header."""
-    if orientation == Orientation.NO_TRANSFORM:
+    if orientation is Orientation.NO_TRANSFORM:
         return init
     # Find moov
     moov_location = next(find_box(init, b"moov"))

--- a/homeassistant/components/sunricher_dali/binary_sensor.py
+++ b/homeassistant/components/sunricher_dali/binary_sensor.py
@@ -79,7 +79,7 @@ class SunricherDaliMotionSensor(DaliDeviceEntity, BinarySensorEntity):
     def _handle_motion_status(self, status: MotionStatus) -> None:
         """Handle motion status updates."""
         motion_state = status["motion_state"]
-        if motion_state == MotionState.MOTION:
+        if motion_state is MotionState.MOTION:
             self._attr_is_on = True
             self.schedule_update_ha_state()
         elif motion_state == MotionState.NO_MOTION:
@@ -124,6 +124,6 @@ class SunricherDaliOccupancySensor(DaliDeviceEntity, BinarySensorEntity):
         if motion_state in _OCCUPANCY_ON_STATES:
             self._attr_is_on = True
             self.schedule_update_ha_state()
-        elif motion_state == MotionState.VACANT:
+        elif motion_state is MotionState.VACANT:
             self._attr_is_on = False
             self.schedule_update_ha_state()

--- a/homeassistant/components/surepetcare/binary_sensor.py
+++ b/homeassistant/components/surepetcare/binary_sensor.py
@@ -38,7 +38,7 @@ async def async_setup_entry(
             EntityType.FELAQUA,
         ]:
             entities.append(DeviceConnectivity(surepy_entity.id, coordinator))
-        elif surepy_entity.type == EntityType.PET:
+        elif surepy_entity.type is EntityType.PET:
             entities.append(Pet(surepy_entity.id, coordinator))
         elif surepy_entity.type == EntityType.HUB:
             entities.append(Hub(surepy_entity.id, coordinator))
@@ -99,7 +99,7 @@ class Pet(SurePetcareBinarySensor):
         surepy_entity = cast(SurepyPet, surepy_entity)
         state = surepy_entity.location
         try:
-            self._attr_is_on = bool(Location(state.where) == Location.INSIDE)
+            self._attr_is_on = bool(Location(state.where) is Location.INSIDE)
         except KeyError, TypeError:
             self._attr_is_on = False
         if state:

--- a/homeassistant/components/surepetcare/coordinator.py
+++ b/homeassistant/components/surepetcare/coordinator.py
@@ -78,7 +78,7 @@ class SurePetcareDataCoordinator(DataUpdateCoordinator[dict[int, SurepyEntity]])
         """Get pets."""
         pets = {}
         for surepy_entity in self.data.values():
-            if surepy_entity.type == EntityType.PET and surepy_entity.name:
+            if surepy_entity.type is EntityType.PET and surepy_entity.name:
                 pets[surepy_entity.name] = surepy_entity.id
         return pets
 

--- a/homeassistant/components/surepetcare/sensor.py
+++ b/homeassistant/components/surepetcare/sensor.py
@@ -37,9 +37,9 @@ async def async_setup_entry(
         ]:
             entities.append(SureBattery(surepy_entity.id, coordinator))
 
-        if surepy_entity.type == EntityType.FELAQUA:
+        if surepy_entity.type is EntityType.FELAQUA:
             entities.append(Felaqua(surepy_entity.id, coordinator))
-        if surepy_entity.type == EntityType.PET:
+        if surepy_entity.type is EntityType.PET:
             entities.append(PetLastSeenFlapDevice(surepy_entity.id, coordinator))
             entities.append(PetLastSeenUser(surepy_entity.id, coordinator))
 

--- a/homeassistant/components/switch_as_x/__init__.py
+++ b/homeassistant/components/switch_as_x/__init__.py
@@ -136,7 +136,7 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
         return
 
     # Unhide the wrapped entity
-    if switch_entity_entry.hidden_by == er.RegistryEntryHider.INTEGRATION:
+    if switch_entity_entry.hidden_by is er.RegistryEntryHider.INTEGRATION:
         registry.async_update_entity(switch_entity_id, hidden_by=None)
 
     switch_as_x_entries = er.async_entries_for_config_entry(registry, entry.entry_id)

--- a/homeassistant/components/switchbee/button.py
+++ b/homeassistant/components/switchbee/button.py
@@ -22,7 +22,7 @@ async def async_setup_entry(
     async_add_entities(
         SwitchBeeButton(switchbee_device, coordinator)
         for switchbee_device in coordinator.data.values()
-        if switchbee_device.type == DeviceType.Scenario
+        if switchbee_device.type is DeviceType.Scenario
     )
 
 

--- a/homeassistant/components/switchbee/climate.py
+++ b/homeassistant/components/switchbee/climate.py
@@ -132,7 +132,7 @@ class SwitchBeeClimateEntity(SwitchBeeDeviceEntity[SwitchBeeThermostat], Climate
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set hvac mode."""
 
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             await self._operate(power=ApiStateCommand.OFF)
         else:
             await self._operate(
@@ -158,7 +158,7 @@ class SwitchBeeClimateEntity(SwitchBeeDeviceEntity[SwitchBeeThermostat], Climate
 
         if power is None:
             power = ApiStateCommand.ON
-            if self.hvac_mode == HVACMode.OFF:
+            if self.hvac_mode is HVACMode.OFF:
                 power = ApiStateCommand.OFF
         if mode is None:
             mode = HVAC_MODE_HASS_TO_SB[self.hvac_mode]

--- a/homeassistant/components/switchbee/entity.py
+++ b/homeassistant/components/switchbee/entity.py
@@ -48,7 +48,7 @@ class SwitchBeeDeviceEntity[_DeviceTypeT: SwitchBeeBaseDevice](
         super().__init__(device, coordinator)
         self._is_online: bool = True
         identifier = (
-            device.id if device.type == DeviceType.Thermostat else device.unit_id
+            device.id if device.type is DeviceType.Thermostat else device.unit_id
         )
         self._attr_device_info = DeviceInfo(
             name=device.zone,

--- a/homeassistant/components/switchbee/light.py
+++ b/homeassistant/components/switchbee/light.py
@@ -40,7 +40,7 @@ async def async_setup_entry(
     async_add_entities(
         SwitchBeeLightEntity(cast(SwitchBeeDimmer, switchbee_device), coordinator)
         for switchbee_device in coordinator.data.values()
-        if switchbee_device.type == DeviceType.Dimmer
+        if switchbee_device.type is DeviceType.Dimmer
     )
 
 

--- a/homeassistant/components/switchbot/config_flow.py
+++ b/homeassistant/components/switchbot/config_flow.py
@@ -139,7 +139,7 @@ class SwitchbotConfigFlow(ConfigFlow, domain=DOMAIN):
         sensor_type = SUPPORTED_MODEL_TYPES[model_name]
 
         options: dict[str, Any] = {CONF_RETRY_COUNT: DEFAULT_RETRY_COUNT}
-        if sensor_type == SupportedModels.CURTAIN:
+        if sensor_type is SupportedModels.CURTAIN:
             options[CONF_CURTAIN_SPEED] = DEFAULT_CURTAIN_SPEED
 
         return self.async_create_entry(

--- a/homeassistant/components/switchbot_cloud/climate.py
+++ b/homeassistant/components/switchbot_cloud/climate.py
@@ -140,7 +140,7 @@ class SwitchBotCloudAirConditioner(SwitchBotCloudEntity, ClimateEntity, RestoreE
             hvac_mode,
             self._attr_hvac_mode,
         )
-        if new_hvac_mode == HVACMode.OFF:
+        if new_hvac_mode is HVACMode.OFF:
             return _SWITCHBOT_HVAC_MODES.get(
                 self._attr_hvac_mode, _DEFAULT_SWITCHBOT_HVAC_MODE
             )
@@ -157,7 +157,7 @@ class SwitchBotCloudAirConditioner(SwitchBotCloudEntity, ClimateEntity, RestoreE
         new_fan_speed = _SWITCHBOT_FAN_MODES.get(
             fan_mode or self._attr_fan_mode, _DEFAULT_SWITCHBOT_FAN_MODE
         )
-        new_power_state = "on" if hvac_mode != HVACMode.OFF else "off"
+        new_power_state = "on" if hvac_mode is not HVACMode.OFF else "off"
         command = f"{int(new_temperature)},{new_mode},{new_fan_speed},{new_power_state}"
         _LOGGER.debug("Sending command to %s: %s", self._attr_unique_id, command)
         await self.send_api_command(
@@ -195,7 +195,7 @@ class SwitchBotCloudAirConditioner(SwitchBotCloudEntity, ClimateEntity, RestoreE
         Uses the last known hvac_mode (if not OFF), otherwise defaults to FAN_ONLY.
         """
         hvac_mode = self._attr_hvac_mode
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             hvac_mode = HVACMode.FAN_ONLY
         await self.async_set_hvac_mode(hvac_mode)
 

--- a/homeassistant/components/switcher_kis/button.py
+++ b/homeassistant/components/switcher_kis/button.py
@@ -70,7 +70,7 @@ async def async_setup_entry(
     async def async_add_buttons(coordinator: SwitcherDataUpdateCoordinator) -> None:
         """Get remote and add button from Switcher device."""
         data = cast(SwitcherBreezeRemote, coordinator.data)
-        if coordinator.data.device_type.category == DeviceCategory.THERMOSTAT:
+        if coordinator.data.device_type.category is DeviceCategory.THERMOSTAT:
             remote: SwitcherBreezeRemote = await hass.async_add_executor_job(
                 get_breeze_remote_manager(hass).get_remote, data.remote_id
             )

--- a/homeassistant/components/switcher_kis/climate.py
+++ b/homeassistant/components/switcher_kis/climate.py
@@ -67,7 +67,7 @@ async def async_setup_entry(
     async def async_add_climate(coordinator: SwitcherDataUpdateCoordinator) -> None:
         """Get remote and add climate from Switcher device."""
         data = cast(SwitcherThermostat, coordinator.data)
-        if coordinator.data.device_type.category == DeviceCategory.THERMOSTAT:
+        if coordinator.data.device_type.category is DeviceCategory.THERMOSTAT:
             remote: SwitcherBreezeRemote = await hass.async_add_executor_job(
                 get_breeze_remote_manager(hass).get_remote, data.remote_id
             )
@@ -130,7 +130,7 @@ class SwitcherClimateEntity(SwitcherEntity, ClimateEntity):
         self._attr_target_temperature = float(data.target_temperature)
 
         self._attr_hvac_mode = HVACMode.OFF
-        if data.device_state == DeviceState.ON:
+        if data.device_state is DeviceState.ON:
             self._attr_hvac_mode = DEVICE_MODE_TO_HA[data.mode]
 
         self._attr_fan_mode = None
@@ -144,7 +144,7 @@ class SwitcherClimateEntity(SwitcherEntity, ClimateEntity):
         if features["swing"]:
             self._attr_swing_mode = SWING_OFF
             self._attr_swing_modes = [SWING_VERTICAL, SWING_OFF]
-            if data.swing == ThermostatSwing.ON:
+            if data.swing is ThermostatSwing.ON:
                 self._attr_swing_mode = SWING_VERTICAL
 
     async def _async_control_breeze_device(self, **kwargs: Any) -> None:
@@ -169,7 +169,7 @@ class SwitcherClimateEntity(SwitcherEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target operation mode."""
-        if hvac_mode == hvac_mode.OFF:
+        if hvac_mode is hvac_mode.OFF:
             await self._async_control_breeze_device(state=DeviceState.OFF)
         else:
             await self._async_control_breeze_device(

--- a/homeassistant/components/switcher_kis/cover.py
+++ b/homeassistant/components/switcher_kis/cover.py
@@ -75,10 +75,10 @@ class SwitcherBaseCoverEntity(SwitcherEntity, CoverEntity):
         self._attr_current_cover_position = data.position[self._cover_id]
         self._attr_is_closed = data.position[self._cover_id] == 0
         self._attr_is_closing = (
-            data.direction[self._cover_id] == ShutterDirection.SHUTTER_DOWN
+            data.direction[self._cover_id] is ShutterDirection.SHUTTER_DOWN
         )
         self._attr_is_opening = (
-            data.direction[self._cover_id] == ShutterDirection.SHUTTER_UP
+            data.direction[self._cover_id] is ShutterDirection.SHUTTER_UP
         )
 
     async def async_close_cover(self, **kwargs: Any) -> None:

--- a/homeassistant/components/switcher_kis/light.py
+++ b/homeassistant/components/switcher_kis/light.py
@@ -78,7 +78,7 @@ class SwitcherBaseLightEntity(SwitcherEntity, LightEntity):
             return
 
         data = cast(SwitcherLight, self.coordinator.data)
-        self._attr_is_on = bool(data.light[self._light_id] == DeviceState.ON)
+        self._attr_is_on = bool(data.light[self._light_id] is DeviceState.ON)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""

--- a/homeassistant/components/switcher_kis/sensor.py
+++ b/homeassistant/components/switcher_kis/sensor.py
@@ -93,7 +93,7 @@ async def async_setup_entry(
     @callback
     def async_add_sensors(coordinator: SwitcherDataUpdateCoordinator) -> None:
         """Add sensors from Switcher device."""
-        if coordinator.data.device_type.category == DeviceCategory.POWER_PLUG:
+        if coordinator.data.device_type.category is DeviceCategory.POWER_PLUG:
             async_add_entities(
                 SwitcherSensorEntity(coordinator, description)
                 for description in POWER_PLUG_SENSORS

--- a/homeassistant/components/switcher_kis/switch.py
+++ b/homeassistant/components/switcher_kis/switch.py
@@ -75,7 +75,7 @@ async def async_setup_entry(
         """Add switch from Switcher device."""
         entities: list[SwitchEntity] = []
 
-        if coordinator.data.device_type.category == DeviceCategory.POWER_PLUG:
+        if coordinator.data.device_type.category is DeviceCategory.POWER_PLUG:
             entities.append(SwitcherPowerPlugSwitchEntity(coordinator))
         elif coordinator.data.device_type.category in [
             DeviceCategory.WATER_HEATER,
@@ -123,7 +123,7 @@ class SwitcherBaseSwitchEntity(SwitcherEntity, SwitchEntity):
             self.control_result = None
             return
 
-        self._attr_is_on = bool(self.coordinator.data.device_state == DeviceState.ON)
+        self._attr_is_on = bool(self.coordinator.data.device_state is DeviceState.ON)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
@@ -188,7 +188,7 @@ class SwitcherShutterChildLockBaseSwitchEntity(SwitcherEntity, SwitchEntity):
             return
 
         data = cast(SwitcherShutter, self.coordinator.data)
-        self._attr_is_on = bool(data.child_lock[self._cover_id] == ShutterChildLock.ON)
+        self._attr_is_on = bool(data.child_lock[self._cover_id] is ShutterChildLock.ON)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""

--- a/homeassistant/components/system_bridge/__init__.py
+++ b/homeassistant/components/system_bridge/__init__.py
@@ -217,7 +217,7 @@ async def async_setup_entry(
 
     # Set up all platforms except notify
     await hass.config_entries.async_forward_entry_setups(
-        entry, [platform for platform in PLATFORMS if platform != Platform.NOTIFY]
+        entry, [platform for platform in PLATFORMS if platform is not Platform.NOTIFY]
     )
 
     # Set up notify platform
@@ -458,7 +458,7 @@ async def async_unload_entry(
 ) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(
-        entry, [platform for platform in PLATFORMS if platform != Platform.NOTIFY]
+        entry, [platform for platform in PLATFORMS if platform is not Platform.NOTIFY]
     )
     if unload_ok:
         coordinator = entry.runtime_data

--- a/homeassistant/components/system_bridge/sensor.py
+++ b/homeassistant/components/system_bridge/sensor.py
@@ -653,7 +653,7 @@ class SystemBridgeSensor(SystemBridgeEntity, SensorEntity):
             description.key,
         )
         self.entity_description = description
-        if description.name != UNDEFINED:
+        if description.name is not UNDEFINED:
             self._attr_has_entity_name = False
 
     @property

--- a/homeassistant/components/systemmonitor/sensor.py
+++ b/homeassistant/components/systemmonitor/sensor.py
@@ -134,7 +134,7 @@ def get_ip_address(
     addresses = entity.coordinator.data.addresses
     if entity.argument in addresses:
         for addr in addresses[entity.argument]:
-            if addr.family == IF_ADDRS_FAMILY[entity.entity_description.key]:
+            if addr.family is IF_ADDRS_FAMILY[entity.entity_description.key]:
                 address = ipaddress.ip_address(addr.address)
                 if address.version == 6 and (
                     address.is_link_local or address.is_loopback

--- a/homeassistant/components/tailwind/cover.py
+++ b/homeassistant/components/tailwind/cover.py
@@ -52,7 +52,7 @@ class TailwindDoorCoverEntity(TailwindDoorEntity, CoverEntity):
     def is_closed(self) -> bool:
         """Return if the cover is closed or not."""
         return (
-            self.coordinator.data.doors[self.door_id].state == TailwindDoorState.CLOSED
+            self.coordinator.data.doors[self.door_id].state is TailwindDoorState.CLOSED
         )
 
     async def async_open_cover(self, **kwargs: Any) -> None:

--- a/homeassistant/components/tankerkoenig/binary_sensor.py
+++ b/homeassistant/components/tankerkoenig/binary_sensor.py
@@ -63,4 +63,4 @@ class StationOpenBinarySensorEntity(TankerkoenigCoordinatorEntity, BinarySensorE
     def is_on(self) -> bool | None:
         """Return true if the station is open."""
         data: PriceInfo = self.coordinator.data[self._station_id]
-        return data is not None and data.status == Status.OPEN
+        return data is not None and data.status is Status.OPEN

--- a/homeassistant/components/tasmota/sensor.py
+++ b/homeassistant/components/tasmota/sensor.py
@@ -318,7 +318,7 @@ class TasmotaSensor(TasmotaAvailability, TasmotaDiscoveryUpdate, SensorEntity):
     @callback
     def sensor_state_updated(self, state: Any, **kwargs: Any) -> None:
         """Handle state updates."""
-        if self.device_class == SensorDeviceClass.TIMESTAMP:
+        if self.device_class is SensorDeviceClass.TIMESTAMP:
             self._state_timestamp = state
         else:
             self._state = state
@@ -327,6 +327,6 @@ class TasmotaSensor(TasmotaAvailability, TasmotaDiscoveryUpdate, SensorEntity):
     @property
     def native_value(self) -> datetime | str | None:
         """Return the state of the entity."""
-        if self._state_timestamp and self.device_class == SensorDeviceClass.TIMESTAMP:
+        if self._state_timestamp and self.device_class is SensorDeviceClass.TIMESTAMP:
             return self._state_timestamp
         return self._state

--- a/homeassistant/components/tedee/lock.py
+++ b/homeassistant/components/tedee/lock.py
@@ -59,27 +59,27 @@ class TedeeLockEntity(TedeeEntity, LockEntity):
             TedeeLockState.UNKNOWN,
         ):
             return None
-        return self._lock.state == TedeeLockState.LOCKED
+        return self._lock.state is TedeeLockState.LOCKED
 
     @property
     def is_unlocking(self) -> bool:
         """Return true if lock is unlocking."""
-        return self._lock.state == TedeeLockState.UNLOCKING
+        return self._lock.state is TedeeLockState.UNLOCKING
 
     @property
     def is_open(self) -> bool:
         """Return true if lock is open."""
-        return self._lock.state == TedeeLockState.PULLED
+        return self._lock.state is TedeeLockState.PULLED
 
     @property
     def is_opening(self) -> bool:
         """Return true if lock is opening."""
-        return self._lock.state == TedeeLockState.PULLING
+        return self._lock.state is TedeeLockState.PULLING
 
     @property
     def is_locking(self) -> bool:
         """Return true if lock is locking."""
-        return self._lock.state == TedeeLockState.LOCKING
+        return self._lock.state is TedeeLockState.LOCKING
 
     @property
     def is_jammed(self) -> bool:
@@ -92,7 +92,7 @@ class TedeeLockEntity(TedeeEntity, LockEntity):
         return (
             super().available
             and self._lock.is_connected
-            and self._lock.state != TedeeLockState.UNCALIBRATED
+            and self._lock.state is not TedeeLockState.UNCALIBRATED
         )
 
     async def async_unlock(self, **kwargs: Any) -> None:

--- a/homeassistant/components/telegram_bot/config_flow.py
+++ b/homeassistant/components/telegram_bot/config_flow.py
@@ -491,7 +491,7 @@ class TelegramBotConfigFlow(ConfigFlow, domain=DOMAIN):
             CONF_API_ENDPOINT
         ]
         if (
-            self._get_reconfigure_entry().state == ConfigEntryState.LOADED
+            self._get_reconfigure_entry().state is ConfigEntryState.LOADED
             and user_input[CONF_API_ENDPOINT] != DEFAULT_API_ENDPOINT
             and existing_api_endpoint == DEFAULT_API_ENDPOINT
         ):
@@ -596,7 +596,7 @@ class AllowedChatIdsSubEntryFlowHandler(ConfigSubentryFlow):
     ) -> SubentryFlowResult:
         """Create allowed chat ID."""
 
-        if self._get_entry().state != ConfigEntryState.LOADED:
+        if self._get_entry().state is not ConfigEntryState.LOADED:
             return self.async_abort(
                 reason="entry_not_loaded",
                 description_placeholders={"telegram_bot": self._get_entry().title},

--- a/homeassistant/components/template/config_flow.py
+++ b/homeassistant/components/template/config_flow.py
@@ -340,7 +340,7 @@ def generate_schema(domain: str, flow_type: str) -> vol.Schema:
                     options=[
                         cls.value
                         for cls in SensorDeviceClass
-                        if cls != SensorDeviceClass.ENUM
+                        if cls is not SensorDeviceClass.ENUM
                     ],
                     mode=selector.SelectSelectorMode.DROPDOWN,
                     translation_key="sensor_device_class",

--- a/homeassistant/components/template/cover.py
+++ b/homeassistant/components/template/cover.py
@@ -225,13 +225,13 @@ class AbstractTemplateCover(AbstractTemplateEntity, CoverEntity):
         """Update the state of the cover."""
         if state:
             if CONF_POSITION not in self._templates:
-                if state == CoverState.OPEN:
+                if state is CoverState.OPEN:
                     self._attr_current_cover_position = 100
                 else:
                     self._attr_current_cover_position = 0
 
-            self._attr_is_opening = state == CoverState.OPENING
-            self._attr_is_closing = state == CoverState.CLOSING
+            self._attr_is_opening = state is CoverState.OPENING
+            self._attr_is_closing = state is CoverState.CLOSING
         else:
             if CONF_POSITION not in self._templates:
                 self._attr_current_cover_position = None

--- a/homeassistant/components/template/lock.py
+++ b/homeassistant/components/template/lock.py
@@ -164,18 +164,18 @@ class AbstractTemplateLock(AbstractTemplateEntity, LockEntity):
                 self._attr_supported_features |= supported_feature
 
     def _set_state(self, state: LockState | None) -> None:
-        self._attr_is_jammed = state == LockState.JAMMED
-        self._attr_is_opening = state == LockState.OPENING
-        self._attr_is_locking = state == LockState.LOCKING
-        self._attr_is_open = state == LockState.OPEN
-        self._attr_is_unlocking = state == LockState.UNLOCKING
+        self._attr_is_jammed = state is LockState.JAMMED
+        self._attr_is_opening = state is LockState.OPENING
+        self._attr_is_locking = state is LockState.LOCKING
+        self._attr_is_open = state is LockState.OPEN
+        self._attr_is_unlocking = state is LockState.UNLOCKING
 
         # All other parameters need to be set False in order
         # for the lock to be unknown.
         if state is None:
             self._attr_is_locked = state
         else:
-            self._attr_is_locked = state == LockState.LOCKED
+            self._attr_is_locked = state is LockState.LOCKED
 
     @callback
     def _update_code_format(self, render: str | TemplateError | None):

--- a/homeassistant/components/tesla_fleet/climate.py
+++ b/homeassistant/components/tesla_fleet/climate.py
@@ -163,7 +163,7 @@ class TeslaFleetClimateEntity(TeslaFleetVehicleEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the climate mode and state."""
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             await self.async_turn_off()
         else:
             await self.async_turn_on()
@@ -307,7 +307,7 @@ class TeslaFleetCabinOverheatProtectionEntity(TeslaFleetVehicleEntity, ClimateEn
         self.async_write_ha_state()
 
     async def _async_set_cop(self, hvac_mode: HVACMode) -> None:
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             await handle_vehicle_command(
                 self.api.set_cabin_overheat_protection(on=False, fan_only=False)
             )

--- a/homeassistant/components/tesla_fleet/coordinator.py
+++ b/homeassistant/components/tesla_fleet/coordinator.py
@@ -113,7 +113,7 @@ class TeslaFleetVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.endpoints = (
             ENDPOINTS
             if location
-            else [ep for ep in ENDPOINTS if ep != VehicleDataEndpoint.LOCATION_DATA]
+            else [ep for ep in ENDPOINTS if ep is not VehicleDataEndpoint.LOCATION_DATA]
         )
 
     async def _async_update_data(self) -> dict[str, Any]:

--- a/homeassistant/components/tesla_fleet/media_player.py
+++ b/homeassistant/components/tesla_fleet/media_player.py
@@ -122,7 +122,7 @@ class TeslaFleetMediaEntity(TeslaFleetVehicleEntity, MediaPlayerEntity):
 
     async def async_media_play(self) -> None:
         """Send play command."""
-        if self.state != MediaPlayerState.PLAYING:
+        if self.state is not MediaPlayerState.PLAYING:
             await self.wake_up_if_asleep()
             await handle_vehicle_command(self.api.media_toggle_playback())
             self._attr_state = MediaPlayerState.PLAYING
@@ -130,7 +130,7 @@ class TeslaFleetMediaEntity(TeslaFleetVehicleEntity, MediaPlayerEntity):
 
     async def async_media_pause(self) -> None:
         """Send pause command."""
-        if self.state == MediaPlayerState.PLAYING:
+        if self.state is MediaPlayerState.PLAYING:
             await self.wake_up_if_asleep()
             await handle_vehicle_command(self.api.media_toggle_playback())
             self._attr_state = MediaPlayerState.PAUSED

--- a/homeassistant/components/teslemetry/climate.py
+++ b/homeassistant/components/teslemetry/climate.py
@@ -137,7 +137,7 @@ class TeslemetryClimateEntity(TeslemetryRootEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the climate mode and state."""
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             await self.async_turn_off()
         else:
             await self.async_turn_on()
@@ -299,7 +299,7 @@ class TeslemetryStreamingClimateEntity(
             self.vehicle.stream_vehicle.listen_RightHandDrive(self._async_handle_rhd)
         )
 
-        if self.side == TeslemetryClimateSide.DRIVER:
+        if self.side is TeslemetryClimateSide.DRIVER:
             if self.rhd:
                 self.async_on_remove(
                     self.vehicle.stream_vehicle.listen_HvacRightTemperatureRequest(
@@ -412,7 +412,7 @@ class TeslemetryCabinOverheatProtectionEntity(TeslemetryRootEntity, ClimateEntit
         """Set the climate mode and state."""
         self.raise_for_scope(Scope.VEHICLE_CMDS)
 
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             await handle_vehicle_command(
                 self.api.set_cabin_overheat_protection(on=False, fan_only=False)
             )

--- a/homeassistant/components/teslemetry/media_player.py
+++ b/homeassistant/components/teslemetry/media_player.py
@@ -74,7 +74,7 @@ class TeslemetryMediaEntity(TeslemetryRootEntity, MediaPlayerEntity):
 
     async def async_media_play(self) -> None:
         """Send play command."""
-        if self.state != MediaPlayerState.PLAYING:
+        if self.state is not MediaPlayerState.PLAYING:
             self.raise_for_scope(Scope.VEHICLE_CMDS)
 
             await handle_vehicle_command(self.api.media_toggle_playback())
@@ -84,7 +84,7 @@ class TeslemetryMediaEntity(TeslemetryRootEntity, MediaPlayerEntity):
     async def async_media_pause(self) -> None:
         """Send pause command."""
 
-        if self.state == MediaPlayerState.PLAYING:
+        if self.state is MediaPlayerState.PLAYING:
             self.raise_for_scope(Scope.VEHICLE_CMDS)
 
             await handle_vehicle_command(self.api.media_toggle_playback())

--- a/homeassistant/components/tessie/climate.py
+++ b/homeassistant/components/tessie/climate.py
@@ -122,7 +122,7 @@ class TessieClimateEntity(TessieEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the climate mode and state."""
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             await self.async_turn_off()
         else:
             await self.async_turn_on()

--- a/homeassistant/components/thread/dataset_store.py
+++ b/homeassistant/components/thread/dataset_store.py
@@ -286,7 +286,7 @@ class DatasetStore:
                 dataset_without_wakeup = {
                     k: v
                     for k, v in dataset.items()
-                    if k != MeshcopTLVType.WAKEUP_CHANNEL
+                    if k is not MeshcopTLVType.WAKEUP_CHANNEL
                 }
                 if old_ts > new_ts or dataset_without_wakeup != entry.dataset:
                     _LOGGER.warning(

--- a/homeassistant/components/todo/__init__.py
+++ b/homeassistant/components/todo/__init__.py
@@ -246,7 +246,7 @@ class TodoListEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         items = self.todo_items
         if items is None:
             return None
-        return sum([item.status == TodoItemStatus.NEEDS_ACTION for item in items])
+        return sum([item.status is TodoItemStatus.NEEDS_ACTION for item in items])
 
     @cached_property
     def todo_items(self) -> list[TodoItem] | None:
@@ -532,7 +532,7 @@ async def _async_remove_completed_items(entity: TodoListEntity, _: ServiceCall) 
     uids = [
         item.uid
         for item in entity.todo_items or ()
-        if item.status == TodoItemStatus.COMPLETED and item.uid
+        if item.status is TodoItemStatus.COMPLETED and item.uid
     ]
     if uids:
         await entity.async_delete_todo_items(uids=uids)

--- a/homeassistant/components/todo/intent.py
+++ b/homeassistant/components/todo/intent.py
@@ -110,7 +110,7 @@ class ListCompleteItemIntentHandler(ListBaseIntentHandler):
             if (
                 item == todo_item.uid
                 or item.casefold() == (todo_item.summary or "").casefold()
-            ) and todo_item.status == TodoItemStatus.NEEDS_ACTION:
+            ) and todo_item.status is TodoItemStatus.NEEDS_ACTION:
                 matching_item = todo_item
                 break
         if not matching_item or not matching_item.uid:

--- a/homeassistant/components/todo/trigger.py
+++ b/homeassistant/components/todo/trigger.py
@@ -286,7 +286,7 @@ class ItemCompletedTrigger(ItemChangeTriggerBase):
     @override
     def _is_matching_item(self, item: TodoItem) -> bool:
         """Return true if the item matches the trigger condition."""
-        return item.status == TodoItemStatus.COMPLETED
+        return item.status is TodoItemStatus.COMPLETED
 
     @override
     def _get_items_diff(

--- a/homeassistant/components/todoist/todo.py
+++ b/homeassistant/components/todoist/todo.py
@@ -115,7 +115,7 @@ class TodoistTodoListEntity(CoordinatorEntity[TodoistCoordinator], TodoListEntit
 
     async def async_create_todo_item(self, item: TodoItem) -> None:
         """Create a To-do item."""
-        if item.status != TodoItemStatus.NEEDS_ACTION:
+        if item.status is not TodoItemStatus.NEEDS_ACTION:
             raise ValueError("Only active tasks may be created.")
         await self.coordinator.api.add_task(
             **_task_api_data(item),
@@ -136,7 +136,7 @@ class TodoistTodoListEntity(CoordinatorEntity[TodoistCoordinator], TodoListEntit
                     continue
 
                 if item.status != existing_item.status:
-                    if item.status == TodoItemStatus.COMPLETED:
+                    if item.status is TodoItemStatus.COMPLETED:
                         await self.coordinator.api.complete_task(task_id=uid)
                     else:
                         await self.coordinator.api.uncomplete_task(task_id=uid)

--- a/homeassistant/components/tolo/button.py
+++ b/homeassistant/components/tolo/button.py
@@ -44,7 +44,7 @@ class ToloLampNextColorButton(ToloSaunaCoordinatorEntity, ButtonEntity):
         """Return if entity is available."""
         return (
             self.coordinator.data.status.lamp_on
-            and self.coordinator.data.settings.lamp_mode == LampMode.MANUAL
+            and self.coordinator.data.settings.lamp_mode is LampMode.MANUAL
         )
 
     def press(self) -> None:

--- a/homeassistant/components/tolo/climate.py
+++ b/homeassistant/components/tolo/climate.py
@@ -100,7 +100,7 @@ class SaunaClimate(ToloSaunaCoordinatorEntity, ClimateEntity):
     @property
     def hvac_action(self) -> HVACAction | None:
         """Execute HVAC action."""
-        if self.coordinator.data.status.calefaction == Calefaction.HEAT:
+        if self.coordinator.data.status.calefaction is Calefaction.HEAT:
             return HVACAction.HEATING
         if self.coordinator.data.status.calefaction == Calefaction.KEEP:
             return HVACAction.IDLE
@@ -119,11 +119,11 @@ class SaunaClimate(ToloSaunaCoordinatorEntity, ClimateEntity):
 
     def set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set HVAC mode."""
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             self._set_power_and_fan(False, False)
-        if hvac_mode == HVACMode.HEAT:
+        if hvac_mode is HVACMode.HEAT:
             self._set_power_and_fan(True, False)
-        if hvac_mode == HVACMode.DRY:
+        if hvac_mode is HVACMode.DRY:
             self._set_power_and_fan(False, True)
 
     def set_fan_mode(self, fan_mode: str) -> None:

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -433,7 +433,7 @@ class CoordinatedTPLinkFeatureEntity(CoordinatedTPLinkEntity, ABC):
                 parent=parent,
             )
             for feat in device.features.values()
-            if feat.type == feature_type
+            if feat.type is feature_type
             and feat.id not in EXCLUDED_FEATURES
             and (
                 feat.category is not Feature.Category.Primary

--- a/homeassistant/components/tplink_omada/binary_sensor.py
+++ b/homeassistant/components/tplink_omada/binary_sensor.py
@@ -62,7 +62,7 @@ async def async_setup_entry(
     await controller.async_register_device_entities(
         lambda device: (
             device.type == "gateway"
-            and device.status_category == DeviceStatusCategory.CONNECTED
+            and device.status_category is DeviceStatusCategory.CONNECTED
         ),
         _create_gateway_port_entities,
     )
@@ -81,29 +81,29 @@ GATEWAY_PORT_SENSORS: list[GatewayPortBinarySensorEntityDescription] = [
         key="wan_link",
         translation_key="wan_link",
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
-        exists_func=lambda p: p.port_status.mode == GatewayPortMode.WAN,
+        exists_func=lambda p: p.port_status.mode is GatewayPortMode.WAN,
         update_func=lambda p: p.wan_connected,
     ),
     GatewayPortBinarySensorEntityDescription(
         key="online_detection",
         translation_key="online_detection",
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
-        exists_func=lambda p: p.port_status.mode == GatewayPortMode.WAN,
+        exists_func=lambda p: p.port_status.mode is GatewayPortMode.WAN,
         update_func=lambda p: p.online_detection,
     ),
     GatewayPortBinarySensorEntityDescription(
         key="lan_status",
         translation_key="lan_status",
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
-        exists_func=lambda p: p.port_status.mode == GatewayPortMode.LAN,
-        update_func=lambda p: p.link_status == LinkStatus.LINK_UP,
+        exists_func=lambda p: p.port_status.mode is GatewayPortMode.LAN,
+        update_func=lambda p: p.link_status is LinkStatus.LINK_UP,
     ),
     GatewayPortBinarySensorEntityDescription(
         key="poe_delivery",
         translation_key="poe_delivery",
         device_class=BinarySensorDeviceClass.POWER,
         exists_func=lambda p: (
-            p.port_status.mode == GatewayPortMode.LAN and p.poe_mode == PoEMode.ENABLED
+            p.port_status.mode is GatewayPortMode.LAN and p.poe_mode is PoEMode.ENABLED
         ),
         update_func=lambda p: p.poe_active,
     ),

--- a/homeassistant/components/tplink_omada/switch.py
+++ b/homeassistant/components/tplink_omada/switch.py
@@ -80,7 +80,7 @@ async def async_setup_entry(
     # connected, so we can determine the port information
     await controller.async_register_device_entities(
         device_filter=lambda d: (
-            d.type == "switch" and d.status_category == DeviceStatusCategory.CONNECTED
+            d.type == "switch" and d.status_category is DeviceStatusCategory.CONNECTED
         ),
         entity_callback=_create_switch_port_entities,
     )
@@ -114,7 +114,7 @@ async def async_setup_entry(
 
     await controller.async_register_device_entities(
         device_filter=lambda d: (
-            d.type == "gateway" and d.status_category == DeviceStatusCategory.CONNECTED
+            d.type == "gateway" and d.status_category is DeviceStatusCategory.CONNECTED
         ),
         entity_callback=_create_gateway_port_entities,
     )
@@ -213,7 +213,7 @@ SWITCH_PORT_DETAILS_SWITCHES: list[OmadaSwitchPortSwitchEntityDescription] = [
             lambda d, p: (
                 d.device_capabilities.supports_poe
                 and p.supports_poe
-                and p.type != PortType.SFP
+                and p.type is not PortType.SFP
             )
         ),
         set_func=(
@@ -226,7 +226,7 @@ SWITCH_PORT_DETAILS_SWITCHES: list[OmadaSwitchPortSwitchEntityDescription] = [
                 ),
             )
         ),
-        update_func=lambda p: p.poe_mode != PoEMode.DISABLED,
+        update_func=lambda p: p.poe_mode is not PoEMode.DISABLED,
         entity_category=EntityCategory.CONFIG,
     )
 ]
@@ -235,14 +235,14 @@ GATEWAY_PORT_STATUS_SWITCHES: list[OmadaGatewayPortStatusSwitchEntityDescription
     OmadaGatewayPortStatusSwitchEntityDescription(
         key="wan_connect_ipv4",
         translation_key="wan_connect_ipv4",
-        exists_func=lambda _, p: p.mode == GatewayPortMode.WAN,
+        exists_func=lambda _, p: p.mode is GatewayPortMode.WAN,
         set_func=partial(_wan_connect_disconnect, ipv6=False),
         update_func=lambda p: p.wan_connected,
     ),
     OmadaGatewayPortStatusSwitchEntityDescription(
         key="wan_connect_ipv6",
         translation_key="wan_connect_ipv6",
-        exists_func=lambda _, p: p.mode == GatewayPortMode.WAN and p.wan_ipv6_enabled,
+        exists_func=lambda _, p: p.mode is GatewayPortMode.WAN and p.wan_ipv6_enabled,
         set_func=partial(_wan_connect_disconnect, ipv6=True),
         update_func=lambda p: p.ipv6_wan_connected,
     ),
@@ -252,11 +252,11 @@ GATEWAY_PORT_CONFIG_SWITCHES: list[OmadaGatewayPortConfigSwitchEntityDescription
     OmadaGatewayPortConfigSwitchEntityDescription(
         key="poe",
         translation_key="poe_control",
-        exists_func=lambda _, port: port.poe_mode != PoEMode.NONE,
+        exists_func=lambda _, port: port.poe_mode is not PoEMode.NONE,
         set_func=lambda client, device, port, enable: client.set_gateway_port_settings(
             port.port_number, GatewayPortSettings(enable_poe=enable), device
         ),
-        update_func=lambda p: p.poe_mode != PoEMode.DISABLED,
+        update_func=lambda p: p.poe_mode is not PoEMode.DISABLED,
     ),
 ]
 

--- a/homeassistant/components/trane/climate.py
+++ b/homeassistant/components/trane/climate.py
@@ -86,7 +86,7 @@ class TraneClimateEntity(TraneZoneEntity, ClimateEntity):
                 continue
             modes.append(ha_mode)
             # AUTO in steamloop maps to both AUTO (schedule) and HEAT_COOL (manual hold)
-            if zone_mode == ZoneMode.AUTO:
+            if zone_mode is ZoneMode.AUTO:
                 modes.append(HVACMode.HEAT_COOL)
         self._attr_hvac_modes = modes
 
@@ -112,7 +112,7 @@ class TraneClimateEntity(TraneZoneEntity, ClimateEntity):
     def hvac_mode(self) -> HVACMode:
         """Return the current HVAC mode."""
         zone = self._zone
-        if zone.mode == ZoneMode.AUTO and zone.hold_type == HoldType.MANUAL:
+        if zone.mode is ZoneMode.AUTO and zone.hold_type is HoldType.MANUAL:
             return HVACMode.HEAT_COOL
         return ZONE_MODE_TO_HA.get(zone.mode, HVACMode.OFF)
 
@@ -123,7 +123,7 @@ class TraneClimateEntity(TraneZoneEntity, ClimateEntity):
         # protocol ("0"=off, "1"=idle, "2"=running); filter by zone mode so
         # a zone in COOL never reports HEATING and vice versa
         zone_mode = self._zone.mode
-        if zone_mode == ZoneMode.OFF:
+        if zone_mode is ZoneMode.OFF:
             return HVACAction.OFF
         state = self._conn.state
         if zone_mode != ZoneMode.HEAT and state.cooling_active == "2":
@@ -137,7 +137,7 @@ class TraneClimateEntity(TraneZoneEntity, ClimateEntity):
         """Return target temperature for single-setpoint modes."""
         # Setpoints are strings from the protocol or empty string if not yet received
         zone = self._zone
-        if zone.mode == ZoneMode.COOL:
+        if zone.mode is ZoneMode.COOL:
             return float(zone.cool_setpoint) if zone.cool_setpoint else None
         if zone.mode == ZoneMode.HEAT:
             return float(zone.heat_setpoint) if zone.heat_setpoint else None
@@ -166,7 +166,7 @@ class TraneClimateEntity(TraneZoneEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the HVAC mode."""
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             self._conn.set_zone_mode(self._zone_id, ZoneMode.OFF)
             return
 
@@ -182,7 +182,7 @@ class TraneClimateEntity(TraneZoneEntity, ClimateEntity):
         set_temp = kwargs.get(ATTR_TEMPERATURE)
 
         if set_temp is not None:
-            if self._zone.mode == ZoneMode.COOL:
+            if self._zone.mode is ZoneMode.COOL:
                 cool_temp = set_temp
             elif self._zone.mode == ZoneMode.HEAT:
                 heat_temp = set_temp

--- a/homeassistant/components/trane/switch.py
+++ b/homeassistant/components/trane/switch.py
@@ -39,7 +39,7 @@ class TraneHoldSwitch(TraneZoneEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return true if the zone is in permanent hold."""
-        return self._zone.hold_type == HoldType.MANUAL
+        return self._zone.hold_type is HoldType.MANUAL
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Enable permanent hold."""

--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -190,7 +190,7 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
             ):
                 if (
                     ha_mode := _TUYA_TO_HA_HVACMODE_MAPPINGS.get(tuya_mode)
-                ) and ha_mode != HVACMode.OFF:
+                ) and ha_mode is not HVACMode.OFF:
                     # OFF is always added first
                     self._attr_hvac_modes.append(ha_mode)
 
@@ -243,7 +243,7 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
         if self._switch_wrapper:
             commands.extend(
                 self._switch_wrapper.get_update_commands(
-                    self.device, hvac_mode != HVACMode.OFF
+                    self.device, hvac_mode is not HVACMode.OFF
                 )
             )
         if (

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -489,7 +489,7 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
             ATTR_HS_COLOR in kwargs
             or (
                 ATTR_BRIGHTNESS in kwargs
-                and self.color_mode == ColorMode.HS
+                and self.color_mode is ColorMode.HS
                 and ATTR_WHITE not in kwargs
                 and ATTR_COLOR_TEMP_KELVIN not in kwargs
             )
@@ -536,7 +536,7 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
         """Return the brightness of this light between 0..255."""
         # If the light is currently in color mode,
         # extract the brightness from the color data
-        if self.color_mode == ColorMode.HS and self._color_data_wrapper:
+        if self.color_mode is ColorMode.HS and self._color_data_wrapper:
             hsv_data = self._read_wrapper(self._color_data_wrapper)
             return None if hsv_data is None else round(hsv_data[2])
 

--- a/homeassistant/components/unifi_access/binary_sensor.py
+++ b/homeassistant/components/unifi_access/binary_sensor.py
@@ -58,4 +58,4 @@ class UnifiAccessDoorPositionBinarySensor(UnifiAccessEntity, BinarySensorEntity)
     @property
     def is_on(self) -> bool:
         """Return whether the door is open."""
-        return self._door.door_position_status == DoorPositionStatus.OPEN
+        return self._door.door_position_status is DoorPositionStatus.OPEN

--- a/homeassistant/components/unifi_access/coordinator.py
+++ b/homeassistant/components/unifi_access/coordinator.py
@@ -152,7 +152,7 @@ class UnifiAccessCoordinator(DataUpdateCoordinator[UnifiAccessData]):
             return
         new_status = DoorLockRuleStatus(
             type=DoorLockRuleType.NONE
-            if lock_rule_type == DoorLockRuleType.RESET
+            if lock_rule_type is DoorLockRuleType.RESET
             else lock_rule_type
         )
         updated_data = replace(

--- a/homeassistant/components/unifi_access/sensor.py
+++ b/homeassistant/components/unifi_access/sensor.py
@@ -50,7 +50,9 @@ class UnifiAccessDoorLockRuleSensor(UnifiAccessEntity, SensorEntity):
 
     _attr_device_class = SensorDeviceClass.ENUM
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_options = [t.value for t in DoorLockRuleType if t != DoorLockRuleType.NONE]
+    _attr_options = [
+        t.value for t in DoorLockRuleType if t is not DoorLockRuleType.NONE
+    ]
     _attr_translation_key = "door_lock_rule"
 
     def __init__(

--- a/homeassistant/components/unifiprotect/media_player.py
+++ b/homeassistant/components/unifiprotect/media_player.py
@@ -130,7 +130,7 @@ class ProtectMediaPlayer(ProtectDeviceEntity, MediaPlayerEntity):
             )
             media_id = async_process_play_media_url(self.hass, play_item.url)
 
-        if media_type != MediaType.MUSIC:
+        if media_type is not MediaType.MUSIC:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="only_music_supported",

--- a/homeassistant/components/unifiprotect/media_source.py
+++ b/homeassistant/components/unifiprotect/media_source.py
@@ -325,7 +325,7 @@ class ProtectMediaSource(MediaSource):
             _bad_identifier(item.identifier)
 
         # {nvr_id}:browse:all|{camera_id}:all|{event_type}:recent:{day_count}
-        if time_type == IdentifierTimeType.RECENT:
+        if time_type is IdentifierTimeType.RECENT:
             try:
                 days = int(parts.pop(0))
             except (IndexError, ValueError) as err:

--- a/homeassistant/components/unifiprotect/utils.py
+++ b/homeassistant/components/unifiprotect/utils.py
@@ -65,7 +65,7 @@ async def _async_resolve(hass: HomeAssistant, host: str) -> str | None:
                 for family, _, _, _, raw in await hass.loop.getaddrinfo(
                     host, None, type=socket.SOCK_STREAM, proto=socket.IPPROTO_TCP
                 )
-                if family == socket.AF_INET
+                if family is socket.AF_INET
             ),
             None,
         )

--- a/homeassistant/components/unifiprotect/views.py
+++ b/homeassistant/components/unifiprotect/views.py
@@ -105,7 +105,7 @@ def async_generate_proxy_event_video_url(
 @callback
 def _client_error(message: Any, code: HTTPStatus) -> web.Response:
     _LOGGER.warning("Client error (%s): %s", code.value, message)
-    if code == HTTPStatus.BAD_REQUEST:
+    if code is HTTPStatus.BAD_REQUEST:
         return web.Response(body=message, status=code)
     return web.Response(status=code)
 

--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -49,7 +49,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: UpnpConfigEntry) -> bool
     async def device_discovered(
         headers: SsdpServiceInfo, change: ssdp.SsdpChange
     ) -> None:
-        if change == ssdp.SsdpChange.BYEBYE:
+        if change is ssdp.SsdpChange.BYEBYE:
             return
 
         nonlocal discovery_info

--- a/homeassistant/components/v2c/switch.py
+++ b/homeassistant/components/v2c/switch.py
@@ -44,21 +44,21 @@ TRYDAN_SWITCHES = (
     V2CSwitchEntityDescription(
         key="locked",
         translation_key="locked",
-        value_fn=lambda evse_data: evse_data.locked == LockState.ENABLED,
+        value_fn=lambda evse_data: evse_data.locked is LockState.ENABLED,
         turn_on_fn=lambda evse: evse.lock(),
         turn_off_fn=lambda evse: evse.unlock(),
     ),
     V2CSwitchEntityDescription(
         key="timer",
         translation_key="timer",
-        value_fn=lambda evse_data: evse_data.timer == ChargePointTimerState.TIMER_ON,
+        value_fn=lambda evse_data: evse_data.timer is ChargePointTimerState.TIMER_ON,
         turn_on_fn=lambda evse: evse.timer(),
         turn_off_fn=lambda evse: evse.timer_disable(),
     ),
     V2CSwitchEntityDescription(
         key="dynamic",
         translation_key="dynamic",
-        value_fn=lambda evse_data: evse_data.dynamic == DynamicState.ENABLED,
+        value_fn=lambda evse_data: evse_data.dynamic is DynamicState.ENABLED,
         turn_on_fn=lambda evse: evse.dynamic(),
         turn_off_fn=lambda evse: evse.dynamic_disable(),
     ),
@@ -67,7 +67,7 @@ TRYDAN_SWITCHES = (
         translation_key="pause_dynamic",
         icon="mdi:pause",
         value_fn=lambda evse_data: (
-            evse_data.pause_dynamic == PauseDynamicState.NOT_MODULATING
+            evse_data.pause_dynamic is PauseDynamicState.NOT_MODULATING
         ),
         turn_on_fn=lambda evse: evse.pause_dynamic(),
         turn_off_fn=lambda evse: evse.resume_dynamic(),

--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -298,7 +298,7 @@ class StateVacuumEntity(
     @property
     def battery_icon(self) -> str:
         """Return the battery icon for the vacuum cleaner."""
-        charging = bool(self.activity == VacuumActivity.DOCKED)
+        charging = bool(self.activity is VacuumActivity.DOCKED)
 
         return icon_for_battery_level(
             battery_level=self.battery_level, charging=charging

--- a/homeassistant/components/velux/cover.py
+++ b/homeassistant/components/velux/cover.py
@@ -162,7 +162,7 @@ class VeluxDualRollerShutter(VeluxCover):
     ) -> None:
         """Initialize VeluxDualRollerShutter."""
         super().__init__(node, config_entry_id)
-        if part == VeluxDualRollerPart.DUAL:
+        if part is VeluxDualRollerPart.DUAL:
             self._attr_name = None
         else:
             self._attr_unique_id = f"{self._attr_unique_id}_{part}"
@@ -172,7 +172,7 @@ class VeluxDualRollerShutter(VeluxCover):
     @property
     def _part_position(self) -> Position:
         """Return the pyvlx Position for this part of the shutter."""
-        if self.part == VeluxDualRollerPart.UPPER:
+        if self.part is VeluxDualRollerPart.UPPER:
             return self.node.position_upper_curtain
         if self.part == VeluxDualRollerPart.LOWER:
             return self.node.position_lower_curtain

--- a/homeassistant/components/venstar/climate.py
+++ b/homeassistant/components/venstar/climate.py
@@ -243,7 +243,7 @@ class VenstarThermostat(VenstarEntity, ClimateEntity):
 
     def _set_operation_mode(self, operation_mode: HVACMode):
         """Change the operation mode (internal)."""
-        if operation_mode == HVACMode.HEAT:
+        if operation_mode is HVACMode.HEAT:
             success = self._client.set_mode(self._client.MODE_HEAT)
         elif operation_mode == HVACMode.COOL:
             success = self._client.set_mode(self._client.MODE_COOL)

--- a/homeassistant/components/vera/climate.py
+++ b/homeassistant/components/vera/climate.py
@@ -124,7 +124,7 @@ class VeraThermostat(VeraEntity[veraApi.VeraThermostat], ClimateEntity):
 
     def set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             self.vera_device.turn_off()
         elif hvac_mode == HVACMode.HEAT_COOL:
             self.vera_device.turn_auto_on()

--- a/homeassistant/components/verisure/lock.py
+++ b/homeassistant/components/verisure/lock.py
@@ -120,7 +120,7 @@ class VerisureDoorlock(CoordinatorEntity[VerisureDataUpdateCoordinator], LockEnt
         """Send set lock state command."""
         command = (
             self.coordinator.verisure.door_lock(self.serial_number, code)
-            if state == LockState.LOCKED
+            if state is LockState.LOCKED
             else self.coordinator.verisure.door_unlock(self.serial_number, code)
         )
         lock_request = await self.hass.async_add_executor_job(
@@ -129,7 +129,7 @@ class VerisureDoorlock(CoordinatorEntity[VerisureDataUpdateCoordinator], LockEnt
         )
         LOGGER.debug("Verisure doorlock %s", state)
         transaction_id = lock_request.get("data", {}).get(command["operationName"])
-        target_state = "LOCKED" if state == LockState.LOCKED else "UNLOCKED"
+        target_state = "LOCKED" if state is LockState.LOCKED else "UNLOCKED"
         lock_status = None
         attempts = 0
         while lock_status is None:
@@ -152,7 +152,7 @@ class VerisureDoorlock(CoordinatorEntity[VerisureDataUpdateCoordinator], LockEnt
             )
             LOGGER.debug("Lock status is %s", lock_status)
         if lock_status == "OK":
-            self._attr_is_locked = state == LockState.LOCKED
+            self._attr_is_locked = state is LockState.LOCKED
             self.async_write_ha_state()
 
     def disable_autolock(self) -> None:

--- a/homeassistant/components/vesync/light.py
+++ b/homeassistant/components/vesync/light.py
@@ -103,7 +103,7 @@ class VeSyncBaseLightHA(VeSyncBaseEntity[VeSyncSwitch | VeSyncBulb], LightEntity
         attribute_adjustment_only = False
         # set white temperature
         if (
-            self.color_mode == ColorMode.COLOR_TEMP
+            self.color_mode is ColorMode.COLOR_TEMP
             and ATTR_COLOR_TEMP_KELVIN in kwargs
             and hasattr(self.device, "set_color_temp")
         ):

--- a/homeassistant/components/victron_gx/hub.py
+++ b/homeassistant/components/victron_gx/hub.py
@@ -170,7 +170,7 @@ class Hub:
                     metric.short_id: {
                         "name": metric.name,
                         "value": "**REDACTED**"
-                        if metric.metric_type == MetricType.LOCATION
+                        if metric.metric_type is MetricType.LOCATION
                         else metric.value
                         if not isinstance(metric.value, VictronEnum)
                         else metric.value.id,

--- a/homeassistant/components/victron_gx/sensor.py
+++ b/homeassistant/components/victron_gx/sensor.py
@@ -90,7 +90,7 @@ class VictronSensor(VictronBaseEntity, SensorEntity):
         super().__init__(device, metric, device_info, installation_id)
         self._attr_device_class = METRIC_TYPE_TO_DEVICE_CLASS.get(metric.metric_type)
         # Enum sensors must not have a state class
-        if self._attr_device_class == SensorDeviceClass.ENUM:
+        if self._attr_device_class is SensorDeviceClass.ENUM:
             self._attr_options = metric.enum_values
         else:
             self._attr_state_class = METRIC_NATURE_TO_STATE_CLASS.get(

--- a/homeassistant/components/victron_remote_monitoring/energy.py
+++ b/homeassistant/components/victron_remote_monitoring/energy.py
@@ -10,7 +10,7 @@ async def async_get_solar_forecast(
     """Get solar forecast for a config entry ID."""
     if (
         entry := hass.config_entries.async_get_entry(config_entry_id)
-    ) is None or entry.state != ConfigEntryState.LOADED:
+    ) is None or entry.state is not ConfigEntryState.LOADED:
         return None
     data = entry.runtime_data.data.solar
     if data is None:

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -207,7 +207,7 @@ class VizioDevice(CoordinatorEntity[VizioDeviceCoordinator], MediaPlayerEntity):
 
         # App state (TV only) - check if device supports apps
         if (
-            self._attr_device_class == MediaPlayerDeviceClass.TV
+            self._attr_device_class is MediaPlayerDeviceClass.TV
             and self._available_inputs
             and any(app in self._available_inputs for app in INPUT_APPS)
         ):

--- a/homeassistant/components/vlc/media_player.py
+++ b/homeassistant/components/vlc/media_player.py
@@ -127,7 +127,7 @@ class VlcDevice(MediaPlayerEntity):
             )
             media_id = sourced_media.url
 
-        elif media_type != MediaType.MUSIC:
+        elif media_type is not MediaType.MUSIC:
             _LOGGER.error(
                 "Invalid media type %s. Only %s is supported",
                 media_type,

--- a/homeassistant/components/vlc_telnet/media_player.py
+++ b/homeassistant/components/vlc_telnet/media_player.py
@@ -171,7 +171,7 @@ class VlcDevice(MediaPlayerEntity):
         else:
             self._attr_state = MediaPlayerState.IDLE
 
-        if self._attr_state != MediaPlayerState.IDLE:
+        if self._attr_state is not MediaPlayerState.IDLE:
             self._attr_media_duration = (await self._vlc.get_length()).length
             time_output = await self._vlc.get_time()
             vlc_position = time_output.time

--- a/homeassistant/components/voip/assist_satellite.py
+++ b/homeassistant/components/voip/assist_satellite.py
@@ -189,7 +189,7 @@ class VoipAssistSatellite(VoIPEntity, AssistSatelliteEntity, RtpDatagramProtocol
         timer_info: TimerInfo,
     ) -> None:
         """Handle timer event."""
-        if event_type != TimerEventType.FINISHED:
+        if event_type is not TimerEventType.FINISHED:
             return
 
         if timer_info.name:
@@ -507,7 +507,7 @@ class VoipAssistSatellite(VoIPEntity, AssistSatelliteEntity, RtpDatagramProtocol
 
     def on_pipeline_event(self, event: PipelineEvent) -> None:
         """Set state based on pipeline stage."""
-        if event.type == PipelineEventType.STT_END:
+        if event.type is PipelineEventType.STT_END:
             if (self._tones & Tones.PROCESSING) == Tones.PROCESSING:
                 self._processing_tone_done.clear()
                 self.config_entry.async_create_background_task(

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -205,7 +205,7 @@ class Volumio(MediaPlayerEntity):
 
     async def async_set_repeat(self, repeat: RepeatMode) -> None:
         """Set repeat mode."""
-        if repeat == RepeatMode.OFF:
+        if repeat is RepeatMode.OFF:
             await self._volumio.repeatAll("false")
         else:
             await self._volumio.repeatAll("true")

--- a/homeassistant/components/volvo/sensor.py
+++ b/homeassistant/components/volvo/sensor.py
@@ -426,7 +426,7 @@ class VolvoSensor(VolvoEntity, SensorEntity):
         elif isinstance(api_field, VolvoCarsValue):
             native_value = api_field.value
 
-        if self.device_class == SensorDeviceClass.ENUM and native_value:
+        if self.device_class is SensorDeviceClass.ENUM and native_value:
             # Entities having an "unknown" value should report None as the state
             native_value = str(native_value)
             native_value = (

--- a/homeassistant/components/water_heater/__init__.py
+++ b/homeassistant/components/water_heater/__init__.py
@@ -191,7 +191,7 @@ class WaterHeaterEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         """Return the precision of the system."""
         if hasattr(self, "_attr_precision"):
             return self._attr_precision
-        if self.hass.config.units.temperature_unit == UnitOfTemperature.CELSIUS:
+        if self.hass.config.units.temperature_unit is UnitOfTemperature.CELSIUS:
             return PRECISION_TENTHS
         return PRECISION_WHOLE
 

--- a/homeassistant/components/water_heater/significant_change.py
+++ b/homeassistant/components/water_heater/significant_change.py
@@ -64,7 +64,7 @@ def async_check_significant_change(
             # Old attribute value was invalid, we should report again
             return True
 
-        if ha_unit == UnitOfTemperature.FAHRENHEIT:
+        if ha_unit is UnitOfTemperature.FAHRENHEIT:
             absolute_change = 1.0
         else:
             absolute_change = 0.5

--- a/homeassistant/components/waterfurnace/climate.py
+++ b/homeassistant/components/waterfurnace/climate.py
@@ -98,14 +98,14 @@ class WaterFurnaceClimate(WaterFurnaceEntity, ClimateEntity):
     @property
     def min_temp(self) -> float:
         """Return the minimum temperature based on current mode."""
-        if self.hvac_mode == HVACMode.COOL:
+        if self.hvac_mode is HVACMode.COOL:
             return COOLING_MIN
         return HEATING_MIN
 
     @property
     def max_temp(self) -> float:
         """Return the maximum temperature based on current mode."""
-        if self.hvac_mode == HVACMode.HEAT:
+        if self.hvac_mode is HVACMode.HEAT:
             return HEATING_MAX
         return COOLING_MAX
 
@@ -132,7 +132,7 @@ class WaterFurnaceClimate(WaterFurnaceEntity, ClimateEntity):
     @property
     def target_temperature(self) -> float | None:
         """Return the target temperature (single setpoint modes)."""
-        if self.hvac_mode == HVACMode.COOL:
+        if self.hvac_mode is HVACMode.COOL:
             return self.coordinator.data.tstatcoolingsetpoint
         if self.hvac_mode == HVACMode.HEAT:
             return self.coordinator.data.tstatheatingsetpoint
@@ -141,14 +141,14 @@ class WaterFurnaceClimate(WaterFurnaceEntity, ClimateEntity):
     @property
     def target_temperature_high(self) -> float | None:
         """Return the upper bound target temperature (Heat/Cool mode)."""
-        if self.hvac_mode == HVACMode.HEAT_COOL:
+        if self.hvac_mode is HVACMode.HEAT_COOL:
             return self.coordinator.data.tstatcoolingsetpoint
         return None
 
     @property
     def target_temperature_low(self) -> float | None:
         """Return the lower bound target temperature (Heat/Cool mode)."""
-        if self.hvac_mode == HVACMode.HEAT_COOL:
+        if self.hvac_mode is HVACMode.HEAT_COOL:
             return self.coordinator.data.tstatheatingsetpoint
         return None
 
@@ -195,7 +195,7 @@ class WaterFurnaceClimate(WaterFurnaceEntity, ClimateEntity):
             client.set_heating_setpoint(low)
             client.set_cooling_setpoint(high)
         elif temp is not None:
-            if current_mode == HVACMode.COOL:
+            if current_mode is HVACMode.COOL:
                 client.set_cooling_setpoint(temp)
             else:
                 client.set_heating_setpoint(temp)

--- a/homeassistant/components/weatherflow/sensor.py
+++ b/homeassistant/components/weatherflow/sensor.py
@@ -362,7 +362,7 @@ class WeatherFlowSensorEntity(SensorEntity):
     @property
     def last_reset(self) -> datetime | None:
         """Return the time when the sensor was last reset, if any."""
-        if self.entity_description.state_class == SensorStateClass.TOTAL:
+        if self.entity_description.state_class is SensorStateClass.TOTAL:
             return self.device.last_report
         return None
 

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -149,7 +149,7 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
         )
 
         if (
-            self.state == MediaPlayerState.OFF
+            self.state is MediaPlayerState.OFF
             and (state := await self.async_get_last_state()) is not None
         ):
             self._supported_features = (
@@ -204,7 +204,7 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
                 icon = tv_state.apps[tv_state.current_app_id]["icon"]
             self._attr_media_image_url = icon
 
-        if self.state != MediaPlayerState.OFF or not self._supported_features:
+        if self.state is not MediaPlayerState.OFF or not self._supported_features:
             supported = SUPPORT_WEBOSTV
             if tv_state.sound_output == "external_speaker":
                 supported = supported | SUPPORT_WEBOSTV_VOLUME
@@ -235,7 +235,7 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
                     self._attr_state = MediaPlayerState.IDLE
 
         tv_info = self._client.tv_info
-        if self.state != MediaPlayerState.OFF:
+        if self.state is not MediaPlayerState.OFF:
             maj_v = tv_info.software.get("major_ver")
             min_v = tv_info.software.get("minor_ver")
             if maj_v and min_v:
@@ -248,7 +248,7 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
                 self._attr_device_info["serial_number"] = serial_number
 
         self._attr_extra_state_attributes = {}
-        if tv_state.sound_output is not None or self.state != MediaPlayerState.OFF:
+        if tv_state.sound_output is not None or self.state is not MediaPlayerState.OFF:
             self._attr_extra_state_attributes = {
                 ATTR_SOUND_OUTPUT: tv_state.sound_output
             }
@@ -407,7 +407,7 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
         """Play a piece of media."""
         _LOGGER.debug("Call play media type <%s>, Id <%s>", media_type, media_id)
 
-        if media_type == MediaType.CHANNEL and self._client.tv_state.channels:
+        if media_type is MediaType.CHANNEL and self._client.tv_state.channels:
             _LOGGER.debug("Searching channel")
             partial_match_channel_id = None
             perfect_match_channel_id = None

--- a/homeassistant/components/wemo/binary_sensor.py
+++ b/homeassistant/components/wemo/binary_sensor.py
@@ -56,4 +56,4 @@ class InsightBinarySensor(WemoBinarySensor):
     @property
     def is_on(self) -> bool:
         """Return true device connected to the Insight Switch is on."""
-        return super().is_on and self.wemo.standby_state == StandbyState.ON
+        return super().is_on and self.wemo.standby_state is StandbyState.ON

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -86,7 +86,7 @@ class WemoHumidifier(WemoBinaryStateEntity, FanEntity):
     def __init__(self, coordinator: DeviceCoordinator) -> None:
         """Initialize the WeMo switch."""
         super().__init__(coordinator)
-        if self.wemo.fan_mode != FanMode.Off:
+        if self.wemo.fan_mode is not FanMode.Off:
             self._last_fan_on_mode = self.wemo.fan_mode
         else:
             self._last_fan_on_mode = FanMode.High
@@ -121,7 +121,7 @@ class WemoHumidifier(WemoBinaryStateEntity, FanEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        if self.wemo.fan_mode != FanMode.Off:
+        if self.wemo.fan_mode is not FanMode.Off:
             self._last_fan_on_mode = self.wemo.fan_mode
         super()._handle_coordinator_update()
 

--- a/homeassistant/components/wemo/switch.py
+++ b/homeassistant/components/wemo/switch.py
@@ -100,7 +100,7 @@ class WemoSwitch(WemoBinaryStateEntity, SwitchEntity):
             return self.wemo.mode_string
         if isinstance(self.wemo, Insight):
             standby_state = self.wemo.standby_state
-            if standby_state == StandbyState.ON:
+            if standby_state is StandbyState.ON:
                 return STATE_ON
             if standby_state == StandbyState.OFF:
                 return STATE_OFF

--- a/homeassistant/components/whirlpool/climate.py
+++ b/homeassistant/components/whirlpool/climate.py
@@ -112,7 +112,7 @@ class AirConEntity(WhirlpoolEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set HVAC mode."""
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             AirConEntity._check_service_request(
                 await self._appliance.set_power_on(False)
             )

--- a/homeassistant/components/wiim/media_player.py
+++ b/homeassistant/components/wiim/media_player.py
@@ -170,7 +170,7 @@ class WiimMediaPlayerEntity(WiimBaseEntity, MediaPlayerEntity):
     def _metadata_device(self) -> WiimDevice:
         """Return the device whose metadata should back this entity."""
         group_snapshot = self._get_group_snapshot()
-        if group_snapshot.role != WiimGroupRole.FOLLOWER:
+        if group_snapshot.role is not WiimGroupRole.FOLLOWER:
             return self._device
 
         return self._wiim_data.controller.get_device(group_snapshot.leader_udn)
@@ -192,7 +192,7 @@ class WiimMediaPlayerEntity(WiimBaseEntity, MediaPlayerEntity):
     def _get_command_target_device(self, action_name: str) -> WiimDevice:
         """Return the device that should receive a grouped playback command."""
         group_snapshot = self._get_group_snapshot()
-        if group_snapshot.role != WiimGroupRole.FOLLOWER:
+        if group_snapshot.role is not WiimGroupRole.FOLLOWER:
             return self._device
 
         target_device = self._wiim_data.controller.get_device(
@@ -244,7 +244,7 @@ class WiimMediaPlayerEntity(WiimBaseEntity, MediaPlayerEntity):
         group_snapshot = self._get_group_snapshot()
 
         metadata_device = self._metadata_device
-        if group_snapshot.role == WiimGroupRole.FOLLOWER:
+        if group_snapshot.role is WiimGroupRole.FOLLOWER:
             LOGGER.debug(
                 "Follower %s: Actively pulling metadata from leader %s",
                 self.entity_id,
@@ -350,7 +350,7 @@ class WiimMediaPlayerEntity(WiimBaseEntity, MediaPlayerEntity):
                 )
             else:
                 self._device.playing_status = sdk_status
-                if sdk_status == SDKPlayingStatus.STOPPED:
+                if sdk_status is SDKPlayingStatus.STOPPED:
                     LOGGER.debug(
                         "Device %s: TransportState is STOPPED."
                         " Resetting media position and metadata",
@@ -591,7 +591,7 @@ class WiimMediaPlayerEntity(WiimBaseEntity, MediaPlayerEntity):
             self._attr_media_content_id = f"wiim_preset_{preset_number}"
             self._attr_media_content_type = MediaType.PLAYLIST
             self._attr_state = MediaPlayerState.PLAYING
-        elif media_type == MediaType.MUSIC:
+        elif media_type is MediaType.MUSIC:
             if media_id.isdigit():
                 preset_number = int(media_id)
                 await target_device.play_preset(preset_number)

--- a/homeassistant/components/withings/coordinator.py
+++ b/homeassistant/components/withings/coordinator.py
@@ -215,7 +215,7 @@ class WithingsBedPresenceDataUpdateCoordinator(WithingsDataUpdateCoordinator[Non
         self, notification_category: NotificationCategory
     ) -> None:
         """Only set new in bed value instead of refresh."""
-        self.in_bed = notification_category == NotificationCategory.IN_BED
+        self.in_bed = notification_category is NotificationCategory.IN_BED
         self.async_update_listeners()
 
     async def _internal_update_data(self) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

<!-- Part 2 of 3. No "Breaking change" — pure semantic equivalence. -->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Mechanical codemod that replaces `==` with `is` (and `!=` with `is not`)
on every line where both operands statically resolve to the same
`enum.Enum` subclass. This is a prerequisite to #171551 (the
`mypy_plugins.enum_identity_compare` plugin that identifies these
sites).

**Part 2 of 3** — covers files alphabetically from
`homeassistant/components/matter/climate.py` through
`homeassistant/components/withings/coordinator.py`.

```python
# Before:
assert result["type"] == FlowResultType.FORM   # type-checker sees both sides as FlowResultType
# After:
assert result["type"] is FlowResultType.FORM
```

**Scope of this PR:** ~499 sites across 254 files.

**Scope of the full codemod (all 3 parts):** 2,159 sites across 762
files, touching 378 of 1,468 integrations (~26%) plus ~20
core/helper/util files.

**What is NOT changed:**

- `Flag`/`IntFlag` patterns (`features & FEATURE_X == FEATURE_X`) —
  bitwise `==` is idiomatic there.
- StrEnum/IntEnum sites where the LHS is a raw `str`/`int`:
  `state.state == HVACMode.HEAT` (state-machine string),
  `response.status_code == HTTPStatus.OK` (HTTP-client integer), etc.
  The plugin correctly skips these and the codemod doesn't touch them.

**Validation:**

1. Every changed line corresponds to a `ha-enum-identity-compare`
   violation reported by the mypy plugin against `dev`.
2. The codemod was run iteratively; after the final pass the mypy
   plugin reports **zero** remaining violations.
3. Each individual swap was verified by a custom diff checker:
   removed-line == added-line modulo a single `==` → `is` (or
   `!=` → `is not`) substitution, with the swap adjacent to an
   enum-class reference.
4. All modified files parse (`ast.parse`).
5. No new mypy error categories appeared on the touched files
   (informational delta check).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #171551
- Companion parts: #171591 (part 1, `auth` → `manual_mqtt`), #PART3_PR (part 3, `withings/sensor` → tests).
- Land order across the 3 parts and the plugin (#171551) does not matter for correctness, only for CI temporary noise.
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
