### PR TITLE
Promote growatt_server to Gold quality scale

### DIFF
--- a/homeassistant/components/growatt_server/__init__.py
+++ b/homeassistant/components/growatt_server/__init__.py
@@ -282,7 +282,9 @@ def get_device_list_v1(
             ) from e
         if e.error_code == V1_API_ERROR_RATE_LIMITED:
             raise ConfigEntryNotReady(
-                f"Growatt API rate limited, will retry: {e.error_msg or str(e)}"
+                translation_domain=DOMAIN,
+                translation_key="rate_limited",
+                translation_placeholders={"error": e.error_msg or str(e)},
             ) from e
         raise ConfigEntryError(
             translation_domain=DOMAIN,

--- a/homeassistant/components/growatt_server/__init__.py
+++ b/homeassistant/components/growatt_server/__init__.py
@@ -239,15 +239,24 @@ def _login_classic_api(
         login_response = api.login(username, password)
     except (RequestException, JSONDecodeError) as ex:
         raise ConfigEntryError(
-            f"Error communicating with Growatt API during login: {ex}"
+            translation_domain=DOMAIN,
+            translation_key="communication_error",
+            translation_placeholders={"error": str(ex)},
         ) from ex
 
     if not login_response.get("success"):
         msg = login_response.get("msg", "Unknown error")
         _LOGGER.debug("Growatt login failed: %s", msg)
         if msg == LOGIN_INVALID_AUTH_CODE:
-            raise ConfigEntryAuthFailed("Username, Password or URL may be incorrect!")
-        raise ConfigEntryError(f"Growatt login failed: {msg}")
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="invalid_credentials",
+            )
+        raise ConfigEntryError(
+            translation_domain=DOMAIN,
+            translation_key="login_failed",
+            translation_placeholders={"message": msg},
+        )
 
     return login_response
 
@@ -267,15 +276,21 @@ def get_device_list_v1(
     except growattServer.GrowattV1ApiError as e:
         if e.error_code == V1_API_ERROR_NO_PRIVILEGE:
             raise ConfigEntryAuthFailed(
-                f"Authentication failed for Growatt API: {e.error_msg or str(e)}"
+                translation_domain=DOMAIN,
+                translation_key="auth_failed",
+                translation_placeholders={"error": e.error_msg or str(e)},
             ) from e
         if e.error_code == V1_API_ERROR_RATE_LIMITED:
             raise ConfigEntryNotReady(
                 f"Growatt API rate limited, will retry: {e.error_msg or str(e)}"
             ) from e
         raise ConfigEntryError(
-            f"API error during device list: {e.error_msg or str(e)}"
-            f" (Code: {e.error_code})"
+            translation_domain=DOMAIN,
+            translation_key="api_error_with_code",
+            translation_placeholders={
+                "error": e.error_msg or str(e),
+                "code": str(e.error_code),
+            },
         ) from e
     devices = devices_dict.get("devices", [])
     supported_devices = [
@@ -349,10 +364,15 @@ async def async_setup_entry(
             devices = await hass.async_add_executor_job(api.device_list, plant_id)
         except (RequestException, JSONDecodeError) as ex:
             raise ConfigEntryError(
-                f"Error communicating with Growatt API during device list: {ex}"
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+                translation_placeholders={"error": str(ex)},
             ) from ex
     else:
-        raise ConfigEntryError("Unknown authentication type in config entry.")
+        raise ConfigEntryError(
+            translation_domain=DOMAIN,
+            translation_key="unknown_auth_type",
+        )
 
     # Create a coordinator for the total sensors
     total_coordinator = GrowattCoordinator(

--- a/homeassistant/components/growatt_server/coordinator.py
+++ b/homeassistant/components/growatt_server/coordinator.py
@@ -115,7 +115,9 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             except growattServer.GrowattV1ApiError as err:
                 if err.error_code == V1_API_ERROR_NO_PRIVILEGE:
                     raise ConfigEntryAuthFailed(
-                        f"Authentication failed for Growatt API: {err.error_msg or str(err)}"
+                        translation_domain=DOMAIN,
+                        translation_key="auth_failed",
+                        translation_placeholders={"error": err.error_msg or str(err)},
                     ) from err
                 _LOGGER.debug("Failed to fetch V1 device list during scan: %s", err)
                 self.device_list = None

--- a/homeassistant/components/growatt_server/coordinator.py
+++ b/homeassistant/components/growatt_server/coordinator.py
@@ -157,9 +157,14 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 msg = login_response.get("msg", "Unknown error")
                 if msg == LOGIN_INVALID_AUTH_CODE:
                     raise ConfigEntryAuthFailed(
-                        "Username, password, or URL may be incorrect"
+                        translation_domain=DOMAIN,
+                        translation_key="invalid_credentials",
                     )
-                raise UpdateFailed(f"Growatt login failed: {msg}")
+                raise UpdateFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="login_failed",
+                    translation_placeholders={"message": msg},
+                )
 
         if self.device_type == "total":
             if self.api_version == "v1":
@@ -181,11 +186,16 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 except growattServer.GrowattV1ApiError as err:
                     if err.error_code == V1_API_ERROR_NO_PRIVILEGE:
                         raise ConfigEntryAuthFailed(
-                            "Authentication failed for Growatt API:"
-                            f" {err.error_msg or str(err)}"
+                            translation_domain=DOMAIN,
+                            translation_key="auth_failed",
+                            translation_placeholders={
+                                "error": err.error_msg or str(err)
+                            },
                         ) from err
                     raise UpdateFailed(
-                        f"Error fetching plant energy overview: {err}"
+                        translation_domain=DOMAIN,
+                        translation_key="fetch_data_failed",
+                        translation_placeholders={"error": str(err)},
                     ) from err
                 total_info["todayEnergy"] = total_info["today_energy"]
                 total_info["totalEnergy"] = total_info["total_energy"]
@@ -214,10 +224,15 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             except growattServer.GrowattV1ApiError as err:
                 if err.error_code == V1_API_ERROR_NO_PRIVILEGE:
                     raise ConfigEntryAuthFailed(
-                        "Authentication failed for Growatt API:"
-                        f" {err.error_msg or str(err)}"
+                        translation_domain=DOMAIN,
+                        translation_key="auth_failed",
+                        translation_placeholders={"error": err.error_msg or str(err)},
                     ) from err
-                raise UpdateFailed(f"Error fetching min device data: {err}") from err
+                raise UpdateFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="fetch_data_failed",
+                    translation_placeholders={"error": str(err)},
+                ) from err
 
             min_info = {**min_details, **min_settings, **min_energy}
             self.data = min_info
@@ -242,10 +257,15 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             except growattServer.GrowattV1ApiError as err:
                 if err.error_code == V1_API_ERROR_NO_PRIVILEGE:
                     raise ConfigEntryAuthFailed(
-                        "Authentication failed for Growatt API:"
-                        f" {err.error_msg or str(err)}"
+                        translation_domain=DOMAIN,
+                        translation_key="auth_failed",
+                        translation_placeholders={"error": err.error_msg or str(err)},
                     ) from err
-                raise UpdateFailed(f"Error fetching SPH device data: {err}") from err
+                raise UpdateFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="fetch_data_failed",
+                    translation_placeholders={"error": str(err)},
+                ) from err
 
             combined = {**sph_detail, **sph_energy}
 
@@ -313,7 +333,11 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         try:
             return await self.hass.async_add_executor_job(self._sync_update_data)
         except json.decoder.JSONDecodeError as err:
-            raise UpdateFailed(f"Error fetching data: {err}") from err
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="fetch_data_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err
 
     def request_device_list_scan(self) -> None:
         """Request that the next _sync_update_data also fetches the device list.

--- a/homeassistant/components/growatt_server/manifest.json
+++ b/homeassistant/components/growatt_server/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "loggers": ["growattServer"],
-  "quality_scale": "silver",
+  "quality_scale": "gold",
   "requirements": ["growattServer==2.1.0"]
 }

--- a/homeassistant/components/growatt_server/quality_scale.yaml
+++ b/homeassistant/components/growatt_server/quality_scale.yaml
@@ -56,7 +56,7 @@ rules:
   entity-device-class: done
   entity-disabled-by-default: done
   entity-translations: done
-  exception-translations: todo
+  exception-translations: done
   icon-translations: done
   reconfiguration-flow: done
   repair-issues:

--- a/homeassistant/components/growatt_server/strings.json
+++ b/homeassistant/components/growatt_server/strings.json
@@ -595,6 +595,15 @@
     "api_error": {
       "message": "Growatt API error: {error}"
     },
+    "api_error_with_code": {
+      "message": "API error: {error} (Code: {code})"
+    },
+    "auth_failed": {
+      "message": "Authentication failed for Growatt API: {error}"
+    },
+    "communication_error": {
+      "message": "Error communicating with Growatt API: {error}"
+    },
     "device_not_configured": {
       "message": "{device_type} device {serial_number} is not configured for actions."
     },
@@ -604,6 +613,9 @@
     "device_not_growatt": {
       "message": "Device {device_id} is not a Growatt device."
     },
+    "fetch_data_failed": {
+      "message": "Error fetching data from Growatt API: {error}"
+    },
     "invalid_batt_mode": {
       "message": "{batt_mode} is not a valid battery mode. Allowed values: {allowed_modes}."
     },
@@ -612,6 +624,9 @@
     },
     "invalid_charge_stop_soc": {
       "message": "'Charge stop SOC' must be between 0 and 100, got {value}."
+    },
+    "invalid_credentials": {
+      "message": "Username, password, or URL may be incorrect"
     },
     "invalid_discharge_power": {
       "message": "'Discharge power' must be between 0 and 100, got {value}."
@@ -634,11 +649,17 @@
     "invalid_time_format_start_time": {
       "message": "'Start time' must be in HH:MM or HH:MM:SS format."
     },
+    "login_failed": {
+      "message": "Growatt login failed: {message}"
+    },
     "no_devices_configured": {
       "message": "No {device_type} devices with token authentication are configured. Actions require {device_type} devices with V1 API access."
     },
     "token_auth_required": {
       "message": "This action requires token authentication (V1 API)."
+    },
+    "unknown_auth_type": {
+      "message": "Unknown authentication type in config entry"
     }
   },
   "selector": {

--- a/homeassistant/components/growatt_server/strings.json
+++ b/homeassistant/components/growatt_server/strings.json
@@ -655,6 +655,9 @@
     "no_devices_configured": {
       "message": "No {device_type} devices with token authentication are configured. Actions require {device_type} devices with V1 API access."
     },
+    "rate_limited": {
+      "message": "Growatt API rate limited, will retry: {error}"
+    },
     "token_auth_required": {
       "message": "This action requires token authentication (V1 API)."
     },


### PR DESCRIPTION

## Proposed change

Promote the Growatt Server integration to Gold quality scale level.

All Gold rules are now satisfied:
- **dynamic-devices**: done (implemented in #166081, marked done in quality_scale.yaml)
- **stale-devices**: done (implemented in #166081, marked done in quality_scale.yaml)
- **exception-translations**: done (all exceptions now use translation_domain/translation_key with entries in strings.json)
- All other Gold rules were already marked as done or exempt

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (ruff format homeassistant tests)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: python3 -m script.hassfest.
- [ ] New or updated dependencies have been added to requirements_all.txt.  
      Updated by running python3 -m script.gen_requirements_all.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
