### PR TITLE
Use `is`/`is not` for same-enum identity comparisons (3/3)

### DIFF
--- a/homeassistant/components/withings/sensor.py
+++ b/homeassistant/components/withings/sensor.py
@@ -857,7 +857,7 @@ async def async_setup_entry(
                                 config_entry_id
                             )
                         )
-                        and config_entry.state == ConfigEntryState.LOADED
+                        and config_entry.state is ConfigEntryState.LOADED
                         for config_entry_id in device.config_entries
                     ):
                         continue

--- a/homeassistant/components/wyoming/assist_satellite.py
+++ b/homeassistant/components/wyoming/assist_satellite.py
@@ -178,7 +178,7 @@ class WyomingAssistSatellite(WyomingSatelliteEntity, AssistSatelliteEntity):
 
     def on_pipeline_event(self, event: PipelineEvent) -> None:
         """Set state based on pipeline stage."""
-        if event.type == assist_pipeline.PipelineEventType.RUN_END:
+        if event.type is assist_pipeline.PipelineEventType.RUN_END:
             # Pipeline run is complete — always update bookkeeping state
             # even after a disconnect so follow-up reconnects don't retain
             # stale _is_pipeline_running / _pipeline_ended_event state.
@@ -192,7 +192,7 @@ class WyomingAssistSatellite(WyomingSatelliteEntity, AssistSatelliteEntity):
             # Satellite disconnected, don't try to write to the client
             return
 
-        if event.type == assist_pipeline.PipelineEventType.RUN_START:
+        if event.type is assist_pipeline.PipelineEventType.RUN_START:
             if event.data and (tts_output := event.data.get("tts_output")):
                 # Get stream token early.
                 # If "tts_start_streaming" is True in INTENT_PROGRESS event, we
@@ -861,7 +861,7 @@ class WyomingAssistSatellite(WyomingSatelliteEntity, AssistSatelliteEntity):
 
         _LOGGER.debug("Timer event: type=%s, info=%s", event_type, timer)
         event: Event | None = None
-        if event_type == intent.TimerEventType.STARTED:
+        if event_type is intent.TimerEventType.STARTED:
             event = TimerStarted(
                 id=timer.id,
                 total_seconds=timer.seconds,

--- a/homeassistant/components/wyoming/devices.py
+++ b/homeassistant/components/wyoming/devices.py
@@ -80,7 +80,7 @@ class SatelliteDevice:
     @callback
     def set_vad_sensitivity(self, vad_sensitivity: VadSensitivity) -> None:
         """Set VAD sensitivity."""
-        if vad_sensitivity != self.vad_sensitivity:
+        if vad_sensitivity is not self.vad_sensitivity:
             self.vad_sensitivity = vad_sensitivity
             if self._audio_settings_listener is not None:
                 self._audio_settings_listener()

--- a/homeassistant/components/xbox/remote.py
+++ b/homeassistant/components/xbox/remote.py
@@ -113,7 +113,7 @@ class XboxRemote(XboxConsoleBaseEntity, RemoteEntity):
     @property
     def is_on(self) -> bool:
         """Return True if device is on."""
-        return self.data.status.power_state == PowerState.On
+        return self.data.status.power_state is PowerState.On
 
     @exception_handler
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/homeassistant/components/xiaomi_ble/__init__.py
+++ b/homeassistant/components/xiaomi_ble/__init__.py
@@ -100,7 +100,7 @@ def process_service_info(
     # not verified then we need to reauth
     if (
         not data.pending
-        and data.encryption_scheme != EncryptionScheme.NONE
+        and data.encryption_scheme is not EncryptionScheme.NONE
         and not data.bindkey_verified
     ):
         entry.async_start_reauth(hass, data={"device": data})

--- a/homeassistant/components/xiaomi_ble/config_flow.py
+++ b/homeassistant/components/xiaomi_ble/config_flow.py
@@ -109,7 +109,7 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
             # encryption later, we can do a reauth
             return await self.async_step_confirm_slow()
 
-        if device.encryption_scheme == EncryptionScheme.MIBEACON_LEGACY:
+        if device.encryption_scheme is EncryptionScheme.MIBEACON_LEGACY:
             return await self.async_step_get_encryption_key_legacy()
         if device.encryption_scheme == EncryptionScheme.MIBEACON_4_5:
             return await self.async_step_get_encryption_key_4_5_choose_method()
@@ -296,7 +296,7 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
 
             self._discovered_device = discovery.device
 
-            if discovery.device.encryption_scheme == EncryptionScheme.MIBEACON_LEGACY:
+            if discovery.device.encryption_scheme is EncryptionScheme.MIBEACON_LEGACY:
                 return await self.async_step_get_encryption_key_legacy()
 
             if discovery.device.encryption_scheme == EncryptionScheme.MIBEACON_4_5:
@@ -338,7 +338,7 @@ class XiaomiConfigFlow(ConfigFlow, domain=DOMAIN):
 
         self._discovery_info = device.last_service_info
 
-        if device.encryption_scheme == EncryptionScheme.MIBEACON_LEGACY:
+        if device.encryption_scheme is EncryptionScheme.MIBEACON_LEGACY:
             return await self.async_step_get_encryption_key_legacy()
 
         if device.encryption_scheme == EncryptionScheme.MIBEACON_4_5:

--- a/homeassistant/components/xiaomi_miio/humidifier.py
+++ b/homeassistant/components/xiaomi_miio/humidifier.py
@@ -253,7 +253,7 @@ class XiaomiAirHumidifier(XiaomiGenericHumidifier, HumidifierEntity):
         if (
             self.supported_features & HumidifierEntityFeature.MODES == 0
             or AirhumidifierOperationMode(self._attributes[ATTR_MODE])
-            == AirhumidifierOperationMode.Auto
+            is AirhumidifierOperationMode.Auto
             or AirhumidifierOperationMode.Auto.name not in self.available_modes
         ):
             self.async_write_ha_state()
@@ -310,7 +310,7 @@ class XiaomiAirHumidifierMiot(XiaomiAirHumidifier):
             return (
                 self._target_humidity
                 if AirhumidifierMiotOperationMode(self._mode)
-                == AirhumidifierMiotOperationMode.Auto
+                is AirhumidifierMiotOperationMode.Auto
                 else None
             )
         return None
@@ -331,7 +331,7 @@ class XiaomiAirHumidifierMiot(XiaomiAirHumidifier):
         if (
             self.supported_features & HumidifierEntityFeature.MODES == 0
             or AirhumidifierMiotOperationMode(self._attributes[ATTR_MODE])
-            == AirhumidifierMiotOperationMode.Auto
+            is AirhumidifierMiotOperationMode.Auto
         ):
             self.async_write_ha_state()
             return
@@ -385,7 +385,7 @@ class XiaomiAirHumidifierMjjsq(XiaomiAirHumidifier):
         if self.is_on:
             if (
                 AirhumidifierMjjsqOperationMode(self._mode)
-                == AirhumidifierMjjsqOperationMode.Humidity
+                is AirhumidifierMjjsqOperationMode.Humidity
             ):
                 return self._target_humidity
         return None
@@ -406,7 +406,7 @@ class XiaomiAirHumidifierMjjsq(XiaomiAirHumidifier):
         if (
             self.supported_features & HumidifierEntityFeature.MODES == 0
             or AirhumidifierMjjsqOperationMode(self._attributes[ATTR_MODE])
-            == AirhumidifierMjjsqOperationMode.Humidity
+            is AirhumidifierMjjsqOperationMode.Humidity
         ):
             self.async_write_ha_state()
             return

--- a/homeassistant/components/xiaomi_tv/media_player.py
+++ b/homeassistant/components/xiaomi_tv/media_player.py
@@ -80,14 +80,14 @@ class XiaomiTV(MediaPlayerEntity):
         because the TV won't accept any input when turned off. Thus, the user
         would be unable to turn the TV back on, unless it's done manually.
         """
-        if self.state != MediaPlayerState.OFF:
+        if self.state is not MediaPlayerState.OFF:
             self._tv.sleep()
 
             self._attr_state = MediaPlayerState.OFF
 
     def turn_on(self) -> None:
         """Wake the TV back up from sleep."""
-        if self.state != MediaPlayerState.ON:
+        if self.state is not MediaPlayerState.ON:
             self._tv.wake()
 
             self._attr_state = MediaPlayerState.ON

--- a/homeassistant/components/yale_smart_alarm/lock.py
+++ b/homeassistant/components/yale_smart_alarm/lock.py
@@ -97,9 +97,9 @@ class YaleDoorlock(YaleLockEntity, LockEntity):
     @property
     def is_locked(self) -> bool | None:
         """Return true if the lock is locked."""
-        return LOCK_STATE_MAP.get(self.lock_data.state()) == LockState.LOCKED
+        return LOCK_STATE_MAP.get(self.lock_data.state()) is LockState.LOCKED
 
     @property
     def is_open(self) -> bool | None:
         """Return true if the lock is open."""
-        return LOCK_STATE_MAP.get(self.lock_data.state()) == LockState.OPEN
+        return LOCK_STATE_MAP.get(self.lock_data.state()) is LockState.OPEN

--- a/homeassistant/components/yalexs_ble/binary_sensor.py
+++ b/homeassistant/components/yalexs_ble/binary_sensor.py
@@ -35,5 +35,5 @@ class YaleXSBLEDoorSensor(YALEXSBLEEntity, BinarySensorEntity):
         self, new_state: LockState, lock_info: LockInfo, connection_info: ConnectionInfo
     ) -> None:
         """Update the state."""
-        self._attr_is_on = new_state.door == DoorStatus.OPENED
+        self._attr_is_on = new_state.door is DoorStatus.OPENED
         super()._async_update_state(new_state, lock_info, connection_info)

--- a/homeassistant/components/yamaha_musiccast/media_player.py
+++ b/homeassistant/components/yamaha_musiccast/media_player.py
@@ -291,7 +291,7 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
             )
             media_id = play_item.url
 
-        if self.state == MediaPlayerState.OFF:
+        if self.state is MediaPlayerState.OFF:
             await self.async_turn_on()
 
         if media_id:
@@ -468,7 +468,7 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
             supported_features |= MediaPlayerEntityFeature.PLAY
             supported_features |= MediaPlayerEntityFeature.STOP
 
-        if self.state != MediaPlayerState.OFF:
+        if self.state is not MediaPlayerState.OFF:
             supported_features |= MediaPlayerEntityFeature.BROWSE_MEDIA
 
         return supported_features
@@ -729,7 +729,7 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
             if entity.entity_id in group_members
         ]
 
-        if self.state == MediaPlayerState.OFF:
+        if self.state is MediaPlayerState.OFF:
             await self.async_turn_on()
 
         if not self.is_server and self.musiccast_zone_entity.is_server:
@@ -812,7 +812,7 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
         # If we should join the group, which is served by the main zone,
         # we can simply select main_sync as input.
         _LOGGER.debug("%s called service client join", self.entity_id)
-        if self.state == MediaPlayerState.OFF:
+        if self.state is MediaPlayerState.OFF:
             await self.async_turn_on()
         if self.ip_address == server.ip_address:
             if server.zone == DEFAULT_ZONE:

--- a/homeassistant/components/yeelight/config_flow.py
+++ b/homeassistant/components/yeelight/config_flow.py
@@ -106,7 +106,7 @@ class YeelightConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_ID
             ):
                 continue
-            reload = entry.state == ConfigEntryState.SETUP_RETRY
+            reload = entry.state is ConfigEntryState.SETUP_RETRY
             if entry.data.get(CONF_HOST) != self._discovered_ip:
                 self.hass.config_entries.async_update_entry(
                     entry, data={**entry.data, CONF_HOST: self._discovered_ip}

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -639,7 +639,7 @@ class YeelightBaseLight(YeelightEntity, LightEntity):
             return
         if (
             not self.device.is_color_flow_enabled
-            and self.color_mode == ColorMode.HS
+            and self.color_mode is ColorMode.HS
             and self.hs_color == hs_color
         ):
             _LOGGER.debug("HS already set to: %s", hs_color)
@@ -664,7 +664,7 @@ class YeelightBaseLight(YeelightEntity, LightEntity):
             return
         if (
             not self.device.is_color_flow_enabled
-            and self.color_mode == ColorMode.RGB
+            and self.color_mode is ColorMode.RGB
             and self.rgb_color == rgb
         ):
             _LOGGER.debug("RGB already set to: %s", rgb)
@@ -690,7 +690,7 @@ class YeelightBaseLight(YeelightEntity, LightEntity):
 
         if (
             not self.device.is_color_flow_enabled
-            and self.color_mode == ColorMode.COLOR_TEMP
+            and self.color_mode is ColorMode.COLOR_TEMP
             and self.color_temp_kelvin == temp_in_k
         ):
             _LOGGER.debug("Color temp already set to: %s", temp_in_k)

--- a/homeassistant/components/yolink/services.py
+++ b/homeassistant/components/yolink/services.py
@@ -40,7 +40,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
                     continue
                 if entry.domain == DOMAIN:
                     break
-            if entry is None or entry.state != ConfigEntryState.LOADED:
+            if entry is None or entry.state is not ConfigEntryState.LOADED:
                 raise ServiceValidationError(
                     translation_domain=DOMAIN,
                     translation_key="invalid_config_entry",

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -198,7 +198,7 @@ class BaseZhaFlow(ConfigEntryBaseFlow):
             self._radio_mgr.device_path = device_path
 
             probe_result = await self._radio_mgr.detect_radio_type()
-            if probe_result == ProbeResult.WRONG_FIRMWARE_INSTALLED:
+            if probe_result is ProbeResult.WRONG_FIRMWARE_INSTALLED:
                 return self.async_abort(
                     reason="wrong_firmware_installed",
                     description_placeholders={"repair_url": REPAIR_MY_URL},
@@ -333,7 +333,7 @@ class BaseZhaFlow(ConfigEntryBaseFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Choose how to set up the integration from scratch."""
-        if self._flow_strategy == ZigbeeFlowStrategy.RECOMMENDED:
+        if self._flow_strategy is ZigbeeFlowStrategy.RECOMMENDED:
             # Fast path: automatically form a new network
             return await self.async_step_setup_strategy_recommended()
         if self._flow_strategy == ZigbeeFlowStrategy.ADVANCED:
@@ -372,7 +372,7 @@ class BaseZhaFlow(ConfigEntryBaseFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Choose how to deal with the current radio's settings during migration."""
-        if self._flow_strategy == ZigbeeFlowStrategy.RECOMMENDED:
+        if self._flow_strategy is ZigbeeFlowStrategy.RECOMMENDED:
             # Fast path: automatically migrate everything
             return await self.async_step_migration_strategy_recommended()
         if self._flow_strategy == ZigbeeFlowStrategy.ADVANCED:
@@ -852,7 +852,7 @@ class ZhaConfigFlowHandler(BaseZhaFlow, ConfigFlow, domain=DOMAIN):
             else:
                 probe_result = ProbeResult.RADIO_TYPE_DETECTED
 
-            if probe_result == ProbeResult.WRONG_FIRMWARE_INSTALLED:
+            if probe_result is ProbeResult.WRONG_FIRMWARE_INSTALLED:
                 return self.async_abort(
                     reason="wrong_firmware_installed",
                     description_placeholders={"repair_url": REPAIR_MY_URL},

--- a/homeassistant/components/zha/repairs/wrong_silabs_firmware.py
+++ b/homeassistant/components/zha/repairs/wrong_silabs_firmware.py
@@ -87,7 +87,7 @@ async def warn_on_wrong_silabs_firmware(hass: HomeAssistant, device: str) -> boo
         # Failed to probe, we can't tell if the wrong firmware is installed
         return False
 
-    if app_type == ApplicationType.EZSP:
+    if app_type is ApplicationType.EZSP:
         # If connecting fails but we somehow probe EZSP (e.g. stuck in bootloader),
         # reconnect, it should work
         raise AlreadyRunningEZSP
@@ -102,7 +102,7 @@ async def warn_on_wrong_silabs_firmware(hass: HomeAssistant, device: str) -> boo
         severity=ir.IssueSeverity.ERROR,
         translation_key=(
             ISSUE_WRONG_SILABS_FIRMWARE_INSTALLED
-            + ("_nabucasa" if hardware_type != HardwareType.OTHER else "_other")
+            + ("_nabucasa" if hardware_type is not HardwareType.OTHER else "_other")
         ),
         translation_placeholders={"firmware_type": app_type.name},
     )

--- a/homeassistant/components/zhong_hong/climate.py
+++ b/homeassistant/components/zhong_hong/climate.py
@@ -236,7 +236,7 @@ class ZhongHongClimate(ClimateEntity):
 
     def set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target operation mode."""
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             if self.is_on:
                 self.turn_off()
             return

--- a/homeassistant/components/ziggo_mediabox_xl/media_player.py
+++ b/homeassistant/components/ziggo_mediabox_xl/media_player.py
@@ -104,7 +104,7 @@ class ZiggoMediaboxXLDevice(MediaPlayerEntity):
         try:
             if self._mediabox.test_connection():
                 if self._mediabox.turned_on():
-                    if self.state != MediaPlayerState.PAUSED:
+                    if self.state is not MediaPlayerState.PAUSED:
                         self._attr_state = MediaPlayerState.PLAYING
                 else:
                     self._attr_state = MediaPlayerState.OFF
@@ -151,7 +151,7 @@ class ZiggoMediaboxXLDevice(MediaPlayerEntity):
     def media_play_pause(self) -> None:
         """Simulate play pause media player."""
         self.send_keys(["PAUSE"])
-        if self.state == MediaPlayerState.PAUSED:
+        if self.state is MediaPlayerState.PAUSED:
             self._attr_state = MediaPlayerState.PLAYING
         else:
             self._attr_state = MediaPlayerState.PAUSED

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -576,7 +576,7 @@ class ControllerEvents:
             # We don't want to remove the device so we can keep the user customizations
             return
 
-        if reason == RemoveNodeReason.RESET:
+        if reason is RemoveNodeReason.RESET:
             device_name = device.name_by_user or device.name or f"Node {node.node_id}"
             identifier = get_network_identifier_for_notification(
                 self.hass, self.config_entry, self.driver_events.driver.controller
@@ -1207,7 +1207,7 @@ async def async_ensure_addon_running(
     if addon_has_esphome and socket_path is not None:
         addon_config[CONF_ADDON_SOCKET] = socket_path
 
-    if addon_state == AddonState.NOT_INSTALLED:
+    if addon_state is AddonState.NOT_INSTALLED:
         addon_manager.async_schedule_install_setup_addon(
             addon_config,
             catch_error=True,

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -712,7 +712,7 @@ async def websocket_node_alerts(
                 [
                     strategy.value
                     for strategy in InclusionStrategy
-                    if strategy != InclusionStrategy.SMART_START
+                    if strategy is not InclusionStrategy.SMART_START
                 ]
             ),
         ),
@@ -869,7 +869,7 @@ async def websocket_add_node(
         )
         # Check for nodes that have been added but not fully included
         for node in controller.nodes.values():
-            if node.status != NodeStatus.DEAD and not node.ready:
+            if node.status is not NodeStatus.DEAD and not node.ready:
                 forward_node_added(
                     node,
                     not node.is_secure,
@@ -1470,7 +1470,7 @@ async def websocket_remove_node(
                 [
                     strategy.value
                     for strategy in InclusionStrategy
-                    if strategy != InclusionStrategy.SMART_START
+                    if strategy is not InclusionStrategy.SMART_START
                 ]
             ),
         ),

--- a/homeassistant/components/zwave_js/climate.py
+++ b/homeassistant/components/zwave_js/climate.py
@@ -159,7 +159,7 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
             # temperature unit
             if (
                 not self._unit_value
-                and enum != ThermostatSetpointType.NA
+                and enum is not ThermostatSetpointType.NA
                 and self._setpoint_values[enum]
             ):
                 self._unit_value = self._setpoint_values[enum]
@@ -499,7 +499,7 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
 
         # When turning the HVAC off from an on state, store the last HVAC mode ID so we
         # can set it again when turning the device back on.
-        if hvac_mode == HVACMode.OFF and self._current_mode.value != ThermostatMode.OFF:
+        if hvac_mode is HVACMode.OFF and self._current_mode.value != ThermostatMode.OFF:
             self._last_hvac_mode_id_before_off = self._current_mode.value
         await self._async_set_value(self._current_mode, self._hvac_modes[hvac_mode])
 
@@ -510,7 +510,7 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
     async def async_turn_on(self) -> None:
         """Turn the entity on."""
         # If current mode is not off, do nothing
-        if self.hvac_mode != HVACMode.OFF:
+        if self.hvac_mode is not HVACMode.OFF:
             return
 
         # We can safely assert here because this function can only be called if the
@@ -542,7 +542,9 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
                 if mode in self._hvac_modes
             )
         except StopIteration:
-            hvac_mode = next(mode for mode in self._hvac_modes if mode != HVACMode.OFF)
+            hvac_mode = next(
+                mode for mode in self._hvac_modes if mode is not HVACMode.OFF
+            )
         await self.async_set_hvac_mode(hvac_mode)
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
@@ -554,7 +556,7 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
                 # Current preset mode doesn't map to a supported HVAC mode.
                 # Pick the first supported non-off mode.
                 hvac_mode = next(
-                    mode for mode in self._hvac_modes if mode != HVACMode.OFF
+                    mode for mode in self._hvac_modes if mode is not HVACMode.OFF
                 )
             await self.async_set_hvac_mode(hvac_mode)
             return

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -382,7 +382,7 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
         if new_addon_config == addon_config:
             return
 
-        if addon_info.state == AddonState.RUNNING:
+        if addon_info.state is AddonState.RUNNING:
             self.restart_addon = True
         # Copy the add-on config to keep the objects separate.
         self.original_addon_config = dict(addon_config)
@@ -732,7 +732,7 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
 
         addon_info = await self._async_get_addon_info()
 
-        if addon_info.state == AddonState.RUNNING:
+        if addon_info.state is AddonState.RUNNING:
             addon_config = addon_info.options
             # Use the options set by USB/ESPHome discovery
             if not self._adapter_discovered:
@@ -1230,7 +1230,7 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
 
         addon_info = await self._async_get_addon_info()
 
-        if addon_info.state == AddonState.NOT_INSTALLED:
+        if addon_info.state is AddonState.NOT_INSTALLED:
             return await self.async_step_install_addon()
 
         return await self.async_step_configure_addon_reconfigure()
@@ -1268,7 +1268,7 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
 
             await self._async_set_addon_config(addon_config_updates)
 
-            if addon_info.state == AddonState.RUNNING and not self.restart_addon:
+            if addon_info.state is AddonState.RUNNING and not self.restart_addon:
                 return await self.async_step_finish_addon_setup_reconfigure()
 
             if (
@@ -1719,7 +1719,7 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
         """Get the driver from the config entry."""
         config_entry = self._reconfigure_config_entry
         assert config_entry is not None
-        if config_entry.state != ConfigEntryState.LOADED:
+        if config_entry.state is not ConfigEntryState.LOADED:
             raise AbortFlow("Configuration entry is not loaded")
         client: Client = config_entry.runtime_data.client
         assert client.driver is not None

--- a/homeassistant/components/zwave_js/device_automation_helpers.py
+++ b/homeassistant/components/zwave_js/device_automation_helpers.py
@@ -44,7 +44,7 @@ def async_bypass_dynamic_config_validation(hass: HomeAssistant, device_id: str) 
             config_entry
             for config_entry in hass.config_entries.async_entries(DOMAIN)
             if config_entry.entry_id in device.config_entries
-            and config_entry.state == ConfigEntryState.LOADED
+            and config_entry.state is ConfigEntryState.LOADED
         ),
         None,
     )

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -1443,7 +1443,7 @@ def async_discover_single_configuration_value(
 ) -> Generator[ZwaveDiscoveryInfo]:
     """Run discovery on single Z-Wave configuration value and return schema matches."""
     if value.metadata.writeable and value.metadata.readable:
-        if value.configuration_value_type == ConfigurationValueType.ENUMERATED:
+        if value.configuration_value_type is ConfigurationValueType.ENUMERATED:
             yield ZwaveDiscoveryInfo(
                 node=value.node,
                 primary_value=value,
@@ -1480,7 +1480,7 @@ def async_discover_single_configuration_value(
                 entity_registry_enabled_default=False,
             )
     elif not value.metadata.writeable and value.metadata.readable:
-        if value.configuration_value_type == ConfigurationValueType.BOOLEAN:
+        if value.configuration_value_type is ConfigurationValueType.BOOLEAN:
             yield ZwaveDiscoveryInfo(
                 node=value.node,
                 primary_value=value,

--- a/homeassistant/components/zwave_js/discovery_data_template.py
+++ b/homeassistant/components/zwave_js/discovery_data_template.py
@@ -390,7 +390,7 @@ class NumericSensorDataTemplate(BaseDiscoverySchemaDataTemplate):
             unit = self.find_key_from_matching_set(
                 multilevel_sensor_scale_type, MULTILEVEL_SENSOR_UNIT_MAP
             )
-            if sensor_type == MultilevelSensorType.TARGET_TEMPERATURE:
+            if sensor_type is MultilevelSensorType.TARGET_TEMPERATURE:
                 return NumericSensorDataTemplateData(
                     ENTITY_DESC_KEY_TARGET_TEMPERATURE, unit
                 )

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -305,7 +305,7 @@ def async_get_node_from_device_id(
         raise ValueError(
             f"Device {device_id} is not from an existing zwave_js config entry"
         )
-    if entry.state != ConfigEntryState.LOADED:
+    if entry.state is not ConfigEntryState.LOADED:
         raise ValueError(f"Device {device_id} config entry is not loaded")
 
     client = entry.runtime_data.client
@@ -353,7 +353,7 @@ async def async_get_provisioning_entry_from_device_id(
         raise ValueError(
             f"Device {device_id} is not from an existing zwave_js config entry"
         )
-    if entry.state != ConfigEntryState.LOADED:
+    if entry.state is not ConfigEntryState.LOADED:
         raise ValueError(f"Device {device_id} config entry is not loaded")
 
     client = entry.runtime_data.client
@@ -566,7 +566,7 @@ def get_value_state_schema(
         ):
             return vol.All(vol.Coerce(int), vol.Range(min=min_, max=max_))
 
-        if value.configuration_value_type == ConfigurationValueType.BOOLEAN:
+        if value.configuration_value_type is ConfigurationValueType.BOOLEAN:
             return vol.Coerce(bool)
 
         if value.configuration_value_type == ConfigurationValueType.ENUMERATED:

--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -582,7 +582,7 @@ class ZwaveColorOnOffLight(ZwaveLight):
         elif brightness is not None:
             # If brightness gets set, preserve the color
             # and mix it with the new brightness
-            if self.color_mode == ColorMode.HS:
+            if self.color_mode is ColorMode.HS:
                 scale = brightness / 255
             if self._last_on_color is not None:
                 # Changed brightness from 0 to >0
@@ -592,7 +592,7 @@ class ZwaveColorOnOffLight(ZwaveLight):
                 new_colors = {}
                 for color, value in self._last_on_color.items():
                     new_colors[color] = round(value * new_scale)
-            elif hs_color is None and self._attr_color_mode == ColorMode.HS:
+            elif hs_color is None and self._attr_color_mode is ColorMode.HS:
                 hs_color = self._attr_hs_color
         elif hs_color is not None and brightness is None:
             # Turned on by using the color controls

--- a/homeassistant/components/zwave_js/migrate.py
+++ b/homeassistant/components/zwave_js/migrate.py
@@ -160,7 +160,7 @@ def async_migrate_discovered_value(
     ]
 
     if (
-        disc_info.platform == Platform.BINARY_SENSOR
+        disc_info.platform is Platform.BINARY_SENSOR
         and disc_info.primary_value.command_class == CommandClass.NOTIFICATION
     ):
         for state_key in disc_info.primary_value.metadata.states:

--- a/homeassistant/components/zwave_js/triggers/trigger_helpers.py
+++ b/homeassistant/components/zwave_js/triggers/trigger_helpers.py
@@ -21,7 +21,7 @@ def async_bypass_dynamic_config_validation(
     trigger_devices = config.get(ATTR_DEVICE_ID, [])
     trigger_entities = config.get(ATTR_ENTITY_ID, [])
     for entry in hass.config_entries.async_entries(DOMAIN):
-        if entry.state != ConfigEntryState.LOADED and (
+        if entry.state is not ConfigEntryState.LOADED and (
             entry.entry_id == config.get(ATTR_CONFIG_ENTRY_ID)
             or any(
                 device.id in trigger_devices

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -985,7 +985,7 @@ class ConfigEntry[_DataT = Any]:
             self._async_set_state(hass, ConfigEntryState.NOT_LOADED, None)
             return True
 
-        if self.state == ConfigEntryState.NOT_LOADED:
+        if self.state is ConfigEntryState.NOT_LOADED:
             return True
 
         if not integration and (integration := self._integration_for_domain) is None:
@@ -1626,13 +1626,13 @@ class ConfigEntriesFlowManager(
         flow_type, flow_id = next_flow
         if flow_type not in FlowType:
             raise HomeAssistantError(f"Invalid flow type: {flow_type}")
-        if flow_type == FlowType.CONFIG_FLOW:
+        if flow_type is FlowType.CONFIG_FLOW:
             # Raises UnknownFlow if the flow does not exist.
             self.hass.config_entries.flow.async_get(flow_id)
-        if flow_type == FlowType.OPTIONS_FLOW:
+        if flow_type is FlowType.OPTIONS_FLOW:
             # Raises UnknownFlow if the flow does not exist.
             self.hass.config_entries.options.async_get(flow_id)
-        if flow_type == FlowType.CONFIG_SUBENTRIES_FLOW:
+        if flow_type is FlowType.CONFIG_SUBENTRIES_FLOW:
             # Raises UnknownFlow if the flow does not exist.
             self.hass.config_entries.subentries.async_get(flow_id)
 
@@ -1648,7 +1648,7 @@ class ConfigEntriesFlowManager(
         """
         flow = cast(ConfigFlow, flow)
 
-        if result["type"] != data_entry_flow.FlowResultType.CREATE_ENTRY:
+        if result["type"] is not data_entry_flow.FlowResultType.CREATE_ENTRY:
             # If there's a config entry with a matching unique ID,
             # update the discovery key.
             if (
@@ -2177,7 +2177,7 @@ class ConfigEntries:
         """
         entries = self._entries.get_entries_for_domain(domain)
 
-        return [entry for entry in entries if entry.state == ConfigEntryState.LOADED]
+        return [entry for entry in entries if entry.state is ConfigEntryState.LOADED]
 
     @callback
     def async_entry_for_domain_unique_id(
@@ -3338,7 +3338,7 @@ class ConfigFlow(ConfigEntryBaseFlow):
         if next_flow is None:
             return
         flow_type, flow_id = next_flow
-        if flow_type != FlowType.CONFIG_FLOW:
+        if flow_type is not FlowType.CONFIG_FLOW:
             raise HomeAssistantError(
                 "next_flow only supports FlowType.CONFIG_FLOW; "
                 "use async_on_create_entry for options or subentry flows"
@@ -3651,7 +3651,7 @@ class ConfigSubentryFlowManager(
         """
         flow = cast(ConfigSubentryFlow, flow)
 
-        if result["type"] != data_entry_flow.FlowResultType.CREATE_ENTRY:
+        if result["type"] is not data_entry_flow.FlowResultType.CREATE_ENTRY:
             return result
 
         entry_id, subentry_type = flow.handler
@@ -3874,7 +3874,7 @@ class OptionsFlowManager(
         """
         flow = cast(OptionsFlow, flow)
 
-        if result["type"] != data_entry_flow.FlowResultType.CREATE_ENTRY:
+        if result["type"] is not data_entry_flow.FlowResultType.CREATE_ENTRY:
             return result
 
         entry = self.hass.config_entries.async_get_known_entry(flow.handler)

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -326,11 +326,11 @@ class FlowManager(abc.ABC, Generic[_FlowContextT, _FlowResultT, _HandlerT]):
         if flow and flow.deprecated_show_progress:
             if (cur_step := flow.cur_step) and cur_step[
                 "type"
-            ] == FlowResultType.SHOW_PROGRESS:
+            ] is FlowResultType.SHOW_PROGRESS:
                 # Allow the progress task to finish before we call the flow handler
                 await asyncio.sleep(0)
 
-        while not result or result["type"] == FlowResultType.SHOW_PROGRESS_DONE:
+        while not result or result["type"] is FlowResultType.SHOW_PROGRESS_DONE:
             result = await self._async_configure(flow_id, user_input)
             flow = self._progress.get(flow_id)
             if flow and flow.deprecated_show_progress:
@@ -374,7 +374,7 @@ class FlowManager(abc.ABC, Generic[_FlowContextT, _FlowResultT, _HandlerT]):
                 ) from ex
 
         # Handle a menu navigation choice
-        if cur_step["type"] == FlowResultType.MENU and user_input:
+        if cur_step["type"] is FlowResultType.MENU and user_input:
             result = await self._async_handle_step(
                 flow, user_input["next_step_id"], None
             )
@@ -414,7 +414,7 @@ class FlowManager(abc.ABC, Generic[_FlowContextT, _FlowResultT, _HandlerT]):
             # - The step is same but result type is SHOW_PROGRESS and progress_action
             #   or description_placeholders has changed
             if cur_step["step_id"] != result.get("step_id") or (
-                result["type"] == FlowResultType.SHOW_PROGRESS
+                result["type"] is FlowResultType.SHOW_PROGRESS
                 and (
                     cur_step["progress_action"] != result.get("progress_action")
                     or cur_step["description_placeholders"]
@@ -492,7 +492,7 @@ class FlowManager(abc.ABC, Generic[_FlowContextT, _FlowResultT, _HandlerT]):
         if flow.flow_id not in self._progress:
             # The flow was removed during the step, raise UnknownFlow
             # unless the result is an abort
-            if result["type"] != FlowResultType.ABORT:
+            if result["type"] is not FlowResultType.ABORT:
                 raise UnknownFlow
             return result
 
@@ -509,7 +509,7 @@ class FlowManager(abc.ABC, Generic[_FlowContextT, _FlowResultT, _HandlerT]):
             )
 
         if (
-            result["type"] == FlowResultType.SHOW_PROGRESS
+            result["type"] is FlowResultType.SHOW_PROGRESS
             # Mypy does not agree with using pop on _FlowResultT
             and (progress_task := result.pop("progress_task", None))  # type: ignore[arg-type]
             and progress_task != flow.async_get_progress_task()
@@ -526,7 +526,7 @@ class FlowManager(abc.ABC, Generic[_FlowContextT, _FlowResultT, _HandlerT]):
             progress_task.add_done_callback(schedule_configure)  # type: ignore[attr-defined]
             flow.async_set_progress_task(progress_task)  # type: ignore[arg-type]
 
-        elif result["type"] != FlowResultType.SHOW_PROGRESS:
+        elif result["type"] is not FlowResultType.SHOW_PROGRESS:
             flow.async_cancel_progress_task()
 
         if result["type"] in STEP_ID_OPTIONAL_STEPS:
@@ -551,7 +551,7 @@ class FlowManager(abc.ABC, Generic[_FlowContextT, _FlowResultT, _HandlerT]):
             )
 
         # _async_finish_flow may change result type, check it again
-        if result["type"] == FlowResultType.FORM:
+        if result["type"] is FlowResultType.FORM:
             flow.cur_step = result
             return result
 

--- a/homeassistant/helpers/data_entry_flow.py
+++ b/homeassistant/helpers/data_entry_flow.py
@@ -31,7 +31,7 @@ class _BaseFlowManagerView(HomeAssistantView, Generic[_FlowManagerT]):
         self, result: data_entry_flow.FlowResult
     ) -> dict[str, Any]:
         """Convert result to JSON serializable dict."""
-        if result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY:
+        if result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY:
             assert "result" not in result
             return {
                 key: val

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -531,7 +531,7 @@ class DeletedDeviceEntry:
             if config_entry.disabled_by:
                 if disabled_by is None:
                     disabled_by = DeviceEntryDisabler.CONFIG_ENTRY
-            elif disabled_by == DeviceEntryDisabler.CONFIG_ENTRY:
+            elif disabled_by is DeviceEntryDisabler.CONFIG_ENTRY:
                 disabled_by = None
         else:
             disabled_by = disabled_by if disabled_by is not UNDEFINED else None

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -1408,9 +1408,9 @@ class EntityRegistry(BaseRegistry):
                     if config_entry.disabled_by:
                         if disabled_by is None:
                             disabled_by = RegistryEntryDisabler.CONFIG_ENTRY
-                    elif disabled_by == RegistryEntryDisabler.CONFIG_ENTRY:
+                    elif disabled_by is RegistryEntryDisabler.CONFIG_ENTRY:
                         disabled_by = None
-                elif disabled_by == RegistryEntryDisabler.CONFIG_ENTRY:
+                elif disabled_by is RegistryEntryDisabler.CONFIG_ENTRY:
                     disabled_by = None
             # Restore entity_id if it's available
             if self._entity_id_available(deleted_entity.entity_id):
@@ -1800,9 +1800,9 @@ class EntityRegistry(BaseRegistry):
                 if config_entry.disabled_by:
                     if old.disabled_by is None:
                         new_values["disabled_by"] = RegistryEntryDisabler.CONFIG_ENTRY
-                elif old.disabled_by == RegistryEntryDisabler.CONFIG_ENTRY:
+                elif old.disabled_by is RegistryEntryDisabler.CONFIG_ENTRY:
                     new_values["disabled_by"] = None
-            elif old.disabled_by == RegistryEntryDisabler.CONFIG_ENTRY:
+            elif old.disabled_by is RegistryEntryDisabler.CONFIG_ENTRY:
                 new_values["disabled_by"] = None
 
         if new_entity_id is not UNDEFINED and new_entity_id != old.entity_id:
@@ -1957,7 +1957,7 @@ class EntityRegistry(BaseRegistry):
             raise ValueError("Only entities that haven't been loaded can be migrated")
 
         old = self.entities[entity_id]
-        if new_config_entry_id == UNDEFINED and old.config_entry_id is not None:
+        if new_config_entry_id is UNDEFINED and old.config_entry_id is not None:
             raise ValueError(
                 f"new_config_entry_id required because {entity_id} is already linked "
                 "to a config entry"

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -1453,7 +1453,7 @@ class IntentResponse:
 
         response_data: dict[str, Any] = {}
 
-        if self.response_type == IntentResponseType.ERROR:
+        if self.response_type is IntentResponseType.ERROR:
             assert self.error_code is not None, "error code is required"
             response_data["code"] = self.error_code.value
         else:

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1008,12 +1008,12 @@ class _ScriptRun:
             supports_response = self._hass.services.supports_response(
                 params[CONF_DOMAIN], params[CONF_SERVICE]
             )
-            if supports_response == SupportsResponse.ONLY and not return_response:
+            if supports_response is SupportsResponse.ONLY and not return_response:
                 raise vol.Invalid(
                     f"Script requires '{CONF_RESPONSE_VARIABLE}' for response data "
                     f"for service call {params[CONF_DOMAIN]}.{params[CONF_SERVICE]}"
                 )
-            if supports_response == SupportsResponse.NONE and return_response:
+            if supports_response is SupportsResponse.NONE and return_response:
                 raise vol.Invalid(
                     f"Script does not support '{CONF_RESPONSE_VARIABLE}' for service "
                     f"'{params[CONF_DOMAIN]}.{params[CONF_SERVICE]}'"

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1623,7 +1623,7 @@ class NumericThresholdSelector(Selector[NumericThresholdSelectorConfig]):
         """Validate the passed selection."""
         validators: list[Callable[[Any], Any]] = [_NUMERIC_THRESHOLD_VALUE_SCHEMA]
         mode = self.config["mode"]
-        if mode != NumericThresholdMode.CHANGED:
+        if mode is not NumericThresholdMode.CHANGED:
             validators.append(_validate_numeric_threshold_not_any)
         if allowed_units := self.config.get("unit_of_measurement"):
             validators.append(_validate_numeric_threshold_unit(allowed_units))

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -660,7 +660,7 @@ def async_set_service_schema(
 
     if (
         response := hass.services.supports_response(domain, service)
-    ) != SupportsResponse.NONE:
+    ) is not SupportsResponse.NONE:
         description["response"] = {
             "optional": response == SupportsResponse.OPTIONAL,
         }

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -738,7 +738,7 @@ class EntityNumericalStateTriggerBase(EntityTriggerBase):
         if (current_value := self._get_tracked_value(state)) is None:
             return False
 
-        if self._threshold_type == NumericThresholdType.ANY:
+        if self._threshold_type is NumericThresholdType.ANY:
             # If the threshold type is "any" we always trigger on valid state
             # changes
             return True

--- a/homeassistant/util/ssl.py
+++ b/homeassistant/util/ssl.py
@@ -90,7 +90,7 @@ def _client_context_no_verify(
         # This only works for OpenSSL >= 1.0.0
         sslcontext.options |= ssl.OP_NO_COMPRESSION
     sslcontext.set_default_verify_paths()
-    if ssl_cipher_list != SSLCipherList.PYTHON_DEFAULT:
+    if ssl_cipher_list is not SSLCipherList.PYTHON_DEFAULT:
         sslcontext.set_ciphers(SSL_CIPHER_LISTS[ssl_cipher_list])
     # Set ALPN protocols to prevent downstream libraries (e.g., httpx/httpcore)
     # from mutating the shared SSL context with different protocol settings.
@@ -114,7 +114,7 @@ def _create_client_context(
     sslcontext = ssl.create_default_context(
         purpose=ssl.Purpose.SERVER_AUTH, cafile=cafile
     )
-    if ssl_cipher_list != SSLCipherList.PYTHON_DEFAULT:
+    if ssl_cipher_list is not SSLCipherList.PYTHON_DEFAULT:
         sslcontext.set_ciphers(SSL_CIPHER_LISTS[ssl_cipher_list])
     # Set ALPN protocols to prevent downstream libraries (e.g., httpx/httpcore)
     # from mutating the shared SSL context with different protocol settings.

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -260,7 +260,7 @@ class _GlobalTaskContext:
         await self._wait_zone.wait()
         await asyncio.sleep(self._cool_down)  # Allow context switch
         self._on_wait_task = None
-        if self.state != _State.TIMEOUT:
+        if self.state is not _State.TIMEOUT:
             return
         self._cancel_task()
 

--- a/homeassistant/util/unit_system.py
+++ b/homeassistant/util/unit_system.py
@@ -262,7 +262,7 @@ METRIC_SYSTEM = UnitSystem(
         **{
             ("atmospheric_pressure", unit): UnitOfPressure.HPA
             for unit in UnitOfPressure
-            if unit != UnitOfPressure.HPA
+            if unit is not UnitOfPressure.HPA
         },
         # Convert non-metric area
         ("area", UnitOfArea.SQUARE_INCHES): UnitOfArea.SQUARE_CENTIMETERS,
@@ -342,7 +342,7 @@ US_CUSTOMARY_SYSTEM = UnitSystem(
         **{
             ("atmospheric_pressure", unit): UnitOfPressure.INHG
             for unit in UnitOfPressure
-            if unit != UnitOfPressure.INHG
+            if unit is not UnitOfPressure.INHG
         },
         # Convert non-USCS areas
         ("area", UnitOfArea.SQUARE_METERS): UnitOfArea.SQUARE_FEET,

--- a/tests/auth/mfa_modules/test_insecure_example.py
+++ b/tests/auth/mfa_modules/test_insecure_example.py
@@ -102,37 +102,37 @@ async def test_login(hass: HomeAssistant) -> None:
 
     provider = hass.auth.auth_providers[0]
     result = await hass.auth.login_flow.async_init((provider.type, provider.id))
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"username": "incorrect-user", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"username": "test-user", "password": "incorrect-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"username": "test-user", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "mfa"
     assert result["data_schema"].schema.get("pin") is str
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"pin": "invalid-code"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_code"
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"pin": "123456"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"].id == "mock-id"
 
 
@@ -149,9 +149,9 @@ async def test_setup_flow(hass: HomeAssistant) -> None:
     flow = await auth_module.async_setup_flow("new-user")
 
     result = await flow.async_step_init()
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     result = await flow.async_step_init({"pin": "abcdefg"})
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert auth_module._data[1]["user_id"] == "new-user"
     assert auth_module._data[1]["pin"] == "abcdefg"

--- a/tests/auth/mfa_modules/test_notify.py
+++ b/tests/auth/mfa_modules/test_notify.py
@@ -137,25 +137,25 @@ async def test_login_flow_validates_mfa(hass: HomeAssistant) -> None:
     provider = hass.auth.auth_providers[0]
 
     result = await hass.auth.login_flow.async_init((provider.type, provider.id))
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"username": "incorrect-user", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"username": "test-user", "password": "incorrect-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     with patch("pyotp.HOTP.at", return_value=MOCK_CODE):
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"username": "test-user", "password": "test-pass"}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "mfa"
         assert result["data_schema"].schema.get("code") is str
 
@@ -173,7 +173,7 @@ async def test_login_flow_validates_mfa(hass: HomeAssistant) -> None:
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"code": "invalid-code"}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "mfa"
         assert result["errors"]["base"] == "invalid_code"
 
@@ -191,7 +191,7 @@ async def test_login_flow_validates_mfa(hass: HomeAssistant) -> None:
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"code": "invalid-code"}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "mfa"
         assert result["errors"]["base"] == "invalid_code"
 
@@ -199,7 +199,7 @@ async def test_login_flow_validates_mfa(hass: HomeAssistant) -> None:
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"code": "invalid-code"}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["type"] is data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "too_many_retry"
 
     # wait service call finished
@@ -207,13 +207,13 @@ async def test_login_flow_validates_mfa(hass: HomeAssistant) -> None:
 
     # restart login
     result = await hass.auth.login_flow.async_init((provider.type, provider.id))
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     with patch("pyotp.HOTP.at", return_value=MOCK_CODE):
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"username": "test-user", "password": "test-pass"}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "mfa"
         assert result["data_schema"].schema.get("code") is str
 
@@ -231,7 +231,7 @@ async def test_login_flow_validates_mfa(hass: HomeAssistant) -> None:
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"code": MOCK_CODE}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["data"].id == "mock-id"
 
 
@@ -246,7 +246,7 @@ async def test_setup_user_notify_service(hass: HomeAssistant) -> None:
 
     flow = await notify_auth_module.async_setup_flow("test-user")
     step = await flow.async_step_init()
-    assert step["type"] == data_entry_flow.FlowResultType.FORM
+    assert step["type"] is data_entry_flow.FlowResultType.FORM
     assert step["step_id"] == "init"
     schema = step["data_schema"]
     schema({"notify_service": "test2"})
@@ -277,7 +277,7 @@ async def test_setup_user_notify_service(hass: HomeAssistant) -> None:
 
     with patch("pyotp.HOTP.at", return_value=MOCK_CODE):
         step = await flow.async_step_init({"notify_service": "test1"})
-        assert step["type"] == data_entry_flow.FlowResultType.FORM
+        assert step["type"] is data_entry_flow.FlowResultType.FORM
         assert step["step_id"] == "setup"
 
     # wait service call finished
@@ -357,7 +357,7 @@ async def test_setup_user_no_notify_service(hass: HomeAssistant) -> None:
 
     flow = await notify_auth_module.async_setup_flow("test-user")
     step = await flow.async_step_init()
-    assert step["type"] == data_entry_flow.FlowResultType.ABORT
+    assert step["type"] is data_entry_flow.FlowResultType.ABORT
     assert step["reason"] == "no_available_service"
 
 
@@ -394,13 +394,13 @@ async def test_not_raise_exception_when_service_not_exist(hass: HomeAssistant) -
     provider = hass.auth.auth_providers[0]
 
     result = await hass.auth.login_flow.async_init((provider.type, provider.id))
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     with patch("pyotp.HOTP.at", return_value=MOCK_CODE):
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"username": "test-user", "password": "test-pass"}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["type"] is data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "unknown_error"
 
     # wait service call finished

--- a/tests/auth/mfa_modules/test_totp.py
+++ b/tests/auth/mfa_modules/test_totp.py
@@ -95,24 +95,24 @@ async def test_login_flow_validates_mfa(hass: HomeAssistant) -> None:
     provider = hass.auth.auth_providers[0]
 
     result = await hass.auth.login_flow.async_init((provider.type, provider.id))
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"username": "incorrect-user", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"username": "test-user", "password": "incorrect-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"username": "test-user", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "mfa"
     assert result["data_schema"].schema.get("code") is str
 
@@ -120,7 +120,7 @@ async def test_login_flow_validates_mfa(hass: HomeAssistant) -> None:
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"code": "invalid-code"}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "mfa"
         assert result["errors"]["base"] == "invalid_code"
 
@@ -128,7 +128,7 @@ async def test_login_flow_validates_mfa(hass: HomeAssistant) -> None:
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"code": MOCK_CODE}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["data"].id == "mock-id"
 
 

--- a/tests/auth/providers/test_command_line.py
+++ b/tests/auth/providers/test_command_line.py
@@ -139,18 +139,18 @@ async def test_login_flow_validates(
     """Test login flow."""
     flow = await provider.async_login_flow({})
     result = await flow.async_step_init()
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     result = await flow.async_step_init(
         {"username": "bad-user", "password": "bad-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await flow.async_step_init(
         {"username": "good-user", "password": "good-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"]["username"] == "good-user"
 
 
@@ -160,5 +160,5 @@ async def test_strip_username(provider: command_line.CommandLineAuthProvider) ->
     result = await flow.async_step_init(
         {"username": "\t\ngood-user ", "password": "good-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"]["username"] == "good-user"

--- a/tests/auth/providers/test_homeassistant.py
+++ b/tests/auth/providers/test_homeassistant.py
@@ -161,24 +161,24 @@ async def test_login_flow_validates(data: hass_auth.Data, hass: HomeAssistant) -
     )
     flow = await provider.async_login_flow({})
     result = await flow.async_step_init()
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     result = await flow.async_step_init(
         {"username": "incorrect-user", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await flow.async_step_init(
         {"username": "TEST-user ", "password": "incorrect-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await flow.async_step_init(
         {"username": "test-USER", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"]["username"] == "test-USER"
 
 
@@ -260,24 +260,24 @@ async def test_legacy_login_flow_validates(
     )
     flow = await provider.async_login_flow({})
     result = await flow.async_step_init()
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     result = await flow.async_step_init(
         {"username": "incorrect-user", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await flow.async_step_init(
         {"username": "test-user", "password": "incorrect-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await flow.async_step_init(
         {"username": "test-user", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"]["username"] == "test-user"
 
 

--- a/tests/auth/test_init.py
+++ b/tests/auth/test_init.py
@@ -172,12 +172,12 @@ async def test_create_new_user(hass: HomeAssistant) -> None:
     )
 
     step = await manager.login_flow.async_init(("insecure_example", None))
-    assert step["type"] == data_entry_flow.FlowResultType.FORM
+    assert step["type"] is data_entry_flow.FlowResultType.FORM
 
     step = await manager.login_flow.async_configure(
         step["flow_id"], {"username": "test-user", "password": "test-pass"}
     )
-    assert step["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert step["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     credential = step["result"]
     assert credential is not None
 
@@ -241,12 +241,12 @@ async def test_login_as_existing_user(mock_hass) -> None:
     )
 
     step = await manager.login_flow.async_init(("insecure_example", None))
-    assert step["type"] == data_entry_flow.FlowResultType.FORM
+    assert step["type"] is data_entry_flow.FlowResultType.FORM
 
     step = await manager.login_flow.async_configure(
         step["flow_id"], {"username": "test-user", "password": "test-pass"}
     )
-    assert step["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert step["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
     credential = step["result"]
     user = await manager.async_get_user_by_credentials(credential)
@@ -840,14 +840,14 @@ async def test_login_with_auth_module(mock_hass) -> None:
     )
 
     step = await manager.login_flow.async_init(("insecure_example", None))
-    assert step["type"] == data_entry_flow.FlowResultType.FORM
+    assert step["type"] is data_entry_flow.FlowResultType.FORM
 
     step = await manager.login_flow.async_configure(
         step["flow_id"], {"username": "test-user", "password": "test-pass"}
     )
 
     # After auth_provider validated, request auth module input form
-    assert step["type"] == data_entry_flow.FlowResultType.FORM
+    assert step["type"] is data_entry_flow.FlowResultType.FORM
     assert step["step_id"] == "mfa"
 
     step = await manager.login_flow.async_configure(
@@ -855,7 +855,7 @@ async def test_login_with_auth_module(mock_hass) -> None:
     )
 
     # Invalid code error
-    assert step["type"] == data_entry_flow.FlowResultType.FORM
+    assert step["type"] is data_entry_flow.FlowResultType.FORM
     assert step["step_id"] == "mfa"
     assert step["errors"] == {"base": "invalid_code"}
 
@@ -864,7 +864,7 @@ async def test_login_with_auth_module(mock_hass) -> None:
     )
 
     # Finally passed, get credential
-    assert step["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert step["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert step["result"]
     assert step["result"].id == "mock-id"
 
@@ -915,21 +915,21 @@ async def test_login_with_multi_auth_module(mock_hass) -> None:
     )
 
     step = await manager.login_flow.async_init(("insecure_example", None))
-    assert step["type"] == data_entry_flow.FlowResultType.FORM
+    assert step["type"] is data_entry_flow.FlowResultType.FORM
 
     step = await manager.login_flow.async_configure(
         step["flow_id"], {"username": "test-user", "password": "test-pass"}
     )
 
     # After auth_provider validated, request select auth module
-    assert step["type"] == data_entry_flow.FlowResultType.FORM
+    assert step["type"] is data_entry_flow.FlowResultType.FORM
     assert step["step_id"] == "select_mfa_module"
 
     step = await manager.login_flow.async_configure(
         step["flow_id"], {"multi_factor_auth_module": "module2"}
     )
 
-    assert step["type"] == data_entry_flow.FlowResultType.FORM
+    assert step["type"] is data_entry_flow.FlowResultType.FORM
     assert step["step_id"] == "mfa"
 
     step = await manager.login_flow.async_configure(
@@ -937,7 +937,7 @@ async def test_login_with_multi_auth_module(mock_hass) -> None:
     )
 
     # Finally passed, get credential
-    assert step["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert step["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert step["result"]
     assert step["result"].id == "mock-id"
 
@@ -983,13 +983,13 @@ async def test_auth_module_expired_session(mock_hass) -> None:
     )
 
     step = await manager.login_flow.async_init(("insecure_example", None))
-    assert step["type"] == data_entry_flow.FlowResultType.FORM
+    assert step["type"] is data_entry_flow.FlowResultType.FORM
 
     step = await manager.login_flow.async_configure(
         step["flow_id"], {"username": "test-user", "password": "test-pass"}
     )
 
-    assert step["type"] == data_entry_flow.FlowResultType.FORM
+    assert step["type"] is data_entry_flow.FlowResultType.FORM
     assert step["step_id"] == "mfa"
 
     with freeze_time(dt_util.utcnow() + MFA_SESSION_EXPIRATION):
@@ -997,7 +997,7 @@ async def test_auth_module_expired_session(mock_hass) -> None:
             step["flow_id"], {"pin": "test-pin"}
         )
         # login flow abort due session timeout
-        assert step["type"] == data_entry_flow.FlowResultType.ABORT
+        assert step["type"] is data_entry_flow.FlowResultType.ABORT
         assert step["reason"] == "login_expired"
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -2063,7 +2063,7 @@ async def assert_platform_setup_creates_issue(
     assert issue.issue_domain == integration_domain
     assert issue.learn_more_url is not None
     assert issue.translation_key == "platform_config_not_supported"
-    assert issue.severity == ir.IssueSeverity.ERROR
+    assert issue.severity is ir.IssueSeverity.ERROR
     assert issue.translation_placeholders == {
         "platform_domain": platform_domain,
         "integration_domain": integration_domain,

--- a/tests/components/airos/test_config_flow.py
+++ b/tests/components/airos/test_config_flow.py
@@ -231,7 +231,7 @@ async def test_reauth_flow_scenario(
             data=mock_config_entry.data,
         )
 
-    assert flow["type"] == FlowResultType.FORM
+    assert flow["type"] is FlowResultType.FORM
     assert flow["step_id"] == REAUTH_STEP
 
     fw_major = int(ap_status_fixture.host.fwversion.lstrip("v").split(".", 1)[0])
@@ -305,7 +305,7 @@ async def test_reauth_flow_scenarios(
             data=mock_config_entry.data,
         )
 
-    assert flow["type"] == FlowResultType.FORM
+    assert flow["type"] is FlowResultType.FORM
     assert flow["step_id"] == REAUTH_STEP
 
     with patch(
@@ -337,7 +337,7 @@ async def test_reauth_flow_scenarios(
             user_input={CONF_PASSWORD: NEW_PASSWORD},
         )
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
 
     updated_entry = hass.config_entries.async_get_entry(mock_config_entry.entry_id)

--- a/tests/components/airos/test_init.py
+++ b/tests/components/airos/test_init.py
@@ -284,7 +284,7 @@ async def test_setup_entry_failure(
 
     result = await hass.config_entries.async_setup(mock_config_entry.entry_id)
     assert result is False
-    assert mock_config_entry.state == state
+    assert mock_config_entry.state is state
 
 
 async def test_fetch_airos_data_auth_error(mock_airos_client: MagicMock) -> None:

--- a/tests/components/alexa_devices/test_init.py
+++ b/tests/components/alexa_devices/test_init.py
@@ -138,4 +138,4 @@ async def test_migrate_future_version_returns_false(
 
     await setup_integration(hass, config_entry)
 
-    assert config_entry.state == ConfigEntryState.MIGRATION_ERROR
+    assert config_entry.state is ConfigEntryState.MIGRATION_ERROR

--- a/tests/components/anthropic/test_conversation.py
+++ b/tests/components/anthropic/test_conversation.py
@@ -132,7 +132,7 @@ async def test_device(
     assert device.manufacturer == "Anthropic"
     assert device.model == "Claude Haiku 4.5"
     assert device.model_id == "claude-haiku-4-5-20251001"
-    assert device.entry_type == dr.DeviceEntryType.SERVICE
+    assert device.entry_type is dr.DeviceEntryType.SERVICE
 
 
 async def test_translation_key(
@@ -164,7 +164,7 @@ async def test_error_handling(
         hass, "hello", None, Context(), agent_id="conversation.claude_conversation"
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == "unknown", result
 
 
@@ -189,7 +189,7 @@ async def test_template_error(
         hass, "hello", None, Context(), agent_id="conversation.claude_conversation"
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == "unknown", result
 
 
@@ -230,7 +230,7 @@ async def test_template_variables(
             hass, "hello", None, context, agent_id="conversation.claude_conversation"
         )
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert (
         result.response.speech["plain"]["speech"]
         == "Okay, let me take care of that for you."
@@ -382,7 +382,7 @@ async def test_function_call(
     system_text = " ".join(block["text"] for block in system if "text" in block)
     assert "You are a voice assistant for Home Assistant." in system_text
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert (
         result.response.speech["plain"]["speech"]
         == "I have successfully called the function"
@@ -457,7 +457,7 @@ async def test_function_exception(
         agent_id=agent_id,
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert (
         result.response.speech["plain"]["speech"]
         == "There was an error calling the function"
@@ -638,7 +638,7 @@ async def test_refusal(
         agent_id="conversation.claude_conversation",
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == "unknown"
     assert (
         result.response.speech["plain"]["speech"]
@@ -670,7 +670,7 @@ async def test_stream_wrong_type(
         agent_id="conversation.claude_conversation",
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == "unknown"
     assert result.response.speech["plain"]["speech"] == "Expected a stream of messages"
 
@@ -700,7 +700,7 @@ async def test_double_system_messages(
             agent_id="conversation.claude_conversation",
         )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == "unknown"
     assert (
         result.response.speech["plain"]["speech"]

--- a/tests/components/anthropic/test_coordinator.py
+++ b/tests/components/anthropic/test_coordinator.py
@@ -42,7 +42,7 @@ async def test_auth_error_handling(
         hass, "hello", None, Context(), agent_id="conversation.claude_conversation"
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == "unknown", result
 
     await hass.async_block_till_done()
@@ -86,7 +86,7 @@ async def test_connection_error_handling(
         hass, "hello", None, Context(), agent_id="conversation.claude_conversation"
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == "unknown", result
 
     # Check new state

--- a/tests/components/assist_pipeline/test_init.py
+++ b/tests/components/assist_pipeline/test_init.py
@@ -288,10 +288,10 @@ async def test_pipeline_from_audio_stream_no_stt(
     )
 
     assert len(events) == 3
-    assert events[0].type == assist_pipeline.PipelineEventType.RUN_START
-    assert events[1].type == assist_pipeline.PipelineEventType.ERROR
+    assert events[0].type is assist_pipeline.PipelineEventType.RUN_START
+    assert events[1].type is assist_pipeline.PipelineEventType.ERROR
     assert events[1].data["code"] == "validation-error"
-    assert events[2].type == assist_pipeline.PipelineEventType.RUN_END
+    assert events[2].type is assist_pipeline.PipelineEventType.RUN_END
 
 
 async def test_pipeline_from_audio_stream_unknown_pipeline(
@@ -367,13 +367,13 @@ async def test_pipeline_from_audio_stream_validation_pipeline_error(
     )
 
     assert len(events) == 3
-    assert events[0].type == assist_pipeline.PipelineEventType.RUN_START
-    assert events[1].type == assist_pipeline.PipelineEventType.ERROR
+    assert events[0].type is assist_pipeline.PipelineEventType.RUN_START
+    assert events[1].type is assist_pipeline.PipelineEventType.ERROR
     assert events[1].data == {
         "code": "intent-not-supported",
         "message": "Intent recognition engine conversation.non_existing is not found",
     }
-    assert events[2].type == assist_pipeline.PipelineEventType.RUN_END
+    assert events[2].type is assist_pipeline.PipelineEventType.RUN_END
 
 
 async def test_pipeline_from_audio_stream_wake_word(
@@ -737,5 +737,5 @@ async def test_pipeline_from_audio_stream_with_cloud_auth_fail(
 
     assert process_events(events) == snapshot
     assert len(events) == 4  # run start, stt start, error, run end
-    assert events[2].type == assist_pipeline.PipelineEventType.ERROR
+    assert events[2].type is assist_pipeline.PipelineEventType.ERROR
     assert events[2].data["code"] == "cloud-auth-failed"

--- a/tests/components/assist_pipeline/test_pipeline.py
+++ b/tests/components/assist_pipeline/test_pipeline.py
@@ -896,7 +896,7 @@ async def test_tts_audio_output(
         await pipeline_input.execute()
 
         for event in events:
-            if event.type == assist_pipeline.PipelineEventType.TTS_END:
+            if event.type is assist_pipeline.PipelineEventType.TTS_END:
                 # We must fetch the media URL to trigger the TTS
                 assert event.data
                 await client.get(event.data["tts_output"]["url"])
@@ -960,7 +960,7 @@ async def test_tts_wav_preferred_format(
         await pipeline_input.execute()
 
         for event in events:
-            if event.type == assist_pipeline.PipelineEventType.TTS_END:
+            if event.type is assist_pipeline.PipelineEventType.TTS_END:
                 # We must fetch the media URL to trigger the TTS
                 assert event.data
                 await client.get(event.data["tts_output"]["url"])
@@ -1032,7 +1032,7 @@ async def test_tts_dict_preferred_format(
         await pipeline_input.execute()
 
         for event in events:
-            if event.type == assist_pipeline.PipelineEventType.TTS_END:
+            if event.type is assist_pipeline.PipelineEventType.TTS_END:
                 # We must fetch the media URL to trigger the TTS
                 assert event.data
                 await client.get(event.data["tts_output"]["url"])
@@ -1116,7 +1116,7 @@ async def test_sentence_trigger_overrides_conversation_agent(
             (
                 e
                 for e in events
-                if e.type == assist_pipeline.PipelineEventType.INTENT_END
+                if e.type is assist_pipeline.PipelineEventType.INTENT_END
             ),
             None,
         )
@@ -1199,7 +1199,7 @@ async def test_prefer_local_intents(
             (
                 e
                 for e in events
-                if e.type == assist_pipeline.PipelineEventType.INTENT_END
+                if e.type is assist_pipeline.PipelineEventType.INTENT_END
             ),
             None,
         )
@@ -1420,7 +1420,7 @@ async def test_stt_language_used_instead_of_conversation_language(
         assert process_events(events) == snapshot
         intent_start: assist_pipeline.PipelineEvent | None = None
         for event in events:
-            if event.type == assist_pipeline.PipelineEventType.INTENT_START:
+            if event.type is assist_pipeline.PipelineEventType.INTENT_START:
                 intent_start = event
                 break
 
@@ -1496,7 +1496,7 @@ async def test_tts_language_used_instead_of_conversation_language(
         assert process_events(events) == snapshot
         intent_start: assist_pipeline.PipelineEvent | None = None
         for event in events:
-            if event.type == assist_pipeline.PipelineEventType.INTENT_START:
+            if event.type is assist_pipeline.PipelineEventType.INTENT_START:
                 intent_start = event
                 break
 
@@ -1572,7 +1572,7 @@ async def test_pipeline_language_used_instead_of_conversation_language(
         assert process_events(events) == snapshot
         intent_start: assist_pipeline.PipelineEvent | None = None
         for event in events:
-            if event.type == assist_pipeline.PipelineEventType.INTENT_START:
+            if event.type is assist_pipeline.PipelineEventType.INTENT_START:
                 intent_start = event
                 break
 
@@ -2026,7 +2026,7 @@ async def test_acknowledge(
 
     has_acknowledge_override: bool | None = None
     for event in events:
-        if event.type == PipelineEventType.TTS_START:
+        if event.type is PipelineEventType.TTS_START:
             assert event.data
             has_acknowledge_override = event.data["acknowledge_override"]
             break

--- a/tests/components/axis/test_hub.py
+++ b/tests/components/axis/test_hub.py
@@ -190,7 +190,7 @@ async def test_device_trigger_reauth_flow(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
         mock_flow_init.assert_called_once()
-    assert config_entry.state == ConfigEntryState.SETUP_ERROR
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_shutdown(config_entry_data: MappingProxyType[str, Any]) -> None:
@@ -235,4 +235,4 @@ async def test_get_axis_api_errors(
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
-    assert config_entry.state == state
+    assert config_entry.state is state

--- a/tests/components/azure_data_explorer/test_config_flow.py
+++ b/tests/components/azure_data_explorer/test_config_flow.py
@@ -26,7 +26,7 @@ async def test_config_flow(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=None
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -34,7 +34,7 @@ async def test_config_flow(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> 
         BASE_CONFIG.copy(),
     )
 
-    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result2["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert (
         result2["title"]
         == "cluster.region.kusto.windows.net / test-database-name (test-table-name)"
@@ -61,7 +61,7 @@ async def test_config_flow_errors(
         context={"source": config_entries.SOURCE_USER},
         data=None,
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     # Test error handling with error
@@ -71,7 +71,7 @@ async def test_config_flow_errors(
         result["flow_id"],
         BASE_CONFIG.copy(),
     )
-    assert result2["type"] == data_entry_flow.FlowResultType.FORM
+    assert result2["type"] is data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": expected}
 
     schema = result2["data_schema"]
@@ -112,4 +112,4 @@ async def test_config_flow_errors(
 
     await hass.async_block_till_done()
 
-    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result3["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY

--- a/tests/components/backup/test_manager.py
+++ b/tests/components/backup/test_manager.py
@@ -3781,7 +3781,7 @@ async def test_manager_blocked_until_home_assistant_started(
     await setup_backup_integration(hass)
     manager = hass.data[DATA_MANAGER]
 
-    assert manager.state == BackupManagerState.BLOCKED
+    assert manager.state is BackupManagerState.BLOCKED
     assert manager.last_action_event is None
 
     # Fired when Home Assistant changes to starting state

--- a/tests/components/bayesian/test_config_flow.py
+++ b/tests/components/bayesian/test_config_flow.py
@@ -70,9 +70,9 @@ async def test_config_flow_step_user(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        assert result1["type"] == FlowResultType.CREATE_ENTRY
+        assert result1["type"] is FlowResultType.CREATE_ENTRY
         assert result1["result"].title == "Office occupied"
-        assert result1["next_flow"][0] == FlowType.CONFIG_SUBENTRIES_FLOW
+        assert result1["next_flow"][0] is FlowType.CONFIG_SUBENTRIES_FLOW
 
 
 async def test_subentry_flow(hass: HomeAssistant) -> None:
@@ -260,7 +260,7 @@ async def test_single_state_observation(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["type"] is FlowResultType.CREATE_ENTRY
         entry_id = result["result"].entry_id
         sub_flow_id = result["next_flow"][1]
 
@@ -287,7 +287,7 @@ async def test_single_state_observation(hass: HomeAssistant) -> None:
             },
         )
 
-        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["type"] is FlowResultType.CREATE_ENTRY
         await hass.async_block_till_done()
 
         config_entry = hass.config_entries.async_get_entry(entry_id)
@@ -337,7 +337,7 @@ async def test_single_numeric_state_observation(hass: HomeAssistant) -> None:
                 CONF_PRIOR: 20,
             },
         )
-        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["type"] is FlowResultType.CREATE_ENTRY
         config_entry = result["result"]
         sub_flow_id = result["next_flow"][1]
         await hass.async_block_till_done()
@@ -408,7 +408,7 @@ async def test_multi_numeric_state_observation(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["type"] is FlowResultType.CREATE_ENTRY
         config_entry = result["result"]
         sub_flow_id = result["next_flow"][1]
 
@@ -546,7 +546,7 @@ async def test_single_template_observation(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["type"] is FlowResultType.CREATE_ENTRY
         config_entry = result["result"]
         sub_flow_id = result["next_flow"][1]
 
@@ -1086,7 +1086,7 @@ async def test_invalid_configs(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
         assert result.get("errors") is None
 
-        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["type"] is FlowResultType.CREATE_ENTRY
         config_entry = result["result"]
         sub_flow_id = result["next_flow"][1]
 

--- a/tests/components/bluetooth/test_manager.py
+++ b/tests/components/bluetooth/test_manager.py
@@ -1790,7 +1790,7 @@ async def test_repair_issue_created_for_degraded_scanner_in_docker(
         registry = ir.async_get(hass)
         issue = registry.async_get_issue(bluetooth.DOMAIN, issue_id)
         assert issue is not None
-        assert issue.severity == ir.IssueSeverity.WARNING
+        assert issue.severity is ir.IssueSeverity.WARNING
         assert not issue.is_fixable
         assert issue.translation_key == "bluetooth_adapter_missing_permissions"
 
@@ -1946,7 +1946,7 @@ async def test_repair_issue_created_for_passive_mode_fallback(
     registry = ir.async_get(hass)
     issue = registry.async_get_issue(bluetooth.DOMAIN, issue_id)
     assert issue is not None
-    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.severity is ir.IssueSeverity.WARNING
     # Should default to USB translation key when adapter type is unknown
     assert issue.translation_key == "bluetooth_adapter_passive_mode_usb"
     assert not issue.is_fixable
@@ -1997,7 +1997,7 @@ async def test_repair_issue_created_for_passive_mode_fallback_uart(
         registry = ir.async_get(hass)
         issue = registry.async_get_issue(bluetooth.DOMAIN, issue_id)
         assert issue is not None
-        assert issue.severity == ir.IssueSeverity.WARNING
+        assert issue.severity is ir.IssueSeverity.WARNING
         assert issue.translation_key == "bluetooth_adapter_passive_mode_uart"
         assert not issue.is_fixable
 

--- a/tests/components/bring/test_init.py
+++ b/tests/components/bring/test_init.py
@@ -72,7 +72,7 @@ async def test_init_failure(
     """Test an initialization error on integration load."""
     mock_bring_client.login.side_effect = exception
     await setup_integration(hass, bring_config_entry)
-    assert bring_config_entry.state == status
+    assert bring_config_entry.state is status
 
     assert (
         any(

--- a/tests/components/bsblan/test_climate.py
+++ b/tests/components/bsblan/test_climate.py
@@ -163,12 +163,12 @@ async def test_hvac_action_uses_library_mapping(
     mock_action = MagicMock()
     mock_action.value = HeatingCircuitStatus.HEATING_COMFORT
     result = await _async_set_hvac_action(hass, mock_bsblan, freezer, mock_action)
-    assert result == HVACAction.HEATING
+    assert result is HVACAction.HEATING
 
     # Test unknown status code defaults to IDLE
     mock_action.value = 1  # Unknown status code
     result = await _async_set_hvac_action(hass, mock_bsblan, freezer, mock_action)
-    assert result == HVACAction.IDLE
+    assert result is HVACAction.IDLE
 
 
 async def test_climate_without_current_temperature_sensor(

--- a/tests/components/camera/test_prefs.py
+++ b/tests/components/camera/test_prefs.py
@@ -30,7 +30,7 @@ async def test_get_dynamic_camera_stream_settings_success(hass: HomeAssistant) -
 
     # Test with default settings
     settings = await get_dynamic_camera_stream_settings(hass, "camera.test")
-    assert settings.orientation == Orientation.NO_TRANSFORM
+    assert settings.orientation is Orientation.NO_TRANSFORM
     assert settings.preload_stream is False
 
 
@@ -52,7 +52,7 @@ async def test_get_dynamic_camera_stream_settings_with_custom_orientation(
     prefs._dynamic_stream_settings_by_entity_id["camera.test"] = test_settings
 
     settings = await get_dynamic_camera_stream_settings(hass, "camera.test")
-    assert settings.orientation == Orientation.ROTATE_LEFT
+    assert settings.orientation is Orientation.ROTATE_LEFT
     assert settings.preload_stream is False
 
 
@@ -72,5 +72,5 @@ async def test_get_dynamic_camera_stream_settings_with_preload_stream(
     prefs._dynamic_stream_settings_by_entity_id["camera.test"] = test_settings
 
     settings = await get_dynamic_camera_stream_settings(hass, "camera.test")
-    assert settings.orientation == Orientation.NO_TRANSFORM
+    assert settings.orientation is Orientation.NO_TRANSFORM
     assert settings.preload_stream is True

--- a/tests/components/casper_glow/test_init.py
+++ b/tests/components/casper_glow/test_init.py
@@ -56,7 +56,7 @@ async def test_async_unload_entry(
     result = await hass.config_entries.async_unload(config_entry.entry_id)
 
     assert result is True
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_device_info(

--- a/tests/components/climate/test_condition.py
+++ b/tests/components/climate/test_condition.py
@@ -132,7 +132,7 @@ async def test_climate_condition_options_validation(
                 condition="climate.is_hvac_mode",
                 condition_options={"hvac_mode": [mode]},
                 target_states=[mode],
-                other_states=[m for m in HVACMode if m != mode],
+                other_states=[m for m in HVACMode if m is not mode],
             )
         ),
         *parametrize_condition_states_any(
@@ -200,7 +200,7 @@ async def test_climate_state_condition_behavior_any(
                 condition="climate.is_hvac_mode",
                 condition_options={"hvac_mode": [mode]},
                 target_states=[mode],
-                other_states=[m for m in HVACMode if m != mode],
+                other_states=[m for m in HVACMode if m is not mode],
             )
         ),
         *parametrize_condition_states_all(

--- a/tests/components/climate/test_init.py
+++ b/tests/components/climate/test_init.py
@@ -449,7 +449,7 @@ async def test_turn_on_off_toggle(hass: HomeAssistant) -> None:
     climate.hass = hass
 
     await climate.async_turn_on()
-    assert climate.hvac_mode == HVACMode.HEAT
+    assert climate.hvac_mode is HVACMode.HEAT
 
     await climate.async_turn_off()
     assert climate.hvac_mode == HVACMode.OFF

--- a/tests/components/climate/test_intent.py
+++ b/tests/components/climate/test_intent.py
@@ -201,7 +201,7 @@ async def test_set_temperature(
             {"temperature": {"value": 20}},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.MULTIPLE_TARGETS
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.MULTIPLE_TARGETS
 
     # Select by area explicitly (climate_2)
     response = await intent.async_handle(
@@ -211,7 +211,7 @@ async def test_set_temperature(
         {"area": {"value": bedroom_area.name}, "temperature": {"value": 20.1}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == climate_2.entity_id
     state = hass.states.get(climate_2.entity_id)
@@ -228,7 +228,7 @@ async def test_set_temperature(
         },
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.matched_states
     assert response.matched_states[0].entity_id == climate_2.entity_id
     state = hass.states.get(climate_2.entity_id)
@@ -242,7 +242,7 @@ async def test_set_temperature(
         {"floor": {"value": second_floor.name}, "temperature": {"value": 20.3}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.matched_states
     assert response.matched_states[0].entity_id == climate_2.entity_id
     state = hass.states.get(climate_2.entity_id)
@@ -259,7 +259,7 @@ async def test_set_temperature(
         },
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.matched_states
     assert response.matched_states[0].entity_id == climate_2.entity_id
     state = hass.states.get(climate_2.entity_id)
@@ -273,7 +273,7 @@ async def test_set_temperature(
         {"name": {"value": "Climate 2"}, "temperature": {"value": 20.5}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == climate_2.entity_id
     state = hass.states.get(climate_2.entity_id)
@@ -291,7 +291,7 @@ async def test_set_temperature(
 
     # Exception should contain details of what we tried to match
     assert isinstance(error.value, intent.MatchFailedError)
-    assert error.value.result.no_match_reason == intent.MatchFailedReason.AREA
+    assert error.value.result.no_match_reason is intent.MatchFailedReason.AREA
     constraints = error.value.constraints
     assert constraints.name is None
     assert constraints.area_name == office_area.name
@@ -310,7 +310,7 @@ async def test_set_temperature(
             },
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.MULTIPLE_TARGETS
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.MULTIPLE_TARGETS
 
 
 async def test_set_temperature_no_entities(
@@ -330,7 +330,7 @@ async def test_set_temperature_no_entities(
             {"temperature": {"value": 20}},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.DOMAIN
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.DOMAIN
 
 
 async def test_set_temperature_not_supported(hass: HomeAssistant) -> None:
@@ -357,4 +357,4 @@ async def test_set_temperature_not_supported(hass: HomeAssistant) -> None:
 
     # Exception should contain details of what we tried to match
     assert isinstance(error.value, intent.MatchFailedError)
-    assert error.value.result.no_match_reason == intent.MatchFailedReason.FEATURE
+    assert error.value.result.no_match_reason is intent.MatchFailedReason.FEATURE

--- a/tests/components/cloud/test_tts.py
+++ b/tests/components/cloud/test_tts.py
@@ -178,7 +178,7 @@ async def test_deprecated_platform_config(
     assert issue.breaks_in_ha_version == "2024.9.0"
     assert issue.is_fixable is False
     assert issue.is_persistent is False
-    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.severity is ir.IssueSeverity.WARNING
     assert issue.translation_key == "deprecated_tts_platform_config"
 
 
@@ -609,7 +609,7 @@ async def test_deprecated_voice(
     assert issue.breaks_in_ha_version == "2024.8.0"
     assert issue.is_fixable is True
     assert issue.is_persistent is True
-    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.severity is ir.IssueSeverity.WARNING
     assert issue.translation_key == "deprecated_voice"
     assert issue.translation_placeholders == {
         "deprecated_voice": deprecated_voice,
@@ -778,7 +778,7 @@ async def test_deprecated_gender(
     assert issue.breaks_in_ha_version == "2024.10.0"
     assert issue.is_fixable is True
     assert issue.is_persistent is True
-    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.severity is ir.IssueSeverity.WARNING
     assert issue.translation_key == "deprecated_gender"
     assert issue.translation_placeholders == {
         "integration_name": "Home Assistant Cloud",

--- a/tests/components/comelit/test_init.py
+++ b/tests/components/comelit/test_init.py
@@ -114,4 +114,4 @@ async def test_migrate_future_version_returns_false(
 
     await setup_integration(hass, config_entry)
 
-    assert config_entry.state == ConfigEntryState.MIGRATION_ERROR
+    assert config_entry.state is ConfigEntryState.MIGRATION_ERROR

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -785,7 +785,7 @@ async def test_get_progress_index(
         )
 
     for form in (form_hassio, form_user, form_reconfigure):
-        assert form["type"] == data_entry_flow.FlowResultType.FORM
+        assert form["type"] is data_entry_flow.FlowResultType.FORM
         assert form["step_id"] == "account"
 
     await ws_client.send_json({"id": 5, "type": "config_entries/flow/progress"})
@@ -961,9 +961,9 @@ async def test_get_progress_subscribe(
                 "test", context=context
             )
 
-    assert forms["bluetooth"]["type"] == data_entry_flow.FlowResultType.ABORT
+    assert forms["bluetooth"]["type"] is data_entry_flow.FlowResultType.ABORT
     for key in ("hassio", "user", "reauth", "reconfigure"):
-        assert forms[key]["type"] == data_entry_flow.FlowResultType.FORM
+        assert forms[key]["type"] is data_entry_flow.FlowResultType.FORM
         assert forms[key]["step_id"] == "account"
 
     for key in ("hassio", "user", "reauth", "reconfigure"):
@@ -1100,9 +1100,9 @@ async def test_get_progress_subscribe_in_progress(
                 "test", context=context
             )
 
-    assert forms["bluetooth"]["type"] == data_entry_flow.FlowResultType.ABORT
+    assert forms["bluetooth"]["type"] is data_entry_flow.FlowResultType.ABORT
     for key in ("hassio", "user", "reauth", "reconfigure"):
-        assert forms[key]["type"] == data_entry_flow.FlowResultType.FORM
+        assert forms[key]["type"] is data_entry_flow.FlowResultType.FORM
         assert forms[key]["step_id"] == "account"
 
     await ws_client.send_json({"id": 1, "type": "config_entries/flow/subscribe"})
@@ -1235,16 +1235,16 @@ async def test_get_progress_subscribe_in_progress_bad_flow(
                 "test", context=context
             )
 
-    assert forms["bluetooth"]["type"] == data_entry_flow.FlowResultType.ABORT
+    assert forms["bluetooth"]["type"] is data_entry_flow.FlowResultType.ABORT
     for key in ("hassio", "user", "reauth", "reconfigure"):
-        assert forms[key]["type"] == data_entry_flow.FlowResultType.FORM
+        assert forms[key]["type"] is data_entry_flow.FlowResultType.FORM
         assert forms[key]["step_id"] == "account"
 
     with mock_config_flow("test2", BadFlow):
         forms["bad"] = await hass.config_entries.flow.async_init(
             "test2", context={"source": core_ce.SOURCE_REAUTH, "entry_id": "1234"}
         )
-    assert forms["bad"]["type"] == data_entry_flow.FlowResultType.FORM
+    assert forms["bad"]["type"] is data_entry_flow.FlowResultType.FORM
     assert forms["bad"]["step_id"] == "account"
 
     await ws_client.send_json({"id": 1, "type": "config_entries/flow/subscribe"})

--- a/tests/components/config/test_entity_registry.py
+++ b/tests/components/config/test_entity_registry.py
@@ -1098,7 +1098,7 @@ async def test_enable_entity_disabled_device(
     entity_entry = entity_registry.async_get(entity_id)
     assert entity_entry.config_entry_id == config_entry.entry_id
     assert entity_entry.device_id == device.id
-    assert entity_entry.disabled_by == RegistryEntryDisabler.DEVICE
+    assert entity_entry.disabled_by is RegistryEntryDisabler.DEVICE
 
     # UPDATE DISABLED_BY TO NONE
     await client.send_json_auto_id(

--- a/tests/components/conversation/test_chat_log.py
+++ b/tests/components/conversation/test_chat_log.py
@@ -897,7 +897,7 @@ async def test_chat_log_subscription(
             )
         )
         # Check user content with attachments event
-        assert received_events[-1][1] == ChatLogEventType.CONTENT_ADDED
+        assert received_events[-1][1] is ChatLogEventType.CONTENT_ADDED
         user_event = received_events[-1][2]["content"]
         assert user_event["content"] == "Check this image"
         assert len(user_event["attachments"]) == 1
@@ -983,11 +983,11 @@ async def test_chat_log_subscription(
     assert len(received_events) == 8
 
     # Check the first event is CREATED
-    assert received_events[0][1] == ChatLogEventType.CREATED
+    assert received_events[0][1] is ChatLogEventType.CREATED
     assert received_events[0][2]["chat_log"]["conversation_id"] == conversation_id
 
     # Check the second event is CONTENT_ADDED (from mock_conversation_input)
-    assert received_events[1][1] == ChatLogEventType.CONTENT_ADDED
+    assert received_events[1][1] is ChatLogEventType.CONTENT_ADDED
     assert received_events[1][0] == conversation_id
 
     # Test cleanup functionality

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -116,8 +116,8 @@ async def test_hidden_entities_skipped(
     )
 
     assert len(calls) == 0
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.NO_VALID_TARGETS
 
 
 @pytest.mark.usefixtures("init_components")
@@ -135,14 +135,14 @@ async def test_exposed_domains(hass: HomeAssistant) -> None:
     result = await conversation.async_converse(
         hass, "unlock front door", None, Context(), None
     )
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.NO_VALID_TARGETS
 
     result = await conversation.async_converse(
         hass, "run my script", None, Context(), None
     )
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.NO_VALID_TARGETS
 
 
 @pytest.mark.usefixtures("init_components")
@@ -191,7 +191,7 @@ async def test_exposed_areas(
     )
 
     # All is well for the exposed kitchen light
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.intent is not None
     assert result.response.intent.slots["area"]["value"] == area_kitchen.id
     assert result.response.intent.slots["area"]["text"] == area_kitchen.normalized_name
@@ -202,14 +202,14 @@ async def test_exposed_areas(
     )
 
     # This should be an error because the lights in that area are not exposed
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.NO_VALID_TARGETS
 
     # But we can still ask questions about the bedroom, even with no exposed entities
     result = await conversation.async_converse(
         hass, "how many lights are on in the bedroom?", None, Context(), None
     )
-    assert result.response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert result.response.response_type is intent.IntentResponseType.QUERY_ANSWER
 
 
 @pytest.mark.usefixtures("init_components")
@@ -248,7 +248,7 @@ async def test_punctuation(hass: HomeAssistant) -> None:
 
     assert len(calls) == 1
     assert calls[0].data["entity_id"][0] == "light.test_light"
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.intent is not None
     assert result.response.intent.slots["name"]["value"] == "test light"
     assert result.response.intent.slots["name"]["text"] == "test light"
@@ -326,7 +326,7 @@ async def test_unexposed_entities_skipped(
     )
 
     assert len(calls) == 1
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.intent is not None
     assert result.response.intent.slots["area"]["value"] == area_kitchen.id
     assert result.response.intent.slots["area"]["text"] == area_kitchen.normalized_name
@@ -338,7 +338,7 @@ async def test_unexposed_entities_skipped(
         hass, "how many lights are on in the kitchen", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert result.response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(result.response.matched_states) == 1
     assert result.response.matched_states[0].entity_id == exposed_light.entity_id
 
@@ -403,7 +403,7 @@ async def test_duplicated_names_resolved_with_device_area(
         assert len(calls) == 1
         assert calls[0].data["entity_id"][0] == bedroom_light.entity_id
 
-        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
         assert result.response.intent is not None
         assert result.response.intent.slots.get("name", {}).get("value") == name
         assert result.response.intent.slots.get("name", {}).get("text") == name
@@ -421,7 +421,7 @@ async def test_trigger_sentences(hass: HomeAssistant) -> None:
     unregister = manager.register_trigger(trigger_sentences, callback)
 
     result = await conversation.async_converse(hass, "Not the trigger", None, Context())
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
 
     # Using different case and including punctuation
     test_sentences = ["it's party time!", "IT IS TIME TO PARTY."]
@@ -430,7 +430,7 @@ async def test_trigger_sentences(hass: HomeAssistant) -> None:
         result = await conversation.async_converse(hass, sentence, None, Context())
         assert callback.call_count == 1
         assert callback.call_args[0][0].text == sentence
-        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE, (
+        assert result.response.response_type is intent.IntentResponseType.ACTION_DONE, (
             sentence
         )
         assert result.response.speech == {
@@ -443,7 +443,7 @@ async def test_trigger_sentences(hass: HomeAssistant) -> None:
     callback.reset_mock()
     for sentence in test_sentences:
         result = await conversation.async_converse(hass, sentence, None, Context())
-        assert result.response.response_type == intent.IntentResponseType.ERROR, (
+        assert result.response.response_type is intent.IntentResponseType.ERROR, (
             sentence
         )
 
@@ -479,7 +479,7 @@ async def test_trigger_sentence_response_translation(
         result = await conversation.async_converse(
             hass, "test sentence", None, Context()
         )
-        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
         assert result.response.speech == {
             "plain": {"speech": expected, "extra_data": None}
         }
@@ -493,7 +493,7 @@ async def test_shopping_list_add_item(hass: HomeAssistant) -> None:
     result = await conversation.async_converse(
         hass, "add apples to my shopping list", None, Context()
     )
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.speech == {
         "plain": {"speech": "Added apples", "extra_data": None}
     }
@@ -506,7 +506,7 @@ async def test_nevermind_intent(hass: HomeAssistant) -> None:
     assert result.response.intent is not None
     assert result.response.intent.intent_type == intent.INTENT_NEVERMIND
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert not result.response.speech
 
 
@@ -517,7 +517,7 @@ async def test_respond_intent(hass: HomeAssistant) -> None:
     assert result.response.intent is not None
     assert result.response.intent.intent_type == intent.INTENT_RESPOND
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.speech["plain"]["speech"] == "Hello from Home Assistant."
 
 
@@ -584,7 +584,7 @@ async def test_satellite_area_context(
         satellite_id=kitchen_satellite.entity_id,
     )
     await hass.async_block_till_done()
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.intent is not None
     assert result.response.intent.slots["area"]["value"] == area_kitchen.id
     assert result.response.intent.slots["area"]["text"] == area_kitchen.normalized_name
@@ -608,7 +608,7 @@ async def test_satellite_area_context(
         satellite_id=kitchen_satellite.entity_id,
     )
     await hass.async_block_till_done()
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.intent is not None
     assert result.response.intent.slots["area"]["value"] == area_bedroom.id
     assert result.response.intent.slots["area"]["text"] == area_bedroom.normalized_name
@@ -632,7 +632,7 @@ async def test_satellite_area_context(
         device_id=bedroom_satellite.id,
     )
     await hass.async_block_till_done()
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.intent is not None
     assert result.response.intent.slots["area"]["value"] == area_bedroom.id
     assert result.response.intent.slots["area"]["text"] == area_bedroom.normalized_name
@@ -652,7 +652,7 @@ async def test_satellite_area_context(
             hass, f"turn {command} all lights", None, Context(), None
         )
         await hass.async_block_till_done()
-        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
 
         # All lights should have been targeted
         assert {s.entity_id for s in result.response.matched_states} == {
@@ -667,8 +667,8 @@ async def test_error_no_device(hass: HomeAssistant) -> None:
         hass, "turn on missing entity", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
         == "Sorry, I am not aware of any device called missing entity"
@@ -685,8 +685,8 @@ async def test_error_no_device_exposed(hass: HomeAssistant) -> None:
         hass, "turn on kitchen light", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
         == "Sorry, kitchen light is not exposed"
@@ -700,8 +700,8 @@ async def test_error_no_area(hass: HomeAssistant) -> None:
         hass, "turn on the lights in missing area", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
         == "Sorry, I am not aware of any area called missing area"
@@ -715,8 +715,8 @@ async def test_error_no_floor(hass: HomeAssistant) -> None:
         hass, "turn on all the lights on missing floor", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
         == "Sorry, I am not aware of any floor called missing"
@@ -734,8 +734,8 @@ async def test_error_no_device_in_area(
         hass, "turn on missing entity in the kitchen", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
         == "Sorry, I am not aware of any device called"
@@ -754,8 +754,8 @@ async def test_error_no_device_on_floor(
         hass, "turn on missing entity on ground floor", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
         == "Sorry, I am not aware of any device called missing entity on ground floor"
@@ -809,10 +809,10 @@ async def test_error_no_device_on_floor_exposed(
             hass, "turn on test light on the ground floor", None, Context(), None
         )
 
-        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.response_type is intent.IntentResponseType.ERROR
         assert (
             result.response.error_code
-            == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+            is intent.IntentResponseErrorCode.NO_VALID_TARGETS
         )
         assert (
             result.response.speech["plain"]["speech"]
@@ -848,8 +848,8 @@ async def test_error_no_device_in_area_exposed(
         hass, "turn on test light in the kitchen", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
         == "Sorry, test light in the kitchen area is not exposed"
@@ -877,10 +877,10 @@ async def test_error_no_domain(hass: HomeAssistant) -> None:
             hass, "turn on the fans", None, Context(), None
         )
 
-        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.response_type is intent.IntentResponseType.ERROR
         assert (
             result.response.error_code
-            == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+            is intent.IntentResponseErrorCode.NO_VALID_TARGETS
         )
         assert (
             result.response.speech["plain"]["speech"]
@@ -912,10 +912,10 @@ async def test_error_no_domain_exposed(hass: HomeAssistant) -> None:
             hass, "turn on the fans", None, Context(), None
         )
 
-        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.response_type is intent.IntentResponseType.ERROR
         assert (
             result.response.error_code
-            == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+            is intent.IntentResponseErrorCode.NO_VALID_TARGETS
         )
         assert result.response.speech["plain"]["speech"] == "Sorry, no fan is exposed"
 
@@ -931,8 +931,8 @@ async def test_error_no_domain_in_area(
         hass, "turn on the lights in the kitchen", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
         == "Sorry, I am not aware of any light in the kitchen area"
@@ -967,8 +967,8 @@ async def test_error_no_domain_in_area_exposed(
         hass, "turn on the lights in the kitchen", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
         == "Sorry, no light in the kitchen area is exposed"
@@ -991,8 +991,8 @@ async def test_error_no_domain_on_floor(
         hass, "turn on all lights on the ground floor", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
         == "Sorry, I am not aware of any light on the ground floor"
@@ -1009,8 +1009,8 @@ async def test_error_no_domain_on_floor(
         hass, "turn on all lights upstairs", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
         == "Sorry, I am not aware of any light on the upstairs floor"
@@ -1048,8 +1048,8 @@ async def test_error_no_domain_on_floor_exposed(
         hass, "turn on all lights on the ground floor", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
         == "Sorry, no light in the ground floor is exposed"
@@ -1086,10 +1086,10 @@ async def test_error_no_device_class(hass: HomeAssistant) -> None:
             hass, "open the windows", None, Context(), None
         )
 
-        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.response_type is intent.IntentResponseType.ERROR
         assert (
             result.response.error_code
-            == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+            is intent.IntentResponseErrorCode.NO_VALID_TARGETS
         )
         assert (
             result.response.speech["plain"]["speech"]
@@ -1135,10 +1135,10 @@ async def test_error_no_device_class_exposed(hass: HomeAssistant) -> None:
             hass, "open all the windows", None, Context(), None
         )
 
-        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.response_type is intent.IntentResponseType.ERROR
         assert (
             result.response.error_code
-            == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+            is intent.IntentResponseErrorCode.NO_VALID_TARGETS
         )
         assert (
             result.response.speech["plain"]["speech"] == "Sorry, no window is exposed"
@@ -1156,8 +1156,8 @@ async def test_error_no_device_class_in_area(
         hass, "open bedroom windows", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
         == "Sorry, I am not aware of any window in the bedroom area"
@@ -1191,8 +1191,8 @@ async def test_error_no_device_class_in_area_exposed(
         hass, "open bedroom windows", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
         == "Sorry, no window in the bedroom area is exposed"
@@ -1246,10 +1246,10 @@ async def test_error_no_device_class_on_floor_exposed(
             hass, "open ground floor windows", None, Context(), None
         )
 
-        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.response_type is intent.IntentResponseType.ERROR
         assert (
             result.response.error_code
-            == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+            is intent.IntentResponseErrorCode.NO_VALID_TARGETS
         )
         assert (
             result.response.speech["plain"]["speech"]
@@ -1268,9 +1268,9 @@ async def test_error_no_intent(hass: HomeAssistant) -> None:
             hass, "do something", None, Context(), None
         )
 
-        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.response_type is intent.IntentResponseType.ERROR
         assert (
-            result.response.error_code == intent.IntentResponseErrorCode.NO_INTENT_MATCH
+            result.response.error_code is intent.IntentResponseErrorCode.NO_INTENT_MATCH
         )
         assert (
             result.response.speech["plain"]["speech"]
@@ -1305,10 +1305,10 @@ async def test_error_duplicate_names(
         result = await conversation.async_converse(
             hass, f"turn on {name}", None, Context(), None
         )
-        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.response_type is intent.IntentResponseType.ERROR
         assert (
             result.response.error_code
-            == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+            is intent.IntentResponseErrorCode.NO_VALID_TARGETS
         )
         assert (
             result.response.speech["plain"]["speech"]
@@ -1319,10 +1319,10 @@ async def test_error_duplicate_names(
         result = await conversation.async_converse(
             hass, f"is {name} on?", None, Context(), None
         )
-        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.response_type is intent.IntentResponseType.ERROR
         assert (
             result.response.error_code
-            == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+            is intent.IntentResponseErrorCode.NO_VALID_TARGETS
         )
         assert (
             result.response.speech["plain"]["speech"]
@@ -1362,7 +1362,7 @@ async def test_duplicate_names_but_one_is_exposed(
         result = await conversation.async_converse(
             hass, f"turn on {name}", None, Context(), None
         )
-        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
         assert result.response.matched_states[0].entity_id == kitchen_light_1.entity_id
 
 
@@ -1399,10 +1399,10 @@ async def test_error_duplicate_names_same_area(
         result = await conversation.async_converse(
             hass, f"turn on {name} in {area_kitchen.name}", None, Context(), None
         )
-        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.response_type is intent.IntentResponseType.ERROR
         assert (
             result.response.error_code
-            == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+            is intent.IntentResponseErrorCode.NO_VALID_TARGETS
         )
         assert (
             result.response.speech["plain"]["speech"]
@@ -1414,10 +1414,10 @@ async def test_error_duplicate_names_same_area(
         result = await conversation.async_converse(
             hass, f"is {name} on in the {area_kitchen.name}?", None, Context(), None
         )
-        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.response_type is intent.IntentResponseType.ERROR
         assert (
             result.response.error_code
-            == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+            is intent.IntentResponseErrorCode.NO_VALID_TARGETS
         )
         assert (
             result.response.speech["plain"]["speech"]
@@ -1464,7 +1464,7 @@ async def test_duplicate_names_same_area_but_one_is_exposed(
         result = await conversation.async_converse(
             hass, f"turn on {name} in {area_kitchen.name}", None, Context(), None
         )
-        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
         assert result.response.matched_states[0].entity_id == kitchen_light_1.entity_id
 
 
@@ -1530,20 +1530,20 @@ async def test_duplicate_names_different_areas(
         result = await conversation.async_converse(
             hass, f"turn on {name}", None, Context(), None
         )
-        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.response_type is intent.IntentResponseType.ERROR
 
         # Target kitchen light by using kitchen device
         result = await conversation.async_converse(
             hass, f"turn on {name}", None, Context(), None, device_id=device_kitchen.id
         )
-        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
         assert result.response.matched_states[0].entity_id == kitchen_light.entity_id
 
         # Target bedroom light by using bedroom device
         result = await conversation.async_converse(
             hass, f"turn on {name}", None, Context(), None, device_id=device_bedroom.id
         )
-        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
         assert result.response.matched_states[0].entity_id == bedroom_light.entity_id
 
 
@@ -1562,8 +1562,8 @@ async def test_error_wrong_state(hass: HomeAssistant) -> None:
         hass, "pause test player", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert result.response.speech["plain"]["speech"] == "Sorry, no device is playing"
 
 
@@ -1583,8 +1583,8 @@ async def test_error_feature_not_supported(hass: HomeAssistant) -> None:
         hass, "set test player volume to 100%", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
         == "Sorry, no device supports the required features"
@@ -1615,8 +1615,8 @@ async def test_error_no_timer_support(
         hass, "set a 5 minute timer", None, Context(), None, device_id=device_id
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.FAILED_TO_HANDLE
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.FAILED_TO_HANDLE
     assert (
         result.response.speech["plain"]["speech"]
         == "Sorry, timers are not supported on this device"
@@ -1639,8 +1639,8 @@ async def test_error_timer_not_found(hass: HomeAssistant) -> None:
         hass, "pause timer", None, Context(), None, device_id=device_id
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.FAILED_TO_HANDLE
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.FAILED_TO_HANDLE
     assert (
         result.response.speech["plain"]["speech"] == "Sorry, I couldn't find that timer"
     )
@@ -1677,19 +1677,19 @@ async def test_error_multiple_timers_matched(
     result = await conversation.async_converse(
         hass, "set a timer for 5 minutes", None, Context(), None, device_id=device_id
     )
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
 
     result = await conversation.async_converse(
         hass, "set a timer for 5 minutes", None, Context(), None, device_id=device_id
     )
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Cannot target multiple timers
     result = await conversation.async_converse(
         hass, "cancel timer", None, Context(), None, device_id=device_id
     )
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.FAILED_TO_HANDLE
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.FAILED_TO_HANDLE
     assert (
         result.response.speech["plain"]["speech"]
         == "Sorry, I am unable to target multiple timers"
@@ -1714,10 +1714,10 @@ async def test_no_states_matched_default_error(
             hass, "turn on lights in the kitchen", None, Context(), None
         )
 
-        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.response_type is intent.IntentResponseType.ERROR
         assert (
             result.response.error_code
-            == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+            is intent.IntentResponseErrorCode.NO_VALID_TARGETS
         )
         assert (
             result.response.speech["plain"]["speech"]
@@ -1802,8 +1802,8 @@ async def test_all_domains_loaded(hass: HomeAssistant) -> None:
     )
 
     # Invalid target vs. no intent recognized
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
         == "Sorry, I am not aware of any device called test light"
@@ -1856,7 +1856,7 @@ async def test_same_named_entities_in_different_areas(
     await hass.async_block_till_done()
 
     assert len(calls) == 1
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.intent is not None
     assert (
         result.response.intent.slots.get("name", {}).get("value") == kitchen_light.name
@@ -1876,7 +1876,7 @@ async def test_same_named_entities_in_different_areas(
     await hass.async_block_till_done()
 
     assert len(calls) == 1
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.intent is not None
     assert (
         result.response.intent.slots.get("name", {}).get("value") == bedroom_light.name
@@ -1892,19 +1892,19 @@ async def test_same_named_entities_in_different_areas(
     result = await conversation.async_converse(
         hass, "turn on overhead light", None, Context(), None
     )
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
 
     # Querying a duplicate name should also fail
     result = await conversation.async_converse(
         hass, "is the overhead light on?", None, Context(), None
     )
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
 
     # But we can still ask questions that don't rely on the name
     result = await conversation.async_converse(
         hass, "how many lights are on?", None, Context(), None
     )
-    assert result.response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert result.response.response_type is intent.IntentResponseType.QUERY_ANSWER
 
 
 @pytest.mark.usefixtures("init_components")
@@ -1955,7 +1955,7 @@ async def test_same_aliased_entities_in_different_areas(
     await hass.async_block_till_done()
 
     assert len(calls) == 1
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.intent is not None
     assert result.response.intent.slots.get("name", {}).get("value") == "overhead light"
     assert result.response.intent.slots.get("name", {}).get("text") == "overhead light"
@@ -1971,7 +1971,7 @@ async def test_same_aliased_entities_in_different_areas(
     await hass.async_block_till_done()
 
     assert len(calls) == 1
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.intent is not None
     assert result.response.intent.slots.get("name", {}).get("value") == "overhead light"
     assert result.response.intent.slots.get("name", {}).get("text") == "overhead light"
@@ -1983,19 +1983,19 @@ async def test_same_aliased_entities_in_different_areas(
     result = await conversation.async_converse(
         hass, "turn on overhead light", None, Context(), None
     )
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
 
     # Querying a duplicate alias should also fail
     result = await conversation.async_converse(
         hass, "is the overhead light on?", None, Context(), None
     )
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
 
     # But we can still ask questions that don't rely on the alias
     result = await conversation.async_converse(
         hass, "how many lights are on?", None, Context(), None
     )
-    assert result.response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert result.response.response_type is intent.IntentResponseType.QUERY_ANSWER
 
 
 @pytest.mark.usefixtures("init_components")
@@ -2027,7 +2027,7 @@ async def test_device_id_in_handler(hass: HomeAssistant) -> None:
         Context(),
         device_id=device_id,
     )
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert handler.device_id == device_id
 
 
@@ -2070,7 +2070,7 @@ async def test_name_wildcard_lower_priority(hass: HomeAssistant) -> None:
     result = await conversation.async_converse(
         hass, "I'd like to order a stout please", None, Context(), None
     )
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert beer_handler.triggered
     assert not food_handler.triggered
 
@@ -2079,7 +2079,7 @@ async def test_name_wildcard_lower_priority(hass: HomeAssistant) -> None:
     result = await conversation.async_converse(
         hass, "I'd like to order a cookie please", None, Context(), None
     )
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert not beer_handler.triggered
     assert food_handler.triggered
 
@@ -2871,7 +2871,7 @@ async def test_query_same_name_different_areas(
     result = await conversation.async_converse(
         hass, "is the overhead light on?", None, Context(), None
     )
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
 
     # Succeeds using area from device (kitchen)
     result = await conversation.async_converse(
@@ -2882,7 +2882,7 @@ async def test_query_same_name_different_areas(
         None,
         device_id=kitchen_device.id,
     )
-    assert result.response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert result.response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(result.response.matched_states) == 1
     assert result.response.matched_states[0].entity_id == kitchen_light.entity_id
 
@@ -3059,7 +3059,7 @@ async def test_entities_names_are_not_templates(hass: HomeAssistant) -> None:
     )
 
     assert result is not None
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Not exposed
     expose_entity(hass, "light.test_light", False)
@@ -3072,7 +3072,7 @@ async def test_entities_names_are_not_templates(hass: HomeAssistant) -> None:
     )
 
     assert result is not None
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
 
 
 @pytest.mark.parametrize(
@@ -3339,7 +3339,7 @@ async def test_state_names_are_not_translated(
         result = await conversation.async_converse(
             hass, "what is the weather like?", None, Context(), None
         )
-        assert result.response.response_type == intent.IntentResponseType.QUERY_ANSWER
+        assert result.response.response_type is intent.IntentResponseType.QUERY_ANSWER
         mock_async_render.assert_called_once()
 
         assert (
@@ -3396,7 +3396,7 @@ async def test_intent_tool_call_in_chat_log(hass: HomeAssistant) -> None:
         hass, "turn on test light", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
 
     with (
         chat_session.async_get_chat_session(hass, result.conversation_id) as session,
@@ -3448,7 +3448,7 @@ async def test_trigger_tool_call_in_chat_log(hass: HomeAssistant) -> None:
         hass, trigger_sentence, None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
 
     with (
         chat_session.async_get_chat_session(hass, result.conversation_id) as session,
@@ -3486,7 +3486,7 @@ async def test_no_tool_call_on_no_intent_match(hass: HomeAssistant) -> None:
         hass, "this is a random sentence that should not match", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
 
     with (
         chat_session.async_get_chat_session(hass, result.conversation_id) as session,
@@ -3511,8 +3511,8 @@ async def test_intent_tool_call_with_error_response(hass: HomeAssistant) -> None
         hass, "turn on the non existent device", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.NO_VALID_TARGETS
 
     with (
         chat_session.async_get_chat_session(hass, result.conversation_id) as session,

--- a/tests/components/conversation/test_default_agent_intents.py
+++ b/tests/components/conversation/test_default_agent_intents.py
@@ -88,7 +88,7 @@ async def test_cover_set_position(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "Opening"
     assert len(calls) == 1
     call = calls[0]
@@ -102,7 +102,7 @@ async def test_cover_set_position(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "Closing"
     assert len(calls) == 1
     call = calls[0]
@@ -116,7 +116,7 @@ async def test_cover_set_position(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "Position set"
     assert len(calls) == 1
     call = calls[0]
@@ -144,7 +144,7 @@ async def test_cover_device_class(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "Opening the garage"
     assert len(calls) == 1
     call = calls[0]
@@ -168,7 +168,7 @@ async def test_valve_intents(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "Opening"
     assert len(calls) == 1
     call = calls[0]
@@ -182,7 +182,7 @@ async def test_valve_intents(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "Closing"
     assert len(calls) == 1
     call = calls[0]
@@ -196,7 +196,7 @@ async def test_valve_intents(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "Position set"
     assert len(calls) == 1
     call = calls[0]
@@ -229,7 +229,7 @@ async def test_vacuum_intents(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "Started"
     assert len(calls) == 1
     call = calls[0]
@@ -243,7 +243,7 @@ async def test_vacuum_intents(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "Returning"
     assert len(calls) == 1
     call = calls[0]
@@ -275,7 +275,7 @@ async def test_media_player_intents(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "Paused"
     assert len(calls) == 1
     call = calls[0]
@@ -294,7 +294,7 @@ async def test_media_player_intents(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "Resumed"
     assert len(calls) == 1
     call = calls[0]
@@ -313,7 +313,7 @@ async def test_media_player_intents(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "Playing next"
     assert len(calls) == 1
     call = calls[0]
@@ -329,7 +329,7 @@ async def test_media_player_intents(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "Volume set"
     assert len(calls) == 1
     call = calls[0]
@@ -399,7 +399,7 @@ async def test_turn_floor_lights_on_off(
     )
 
     assert len(on_calls) == 2
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert {s.entity_id for s in result.response.matched_states} == {
         kitchen_light.entity_id,
         living_room_light.entity_id,
@@ -411,7 +411,7 @@ async def test_turn_floor_lights_on_off(
     )
 
     assert len(on_calls) == 1
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert {s.entity_id for s in result.response.matched_states} == {
         bedroom_light.entity_id
     }
@@ -422,7 +422,7 @@ async def test_turn_floor_lights_on_off(
     )
 
     assert len(off_calls) == 1
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert {s.entity_id for s in result.response.matched_states} == {
         bedroom_light.entity_id
     }
@@ -474,7 +474,7 @@ async def test_date_time(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "September 17th, 2013"
 
     result = await conversation.async_converse(
@@ -483,5 +483,5 @@ async def test_date_time(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "1:02 AM"

--- a/tests/components/cookidoo/test_init.py
+++ b/tests/components/cookidoo/test_init.py
@@ -57,7 +57,7 @@ async def test_init_failure(
     """Test an initialization error on integration load."""
     mock_cookidoo_client.login.side_effect = exception
     await setup_integration(hass, cookidoo_config_entry)
-    assert cookidoo_config_entry.state == status
+    assert cookidoo_config_entry.state is status
 
 
 @pytest.mark.parametrize(

--- a/tests/components/cover/test_intent.py
+++ b/tests/components/cover/test_intent.py
@@ -43,7 +43,7 @@ async def test_open_cover_intent(hass: HomeAssistant, slots: dict[str, Any]) -> 
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -75,7 +75,7 @@ async def test_close_cover_intent(hass: HomeAssistant, slots: dict[str, Any]) ->
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -110,7 +110,7 @@ async def test_set_cover_position(hass: HomeAssistant, slots: dict[str, Any]) ->
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN

--- a/tests/components/device_tracker/test_config_entry.py
+++ b/tests/components/device_tracker/test_config_entry.py
@@ -778,7 +778,7 @@ async def test_register_mac(
 
     entity_entry = entity_registry.async_get(entity_id)
     assert entity_entry is not None
-    assert entity_entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
+    assert entity_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
@@ -827,7 +827,7 @@ async def test_register_mac_not_found(
 
     test_entity_entry = entity_registry.async_get(entity_id)
     assert test_entity_entry is not None
-    assert test_entity_entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
+    assert test_entity_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
@@ -839,7 +839,7 @@ async def test_register_mac_not_found(
     # The entity entry under test should still be disabled.
     test_entity_entry = entity_registry.async_get(entity_id)
     assert test_entity_entry is not None
-    assert test_entity_entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
+    assert test_entity_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
 @pytest.mark.parametrize(
@@ -862,7 +862,7 @@ async def test_register_mac_ignored(
 
     entity_entry = entity_registry.async_get(entity_id)
     assert entity_entry is not None
-    assert entity_entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
+    assert entity_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
@@ -872,7 +872,7 @@ async def test_register_mac_ignored(
 
     entity_entry = entity_registry.async_get(entity_id)
     assert entity_entry is not None
-    assert entity_entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
+    assert entity_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
 async def test_connected_device_registered(

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -69,7 +69,7 @@ async def test_iaq_sensor_entities_disabled_by_default(
     ):
         entry = entity_registry.async_get(entity_id)
         assert entry is not None
-        assert entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
+        assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
 @pytest.mark.usefixtures("init_integration")
@@ -81,7 +81,7 @@ async def test_diagnostic_sensor_entities_disabled_by_default(
     for entity_id in ("sensor.living_signal_strength",):
         entry = entity_registry.async_get(entity_id)
         assert entry is not None
-        assert entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
+        assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
 @pytest.mark.usefixtures("init_integration")
@@ -369,7 +369,7 @@ async def test_ventilation_state_unknown_returns_state_unknown(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test that VentilationState.UNKNOWN makes the sensor report unknown."""
-    box_node = next(n for n in mock_sensor_nodes if n.general.node_type == NodeType.BOX)
+    box_node = next(n for n in mock_sensor_nodes if n.general.node_type is NodeType.BOX)
     updated_nodes = [
         Node(
             node_id=box_node.node_id,

--- a/tests/components/ecovacs/test_config_flow.py
+++ b/tests/components/ecovacs/test_config_flow.py
@@ -241,7 +241,7 @@ async def test_user_flow_self_hosted_error(
         mock_create_mqtt_config.assert_called_once()
         ssl_context = mock_create_mqtt_config.call_args[1]["ssl_context"]
         assert isinstance(ssl_context, ssl.SSLContext)
-        assert ssl_context.verify_mode == ssl.CERT_NONE
+        assert ssl_context.verify_mode is ssl.CERT_NONE
         assert ssl_context.check_hostname is False
 
     assert result["type"] is FlowResultType.CREATE_ENTRY

--- a/tests/components/elevenlabs/test_stt.py
+++ b/tests/components/elevenlabs/test_stt.py
@@ -121,7 +121,7 @@ async def test_stt_transcription_success(
     result = await entity.async_process_audio_stream(
         default_metadata, two_chunk_stream()
     )
-    assert result.result == stt.SpeechResultState.SUCCESS
+    assert result.result is stt.SpeechResultState.SUCCESS
     assert result.text == "hello world"
     entity._client.speech_to_text.convert.assert_called_once()
 
@@ -153,7 +153,7 @@ async def test_stt_transcription_success_auto_language(
     entity = stt.async_get_speech_to_text_engine(hass, "stt.elevenlabs_speech_to_text")
     assert entity is not None
     result = await entity.async_process_audio_stream(metadata, simple_stream())
-    assert result.result == stt.SpeechResultState.SUCCESS
+    assert result.result is stt.SpeechResultState.SUCCESS
     assert result.text == "hello world"
     entity._client.speech_to_text.convert.assert_called_once()
     # Verify language_code is NOT passed when auto-detect is enabled
@@ -172,7 +172,7 @@ async def test_stt_transcription_passes_language_code(
     assert entity is not None
     assert not entity._auto_detect_language
     result = await entity.async_process_audio_stream(default_metadata, simple_stream())
-    assert result.result == stt.SpeechResultState.SUCCESS
+    assert result.result is stt.SpeechResultState.SUCCESS
     # Verify language_code IS passed when auto-detect is disabled
     call_kwargs = entity._client.speech_to_text.convert.call_args.kwargs
     assert call_kwargs["language_code"] == "en"
@@ -203,7 +203,7 @@ async def test_stt_edge_cases(
     stream = request.getfixturevalue(stream_fixture)
     assert not entity._auto_detect_language
     result = await entity.async_process_audio_stream(metadata, stream())
-    assert result.result == stt.SpeechResultState.ERROR
+    assert result.result is stt.SpeechResultState.ERROR
     assert result.text is None
 
 
@@ -218,7 +218,7 @@ async def test_stt_convert_api_error(
     assert entity is not None
     entity._client.speech_to_text.convert.side_effect = ApiError()
     result = await entity.async_process_audio_stream(default_metadata, simple_stream())
-    assert result.result == stt.SpeechResultState.ERROR
+    assert result.result is stt.SpeechResultState.ERROR
     assert result.text is None
 
 

--- a/tests/components/elevenlabs/test_tts.py
+++ b/tests/components/elevenlabs/test_tts.py
@@ -248,7 +248,7 @@ async def test_tts_service_speak(
 
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
     assert len(stream_calls) == 1
     voice_id = service_data[tts.ATTR_OPTIONS].get(tts.ATTR_VOICE, "voice1")
@@ -315,7 +315,7 @@ async def test_tts_service_speak_lang_config(
 
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
 
     assert len(stream_calls) == 1
@@ -369,7 +369,7 @@ async def test_tts_service_speak_error(
 
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.INTERNAL_SERVER_ERROR
+        is HTTPStatus.INTERNAL_SERVER_ERROR
     )
 
     assert len(stream_calls) == 1
@@ -444,7 +444,7 @@ async def test_tts_service_speak_voice_settings(
 
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
 
     assert len(stream_calls) == 1
@@ -497,7 +497,7 @@ async def test_tts_service_speak_without_options(
 
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
 
     assert len(stream_calls) == 1

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -1331,7 +1331,7 @@ async def perform_get_light_state_by_number(
 
     assert result.status == expected_status
 
-    if expected_status == HTTPStatus.OK:
+    if expected_status is HTTPStatus.OK:
         assert CONTENT_TYPE_JSON in result.headers["content-type"]
 
         return await result.json()

--- a/tests/components/energy/test_sensor.py
+++ b/tests/components/energy/test_sensor.py
@@ -139,7 +139,7 @@ async def test_cost_sensor_attributes(
     entry = entity_registry.async_get(cost_sensor_entity_id)
     assert entry.entity_category is None
     assert entry.disabled_by is None
-    assert entry.hidden_by == er.RegistryEntryHider.INTEGRATION
+    assert entry.hidden_by is er.RegistryEntryHider.INTEGRATION
 
 
 @pytest.mark.parametrize(

--- a/tests/components/enphase_envoy/test_sensor.py
+++ b/tests/components/enphase_envoy/test_sensor.py
@@ -1322,7 +1322,7 @@ def integration_disabled_entities(
         for entity_entry in er.async_entries_for_config_entry(
             entity_registry, config_entry.entry_id
         )
-        if entity_entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
+        if entity_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
     ]
 
 

--- a/tests/components/esphome/test_enum_mapper.py
+++ b/tests/components/esphome/test_enum_mapper.py
@@ -32,12 +32,12 @@ MOCK_MAPPING: EsphomeEnumMapper[MockEnum, MockStrEnum] = EsphomeEnumMapper(
 async def test_map_esphome_to_ha() -> None:
     """Test mapping from ESPHome to HA."""
 
-    assert MOCK_MAPPING.from_esphome(MockEnum.ESPHOME_FOO) == MockStrEnum.HA_FOO
-    assert MOCK_MAPPING.from_esphome(MockEnum.ESPHOME_BAR) == MockStrEnum.HA_BAR
+    assert MOCK_MAPPING.from_esphome(MockEnum.ESPHOME_FOO) is MockStrEnum.HA_FOO
+    assert MOCK_MAPPING.from_esphome(MockEnum.ESPHOME_BAR) is MockStrEnum.HA_BAR
 
 
 async def test_map_ha_to_esphome() -> None:
     """Test mapping from HA to ESPHome."""
 
-    assert MOCK_MAPPING.from_hass(MockStrEnum.HA_FOO) == MockEnum.ESPHOME_FOO
-    assert MOCK_MAPPING.from_hass(MockStrEnum.HA_BAR) == MockEnum.ESPHOME_BAR
+    assert MOCK_MAPPING.from_hass(MockStrEnum.HA_FOO) is MockEnum.ESPHOME_FOO
+    assert MOCK_MAPPING.from_hass(MockStrEnum.HA_BAR) is MockEnum.ESPHOME_BAR

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -101,7 +101,7 @@ async def test_esphome_device_subscribe_logs(
     async with async_call_logger_set_level(
         "homeassistant.components.esphome", "DEBUG", hass=hass, caplog=caplog
     ):
-        assert device.current_log_level == LogLevel.LOG_LEVEL_VERY_VERBOSE
+        assert device.current_log_level is LogLevel.LOG_LEVEL_VERY_VERBOSE
 
         caplog.set_level(logging.DEBUG)
         device.mock_on_log_message(
@@ -3260,17 +3260,17 @@ async def test_service_registration_response_types(
     # STATUS -> SupportsResponse.NONE (no data returned to HA)
     assert (
         hass.services.supports_response(DOMAIN, "test_none_service")
-        == SupportsResponse.NONE
+        is SupportsResponse.NONE
     )
     assert (
         hass.services.supports_response(DOMAIN, "test_optional_service")
-        == SupportsResponse.OPTIONAL
+        is SupportsResponse.OPTIONAL
     )
     assert (
         hass.services.supports_response(DOMAIN, "test_only_service")
-        == SupportsResponse.ONLY
+        is SupportsResponse.ONLY
     )
     assert (
         hass.services.supports_response(DOMAIN, "test_status_service")
-        == SupportsResponse.NONE
+        is SupportsResponse.NONE
     )

--- a/tests/components/evohome/conftest.py
+++ b/tests/components/evohome/conftest.py
@@ -94,7 +94,7 @@ def mock_make_request(install: str) -> Callable:
     ) -> JsonArrayType | JsonObjectType:
         """Return the JSON for a HTTP get of a given URL."""
 
-        if method != HTTPMethod.GET:
+        if method is not HTTPMethod.GET:
             pytest.fail(f"Unmocked method: {method} {url}")
 
         await self._headers()

--- a/tests/components/fan/test_intent.py
+++ b/tests/components/fan/test_intent.py
@@ -29,7 +29,7 @@ async def test_set_speed_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN

--- a/tests/components/firefly_iii/test_init.py
+++ b/tests/components/firefly_iii/test_init.py
@@ -35,4 +35,4 @@ async def test_setup_exceptions(
     """Test the _async_setup."""
     mock_firefly_client.get_about.side_effect = exception
     await setup_integration(hass, mock_config_entry)
-    assert mock_config_entry.state == expected_state
+    assert mock_config_entry.state is expected_state

--- a/tests/components/fish_audio/test_tts.py
+++ b/tests/components/fish_audio/test_tts.py
@@ -205,7 +205,7 @@ async def test_tts_service_speak(
     assert len(calls) == 1
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
 
 
@@ -236,7 +236,7 @@ async def test_tts_service_speak_with_language(
     assert len(calls) == 1
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
 
 
@@ -273,7 +273,7 @@ async def test_tts_service_speak_server_error(
     assert len(calls) == 1
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.INTERNAL_SERVER_ERROR
+        is HTTPStatus.INTERNAL_SERVER_ERROR
     )
 
 
@@ -310,5 +310,5 @@ async def test_tts_service_speak_rate_limit_error(
     assert len(calls) == 1
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.INTERNAL_SERVER_ERROR
+        is HTTPStatus.INTERNAL_SERVER_ERROR
     )

--- a/tests/components/fully_kiosk/test_binary_sensor.py
+++ b/tests/components/fully_kiosk/test_binary_sensor.py
@@ -39,7 +39,7 @@ async def test_binary_sensors(
     entry = entity_registry.async_get("binary_sensor.amazon_fire_plugged_in")
     assert entry
     assert entry.unique_id == "abcdef-123456-plugged"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
     state = hass.states.get("binary_sensor.amazon_fire_kiosk_mode")
     assert state
@@ -50,7 +50,7 @@ async def test_binary_sensors(
     entry = entity_registry.async_get("binary_sensor.amazon_fire_kiosk_mode")
     assert entry
     assert entry.unique_id == "abcdef-123456-kioskMode"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
     state = hass.states.get("binary_sensor.amazon_fire_device_admin")
     assert state
@@ -61,7 +61,7 @@ async def test_binary_sensors(
     entry = entity_registry.async_get("binary_sensor.amazon_fire_device_admin")
     assert entry
     assert entry.unique_id == "abcdef-123456-isDeviceAdmin"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
     assert entry.device_id
     device_entry = device_registry.async_get(entry.device_id)

--- a/tests/components/fully_kiosk/test_sensor.py
+++ b/tests/components/fully_kiosk/test_sensor.py
@@ -64,7 +64,7 @@ async def test_sensors_sensors(
     entry = entity_registry.async_get("sensor.amazon_fire_battery_temperature")
     assert entry
     assert entry.unique_id == "abcdef-123456-batteryTemperature"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
     state = hass.states.get("sensor.amazon_fire_foreground_app")
     assert state
@@ -100,7 +100,7 @@ async def test_sensors_sensors(
     entry = entity_registry.async_get("sensor.amazon_fire_internal_storage_free_space")
     assert entry
     assert entry.unique_id == "abcdef-123456-internalStorageFreeSpace"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
     state = hass.states.get("sensor.amazon_fire_internal_storage_total_space")
     assert state
@@ -115,7 +115,7 @@ async def test_sensors_sensors(
     entry = entity_registry.async_get("sensor.amazon_fire_internal_storage_total_space")
     assert entry
     assert entry.unique_id == "abcdef-123456-internalStorageTotalSpace"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
     state = hass.states.get("sensor.amazon_fire_free_memory")
     assert state
@@ -127,7 +127,7 @@ async def test_sensors_sensors(
     entry = entity_registry.async_get("sensor.amazon_fire_free_memory")
     assert entry
     assert entry.unique_id == "abcdef-123456-ramFreeMemory"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
     state = hass.states.get("sensor.amazon_fire_total_memory")
     assert state
@@ -139,7 +139,7 @@ async def test_sensors_sensors(
     entry = entity_registry.async_get("sensor.amazon_fire_total_memory")
     assert entry
     assert entry.unique_id == "abcdef-123456-ramTotalMemory"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
     assert entry.device_id
     device_entry = device_registry.async_get(entry.device_id)

--- a/tests/components/go2rtc/test_init.py
+++ b/tests/components/go2rtc/test_init.py
@@ -679,7 +679,7 @@ async def test_setup_with_retryable_setup_entry_error_custom_server(
     await hass.async_block_till_done(wait_background_tasks=True)
     config_entries = hass.config_entries.async_entries(DOMAIN)
     assert len(config_entries) == 1
-    assert config_entries[0].state == expected_config_entry_state
+    assert config_entries[0].state is expected_config_entry_state
     assert expected_log_message in caplog.text
 
 
@@ -716,7 +716,7 @@ async def test_setup_with_retryable_setup_entry_error_default_server(
     config_entries = hass.config_entries.async_entries(DOMAIN)
     assert len(config_entries) == has_go2rtc_entry
     for config_entry in config_entries:
-        assert config_entry.state == expected_config_entry_state
+        assert config_entry.state is expected_config_entry_state
     assert expected_log_message in caplog.text
 
 
@@ -750,7 +750,7 @@ async def test_setup_with_version_error(
     await hass.async_block_till_done(wait_background_tasks=True)
     config_entries = hass.config_entries.async_entries(DOMAIN)
     assert len(config_entries) == 1
-    assert config_entries[0].state == expected_config_entry_state
+    assert config_entries[0].state is expected_config_entry_state
     assert expected_log_message in caplog.text
 
 
@@ -781,7 +781,7 @@ async def test_setup_with_recommended_version_repair(
     assert issue
     assert issue.is_fixable is False
     assert issue.is_persistent is False
-    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.severity is ir.IssueSeverity.WARNING
     assert issue.issue_id == "recommended_version"
     assert issue.translation_key == "recommended_version"
     assert issue.translation_placeholders == {

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -1482,7 +1482,7 @@ async def test_working_location_entity(
 
     entity_entry = entity_registry.async_get("calendar.working_location")
     assert entity_entry
-    assert entity_entry.disabled_by == RegistryEntryDisabler.INTEGRATION
+    assert entity_entry.disabled_by is RegistryEntryDisabler.INTEGRATION
 
     entity_registry.async_update_entity(
         entity_id="calendar.working_location", disabled_by=None

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -4307,7 +4307,7 @@ async def test_sensorstate(
         name = item[0]
         unit = item[1]
 
-        if sensor_type == sensor.SensorDeviceClass.AQI:
+        if sensor_type is sensor.SensorDeviceClass.AQI:
             assert trt.sync_attributes() == {
                 "sensorStatesSupported": [
                     {
@@ -4337,7 +4337,7 @@ async def test_sensorstate(
                 ]
             }
 
-        if sensor_type == sensor.SensorDeviceClass.AQI:
+        if sensor_type is sensor.SensorDeviceClass.AQI:
             assert trt.query_attributes() == {
                 "currentSensorStateData": [
                     {

--- a/tests/components/google_generative_ai_conversation/test_conversation.py
+++ b/tests/components/google_generative_ai_conversation/test_conversation.py
@@ -74,7 +74,7 @@ async def test_error_handling(
             Context(),
             agent_id="conversation.google_ai_conversation",
         )
-    assert result.response.response_type == intent.IntentResponseType.ERROR, result
+    assert result.response.response_type is intent.IntentResponseType.ERROR, result
     assert result.response.error_code == "unknown", result
     assert (
         result.response.as_dict()["speech"]["plain"]["speech"] == ERROR_GETTING_RESPONSE
@@ -249,7 +249,7 @@ async def test_function_call(
         agent_id=agent_id,
         device_id="test_device",
     )
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert (
         result.response.as_dict()["speech"]["plain"]["speech"]
         == "I've called the test function with the provided parameters."
@@ -356,7 +356,7 @@ async def test_google_search_tool_is_sent(
             agent_id=agent_id,
             device_id="test_device",
         )
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert (
         result.response.as_dict()["speech"]["plain"]["speech"]
         == "The last winner of the 2024 FIFA World Cup was Argentina."
@@ -406,7 +406,7 @@ async def test_blocked_response(
         device_id="test_device",
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR, result
+    assert result.response.response_type is intent.IntentResponseType.ERROR, result
     assert result.response.error_code == "unknown", result
     assert result.response.as_dict()["speech"]["plain"]["speech"] == (
         "The message got blocked due to content violations, reason: SAFETY"
@@ -450,7 +450,7 @@ async def test_empty_response(
         agent_id=agent_id,
         device_id="test_device",
     )
-    assert result.response.response_type == intent.IntentResponseType.ERROR, result
+    assert result.response.response_type is intent.IntentResponseType.ERROR, result
     assert result.response.error_code == "unknown", result
     assert result.response.as_dict()["speech"]["plain"]["speech"] == (
         "Unable to get response"
@@ -485,7 +485,7 @@ async def test_none_response(
         device_id="test_device",
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR, result
+    assert result.response.response_type is intent.IntentResponseType.ERROR, result
     assert result.response.error_code == "unknown", result
     assert result.response.as_dict()["speech"]["plain"]["speech"] == (
         "The message got blocked due to content violations, reason: unknown"
@@ -514,7 +514,7 @@ async def test_converse_error(
         agent_id="conversation.google_ai_conversation",
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR, result
+    assert result.response.response_type is intent.IntentResponseType.ERROR, result
     assert result.response.error_code == "unknown", result
     assert result.response.as_dict()["speech"]["plain"]["speech"] == (
         "Error preparing LLM API"

--- a/tests/components/google_generative_ai_conversation/test_tts.py
+++ b/tests/components/google_generative_ai_conversation/test_tts.py
@@ -170,7 +170,7 @@ async def test_tts_service_speak(
     assert len(calls) == 1
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
     voice_id = service_data[tts.ATTR_OPTIONS].get(tts.ATTR_VOICE, "zephyr")
 
@@ -238,7 +238,7 @@ async def test_tts_service_speak_error(
     assert len(calls) == 1
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.INTERNAL_SERVER_ERROR
+        is HTTPStatus.INTERNAL_SERVER_ERROR
     )
 
     voice_id = service_data[tts.ATTR_OPTIONS].get(tts.ATTR_VOICE)

--- a/tests/components/google_translate/test_tts.py
+++ b/tests/components/google_translate/test_tts.py
@@ -154,7 +154,7 @@ async def test_tts_service(
         await retrieve_media(
             hass, hass_client, service_calls[1].data[ATTR_MEDIA_CONTENT_ID]
         )
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
     assert len(mock_gtts.mock_calls) == 2
 
@@ -211,7 +211,7 @@ async def test_service_say_german_config(
         await retrieve_media(
             hass, hass_client, service_calls[1].data[ATTR_MEDIA_CONTENT_ID]
         )
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
     assert len(mock_gtts.mock_calls) == 2
     assert mock_gtts.mock_calls[0][2] == {
@@ -268,7 +268,7 @@ async def test_service_say_german_service(
         await retrieve_media(
             hass, hass_client, service_calls[1].data[ATTR_MEDIA_CONTENT_ID]
         )
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
     assert len(mock_gtts.mock_calls) == 2
     assert mock_gtts.mock_calls[0][2] == {
@@ -324,7 +324,7 @@ async def test_service_say_en_uk_config(
         await retrieve_media(
             hass, hass_client, service_calls[1].data[ATTR_MEDIA_CONTENT_ID]
         )
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
     assert len(mock_gtts.mock_calls) == 2
     assert mock_gtts.mock_calls[0][2] == {
@@ -381,7 +381,7 @@ async def test_service_say_en_uk_service(
         await retrieve_media(
             hass, hass_client, service_calls[1].data[ATTR_MEDIA_CONTENT_ID]
         )
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
     assert len(mock_gtts.mock_calls) == 2
     assert mock_gtts.mock_calls[0][2] == {
@@ -438,7 +438,7 @@ async def test_service_say_en_couk(
         await retrieve_media(
             hass, hass_client, service_calls[1].data[ATTR_MEDIA_CONTENT_ID]
         )
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
     assert len(mock_gtts.mock_calls) == 2
 
@@ -496,6 +496,6 @@ async def test_service_say_error(
         await retrieve_media(
             hass, hass_client, service_calls[1].data[ATTR_MEDIA_CONTENT_ID]
         )
-        == HTTPStatus.INTERNAL_SERVER_ERROR
+        is HTTPStatus.INTERNAL_SERVER_ERROR
     )
     assert len(mock_gtts.mock_calls) == 2

--- a/tests/components/gree/test_climate.py
+++ b/tests/components/gree/test_climate.py
@@ -428,7 +428,7 @@ async def test_send_target_temperature(
     device().mode = HVAC_MODES_REVERSE.get(HVACMode.AUTO)
 
     fake_device = device()
-    if units.temperature_unit == UnitOfTemperature.FAHRENHEIT:
+    if units.temperature_unit is UnitOfTemperature.FAHRENHEIT:
         fake_device.temperature_units = 1
 
     await async_setup_gree(hass)
@@ -504,7 +504,7 @@ async def test_send_target_temperature_device_timeout(
 ) -> None:
     """Test sending target temperature command with device timeout."""
     hass.config.units = units
-    if units.temperature_unit == UnitOfTemperature.FAHRENHEIT:
+    if units.temperature_unit is UnitOfTemperature.FAHRENHEIT:
         device().temperature_units = 1
     device().push_state_update.side_effect = DeviceTimeoutError
 
@@ -535,7 +535,7 @@ async def test_update_target_temperature(
 ) -> None:
     """Test for updating target temperature from the device."""
     hass.config.units = units
-    if units.temperature_unit == UnitOfTemperature.FAHRENHEIT:
+    if units.temperature_unit is UnitOfTemperature.FAHRENHEIT:
         device().temperature_units = 1
     device().target_temperature = temperature
 

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -1215,7 +1215,7 @@ async def test_deprecated_installation_issue_os_armv7(
     assert len(issue_registry.issues) == 1
     issue = issue_registry.async_get_issue("homeassistant", issue_id)
     assert issue.domain == "homeassistant"
-    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.severity is ir.IssueSeverity.WARNING
     assert issue.translation_placeholders == {
         "installation_guide": "https://www.home-assistant.io/installation/",
     }
@@ -1278,7 +1278,7 @@ async def test_deprecated_installation_issue_32bit_os(
     assert len(issue_registry.issues) == 1
     issue = issue_registry.async_get_issue("homeassistant", "deprecated_architecture")
     assert issue.domain == "homeassistant"
-    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.severity is ir.IssueSeverity.WARNING
     assert issue.translation_placeholders == {"installation_type": "OS", "arch": arch}
 
 
@@ -1341,7 +1341,7 @@ async def test_deprecated_installation_issue_32bit_supervised(
         "homeassistant", "deprecated_method_architecture"
     )
     assert issue.domain == "homeassistant"
-    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.severity is ir.IssueSeverity.WARNING
     assert issue.translation_placeholders == {
         "installation_type": "Supervised",
         "arch": arch,
@@ -1404,7 +1404,7 @@ async def test_deprecated_installation_issue_64bit_supervised(
     assert len(issue_registry.issues) == 1
     issue = issue_registry.async_get_issue("homeassistant", "deprecated_method")
     assert issue.domain == "homeassistant"
-    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.severity is ir.IssueSeverity.WARNING
     assert issue.translation_placeholders == {
         "installation_type": "Supervised",
         "arch": arch,

--- a/tests/components/hassio/test_issues.py
+++ b/tests/components/hassio/test_issues.py
@@ -218,7 +218,7 @@ async def test_unsupported_issues(
 @pytest.mark.usefixtures("all_setup_requests")
 @pytest.mark.parametrize(
     "unsupported_reason",
-    [r for r in UnsupportedReason if r != UnsupportedReason.PRIVILEGED],
+    [r for r in UnsupportedReason if r is not UnsupportedReason.PRIVILEGED],
 )
 async def test_unsupported_reasons(
     hass: HomeAssistant,

--- a/tests/components/hikvision/test_binary_sensor.py
+++ b/tests/components/hikvision/test_binary_sensor.py
@@ -234,7 +234,7 @@ async def test_yaml_import_creates_deprecation_issue(
         HOMEASSISTANT_DOMAIN, f"deprecated_yaml_{DOMAIN}"
     )
     assert issue is not None
-    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.severity is ir.IssueSeverity.WARNING
 
 
 async def test_yaml_import_with_name(
@@ -294,7 +294,7 @@ async def test_yaml_import_abort_creates_issue(
         DOMAIN, "deprecated_yaml_import_issue_cannot_connect"
     )
     assert issue is not None
-    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.severity is ir.IssueSeverity.WARNING
 
 
 async def test_binary_sensor_update_callback(

--- a/tests/components/home_connect/test_button.py
+++ b/tests/components/home_connect/test_button.py
@@ -340,7 +340,7 @@ async def test_enable_resume_command_on_pause(
         )
         if ha_id == appliance.ha_id:
             for command in array_of_commands.commands:
-                if command.key == CommandKey.BSH_COMMON_RESUME_PROGRAM:
+                if command.key is CommandKey.BSH_COMMON_RESUME_PROGRAM:
                     # Simulate that the resume command is not available initially
                     array_of_commands.commands.remove(command)
                     break

--- a/tests/components/home_connect/test_init.py
+++ b/tests/components/home_connect/test_init.py
@@ -199,7 +199,7 @@ async def test_client_error(
     client_with_exception.get_home_appliances.return_value = None
     client_with_exception.get_home_appliances.side_effect = exception
     assert not await integration_setup(client_with_exception)
-    assert config_entry.state == expected_state
+    assert config_entry.state is expected_state
     assert client_with_exception.get_home_appliances.call_count == 1
 
 

--- a/tests/components/home_connect/test_select.py
+++ b/tests/components/home_connect/test_select.py
@@ -638,7 +638,7 @@ async def test_fetch_allowed_values(
     async def get_setting_side_effect(
         ha_id: str, setting_key: SettingKey
     ) -> GetSetting:
-        if ha_id != appliance.ha_id or setting_key != test_setting_key:
+        if ha_id != appliance.ha_id or setting_key is not test_setting_key:
             return await original_get_setting_side_effect(ha_id, setting_key)
         return GetSetting(
             key=test_setting_key,

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -740,7 +740,7 @@ async def test_deprecated_installation_issue_core(
     for expected_issue, expected_placeholders in expected_issues:
         issue = issue_registry.async_get_issue(DOMAIN, expected_issue)
         assert issue.domain == DOMAIN
-        assert issue.severity == ir.IssueSeverity.WARNING
+        assert issue.severity is ir.IssueSeverity.WARNING
         assert issue.translation_placeholders == expected_placeholders
 
 
@@ -781,5 +781,5 @@ async def test_deprecated_installation_issue_container_32bit(
     assert len(issue_registry.issues) == 1
     issue = issue_registry.async_get_issue(DOMAIN, "deprecated_container")
     assert issue.domain == DOMAIN
-    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.severity is ir.IssueSeverity.WARNING
     assert issue.translation_placeholders == {"arch": arch}

--- a/tests/components/homeassistant_hardware/test_config_flow.py
+++ b/tests/components/homeassistant_hardware/test_config_flow.py
@@ -357,7 +357,7 @@ async def consume_progress_flow(
         result = await hass.config_entries.flow.async_configure(flow_id)
         flow_id = result["flow_id"]
 
-        if result["type"] != FlowResultType.SHOW_PROGRESS:
+        if result["type"] is not FlowResultType.SHOW_PROGRESS:
             break
 
         assert result["type"] is FlowResultType.SHOW_PROGRESS

--- a/tests/components/homeassistant_hardware/test_switch.py
+++ b/tests/components/homeassistant_hardware/test_switch.py
@@ -207,7 +207,7 @@ async def test_switch_restore_state(
     entity_registry = er.async_get(hass)
     entity_entry = entity_registry.async_get(TEST_SWITCH_ENTITY_ID)
     assert entity_entry is not None
-    assert entity_entry.entity_category == EntityCategory.CONFIG
+    assert entity_entry.entity_category is EntityCategory.CONFIG
     assert entity_entry.translation_key == "beta_firmware"
 
 

--- a/tests/components/homeassistant_sky_connect/test_const.py
+++ b/tests/components/homeassistant_sky_connect/test_const.py
@@ -16,7 +16,7 @@ def test_hardware_variant(
     usb_product_name: str, expected_variant: HardwareVariant
 ) -> None:
     """Test hardware variant parsing."""
-    assert HardwareVariant.from_usb_product_name(usb_product_name) == expected_variant
+    assert HardwareVariant.from_usb_product_name(usb_product_name) is expected_variant
 
 
 def test_hardware_variant_invalid() -> None:

--- a/tests/components/homeassistant_sky_connect/test_util.py
+++ b/tests/components/homeassistant_sky_connect/test_util.py
@@ -65,7 +65,7 @@ def test_get_usb_service_info() -> None:
 
 def test_get_hardware_variant() -> None:
     """Test `get_hardware_variant` extraction."""
-    assert get_hardware_variant(SKYCONNECT_CONFIG_ENTRY) == HardwareVariant.SKYCONNECT
+    assert get_hardware_variant(SKYCONNECT_CONFIG_ENTRY) is HardwareVariant.SKYCONNECT
     assert (
-        get_hardware_variant(CONNECT_ZBT1_CONFIG_ENTRY) == HardwareVariant.CONNECT_ZBT1
+        get_hardware_variant(CONNECT_ZBT1_CONFIG_ENTRY) is HardwareVariant.CONNECT_ZBT1
     )

--- a/tests/components/html5/test_config_flow.py
+++ b/tests/components/html5/test_config_flow.py
@@ -110,7 +110,7 @@ async def test_step_user_form_invalid_key(
 
         await hass.async_block_till_done()
 
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
         assert mock_setup_entry.call_count == 0
 
         result = await hass.config_entries.flow.async_configure(

--- a/tests/components/hue/test_sensor_v1.py
+++ b/tests/components/hue/test_sensor_v1.py
@@ -363,7 +363,7 @@ async def test_sensors(
         entity_registry.async_get(
             "sensor.hue_dimmer_switch_1_battery_level"
         ).entity_category
-        == EntityCategory.DIAGNOSTIC
+        is EntityCategory.DIAGNOSTIC
     )
 
 

--- a/tests/components/humidifier/test_intent.py
+++ b/tests/components/humidifier/test_intent.py
@@ -263,7 +263,7 @@ async def test_intent_errors(hass: HomeAssistant) -> None:
         {"name": {"value": "Bedroom humidifier"}, "humidity": {"value": "50"}},
         assistant=conversation.DOMAIN,
     )
-    assert result.response_type == IntentResponseType.ACTION_DONE
+    assert result.response_type is IntentResponseType.ACTION_DONE
 
     result = await async_handle(
         hass,
@@ -272,7 +272,7 @@ async def test_intent_errors(hass: HomeAssistant) -> None:
         {"name": {"value": "Bedroom humidifier"}, "mode": {"value": "away"}},
         assistant=conversation.DOMAIN,
     )
-    assert result.response_type == IntentResponseType.ACTION_DONE
+    assert result.response_type is IntentResponseType.ACTION_DONE
 
     # Unexposing it should fail
     async_expose_entity(hass, conversation.DOMAIN, entity_id, False)
@@ -285,7 +285,7 @@ async def test_intent_errors(hass: HomeAssistant) -> None:
             {"name": {"value": "Bedroom humidifier"}, "humidity": {"value": "50"}},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == MatchFailedReason.ASSISTANT
+    assert err.value.result.no_match_reason is MatchFailedReason.ASSISTANT
 
     with pytest.raises(MatchFailedError) as err:
         await async_handle(
@@ -295,7 +295,7 @@ async def test_intent_errors(hass: HomeAssistant) -> None:
             {"name": {"value": "Bedroom humidifier"}, "mode": {"value": "away"}},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == MatchFailedReason.ASSISTANT
+    assert err.value.result.no_match_reason is MatchFailedReason.ASSISTANT
 
     # Expose again to test other errors
     async_expose_entity(hass, conversation.DOMAIN, entity_id, True)
@@ -328,7 +328,7 @@ async def test_intent_errors(hass: HomeAssistant) -> None:
             {"name": {"value": "does not exist"}, "humidity": {"value": "50"}},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == MatchFailedReason.NAME
+    assert err.value.result.no_match_reason is MatchFailedReason.NAME
 
     with pytest.raises(MatchFailedError) as err:
         await async_handle(
@@ -338,4 +338,4 @@ async def test_intent_errors(hass: HomeAssistant) -> None:
             {"name": {"value": "does not exist"}, "mode": {"value": "away"}},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == MatchFailedReason.NAME
+    assert err.value.result.no_match_reason is MatchFailedReason.NAME

--- a/tests/components/imap/test_config_flow.py
+++ b/tests/components/imap/test_config_flow.py
@@ -440,7 +440,7 @@ async def test_options_flow_when_connection_fails(
             result2 = await hass.config_entries.options.async_configure(
                 result["flow_id"], new_config
             )
-            assert result2["type"] == assert_result
+            assert result2["type"] is assert_result
 
             if result2.get("errors") is not None:
                 assert assert_result is FlowResultType.FORM

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -167,7 +167,7 @@ async def test_setup_config_full(
     full_config.update(config_update)
     full_config.update(config_ext)
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert entry.data == full_config
     assert issue_registry.async_get_issue(
         domain=DOMAIN,
@@ -351,7 +351,7 @@ async def test_setup_minimal_config_no_connection_keys(
 
     entry = conf_entries[0]
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert entry.data == BASE_V1_CONFIG
 
     assert not issue_registry.async_get_issue(domain=DOMAIN, issue_id="deprecated_yaml")
@@ -396,7 +396,7 @@ async def test_setup_minimal_config_with_connection_keys(
 
     entry = conf_entries[0]
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert entry.data == config_base
 
     assert issue_registry.async_get_issue(domain=DOMAIN, issue_id="deprecated_yaml")

--- a/tests/components/intent/test_init.py
+++ b/tests/components/intent/test_init.py
@@ -591,7 +591,7 @@ async def test_get_state_intent(
     )
 
     # yes
-    assert result.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert result.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert result.matched_states and (
         result.matched_states[0].entity_id == bedroom_light.entity_id
     )
@@ -611,7 +611,7 @@ async def test_get_state_intent(
     )
 
     # no, it's on
-    assert result.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert result.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert not result.matched_states
     assert result.unmatched_states and (
         result.unmatched_states[0].entity_id == kitchen_light.entity_id
@@ -628,7 +628,7 @@ async def test_get_state_intent(
         },
     )
 
-    assert result.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert result.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert result.matched_states and (
         result.matched_states[0].entity_id == kitchen_sensor.entity_id
     )
@@ -648,7 +648,7 @@ async def test_get_state_intent(
     )
 
     # yes
-    assert result.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert result.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert result.matched_states and (
         result.matched_states[0].entity_id == problem_sensor.entity_id
     )
@@ -667,7 +667,7 @@ async def test_get_state_intent(
     )
 
     # yes, 2 of them
-    assert result.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert result.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(result.matched_states) == 2 and {
         state.entity_id for state in result.matched_states
     } == {problem_sensor.entity_id, moisture_sensor.entity_id}
@@ -686,7 +686,7 @@ async def test_get_state_intent(
     )
 
     # no
-    assert result.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert result.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert not result.matched_states and not result.unmatched_states
 
     # Test unknown area failure
@@ -754,7 +754,7 @@ async def test_stop_moving_valve(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == VALVE_DOMAIN
@@ -782,7 +782,7 @@ async def test_stop_moving_cover(hass: HomeAssistant, slots: dict[str, Any]) -> 
     response = await intent.async_handle(hass, "test", intent.INTENT_STOP_MOVING, slots)
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == COVER_DOMAIN

--- a/tests/components/intent/test_temperature.py
+++ b/tests/components/intent/test_temperature.py
@@ -261,7 +261,7 @@ async def test_get_temperature(
     # Exception should contain details of what we tried to match
     assert isinstance(error.value, intent.MatchFailedError)
     assert (
-        error.value.result.no_match_reason == intent.MatchFailedReason.MULTIPLE_TARGETS
+        error.value.result.no_match_reason is intent.MatchFailedReason.MULTIPLE_TARGETS
     )
 
     # Select by area (office_temperature)
@@ -272,7 +272,7 @@ async def test_get_temperature(
         {"area": {"value": office_area.name}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == office_temperature_id
     state = response.matched_states[0]
@@ -286,7 +286,7 @@ async def test_get_temperature(
         {"preferred_area_id": {"value": attic_area.id}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == attic_temperature_id
     state = response.matched_states[0]
@@ -300,7 +300,7 @@ async def test_get_temperature(
         {"area": {"value": bedroom_area.name}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == climate_2.entity_id
     state = response.matched_states[0]
@@ -314,7 +314,7 @@ async def test_get_temperature(
         {"name": {"value": "Climate 2"}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == climate_2.entity_id
     state = response.matched_states[0]
@@ -332,7 +332,7 @@ async def test_get_temperature(
 
     # Exception should contain details of what we tried to match
     assert isinstance(error.value, intent.MatchFailedError)
-    assert error.value.result.no_match_reason == intent.MatchFailedReason.AREA
+    assert error.value.result.no_match_reason is intent.MatchFailedReason.AREA
     constraints = error.value.constraints
     assert constraints.name is None
     assert constraints.area_name == bathroom_area.name
@@ -349,7 +349,7 @@ async def test_get_temperature(
         )
 
     assert isinstance(error.value, intent.MatchFailedError)
-    assert error.value.result.no_match_reason == intent.MatchFailedReason.NAME
+    assert error.value.result.no_match_reason is intent.MatchFailedReason.NAME
     constraints = error.value.constraints
     assert constraints.name == "Does not exist"
     assert constraints.area_name is None
@@ -366,7 +366,7 @@ async def test_get_temperature(
         )
 
     assert isinstance(error.value, intent.MatchFailedError)
-    assert error.value.result.no_match_reason == intent.MatchFailedReason.AREA
+    assert error.value.result.no_match_reason is intent.MatchFailedReason.AREA
     constraints = error.value.constraints
     assert constraints.name == "Climate 1"
     assert constraints.area_name == bedroom_area.name
@@ -381,7 +381,7 @@ async def test_get_temperature(
         {"floor": {"value": first_floor.name}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == climate_1.entity_id
     state = response.matched_states[0]
@@ -395,7 +395,7 @@ async def test_get_temperature(
         {"preferred_area_id": {"value": bedroom_area.id}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == climate_2.entity_id
     state = response.matched_states[0]
@@ -409,7 +409,7 @@ async def test_get_temperature(
         {"preferred_floor_id": {"value": first_floor.floor_id}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == climate_1.entity_id
     state = response.matched_states[0]
@@ -433,7 +433,7 @@ async def test_get_temperature_no_entities(
             {},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.DOMAIN
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.DOMAIN
 
 
 async def test_not_exposed(
@@ -505,7 +505,7 @@ async def test_not_exposed(
         {},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == climate_2.entity_id
 
@@ -517,7 +517,7 @@ async def test_not_exposed(
         {"area": {"value": living_room_area.name}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == climate_2.entity_id
 
@@ -529,7 +529,7 @@ async def test_not_exposed(
         {"name": {"value": climate_2.name}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == climate_2.entity_id
 
@@ -542,7 +542,7 @@ async def test_not_exposed(
             {"name": {"value": climate_1.name}},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.ASSISTANT
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.ASSISTANT
 
     # Expose first, hide second
     async_expose_entity(hass, conversation.DOMAIN, climate_1.entity_id, True)
@@ -556,7 +556,7 @@ async def test_not_exposed(
         {},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == climate_1.entity_id
 
@@ -569,7 +569,7 @@ async def test_not_exposed(
             {"area": {"value": bedroom_area.name}},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.AREA
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.AREA
 
     # Neither are exposed
     async_expose_entity(hass, conversation.DOMAIN, climate_1.entity_id, False)
@@ -583,7 +583,7 @@ async def test_not_exposed(
             {},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.ASSISTANT
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.ASSISTANT
 
     # Should fail with area
     with pytest.raises(intent.MatchFailedError) as err:
@@ -594,7 +594,7 @@ async def test_not_exposed(
             {"area": {"value": living_room_area.name}},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.ASSISTANT
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.ASSISTANT
 
     # Should fail with both names
     for name in (climate_1.name, climate_2.name):
@@ -606,4 +606,4 @@ async def test_not_exposed(
                 {"name": {"value": name}},
                 assistant=conversation.DOMAIN,
             )
-        assert err.value.result.no_match_reason == intent.MatchFailedReason.ASSISTANT
+        assert err.value.result.no_match_reason is intent.MatchFailedReason.ASSISTANT

--- a/tests/components/intent/test_timers.py
+++ b/tests/components/intent/test_timers.py
@@ -61,7 +61,7 @@ async def test_start_finish_timer(hass: HomeAssistant, init_components) -> None:
         assert timer.seconds_left == 0
         assert timer.created_seconds == 0
 
-        if event_type == TimerEventType.STARTED:
+        if event_type is TimerEventType.STARTED:
             timer_id = timer.id
             started_event.set()
         elif event_type == TimerEventType.FINISHED:
@@ -82,7 +82,7 @@ async def test_start_finish_timer(hass: HomeAssistant, init_components) -> None:
         device_id=device_id,
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await asyncio.gather(started_event.wait(), finished_event.wait())
@@ -109,7 +109,7 @@ async def test_cancel_timer(hass: HomeAssistant, init_components) -> None:
         if timer_name is not None:
             assert timer.name == timer_name
 
-        if event_type == TimerEventType.STARTED:
+        if event_type is TimerEventType.STARTED:
             timer_id = timer.id
             assert (
                 timer.seconds_left
@@ -153,7 +153,7 @@ async def test_cancel_timer(hass: HomeAssistant, init_components) -> None:
         device_id=device_id,
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await cancelled_event.wait()
@@ -187,7 +187,7 @@ async def test_cancel_timer(hass: HomeAssistant, init_components) -> None:
         device_id=device_id,
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await cancelled_event.wait()
@@ -211,7 +211,7 @@ async def test_cancel_timer(hass: HomeAssistant, init_components) -> None:
         await started_event.wait()
 
     result = await intent.async_handle(hass, "test", intent.INTENT_CANCEL_TIMER, {})
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
 
 async def test_increase_timer(hass: HomeAssistant, init_components) -> None:
@@ -238,7 +238,7 @@ async def test_increase_timer(hass: HomeAssistant, init_components) -> None:
         if timer_name is not None:
             assert timer.name == timer_name
 
-        if event_type == TimerEventType.STARTED:
+        if event_type is TimerEventType.STARTED:
             timer_id = timer.id
             original_total_seconds = (
                 (60 * 60 * timer.start_hours)
@@ -273,7 +273,7 @@ async def test_increase_timer(hass: HomeAssistant, init_components) -> None:
         device_id=device_id,
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await started_event.wait()
@@ -294,7 +294,7 @@ async def test_increase_timer(hass: HomeAssistant, init_components) -> None:
         },
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     assert not updated_event.is_set()
 
     # Add 30 seconds to the timer
@@ -313,7 +313,7 @@ async def test_increase_timer(hass: HomeAssistant, init_components) -> None:
         },
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await updated_event.wait()
@@ -326,7 +326,7 @@ async def test_increase_timer(hass: HomeAssistant, init_components) -> None:
         {"name": {"value": timer_name}},
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await cancelled_event.wait()
@@ -355,7 +355,7 @@ async def test_decrease_timer(hass: HomeAssistant, init_components) -> None:
         if timer_name is not None:
             assert timer.name == timer_name
 
-        if event_type == TimerEventType.STARTED:
+        if event_type is TimerEventType.STARTED:
             timer_id = timer.id
             original_total_seconds = (
                 (60 * 60 * timer.start_hours)
@@ -390,7 +390,7 @@ async def test_decrease_timer(hass: HomeAssistant, init_components) -> None:
         device_id=device_id,
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await started_event.wait()
@@ -408,7 +408,7 @@ async def test_decrease_timer(hass: HomeAssistant, init_components) -> None:
         },
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await started_event.wait()
@@ -421,7 +421,7 @@ async def test_decrease_timer(hass: HomeAssistant, init_components) -> None:
         {"name": {"value": timer_name}},
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await cancelled_event.wait()
@@ -447,7 +447,7 @@ async def test_decrease_timer_below_zero(hass: HomeAssistant, init_components) -
         assert timer.start_minutes == 2
         assert timer.start_seconds == 3
 
-        if event_type == TimerEventType.STARTED:
+        if event_type is TimerEventType.STARTED:
             timer_id = timer.id
             original_total_seconds = (
                 (60 * 60 * timer.start_hours)
@@ -480,7 +480,7 @@ async def test_decrease_timer_below_zero(hass: HomeAssistant, init_components) -
         device_id=device_id,
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await started_event.wait()
@@ -498,7 +498,7 @@ async def test_decrease_timer_below_zero(hass: HomeAssistant, init_components) -
         },
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await asyncio.gather(
@@ -545,7 +545,7 @@ async def test_find_timer_failed(hass: HomeAssistant, init_components) -> None:
         {"name": {"value": "pizza"}, "minutes": {"value": 5}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Right name
     result = await intent.async_handle(
@@ -554,7 +554,7 @@ async def test_find_timer_failed(hass: HomeAssistant, init_components) -> None:
         intent.INTENT_INCREASE_TIMER,
         {"name": {"value": "PIZZA "}, "minutes": {"value": 1}},
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Wrong name
     with pytest.raises(intent.IntentError):
@@ -572,7 +572,7 @@ async def test_find_timer_failed(hass: HomeAssistant, init_components) -> None:
         intent.INTENT_INCREASE_TIMER,
         {"start_minutes": {"value": 5}, "minutes": {"value": 1}},
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Wrong start time
     with pytest.raises(intent.IntentError):
@@ -602,7 +602,7 @@ async def test_disambiguation(
     def handle_timer(event_type: TimerEventType, timer: TimerInfo) -> None:
         nonlocal timer_info
 
-        if event_type == TimerEventType.CANCELLED:
+        if event_type is TimerEventType.CANCELLED:
             timer_info = timer
             cancelled_event.set()
 
@@ -645,7 +645,7 @@ async def test_disambiguation(
         {"minutes": {"value": 3}},
         device_id=device_alice_study.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Bob: set a 3 minute timer
     result = await intent.async_handle(
@@ -655,13 +655,13 @@ async def test_disambiguation(
         {"minutes": {"value": 3}},
         device_id=device_bob_kitchen_1.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Alice should hear her timer listed first
     result = await intent.async_handle(
         hass, "test", intent.INTENT_TIMER_STATUS, {}, device_id=device_alice_study.id
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 2
     assert timers[0].get(ATTR_DEVICE_ID) == device_alice_study.id
@@ -671,7 +671,7 @@ async def test_disambiguation(
     result = await intent.async_handle(
         hass, "test", intent.INTENT_TIMER_STATUS, {}, device_id=device_bob_kitchen_1.id
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 2
     assert timers[0].get(ATTR_DEVICE_ID) == device_bob_kitchen_1.id
@@ -683,7 +683,7 @@ async def test_disambiguation(
     result = await intent.async_handle(
         hass, "test", intent.INTENT_CANCEL_TIMER, {}, device_id=device_alice_study.id
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await cancelled_event.wait()
@@ -887,7 +887,7 @@ async def test_pause_unpause_timer(hass: HomeAssistant, init_components) -> None
 
     @callback
     def handle_timer(event_type: TimerEventType, timer: TimerInfo) -> None:
-        if event_type == TimerEventType.STARTED:
+        if event_type is TimerEventType.STARTED:
             started_event.set()
         elif event_type == TimerEventType.UPDATED:
             assert timer.is_active == expected_active
@@ -902,7 +902,7 @@ async def test_pause_unpause_timer(hass: HomeAssistant, init_components) -> None
         {"minutes": {"value": 5}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await started_event.wait()
@@ -910,7 +910,7 @@ async def test_pause_unpause_timer(hass: HomeAssistant, init_components) -> None
     # Pause the timer
     expected_active = False
     result = await intent.async_handle(hass, "test", intent.INTENT_PAUSE_TIMER, {})
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await updated_event.wait()
@@ -923,7 +923,7 @@ async def test_pause_unpause_timer(hass: HomeAssistant, init_components) -> None
     updated_event.clear()
     expected_active = True
     result = await intent.async_handle(hass, "test", intent.INTENT_UNPAUSE_TIMER, {})
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await updated_event.wait()
@@ -1050,7 +1050,7 @@ async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> 
     def handle_timer(event_type: TimerEventType, timer: TimerInfo) -> None:
         nonlocal num_started
 
-        if event_type == TimerEventType.STARTED:
+        if event_type is TimerEventType.STARTED:
             num_started += 1
             if num_started == 4:
                 started_event.set()
@@ -1065,7 +1065,7 @@ async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> 
         {"name": {"value": "pizza"}, "minutes": {"value": 10}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     result = await intent.async_handle(
         hass,
@@ -1074,7 +1074,7 @@ async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> 
         {"name": {"value": "pizza"}, "minutes": {"value": 15}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     result = await intent.async_handle(
         hass,
@@ -1083,7 +1083,7 @@ async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> 
         {"name": {"value": "cookies"}, "minutes": {"value": 20}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     result = await intent.async_handle(
         hass,
@@ -1092,7 +1092,7 @@ async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> 
         {"name": {"value": "chicken"}, "hours": {"value": 2}, "seconds": {"value": 30}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Wait for all timers to start
     async with asyncio.timeout(1):
@@ -1103,7 +1103,7 @@ async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> 
         result = await intent.async_handle(
             hass, "test", intent.INTENT_TIMER_STATUS, {}, device_id=handle_device_id
         )
-        assert result.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response_type is intent.IntentResponseType.ACTION_DONE
         timers = result.speech_slots.get("timers", [])
         assert len(timers) == 4
         assert {t.get(ATTR_NAME) for t in timers} == {"pizza", "cookies", "chicken"}
@@ -1116,7 +1116,7 @@ async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> 
         {"name": {"value": "cookies"}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 1
     assert timers[0].get(ATTR_NAME) == "cookies"
@@ -1130,7 +1130,7 @@ async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> 
         {"name": {"value": "pizza"}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 2
     assert timers[0].get(ATTR_NAME) == "pizza"
@@ -1145,7 +1145,7 @@ async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> 
         {"name": {"value": "pizza"}, "start_minutes": {"value": 10}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 1
     assert timers[0].get(ATTR_NAME) == "pizza"
@@ -1163,7 +1163,7 @@ async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> 
         },
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 1
     assert timers[0].get(ATTR_NAME) == "chicken"
@@ -1179,7 +1179,7 @@ async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> 
         {"name": {"value": "does-not-exist"}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 0
 
@@ -1195,7 +1195,7 @@ async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> 
         },
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 0
 
@@ -1236,7 +1236,7 @@ async def test_area_filter(
     def handle_timer(event_type: TimerEventType, timer: TimerInfo) -> None:
         nonlocal num_started
 
-        if event_type == TimerEventType.STARTED:
+        if event_type is TimerEventType.STARTED:
             num_started += 1
             if num_started == num_timers:
                 started_event.set()
@@ -1252,7 +1252,7 @@ async def test_area_filter(
         {"name": {"value": "pizza"}, "minutes": {"value": 10}},
         device_id=device_kitchen.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     result = await intent.async_handle(
         hass,
@@ -1261,7 +1261,7 @@ async def test_area_filter(
         {"name": {"value": "tv"}, "minutes": {"value": 10}},
         device_id=device_living_room.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     result = await intent.async_handle(
         hass,
@@ -1270,7 +1270,7 @@ async def test_area_filter(
         {"name": {"value": "media"}, "minutes": {"value": 15}},
         device_id=device_living_room.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Wait for all timers to start
     async with asyncio.timeout(1):
@@ -1280,7 +1280,7 @@ async def test_area_filter(
     result = await intent.async_handle(
         hass, "test", intent.INTENT_TIMER_STATUS, {}, device_id=device_kitchen.id
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == num_timers
     assert {t.get(ATTR_NAME) for t in timers} == {"pizza", "tv", "media"}
@@ -1293,7 +1293,7 @@ async def test_area_filter(
         {"area": {"value": "kitchen"}},
         device_id=device_living_room.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 1
     assert timers[0].get(ATTR_NAME) == "pizza"
@@ -1306,7 +1306,7 @@ async def test_area_filter(
         {"area": {"value": "living room"}},
         device_id=device_kitchen.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 2
     assert {t.get(ATTR_NAME) for t in timers} == {"tv", "media"}
@@ -1319,7 +1319,7 @@ async def test_area_filter(
         {"area": {"value": "living room"}, "name": {"value": "tv"}},
         device_id=device_kitchen.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 1
     assert timers[0].get(ATTR_NAME) == "tv"
@@ -1332,7 +1332,7 @@ async def test_area_filter(
         {"area": {"value": "living room"}, "start_minutes": {"value": 15}},
         device_id=device_kitchen.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 1
     assert timers[0].get(ATTR_NAME) == "media"
@@ -1345,7 +1345,7 @@ async def test_area_filter(
         {"area": {"value": "does-not-exist"}},
         device_id=device_kitchen.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 0
 
@@ -1357,7 +1357,7 @@ async def test_area_filter(
         {"area": {"value": "living room"}, "start_minutes": {"value": 15}},
         device_id=device_living_room.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Cancel by area
     result = await intent.async_handle(
@@ -1367,7 +1367,7 @@ async def test_area_filter(
         {"area": {"value": "living room"}},
         device_id=device_living_room.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Get status with device missing
     with patch(
@@ -1380,7 +1380,7 @@ async def test_area_filter(
             intent.INTENT_TIMER_STATUS,
             device_id=device_kitchen.id,
         )
-        assert result.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response_type is intent.IntentResponseType.ACTION_DONE
         timers = result.speech_slots.get("timers", [])
         assert len(timers) == 1
 
@@ -1395,7 +1395,7 @@ async def test_area_filter(
             intent.INTENT_TIMER_STATUS,
             device_id=device_kitchen.id,
         )
-        assert result.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response_type is intent.IntentResponseType.ACTION_DONE
         timers = result.speech_slots.get("timers", [])
         assert len(timers) == 1
 
@@ -1457,7 +1457,7 @@ async def test_start_timer_with_conversation_command(
             conversation_agent_id=agent_id,
         )
 
-        assert result.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
         # No timer events for delayed commands
         mock_handle_timer.assert_not_called()
@@ -1500,7 +1500,7 @@ async def test_start_timer_with_sentence_trigger_validation(
             conversation_agent_id=agent_id,
         )
 
-        assert result.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
         # Verify the sentence trigger was checked
         mock_agent.async_recognize_sentence_trigger.assert_called_once()
@@ -1562,7 +1562,7 @@ async def test_start_timer_with_conversation_command_skip_validation(
         conversation_agent_id=agent_id,
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Verify timer was created successfully despite invalid command
     timer_manager = hass.data[TIMER_DATA]
@@ -1583,7 +1583,7 @@ async def test_pause_unpause_timer_disambiguate(
 
     @callback
     def handle_timer(event_type: TimerEventType, timer: TimerInfo) -> None:
-        if event_type == TimerEventType.STARTED:
+        if event_type is TimerEventType.STARTED:
             started_event.set()
             started_timer_ids.append(timer.id)
         elif event_type == TimerEventType.UPDATED:
@@ -1602,7 +1602,7 @@ async def test_pause_unpause_timer_disambiguate(
         {"minutes": {"value": 5}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await started_event.wait()
@@ -1611,7 +1611,7 @@ async def test_pause_unpause_timer_disambiguate(
     result = await intent.async_handle(
         hass, "test", intent.INTENT_PAUSE_TIMER, {}, device_id=device_id
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await updated_event.wait()
@@ -1625,7 +1625,7 @@ async def test_pause_unpause_timer_disambiguate(
         {"minutes": {"value": 10}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await started_event.wait()
@@ -1637,7 +1637,7 @@ async def test_pause_unpause_timer_disambiguate(
     result = await intent.async_handle(
         hass, "test", intent.INTENT_PAUSE_TIMER, {}, device_id=device_id
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await updated_event.wait()
@@ -1653,7 +1653,7 @@ async def test_pause_unpause_timer_disambiguate(
         {"start_minutes": {"value": 10}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await updated_event.wait()
@@ -1666,7 +1666,7 @@ async def test_pause_unpause_timer_disambiguate(
     result = await intent.async_handle(
         hass, "test", intent.INTENT_UNPAUSE_TIMER, {}, device_id=device_id
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await updated_event.wait()
@@ -1706,7 +1706,7 @@ async def test_cancel_all_timers(hass: HomeAssistant, init_components) -> None:
     def handle_timer(event_type: TimerEventType, timer: TimerInfo) -> None:
         nonlocal num_started
 
-        if event_type == TimerEventType.STARTED:
+        if event_type is TimerEventType.STARTED:
             num_started += 1
             if num_started == 3:
                 started_event.set()
@@ -1721,7 +1721,7 @@ async def test_cancel_all_timers(hass: HomeAssistant, init_components) -> None:
         {"name": {"value": "pizza"}, "minutes": {"value": 10}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     result = await intent.async_handle(
         hass,
@@ -1730,7 +1730,7 @@ async def test_cancel_all_timers(hass: HomeAssistant, init_components) -> None:
         {"name": {"value": "tv"}, "minutes": {"value": 10}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     result2 = await intent.async_handle(
         hass,
@@ -1739,7 +1739,7 @@ async def test_cancel_all_timers(hass: HomeAssistant, init_components) -> None:
         {"name": {"value": "media"}, "minutes": {"value": 15}},
         device_id=device_id,
     )
-    assert result2.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result2.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Wait for all timers to start
     async with asyncio.timeout(1):
@@ -1749,14 +1749,14 @@ async def test_cancel_all_timers(hass: HomeAssistant, init_components) -> None:
     result = await intent.async_handle(
         hass, "test", intent.INTENT_CANCEL_ALL_TIMERS, {}, device_id=device_id
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.speech_slots.get("canceled", 0) == 3
 
     # No timers should be running for test_device
     result = await intent.async_handle(
         hass, "test", intent.INTENT_TIMER_STATUS, {}, device_id=device_id
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 0
 
@@ -1797,7 +1797,7 @@ async def test_cancel_all_timers_area(
     def handle_timer(event_type: TimerEventType, timer: TimerInfo) -> None:
         nonlocal num_started
 
-        if event_type == TimerEventType.STARTED:
+        if event_type is TimerEventType.STARTED:
             num_started += 1
             if num_started == num_timers:
                 started_event.set()
@@ -1813,7 +1813,7 @@ async def test_cancel_all_timers_area(
         {"name": {"value": "pizza"}, "minutes": {"value": 10}},
         device_id=device_kitchen.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     result = await intent.async_handle(
         hass,
@@ -1822,7 +1822,7 @@ async def test_cancel_all_timers_area(
         {"name": {"value": "tv"}, "minutes": {"value": 10}},
         device_id=device_living_room.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     result = await intent.async_handle(
         hass,
@@ -1831,7 +1831,7 @@ async def test_cancel_all_timers_area(
         {"name": {"value": "media"}, "minutes": {"value": 15}},
         device_id=device_living_room.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Wait for all timers to start
     async with asyncio.timeout(1):
@@ -1845,7 +1845,7 @@ async def test_cancel_all_timers_area(
         {"area": {"value": "kitchen"}},
         device_id=device_kitchen.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.speech_slots.get("canceled", 0) == 1
     assert result.speech_slots.get("area") == "kitchen"
 
@@ -1857,7 +1857,7 @@ async def test_cancel_all_timers_area(
         {"area": {"value": "kitchen"}},
         device_id=device_kitchen.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 0
 
@@ -1869,6 +1869,6 @@ async def test_cancel_all_timers_area(
         {"area": {"value": "living room"}},
         device_id=device_living_room.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 2

--- a/tests/components/jewish_calendar/test_calendar.py
+++ b/tests/components/jewish_calendar/test_calendar.py
@@ -433,7 +433,7 @@ async def test_event_property(hass: HomeAssistant) -> None:
             CONF_DAILY_EVENTS: [
                 event_type
                 for event_type in DailyCalendarEventType
-                if event_type != DailyCalendarEventType.DATE
+                if event_type is not DailyCalendarEventType.DATE
             ],
             CONF_YEARLY_EVENTS: [],
             CONF_LEARNING_SCHEDULE: [],

--- a/tests/components/kitchen_sink/test_init.py
+++ b/tests/components/kitchen_sink/test_init.py
@@ -424,7 +424,7 @@ async def test_special_repair_issue_created_when_enabled(
     assert issue.domain == DOMAIN
     assert issue.translation_key == "special_repair"
     assert issue.is_fixable is False
-    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.severity is ir.IssueSeverity.WARNING
 
 
 async def test_special_repair_preview_feature_toggle(

--- a/tests/components/lamarzocco/__init__.py
+++ b/tests/components/lamarzocco/__init__.py
@@ -41,7 +41,7 @@ def get_bluetooth_service_info(model: ModelName, serial: str) -> BluetoothServic
     """Return a mocked BluetoothServiceInfo."""
     if model in (ModelName.GS3_AV, ModelName.GS3_MP):
         name = f"GS3_{serial}"
-    elif model == ModelName.LINEA_MINI:
+    elif model is ModelName.LINEA_MINI:
         name = f"MINI_{serial}"
     elif model == ModelName.LINEA_MICRA:
         name = f"MICRA_{serial}"

--- a/tests/components/lamarzocco/conftest.py
+++ b/tests/components/lamarzocco/conftest.py
@@ -102,7 +102,7 @@ def mock_cloud_client() -> Generator[MagicMock]:
 def mock_lamarzocco(device_fixture: ModelName) -> Generator[MagicMock]:
     """Return a mocked LM client."""
 
-    if device_fixture == ModelName.LINEA_MINI:
+    if device_fixture is ModelName.LINEA_MINI:
         config = load_json_object_fixture("config_mini.json", DOMAIN)
     elif device_fixture == ModelName.LINEA_MICRA:
         config = load_json_object_fixture("config_micra.json", DOMAIN)

--- a/tests/components/lametric/test_button.py
+++ b/tests/components/lametric/test_button.py
@@ -37,7 +37,7 @@ async def test_button_app_next(
     entry = entity_registry.async_get("button.frenck_s_lametric_next_app")
     assert entry
     assert entry.unique_id == "SA110405124500W00BS9-app_next"
-    assert entry.entity_category == EntityCategory.CONFIG
+    assert entry.entity_category is EntityCategory.CONFIG
 
     assert entry.device_id
     device_entry = device_registry.async_get(entry.device_id)
@@ -85,7 +85,7 @@ async def test_button_app_previous(
     entry = entity_registry.async_get("button.frenck_s_lametric_previous_app")
     assert entry
     assert entry.unique_id == "SA110405124500W00BS9-app_previous"
-    assert entry.entity_category == EntityCategory.CONFIG
+    assert entry.entity_category is EntityCategory.CONFIG
 
     assert entry.device_id
     device_entry = device_registry.async_get(entry.device_id)
@@ -134,7 +134,7 @@ async def test_button_dismiss_current_notification(
     )
     assert entry
     assert entry.unique_id == "SA110405124500W00BS9-dismiss_current"
-    assert entry.entity_category == EntityCategory.CONFIG
+    assert entry.entity_category is EntityCategory.CONFIG
 
     assert entry.device_id
     device_entry = device_registry.async_get(entry.device_id)
@@ -183,7 +183,7 @@ async def test_button_dismiss_all_notifications(
     )
     assert entry
     assert entry.unique_id == "SA110405124500W00BS9-dismiss_all"
-    assert entry.entity_category == EntityCategory.CONFIG
+    assert entry.entity_category is EntityCategory.CONFIG
 
     assert entry.device_id
     device_entry = device_registry.async_get(entry.device_id)

--- a/tests/components/lawn_mower/test_intent.py
+++ b/tests/components/lawn_mower/test_intent.py
@@ -35,7 +35,7 @@ async def test_start_lawn_mower_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -60,7 +60,7 @@ async def test_start_lawn_mower_without_name(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -88,7 +88,7 @@ async def test_stop_lawn_mower_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -113,7 +113,7 @@ async def test_stop_lawn_mower_without_name(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN

--- a/tests/components/lcn/test_config_flow.py
+++ b/tests/components/lcn/test_config_flow.py
@@ -58,7 +58,7 @@ async def test_show_form(hass: HomeAssistant) -> None:
 
     result = await flow.async_step_user(user_input=None)
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -73,7 +73,7 @@ async def test_step_user(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": config_entries.SOURCE_USER}, data=data
         )
 
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == CONNECTION_DATA[CONF_HOST]
         assert result["data"] == {
             **CONNECTION_DATA,
@@ -94,7 +94,7 @@ async def test_step_user_existing_host(
             DOMAIN, context={"source": config_entries.SOURCE_USER}, data=config_data
         )
 
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["type"] is data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "already_configured"
 
 
@@ -121,7 +121,7 @@ async def test_step_user_error(
             DOMAIN, context={"source": config_entries.SOURCE_USER}, data=data
         )
 
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
         assert result["errors"] == errors
 
 
@@ -131,7 +131,7 @@ async def test_step_reconfigure(hass: HomeAssistant, entry: MockConfigEntry) -> 
     old_entry_data = entry.data.copy()
 
     result = await entry.start_reconfigure_flow(hass)
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reconfigure"
 
     with (
@@ -142,7 +142,7 @@ async def test_step_reconfigure(hass: HomeAssistant, entry: MockConfigEntry) -> 
             result["flow_id"],
             CONFIG_DATA.copy(),
         )
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["type"] is data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "reconfigure_successful"
 
         entry = hass.config_entries.async_get_entry(entry.entry_id)
@@ -169,7 +169,7 @@ async def test_step_reconfigure_error(
     entry.add_to_hass(hass)
 
     result = await entry.start_reconfigure_flow(hass)
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reconfigure"
 
     with patch(
@@ -181,7 +181,7 @@ async def test_step_reconfigure_error(
             CONFIG_DATA.copy(),
         )
 
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
         assert result["errors"] == errors
 
 

--- a/tests/components/lg_netcast/test_config_flow.py
+++ b/tests/components/lg_netcast/test_config_flow.py
@@ -31,7 +31,7 @@ async def test_show_form(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -52,12 +52,12 @@ async def test_manual_host(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: IP_ADDRESS}
         )
 
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "authorize"
         assert not result["errors"]
 
         result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result2["type"] == data_entry_flow.FlowResultType.FORM
+        assert result2["type"] is data_entry_flow.FlowResultType.FORM
         assert result2["step_id"] == "authorize"
         assert result2["errors"] is not None
         assert result2["errors"][CONF_ACCESS_TOKEN] == "invalid_access_token"
@@ -66,7 +66,7 @@ async def test_manual_host(hass: HomeAssistant) -> None:
             result["flow_id"], {CONF_ACCESS_TOKEN: FAKE_PIN}
         )
 
-        assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result3["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result3["title"] == FRIENDLY_NAME
         assert result3["data"] == {
             CONF_HOST: IP_ADDRESS,
@@ -84,7 +84,7 @@ async def test_manual_host_no_connection_during_authorize(hass: HomeAssistant) -
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: IP_ADDRESS}
         )
 
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["type"] is data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "cannot_connect"
 
 
@@ -97,7 +97,7 @@ async def test_manual_host_invalid_details_during_authorize(
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: IP_ADDRESS}
         )
 
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["type"] is data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "cannot_connect"
 
 
@@ -108,7 +108,7 @@ async def test_manual_host_unsuccessful_details_response(hass: HomeAssistant) ->
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: IP_ADDRESS}
         )
 
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["type"] is data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "cannot_connect"
 
 
@@ -119,7 +119,7 @@ async def test_manual_host_no_unique_id_response(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: IP_ADDRESS}
         )
 
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["type"] is data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "invalid_host"
 
 
@@ -130,7 +130,7 @@ async def test_invalid_session_id(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: IP_ADDRESS}
         )
 
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "authorize"
         assert not result["errors"]
 
@@ -138,7 +138,7 @@ async def test_invalid_session_id(hass: HomeAssistant) -> None:
             result["flow_id"], {CONF_ACCESS_TOKEN: FAKE_PIN}
         )
 
-        assert result2["type"] == data_entry_flow.FlowResultType.FORM
+        assert result2["type"] is data_entry_flow.FlowResultType.FORM
         assert result2["step_id"] == "authorize"
         assert result2["errors"] is not None
         assert result2["errors"]["base"] == "cannot_connect"
@@ -169,7 +169,7 @@ async def test_display_access_token_aborted(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: IP_ADDRESS}
         )
 
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "authorize"
         assert not result["errors"]
 

--- a/tests/components/lifx/test_binary_sensor.py
+++ b/tests/components/lifx/test_binary_sensor.py
@@ -63,7 +63,7 @@ async def test_hev_cycle_state(
     entry = entity_registry.async_get(entity_id)
     assert state
     assert entry.unique_id == f"{SERIAL}_hev_cycle_state"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
     bulb.hev_cycle = {"duration": 7200, "remaining": 0, "last_power": False}
 

--- a/tests/components/lovelace/test_cast.py
+++ b/tests/components/lovelace/test_cast.py
@@ -91,7 +91,7 @@ async def test_root_object(hass: HomeAssistant) -> None:
     assert len(root) == 1
     item = root[0]
     assert item.title == "Dashboards"
-    assert item.media_class == MediaClass.APP
+    assert item.media_class is MediaClass.APP
     assert item.media_content_id == ""
     assert item.media_content_type == lovelace_cast.DOMAIN
     assert item.thumbnail == "/api/brands/integration/lovelace/logo.png"

--- a/tests/components/lovelace/test_dashboard.py
+++ b/tests/components/lovelace/test_dashboard.py
@@ -375,7 +375,7 @@ async def test_lovelace_from_yaml_creates_repair_issue(
     issue_registry = ir.async_get(hass)
     issue = issue_registry.async_get_issue("lovelace", "yaml_mode_deprecated")
     assert issue is not None
-    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.severity is ir.IssueSeverity.WARNING
     assert issue.is_fixable is False
     assert issue.breaks_in_ha_version == "2026.8.0"
 

--- a/tests/components/marytts/test_tts.py
+++ b/tests/components/marytts/test_tts.py
@@ -77,7 +77,7 @@ async def test_service_say(
             await retrieve_media(
                 hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID]
             )
-            == HTTPStatus.OK
+            is HTTPStatus.OK
         )
         await hass.async_block_till_done(wait_background_tasks=True)
 
@@ -117,7 +117,7 @@ async def test_service_say_with_effect(
             await retrieve_media(
                 hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID]
             )
-            == HTTPStatus.OK
+            is HTTPStatus.OK
         )
         await hass.async_block_till_done(wait_background_tasks=True)
 
@@ -157,7 +157,7 @@ async def test_service_say_http_error(
             await retrieve_media(
                 hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID]
             )
-            == HTTPStatus.INTERNAL_SERVER_ERROR
+            is HTTPStatus.INTERNAL_SERVER_ERROR
         )
 
     mock_speak.assert_called_once()

--- a/tests/components/matter/test_sensor.py
+++ b/tests/components/matter/test_sensor.py
@@ -146,7 +146,7 @@ async def test_battery_sensor(
     entry = entity_registry.async_get(entity_id)
 
     assert entry
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
 
 @pytest.mark.parametrize("node_fixture", ["eve_contact_sensor"])
@@ -172,7 +172,7 @@ async def test_battery_sensor_voltage(
     entry = entity_registry.async_get(entity_id)
 
     assert entry
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
 
 @pytest.mark.parametrize("node_fixture", ["heiman_smoke_detector"])

--- a/tests/components/maxcube/test_maxcube_binary_sensor.py
+++ b/tests/components/maxcube/test_maxcube_binary_sensor.py
@@ -33,7 +33,7 @@ async def test_window_shuttler(
     assert entity_registry.async_is_registered(ENTITY_ID)
     entity = entity_registry.async_get(ENTITY_ID)
     assert entity.unique_id == "AABBCCDD03"
-    assert entity.entity_category == EntityCategory.DIAGNOSTIC
+    assert entity.entity_category is EntityCategory.DIAGNOSTIC
 
     state = hass.states.get(ENTITY_ID)
     assert state is not None
@@ -59,7 +59,7 @@ async def test_window_shuttler_battery(
     assert entity_registry.async_is_registered(BATTERY_ENTITY_ID)
     entity = entity_registry.async_get(BATTERY_ENTITY_ID)
     assert entity.unique_id == "AABBCCDD03_battery"
-    assert entity.entity_category == EntityCategory.DIAGNOSTIC
+    assert entity.entity_category is EntityCategory.DIAGNOSTIC
 
     state = hass.states.get(BATTERY_ENTITY_ID)
     assert state is not None

--- a/tests/components/media_player/test_intent.py
+++ b/tests/components/media_player/test_intent.py
@@ -68,7 +68,7 @@ async def test_pause_media_player_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -115,7 +115,7 @@ async def test_unpause_media_player_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -141,7 +141,7 @@ async def test_next_media_player_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -192,7 +192,7 @@ async def test_previous_media_player_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -243,7 +243,7 @@ async def test_volume_media_player_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -284,7 +284,7 @@ async def test_media_player_mute_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -325,7 +325,7 @@ async def test_media_player_unmute_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -479,7 +479,7 @@ async def test_multiple_media_players(
         {"name": {"value": "TV"}, "floor": {"value": "upstairs"}},
     )
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     assert calls[0].data == {"entity_id": bedroom_tv.entity_id}
     hass.states.async_set(bedroom_tv.entity_id, STATE_PAUSED, attributes=attributes)
@@ -494,7 +494,7 @@ async def test_multiple_media_players(
     )
 
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     assert calls[0].data == {"entity_id": living_room_tv.entity_id}
     hass.states.async_set(living_room_tv.entity_id, STATE_PAUSED, attributes=attributes)
@@ -508,7 +508,7 @@ async def test_multiple_media_players(
         {"name": {"value": "smart speaker"}, "area": {"value": "kitchen"}},
     )
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     assert calls[0].data == {"entity_id": kitchen_smart_speaker.entity_id}
     hass.states.async_set(
@@ -527,7 +527,7 @@ async def test_multiple_media_players(
         },
     )
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     assert calls[0].data == {"entity_id": living_room_smart_speaker.entity_id}
     hass.states.async_set(
@@ -543,7 +543,7 @@ async def test_multiple_media_players(
         {"floor": {"value": "upstairs"}},
     )
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 3
     assert {call.data["entity_id"] for call in calls} == {
         bedroom_tv.entity_id,
@@ -565,7 +565,7 @@ async def test_multiple_media_players(
         },
     )
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     assert calls[0].data == {"entity_id": bedroom_tv.entity_id}
     hass.states.async_set(bedroom_tv.entity_id, STATE_PAUSED, attributes=attributes)
@@ -579,7 +579,7 @@ async def test_multiple_media_players(
         {"area": {"value": "bathroom"}, "volume_level": {"value": 50}},
     )
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     assert calls[0].data == {
         "entity_id": bathroom_smart_speaker.entity_id,
@@ -599,7 +599,7 @@ async def test_multiple_media_players(
         {"floor": {"value": "ground"}},
     )
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     assert calls[0].data == {"entity_id": kitchen_smart_speaker.entity_id}
 
@@ -612,7 +612,7 @@ async def test_multiple_media_players(
         {"area": {"value": "kitchen"}},
     )
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     assert calls[0].data == {"entity_id": kitchen_smart_speaker.entity_id}
 
@@ -628,7 +628,7 @@ async def test_multiple_media_players(
         media_player_intent.INTENT_MEDIA_UNPAUSE,
     )
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     assert calls[0].data == {"entity_id": kitchen_smart_speaker.entity_id}
 
@@ -666,7 +666,7 @@ async def test_manual_pause_unpause(
         context=context,
     )
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 2
 
     hass.states.async_set(
@@ -686,7 +686,7 @@ async def test_manual_pause_unpause(
         context=context,
     )
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 2
 
     hass.states.async_set(
@@ -707,7 +707,7 @@ async def test_manual_pause_unpause(
         context=context,
     )
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     assert calls[0].data == {"entity_id": device_1.entity_id}
 
@@ -732,7 +732,7 @@ async def test_manual_pause_unpause(
         context=context,
     )
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     assert calls[0].data == {"entity_id": device_2.entity_id}
 
@@ -776,7 +776,7 @@ async def test_search_and_play_media_player_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Response should contain a "media" slot with the matched item.
     assert not response.speech
@@ -812,7 +812,7 @@ async def test_search_and_play_media_player_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
 
     # A search failure is indicated by no "media" slot in the response.
     assert not response.speech
@@ -928,7 +928,7 @@ async def test_search_and_play_media_player_intent_with_media_class(
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Response should contain a "media" slot with the matched item.
     assert not response.speech
@@ -1020,7 +1020,7 @@ async def test_volume_relative_media_player_intent(
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     idle_expected_volume += volume_change
     assert math.isclose(idle_entity.volume_level, idle_expected_volume)
 
@@ -1051,7 +1051,7 @@ async def test_volume_relative_media_player_intent(
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     playing_expected_volume += volume_change
     assert math.isclose(idle_entity.volume_level, idle_expected_volume)
     assert math.isclose(playing_entity.volume_level, playing_expected_volume)
@@ -1065,7 +1065,7 @@ async def test_volume_relative_media_player_intent(
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     idle_expected_volume += volume_change
     assert math.isclose(idle_entity.volume_level, idle_expected_volume)
     assert math.isclose(playing_entity.volume_level, playing_expected_volume)
@@ -1079,7 +1079,7 @@ async def test_volume_relative_media_player_intent(
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     playing_expected_volume += volume_change_int / 100
     assert math.isclose(idle_entity.volume_level, idle_expected_volume)
     assert math.isclose(playing_entity.volume_level, playing_expected_volume)

--- a/tests/components/microsoft/test_tts.py
+++ b/tests/components/microsoft/test_tts.py
@@ -70,7 +70,7 @@ async def test_service_say(
         await retrieve_media(
             hass, hass_client, service_calls[1].data[ATTR_MEDIA_CONTENT_ID]
         )
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
 
     assert len(mock_tts.mock_calls) == 2
@@ -125,7 +125,7 @@ async def test_service_say_en_gb_config(
         await retrieve_media(
             hass, hass_client, service_calls[1].data[ATTR_MEDIA_CONTENT_ID]
         )
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
 
     assert len(mock_tts.mock_calls) == 2
@@ -174,7 +174,7 @@ async def test_service_say_en_gb_service(
         await retrieve_media(
             hass, hass_client, service_calls[1].data[ATTR_MEDIA_CONTENT_ID]
         )
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
 
     assert len(mock_tts.mock_calls) == 2
@@ -228,7 +228,7 @@ async def test_service_say_fa_ir_config(
         await retrieve_media(
             hass, hass_client, service_calls[1].data[ATTR_MEDIA_CONTENT_ID]
         )
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
 
     assert len(mock_tts.mock_calls) == 2
@@ -281,7 +281,7 @@ async def test_service_say_fa_ir_service(
         await retrieve_media(
             hass, hass_client, service_calls[1].data[ATTR_MEDIA_CONTENT_ID]
         )
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
 
     assert len(mock_tts.mock_calls) == 2
@@ -366,7 +366,7 @@ async def test_service_say_error(
         await retrieve_media(
             hass, hass_client, service_calls[1].data[ATTR_MEDIA_CONTENT_ID]
         )
-        == HTTPStatus.INTERNAL_SERVER_ERROR
+        is HTTPStatus.INTERNAL_SERVER_ERROR
     )
 
     assert len(mock_tts.mock_calls) == 2

--- a/tests/components/mobile_app/test_sensor.py
+++ b/tests/components/mobile_app/test_sensor.py
@@ -559,7 +559,7 @@ async def test_default_disabling_entity(
 
     assert (
         entity_registry.async_get("sensor.test_1_battery_state").disabled_by
-        == er.RegistryEntryDisabler.INTEGRATION
+        is er.RegistryEntryDisabler.INTEGRATION
     )
 
 

--- a/tests/components/mobile_app/test_webhook.py
+++ b/tests/components/mobile_app/test_webhook.py
@@ -1126,7 +1126,7 @@ async def test_reregister_sensor(
     assert entry.unit_of_measurement == "%"
     assert entry.entity_category == "diagnostic"
     assert entry.original_icon == "mdi:new-icon"
-    assert entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
     reg_resp = await webhook_client.post(
         webhook_url,

--- a/tests/components/mqtt/common.py
+++ b/tests/components/mqtt/common.py
@@ -2494,7 +2494,7 @@ async def help_test_entity_category(
     entity_id = ent_registry.async_get_entity_id(domain, mqtt.DOMAIN, unique_id)
     assert entity_id is not None and hass.states.get(entity_id)
     entry = ent_registry.async_get(entity_id)
-    assert entry is not None and entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry is not None and entry.entity_category is EntityCategory.DIAGNOSTIC
 
     # Discover an entity with entity category set to "no_such_category"
     unique_id = "veryunique3"

--- a/tests/components/nextcloud/test_init.py
+++ b/tests/components/nextcloud/test_init.py
@@ -92,4 +92,4 @@ async def test_setup_entry_errors(
     ):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
-        assert entry.state == expcted_entry_state
+        assert entry.state is expcted_entry_state

--- a/tests/components/ntfy/test_config_flow.py
+++ b/tests/components/ntfy/test_config_flow.py
@@ -93,7 +93,7 @@ async def test_form(
     await hass.async_block_till_done(wait_background_tasks=True)
     subentry_flows = hass.config_entries.subentries.async_progress()
     assert len(subentry_flows) == 1
-    assert result["next_flow"][0] == FlowType.CONFIG_SUBENTRIES_FLOW
+    assert result["next_flow"][0] is FlowType.CONFIG_SUBENTRIES_FLOW
     result = await hass.config_entries.subentries.async_configure(
         result["next_flow"][1], {"next_step_id": "add_topic"}
     )

--- a/tests/components/ollama/test_conversation.py
+++ b/tests/components/ollama/test_conversation.py
@@ -84,7 +84,7 @@ async def test_chat(
             Message(role="user", content="test message"),
         ]
 
-        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE, (
+        assert result.response.response_type is intent.IntentResponseType.ACTION_DONE, (
             result
         )
         assert result.response.speech["plain"]["speech"] == "test response"
@@ -147,7 +147,7 @@ async def test_chat_stream(
             Message(role="user", content="test message"),
         ]
 
-        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE, (
+        assert result.response.response_type is intent.IntentResponseType.ACTION_DONE, (
             result
         )
         assert result.response.speech["plain"]["speech"] == "test response"
@@ -254,7 +254,7 @@ async def test_template_variables(
             hass, "hello", None, context, agent_id=mock_config_entry.entry_id
         )
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE, (
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE, (
         result
     )
 
@@ -357,7 +357,7 @@ async def test_function_call(
         )
 
     assert mock_chat.call_count == 2
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert (
         result.response.speech["plain"]["speech"]
         == "I have successfully called the function"
@@ -441,7 +441,7 @@ async def test_function_exception(
         )
 
     assert mock_chat.call_count == 2
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert (
         result.response.speech["plain"]["speech"]
         == "There was an error calling the function"
@@ -559,7 +559,7 @@ async def test_history_conversion(
             Message(role="user", content="test message"),
         ]
 
-        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE, (
+        assert result.response.response_type is intent.IntentResponseType.ACTION_DONE, (
             result
         )
         assert result.response.speech["plain"]["speech"] == "test response"
@@ -624,7 +624,7 @@ async def test_message_history_trimming(
                 agent_id=mock_config_entry.entry_id,
             )
             assert (
-                result.response.response_type == intent.IntentResponseType.ACTION_DONE
+                result.response.response_type is intent.IntentResponseType.ACTION_DONE
             ), result
 
         assert mock_chat.call_count == 5
@@ -725,7 +725,7 @@ async def test_message_history_unlimited(
                 agent_id=mock_config_entry.entry_id,
             )
             assert (
-                result.response.response_type == intent.IntentResponseType.ACTION_DONE
+                result.response.response_type is intent.IntentResponseType.ACTION_DONE
             ), result
 
         args = mock_chat.call_args_list
@@ -750,7 +750,7 @@ async def test_error_handling(
             hass, "hello", None, Context(), agent_id=mock_config_entry.entry_id
         )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR, result
+    assert result.response.response_type is intent.IntentResponseType.ERROR, result
     assert result.response.error_code == "unknown", result
 
 
@@ -776,7 +776,7 @@ async def test_template_error(
             hass, "hello", None, Context(), agent_id=mock_config_entry.entry_id
         )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR, result
+    assert result.response.response_type is intent.IntentResponseType.ERROR, result
     assert result.response.error_code == "unknown", result
 
 
@@ -808,7 +808,7 @@ async def test_conversation_agent(
     assert device_entry.identifiers == {(ollama.DOMAIN, subentry.subentry_id)}
     assert device_entry.name == subentry.title
     assert device_entry.manufacturer == "Ollama"
-    assert device_entry.entry_type == dr.DeviceEntryType.SERVICE
+    assert device_entry.entry_type is dr.DeviceEntryType.SERVICE
 
     model, _, version = subentry.data[ollama.CONF_MODEL].partition(":")
     assert device_entry.model == model

--- a/tests/components/open_router/test_conversation.py
+++ b/tests/components/open_router/test_conversation.py
@@ -69,7 +69,7 @@ async def test_default_prompt(
         agent_id="conversation.gpt_3_5_turbo",
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert mock_chat_log.content[1:] == snapshot
     call = mock_openai_client.chat.completions.create.call_args_list[0][1]
     assert call["model"] == "openai/gpt-3.5-turbo"
@@ -136,7 +136,7 @@ async def test_empty_api_response(
         agent_id="conversation.gpt_3_5_turbo",
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
 
 
 @pytest.mark.parametrize("enable_assist", [True])
@@ -258,7 +258,7 @@ async def test_function_call(
         agent_id="conversation.gpt_3_5_turbo",
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     # Don't test the prompt, as it's not deterministic
     assert mock_chat_log.content[1:] == snapshot
     assert mock_openai_client.chat.completions.create.call_count == 2

--- a/tests/components/openai_conversation/test_conversation.py
+++ b/tests/components/openai_conversation/test_conversation.py
@@ -115,7 +115,7 @@ async def test_error_handling(
         hass, "hello", None, Context(), agent_id=mock_config_entry.entry_id
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR, result
+    assert result.response.response_type is intent.IntentResponseType.ERROR, result
     assert result.response.speech["plain"]["speech"] == message, result.response.speech
 
 
@@ -167,7 +167,7 @@ async def test_incomplete_response(
         agent_id="conversation.openai_conversation",
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR, result
+    assert result.response.response_type is intent.IntentResponseType.ERROR, result
     assert (
         result.response.speech["plain"]["speech"]
         == f"OpenAI response incomplete: {message}"
@@ -191,7 +191,7 @@ async def test_incomplete_response(
         agent_id="conversation.openai_conversation",
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR, result
+    assert result.response.response_type is intent.IntentResponseType.ERROR, result
     assert (
         result.response.speech["plain"]["speech"]
         == f"OpenAI response incomplete: {message}"
@@ -230,7 +230,7 @@ async def test_failed_response(
         agent_id="conversation.openai_conversation",
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR, result
+    assert result.response.response_type is intent.IntentResponseType.ERROR, result
     assert result.response.speech["plain"]["speech"] == message, result.response.speech
 
 
@@ -338,7 +338,7 @@ async def test_function_call(
         agent_id="conversation.openai_conversation",
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     # Don't test the prompt, as it's not deterministic
     assert mock_chat_log.content[1:] == snapshot
     assert mock_create_stream.call_args.kwargs["input"][1:] == snapshot
@@ -382,7 +382,7 @@ async def test_function_call_without_reasoning(
         agent_id="conversation.openai_conversation",
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     # Don't test the prompt, as it's not deterministic
     assert mock_chat_log.content[1:] == snapshot
 
@@ -568,7 +568,7 @@ async def test_store_responses_forwarded_for_conversation_agent(
         hass, "hello", None, Context(), agent_id=mock_config_entry.entry_id
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert mock_create_stream.call_args is not None
     assert mock_create_stream.call_args.kwargs["store"] is expected_store
 
@@ -637,7 +637,7 @@ async def test_web_search(
             },
         }
     ]
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Test follow-up message in multi-turn conversation
     mock_create_stream.return_value = [
@@ -707,7 +707,7 @@ async def test_code_interpreter(
     assert mock_create_stream.mock_calls[0][2]["tools"] == [
         {"type": "code_interpreter", "container": {"type": "auto"}}
     ]
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.speech["plain"]["speech"] == message, result.response.speech
 
     # Test follow-up message in multi-turn conversation
@@ -765,7 +765,7 @@ async def test_flex_tier_retry(
     )
 
     assert mock_create_stream.call_count == 2
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.speech["plain"]["speech"] == "How can I assist?", (
         result.response.speech
     )

--- a/tests/components/openai_conversation/test_tts.py
+++ b/tests/components/openai_conversation/test_tts.py
@@ -105,7 +105,7 @@ async def test_tts(
     assert len(calls) == 1
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
     voice_id = service_data[tts.ATTR_OPTIONS].get(tts.ATTR_VOICE, "marin")
     mock_create_speech.assert_called_once_with(
@@ -153,7 +153,7 @@ async def test_tts_preferred_format(
     assert len(calls) == 1
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
     mock_create_speech.assert_called_once_with(
         model="gpt-4o-mini-tts",
@@ -225,7 +225,7 @@ async def test_tts_error(
     assert len(calls) == 1
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.INTERNAL_SERVER_ERROR
+        is HTTPStatus.INTERNAL_SERVER_ERROR
     )
     mock_create_speech.assert_called_once_with(
         model="gpt-4o-mini-tts",

--- a/tests/components/opentherm_gw/test_switch.py
+++ b/tests/components/opentherm_gw/test_switch.py
@@ -50,7 +50,7 @@ async def test_switch_added_disabled(
     ) is not None
 
     assert (entity_entry := entity_registry.async_get(switch_entity_id)) is not None
-    assert entity_entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
+    assert entity_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")

--- a/tests/components/opower/test_coordinator.py
+++ b/tests/components/opower/test_coordinator.py
@@ -241,7 +241,7 @@ async def test_coordinator_migration(
     issue_registry = ir.async_get(hass)
     issue = issue_registry.async_get_issue(DOMAIN, "return_to_grid_migration_111111")
     assert issue is not None
-    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.severity is ir.IssueSeverity.WARNING
 
 
 @pytest.mark.parametrize(

--- a/tests/components/orvibo/test_config_flow.py
+++ b/tests/components/orvibo/test_config_flow.py
@@ -23,7 +23,7 @@ async def test_user_menu_display(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == FlowResultType.MENU
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "user"
     assert set(result["menu_options"]) == {"start_discovery", "edit"}
 
@@ -62,7 +62,7 @@ async def test_edit_flow_success(
         result["flow_id"], user_input
     )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == f"{DEFAULT_NAME} (192.168.1.2)"
     assert result["data"][CONF_HOST] == "192.168.1.2"
     assert result["data"][CONF_MAC] == expected_mac
@@ -113,7 +113,7 @@ async def test_edit_flow_errors(
         result["flow_id"], user_input
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"]["base"] == expected_error
 
     mock_s20.side_effect = None
@@ -124,7 +124,7 @@ async def test_edit_flow_errors(
         {CONF_HOST: "192.168.1.2", CONF_MAC: "ac:cf:23:12:34:56"},
     )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == f"{DEFAULT_NAME} (192.168.1.2)"
     assert result["data"][CONF_HOST] == "192.168.1.2"
     assert result["data"][CONF_MAC] == "ac:cf:23:12:34:56"
@@ -136,12 +136,12 @@ async def test_discovery_success(hass: HomeAssistant, mock_discover) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == FlowResultType.MENU
+    assert result["type"] is FlowResultType.MENU
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "start_discovery"}
     )
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "start_discovery"
     assert result["progress_action"] == "start_discovery"
 
@@ -149,14 +149,14 @@ async def test_discovery_success(hass: HomeAssistant, mock_discover) -> None:
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "choose_switch"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_SWITCH_LIST: "192.168.1.100"}
     )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == f"{DEFAULT_NAME} (192.168.1.100)"
     assert result["data"][CONF_HOST] == "192.168.1.100"
     assert result["data"][CONF_MAC] == "ac:cf:23:12:34:56"
@@ -181,14 +181,14 @@ async def test_discovery_no_devices(
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result["type"] == FlowResultType.MENU
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "discovery_failed"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "edit"}
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "edit"
 
     mock_s20.return_value._mac = b"\xaa\xbb\xcc\xdd\xee\xff"
@@ -198,7 +198,7 @@ async def test_discovery_no_devices(
         {CONF_HOST: "192.168.1.10", CONF_MAC: "aa:bb:cc:dd:ee:ff"},
     )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == f"{DEFAULT_NAME} (192.168.1.10)"
     assert result["data"][CONF_HOST] == "192.168.1.10"
     assert result["data"][CONF_MAC] == "aa:bb:cc:dd:ee:ff"
@@ -232,7 +232,7 @@ async def test_import_flow_success(
         DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=import_data
     )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "192.168.1.5"
     assert result["data"][CONF_MAC] == expected_mac
 
@@ -267,7 +267,7 @@ async def test_import_flow_errors(
         DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=import_data
     )
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == expected_reason
 
 
@@ -295,7 +295,7 @@ async def test_discover_skips_existing_and_invalid_mac(
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "choose_switch"
 
     schema = result["data_schema"].schema
@@ -320,11 +320,11 @@ async def test_start_discovery_shows_progress(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"next_step_id": "start_discovery"}
         )
-        assert result["type"] == FlowResultType.SHOW_PROGRESS
+        assert result["type"] is FlowResultType.SHOW_PROGRESS
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-        assert result["type"] == FlowResultType.SHOW_PROGRESS
+        assert result["type"] is FlowResultType.SHOW_PROGRESS
         assert result["progress_action"] == "start_discovery"
 
     await hass.async_block_till_done()
@@ -348,5 +348,5 @@ async def test_discovery_flow_task_exception(
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result["type"] == FlowResultType.MENU
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "discovery_failed"

--- a/tests/components/otbr/conftest.py
+++ b/tests/components/otbr/conftest.py
@@ -64,7 +64,7 @@ def mock_api_actions(
     that speak camelCase and 404 for older PascalCase OTBRs.
     """
     status = (
-        HTTPStatus.OK if key_format == KeyFormat.CAMEL_CASE else HTTPStatus.NOT_FOUND
+        HTTPStatus.OK if key_format is KeyFormat.CAMEL_CASE else HTTPStatus.NOT_FOUND
     )
     aioclient_mock.get(re.compile(r".*/api/actions$"), status=status)
 

--- a/tests/components/otbr/test_config_flow.py
+++ b/tests/components/otbr/test_config_flow.py
@@ -68,7 +68,7 @@ def _expected_dataset_body(pan_id: int, key_format: KeyFormat) -> dict[str, Any]
     python_otbr_api emits camelCase by default and rewrites to PascalCase only
     when the /api/actions probe returns 404.
     """
-    if key_format == KeyFormat.PASCAL_CASE:
+    if key_format is KeyFormat.PASCAL_CASE:
         return {
             "Channel": 15,
             "NetworkName": f"ha-thread-{pan_id:04x}",
@@ -306,7 +306,7 @@ async def test_user_flow_router_not_setup(
     assert aioclient_mock.mock_calls[-2][0] == "PUT"
     assert aioclient_mock.mock_calls[-2][1].path == "/node/dataset/active"
     body = aioclient_mock.mock_calls[-2][2]
-    pan_id = body["PanId" if key_format == KeyFormat.PASCAL_CASE else "panId"]
+    pan_id = body["PanId" if key_format is KeyFormat.PASCAL_CASE else "panId"]
     assert body == _expected_dataset_body(pan_id, key_format)
 
     assert aioclient_mock.mock_calls[-1][0] == "PUT"
@@ -731,7 +731,7 @@ async def test_hassio_discovery_flow_router_not_setup(
     assert aioclient_mock.mock_calls[-2][0] == "PUT"
     assert aioclient_mock.mock_calls[-2][1].path == "/node/dataset/active"
     body = aioclient_mock.mock_calls[-2][2]
-    pan_id = body["PanId" if key_format == KeyFormat.PASCAL_CASE else "panId"]
+    pan_id = body["PanId" if key_format is KeyFormat.PASCAL_CASE else "panId"]
     assert body == _expected_dataset_body(pan_id, key_format)
 
     assert aioclient_mock.mock_calls[-1][0] == "PUT"
@@ -850,7 +850,7 @@ async def test_hassio_discovery_flow_router_not_setup_has_preferred_2(
     assert aioclient_mock.mock_calls[-2][0] == "PUT"
     assert aioclient_mock.mock_calls[-2][1].path == "/node/dataset/active"
     body = aioclient_mock.mock_calls[-2][2]
-    pan_id = body["PanId" if key_format == KeyFormat.PASCAL_CASE else "panId"]
+    pan_id = body["PanId" if key_format is KeyFormat.PASCAL_CASE else "panId"]
     assert body == _expected_dataset_body(pan_id, key_format)
 
     assert aioclient_mock.mock_calls[-1][0] == "PUT"

--- a/tests/components/ourgroceries/test_init.py
+++ b/tests/components/ourgroceries/test_init.py
@@ -49,4 +49,4 @@ async def test_init_failure(
     ourgroceries_config_entry: MockConfigEntry | None,
 ) -> None:
     """Test an initialization error on integration load."""
-    assert ourgroceries_config_entry.state == status
+    assert ourgroceries_config_entry.state is status

--- a/tests/components/overseerr/test_init.py
+++ b/tests/components/overseerr/test_init.py
@@ -45,7 +45,7 @@ async def test_initialization_errors(
 
     await setup_integration(hass, mock_config_entry)
 
-    assert mock_config_entry.state == config_entry_state
+    assert mock_config_entry.state is config_entry_state
 
 
 async def test_device_info(

--- a/tests/components/paperless_ngx/test_init.py
+++ b/tests/components/paperless_ngx/test_init.py
@@ -79,5 +79,5 @@ async def test_setup_config_error_handling(
 
     await setup_integration(hass, mock_config_entry)
 
-    assert mock_config_entry.state == expected_state
+    assert mock_config_entry.state is expected_state
     assert mock_config_entry.error_reason_translation_key == expected_error_key

--- a/tests/components/picotts/test_tts.py
+++ b/tests/components/picotts/test_tts.py
@@ -125,7 +125,7 @@ async def test_tts_service(
             await retrieve_media(
                 hass, hass_client, service_calls[1].data[ATTR_MEDIA_CONTENT_ID]
             )
-            == HTTPStatus.OK
+            is HTTPStatus.OK
         )
         await hass.async_block_till_done(wait_background_tasks=True)
 

--- a/tests/components/portainer/test_init.py
+++ b/tests/components/portainer/test_init.py
@@ -52,7 +52,7 @@ async def test_setup_exceptions(
     """Test the _async_setup."""
     mock_portainer_client.get_endpoints.side_effect = exception
     await setup_integration(hass, mock_config_entry)
-    assert mock_config_entry.state == expected_state
+    assert mock_config_entry.state is expected_state
 
 
 async def test_migrations(
@@ -232,7 +232,7 @@ async def test_migration_v4_to_v5_exceptions(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.MIGRATION_ERROR
+    assert entry.state is ConfigEntryState.MIGRATION_ERROR
 
 
 async def test_device_registry(

--- a/tests/components/proxmoxve/test_init.py
+++ b/tests/components/proxmoxve/test_init.py
@@ -162,7 +162,7 @@ async def test_setup_exceptions(
     attr_to_mock.side_effect = exception
 
     await setup_integration(hass, mock_config_entry)
-    assert mock_config_entry.state == expected_state
+    assert mock_config_entry.state is expected_state
 
 
 async def test_migration_v1_to_v3(
@@ -317,7 +317,7 @@ async def test_new_vm_creates_entity(
     """Test that a VM appearing after initial load gets an entity created."""
     mock_proxmox_client._node_mock.qemu.get.return_value = []
     await setup_integration(hass, mock_config_entry)
-    assert mock_config_entry.state == ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
     initial_count = len(
         er.async_entries_for_config_entry(entity_registry, mock_config_entry.entry_id)
@@ -350,7 +350,7 @@ async def test_new_container_creates_entity(
     """Test that a container appearing after initial load gets an entity created."""
     mock_proxmox_client._node_mock.lxc.get.return_value = []
     await setup_integration(hass, mock_config_entry)
-    assert mock_config_entry.state == ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
     initial_count = len(
         er.async_entries_for_config_entry(entity_registry, mock_config_entry.entry_id)

--- a/tests/components/radio_browser/conftest.py
+++ b/tests/components/radio_browser/conftest.py
@@ -45,7 +45,7 @@ async def init_integration(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert mock_config_entry.state == ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
     return mock_config_entry
 

--- a/tests/components/radio_browser/test_media_source.py
+++ b/tests/components/radio_browser/test_media_source.py
@@ -98,7 +98,7 @@ async def test_browsing_exceptions(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-        assert mock_config_entry.state == ConfigEntryState.LOADED
+        assert mock_config_entry.state is ConfigEntryState.LOADED
 
         mock_browser.return_value.stations.side_effect = exception
         with pytest.raises(BrowseError) as exc_info:
@@ -124,7 +124,7 @@ async def test_browsing_not_ready(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-        assert mock_config_entry.state == ConfigEntryState.SETUP_RETRY
+        assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
         with pytest.raises(BrowseError) as exc_info:
             await media_source.async_browse_media(
@@ -153,7 +153,7 @@ async def test_resolve_media_exceptions(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-        assert mock_config_entry.state == ConfigEntryState.LOADED
+        assert mock_config_entry.state is ConfigEntryState.LOADED
 
         mock_browser.return_value.station.side_effect = exception
         with pytest.raises(media_source.Unresolvable) as exc_info:
@@ -179,7 +179,7 @@ async def test_resolve_media_not_ready(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-        assert mock_config_entry.state == ConfigEntryState.SETUP_RETRY
+        assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
         with pytest.raises(media_source.Unresolvable) as exc_info:
             await media_source.async_resolve_media(

--- a/tests/components/recorder/common.py
+++ b/tests/components/recorder/common.py
@@ -255,7 +255,7 @@ def assert_events_equal_without_context(event: Event, other: Event) -> None:
     """Assert that two events are equal, ignoring context."""
     assert event.data == other.data
     assert event.event_type == other.event_type
-    assert event.origin == other.origin
+    assert event.origin is other.origin
     assert event.time_fired == other.time_fired
 
 

--- a/tests/components/recorder/db_schema_43.py
+++ b/tests/components/recorder/db_schema_43.py
@@ -371,7 +371,7 @@ class EventData(Base):
         event: Event, dialect: SupportedDialect | None
     ) -> bytes:
         """Create shared_data from an event."""
-        if dialect == SupportedDialect.POSTGRESQL:
+        if dialect is SupportedDialect.POSTGRESQL:
             bytes_result = json_bytes_strip_null(event.data)
         bytes_result = json_bytes(event.data)
         if len(bytes_result) > MAX_EVENT_DATA_BYTES:
@@ -613,7 +613,7 @@ class StateAttributes(Base):
                 exclude_attrs -= _MATCH_ALL_KEEP
         else:
             exclude_attrs = ALL_DOMAIN_EXCLUDE_ATTRS
-        encoder = json_bytes_strip_null if dialect == PSQL_DIALECT else json_bytes
+        encoder = json_bytes_strip_null if dialect is PSQL_DIALECT else json_bytes
         bytes_result = encoder(
             {k: v for k, v in state.attributes.items() if k not in exclude_attrs}
         )

--- a/tests/components/recorder/db_schema_48.py
+++ b/tests/components/recorder/db_schema_48.py
@@ -392,7 +392,7 @@ class EventData(Base):
         event: Event, dialect: SupportedDialect | None
     ) -> bytes:
         """Create shared_data from an event."""
-        encoder = json_bytes_strip_null if dialect == PSQL_DIALECT else json_bytes
+        encoder = json_bytes_strip_null if dialect is PSQL_DIALECT else json_bytes
         bytes_result = encoder(event.data)
         if len(bytes_result) > MAX_EVENT_DATA_BYTES:
             _LOGGER.warning(
@@ -655,7 +655,7 @@ class StateAttributes(Base):
                 exclude_attrs -= _MATCH_ALL_KEEP
         else:
             exclude_attrs = ALL_DOMAIN_EXCLUDE_ATTRS
-        encoder = json_bytes_strip_null if dialect == PSQL_DIALECT else json_bytes
+        encoder = json_bytes_strip_null if dialect is PSQL_DIALECT else json_bytes
         bytes_result = encoder(
             {k: v for k, v in state.attributes.items() if k not in exclude_attrs}
         )

--- a/tests/components/recorder/db_schema_50.py
+++ b/tests/components/recorder/db_schema_50.py
@@ -365,7 +365,7 @@ class EventData(Base):
         event: Event, dialect: SupportedDialect | None
     ) -> bytes:
         """Create shared_data from an event."""
-        encoder = json_bytes_strip_null if dialect == PSQL_DIALECT else json_bytes
+        encoder = json_bytes_strip_null if dialect is PSQL_DIALECT else json_bytes
         bytes_result = encoder(event.data)
         if len(bytes_result) > MAX_EVENT_DATA_BYTES:
             _LOGGER.warning(
@@ -579,7 +579,7 @@ class StateAttributes(Base):
                 exclude_attrs -= _MATCH_ALL_KEEP
         else:
             exclude_attrs = ALL_DOMAIN_EXCLUDE_ATTRS
-        encoder = json_bytes_strip_null if dialect == PSQL_DIALECT else json_bytes
+        encoder = json_bytes_strip_null if dialect is PSQL_DIALECT else json_bytes
         bytes_result = encoder(
             {k: v for k, v in state.attributes.items() if k not in exclude_attrs}
         )

--- a/tests/components/recorder/db_schema_51.py
+++ b/tests/components/recorder/db_schema_51.py
@@ -365,7 +365,7 @@ class EventData(Base):
         event: Event, dialect: SupportedDialect | None
     ) -> bytes:
         """Create shared_data from an event."""
-        encoder = json_bytes_strip_null if dialect == PSQL_DIALECT else json_bytes
+        encoder = json_bytes_strip_null if dialect is PSQL_DIALECT else json_bytes
         bytes_result = encoder(event.data)
         if len(bytes_result) > MAX_EVENT_DATA_BYTES:
             _LOGGER.warning(
@@ -579,7 +579,7 @@ class StateAttributes(Base):
                 exclude_attrs -= _MATCH_ALL_KEEP
         else:
             exclude_attrs = ALL_DOMAIN_EXCLUDE_ATTRS
-        encoder = json_bytes_strip_null if dialect == PSQL_DIALECT else json_bytes
+        encoder = json_bytes_strip_null if dialect is PSQL_DIALECT else json_bytes
         bytes_result = encoder(
             {k: v for k, v in state.attributes.items() if k not in exclude_attrs}
         )

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -133,7 +133,7 @@ async def test_failures_parametrized(
     )
     await hass.async_block_till_done()
 
-    assert config_entry.state == expected
+    assert config_entry.state is expected
 
 
 async def test_firmware_error_twice(

--- a/tests/components/rituals_perfume_genie/test_binary_sensor.py
+++ b/tests/components/rituals_perfume_genie/test_binary_sensor.py
@@ -31,4 +31,4 @@ async def test_binary_sensors(
     entry = entity_registry.async_get("binary_sensor.genie_charging")
     assert entry
     assert entry.unique_id == f"{hublot}-charging"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC

--- a/tests/components/rituals_perfume_genie/test_select.py
+++ b/tests/components/rituals_perfume_genie/test_select.py
@@ -42,7 +42,7 @@ async def test_select_entity(
     assert entry
     assert entry.unique_id == f"{diffuser.hublot}-room_size_square_meter"
     assert entry.unit_of_measurement == UnitOfArea.SQUARE_METERS
-    assert entry.entity_category == EntityCategory.CONFIG
+    assert entry.entity_category is EntityCategory.CONFIG
 
 
 async def test_select_option(hass: HomeAssistant) -> None:

--- a/tests/components/rituals_perfume_genie/test_sensor.py
+++ b/tests/components/rituals_perfume_genie/test_sensor.py
@@ -51,7 +51,7 @@ async def test_sensors_diffuser_v1_battery_cartridge(
     entry = entity_registry.async_get("sensor.genie_battery")
     assert entry
     assert entry.unique_id == f"{hublot}-battery_percentage"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
     state = hass.states.get("sensor.genie_wi_fi_signal")
     assert state
@@ -62,4 +62,4 @@ async def test_sensors_diffuser_v1_battery_cartridge(
     entry = entity_registry.async_get("sensor.genie_wi_fi_signal")
     assert entry
     assert entry.unique_id == f"{hublot}-wifi_percentage"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC

--- a/tests/components/roborock/conftest.py
+++ b/tests/components/roborock/conftest.py
@@ -437,7 +437,7 @@ def fake_devices_fixture() -> list[FakeDevice]:
                 NETWORK_INFO_BY_DEVICE[device_data.duid]
             )
         elif device_data.pv == "A01":
-            if device_product_data.category == RoborockCategory.WET_DRY_VAC:
+            if device_product_data.category is RoborockCategory.WET_DRY_VAC:
                 fake_device.dyad = create_dyad_trait()
             elif device_product_data.category == RoborockCategory.WASHING_MACHINE:
                 fake_device.zeo = create_zeo_trait()

--- a/tests/components/roborock/test_vacuum.py
+++ b/tests/components/roborock/test_vacuum.py
@@ -589,7 +589,7 @@ async def test_segments_changed_issue(
     issue_id = f"segments_changed_{entity_entry.id}"
     issue = ir.async_get(hass).async_get_issue(VACUUM_DOMAIN, issue_id)
     assert issue is not None
-    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.severity is ir.IssueSeverity.WARNING
     assert issue.translation_key == "segments_changed"
 
 

--- a/tests/components/roku/test_binary_sensor.py
+++ b/tests/components/roku/test_binary_sensor.py
@@ -42,7 +42,7 @@ async def test_roku_binary_sensors(
     assert entry
     assert state
     assert entry.unique_id == f"{UPNP_SERIAL}_supports_airplay"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
     assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_FRIENDLY_NAME) == "My Roku 3 Supports AirPlay"
     assert ATTR_DEVICE_CLASS not in state.attributes
@@ -52,7 +52,7 @@ async def test_roku_binary_sensors(
     assert entry
     assert state
     assert entry.unique_id == f"{UPNP_SERIAL}_supports_ethernet"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
     assert state.state == STATE_ON
     assert state.attributes.get(ATTR_FRIENDLY_NAME) == "My Roku 3 Supports Ethernet"
     assert ATTR_DEVICE_CLASS not in state.attributes
@@ -62,7 +62,7 @@ async def test_roku_binary_sensors(
     assert entry
     assert state
     assert entry.unique_id == f"{UPNP_SERIAL}_supports_find_remote"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
     assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_FRIENDLY_NAME) == "My Roku 3 Supports find remote"
     assert ATTR_DEVICE_CLASS not in state.attributes
@@ -119,7 +119,7 @@ async def test_rokutv_binary_sensors(
     assert entry
     assert state
     assert entry.unique_id == "YN00H5555555_supports_airplay"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
     assert state.state == STATE_ON
     assert (
         state.attributes.get(ATTR_FRIENDLY_NAME) == '58" Onn Roku TV Supports AirPlay'
@@ -135,7 +135,7 @@ async def test_rokutv_binary_sensors(
     assert entry
     assert state
     assert entry.unique_id == "YN00H5555555_supports_ethernet"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
     assert state.state == STATE_ON
     assert (
         state.attributes.get(ATTR_FRIENDLY_NAME) == '58" Onn Roku TV Supports Ethernet'
@@ -151,7 +151,7 @@ async def test_rokutv_binary_sensors(
     assert entry
     assert state
     assert entry.unique_id == "YN00H5555555_supports_find_remote"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
     assert state.state == STATE_ON
     assert (
         state.attributes.get(ATTR_FRIENDLY_NAME)

--- a/tests/components/roku/test_sensor.py
+++ b/tests/components/roku/test_sensor.py
@@ -35,7 +35,7 @@ async def test_roku_sensors(
     assert entry
     assert state
     assert entry.unique_id == f"{UPNP_SERIAL}_active_app"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
     assert state.state == "Roku"
     assert state.attributes.get(ATTR_FRIENDLY_NAME) == "My Roku 3 Active app"
     assert ATTR_DEVICE_CLASS not in state.attributes
@@ -45,7 +45,7 @@ async def test_roku_sensors(
     assert entry
     assert state
     assert entry.unique_id == f"{UPNP_SERIAL}_active_app_id"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
     assert state.state == STATE_UNKNOWN
     assert state.attributes.get(ATTR_FRIENDLY_NAME) == "My Roku 3 Active app ID"
     assert ATTR_DEVICE_CLASS not in state.attributes
@@ -82,7 +82,7 @@ async def test_rokutv_sensors(
     assert entry
     assert state
     assert entry.unique_id == "YN00H5555555_active_app"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
     assert state.state == "Antenna TV"
     assert state.attributes.get(ATTR_FRIENDLY_NAME) == '58" Onn Roku TV Active app'
     assert ATTR_DEVICE_CLASS not in state.attributes
@@ -92,7 +92,7 @@ async def test_rokutv_sensors(
     assert entry
     assert state
     assert entry.unique_id == "YN00H5555555_active_app_id"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
     assert state.state == "tvinput.dtv"
     assert state.attributes.get(ATTR_FRIENDLY_NAME) == '58" Onn Roku TV Active app ID'
     assert ATTR_DEVICE_CLASS not in state.attributes

--- a/tests/components/samsungtv/test_init.py
+++ b/tests/components/samsungtv/test_init.py
@@ -157,4 +157,4 @@ async def test_migrate_future_version_returns_false(
 
     await hass.config_entries.async_setup(entry.entry_id)
 
-    assert entry.state == ConfigEntryState.MIGRATION_ERROR
+    assert entry.state is ConfigEntryState.MIGRATION_ERROR

--- a/tests/components/satel_integra/test_init.py
+++ b/tests/components/satel_integra/test_init.py
@@ -242,4 +242,4 @@ async def test_setup_exceptions(
     """Test the client async_connect."""
     mock_satel.connect.side_effect = exception
     await setup_integration(hass, mock_config_entry)
-    assert mock_config_entry.state == expected_state
+    assert mock_config_entry.state is expected_state

--- a/tests/components/sftp_storage/test_backup.py
+++ b/tests/components/sftp_storage/test_backup.py
@@ -87,7 +87,7 @@ async def test_agents_info(
     assert (
         response["result"]
         == {"agents": [{"agent_id": "backup.local", "name": "local"}]}
-        or config_entry.state == ConfigEntryState.NOT_LOADED
+        or config_entry.state is ConfigEntryState.NOT_LOADED
     )
 
 

--- a/tests/components/shell_command/test_init.py
+++ b/tests/components/shell_command/test_init.py
@@ -326,7 +326,7 @@ async def test_repair_issue_on_reserved_reload_name(
     issue = issue_registry.async_get_issue(shell_command.DOMAIN, "reserved_reload")
     assert issue is not None
     assert issue.translation_key == "reserved_reload_name"
-    assert issue.severity == ir.IssueSeverity.ERROR
+    assert issue.severity is ir.IssueSeverity.ERROR
     assert issue.translation_placeholders["name"] == "reload"
     with patch(
         "homeassistant.config.load_yaml_config_file",

--- a/tests/components/shopping_list/test_init.py
+++ b/tests/components/shopping_list/test_init.py
@@ -59,7 +59,7 @@ async def test_add_item(
     assert _get_shopping_data(hass).items[0]["name"] == "beer"  # name was trimmed
 
     # Response text is now handled by default conversation agent
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert_shopping_list_data(hass, snapshot)
 
 

--- a/tests/components/shopping_list/test_intent.py
+++ b/tests/components/shopping_list/test_intent.py
@@ -24,7 +24,7 @@ async def test_complete_item_intent(hass: HomeAssistant, sl_setup) -> None:
         hass, "test", "HassShoppingListCompleteItem", {"item": {"value": "beer"}}
     )
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     completed_items = response.speech_slots.get("completed_items")
     assert len(completed_items) == 2
     assert completed_items[0]["name"] == "beer"
@@ -36,7 +36,7 @@ async def test_complete_item_intent(hass: HomeAssistant, sl_setup) -> None:
         hass, "test", "HassShoppingListCompleteItem", {"item": {"value": "beer"}}
     )
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech_slots.get("completed_items") == []
     assert _get_shopping_data(hass).items[1]["complete"]
     assert _get_shopping_data(hass).items[2]["complete"]
@@ -47,7 +47,7 @@ async def test_complete_item_intent_not_found(hass: HomeAssistant, sl_setup) -> 
     response = await intent.async_handle(
         hass, "test", "HassShoppingListCompleteItem", {"item": {"value": "beer"}}
     )
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech_slots.get("completed_items") == []
 
 

--- a/tests/components/sma/test_init.py
+++ b/tests/components/sma/test_init.py
@@ -55,4 +55,4 @@ async def test_setup_exceptions(
     """Test the _async_setup."""
     mock_sma_client.device_info.side_effect = exception
     await setup_integration(hass, mock_config_entry)
-    assert mock_config_entry.state == expected_state
+    assert mock_config_entry.state is expected_state

--- a/tests/components/smartthings/__init__.py
+++ b/tests/components/smartthings/__init__.py
@@ -160,7 +160,7 @@ def snapshot_smartthings_entities(
     for entity_state in entities:
         entity_entry = entity_registry.async_get(entity_state.entity_id)
         prefix = ""
-        if platform != Platform.SCENE:
+        if platform is not Platform.SCENE:
             # SCENE unique id is not based on device fixture
             device_id = entity_entry.unique_id[:36]
             prefix = f"{get_fixture_name(device_id)}]["

--- a/tests/components/snooz/__init__.py
+++ b/tests/components/snooz/__init__.py
@@ -88,7 +88,7 @@ class MockSnoozDevice(ParentMockSnoozDevice):
             if self._api is not None:
                 await self._api.async_disconnect()
 
-            if self.connection_status != SnoozConnectionStatus.DISCONNECTED:
+            if self.connection_status is not SnoozConnectionStatus.DISCONNECTED:
                 self._machine.device_disconnected(reason=DisconnectionReason.USER)
 
         finally:

--- a/tests/components/sonos/test_media_browser.py
+++ b/tests/components/sonos/test_media_browser.py
@@ -73,7 +73,7 @@ async def test_build_item_response(
         ),
     )
     assert browse_item.title == "Abbey Road"
-    assert browse_item.media_class == MediaClass.ALBUM
+    assert browse_item.media_class is MediaClass.ALBUM
     assert browse_item.media_content_id == "A:ALBUM/Abbey%20Road"
     assert len(browse_item.children) == 2
     assert browse_item.children[0].media_class == MediaClass.TRACK

--- a/tests/components/steam_online/test_init.py
+++ b/tests/components/steam_online/test_init.py
@@ -48,7 +48,7 @@ async def test_device_info(
     device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
 
     assert device.configuration_url == "https://store.steampowered.com"
-    assert device.entry_type == dr.DeviceEntryType.SERVICE
+    assert device.entry_type is dr.DeviceEntryType.SERVICE
     assert device.identifiers == {(DOMAIN, entry.entry_id)}
     assert device.manufacturer == DEFAULT_NAME
     assert device.name == DEFAULT_NAME

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -376,7 +376,7 @@ async def test_stream_open_fails(
         with pytest.raises(StreamWorkerError) as err:
             run_worker(hass, stream, STREAM_SOURCE)
         av_open.assert_called_once()
-        assert err.value.error_code == error_code
+        assert err.value.error_code is error_code
 
 
 async def test_stream_worker_success(hass: HomeAssistant) -> None:

--- a/tests/components/stt/test_init.py
+++ b/tests/components/stt/test_init.py
@@ -264,15 +264,15 @@ async def test_stream_audio_uses_enum_values(
     metadata, _ = setup.calls[0]
 
     assert isinstance(metadata.format, AudioFormats)
-    assert metadata.format == AudioFormats.WAV
+    assert metadata.format is AudioFormats.WAV
     assert isinstance(metadata.codec, AudioCodecs)
-    assert metadata.codec == AudioCodecs.PCM
+    assert metadata.codec is AudioCodecs.PCM
     assert isinstance(metadata.bit_rate, AudioBitRates)
-    assert metadata.bit_rate == AudioBitRates.BITRATE_16
+    assert metadata.bit_rate is AudioBitRates.BITRATE_16
     assert isinstance(metadata.sample_rate, AudioSampleRates)
-    assert metadata.sample_rate == AudioSampleRates.SAMPLERATE_16000
+    assert metadata.sample_rate is AudioSampleRates.SAMPLERATE_16000
     assert isinstance(metadata.channel, AudioChannels)
-    assert metadata.channel == AudioChannels.CHANNEL_MONO
+    assert metadata.channel is AudioChannels.CHANNEL_MONO
 
 
 @pytest.mark.parametrize(

--- a/tests/components/surepetcare/test_sensor.py
+++ b/tests/components/surepetcare/test_sensor.py
@@ -66,5 +66,5 @@ async def test_default_disabled_sensors(
     for entity_id in DEFAULT_DISABLED_ENTITIES:
         entity = entity_registry.async_get(entity_id)
         assert entity
-        assert entity.disabled_by == RegistryEntryDisabler.INTEGRATION
+        assert entity.disabled_by is RegistryEntryDisabler.INTEGRATION
         assert not hass.states.get(entity_id)

--- a/tests/components/switch_as_x/test_config_flow.py
+++ b/tests/components/switch_as_x/test_config_flow.py
@@ -121,7 +121,7 @@ async def test_config_flow_registered_entity(
     }
 
     switch_entity_entry = entity_registry.async_get("switch.ceiling")
-    assert switch_entity_entry.hidden_by == hidden_by_after
+    assert switch_entity_entry.hidden_by is hidden_by_after
 
 
 @pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)

--- a/tests/components/switch_as_x/test_init.py
+++ b/tests/components/switch_as_x/test_init.py
@@ -626,7 +626,7 @@ async def test_reset_hidden_by(
 
     # Check hidden by is reset
     switch_entity_entry = entity_registry.async_get(switch_entity_entry.entity_id)
-    assert switch_entity_entry.hidden_by == hidden_by_after
+    assert switch_entity_entry.hidden_by is hidden_by_after
 
 
 @pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)

--- a/tests/components/switchbot_cloud/test_init.py
+++ b/tests/components/switchbot_cloud/test_init.py
@@ -147,7 +147,7 @@ async def test_setup_entry_fails_when_listing_devices(
     """Test error handling when list_devices in setup of entry."""
     mock_list_devices.side_effect = error
     entry = await configure_integration(hass)
-    assert entry.state == state
+    assert entry.state is state
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()

--- a/tests/components/synology_dsm/test_media_source.py
+++ b/tests/components/synology_dsm/test_media_source.py
@@ -410,7 +410,7 @@ async def test_browse_media_get_items(
     assert isinstance(item, BrowseMedia)
     assert item.identifier == "mocked_syno_dsm_entry/1_/10_1298753/filename.jpg"
     assert item.title == "filename.jpg"
-    assert item.media_class == MediaClass.IMAGE
+    assert item.media_class is MediaClass.IMAGE
     assert item.media_content_type == "image/jpeg"
     assert item.can_play
     assert not item.can_expand
@@ -419,7 +419,7 @@ async def test_browse_media_get_items(
     assert isinstance(item, BrowseMedia)
     assert item.identifier == "mocked_syno_dsm_entry/1_/10_1298753/filename.jpg_shared"
     assert item.title == "filename.jpg"
-    assert item.media_class == MediaClass.IMAGE
+    assert item.media_class is MediaClass.IMAGE
     assert item.media_content_type == "image/jpeg"
     assert item.can_play
     assert not item.can_expand

--- a/tests/components/tailscale/test_binary_sensor.py
+++ b/tests/components/tailscale/test_binary_sensor.py
@@ -25,7 +25,7 @@ async def test_tailscale_binary_sensors(
     assert entry
     assert state
     assert entry.unique_id == "123456_update_available"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
     assert state.state == STATE_ON
     assert state.attributes.get(ATTR_FRIENDLY_NAME) == "frencks-iphone Client"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == BinarySensorDeviceClass.UPDATE
@@ -37,7 +37,7 @@ async def test_tailscale_binary_sensors(
     assert entry
     assert state
     assert entry.unique_id == "123456_key_expiry_disabled"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
     assert state.state == STATE_OFF
     assert (
         state.attributes.get(ATTR_FRIENDLY_NAME) == "frencks-iphone Key expiry disabled"
@@ -49,7 +49,7 @@ async def test_tailscale_binary_sensors(
     assert entry
     assert state
     assert entry.unique_id == "123456_client_supports_ipv6"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
     assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_FRIENDLY_NAME) == "frencks-iphone Supports IPv6"
     assert ATTR_DEVICE_CLASS not in state.attributes
@@ -59,7 +59,7 @@ async def test_tailscale_binary_sensors(
     assert entry
     assert state
     assert entry.unique_id == "123456_client_supports_pcp"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
     assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_FRIENDLY_NAME) == "frencks-iphone Supports PCP"
     assert ATTR_DEVICE_CLASS not in state.attributes
@@ -69,7 +69,7 @@ async def test_tailscale_binary_sensors(
     assert entry
     assert state
     assert entry.unique_id == "123456_client_supports_pmp"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
     assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_FRIENDLY_NAME) == "frencks-iphone Supports NAT-PMP"
     assert ATTR_DEVICE_CLASS not in state.attributes
@@ -79,7 +79,7 @@ async def test_tailscale_binary_sensors(
     assert entry
     assert state
     assert entry.unique_id == "123456_client_supports_udp"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
     assert state.state == STATE_ON
     assert state.attributes.get(ATTR_FRIENDLY_NAME) == "frencks-iphone Supports UDP"
     assert ATTR_DEVICE_CLASS not in state.attributes
@@ -89,7 +89,7 @@ async def test_tailscale_binary_sensors(
     assert entry
     assert state
     assert entry.unique_id == "123456_client_supports_upnp"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
     assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_FRIENDLY_NAME) == "frencks-iphone Supports UPnP"
     assert ATTR_DEVICE_CLASS not in state.attributes
@@ -101,7 +101,7 @@ async def test_tailscale_binary_sensors(
     assert device_entry.manufacturer == "Tailscale Inc."
     assert device_entry.model == "iOS"
     assert device_entry.name == "frencks-iphone"
-    assert device_entry.entry_type == dr.DeviceEntryType.SERVICE
+    assert device_entry.entry_type is dr.DeviceEntryType.SERVICE
     assert device_entry.sw_version == "1.12.3-td91ea7286-ge1bbbd90c"
     assert (
         device_entry.configuration_url

--- a/tests/components/tailscale/test_sensor.py
+++ b/tests/components/tailscale/test_sensor.py
@@ -21,7 +21,7 @@ async def test_tailscale_sensors(
     assert entry
     assert state
     assert entry.unique_id == "123457_expires"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
     assert state.state == "2022-02-25T09:49:06+00:00"
     assert state.attributes.get(ATTR_FRIENDLY_NAME) == "router Expires"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.TIMESTAMP
@@ -41,7 +41,7 @@ async def test_tailscale_sensors(
     assert entry
     assert state
     assert entry.unique_id == "123457_ip"
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
     assert state.state == "100.11.11.112"
     assert state.attributes.get(ATTR_FRIENDLY_NAME) == "router IP address"
     assert ATTR_DEVICE_CLASS not in state.attributes
@@ -53,7 +53,7 @@ async def test_tailscale_sensors(
     assert device_entry.manufacturer == "Tailscale Inc."
     assert device_entry.model == "linux"
     assert device_entry.name == "router"
-    assert device_entry.entry_type == dr.DeviceEntryType.SERVICE
+    assert device_entry.entry_type is dr.DeviceEntryType.SERVICE
     assert device_entry.sw_version == "1.14.0-t5cff36945-g809e87bba"
     assert (
         device_entry.configuration_url

--- a/tests/components/tami4/test_init.py
+++ b/tests/components/tami4/test_init.py
@@ -46,7 +46,7 @@ async def test_init_error_raised(
     """Test init when an error is raised."""
 
     entry = await create_config_entry(hass)
-    assert entry.state == expected_state
+    assert entry.state is expected_state
 
 
 async def test_load_unload(mock_api, hass: HomeAssistant) -> None:

--- a/tests/components/telegram_bot/test_telegram_bot.py
+++ b/tests/components/telegram_bot/test_telegram_bot.py
@@ -149,7 +149,7 @@ async def test_polling_platform_init_failed(
         await hass.async_block_till_done()
 
     mock_get_me.assert_called_once()
-    assert mock_polling_config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert mock_polling_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 @pytest.mark.parametrize(

--- a/tests/components/template/conftest.py
+++ b/tests/components/template/conftest.py
@@ -164,7 +164,7 @@ async def setup_entity(
         **({"attributes": attributes} if attributes else {}),
         **(extra_config or {}),
     }
-    if style == ConfigurationStyle.MODERN:
+    if style is ConfigurationStyle.MODERN:
         await async_setup_modern_state_format(
             hass, platform_setup.domain, count, entity_config, extra_section_config
         )
@@ -200,7 +200,7 @@ async def setup_and_test_unique_id(
         {"name": "template_entity_1", **entity_config},
         {"name": "template_entity_2", **entity_config},
     ]
-    if style == ConfigurationStyle.MODERN:
+    if style is ConfigurationStyle.MODERN:
         await async_setup_modern_state_format(hass, platform_setup.domain, 1, entities)
     elif style == ConfigurationStyle.TRIGGER:
         await async_setup_modern_trigger_format(
@@ -232,7 +232,7 @@ async def setup_and_test_nested_unique_id(
         {"name": "test_b", "unique_id": "b", **(entity_config or {}), **state_config},
     ]
     extra_section_config = {"unique_id": "x"}
-    if style == ConfigurationStyle.MODERN:
+    if style is ConfigurationStyle.MODERN:
         await async_setup_modern_state_format(
             hass, platform_setup.domain, 1, entities, extra_section_config
         )

--- a/tests/components/template/test_config.py
+++ b/tests/components/template/test_config.py
@@ -501,7 +501,7 @@ async def test_invalid_schema_raises_issue(
     issue = next(iter(issue_registry.issues.values()))
 
     assert issue.domain == "template"
-    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.severity is ir.IssueSeverity.WARNING
 
 
 async def test_multiple_configuration_keys(

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -358,7 +358,7 @@ async def test_battery_level_template_repair(
         "template", f"deprecated_battery_level_{TEST_VACUUM.entity_id}"
     )
     assert issue.domain == "template"
-    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.severity is ir.IssueSeverity.WARNING
     assert issue.translation_placeholders["entity_name"] == TEST_VACUUM.object_id
     assert issue.translation_placeholders["entity_id"] == TEST_VACUUM.entity_id
     assert "Detected that integration 'template' is setting the" not in caplog.text

--- a/tests/components/text/test_init.py
+++ b/tests/components/text/test_init.py
@@ -170,7 +170,7 @@ async def test_restore_number_restore_state(
 
     assert entity0.native_max == native_max
     assert entity0.native_min == native_min
-    assert entity0.mode == TextMode.TEXT
+    assert entity0.mode is TextMode.TEXT
     assert entity0.pattern is None
     assert entity0.native_value == native_value
     assert isinstance(entity0.native_value, native_value_type)

--- a/tests/components/todo/test_init.py
+++ b/tests/components/todo/test_init.py
@@ -1255,11 +1255,11 @@ async def test_async_subscribe_updates(
     assert isinstance(items[0], TodoItem)
     assert items[0].summary == "Item #1"
     assert items[0].uid == "1"
-    assert items[0].status == TodoItemStatus.NEEDS_ACTION
+    assert items[0].status is TodoItemStatus.NEEDS_ACTION
     assert isinstance(items[1], TodoItem)
     assert items[1].summary == "Item #2"
     assert items[1].uid == "2"
-    assert items[1].status == TodoItemStatus.COMPLETED
+    assert items[1].status is TodoItemStatus.COMPLETED
 
     # Verify items are copies (not the same objects)
     assert items[0] is not test_entity.todo_items[0]
@@ -1293,7 +1293,7 @@ async def test_async_subscribe_updates(
     assert len(items) == 1
     assert items[0].summary == "New item"
     assert items[0].uid == "4"
-    assert items[0].status == TodoItemStatus.NEEDS_ACTION
+    assert items[0].status is TodoItemStatus.NEEDS_ACTION
 
     # Unsubscribe and verify no more updates
     unsub()

--- a/tests/components/todo/test_intent.py
+++ b/tests/components/todo/test_intent.py
@@ -59,15 +59,15 @@ async def test_add_item_intent(
         {ATTR_ITEM: {"value": " beer "}, "name": {"value": "list 1"}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.success_results[0].name == "list 1"
-    assert response.success_results[0].type == intent.IntentResponseTargetType.ENTITY
+    assert response.success_results[0].type is intent.IntentResponseTargetType.ENTITY
     assert response.success_results[0].id == entity1.entity_id
 
     assert len(entity1.items) == 1
     assert len(entity2.items) == 0
     assert entity1.items[0].summary == "Beer"  # summary is trimmed and capitalized
-    assert entity1.items[0].status == TodoItemStatus.NEEDS_ACTION
+    assert entity1.items[0].status is TodoItemStatus.NEEDS_ACTION
     entity1.items.clear()
 
     # Add to second list
@@ -78,12 +78,12 @@ async def test_add_item_intent(
         {ATTR_ITEM: {"value": "cheese"}, "name": {"value": "List 2"}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
 
     assert len(entity1.items) == 0
     assert len(entity2.items) == 1
     assert entity2.items[0].summary == "Cheese"
-    assert entity2.items[0].status == TodoItemStatus.NEEDS_ACTION
+    assert entity2.items[0].status is TodoItemStatus.NEEDS_ACTION
 
     # List name is case insensitive
     response = await intent.async_handle(
@@ -93,12 +93,12 @@ async def test_add_item_intent(
         {ATTR_ITEM: {"value": "wine"}, "name": {"value": "lIST 2"}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
 
     assert len(entity1.items) == 0
     assert len(entity2.items) == 2
     assert entity2.items[1].summary == "Wine"
-    assert entity2.items[1].status == TodoItemStatus.NEEDS_ACTION
+    assert entity2.items[1].status is TodoItemStatus.NEEDS_ACTION
 
     # Should fail if lists are not exposed
     async_expose_entity(hass, conversation.DOMAIN, entity1.entity_id, False)
@@ -111,7 +111,7 @@ async def test_add_item_intent(
             {"item": {"value": "cookies"}, "name": {"value": "list 1"}},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.ASSISTANT
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.ASSISTANT
 
     # Missing list
     with pytest.raises(intent.MatchFailedError):
@@ -199,7 +199,7 @@ async def test_complete_item_intent(
     assert config_entry.state is ConfigEntryState.LOADED
 
     assert len(entity1.items) == 2
-    assert entity1.items[0].status == TodoItemStatus.NEEDS_ACTION
+    assert entity1.items[0].status is TodoItemStatus.NEEDS_ACTION
 
     # Complete item
     async_mock_service(hass, DOMAIN, todo_intent.INTENT_LIST_COMPLETE_ITEM)
@@ -210,7 +210,7 @@ async def test_complete_item_intent(
         {ATTR_ITEM: {"value": "beer"}, ATTR_NAME: {"value": "list 1"}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
 
     assert len(entity1.items) == 2
     assert entity1.items[0].status == TodoItemStatus.COMPLETED
@@ -321,7 +321,7 @@ async def test_remove_item_intent(
         {ATTR_ITEM: {"value": "beer"}, ATTR_NAME: {"value": "list 1"}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
 
     # only the first matching item has been removed
     assert len(entity1.items) == 2

--- a/tests/components/tplink/test_config_flow.py
+++ b/tests/components/tplink/test_config_flow.py
@@ -2135,9 +2135,9 @@ async def test_pick_device_errors(
             {CONF_DEVICE: MAC_ADDRESS},
         )
         await hass.async_block_till_done()
-    assert result3["type"] == expected_flow
+    assert result3["type"] is expected_flow
 
-    if expected_flow != FlowResultType.ABORT:
+    if expected_flow is not FlowResultType.ABORT:
         result4 = await hass.config_entries.flow.async_configure(
             result3["flow_id"],
             user_input={

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -451,7 +451,7 @@ async def test_feature_no_category(
     entity_id = "switch.my_plug_led"
     entity = entity_registry.async_get(entity_id)
     assert entity
-    assert entity.entity_category == EntityCategory.DIAGNOSTIC
+    assert entity.entity_category is EntityCategory.DIAGNOSTIC
     assert "Unhandled category Category.Unset, fallback to DIAGNOSTIC" in caplog.text
 
 

--- a/tests/components/tplink_lte/test_init.py
+++ b/tests/components/tplink_lte/test_init.py
@@ -19,5 +19,5 @@ async def test_tplink_lte_repair_issue(
 
     assert issue_registry.async_get_issue(DOMAIN, DOMAIN)
     issue = issue_registry.async_get_issue(DOMAIN, DOMAIN)
-    assert issue.severity == ir.IssueSeverity.ERROR
+    assert issue.severity is ir.IssueSeverity.ERROR
     assert issue.translation_key == "integration_removed"

--- a/tests/components/tplink_omada/test_init.py
+++ b/tests/components/tplink_omada/test_init.py
@@ -57,7 +57,7 @@ async def test_setup_entry_login_failed_raises_configentryauthfailed(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert mock_config_entry.state == entry_state
+    assert mock_config_entry.state is entry_state
 
 
 async def test_missing_devices_removed_at_startup(

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -83,7 +83,7 @@ async def test_config_entry_unload(
 
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
     await hass.async_block_till_done()
 
@@ -1190,7 +1190,7 @@ async def test_service_get_tts_error(
     assert len(calls) == 1
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.INTERNAL_SERVER_ERROR
+        is HTTPStatus.INTERNAL_SERVER_ERROR
     )
 
 

--- a/tests/components/tts/test_media_source.py
+++ b/tests/components/tts/test_media_source.py
@@ -128,7 +128,7 @@ async def test_legacy_resolving(
     media = await media_source.async_resolve_media(hass, media_id, None)
     assert media.url.startswith("/api/tts_proxy/")
     assert media.mime_type == "audio/mpeg"
-    assert await retrieve_media(hass, hass_client, media_id) == HTTPStatus.OK
+    assert await retrieve_media(hass, hass_client, media_id) is HTTPStatus.OK
 
     assert len(mock_get_tts_audio.mock_calls) == 1
     message, language = mock_get_tts_audio.mock_calls[0][1]
@@ -144,7 +144,7 @@ async def test_legacy_resolving(
     media = await media_source.async_resolve_media(hass, media_id, None)
     assert media.url.startswith("/api/tts_proxy/")
     assert media.mime_type == "audio/mpeg"
-    assert await retrieve_media(hass, hass_client, media_id) == HTTPStatus.OK
+    assert await retrieve_media(hass, hass_client, media_id) is HTTPStatus.OK
 
     assert len(mock_get_tts_audio.mock_calls) == 1
     message, language = mock_get_tts_audio.mock_calls[0][1]
@@ -175,7 +175,7 @@ async def test_resolving(
     media = await media_source.async_resolve_media(hass, media_id, None)
     assert media.url.startswith("/api/tts_proxy/")
     assert media.mime_type == "audio/mpeg"
-    assert await retrieve_media(hass, hass_client, media_id) == HTTPStatus.OK
+    assert await retrieve_media(hass, hass_client, media_id) is HTTPStatus.OK
 
     assert len(mock_get_tts_audio.mock_calls) == 1
     message, language = mock_get_tts_audio.mock_calls[0][1]
@@ -191,7 +191,7 @@ async def test_resolving(
     media = await media_source.async_resolve_media(hass, media_id, None)
     assert media.url.startswith("/api/tts_proxy/")
     assert media.mime_type == "audio/mpeg"
-    assert await retrieve_media(hass, hass_client, media_id) == HTTPStatus.OK
+    assert await retrieve_media(hass, hass_client, media_id) is HTTPStatus.OK
 
     assert len(mock_get_tts_audio.mock_calls) == 1
     message, language = mock_get_tts_audio.mock_calls[0][1]

--- a/tests/components/uhoo/test_config_flow.py
+++ b/tests/components/uhoo/test_config_flow.py
@@ -74,7 +74,7 @@ async def test_user_flow_exceptions(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert not result["errors"]
 

--- a/tests/components/unifi/test_button.py
+++ b/tests/components/unifi/test_button.py
@@ -289,7 +289,7 @@ async def test_wlan_button_entities(
     assert len(hass.states.async_entity_ids(BUTTON_DOMAIN)) == 0
 
     ent_reg_entry = entity_registry.async_get(entity_id)
-    assert ent_reg_entry.disabled_by == RegistryEntryDisabler.INTEGRATION
+    assert ent_reg_entry.disabled_by is RegistryEntryDisabler.INTEGRATION
 
     # Enable entity
     entity_registry.async_update_entity(entity_id=entity_id, disabled_by=None)

--- a/tests/components/unifi/test_image.py
+++ b/tests/components/unifi/test_image.py
@@ -114,7 +114,7 @@ async def test_wlan_qr_code(
     assert len(hass.states.async_entity_ids(IMAGE_DOMAIN)) == 0
 
     ent_reg_entry = entity_registry.async_get("image.ssid_1_qr_code")
-    assert ent_reg_entry.disabled_by == RegistryEntryDisabler.INTEGRATION
+    assert ent_reg_entry.disabled_by is RegistryEntryDisabler.INTEGRATION
 
     # Enable entity
     entity_registry.async_update_entity(

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -627,7 +627,7 @@ async def test_poe_port_switches(
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 2
 
     ent_reg_entry = entity_registry.async_get("sensor.mock_name_port_1_poe_power")
-    assert ent_reg_entry.disabled_by == RegistryEntryDisabler.INTEGRATION
+    assert ent_reg_entry.disabled_by is RegistryEntryDisabler.INTEGRATION
 
     # Enable entity
     entity_registry.async_update_entity(
@@ -1050,10 +1050,10 @@ async def test_bandwidth_port_sensors(
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 2
 
     p1rx_reg_entry = entity_registry.async_get("sensor.mock_name_port_1_rx")
-    assert p1rx_reg_entry.disabled_by == RegistryEntryDisabler.INTEGRATION
+    assert p1rx_reg_entry.disabled_by is RegistryEntryDisabler.INTEGRATION
 
     p1tx_reg_entry = entity_registry.async_get("sensor.mock_name_port_1_tx")
-    assert p1tx_reg_entry.disabled_by == RegistryEntryDisabler.INTEGRATION
+    assert p1tx_reg_entry.disabled_by is RegistryEntryDisabler.INTEGRATION
 
     # Enable entity
     entity_registry.async_update_entity(
@@ -1198,10 +1198,10 @@ async def test_port_link_speed_sensors(
 ) -> None:
     """Verify that port link speed sensors are working as expected."""
     p1_reg_entry = entity_registry.async_get("sensor.mock_name_port_1_link_speed")
-    assert p1_reg_entry.disabled_by == RegistryEntryDisabler.INTEGRATION
+    assert p1_reg_entry.disabled_by is RegistryEntryDisabler.INTEGRATION
 
     p2_reg_entry = entity_registry.async_get("sensor.mock_name_port_2_link_speed")
-    assert p2_reg_entry.disabled_by == RegistryEntryDisabler.INTEGRATION
+    assert p2_reg_entry.disabled_by is RegistryEntryDisabler.INTEGRATION
 
     # Port with speed 0 should not create an entity
     assert not entity_registry.async_get("sensor.mock_name_port_3_link_speed")
@@ -1298,10 +1298,10 @@ async def test_device_client_sensors(
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 4
 
     ent_reg_entry = entity_registry.async_get("sensor.wired_device_clients")
-    assert ent_reg_entry.disabled_by == RegistryEntryDisabler.INTEGRATION
+    assert ent_reg_entry.disabled_by is RegistryEntryDisabler.INTEGRATION
 
     ent_reg_entry = entity_registry.async_get("sensor.wireless_device_clients")
-    assert ent_reg_entry.disabled_by == RegistryEntryDisabler.INTEGRATION
+    assert ent_reg_entry.disabled_by is RegistryEntryDisabler.INTEGRATION
 
     # Enable entity
     entity_registry.async_update_entity(
@@ -1564,7 +1564,7 @@ async def test_wan_monitor_latency(
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 2
 
     latency_entry = entity_registry.async_get(entity_id)
-    assert latency_entry.disabled_by == RegistryEntryDisabler.INTEGRATION
+    assert latency_entry.disabled_by is RegistryEntryDisabler.INTEGRATION
 
     # Enable entity
     entity_registry.async_update_entity(entity_id=entity_id, disabled_by=None)
@@ -1746,7 +1746,7 @@ async def test_device_temperatures(
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 2
 
     temperature_entity = entity_registry.async_get(entity_id)
-    assert temperature_entity.disabled_by == RegistryEntryDisabler.INTEGRATION
+    assert temperature_entity.disabled_by is RegistryEntryDisabler.INTEGRATION
 
     # Enable entity
     entity_registry.async_update_entity(entity_id=entity_id, disabled_by=None)
@@ -1813,7 +1813,7 @@ async def test_device_temperature_with_missing_value(
     entity_id = "sensor.device_cpu_temperature"
 
     temperature_entity = entity_registry.async_get(entity_id)
-    assert temperature_entity.disabled_by == RegistryEntryDisabler.INTEGRATION
+    assert temperature_entity.disabled_by is RegistryEntryDisabler.INTEGRATION
 
     # Enable entity
     entity_registry.async_update_entity(entity_id=entity_id, disabled_by=None)

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -1542,7 +1542,7 @@ async def test_poe_port_switches(
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 0
 
     ent_reg_entry = entity_registry.async_get("switch.mock_name_port_1_poe")
-    assert ent_reg_entry.disabled_by == RegistryEntryDisabler.INTEGRATION
+    assert ent_reg_entry.disabled_by is RegistryEntryDisabler.INTEGRATION
 
     # Enable entity
     entity_registry.async_update_entity(
@@ -1786,7 +1786,7 @@ async def test_port_control_switches(
 
     ent_reg_entry = entity_registry.async_get("switch.mock_name_port_1")
     assert (
-        ent_reg_entry.disabled_by == RegistryEntryDisabler.INTEGRATION
+        ent_reg_entry.disabled_by is RegistryEntryDisabler.INTEGRATION
     )  # ✅ Disabled by default
 
     # Enable entity

--- a/tests/components/unifiprotect/test_media_source.py
+++ b/tests/components/unifiprotect/test_media_source.py
@@ -808,7 +808,7 @@ async def test_browse_media_event(
 
     assert browse.identifier == "test_id:event:test_event_id"
     assert browse.children is None
-    assert browse.media_class == MediaClass.VIDEO
+    assert browse.media_class is MediaClass.VIDEO
     assert title == expected_title
 
 
@@ -841,7 +841,7 @@ async def test_browse_media_eventthumb(
 
     assert browse.identifier == "test_id:eventthumb:test_event_id"
     assert browse.children is None
-    assert browse.media_class == MediaClass.IMAGE
+    assert browse.media_class is MediaClass.IMAGE
 
 
 @pytest.mark.freeze_time("2022-09-15 03:00:00-07:00")

--- a/tests/components/vacuum/test_init.py
+++ b/tests/components/vacuum/test_init.py
@@ -535,7 +535,7 @@ async def test_segments_changed_issue(
     issue_id = f"segments_changed_{entity_entry.id}"
     issue = ir.async_get(hass).async_get_issue(DOMAIN, issue_id)
     assert issue is not None
-    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.severity is ir.IssueSeverity.WARNING
     assert issue.translation_key == "segments_changed"
 
     entity_registry.async_update_entity_options(

--- a/tests/components/vacuum/test_intent.py
+++ b/tests/components/vacuum/test_intent.py
@@ -37,7 +37,7 @@ async def test_start(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -60,7 +60,7 @@ async def test_start_without_name(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -88,7 +88,7 @@ async def test_return_to_base(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -113,7 +113,7 @@ async def test_return_to_base_without_name(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -147,16 +147,16 @@ async def test_clean_area(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     assert set(calls[0].data["entity_id"]) == {vacuum_1, vacuum_2}
     assert calls[0].data["cleaning_area_id"] == [kitchen.id]
 
     assert len(response.success_results) == 3
-    assert response.success_results[0].type == intent.IntentResponseTargetType.AREA
+    assert response.success_results[0].type is intent.IntentResponseTargetType.AREA
     assert response.success_results[0].id == kitchen.id
     assert all(
-        t.type == intent.IntentResponseTargetType.ENTITY
+        t.type is intent.IntentResponseTargetType.ENTITY
         for t in response.success_results[1:]
     )
     assert {t.id for t in response.success_results[1:]} == {vacuum_1, vacuum_2}
@@ -171,7 +171,7 @@ async def test_clean_area(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     assert calls[0].data == {
         "entity_id": [vacuum_1],
@@ -194,7 +194,7 @@ async def test_clean_area_no_matching_vacuum(hass: HomeAssistant) -> None:
             vacuum_intent.INTENT_VACUUM_CLEAN_AREA,
             {"area": {"value": "Kitchen"}},
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.DOMAIN
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.DOMAIN
 
     # Vacuum without CLEAN_AREA feature
     hass.states.async_set(
@@ -210,7 +210,7 @@ async def test_clean_area_no_matching_vacuum(hass: HomeAssistant) -> None:
             vacuum_intent.INTENT_VACUUM_CLEAN_AREA,
             {"area": {"value": "Kitchen"}},
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.FEATURE
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.FEATURE
 
 
 async def test_clean_area_invalid_area(hass: HomeAssistant) -> None:
@@ -230,7 +230,7 @@ async def test_clean_area_invalid_area(hass: HomeAssistant) -> None:
             vacuum_intent.INTENT_VACUUM_CLEAN_AREA,
             {"area": {"value": "Nonexistent room"}},
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.INVALID_AREA
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.INVALID_AREA
     assert err.value.result.no_match_name == "Nonexistent room"
 
 

--- a/tests/components/valve/test_intent.py
+++ b/tests/components/valve/test_intent.py
@@ -28,7 +28,7 @@ async def test_open_valve_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -49,7 +49,7 @@ async def test_close_valve_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -75,7 +75,7 @@ async def test_set_valve_position(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN

--- a/tests/components/vera/common.py
+++ b/tests/components/vera/common.py
@@ -139,7 +139,7 @@ class ComponentFactory:
         self.vera_controller_class_mock.return_value = controller
 
         # Setup component through config flow.
-        if controller_config.config_source == ConfigSource.CONFIG_FLOW:
+        if controller_config.config_source is ConfigSource.CONFIG_FLOW:
             await hass.config_entries.flow.async_init(
                 DOMAIN,
                 context={"source": config_entries.SOURCE_USER},
@@ -148,7 +148,7 @@ class ComponentFactory:
             await hass.async_block_till_done()
 
         # Setup component directly from config entry.
-        if controller_config.config_source == ConfigSource.CONFIG_ENTRY:
+        if controller_config.config_source is ConfigSource.CONFIG_ENTRY:
             entry = MockConfigEntry(
                 domain=DOMAIN,
                 data=controller_config.config,

--- a/tests/components/vicare/test_init.py
+++ b/tests/components/vicare/test_init.py
@@ -169,7 +169,7 @@ async def test_migrate_entry_creates_repair_issue(hass: HomeAssistant) -> None:
 
     issue = ir.async_get(hass).async_get_issue(DOMAIN, "update_redirect_uri")
     assert issue is not None
-    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.severity is ir.IssueSeverity.WARNING
 
 
 @pytest.mark.usefixtures("mock_setup_entry")

--- a/tests/components/vodafone_station/test_init.py
+++ b/tests/components/vodafone_station/test_init.py
@@ -107,4 +107,4 @@ async def test_migrate_future_version_returns_false(
 
     await setup_integration(hass, config_entry)
 
-    assert config_entry.state == ConfigEntryState.MIGRATION_ERROR
+    assert config_entry.state is ConfigEntryState.MIGRATION_ERROR

--- a/tests/components/voicerss/test_tts.py
+++ b/tests/components/voicerss/test_tts.py
@@ -87,7 +87,7 @@ async def test_service_say(
     assert len(calls) == 1
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
     assert len(aioclient_mock.mock_calls) == 1
     assert aioclient_mock.mock_calls[0][2] == FORM_DATA
@@ -129,7 +129,7 @@ async def test_service_say_german_config(
     assert len(calls) == 1
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
     assert len(aioclient_mock.mock_calls) == 1
     assert aioclient_mock.mock_calls[0][2] == form_data
@@ -166,7 +166,7 @@ async def test_service_say_german_service(
     assert len(calls) == 1
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
     assert len(aioclient_mock.mock_calls) == 1
     assert aioclient_mock.mock_calls[0][2] == form_data
@@ -200,7 +200,7 @@ async def test_service_say_error(
 
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.INTERNAL_SERVER_ERROR
+        is HTTPStatus.INTERNAL_SERVER_ERROR
     )
     assert len(aioclient_mock.mock_calls) == 1
     assert aioclient_mock.mock_calls[0][2] == FORM_DATA
@@ -234,7 +234,7 @@ async def test_service_say_timeout(
 
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.INTERNAL_SERVER_ERROR
+        is HTTPStatus.INTERNAL_SERVER_ERROR
     )
     assert len(aioclient_mock.mock_calls) == 1
     assert aioclient_mock.mock_calls[0][2] == FORM_DATA
@@ -273,7 +273,7 @@ async def test_service_say_error_msg(
 
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.INTERNAL_SERVER_ERROR
+        is HTTPStatus.INTERNAL_SERVER_ERROR
     )
     assert len(aioclient_mock.mock_calls) == 1
     assert aioclient_mock.mock_calls[0][2] == FORM_DATA

--- a/tests/components/wake_word/test_init.py
+++ b/tests/components/wake_word/test_init.py
@@ -277,7 +277,7 @@ async def test_entity_attributes(
     hass: HomeAssistant, mock_provider_entity: MockProviderEntity
 ) -> None:
     """Test that the provider entity attributes match expectations."""
-    assert mock_provider_entity.entity_category == EntityCategory.DIAGNOSTIC
+    assert mock_provider_entity.entity_category is EntityCategory.DIAGNOSTIC
 
 
 async def test_list_wake_words(

--- a/tests/components/watergate/test_sensor.py
+++ b/tests/components/watergate/test_sensor.py
@@ -49,7 +49,7 @@ async def test_diagnostics_are_disabled_by_default(
         for entry in entity_registry.entities.get_entries_for_config_entry_id(
             mock_entry.entry_id
         )
-        if entry.entity_category == EntityCategory.DIAGNOSTIC
+        if entry.entity_category is EntityCategory.DIAGNOSTIC
     ]
 
     assert len(entries) == 5

--- a/tests/components/weather/test_intent.py
+++ b/tests/components/weather/test_intent.py
@@ -37,7 +37,7 @@ async def test_get_weather(hass: HomeAssistant) -> None:
     response = await intent.async_handle(
         hass, "test", weather_intent.INTENT_GET_WEATHER, {}
     )
-    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     state = response.matched_states[0]
     assert state.entity_id == entity1.entity_id
@@ -50,7 +50,7 @@ async def test_get_weather(hass: HomeAssistant) -> None:
         {"name": {"value": "Weather 2"}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     state = response.matched_states[0]
     assert state.entity_id == entity2.entity_id
@@ -67,7 +67,7 @@ async def test_get_weather(hass: HomeAssistant) -> None:
                 {"name": {"value": name}},
                 assistant=conversation.DOMAIN,
             )
-        assert err.value.result.no_match_reason == intent.MatchFailedReason.ASSISTANT
+        assert err.value.result.no_match_reason is intent.MatchFailedReason.ASSISTANT
 
 
 async def test_get_weather_wrong_name(hass: HomeAssistant) -> None:
@@ -93,7 +93,7 @@ async def test_get_weather_wrong_name(hass: HomeAssistant) -> None:
             {"name": {"value": "not the right name"}},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.NAME
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.NAME
 
     # Empty name
     with pytest.raises(intent.InvalidSlotInfo):
@@ -121,4 +121,4 @@ async def test_get_weather_no_entities(hass: HomeAssistant) -> None:
             {},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.DOMAIN
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.DOMAIN

--- a/tests/components/websocket_api/test_auth.py
+++ b/tests/components/websocket_api/test_auth.py
@@ -301,7 +301,7 @@ async def test_auth_sending_invalid_json_disconnects(
         await ws.send_str("[--INVALID--JSON--]")
 
         auth_msg = await ws.receive()
-        assert auth_msg.type == WSMsgType.close
+        assert auth_msg.type is WSMsgType.close
 
 
 async def test_auth_sending_binary_disconnects(
@@ -390,7 +390,7 @@ async def test_auth_sending_unknown_type_disconnects(
 
         await ws._writer.send_frame(b"1" * 130, 0x30)
         auth_msg = await ws.receive()
-        assert auth_msg.type == WSMsgType.close
+        assert auth_msg.type is WSMsgType.close
 
 
 async def test_error_right_after_auth_disconnects(

--- a/tests/components/websocket_api/test_http.py
+++ b/tests/components/websocket_api/test_http.py
@@ -136,7 +136,7 @@ async def test_cleanup_on_cancellation(
     await websocket_client.send_json({"id": 4, "type": "cancel_in_handler"})
     await hass.async_block_till_done()
     msg = await websocket_client.receive()
-    assert msg.type == WSMsgType.close
+    assert msg.type is WSMsgType.close
     assert len(subscriptions) == 0
 
 
@@ -204,7 +204,7 @@ async def test_ensure_disconnect_invalid_json(
     assert msg["type"] == "pong"
     await websocket_client.send_str("[--INVALID-JSON--]")
     msg = await websocket_client.receive()
-    assert msg.type == WSMsgType.CLOSE
+    assert msg.type is WSMsgType.CLOSE
 
 
 async def test_ensure_disconnect_invalid_binary(
@@ -220,7 +220,7 @@ async def test_ensure_disconnect_invalid_binary(
     assert msg["type"] == "pong"
     await websocket_client.send_bytes(b"")
     msg = await websocket_client.receive()
-    assert msg.type == WSMsgType.CLOSE
+    assert msg.type is WSMsgType.CLOSE
 
 
 async def test_pending_msg_peak(
@@ -290,11 +290,11 @@ async def test_pending_msg_peak_recovery(
 
     for _ in range(10):
         msg = await websocket_client.receive()
-        assert msg.type == WSMsgType.TEXT
+        assert msg.type is WSMsgType.TEXT
 
     instance._send_message({})
     msg = await websocket_client.receive()
-    assert msg.type == WSMsgType.TEXT
+    assert msg.type is WSMsgType.TEXT
 
     # Cleanly shutdown
     instance._send_message({})
@@ -346,7 +346,7 @@ async def test_pending_msg_peak_but_does_not_overflow(
     )
 
     msg = await websocket_client.receive()
-    assert msg.type == WSMsgType.TEXT
+    assert msg.type is WSMsgType.TEXT
 
     assert "Client unable to keep up with pending messages" not in caplog.text
 

--- a/tests/components/wled/test_init.py
+++ b/tests/components/wled/test_init.py
@@ -93,7 +93,7 @@ async def test_migrate_entry_future_version_is_downgrade(
     await hass.async_block_till_done()
 
     assert result is False
-    assert entry.state == ConfigEntryState.MIGRATION_ERROR
+    assert entry.state is ConfigEntryState.MIGRATION_ERROR
     assert entry.version == 2
     assert entry.minor_version == 0
     assert entry.unique_id == "AABBCCDDEEFF"
@@ -110,7 +110,7 @@ async def test_migrate_entry_v1_to_1_2_no_duplicates(
     await hass.async_block_till_done()
 
     assert result is True
-    assert config_entry_v1.state == ConfigEntryState.LOADED
+    assert config_entry_v1.state is ConfigEntryState.LOADED
     assert config_entry_v1.version == 1
     assert config_entry_v1.minor_version == 2
     assert config_entry_v1.unique_id == "aabbccddeeff"
@@ -149,7 +149,7 @@ async def test_migrate_entry_v1_with_ignored_duplicates(
     await hass.async_block_till_done()
 
     assert result is True
-    assert config_entry_v1.state == ConfigEntryState.LOADED
+    assert config_entry_v1.state is ConfigEntryState.LOADED
     assert config_entry_v1.version == 1
     assert config_entry_v1.minor_version == 2
     assert config_entry_v1.unique_id == "aabbccddeeff"
@@ -181,7 +181,7 @@ async def test_migrate_entry_v1_with_non_ignored_duplicate_aborts(
     await hass.async_block_till_done()
 
     assert result is False
-    assert config_entry_v1.state == ConfigEntryState.MIGRATION_ERROR
+    assert config_entry_v1.state is ConfigEntryState.MIGRATION_ERROR
     assert config_entry_v1.version == 1
     assert config_entry_v1.minor_version == 1
     assert config_entry_v1.unique_id == "AABBCCDDEEFF"
@@ -207,7 +207,7 @@ async def test_migrate_entry_already_at_1_2_is_noop(
     await hass.async_block_till_done()
 
     assert result is True
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert entry.version == 1
     assert entry.minor_version == 2
     assert entry.unique_id == "aabbccddeeff"

--- a/tests/components/wyoming/test_conversation.py
+++ b/tests/components/wyoming/test_conversation.py
@@ -104,7 +104,7 @@ async def test_intent(
         "device_id": device_id,
     }
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.speech, "No speech"
     assert result.response.speech.get("plain", {}).get("speech") == "success"
     assert result.conversation_id == conversation_id
@@ -157,8 +157,8 @@ async def test_intent_handle_error(
             agent_id=agent_id,
         )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.FAILED_TO_HANDLE
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.FAILED_TO_HANDLE
 
 
 async def test_not_recognized(
@@ -180,8 +180,8 @@ async def test_not_recognized(
             agent_id=agent_id,
         )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.NO_INTENT_MATCH
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.NO_INTENT_MATCH
     assert result.response.speech, "No speech"
     assert result.response.speech.get("plain", {}).get("speech") == "failure"
 
@@ -218,7 +218,7 @@ async def test_handle(hass: HomeAssistant, init_wyoming_handle: ConfigEntry) -> 
         "device_id": device_id,
     }
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.speech, "No speech"
     assert result.response.speech.get("plain", {}).get("speech") == "success"
     assert result.conversation_id == conversation_id
@@ -243,8 +243,8 @@ async def test_not_handled(
             agent_id=agent_id,
         )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.FAILED_TO_HANDLE
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.FAILED_TO_HANDLE
     assert result.response.speech, "No speech"
     assert result.response.speech.get("plain", {}).get("speech") == "failure"
 
@@ -268,8 +268,8 @@ async def test_connection_lost(
             agent_id=agent_id,
         )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.UNKNOWN
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.UNKNOWN
     assert result.response.speech, "No speech"
     assert result.response.speech.get("plain", {}).get("speech") == snapshot
 
@@ -297,8 +297,8 @@ async def test_oserror(
             agent_id=agent_id,
         )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.UNKNOWN
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.UNKNOWN
     assert result.response.speech, "No speech"
     assert result.response.speech.get("plain", {}).get("speech") == snapshot
 

--- a/tests/components/wyoming/test_satellite.py
+++ b/tests/components/wyoming/test_satellite.py
@@ -1508,7 +1508,7 @@ async def test_timers(hass: HomeAssistant) -> None:
             device_id=device.device_id,
         )
 
-        assert result.response_type == intent_helper.IntentResponseType.ACTION_DONE
+        assert result.response_type is intent_helper.IntentResponseType.ACTION_DONE
         async with asyncio.timeout(1):
             await mock_client.timer_started_event.wait()
             timer_started = mock_client.timer_started
@@ -1530,7 +1530,7 @@ async def test_timers(hass: HomeAssistant) -> None:
             device_id=device.device_id,
         )
 
-        assert result.response_type == intent_helper.IntentResponseType.ACTION_DONE
+        assert result.response_type is intent_helper.IntentResponseType.ACTION_DONE
         async with asyncio.timeout(1):
             await mock_client.timer_updated_event.wait()
             timer_updated = mock_client.timer_updated
@@ -1548,7 +1548,7 @@ async def test_timers(hass: HomeAssistant) -> None:
             device_id=device.device_id,
         )
 
-        assert result.response_type == intent_helper.IntentResponseType.ACTION_DONE
+        assert result.response_type is intent_helper.IntentResponseType.ACTION_DONE
         async with asyncio.timeout(1):
             await mock_client.timer_updated_event.wait()
             timer_updated = mock_client.timer_updated
@@ -1570,7 +1570,7 @@ async def test_timers(hass: HomeAssistant) -> None:
             device_id=device.device_id,
         )
 
-        assert result.response_type == intent_helper.IntentResponseType.ACTION_DONE
+        assert result.response_type is intent_helper.IntentResponseType.ACTION_DONE
         async with asyncio.timeout(1):
             await mock_client.timer_updated_event.wait()
             timer_updated = mock_client.timer_updated
@@ -1592,7 +1592,7 @@ async def test_timers(hass: HomeAssistant) -> None:
             device_id=device.device_id,
         )
 
-        assert result.response_type == intent_helper.IntentResponseType.ACTION_DONE
+        assert result.response_type is intent_helper.IntentResponseType.ACTION_DONE
         async with asyncio.timeout(1):
             await mock_client.timer_updated_event.wait()
             timer_updated = mock_client.timer_updated
@@ -1609,7 +1609,7 @@ async def test_timers(hass: HomeAssistant) -> None:
             device_id=device.device_id,
         )
 
-        assert result.response_type == intent_helper.IntentResponseType.ACTION_DONE
+        assert result.response_type is intent_helper.IntentResponseType.ACTION_DONE
         async with asyncio.timeout(1):
             await mock_client.timer_cancelled_event.wait()
             timer_cancelled = mock_client.timer_cancelled
@@ -1629,7 +1629,7 @@ async def test_timers(hass: HomeAssistant) -> None:
             device_id=device.device_id,
         )
 
-        assert result.response_type == intent_helper.IntentResponseType.ACTION_DONE
+        assert result.response_type is intent_helper.IntentResponseType.ACTION_DONE
         async with asyncio.timeout(1):
             await mock_client.timer_started_event.wait()
             timer_started = mock_client.timer_started
@@ -1646,7 +1646,7 @@ async def test_timers(hass: HomeAssistant) -> None:
             device_id=device.device_id,
         )
 
-        assert result.response_type == intent_helper.IntentResponseType.ACTION_DONE
+        assert result.response_type is intent_helper.IntentResponseType.ACTION_DONE
         async with asyncio.timeout(1):
             await mock_client.timer_finished_event.wait()
             timer_finished = mock_client.timer_finished

--- a/tests/components/wyoming/test_select.py
+++ b/tests/components/wyoming/test_select.py
@@ -156,7 +156,7 @@ async def test_vad_sensitivity_select(
     state = hass.states.get(vs_entity_id)
     assert state is not None
     assert state.state == VadSensitivity.DEFAULT
-    assert satellite_device.vad_sensitivity == VadSensitivity.DEFAULT
+    assert satellite_device.vad_sensitivity is VadSensitivity.DEFAULT
 
     # Change setting
     with patch.object(satellite_device, "set_vad_sensitivity") as mock_vs_changed:
@@ -188,4 +188,4 @@ async def test_vad_sensitivity_select(
         blocking=True,
     )
 
-    assert satellite_device.vad_sensitivity == VadSensitivity.RELAXED
+    assert satellite_device.vad_sensitivity is VadSensitivity.RELAXED

--- a/tests/components/wyoming/test_stt.py
+++ b/tests/components/wyoming/test_stt.py
@@ -44,7 +44,7 @@ async def test_streaming_audio(
     ) as mock_client:
         result = await entity.async_process_audio_stream(metadata, audio_stream())
 
-    assert result.result == stt.SpeechResultState.SUCCESS
+    assert result.result is stt.SpeechResultState.SUCCESS
     assert result.text == "Hello world"
     assert mock_client.written == snapshot
 
@@ -65,7 +65,7 @@ async def test_streaming_audio_connection_lost(
     ):
         result = await entity.async_process_audio_stream(metadata, audio_stream())
 
-    assert result.result == stt.SpeechResultState.ERROR
+    assert result.result is stt.SpeechResultState.ERROR
     assert result.text is None
 
 
@@ -90,5 +90,5 @@ async def test_streaming_audio_oserror(
     ):
         result = await entity.async_process_audio_stream(metadata, audio_stream())
 
-    assert result.result == stt.SpeechResultState.ERROR
+    assert result.result is stt.SpeechResultState.ERROR
     assert result.text is None

--- a/tests/components/yale_smart_alarm/test_config_flow.py
+++ b/tests/components/yale_smart_alarm/test_config_flow.py
@@ -466,4 +466,4 @@ async def test_options_flow(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {"lock_code_digits": 4}
 
-    assert entry.state == config_entries.ConfigEntryState.LOADED
+    assert entry.state is config_entries.ConfigEntryState.LOADED

--- a/tests/components/yandextts/test_tts.py
+++ b/tests/components/yandextts/test_tts.py
@@ -85,7 +85,7 @@ async def test_service_say(
     assert len(calls) == 1
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
 
     assert len(aioclient_mock.mock_calls) == 1
@@ -132,7 +132,7 @@ async def test_service_say_russian_config(
     assert len(calls) == 1
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
 
     assert len(aioclient_mock.mock_calls) == 1
@@ -176,7 +176,7 @@ async def test_service_say_russian_service(
     assert len(calls) == 1
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
 
     assert len(aioclient_mock.mock_calls) == 1
@@ -223,7 +223,7 @@ async def test_service_say_timeout(
     assert len(calls) == 1
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.INTERNAL_SERVER_ERROR
+        is HTTPStatus.INTERNAL_SERVER_ERROR
     )
 
     assert len(aioclient_mock.mock_calls) == 1
@@ -269,7 +269,7 @@ async def test_service_say_http_error(
     assert len(calls) == 1
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.INTERNAL_SERVER_ERROR
+        is HTTPStatus.INTERNAL_SERVER_ERROR
     )
 
 
@@ -313,7 +313,7 @@ async def test_service_say_specified_speaker(
     assert len(calls) == 1
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
 
     assert len(aioclient_mock.mock_calls) == 1
@@ -359,7 +359,7 @@ async def test_service_say_specified_emotion(
     assert len(calls) == 1
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
 
     assert len(aioclient_mock.mock_calls) == 1
@@ -401,7 +401,7 @@ async def test_service_say_specified_low_speed(
     assert len(calls) == 1
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
 
     assert len(aioclient_mock.mock_calls) == 1
@@ -441,7 +441,7 @@ async def test_service_say_specified_speed(
     assert len(calls) == 1
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
 
     assert len(aioclient_mock.mock_calls) == 1
@@ -484,7 +484,7 @@ async def test_service_say_specified_options(
     assert len(calls) == 1
     assert (
         await retrieve_media(hass, hass_client, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == HTTPStatus.OK
+        is HTTPStatus.OK
     )
 
     assert len(aioclient_mock.mock_calls) == 1

--- a/tests/components/zeroconf/test_repairs.py
+++ b/tests/components/zeroconf/test_repairs.py
@@ -89,7 +89,7 @@ async def test_instance_id_conflict_creates_repair_issue_remove(
             domain="zeroconf", issue_id="duplicate_instance_id"
         )
         assert issue
-        assert issue.severity == ir.IssueSeverity.ERROR
+        assert issue.severity is ir.IssueSeverity.ERROR
         assert issue.translation_key == "duplicate_instance_id"
         assert issue.translation_placeholders == {
             "other_host_url": "other-host.local",
@@ -135,7 +135,7 @@ async def test_instance_id_conflict_creates_repair_issue_changing_id(
             domain="zeroconf", issue_id="duplicate_instance_id"
         )
         assert issue
-        assert issue.severity == ir.IssueSeverity.ERROR
+        assert issue.severity is ir.IssueSeverity.ERROR
         assert issue.translation_key == "duplicate_instance_id"
         assert issue.translation_placeholders == {
             "other_host_url": "other-host.local",

--- a/tests/components/zha/test_button.py
+++ b/tests/components/zha/test_button.py
@@ -103,7 +103,7 @@ async def test_button(
 
     entry = entity_registry.async_get(entity_id)
     assert entry
-    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
     with patch(
         "zigpy.zcl.Cluster.request",

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -200,7 +200,7 @@ async def consume_progress_flow(
         result = await flow_manager.async_configure(flow_id)
         flow_id = result["flow_id"]
 
-        if result["type"] != FlowResultType.SHOW_PROGRESS:
+        if result["type"] is not FlowResultType.SHOW_PROGRESS:
             break
 
         assert result["type"] is FlowResultType.SHOW_PROGRESS

--- a/tests/components/zha/test_helpers.py
+++ b/tests/components/zha/test_helpers.py
@@ -108,11 +108,11 @@ async def test_zcl_schema_conversions(hass: HomeAssistant) -> None:
     assert isinstance(converted_data["action"], lighting.Color.ColorLoopAction)
     assert (
         converted_data["action"]
-        == lighting.Color.ColorLoopAction.Activate_from_current_hue
+        is lighting.Color.ColorLoopAction.Activate_from_current_hue
     )
 
     assert isinstance(converted_data["direction"], lighting.Color.ColorLoopDirection)
-    assert converted_data["direction"] == lighting.Color.ColorLoopDirection.Increment
+    assert converted_data["direction"] is lighting.Color.ColorLoopDirection.Increment
 
     assert isinstance(converted_data["time"], uint16_t)
     assert converted_data["time"] == 20
@@ -141,11 +141,11 @@ async def test_zcl_schema_conversions(hass: HomeAssistant) -> None:
     assert isinstance(converted_data["action"], lighting.Color.ColorLoopAction)
     assert (
         converted_data["action"]
-        == lighting.Color.ColorLoopAction.Activate_from_current_hue
+        is lighting.Color.ColorLoopAction.Activate_from_current_hue
     )
 
     assert isinstance(converted_data["direction"], lighting.Color.ColorLoopDirection)
-    assert converted_data["direction"] == lighting.Color.ColorLoopDirection.Increment
+    assert converted_data["direction"] is lighting.Color.ColorLoopDirection.Increment
 
     assert isinstance(converted_data["time"], uint16_t)
     assert converted_data["time"] == 20

--- a/tests/components/zha/test_radio_manager.py
+++ b/tests/components/zha/test_radio_manager.py
@@ -437,7 +437,7 @@ async def test_detect_radio_type_success(radio_manager: ZhaRadioManager) -> None
         ),
     ):
         assert (
-            await radio_manager.detect_radio_type() == ProbeResult.RADIO_TYPE_DETECTED
+            await radio_manager.detect_radio_type() is ProbeResult.RADIO_TYPE_DETECTED
         )
         assert radio_manager.radio_type == RadioType.znp
 
@@ -455,7 +455,7 @@ async def test_detect_radio_type_failure_wrong_firmware(
     ):
         assert (
             await radio_manager.detect_radio_type()
-            == ProbeResult.WRONG_FIRMWARE_INSTALLED
+            is ProbeResult.WRONG_FIRMWARE_INSTALLED
         )
         assert radio_manager.radio_type is None
 
@@ -471,7 +471,7 @@ async def test_detect_radio_type_failure_no_detect(
             return_value=False,
         ),
     ):
-        assert await radio_manager.detect_radio_type() == ProbeResult.PROBING_FAILED
+        assert await radio_manager.detect_radio_type() is ProbeResult.PROBING_FAILED
         assert radio_manager.radio_type is None
 
 

--- a/tests/components/zha/test_repairs.py
+++ b/tests/components/zha/test_repairs.py
@@ -83,21 +83,21 @@ async def test_detect_radio_hardware(hass: HomeAssistant) -> None:
     await async_setup_component(hass, SKYCONNECT_DOMAIN, {})
     await hass.async_block_till_done()
 
-    assert _detect_radio_hardware(hass, CONNECT_ZBT1_DEVICE) == HardwareType.SKYCONNECT
-    assert _detect_radio_hardware(hass, SKYCONNECT_DEVICE) == HardwareType.SKYCONNECT
+    assert _detect_radio_hardware(hass, CONNECT_ZBT1_DEVICE) is HardwareType.SKYCONNECT
+    assert _detect_radio_hardware(hass, SKYCONNECT_DEVICE) is HardwareType.SKYCONNECT
     assert (
-        _detect_radio_hardware(hass, SKYCONNECT_DEVICE + "_foo") == HardwareType.OTHER
+        _detect_radio_hardware(hass, SKYCONNECT_DEVICE + "_foo") is HardwareType.OTHER
     )
-    assert _detect_radio_hardware(hass, "/dev/ttyAMA1") == HardwareType.OTHER
+    assert _detect_radio_hardware(hass, "/dev/ttyAMA1") is HardwareType.OTHER
 
     with patch(
         "homeassistant.components.homeassistant_yellow.hardware.get_os_info",
         return_value={"board": "yellow"},
     ):
-        assert _detect_radio_hardware(hass, "/dev/ttyAMA1") == HardwareType.YELLOW
-        assert _detect_radio_hardware(hass, "/dev/ttyAMA2") == HardwareType.OTHER
+        assert _detect_radio_hardware(hass, "/dev/ttyAMA1") is HardwareType.YELLOW
+        assert _detect_radio_hardware(hass, "/dev/ttyAMA2") is HardwareType.OTHER
         assert (
-            _detect_radio_hardware(hass, SKYCONNECT_DEVICE) == HardwareType.SKYCONNECT
+            _detect_radio_hardware(hass, SKYCONNECT_DEVICE) is HardwareType.SKYCONNECT
         )
 
 
@@ -114,7 +114,7 @@ def test_detect_radio_hardware_failure(hass: HomeAssistant) -> None:
             side_effect=HomeAssistantError(),
         ),
     ):
-        assert _detect_radio_hardware(hass, SKYCONNECT_DEVICE) == HardwareType.OTHER
+        assert _detect_radio_hardware(hass, SKYCONNECT_DEVICE) is HardwareType.OTHER
 
 
 @pytest.mark.parametrize(

--- a/tests/components/zha/test_select.py
+++ b/tests/components/zha/test_select.py
@@ -96,7 +96,7 @@ async def test_select(
 
     entity_entry = entity_registry.async_get(entity_id)
     assert entity_entry
-    assert entity_entry.entity_category == EntityCategory.CONFIG
+    assert entity_entry.entity_category is EntityCategory.CONFIG
 
     # Test select option with string value
     await hass.services.async_call(

--- a/tests/components/zwave_js/test_binary_sensor.py
+++ b/tests/components/zwave_js/test_binary_sensor.py
@@ -932,7 +932,7 @@ async def test_access_control_lock_state_notification_sensors(
         and entry.original_name == "Lock jammed"
     )
     assert jammed_entry.original_device_class == BinarySensorDeviceClass.PROBLEM
-    assert jammed_entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert jammed_entry.entity_category is EntityCategory.DIAGNOSTIC
 
     jammed_state = hass.states.get(jammed_entry.entity_id)
     assert jammed_state
@@ -963,7 +963,7 @@ async def test_access_control_catch_all_with_opening_state_present(
         for reg_entry in entity_registry.entities.values()
         if reg_entry.domain == "binary_sensor"
         and reg_entry.platform == "zwave_js"
-        and reg_entry.entity_category == EntityCategory.DIAGNOSTIC
+        and reg_entry.entity_category is EntityCategory.DIAGNOSTIC
         and reg_entry.original_name
         and "barrier" in reg_entry.original_name.lower()
     ]
@@ -988,7 +988,7 @@ async def test_config_parameter_binary_sensor(
     entity_entry = entity_registry.async_get(binary_sensor_entity_id)
     assert entity_entry
     assert entity_entry.disabled
-    assert entity_entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entity_entry.entity_category is EntityCategory.DIAGNOSTIC
 
     updated_entry = entity_registry.async_update_entity(
         binary_sensor_entity_id, disabled_by=None
@@ -1020,7 +1020,7 @@ async def test_smoke_co_notification_sensors(
     assert state.attributes[ATTR_DEVICE_CLASS] == BinarySensorDeviceClass.SMOKE
     entity_entry = entity_registry.async_get(smoke_sensor)
     assert entity_entry
-    assert entity_entry.entity_category != EntityCategory.DIAGNOSTIC
+    assert entity_entry.entity_category is not EntityCategory.DIAGNOSTIC
 
     # Test smoke alarm diagnostic sensor
     smoke_diagnostic = "binary_sensor.zcombo_g_smoke_co_alarm_smoke_alarm_test"
@@ -1029,7 +1029,7 @@ async def test_smoke_co_notification_sensors(
     assert state.state == STATE_OFF
     entity_entry = entity_registry.async_get(smoke_diagnostic)
     assert entity_entry
-    assert entity_entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert entity_entry.entity_category is EntityCategory.DIAGNOSTIC
 
     # Test CO alarm sensor
     co_sensor = "binary_sensor.zcombo_g_smoke_co_alarm_carbon_monoxide_detected"
@@ -1039,7 +1039,7 @@ async def test_smoke_co_notification_sensors(
     assert state.attributes[ATTR_DEVICE_CLASS] == BinarySensorDeviceClass.CO
     entity_entry = entity_registry.async_get(co_sensor)
     assert entity_entry
-    assert entity_entry.entity_category != EntityCategory.DIAGNOSTIC
+    assert entity_entry.entity_category is not EntityCategory.DIAGNOSTIC
 
     # Test diagnostic entities
     entity_ids = [
@@ -1053,7 +1053,7 @@ async def test_smoke_co_notification_sensors(
     for entity_id in entity_ids:
         entity_entry = entity_registry.async_get(entity_id)
         assert entity_entry
-        assert entity_entry.entity_category == EntityCategory.DIAGNOSTIC
+        assert entity_entry.entity_category is EntityCategory.DIAGNOSTIC
 
     # Test that no idle states are created as entities
     entity_id = "binary_sensor.zcombo_g_smoke_co_alarm_idle"

--- a/tests/components/zwave_js/test_discovery.py
+++ b/tests/components/zwave_js/test_discovery.py
@@ -288,7 +288,7 @@ async def test_zooz_zen72(
     entity_id = "number.z_wave_plus_700_series_dimmer_switch_indicator_value"
     entity_entry = entity_registry.async_get(entity_id)
     assert entity_entry
-    assert entity_entry.entity_category == EntityCategory.CONFIG
+    assert entity_entry.entity_category is EntityCategory.CONFIG
     assert entity_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
     assert hass.states.get(entity_id) is None  # disabled by default
     entity_registry.async_update_entity(entity_id, disabled_by=None)
@@ -327,7 +327,7 @@ async def test_zooz_zen72(
     entity_id = "button.z_wave_plus_700_series_dimmer_switch_identify"
     entity_entry = entity_registry.async_get(entity_id)
     assert entity_entry
-    assert entity_entry.entity_category == EntityCategory.CONFIG
+    assert entity_entry.entity_category is EntityCategory.CONFIG
     assert entity_entry.disabled_by is None
     assert hass.states.get(entity_id) is not None
     await hass.services.async_call(
@@ -373,7 +373,7 @@ async def test_indicator_test(
     ):
         entity_entry = entity_registry.async_get(entity_id)
         assert entity_entry
-        assert entity_entry.entity_category == EntityCategory.DIAGNOSTIC
+        assert entity_entry.entity_category is EntityCategory.DIAGNOSTIC
         assert entity_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
         assert hass.states.get(entity_id) is None  # disabled by default
         entity_registry.async_update_entity(entity_id, disabled_by=None)
@@ -381,7 +381,7 @@ async def test_indicator_test(
     entity_id = switch_entity_id
     entity_entry = entity_registry.async_get(entity_id)
     assert entity_entry
-    assert entity_entry.entity_category == EntityCategory.CONFIG
+    assert entity_entry.entity_category is EntityCategory.CONFIG
     assert entity_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
     assert hass.states.get(entity_id) is None  # disabled by default
     entity_registry.async_update_entity(entity_id, disabled_by=None)

--- a/tests/components/zwave_js/test_number.py
+++ b/tests/components/zwave_js/test_number.py
@@ -231,7 +231,7 @@ async def test_config_parameter_number(
         entity_entry = entity_registry.async_get(entity_id)
         assert entity_entry
         assert entity_entry.disabled
-        assert entity_entry.entity_category == EntityCategory.CONFIG
+        assert entity_entry.entity_category is EntityCategory.CONFIG
 
     for entity_id in (number_entity_id, number_with_states_entity_id):
         updated_entry = entity_registry.async_update_entity(entity_id, disabled_by=None)

--- a/tests/components/zwave_js/test_select.py
+++ b/tests/components/zwave_js/test_select.py
@@ -308,7 +308,7 @@ async def test_config_parameter_select(
     entity_entry = entity_registry.async_get(select_entity_id)
     assert entity_entry
     assert entity_entry.disabled
-    assert entity_entry.entity_category == EntityCategory.CONFIG
+    assert entity_entry.entity_category is EntityCategory.CONFIG
 
     updated_entry = entity_registry.async_update_entity(
         select_entity_id, disabled_by=None

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -326,7 +326,7 @@ async def test_config_parameter_sensor(
         entity_entry = entity_registry.async_get(entity_id)
         assert entity_entry
         assert entity_entry.disabled
-        assert entity_entry.entity_category == EntityCategory.DIAGNOSTIC
+        assert entity_entry.entity_category is EntityCategory.DIAGNOSTIC
 
     for entity_id in (sensor_entity_id, sensor_with_states_entity_id):
         updated_entry = entity_registry.async_update_entity(entity_id, disabled_by=None)

--- a/tests/components/zwave_js/test_switch.py
+++ b/tests/components/zwave_js/test_switch.py
@@ -240,7 +240,7 @@ async def test_config_parameter_switch(
     )
     assert updated_entry != entity_entry
     assert updated_entry.disabled is False
-    assert entity_entry.entity_category == EntityCategory.CONFIG
+    assert entity_entry.entity_category is EntityCategory.CONFIG
 
     # reload integration and check if entity is correctly there
     await hass.config_entries.async_reload(integration.entry_id)

--- a/tests/helpers/test_config_entry_flow.py
+++ b/tests/helpers/test_config_entry_flow.py
@@ -75,7 +75,7 @@ async def test_single_entry_allowed(
     MockConfigEntry(domain="test").add_to_hass(hass)
     result = await flow.async_step_user()
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
 
@@ -103,7 +103,7 @@ async def test_user_has_confirmation(
         "test", context={"source": config_entries.SOURCE_USER}, data={}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "confirm"
 
     progress = hass.config_entries.flow.async_progress()
@@ -116,7 +116,7 @@ async def test_user_has_confirmation(
     }
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 async def test_user_has_confirmation_async_discovery_flow(
@@ -130,7 +130,7 @@ async def test_user_has_confirmation_async_discovery_flow(
         "test", context={"source": config_entries.SOURCE_USER}, data={}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "confirm"
 
     progress = hass.config_entries.flow.async_progress()
@@ -143,7 +143,7 @@ async def test_user_has_confirmation_async_discovery_flow(
     }
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 @pytest.mark.parametrize(
@@ -236,13 +236,13 @@ async def test_multiple_discoveries(
     result = await hass.config_entries.flow.async_init(
         "test", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     # Second discovery
     result = await hass.config_entries.flow.async_init(
         "test", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
 
 
 async def test_only_one_in_progress(
@@ -255,21 +255,21 @@ async def test_only_one_in_progress(
     result = await hass.config_entries.flow.async_init(
         "test", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     # User starts flow
     result = await hass.config_entries.flow.async_init(
         "test", context={"source": config_entries.SOURCE_USER}, data={}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     # Discovery flow has not been aborted
     assert len(hass.config_entries.flow.async_progress()) == 2
 
     # Discovery should be aborted once user confirms
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert len(hass.config_entries.flow.async_progress()) == 0
 
 
@@ -283,14 +283,14 @@ async def test_import_abort_discovery(
     result = await hass.config_entries.flow.async_init(
         "test", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     # Start import flow
     result = await hass.config_entries.flow.async_init(
         "test", context={"source": config_entries.SOURCE_IMPORT}, data={}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
     # Discovery flow has been aborted
     assert len(hass.config_entries.flow.async_progress()) == 0
@@ -332,7 +332,7 @@ async def test_ignored_discoveries(
     result = await hass.config_entries.flow.async_init(
         "test", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     flow = next(
         (
@@ -354,7 +354,7 @@ async def test_ignored_discoveries(
     result = await hass.config_entries.flow.async_init(
         "test", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
 
 
 async def test_webhook_single_entry_allowed(
@@ -367,7 +367,7 @@ async def test_webhook_single_entry_allowed(
     MockConfigEntry(domain="test_single").add_to_hass(hass)
     result = await flow.async_step_user()
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
 
@@ -382,7 +382,7 @@ async def test_webhook_multiple_entries_allowed(
     hass.config.api = Mock(base_url="http://example.com")
 
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
 
 async def test_webhook_config_flow_registers_webhook(
@@ -398,7 +398,7 @@ async def test_webhook_config_flow_registers_webhook(
     )
     result = await flow.async_step_user(user_input={})
 
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"]["webhook_id"] is not None
 
 
@@ -425,7 +425,7 @@ async def test_webhook_create_cloudhook(
     result = await hass.config_entries.flow.async_init(
         "test_single", context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     with (
         patch(
@@ -447,7 +447,7 @@ async def test_webhook_create_cloudhook(
     ):
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["description_placeholders"]["webhook_url"] == "https://example.com"
     assert len(mock_create.mock_calls) == 1
     assert len(async_setup_entry.mock_calls) == 1
@@ -486,7 +486,7 @@ async def test_webhook_create_cloudhook_aborts_not_connected(
     result = await hass.config_entries.flow.async_init(
         "test_single", context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     with (
         patch(
@@ -508,7 +508,7 @@ async def test_webhook_create_cloudhook_aborts_not_connected(
     ):
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "cloud_not_connected"
 
 

--- a/tests/helpers/test_config_entry_oauth2_flow.py
+++ b/tests/helpers/test_config_entry_oauth2_flow.py
@@ -149,7 +149,7 @@ async def test_abort_if_no_implementation(
     flow = flow_handler()
     flow.hass = hass
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "missing_configuration"
 
 
@@ -171,7 +171,7 @@ async def test_abort_if_oauth_implementation_unavailable(
     flow = flow_handler()
     flow.hass = hass
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "oauth_implementation_unavailable"
 
 
@@ -185,7 +185,7 @@ async def test_missing_credentials_for_domain(
 
     with patch("homeassistant.loader.APPLICATION_CREDENTIALS", [TEST_DOMAIN]):
         result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "missing_credentials"
 
 
@@ -207,7 +207,7 @@ async def test_abort_if_authorization_timeout(
     ):
         result = await flow.async_step_user()
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "authorize_url_timeout"
 
 
@@ -228,7 +228,7 @@ async def test_abort_if_no_url_available(
     ):
         result = await flow.async_step_user()
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "no_url_available"
 
 
@@ -252,7 +252,7 @@ async def test_abort_if_oauth_error(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pick_implementation"
 
     # Pick implementation
@@ -268,7 +268,7 @@ async def test_abort_if_oauth_error(
         },
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
+    assert result["type"] is data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["url"] == (
         f"{AUTHORIZE_URL}?response_type=code&client_id={CLIENT_ID}"
         "&redirect_uri=https://example.com/auth/external/callback"
@@ -292,7 +292,7 @@ async def test_abort_if_oauth_error(
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "oauth_error"
 
 
@@ -313,7 +313,7 @@ async def test_abort_if_oauth_rejected(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pick_implementation"
 
     # Pick implementation
@@ -329,7 +329,7 @@ async def test_abort_if_oauth_rejected(
         },
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
+    assert result["type"] is data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["url"] == (
         f"{AUTHORIZE_URL}?response_type=code&client_id={CLIENT_ID}"
         "&redirect_uri=https://example.com/auth/external/callback"
@@ -345,7 +345,7 @@ async def test_abort_if_oauth_rejected(
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "user_rejected_authorize"
     assert result["description_placeholders"] == {"error": "access_denied"}
 
@@ -368,7 +368,7 @@ async def test_abort_on_oauth_timeout_error(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pick_implementation"
 
     # Pick implementation
@@ -384,7 +384,7 @@ async def test_abort_on_oauth_timeout_error(
         },
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
+    assert result["type"] is data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["url"] == (
         f"{AUTHORIZE_URL}?response_type=code&client_id={CLIENT_ID}"
         "&redirect_uri=https://example.com/auth/external/callback"
@@ -402,7 +402,7 @@ async def test_abort_on_oauth_timeout_error(
     ):
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "oauth_timeout"
 
 
@@ -423,7 +423,7 @@ async def test_step_discovery(
         data=data_entry_flow.BaseServiceInfo(),
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "oauth_discovery"
 
     result = await hass.config_entries.flow.async_configure(
@@ -431,7 +431,7 @@ async def test_step_discovery(
         user_input={},
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pick_implementation"
 
 
@@ -457,7 +457,7 @@ async def test_abort_discovered_multiple(
         user_input={},
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pick_implementation"
 
     result = await hass.config_entries.flow.async_init(
@@ -466,7 +466,7 @@ async def test_abort_discovered_multiple(
         data=data_entry_flow.BaseServiceInfo(),
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_in_progress"
 
 
@@ -525,7 +525,7 @@ async def test_abort_if_oauth_token_error(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pick_implementation"
 
     # Pick implementation
@@ -541,7 +541,7 @@ async def test_abort_if_oauth_token_error(
         },
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
+    assert result["type"] is data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["url"] == (
         f"{AUTHORIZE_URL}?response_type=code&client_id={CLIENT_ID}"
         "&redirect_uri=https://example.com/auth/external/callback"
@@ -566,7 +566,7 @@ async def test_abort_if_oauth_token_error(
         in caplog.text
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == error_reason
 
 
@@ -589,7 +589,7 @@ async def test_abort_if_oauth_token_closing_error(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pick_implementation"
 
     # Pick implementation
@@ -605,7 +605,7 @@ async def test_abort_if_oauth_token_closing_error(
         },
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
+    assert result["type"] is data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["url"] == (
         f"{AUTHORIZE_URL}?response_type=code&client_id={CLIENT_ID}"
         "&redirect_uri=https://example.com/auth/external/callback"
@@ -627,7 +627,7 @@ async def test_abort_if_oauth_token_closing_error(
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
     assert "Token request for oauth2_test failed (401): unknown" in caplog.text
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "oauth_unauthorized"
 
 
@@ -654,7 +654,7 @@ async def test_abort_discovered_existing_entries(
         data=data_entry_flow.BaseServiceInfo(),
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -687,7 +687,7 @@ async def test_full_flow(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pick_implementation"
 
     # Pick implementation
@@ -703,7 +703,7 @@ async def test_full_flow(
         },
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
+    assert result["type"] is data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["url"] == (
         f"{AUTHORIZE_URL}?response_type=code&client_id={CLIENT_ID}"
         f"&redirect_uri={expected_redirect_uri}"
@@ -1084,7 +1084,7 @@ async def test_abort_oauth_with_pkce_rejected(
     )
 
     code_challenge = local_impl_pkce.compute_code_challenge(MOCK_SECRET_TOKEN_URLSAFE)
-    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
+    assert result["type"] is data_entry_flow.FlowResultType.EXTERNAL_STEP
 
     assert result["url"].startswith(f"{AUTHORIZE_URL}?")
     assert f"client_id={CLIENT_ID}" in result["url"]
@@ -1104,7 +1104,7 @@ async def test_abort_oauth_with_pkce_rejected(
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "user_rejected_authorize"
     assert result["description_placeholders"] == {"error": "access_denied"}
 
@@ -1142,7 +1142,7 @@ async def test_oauth_with_pkce_adds_code_verifier_to_token_resolve(
     )
 
     code_challenge = local_impl_pkce.compute_code_challenge(MOCK_SECRET_TOKEN_URLSAFE)
-    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
+    assert result["type"] is data_entry_flow.FlowResultType.EXTERNAL_STEP
 
     assert result["url"].startswith(f"{AUTHORIZE_URL}?")
     assert f"client_id={CLIENT_ID}" in result["url"]

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -589,7 +589,7 @@ async def test_async_remove_no_platform(hass: HomeAssistant) -> None:
     ent = entity.Entity()
     ent.hass = hass
     ent.entity_id = "test.test"
-    assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
+    assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     ent.async_write_ha_state()
     assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
     assert len(hass.states.async_entity_ids()) == 1
@@ -605,7 +605,7 @@ async def test_async_remove_runs_callbacks(hass: HomeAssistant) -> None:
     platform = MockEntityPlatform(hass, domain="test")
     ent = entity.Entity()
     ent.entity_id = "test.test"
-    assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
+    assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
     assert ent._platform_state == entity.EntityPlatformState.ADDED
     ent.async_on_remove(lambda: result.append(1))
@@ -658,7 +658,7 @@ async def test_async_remove_twice(hass: HomeAssistant) -> None:
     await ent.async_remove()
     assert len(result) == 1
     assert len(ent.remove_calls) == 1
-    assert ent._platform_state == entity.EntityPlatformState.REMOVED
+    assert ent._platform_state is entity.EntityPlatformState.REMOVED
 
     await ent.async_remove()
     assert len(result) == 1
@@ -1838,7 +1838,7 @@ async def test_reuse_entity_object_after_abort(
     platform = MockEntityPlatform(hass, domain="test")
     ent = entity.Entity()
     ent.entity_id = "invalid"
-    assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
+    assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
     assert ent._platform_state == entity.EntityPlatformState.REMOVED
     assert "Invalid entity ID: invalid" in caplog.text
@@ -1860,7 +1860,7 @@ async def test_reuse_entity_object_after_entity_registry_remove(
     platform = MockEntityPlatform(hass, domain="test", platform_name="test")
     ent = entity.Entity()
     ent._attr_unique_id = "5678"
-    assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
+    assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
     assert ent.registry_entry is entry
     assert len(hass.states.async_entity_ids()) == 1
@@ -1887,7 +1887,7 @@ async def test_reuse_entity_object_after_entity_registry_disabled(
     platform = MockEntityPlatform(hass, domain="test", platform_name="test")
     ent = entity.Entity()
     ent._attr_unique_id = "5678"
-    assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
+    assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
     assert ent.registry_entry is entry
     assert len(hass.states.async_entity_ids()) == 1
@@ -1933,7 +1933,7 @@ async def test_change_entity_id(
 
     platform = MockEntityPlatform(hass, domain="test")
     ent = MockEntity()
-    assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
+    assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
     assert hass.states.get("test.test").state == STATE_UNKNOWN
     assert len(ent.added_calls) == 1
@@ -2660,7 +2660,7 @@ async def test_remove_entity_registry(
     assert len(result) == 1
     assert len(ent.added_calls) == 1
     assert len(ent.remove_calls) == 1
-    assert ent._platform_state == entity.EntityPlatformState.REMOVED
+    assert ent._platform_state is entity.EntityPlatformState.REMOVED
 
     assert hass.states.get("test.test") is None
 
@@ -2811,7 +2811,7 @@ async def test_platform_state(
 
     platform = MockEntityPlatform(hass, domain="test")
     ent = MockEntity()
-    assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
+    assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
     assert hass.states.get("test.test").state == "added_to_hass"
     assert ent._platform_state == entity.EntityPlatformState.ADDED
@@ -2839,7 +2839,7 @@ async def test_platform_state_no_platform(hass: HomeAssistant) -> None:
     assert hass.states.get("test.test") is None
 
     # The attempt to write when in state NOT_ADDED should be allowed
-    assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
+    assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     ent.async_set_state("not_added")
     assert hass.states.get("test.test").state == "not_added"
 
@@ -2877,7 +2877,7 @@ async def test_platform_state_fail_to_add(
 
     platform = MockEntityPlatform(hass, domain="test")
     ent = MockEntity()
-    assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
+    assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
     assert hass.states.get("test.test") is None
     assert ent._platform_state == entity.EntityPlatformState.ADDING
@@ -2907,7 +2907,7 @@ async def test_platform_state_write_from_init(
 
     platform = MockEntityPlatform(hass, domain="test")
     ent = MockEntity(hass)
-    assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
+    assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
     assert hass.states.get("test.unnamed_device").state == "init"
     assert ent._platform_state == entity.EntityPlatformState.ADDED
@@ -2934,7 +2934,7 @@ async def test_platform_state_write_from_init_entity_id(
             self.hass = hass
             # The attempt to write when in state NOT_ADDED is not prevented because
             # the platform is not yet set
-            assert self._platform_state == entity.EntityPlatformState.NOT_ADDED
+            assert self._platform_state is entity.EntityPlatformState.NOT_ADDED
             self._attr_state = "init"
             self.async_write_ha_state()
             assert hass.states.get("test.test").state == "init"
@@ -2947,7 +2947,7 @@ async def test_platform_state_write_from_init_entity_id(
 
     platform = MockEntityPlatform(hass, domain="test")
     ent = MockEntity(hass)
-    assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
+    assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
     assert hass.states.get("test.test").state == "init"
     assert ent._platform_state == entity.EntityPlatformState.REMOVED
@@ -2984,7 +2984,7 @@ async def test_platform_state_write_from_init_unique_id(
             self.hass = hass
             # The attempt to write when in state NOT_ADDED is not prevented because
             # the platform is not yet set
-            assert self._platform_state == entity.EntityPlatformState.NOT_ADDED
+            assert self._platform_state is entity.EntityPlatformState.NOT_ADDED
             self._attr_state = "init"
             self.async_write_ha_state()
             assert hass.states.get("test.test").state == "init"
@@ -2997,7 +2997,7 @@ async def test_platform_state_write_from_init_unique_id(
 
     platform = MockEntityPlatform(hass, domain="test")
     ent = MockEntity(hass)
-    assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
+    assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
     assert hass.states.get("test.test").state == "init"
     assert ent._platform_state == entity.EntityPlatformState.REMOVED

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -496,7 +496,7 @@ async def test_loading_saving_data(
     assert new_entry2.disabled_by is er.RegistryEntryDisabler.HASS
     assert new_entry2.entity_category == "config"
     assert new_entry2.icon == "hass:user-icon"
-    assert new_entry2.hidden_by == er.RegistryEntryHider.INTEGRATION
+    assert new_entry2.hidden_by is er.RegistryEntryHider.INTEGRATION
     assert new_entry2.has_entity_name is True
     assert new_entry2.labels == {"label1", "label2"}
     assert new_entry2.name == "User Name"

--- a/tests/helpers/test_intent.py
+++ b/tests/helpers/test_intent.py
@@ -345,7 +345,7 @@ async def test_async_match_targets(
         states=states,
     )
     assert not result.is_match
-    assert result.no_match_reason == intent.MatchFailedReason.DUPLICATE_NAME
+    assert result.no_match_reason is intent.MatchFailedReason.DUPLICATE_NAME
     assert result.no_match_name == "bathroom light"
 
     # Works with duplicate names allowed
@@ -411,7 +411,7 @@ async def test_async_match_targets(
         states=states,
     )
     assert not result.is_match
-    assert result.no_match_reason == intent.MatchFailedReason.DUPLICATE_NAME
+    assert result.no_match_reason is intent.MatchFailedReason.DUPLICATE_NAME
 
     # Disambiguate by area name, if unique
     result = intent.async_match_targets(
@@ -432,7 +432,7 @@ async def test_async_match_targets(
         states=states,
     )
     assert not result.is_match
-    assert result.no_match_reason == intent.MatchFailedReason.DUPLICATE_NAME
+    assert result.no_match_reason is intent.MatchFailedReason.DUPLICATE_NAME
 
     # Does work if floor/area name combo is unique
     result = intent.async_match_targets(
@@ -457,7 +457,7 @@ async def test_async_match_targets(
         states=states,
     )
     assert not result.is_match
-    assert result.no_match_reason == intent.MatchFailedReason.AREA
+    assert result.no_match_reason is intent.MatchFailedReason.AREA
 
     # Check state constraint (only third floor bathroom light is on)
     result = intent.async_match_targets(
@@ -533,7 +533,7 @@ async def test_async_match_targets(
         states=states,
     )
     assert not result.is_match
-    assert result.no_match_reason == intent.MatchFailedReason.MULTIPLE_TARGETS
+    assert result.no_match_reason is intent.MatchFailedReason.MULTIPLE_TARGETS
 
     # Only one light on the ground floor
     result = intent.async_match_targets(
@@ -718,7 +718,7 @@ async def test_validate_then_run_in_background(hass: HomeAssistant) -> None:
         slots={"name": {"value": "kitchen"}},
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     assert not call_done.is_set()
     await call_done.wait()
@@ -765,7 +765,7 @@ async def test_invalid_area_floor_names(hass: HomeAssistant) -> None:
             "TestType",
             slots={"area": {"value": "invalid area"}},
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.INVALID_AREA
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.INVALID_AREA
 
     with pytest.raises(intent.MatchFailedError) as err:
         await intent.async_handle(
@@ -774,7 +774,7 @@ async def test_invalid_area_floor_names(hass: HomeAssistant) -> None:
             "TestType",
             slots={"floor": {"value": "invalid floor"}},
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.INVALID_FLOOR
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.INVALID_FLOOR
 
 
 async def test_service_intent_handler_required_domains(hass: HomeAssistant) -> None:
@@ -798,7 +798,7 @@ async def test_service_intent_handler_required_domains(hass: HomeAssistant) -> N
         "TestType",
         slots={"name": {"value": "kitchen"}, "domain": {"value": "light"}},
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
 
     # Fails because the intent handler is restricted to lights only
@@ -935,7 +935,7 @@ async def test_service_handler_matched_states_uses_updated_state(
         slots={"name": {"value": "kitchen"}},
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(result.matched_states) == 1
     assert result.matched_states[0].entity_id == "light.kitchen"
     assert result.matched_states[0].state == "on"

--- a/tests/helpers/test_schema_config_entry_flow.py
+++ b/tests/helpers/test_schema_config_entry_flow.py
@@ -133,11 +133,11 @@ async def test_config_flow_advanced_option(
 
     # Start flow in basic mode
     result = await manager.async_init("test")
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert list(result["data_schema"].schema.keys()) == ["option1"]
 
     result = await manager.async_configure(result["flow_id"], {"option1": "blabla"})
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {}
     assert result["options"] == {
         "advanced_default": "a very reasonable default",
@@ -149,7 +149,7 @@ async def test_config_flow_advanced_option(
 
     # Start flow in advanced mode
     result = await manager.async_init("test", context={"show_advanced_options": True})
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert list(result["data_schema"].schema.keys()) == [
         "option1",
         "advanced_no_default",
@@ -159,7 +159,7 @@ async def test_config_flow_advanced_option(
     result = await manager.async_configure(
         result["flow_id"], {"advanced_no_default": "abc123", "option1": "blabla"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {}
     assert result["options"] == {
         "advanced_default": "a very reasonable default",
@@ -172,7 +172,7 @@ async def test_config_flow_advanced_option(
 
     # Start flow in advanced mode
     result = await manager.async_init("test", context={"show_advanced_options": True})
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert list(result["data_schema"].schema.keys()) == [
         "option1",
         "advanced_no_default",
@@ -187,7 +187,7 @@ async def test_config_flow_advanced_option(
             "option1": "blabla",
         },
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {}
     assert result["options"] == {
         "advanced_default": "not default",
@@ -241,13 +241,13 @@ async def test_options_flow_advanced_option(
 
     # Start flow in basic mode
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert list(result["data_schema"].schema.keys()) == ["option1"]
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {"option1": "blublu"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         "advanced_default": "not default",
         "advanced_no_default": "abc123",
@@ -261,7 +261,7 @@ async def test_options_flow_advanced_option(
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id, context={"show_advanced_options": True}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert list(result["data_schema"].schema.keys()) == [
         "option1",
         "advanced_no_default",
@@ -271,7 +271,7 @@ async def test_options_flow_advanced_option(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {"advanced_no_default": "def456", "option1": "blabla"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         "advanced_default": "a very reasonable default",
         "advanced_no_default": "def456",
@@ -285,7 +285,7 @@ async def test_options_flow_advanced_option(
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id, context={"show_advanced_options": True}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert list(result["data_schema"].schema.keys()) == [
         "option1",
         "advanced_no_default",
@@ -300,7 +300,7 @@ async def test_options_flow_advanced_option(
             "option1": "blabla",
         },
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         "advanced_default": "also not default",
         "advanced_no_default": "abc123",
@@ -528,7 +528,7 @@ async def test_suggested_values(
 
     # Start flow in basic mode, suggested values should be the existing options
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
     schema_keys: list[vol.Optional] = list(result["data_schema"].schema.keys())
     assert schema_keys == ["option1"]
@@ -538,7 +538,7 @@ async def test_suggested_values(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {"option1": "blublu"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "step_1"
     schema_keys: list[vol.Optional] = list(result["data_schema"].schema.keys())
     assert schema_keys == ["option1"]
@@ -548,7 +548,7 @@ async def test_suggested_values(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {"option1": "blabla"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "step_2"
     schema_keys: list[vol.Optional] = list(result["data_schema"].schema.keys())
     assert schema_keys == ["option1"]
@@ -558,7 +558,7 @@ async def test_suggested_values(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {"option1": "blabla"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "step_3"
     schema_keys: list[vol.Optional] = list(result["data_schema"].schema.keys())
     assert schema_keys == ["option1"]
@@ -568,7 +568,7 @@ async def test_suggested_values(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {"option1": "blabla"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "step_4"
     schema_keys: list[vol.Optional] = list(result["data_schema"].schema.keys())
     assert schema_keys == ["option1"]
@@ -578,7 +578,7 @@ async def test_suggested_values(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {"option1": "not a valid value"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "step_4"
     schema_keys: list[vol.Optional] = list(result["data_schema"].schema.keys())
     assert schema_keys == ["option1"]
@@ -588,7 +588,7 @@ async def test_suggested_values(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {"option1": "blabla"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 async def test_description_placeholders(
@@ -625,7 +625,7 @@ async def test_description_placeholders(
 
     # Start flow and check the description_placeholders is populated
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
     assert result["description_placeholders"] == {"option1": "a dynamic string"}
 
@@ -680,7 +680,7 @@ async def test_options_flow_state(hass: HomeAssistant) -> None:
 
     # Start flow in basic mode, flow state is initialised with None value
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "step_1"
 
     options_handler: SchemaOptionsFlowHandler
@@ -695,7 +695,7 @@ async def test_options_flow_state(hass: HomeAssistant) -> None:
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {"option1": "blublu"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "step_2"
 
     options_handler = hass.config_entries.options._progress[result["flow_id"]]
@@ -705,7 +705,7 @@ async def test_options_flow_state(hass: HomeAssistant) -> None:
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {"option1": "blabla"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         "idx_from_flow_state": "blublu",
         "option1": "blabla",
@@ -755,14 +755,14 @@ async def test_options_flow_omit_optional_keys(
 
     # Start flow in basic mode
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert list(result["data_schema"].schema.keys()) == [
         "optional_no_default",
         "optional_default",
     ]
 
     result = await hass.config_entries.options.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         "advanced_default": "not default",
         "advanced_no_default": "abc123",
@@ -773,7 +773,7 @@ async def test_options_flow_omit_optional_keys(
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id, context={"show_advanced_options": True}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert list(result["data_schema"].schema.keys()) == [
         "optional_no_default",
         "optional_default",
@@ -782,7 +782,7 @@ async def test_options_flow_omit_optional_keys(
     ]
 
     result = await hass.config_entries.options.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         "advanced_default": "a very reasonable default",
         "optional_default": "a very reasonable default",
@@ -849,12 +849,12 @@ async def test_options_flow_with_automatic_reload(
 
     # Start flow in basic mode
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], new_options
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
     assert len(load_entry_mock.mock_calls) == expected_loads
     assert len(unload_entry_mock.mock_calls) == expected_unloads

--- a/tests/helpers/test_trigger_template_entity.py
+++ b/tests/helpers/test_trigger_template_entity.py
@@ -340,4 +340,4 @@ async def test_manual_trigger_sensor_entity_with_date(
         "2025-01-01T00:00:00+00:00", entity.entity_id, entity.device_class
     )
     assert entity.state == "2025-01-01T00:00:00+00:00"
-    assert entity.device_class == device_class
+    assert entity.device_class is device_class

--- a/tests/syrupy.py
+++ b/tests/syrupy.py
@@ -366,7 +366,7 @@ def _merge_serialized_report(report: SnapshotReport, json_data: dict[str, Any]) 
     for key, selected_item in json_data["_selected_items"].items():
         if key in report.selected_items:
             status = ItemStatus(selected_item)
-            if status != ItemStatus.NOT_RUN:
+            if status is not ItemStatus.NOT_RUN:
                 report.selected_items[key] = status
         else:
             report.selected_items[key] = ItemStatus(selected_item)

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -2714,7 +2714,7 @@ async def test_subentry_flow(
         result = await manager.subentries.async_init(
             (entry.entry_id, "test"), context={"source": "user"}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
         assert entry.data == {"first": True}
         assert entry.options == {}
@@ -3403,7 +3403,7 @@ async def test_entry_reload_error(
     assert len(async_setup.mock_calls) == 0
     assert len(async_setup_entry.mock_calls) == 0
 
-    assert entry.state == state
+    assert entry.state is state
 
 
 async def test_entry_disable_succeed(
@@ -3722,7 +3722,7 @@ async def test_unique_id_existing_entry(
             "comp", context={"source": config_entries.SOURCE_USER}
         )
 
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
     entries = hass.config_entries.async_entries("comp")
     assert len(entries) == 1
@@ -4106,7 +4106,7 @@ async def test_unique_id_in_progress(
         result = await manager.flow.async_init(
             "comp", context={"source": existing_flow_source, "entry_id": entry.entry_id}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
 
         result2 = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_USER}
@@ -4145,14 +4145,14 @@ async def test_finish_flow_aborts_progress(
         result = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
 
         # Will finish and cancel other one.
         result2 = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_USER}, data={}
         )
 
-    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result2["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
     assert len(hass.config_entries.flow.async_progress()) == 0
 
@@ -4196,7 +4196,7 @@ async def test_unique_id_ignore(
         result = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
 
         result2 = await manager.flow.async_init(
             "comp",
@@ -4204,7 +4204,7 @@ async def test_unique_id_ignore(
             data={"unique_id": "mock-unique-id", "title": "Ignored Title"},
         )
 
-    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result2["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
     # assert len(hass.config_entries.flow.async_progress()) == 0
 
@@ -4267,7 +4267,7 @@ async def test_manual_add_overrides_ignored_entry(
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert entry.data["host"] == "1.1.1.1"
     assert entry.data["additional"] == "data"
     assert len(async_reload.mock_calls) == 0
@@ -4473,7 +4473,7 @@ async def test_update_discovery_keys(
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == flow_result
+    assert result["type"] is flow_result
     assert entry.data == {}
     assert entry.discovery_keys == updated_discovery_keys
     assert len(async_reload.mock_calls) == 0
@@ -4556,7 +4556,7 @@ async def test_update_discovery_keys_2(
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == flow_result
+    assert result["type"] is flow_result
     assert entry.data == {}
     assert entry.discovery_keys == updated_discovery_keys
     assert len(async_reload.mock_calls) == 0
@@ -4731,7 +4731,7 @@ async def test_partial_flows_hidden(
         # async_progress and have triggered
         # discovery notifications
         result = await init_task
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
         assert len(hass.config_entries.flow.async_progress()) == 1
 
 
@@ -4940,7 +4940,7 @@ async def test_flow_with_default_discovery(
         result = await manager.flow.async_init(
             "comp", context={"source": discovery_source[0]}, data=discovery_source[1]
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
 
         flows = hass.config_entries.flow.async_progress()
         assert len(flows) == 1
@@ -4953,7 +4953,7 @@ async def test_flow_with_default_discovery(
         result2 = await manager.flow.async_configure(
             result["flow_id"], user_input={"fake": "data"}
         )
-        assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result2["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
     assert len(hass.config_entries.flow.async_progress()) == 0
 
@@ -4989,7 +4989,7 @@ async def test_flow_with_default_discovery_with_unique_id(
         result = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_DISCOVERY}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
@@ -5016,7 +5016,7 @@ async def test_default_discovery_abort_existing_entries(
         result = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_DISCOVERY}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["type"] is data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "already_configured"
 
 
@@ -5047,13 +5047,13 @@ async def test_default_discovery_in_progress(
             context={"source": config_entries.SOURCE_DISCOVERY},
             data={"unique_id": "mock-unique-id"},
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
 
         # Second discovery without a unique ID
         result2 = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
         )
-        assert result2["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result2["type"] is data_entry_flow.FlowResultType.ABORT
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
@@ -5086,7 +5086,7 @@ async def test_default_discovery_abort_on_new_unique_flow(
         result2 = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
         )
-        assert result2["type"] == data_entry_flow.FlowResultType.FORM
+        assert result2["type"] is data_entry_flow.FlowResultType.FORM
 
         # Second discovery brings in a unique ID
         result = await manager.flow.async_init(
@@ -5094,7 +5094,7 @@ async def test_default_discovery_abort_on_new_unique_flow(
             context={"source": config_entries.SOURCE_DISCOVERY},
             data={"unique_id": "mock-unique-id"},
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     # Ensure the first one is cancelled and we end up with just the last one
     flows = hass.config_entries.flow.async_progress()
@@ -5133,7 +5133,7 @@ async def test_default_discovery_abort_on_user_flow_complete(
         flow1 = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
         )
-        assert flow1["type"] == data_entry_flow.FlowResultType.FORM
+        assert flow1["type"] is data_entry_flow.FlowResultType.FORM
 
         flows = hass.config_entries.flow.async_progress()
         assert len(flows) == 1
@@ -5142,14 +5142,14 @@ async def test_default_discovery_abort_on_user_flow_complete(
         flow2 = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_USER}
         )
-        assert flow2["type"] == data_entry_flow.FlowResultType.FORM
+        assert flow2["type"] is data_entry_flow.FlowResultType.FORM
 
         flows = hass.config_entries.flow.async_progress()
         assert len(flows) == 2
 
         # Complete the manual flow
         result = await hass.config_entries.flow.async_configure(flow2["flow_id"], {})
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
     # Ensure the first flow is gone now
     flows = hass.config_entries.flow.async_progress()
@@ -5213,7 +5213,7 @@ async def test_flow_same_device_multiple_sources(
         result2 = await manager.flow.async_configure(
             flows[0]["flow_id"], user_input={"fake": "data"}
         )
-        assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result2["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
     assert len(hass.config_entries.flow.async_progress()) == 0
 
@@ -7025,7 +7025,7 @@ async def test_update_entry_and_reload(
     assert entry.unique_id == expected_unique_id
     assert entry.data == expected_data
     assert entry.options == expected_options
-    assert entry.state == config_entries.ConfigEntryState.LOADED
+    assert entry.state is config_entries.ConfigEntryState.LOADED
     if raises:
         assert isinstance(err, raises)
     else:
@@ -7167,7 +7167,7 @@ async def test_update_entry_without_reload(
     assert entry.unique_id == "5678"
     assert entry.data == {"vendor": "data2"}
     assert entry.options == {"vendor": "options2"}
-    assert entry.state == config_entries.ConfigEntryState.LOADED
+    assert entry.state is config_entries.ConfigEntryState.LOADED
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == reason
     # Assert entry is not reloaded
@@ -8028,7 +8028,7 @@ async def test_avoid_adding_second_config_entry_on_single_config_entry(
         result = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
 
         # Add a config entry
         entry = MockConfigEntry(
@@ -8044,7 +8044,7 @@ async def test_avoid_adding_second_config_entry_on_single_config_entry(
         result = await manager.flow.async_configure(
             result["flow_id"], user_input={"host": "127.0.0.1"}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["type"] is data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "single_instance_allowed"
         assert result["translation_domain"] == HOMEASSISTANT_DOMAIN
 
@@ -8112,18 +8112,18 @@ async def test_in_progress_get_canceled_when_entry_is_created(
         result = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
 
         # Will be canceled
         result2 = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_USER}
         )
-        assert result2["type"] == data_entry_flow.FlowResultType.FORM
+        assert result2["type"] is data_entry_flow.FlowResultType.FORM
 
         result = await manager.flow.async_configure(
             result["flow_id"], user_input={"host": "127.0.0.1"}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
     assert len(manager.flow.async_progress()) == 0
     assert len(manager.async_entries()) == 1
@@ -8802,7 +8802,7 @@ async def test_async_has_matching_discovery_flow(
             context={"source": config_entries.SOURCE_HOMEKIT},
             data={"properties": {"id": "aa:bb:cc:dd:ee:ff"}},
         )
-    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+    assert result["type"] is data_entry_flow.FlowResultType.SHOW_PROGRESS
     assert result["progress_action"] == "task_one"
     assert len(manager.flow.async_progress()) == 1
     assert len(manager.flow.async_progress_by_handler("test")) == 1
@@ -10128,10 +10128,10 @@ async def test_config_flow_abort_with_next_flow(hass: HomeAssistant) -> None:
             "test", context={"source": config_entries.SOURCE_USER}
         )
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "provision_successful"
     assert "next_flow" in result
-    assert result["next_flow"][0] == config_entries.FlowType.CONFIG_FLOW
+    assert result["next_flow"][0] is config_entries.FlowType.CONFIG_FLOW
     # Verify the target flow exists
     hass.config_entries.flow.async_get(result["next_flow"][1])
 
@@ -10246,10 +10246,10 @@ async def test_config_flow_create_entry_with_next_flow(hass: HomeAssistant) -> N
             "test", context={"source": config_entries.SOURCE_USER}
         )
 
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Test Entry"
     assert "next_flow" in result
-    assert result["next_flow"][0] == config_entries.FlowType.CONFIG_FLOW
+    assert result["next_flow"][0] is config_entries.FlowType.CONFIG_FLOW
     # Verify the target flow exists
     hass.config_entries.flow.async_get(result["next_flow"][1])
 
@@ -10322,7 +10322,7 @@ async def test_discovery_flow_dismiss_protected_on_configure(
                 type="_tcp.local.",
             ),
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "confirm"
 
         # Before user interaction, dismiss_protected should not be set
@@ -10331,7 +10331,7 @@ async def test_discovery_flow_dismiss_protected_on_configure(
 
         # User configures the flow
         result = await manager.flow.async_configure(result["flow_id"])
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
 
         # After user interaction, dismiss_protected should be set
         context = _get_flow_context(manager, result["flow_id"])
@@ -10341,7 +10341,7 @@ async def test_discovery_flow_dismiss_protected_on_configure(
         result = await manager.flow.async_configure(
             result["flow_id"], user_input={"fake": "data"}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 async def test_user_flow_not_dismiss_protected_on_configure(
@@ -10376,13 +10376,13 @@ async def test_user_flow_not_dismiss_protected_on_configure(
         result = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
 
         # User configures the flow
         result = await manager.flow.async_configure(
             result["flow_id"], user_input={"fake": "data"}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
 
         # User flows should not be marked as dismiss protected
         context = _get_flow_context(manager, result["flow_id"])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -667,7 +667,7 @@ async def test_stage_shutdown_generic_error(
         assert patched_call.called
 
     assert "test_exception" in caplog.text
-    assert hass.state == ha.CoreState.stopped
+    assert hass.state is ha.CoreState.stopped
 
 
 async def test_stage_shutdown_with_exit_code(hass: HomeAssistant) -> None:
@@ -2056,12 +2056,12 @@ async def test_start_taking_too_long(caplog: pytest.LogCaptureFixture) -> None:
         with patch("asyncio.wait", return_value=(set(), {asyncio.Future()})):
             await hass.async_start()
 
-        assert hass.state == ha.CoreState.running
+        assert hass.state is ha.CoreState.running
         assert "Something is blocking Home Assistant" in caplog.text
 
     finally:
         await hass.async_stop()
-        assert hass.state == ha.CoreState.stopped
+        assert hass.state is ha.CoreState.stopped
 
 
 async def test_service_executed_with_subservices(hass: HomeAssistant) -> None:
@@ -3015,7 +3015,7 @@ async def test_get_release_channel(
 ) -> None:
     """Test if release channel detection works from Home Assistant version number."""
     with patch("homeassistant.core.__version__", f"{version}"):
-        assert get_release_channel() == release_channel
+        assert get_release_channel() is release_channel
 
 
 def test_is_callback_check_partial() -> None:
@@ -3029,19 +3029,19 @@ def test_is_callback_check_partial() -> None:
         pass
 
     assert ha.is_callback(callback_func)
-    assert HassJob(callback_func).job_type == ha.HassJobType.Callback
+    assert HassJob(callback_func).job_type is ha.HassJobType.Callback
     assert ha.is_callback_check_partial(functools.partial(callback_func))
-    assert HassJob(functools.partial(callback_func)).job_type == ha.HassJobType.Callback
+    assert HassJob(functools.partial(callback_func)).job_type is ha.HassJobType.Callback
     assert ha.is_callback_check_partial(
         functools.partial(functools.partial(callback_func))
     )
-    assert HassJob(functools.partial(functools.partial(callback_func))).job_type == (
+    assert HassJob(functools.partial(functools.partial(callback_func))).job_type is (
         ha.HassJobType.Callback
     )
     assert not ha.is_callback_check_partial(not_callback_func)
-    assert HassJob(not_callback_func).job_type == ha.HassJobType.Executor
+    assert HassJob(not_callback_func).job_type is ha.HassJobType.Executor
     assert not ha.is_callback_check_partial(functools.partial(not_callback_func))
-    assert HassJob(functools.partial(not_callback_func)).job_type == (
+    assert HassJob(functools.partial(not_callback_func)).job_type is (
         ha.HassJobType.Executor
     )
 
@@ -3049,7 +3049,7 @@ def test_is_callback_check_partial() -> None:
     assert not ha.is_callback_check_partial(
         ha.callback(functools.partial(not_callback_func))
     )
-    assert HassJob(ha.callback(functools.partial(not_callback_func))).job_type == (
+    assert HassJob(ha.callback(functools.partial(not_callback_func))).job_type is (
         ha.HassJobType.Executor
     )
 
@@ -3066,13 +3066,13 @@ def test_hassjob_passing_job_type() -> None:
 
     assert (
         HassJob(callback_func, job_type=ha.HassJobType.Callback).job_type
-        == ha.HassJobType.Callback
+        is ha.HassJobType.Callback
     )
 
     # We should trust the job_type passed in
     assert (
         HassJob(not_callback_func, job_type=ha.HassJobType.Callback).job_type
-        == ha.HassJobType.Callback
+        is ha.HassJobType.Callback
     )
 
 

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -106,7 +106,7 @@ async def test_configure_two_steps(manager: MockFlowManager) -> None:
         form = await manager.async_configure(form["flow_id"], "INCORRECT-DATA")
 
     form = await manager.async_configure(form["flow_id"], ["SECOND-DATA"])
-    assert form["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert form["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert len(manager.async_progress()) == 0
     assert len(manager.mock_created_entries) == 1
     result = manager.mock_created_entries[0]
@@ -128,7 +128,7 @@ async def test_show_form(manager: MockFlowManager) -> None:
             )
 
     form = await manager.async_init("test")
-    assert form["type"] == data_entry_flow.FlowResultType.FORM
+    assert form["type"] is data_entry_flow.FlowResultType.FORM
     assert form["data_schema"] is schema
     assert form["errors"] == {"username": "Should be unique."}
 
@@ -183,7 +183,7 @@ async def test_form_shows_with_added_suggested_values(manager: MockFlowManager) 
             "section_1": {"full_name": "John Doe"},
         },
     )
-    assert form["type"] == data_entry_flow.FlowResultType.FORM
+    assert form["type"] is data_entry_flow.FlowResultType.FORM
     assert form["data_schema"].schema is not schema.schema
     assert form["data_schema"].schema != schema.schema
     compare_schemas(form["data_schema"], schema)
@@ -210,7 +210,7 @@ async def test_form_shows_with_added_suggested_values(manager: MockFlowManager) 
     form = await manager.async_init(
         "test",
     )
-    assert form["type"] == data_entry_flow.FlowResultType.FORM
+    assert form["type"] is data_entry_flow.FlowResultType.FORM
     assert form["data_schema"].schema is not schema.schema
     assert form["data_schema"].schema == schema.schema
     markers = list(form["data_schema"].schema)
@@ -441,16 +441,16 @@ async def test_finish_callback_change_result_type(hass: HomeAssistant) -> None:
     manager = FlowManager(hass)
 
     result = await manager.async_init("test")
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await manager.async_configure(result["flow_id"], {"count": 0})
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
     assert "result" not in result
 
     result = await manager.async_configure(result["flow_id"], {"count": 2})
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["result"] == 2
 
 
@@ -480,7 +480,7 @@ async def test_external_step(hass: HomeAssistant, manager: MockFlowManager) -> N
     )
 
     result = await manager.async_init("test")
-    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
+    assert result["type"] is data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert len(manager.async_progress()) == 1
     assert len(manager.async_progress_by_handler("test")) == 1
     assert manager.async_get(result["flow_id"])["handler"] == "test"
@@ -488,7 +488,7 @@ async def test_external_step(hass: HomeAssistant, manager: MockFlowManager) -> N
     # Mimic external step
     # Called by integrations: `hass.config_entries.flow.async_configure(…)`
     result = await manager.async_configure(result["flow_id"], {"title": "Hello"})
-    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP_DONE
+    assert result["type"] is data_entry_flow.FlowResultType.EXTERNAL_STEP_DONE
 
     await hass.async_block_till_done()
     assert len(events) == 1
@@ -500,7 +500,7 @@ async def test_external_step(hass: HomeAssistant, manager: MockFlowManager) -> N
 
     # Frontend refreshes the flow
     result = await manager.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Hello"
 
 
@@ -573,7 +573,7 @@ async def test_show_progress(hass: HomeAssistant, manager: MockFlowManager) -> N
     )
 
     result = await manager.async_init("test")
-    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+    assert result["type"] is data_entry_flow.FlowResultType.SHOW_PROGRESS
     assert result["progress_action"] == "task_one"
     assert len(manager.async_progress()) == 1
     assert len(manager.async_progress_by_handler("test")) == 1
@@ -592,7 +592,7 @@ async def test_show_progress(hass: HomeAssistant, manager: MockFlowManager) -> N
 
     # Frontend refreshes the flow
     result = await manager.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+    assert result["type"] is data_entry_flow.FlowResultType.SHOW_PROGRESS
     assert result["progress_action"] == "task_two"
     assert len(progress_update_events) == 1
     assert progress_update_events[0].data == {
@@ -620,7 +620,7 @@ async def test_show_progress(hass: HomeAssistant, manager: MockFlowManager) -> N
 
     # Frontend refreshes the flow
     result = await manager.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Hello"
 
 
@@ -667,7 +667,7 @@ async def test_show_progress_error(
     )
 
     result = await manager.async_init("test")
-    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+    assert result["type"] is data_entry_flow.FlowResultType.SHOW_PROGRESS
     assert result["progress_action"] == "task"
     assert len(manager.async_progress()) == 1
     assert len(manager.async_progress_by_handler("test")) == 1
@@ -685,7 +685,7 @@ async def test_show_progress_error(
 
     # Frontend refreshes the flow
     result = await manager.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "error"
 
 
@@ -726,7 +726,7 @@ async def test_show_progress_hidden_from_frontend(
             return self.async_create_entry(title=None, data=self.data)
 
     result = await manager.async_init("test")
-    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+    assert result["type"] is data_entry_flow.FlowResultType.SHOW_PROGRESS
     assert result["progress_action"] == "task"
     assert len(manager.async_progress()) == 1
     assert len(manager.async_progress_by_handler("test")) == 1
@@ -737,7 +737,7 @@ async def test_show_progress_hidden_from_frontend(
 
     # Frontend refreshes the flow
     result = await manager.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert async_show_progress_done_called
 
 
@@ -786,7 +786,7 @@ async def test_show_progress_legacy(
     )
 
     result = await manager.async_init("test")
-    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+    assert result["type"] is data_entry_flow.FlowResultType.SHOW_PROGRESS
     assert result["progress_action"] == "task_one"
     assert len(manager.async_progress()) == 1
     assert len(manager.async_progress_by_handler("test")) == 1
@@ -795,7 +795,7 @@ async def test_show_progress_legacy(
     # Mimic task one done and moving to task two
     # Called by integrations: `hass.config_entries.flow.async_configure(…)`
     result = await manager.async_configure(result["flow_id"], {"task_finished": 1})
-    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+    assert result["type"] is data_entry_flow.FlowResultType.SHOW_PROGRESS
     assert result["progress_action"] == "task_two"
 
     await hass.async_block_till_done()
@@ -808,7 +808,7 @@ async def test_show_progress_legacy(
 
     # Frontend refreshes the flow
     result = await manager.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+    assert result["type"] is data_entry_flow.FlowResultType.SHOW_PROGRESS
     assert result["progress_action"] == "task_two"
 
     # Mimic task two done and continuing step
@@ -818,13 +818,13 @@ async def test_show_progress_legacy(
     )
     # Note: The SHOW_PROGRESS_DONE is not hidden from frontend when flows manage
     # the progress tasks themselves
-    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS_DONE
+    assert result["type"] is data_entry_flow.FlowResultType.SHOW_PROGRESS_DONE
 
     # Frontend refreshes the flow
     result = await manager.async_configure(
         result["flow_id"], {"task_finished": 2, "title": "Hello"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Hello"
 
     await hass.async_block_till_done()
@@ -890,7 +890,7 @@ async def test_show_progress_fires_only_when_changed(
                 },
             },
         )
-        assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+        assert result["type"] is data_entry_flow.FlowResultType.SHOW_PROGRESS
         assert result["progress_action"] == progress_action
         assert (
             result["description_placeholders"]["progress"]
@@ -907,7 +907,7 @@ async def test_show_progress_fires_only_when_changed(
             }
 
     result = await manager.async_init("test")
-    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+    assert result["type"] is data_entry_flow.FlowResultType.SHOW_PROGRESS
     assert result["progress_action"] == "task_one"
     assert len(manager.async_progress()) == 1
     assert len(manager.async_progress_by_handler("test")) == 1
@@ -939,7 +939,7 @@ async def test_abort_flow_exception_step(manager: MockFlowManager) -> None:
             raise data_entry_flow.AbortFlow("mock-reason", {"placeholder": "yo"})
 
     form = await manager.async_init("test")
-    assert form["type"] == data_entry_flow.FlowResultType.ABORT
+    assert form["type"] is data_entry_flow.FlowResultType.ABORT
     assert form["reason"] == "mock-reason"
     assert form["description_placeholders"] == {"placeholder": "yo"}
 
@@ -966,7 +966,7 @@ async def test_abort_flow_exception_finish_flow(hass: HomeAssistant) -> None:
     manager = FlowManager(hass)
 
     form = await manager.async_init("test")
-    assert form["type"] == data_entry_flow.FlowResultType.ABORT
+    assert form["type"] is data_entry_flow.FlowResultType.ABORT
     assert form["reason"] == "mock-reason"
     assert form["description_placeholders"] == {"placeholder": "yo"}
 
@@ -1058,7 +1058,7 @@ async def test_manager_abort_calls_async_flow_removed(manager: MockFlowManager) 
 
     manager.async_flow_removed = Mock()
     result = await manager.async_init("test")
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     manager.async_flow_removed.assert_not_called()
@@ -1109,7 +1109,7 @@ async def test_show_menu(
             return self.async_show_form(step_id="target2")
 
     result = await manager.async_init("test")
-    assert result["type"] == data_entry_flow.FlowResultType.MENU
+    assert result["type"] is data_entry_flow.FlowResultType.MENU
     assert result["menu_options"] == menu_options
     assert result["description_placeholders"] == {"name": "Paulus"}
     assert result.get("sort") == expect_sort
@@ -1121,7 +1121,7 @@ async def test_show_menu(
     result = await manager.async_configure(
         result["flow_id"], {"next_step_id": "target1"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "target1"
 
 
@@ -1196,7 +1196,7 @@ async def test_find_flows_by_init_data_type(manager: MockFlowManager) -> None:
     bluetooth_result = await manager.async_configure(
         bluetooth_form["flow_id"], ["SECOND-DATA"]
     )
-    assert bluetooth_result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert bluetooth_result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert len(manager.async_progress()) == 1
     assert len(manager.mock_created_entries) == 1
     result = manager.mock_created_entries[0]

--- a/tests/util/test_unit_system.py
+++ b/tests/util/test_unit_system.py
@@ -354,14 +354,14 @@ def test_area_to_imperial() -> None:
 
 def test_properties() -> None:
     """Test the unit properties are returned as expected."""
-    assert METRIC_SYSTEM.length_unit == UnitOfLength.KILOMETERS
-    assert METRIC_SYSTEM.wind_speed_unit == UnitOfSpeed.METERS_PER_SECOND
-    assert METRIC_SYSTEM.temperature_unit == UnitOfTemperature.CELSIUS
-    assert METRIC_SYSTEM.mass_unit == UnitOfMass.GRAMS
-    assert METRIC_SYSTEM.volume_unit == UnitOfVolume.LITERS
-    assert METRIC_SYSTEM.pressure_unit == UnitOfPressure.PA
+    assert METRIC_SYSTEM.length_unit is UnitOfLength.KILOMETERS
+    assert METRIC_SYSTEM.wind_speed_unit is UnitOfSpeed.METERS_PER_SECOND
+    assert METRIC_SYSTEM.temperature_unit is UnitOfTemperature.CELSIUS
+    assert METRIC_SYSTEM.mass_unit is UnitOfMass.GRAMS
+    assert METRIC_SYSTEM.volume_unit is UnitOfVolume.LITERS
+    assert METRIC_SYSTEM.pressure_unit is UnitOfPressure.PA
     assert METRIC_SYSTEM.accumulated_precipitation_unit == UnitOfLength.MILLIMETERS
-    assert METRIC_SYSTEM.area_unit == UnitOfArea.SQUARE_METERS
+    assert METRIC_SYSTEM.area_unit is UnitOfArea.SQUARE_METERS
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

<!-- Part 3 of 3. No "Breaking change" — pure semantic equivalence. -->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Mechanical codemod that replaces `==` with `is` (and `!=` with `is not`)
on every line where both operands statically resolve to the same
`enum.Enum` subclass. This is a prerequisite to #171551 (the
`mypy_plugins.enum_identity_compare` plugin that identifies these
sites).

**Part 3 of 3** — covers files alphabetically from
`homeassistant/components/withings/sensor.py` through
`tests/util/test_unit_system.py`.

```python
# Before:
assert result["type"] == FlowResultType.FORM   # type-checker sees both sides as FlowResultType
# After:
assert result["type"] is FlowResultType.FORM
```

**Scope of this PR:** ~1,150 sites across 254 files. (This part is the
test-heavy tail, where many lines have multiple swappable comparisons.)

**Scope of the full codemod (all 3 parts):** 2,159 sites across 762
files, touching 378 of 1,468 integrations (~26%) plus ~20
core/helper/util files.

**What is NOT changed:**

- `Flag`/`IntFlag` patterns (`features & FEATURE_X == FEATURE_X`) —
  bitwise `==` is idiomatic there.
- StrEnum/IntEnum sites where the LHS is a raw `str`/`int`:
  `state.state == HVACMode.HEAT` (state-machine string),
  `response.status_code == HTTPStatus.OK` (HTTP-client integer), etc.
  The plugin correctly skips these and the codemod doesn't touch them.

**Validation:**

1. Every changed line corresponds to a `ha-enum-identity-compare`
   violation reported by the mypy plugin against `dev`.
2. The codemod was run iteratively; after the final pass the mypy
   plugin reports **zero** remaining violations.
3. Each individual swap was verified by a custom diff checker:
   removed-line == added-line modulo a single `==` → `is` (or
   `!=` → `is not`) substitution, with the swap adjacent to an
   enum-class reference.
4. All modified files parse (`ast.parse`).
5. No new mypy error categories appeared on the touched files
   (informational delta check).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #171551
- Companion parts: #171591 (part 1, `auth` → `manual_mqtt`), #171596 (part 2, `matter` → `withings/coordinator`).
- Land order across the 3 parts and the plugin (#171551) does not matter for correctness, only for CI temporary noise.
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
