### PR TITLE
Catch requests.Timeout and apply TIMEOUT constant across CalDAV integration

### DIFF
--- a/homeassistant/components/caldav/__init__.py
+++ b/homeassistant/components/caldav/__init__.py
@@ -45,6 +45,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: CalDavConfigEntry) -> bo
         # on some other unexpected server response.
         _LOGGER.warning("Unexpected CalDAV server response: %s", err)
         return False
+    except requests.Timeout as err:
+        raise ConfigEntryNotReady("Timeout connecting to CalDAV server") from err
     except requests.ConnectionError as err:
         raise ConfigEntryNotReady("Connection error from CalDAV server") from err
     except DAVError as err:

--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -38,6 +38,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import CalDavConfigEntry
 from .api import async_get_calendars
+from .const import TIMEOUT
 from .coordinator import CalDavUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -91,7 +92,12 @@ async def async_setup_platform(
     days = config[CONF_DAYS]
 
     client = caldav.DAVClient(
-        url, None, username, password, ssl_verify_cert=config[CONF_VERIFY_SSL]
+        url,
+        None,
+        username,
+        password,
+        ssl_verify_cert=config[CONF_VERIFY_SSL],
+        timeout=TIMEOUT,
     )
 
     calendars = await async_get_calendars(hass, client, SUPPORTED_COMPONENT)
@@ -231,7 +237,7 @@ class WebDavCalendarEntity(CoordinatorEntity[CalDavUpdateCoordinator], CalendarE
             await self.hass.async_add_executor_job(
                 partial(self.coordinator.calendar.add_event, **item_data),
             )
-        except (requests.ConnectionError, DAVError) as err:
+        except (requests.ConnectionError, requests.Timeout, DAVError) as err:
             raise HomeAssistantError(f"CalDAV save error: {err}") from err
 
     @callback

--- a/homeassistant/components/caldav/todo.py
+++ b/homeassistant/components/caldav/todo.py
@@ -138,7 +138,7 @@ class WebDavTodoListEntity(TodoListEntity):
             )
             # refreshing async otherwise it would take too much time
             self.hass.async_create_task(self.async_update_ha_state(force_refresh=True))
-        except (requests.ConnectionError, DAVError) as err:
+        except (requests.ConnectionError, requests.Timeout, DAVError) as err:
             raise HomeAssistantError(f"CalDAV save error: {err}") from err
 
     async def async_update_todo_item(self, item: TodoItem) -> None:
@@ -150,7 +150,7 @@ class WebDavTodoListEntity(TodoListEntity):
             )
         except NotFoundError as err:
             raise HomeAssistantError(f"Could not find To-do item {uid}") from err
-        except (requests.ConnectionError, DAVError) as err:
+        except (requests.ConnectionError, requests.Timeout, DAVError) as err:
             raise HomeAssistantError(f"CalDAV lookup error: {err}") from err
         vtodo = todo.icalendar_component  # type: ignore[attr-defined]
         vtodo["SUMMARY"] = item.summary or ""
@@ -174,7 +174,7 @@ class WebDavTodoListEntity(TodoListEntity):
             )
             # refreshing async otherwise it would take too much time
             self.hass.async_create_task(self.async_update_ha_state(force_refresh=True))
-        except (requests.ConnectionError, DAVError) as err:
+        except (requests.ConnectionError, requests.Timeout, DAVError) as err:
             raise HomeAssistantError(f"CalDAV save error: {err}") from err
 
     async def async_delete_todo_items(self, uids: list[str]) -> None:
@@ -188,14 +188,14 @@ class WebDavTodoListEntity(TodoListEntity):
             items = await asyncio.gather(*tasks)
         except NotFoundError as err:
             raise HomeAssistantError("Could not find To-do item") from err
-        except (requests.ConnectionError, DAVError) as err:
+        except (requests.ConnectionError, requests.Timeout, DAVError) as err:
             raise HomeAssistantError(f"CalDAV lookup error: {err}") from err
 
         # Run serially as some CalDAV servers do not support concurrent modifications
         for item in items:
             try:
                 await self.hass.async_add_executor_job(item.delete)
-            except (requests.ConnectionError, DAVError) as err:
+            except (requests.ConnectionError, requests.Timeout, DAVError) as err:
                 raise HomeAssistantError(f"CalDAV delete error: {err}") from err
         # refreshing async otherwise it would take too much time
         self.hass.async_create_task(self.async_update_ha_state(force_refresh=True))

--- a/tests/components/caldav/test_init.py
+++ b/tests/components/caldav/test_init.py
@@ -39,6 +39,7 @@ async def test_load_unload(
     [
         (Exception(), ConfigEntryState.SETUP_ERROR, []),
         (requests.ConnectionError(), ConfigEntryState.SETUP_RETRY, []),
+        (requests.Timeout(), ConfigEntryState.SETUP_RETRY, []),
         (DAVError(), ConfigEntryState.SETUP_RETRY, []),
         (
             AuthorizationError(reason="Unauthorized"),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #171463 (which introduced the `TIMEOUT` constant).

This PR extends timeout handling across the rest of the CalDAV integration:

- **`__init__.py`**: Catch `requests.Timeout` during entry setup so it raises `ConfigEntryNotReady` (retry) instead of being unhandled. `requests.Timeout` is not a subclass of `requests.ConnectionError`, so it needs its own except clause.
- **`calendar.py`**: Apply the `TIMEOUT` constant to the YAML platform's `DAVClient` (the only remaining call site without it), and add `requests.Timeout` to the `async_create_event` error handler.
- **`todo.py`**: Add `requests.Timeout` to all five exception handlers for todo CRUD operations.
- **`test_init.py`**: Add a `requests.Timeout` test case verifying setup retry behaviour.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #171463
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
