### PR TITLE
Handle multiple intents in Wyoming conversation

### DIFF
--- a/homeassistant/components/wyoming/conversation.py
+++ b/homeassistant/components/wyoming/conversation.py
@@ -228,7 +228,7 @@ class WyomingConversationEntity(
         intent_responses: list[intent.IntentResponse] = []
         try:
             async with asyncio.TaskGroup() as task_group:
-                intent_tasks: list[tuple[str | None, dict, asyncio.Task]] = []
+                intent_tasks: list[tuple[str, dict, str | None, asyncio.Task]] = []
                 for recognized_intent in intents:
                     _LOGGER.debug("Handling intent: %s", recognized_intent)
 
@@ -237,7 +237,7 @@ class WyomingConversationEntity(
                         e.name: {"value": e.value} for e in recognized_intent.entities
                     }
 
-                    # Add to trace and chat log
+                    # Add to trace
                     conversation.async_conversation_trace_append(
                         conversation.ConversationTraceEventType.TOOL_CALL,
                         {
@@ -245,22 +245,11 @@ class WyomingConversationEntity(
                             "slots": intent_slots,
                         },
                     )
-                    tool_input = llm.ToolInput(
-                        tool_name=intent_type,
-                        tool_args=intent_slots,
-                        external=True,
-                    )
-                    chat_log.async_add_assistant_content_without_tools(
-                        conversation.AssistantContent(
-                            agent_id=user_input.agent_id,
-                            content=None,
-                            tool_calls=[tool_input],
-                        )
-                    )
                     intent_tasks.append(
                         (
-                            recognized_intent.text,
+                            intent_type,
                             intent_slots,
+                            recognized_intent.text,
                             task_group.create_task(
                                 intent.async_handle(
                                     self.hass,
@@ -277,10 +266,21 @@ class WyomingConversationEntity(
                     )
 
                 # Gather intent handling results
-                for intent_text, intent_slots, intent_task in intent_tasks:
+                tool_calls: list[llm.ToolInput] = []
+                for intent_type, intent_slots, intent_text, intent_task in intent_tasks:
                     intent_task_response = await intent_task
                     intent_responses.append(intent_task_response)
 
+                    # For the chat log
+                    tool_calls.append(
+                        llm.ToolInput(
+                            tool_name=intent_type,
+                            tool_args=intent_slots,
+                            external=True,
+                        )
+                    )
+
+                    # Process speech
                     if (not intent_task_response.speech) and intent_text:
                         if template.is_template_string(intent_text):
                             # Render text as a template
@@ -289,6 +289,15 @@ class WyomingConversationEntity(
                             )
 
                         intent_task_response.async_set_speech(intent_text)
+
+                # Add all tool calls to the chat log
+                chat_log.async_add_assistant_content_without_tools(
+                    conversation.AssistantContent(
+                        agent_id=user_input.agent_id,
+                        content=None,
+                        tool_calls=tool_calls,
+                    )
+                )
         except* intent.IntentError as err_group:
             # Bubble up first exception only.
             # There's nothing the caller can do with multiple intent errors.

--- a/homeassistant/components/wyoming/conversation.py
+++ b/homeassistant/components/wyoming/conversation.py
@@ -1,5 +1,6 @@
 """Support for Wyoming intent recognition services."""
 
+import asyncio
 import logging
 from typing import Any, Literal
 
@@ -7,7 +8,7 @@ from wyoming.asr import Transcript
 from wyoming.client import AsyncTcpClient
 from wyoming.handle import Handled, NotHandled
 from wyoming.info import HandleProgram, IntentProgram
-from wyoming.intent import Intent, NotRecognized
+from wyoming.intent import Intent, IntentsStart, IntentsStop, NotRecognized
 
 from homeassistant.components import conversation
 from homeassistant.const import MATCH_ALL
@@ -169,62 +170,27 @@ class WyomingConversationEntity(
         intent_response: intent.IntentResponse,
     ) -> intent.IntentResponse:
         """Process a sentence into an intent response."""
+        has_intents_list = False
+        intents: list[Intent] = []
+
         while True:
             event = await client.read_event()
             if event is None:
                 raise WyomingError("Connection lost")
 
+            if IntentsStart.is_type(event.type):
+                # Multiple intents may be present
+                has_intents_list = True
+                continue
+
             if Intent.is_type(event.type):
-                # Success
-                recognized_intent = Intent.from_event(event)
-                _LOGGER.debug("Recognized intent: %s", recognized_intent)
+                intents.append(Intent.from_event(event))
+                if not has_intents_list:
+                    # Only one intent, no need to wait
+                    break
 
-                intent_type = recognized_intent.name
-                intent_slots = {
-                    e.name: {"value": e.value} for e in recognized_intent.entities
-                }
-
-                # Add to trace and chat log
-                conversation.async_conversation_trace_append(
-                    conversation.ConversationTraceEventType.TOOL_CALL,
-                    {
-                        "intent_name": intent_type,
-                        "slots": intent_slots,
-                    },
-                )
-                tool_input = llm.ToolInput(
-                    tool_name=intent_type,
-                    tool_args=intent_slots,
-                    external=True,
-                )
-                chat_log.async_add_assistant_content_without_tools(
-                    conversation.AssistantContent(
-                        agent_id=user_input.agent_id,
-                        content=None,
-                        tool_calls=[tool_input],
-                    )
-                )
-                intent_response = await intent.async_handle(
-                    self.hass,
-                    DOMAIN,
-                    intent_type,
-                    intent_slots,
-                    text_input=user_input.text,
-                    language=user_input.language,
-                    satellite_id=user_input.satellite_id,
-                    device_id=user_input.device_id,
-                )
-
-                if (not intent_response.speech) and recognized_intent.text:
-                    response_text = recognized_intent.text
-                    if template.is_template_string(response_text):
-                        # Render text as a template
-                        response_text = self._render_speech_template(
-                            response_text, intent_response, intent_slots
-                        )
-
-                    intent_response.async_set_speech(response_text)
-
+            if IntentsStop.is_type(event.type):
+                # End of intents list
                 break
 
             if NotRecognized.is_type(event.type):
@@ -234,6 +200,9 @@ class WyomingConversationEntity(
                     intent.IntentResponseErrorCode.NO_INTENT_MATCH,
                     not_recognized.text or "",
                 )
+
+                # Don't process any intents if one was not recognized
+                intents.clear()
                 break
 
             if Handled.is_type(event.type):
@@ -250,6 +219,97 @@ class WyomingConversationEntity(
                     not_handled.text or "",
                 )
                 break
+
+        if not intents:
+            return intent_response
+
+        # Process recognized intents with a task group.
+        # If any intent fails to be handled, the rest are cancelled.
+        intent_responses: list[intent.IntentResponse] = []
+        try:
+            async with asyncio.TaskGroup() as task_group:
+                intent_tasks: list[tuple[str | None, dict, asyncio.Task]] = []
+                for recognized_intent in intents:
+                    _LOGGER.debug("Handling intent: %s", recognized_intent)
+
+                    intent_type = recognized_intent.name
+                    intent_slots = {
+                        e.name: {"value": e.value} for e in recognized_intent.entities
+                    }
+
+                    # Add to trace and chat log
+                    conversation.async_conversation_trace_append(
+                        conversation.ConversationTraceEventType.TOOL_CALL,
+                        {
+                            "intent_name": intent_type,
+                            "slots": intent_slots,
+                        },
+                    )
+                    tool_input = llm.ToolInput(
+                        tool_name=intent_type,
+                        tool_args=intent_slots,
+                        external=True,
+                    )
+                    chat_log.async_add_assistant_content_without_tools(
+                        conversation.AssistantContent(
+                            agent_id=user_input.agent_id,
+                            content=None,
+                            tool_calls=[tool_input],
+                        )
+                    )
+                    intent_tasks.append(
+                        (
+                            recognized_intent.text,
+                            intent_slots,
+                            task_group.create_task(
+                                intent.async_handle(
+                                    self.hass,
+                                    DOMAIN,
+                                    intent_type,
+                                    intent_slots,
+                                    text_input=user_input.text,
+                                    language=user_input.language,
+                                    satellite_id=user_input.satellite_id,
+                                    device_id=user_input.device_id,
+                                )
+                            ),
+                        )
+                    )
+
+                # Gather intent handling results
+                for intent_text, intent_slots, intent_task in intent_tasks:
+                    intent_task_response = await intent_task
+                    intent_responses.append(intent_task_response)
+
+                    if (not intent_task_response.speech) and intent_text:
+                        if template.is_template_string(intent_text):
+                            # Render text as a template
+                            intent_text = self._render_speech_template(
+                                intent_text, intent_task_response, intent_slots
+                            )
+
+                        intent_task_response.async_set_speech(intent_text)
+        except* intent.IntentError as err_group:
+            # Bubble up first exception only.
+            # There's nothing the caller can do with multiple intent errors.
+            raise err_group.exceptions[0] from err_group
+
+        # Must be the case because an exception would have been thrown otherwise
+        assert intent_responses
+
+        # Use the properties of the first intent (response_type, etc.) and
+        # combine the speech results.
+        intent_response = intent_responses[0]
+        speech_texts: list[str] = [
+            speech
+            for current_response in intent_responses
+            if (speech := current_response.speech.get("plain", {}).get("speech"))
+        ]
+
+        if speech_texts:
+            # Combine response with newlines because punctuation would be
+            # language-dependent.
+            intent_response.async_set_speech("\n".join(speech_texts))
 
         return intent_response
 

--- a/homeassistant/components/wyoming/conversation.py
+++ b/homeassistant/components/wyoming/conversation.py
@@ -265,43 +265,44 @@ class WyomingConversationEntity(
                         )
                     )
 
-                # Gather intent handling results
-                tool_calls: list[llm.ToolInput] = []
-                for intent_type, intent_slots, intent_text, intent_task in intent_tasks:
-                    intent_task_response = await intent_task
-                    intent_responses.append(intent_task_response)
-
-                    # For the chat log
-                    tool_calls.append(
-                        llm.ToolInput(
-                            tool_name=intent_type,
-                            tool_args=intent_slots,
-                            external=True,
-                        )
-                    )
-
-                    # Process speech
-                    if (not intent_task_response.speech) and intent_text:
-                        if template.is_template_string(intent_text):
-                            # Render text as a template
-                            intent_text = self._render_speech_template(
-                                intent_text, intent_task_response, intent_slots
-                            )
-
-                        intent_task_response.async_set_speech(intent_text)
-
-                # Add all tool calls to the chat log
-                chat_log.async_add_assistant_content_without_tools(
-                    conversation.AssistantContent(
-                        agent_id=user_input.agent_id,
-                        content=None,
-                        tool_calls=tool_calls,
-                    )
-                )
         except* intent.IntentError as err_group:
             # Bubble up first exception only.
             # There's nothing the caller can do with multiple intent errors.
             raise err_group.exceptions[0] from err_group
+
+        # Gather intent handling results
+        tool_calls: list[llm.ToolInput] = []
+        for intent_type, intent_slots, intent_text, intent_task in intent_tasks:
+            intent_task_response = await intent_task
+            intent_responses.append(intent_task_response)
+
+            # For the chat log
+            tool_calls.append(
+                llm.ToolInput(
+                    tool_name=intent_type,
+                    tool_args=intent_slots,
+                    external=True,
+                )
+            )
+
+            # Process speech
+            if (not intent_task_response.speech) and intent_text:
+                if template.is_template_string(intent_text):
+                    # Render text as a template
+                    intent_text = self._render_speech_template(
+                        intent_text, intent_task_response, intent_slots
+                    )
+
+                intent_task_response.async_set_speech(intent_text)
+
+        # Add all tool calls to the chat log
+        chat_log.async_add_assistant_content_without_tools(
+            conversation.AssistantContent(
+                agent_id=user_input.agent_id,
+                content=None,
+                tool_calls=tool_calls,
+            )
+        )
 
         # Must be the case because an exception would have been thrown otherwise
         assert intent_responses

--- a/homeassistant/components/wyoming/conversation.py
+++ b/homeassistant/components/wyoming/conversation.py
@@ -86,6 +86,10 @@ class WyomingConversationEntity(
                     model_languages.update(handle_model.languages)
 
             self._attr_name = self._handle_service.name
+            if self._handle_service.supports_home_control:
+                self._attr_supported_features = (
+                    conversation.ConversationEntityFeature.CONTROL
+                )
 
         self._supported_languages = list(model_languages)
         self._attr_unique_id = f"{config_entry.entry_id}-conversation"

--- a/tests/components/wyoming/test_conversation.py
+++ b/tests/components/wyoming/test_conversation.py
@@ -148,30 +148,22 @@ async def test_multiple_intents(
         text="{{ slots.slot_name }}",
     )
 
-    class TestIntentHandler1(intent.IntentHandler):
-        """Test Intent Handler 1."""
+    class TestIntentHandler(intent.IntentHandler):
+        """Test Intent Handler."""
 
-        intent_type = "TestIntent1"
-
-        async def async_handle(self, intent_obj: intent.Intent):
-            """Handle the intent."""
-            response = intent_obj.create_response()
-            response.async_set_speech_slots({"slot_name": "slot value 1"})
-            return response
-
-    class TestIntentHandler2(intent.IntentHandler):
-        """Test Intent Handler 2."""
-
-        intent_type = "TestIntent2"
+        def __init__(self, intent_type: str, slot_value: str) -> None:
+            """Initialize the handler."""
+            self.intent_type = intent_type
+            self._slot_value = slot_value
 
         async def async_handle(self, intent_obj: intent.Intent):
             """Handle the intent."""
             response = intent_obj.create_response()
-            response.async_set_speech_slots({"slot_name": "slot value 2"})
+            response.async_set_speech_slots({"slot_name": self._slot_value})
             return response
 
-    intent.async_register(hass, TestIntentHandler1())
-    intent.async_register(hass, TestIntentHandler2())
+    intent.async_register(hass, TestIntentHandler("TestIntent1", "slot value 1"))
+    intent.async_register(hass, TestIntentHandler("TestIntent2", "slot value 2"))
 
     # Send multiple intent events framed by intents-start and intents-stop.
     client = MockAsyncTcpClient(

--- a/tests/components/wyoming/test_conversation.py
+++ b/tests/components/wyoming/test_conversation.py
@@ -7,7 +7,7 @@ from syrupy.assertion import SnapshotAssertion
 from wyoming.asr import Transcript
 from wyoming.handle import Handled, NotHandled
 from wyoming.info import Info
-from wyoming.intent import Entity, Intent, NotRecognized
+from wyoming.intent import Entity, Intent, IntentsStart, IntentsStop, NotRecognized
 
 from homeassistant.components import conversation
 from homeassistant.components.conversation import chat_log
@@ -125,6 +125,107 @@ async def test_intent(
     }
 
 
+async def test_multiple_intents(
+    hass: HomeAssistant,
+    init_wyoming_intent: ConfigEntry,
+    mock_chat_log: MockChatLog,  # noqa: F811
+) -> None:
+    """Test when more than one intent is recognized."""
+    agent_id = "conversation.test_intent"
+    conversation_id = mock_chat_log.conversation_id
+    satellite_id = "satellite-1234"
+    device_id = "device-1234"
+
+    test_intent1 = Intent(
+        name="TestIntent1",
+        entities=[Entity(name="entity1", value="value1")],
+        text="{{ slots.slot_name }}",
+    )
+
+    test_intent2 = Intent(
+        name="TestIntent2",
+        entities=[Entity(name="entity2", value="value2")],
+        text="{{ slots.slot_name }}",
+    )
+
+    class TestIntentHandler1(intent.IntentHandler):
+        """Test Intent Handler 1."""
+
+        intent_type = "TestIntent1"
+
+        async def async_handle(self, intent_obj: intent.Intent):
+            """Handle the intent."""
+            response = intent_obj.create_response()
+            response.async_set_speech_slots({"slot_name": "slot value 1"})
+            return response
+
+    class TestIntentHandler2(intent.IntentHandler):
+        """Test Intent Handler 2."""
+
+        intent_type = "TestIntent2"
+
+        async def async_handle(self, intent_obj: intent.Intent):
+            """Handle the intent."""
+            response = intent_obj.create_response()
+            response.async_set_speech_slots({"slot_name": "slot value 2"})
+            return response
+
+    intent.async_register(hass, TestIntentHandler1())
+    intent.async_register(hass, TestIntentHandler2())
+
+    # Send multiple intent events framed by intents-start and intents-stop.
+    client = MockAsyncTcpClient(
+        [
+            IntentsStart().event(),
+            test_intent1.event(),
+            test_intent2.event(),
+            IntentsStop().event(),
+        ]
+    )
+    with patch(
+        "homeassistant.components.wyoming.conversation.AsyncTcpClient",
+        client,
+    ):
+        result = await conversation.async_converse(
+            hass=hass,
+            text="test text",
+            conversation_id=conversation_id,
+            context=Context(),
+            language=hass.config.language,
+            agent_id=agent_id,
+            satellite_id=satellite_id,
+            device_id=device_id,
+        )
+
+    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.speech, "No speech"
+
+    # Speech results are joined with newlines because punctuation would be
+    # language-dependent.
+    assert (
+        result.response.speech.get("plain", {}).get("speech")
+        == "slot value 1\nslot value 2"
+    )
+
+    # Verify that chat log recorded all intents as tool calls
+    content: chat_log.AssistantContent | None = next(
+        filter(
+            lambda c: isinstance(c, chat_log.AssistantContent), mock_chat_log.content
+        ),
+        None,
+    )
+    assert content is not None, "Missing assistant content"
+    assert content.tool_calls and len(content.tool_calls) == 2
+
+    for tool_call, test_intent in zip(
+        content.tool_calls, (test_intent1, test_intent2), strict=True
+    ):
+        assert tool_call.tool_name == test_intent.name
+        assert tool_call.tool_args == {
+            e.name: {"value": e.value} for e in test_intent.entities
+        }
+
+
 async def test_intent_handle_error(
     hass: HomeAssistant, init_wyoming_intent: ConfigEntry
 ) -> None:
@@ -159,6 +260,59 @@ async def test_intent_handle_error(
 
     assert result.response.response_type == intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.FAILED_TO_HANDLE
+
+
+async def test_multiple_intents_handle_error(
+    hass: HomeAssistant,
+    init_wyoming_intent: ConfigEntry,
+    mock_chat_log: MockChatLog,  # noqa: F811
+) -> None:
+    """Test error during handling when multiple intents are recognized."""
+    agent_id = "conversation.test_intent"
+
+    test_intent = Intent(name="TestIntent", entities=[], text="success")
+
+    class TestIntentHandler1(intent.IntentHandler):
+        """Test Intent Handler."""
+
+        intent_type = "TestIntent2"
+
+        async def async_handle(self, intent_obj: intent.Intent):
+            """Handle the intent."""
+            return intent_obj.create_response()
+
+    class TestIntentHandler2(intent.IntentHandler):
+        """Test Intent Handler."""
+
+        intent_type = "TestIntent2"
+
+        async def async_handle(self, intent_obj: intent.Intent):
+            """Handle the intent."""
+            raise intent.IntentError
+
+    intent.async_register(hass, TestIntentHandler1())
+    intent.async_register(hass, TestIntentHandler2())
+
+    with patch(
+        "homeassistant.components.wyoming.conversation.AsyncTcpClient",
+        MockAsyncTcpClient([test_intent.event()]),
+    ):
+        result = await conversation.async_converse(
+            hass=hass,
+            text="test text",
+            conversation_id=None,
+            context=Context(),
+            language=hass.config.language,
+            agent_id=agent_id,
+        )
+
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.error_code == intent.IntentResponseErrorCode.FAILED_TO_HANDLE
+
+    # Ensure that no tool calls were recorded
+    assert not any(
+        isinstance(c, chat_log.AssistantContent) for c in mock_chat_log.content
+    )
 
 
 async def test_not_recognized(

--- a/tests/components/wyoming/test_conversation.py
+++ b/tests/components/wyoming/test_conversation.py
@@ -343,3 +343,60 @@ async def test_supported_languages_empty_means_all(
     agent = conversation.async_get_agent(hass, agent_id)
     assert agent is not None
     assert agent.supported_languages == MATCH_ALL
+
+
+async def test_intent_supports_home_control(
+    hass: HomeAssistant, intent_config_entry: ConfigEntry
+) -> None:
+    """Test that the CONTROL supported feature is always set for intent services."""
+    agent_id = "conversation.test_intent"
+
+    with patch(
+        "homeassistant.components.wyoming.data.load_wyoming_info",
+        return_value=Info(intent=INTENT_INFO.intent),
+    ):
+        await hass.config_entries.async_setup(intent_config_entry.entry_id)
+
+    agent = conversation.async_get_agent(hass, agent_id)
+    assert isinstance(agent, conversation.ConversationEntity)
+    assert agent.supported_features is not None
+    assert (
+        agent.supported_features & conversation.ConversationEntityFeature.CONTROL
+    ) == conversation.ConversationEntityFeature.CONTROL
+
+
+@pytest.mark.parametrize(
+    "supports_home_control",
+    [False, True],
+)
+async def test_handle_supports_home_control(
+    hass: HomeAssistant, intent_config_entry: ConfigEntry, supports_home_control: bool
+) -> None:
+    """Test that the CONTROL supported feature matches the Wyoming info."""
+    agent_id = "conversation.test_handle"
+
+    with (
+        patch.object(
+            HANDLE_INFO.handle[0], "supports_home_control", supports_home_control
+        ),
+        patch(
+            "homeassistant.components.wyoming.data.load_wyoming_info",
+            return_value=Info(handle=HANDLE_INFO.handle),
+        ),
+    ):
+        await hass.config_entries.async_setup(intent_config_entry.entry_id)
+
+    agent = conversation.async_get_agent(hass, agent_id)
+    assert isinstance(agent, conversation.ConversationEntity)
+    supported_features = (
+        agent.supported_features or conversation.ConversationEntityFeature(0)
+    )
+
+    control_feature = (
+        supported_features & conversation.ConversationEntityFeature.CONTROL
+    )
+
+    if supports_home_control:
+        assert control_feature == conversation.ConversationEntityFeature.CONTROL
+    else:
+        assert control_feature == conversation.ConversationEntityFeature(0)

--- a/tests/components/wyoming/test_conversation.py
+++ b/tests/components/wyoming/test_conversation.py
@@ -270,12 +270,13 @@ async def test_multiple_intents_handle_error(
     """Test error during handling when multiple intents are recognized."""
     agent_id = "conversation.test_intent"
 
-    test_intent = Intent(name="TestIntent", entities=[], text="success")
+    test_intent_1 = Intent(name="TestIntent1", entities=[], text="success")
+    test_intent_2 = Intent(name="TestIntent2", entities=[], text="success")
 
     class TestIntentHandler1(intent.IntentHandler):
         """Test Intent Handler."""
 
-        intent_type = "TestIntent2"
+        intent_type = "TestIntent1"
 
         async def async_handle(self, intent_obj: intent.Intent):
             """Handle the intent."""
@@ -295,7 +296,14 @@ async def test_multiple_intents_handle_error(
 
     with patch(
         "homeassistant.components.wyoming.conversation.AsyncTcpClient",
-        MockAsyncTcpClient([test_intent.event()]),
+        MockAsyncTcpClient(
+            [
+                IntentsStart().event(),
+                test_intent_1.event(),
+                test_intent_2.event(),
+                IntentsStop().event(),
+            ]
+        ),
     ):
         result = await conversation.async_converse(
             hass=hass,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With the update to `wyoming` 1.9, this PR adds support for handling multiple intents from an external conversation agent. This allows an agent to produce multiple tool calls outside of Home Assistant, similar to how LLM integrations do within their respective integrations.

Handling multiple intents needs careful attention because:

1. One intent may be recognized while others are not
2. One intent may fail to be handled while others succeed
3. Each intent may have its own response text

To address these potential issues, this PR does the following:

1. If any intent is not recognized, **no** intents are handled
2. Intent handling is done with an `asyncio.TaskGroup` so any failure will cancel other intent handlers
3. All response texts are combined with newlines (language independent) so they can all be displayed

In addition to handling multiple intents, this PR sets the `CONTROL` supported feature for intent handling Wyoming services when the new `supports_home_control` flag is set. This feature was always set for intent recognition services, but a new test codifies this.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
