### PR TITLE
Use `is`/`is not` for same-enum identity comparisons (tests)

### DIFF
--- a/tests/auth/mfa_modules/test_insecure_example.py
+++ b/tests/auth/mfa_modules/test_insecure_example.py
@@ -102,37 +102,37 @@ async def test_login(hass: HomeAssistant) -> None:
 
     provider = hass.auth.auth_providers[0]
     result = await hass.auth.login_flow.async_init((provider.type, provider.id))
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"username": "incorrect-user", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"username": "test-user", "password": "incorrect-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"username": "test-user", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "mfa"
     assert result["data_schema"].schema.get("pin") is str
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"pin": "invalid-code"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_code"
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"pin": "123456"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"].id == "mock-id"
 
 
@@ -149,9 +149,9 @@ async def test_setup_flow(hass: HomeAssistant) -> None:
     flow = await auth_module.async_setup_flow("new-user")
 
     result = await flow.async_step_init()
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     result = await flow.async_step_init({"pin": "abcdefg"})
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert auth_module._data[1]["user_id"] == "new-user"
     assert auth_module._data[1]["pin"] == "abcdefg"

--- a/tests/auth/mfa_modules/test_notify.py
+++ b/tests/auth/mfa_modules/test_notify.py
@@ -137,25 +137,25 @@ async def test_login_flow_validates_mfa(hass: HomeAssistant) -> None:
     provider = hass.auth.auth_providers[0]
 
     result = await hass.auth.login_flow.async_init((provider.type, provider.id))
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"username": "incorrect-user", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"username": "test-user", "password": "incorrect-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     with patch("pyotp.HOTP.at", return_value=MOCK_CODE):
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"username": "test-user", "password": "test-pass"}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "mfa"
         assert result["data_schema"].schema.get("code") is str
 
@@ -173,7 +173,7 @@ async def test_login_flow_validates_mfa(hass: HomeAssistant) -> None:
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"code": "invalid-code"}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "mfa"
         assert result["errors"]["base"] == "invalid_code"
 
@@ -191,7 +191,7 @@ async def test_login_flow_validates_mfa(hass: HomeAssistant) -> None:
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"code": "invalid-code"}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "mfa"
         assert result["errors"]["base"] == "invalid_code"
 
@@ -199,7 +199,7 @@ async def test_login_flow_validates_mfa(hass: HomeAssistant) -> None:
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"code": "invalid-code"}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["type"] is data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "too_many_retry"
 
     # wait service call finished
@@ -207,13 +207,13 @@ async def test_login_flow_validates_mfa(hass: HomeAssistant) -> None:
 
     # restart login
     result = await hass.auth.login_flow.async_init((provider.type, provider.id))
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     with patch("pyotp.HOTP.at", return_value=MOCK_CODE):
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"username": "test-user", "password": "test-pass"}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "mfa"
         assert result["data_schema"].schema.get("code") is str
 
@@ -231,7 +231,7 @@ async def test_login_flow_validates_mfa(hass: HomeAssistant) -> None:
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"code": MOCK_CODE}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["data"].id == "mock-id"
 
 
@@ -246,7 +246,7 @@ async def test_setup_user_notify_service(hass: HomeAssistant) -> None:
 
     flow = await notify_auth_module.async_setup_flow("test-user")
     step = await flow.async_step_init()
-    assert step["type"] == data_entry_flow.FlowResultType.FORM
+    assert step["type"] is data_entry_flow.FlowResultType.FORM
     assert step["step_id"] == "init"
     schema = step["data_schema"]
     schema({"notify_service": "test2"})
@@ -277,7 +277,7 @@ async def test_setup_user_notify_service(hass: HomeAssistant) -> None:
 
     with patch("pyotp.HOTP.at", return_value=MOCK_CODE):
         step = await flow.async_step_init({"notify_service": "test1"})
-        assert step["type"] == data_entry_flow.FlowResultType.FORM
+        assert step["type"] is data_entry_flow.FlowResultType.FORM
         assert step["step_id"] == "setup"
 
     # wait service call finished
@@ -357,7 +357,7 @@ async def test_setup_user_no_notify_service(hass: HomeAssistant) -> None:
 
     flow = await notify_auth_module.async_setup_flow("test-user")
     step = await flow.async_step_init()
-    assert step["type"] == data_entry_flow.FlowResultType.ABORT
+    assert step["type"] is data_entry_flow.FlowResultType.ABORT
     assert step["reason"] == "no_available_service"
 
 
@@ -394,13 +394,13 @@ async def test_not_raise_exception_when_service_not_exist(hass: HomeAssistant) -
     provider = hass.auth.auth_providers[0]
 
     result = await hass.auth.login_flow.async_init((provider.type, provider.id))
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     with patch("pyotp.HOTP.at", return_value=MOCK_CODE):
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"username": "test-user", "password": "test-pass"}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["type"] is data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "unknown_error"
 
     # wait service call finished

--- a/tests/auth/mfa_modules/test_totp.py
+++ b/tests/auth/mfa_modules/test_totp.py
@@ -95,24 +95,24 @@ async def test_login_flow_validates_mfa(hass: HomeAssistant) -> None:
     provider = hass.auth.auth_providers[0]
 
     result = await hass.auth.login_flow.async_init((provider.type, provider.id))
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"username": "incorrect-user", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"username": "test-user", "password": "incorrect-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await hass.auth.login_flow.async_configure(
         result["flow_id"], {"username": "test-user", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "mfa"
     assert result["data_schema"].schema.get("code") is str
 
@@ -120,7 +120,7 @@ async def test_login_flow_validates_mfa(hass: HomeAssistant) -> None:
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"code": "invalid-code"}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "mfa"
         assert result["errors"]["base"] == "invalid_code"
 
@@ -128,7 +128,7 @@ async def test_login_flow_validates_mfa(hass: HomeAssistant) -> None:
         result = await hass.auth.login_flow.async_configure(
             result["flow_id"], {"code": MOCK_CODE}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["data"].id == "mock-id"
 
 

--- a/tests/auth/providers/test_command_line.py
+++ b/tests/auth/providers/test_command_line.py
@@ -139,18 +139,18 @@ async def test_login_flow_validates(
     """Test login flow."""
     flow = await provider.async_login_flow({})
     result = await flow.async_step_init()
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     result = await flow.async_step_init(
         {"username": "bad-user", "password": "bad-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await flow.async_step_init(
         {"username": "good-user", "password": "good-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"]["username"] == "good-user"
 
 
@@ -160,5 +160,5 @@ async def test_strip_username(provider: command_line.CommandLineAuthProvider) ->
     result = await flow.async_step_init(
         {"username": "\t\ngood-user ", "password": "good-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"]["username"] == "good-user"

--- a/tests/auth/providers/test_homeassistant.py
+++ b/tests/auth/providers/test_homeassistant.py
@@ -161,24 +161,24 @@ async def test_login_flow_validates(data: hass_auth.Data, hass: HomeAssistant) -
     )
     flow = await provider.async_login_flow({})
     result = await flow.async_step_init()
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     result = await flow.async_step_init(
         {"username": "incorrect-user", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await flow.async_step_init(
         {"username": "TEST-user ", "password": "incorrect-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await flow.async_step_init(
         {"username": "test-USER", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"]["username"] == "test-USER"
 
 
@@ -260,24 +260,24 @@ async def test_legacy_login_flow_validates(
     )
     flow = await provider.async_login_flow({})
     result = await flow.async_step_init()
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     result = await flow.async_step_init(
         {"username": "incorrect-user", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await flow.async_step_init(
         {"username": "test-user", "password": "incorrect-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_auth"
 
     result = await flow.async_step_init(
         {"username": "test-user", "password": "test-pass"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"]["username"] == "test-user"
 
 

--- a/tests/auth/test_init.py
+++ b/tests/auth/test_init.py
@@ -172,12 +172,12 @@ async def test_create_new_user(hass: HomeAssistant) -> None:
     )
 
     step = await manager.login_flow.async_init(("insecure_example", None))
-    assert step["type"] == data_entry_flow.FlowResultType.FORM
+    assert step["type"] is data_entry_flow.FlowResultType.FORM
 
     step = await manager.login_flow.async_configure(
         step["flow_id"], {"username": "test-user", "password": "test-pass"}
     )
-    assert step["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert step["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     credential = step["result"]
     assert credential is not None
 
@@ -241,12 +241,12 @@ async def test_login_as_existing_user(mock_hass) -> None:
     )
 
     step = await manager.login_flow.async_init(("insecure_example", None))
-    assert step["type"] == data_entry_flow.FlowResultType.FORM
+    assert step["type"] is data_entry_flow.FlowResultType.FORM
 
     step = await manager.login_flow.async_configure(
         step["flow_id"], {"username": "test-user", "password": "test-pass"}
     )
-    assert step["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert step["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
     credential = step["result"]
     user = await manager.async_get_user_by_credentials(credential)
@@ -840,14 +840,14 @@ async def test_login_with_auth_module(mock_hass) -> None:
     )
 
     step = await manager.login_flow.async_init(("insecure_example", None))
-    assert step["type"] == data_entry_flow.FlowResultType.FORM
+    assert step["type"] is data_entry_flow.FlowResultType.FORM
 
     step = await manager.login_flow.async_configure(
         step["flow_id"], {"username": "test-user", "password": "test-pass"}
     )
 
     # After auth_provider validated, request auth module input form
-    assert step["type"] == data_entry_flow.FlowResultType.FORM
+    assert step["type"] is data_entry_flow.FlowResultType.FORM
     assert step["step_id"] == "mfa"
 
     step = await manager.login_flow.async_configure(
@@ -855,7 +855,7 @@ async def test_login_with_auth_module(mock_hass) -> None:
     )
 
     # Invalid code error
-    assert step["type"] == data_entry_flow.FlowResultType.FORM
+    assert step["type"] is data_entry_flow.FlowResultType.FORM
     assert step["step_id"] == "mfa"
     assert step["errors"] == {"base": "invalid_code"}
 
@@ -864,7 +864,7 @@ async def test_login_with_auth_module(mock_hass) -> None:
     )
 
     # Finally passed, get credential
-    assert step["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert step["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert step["result"]
     assert step["result"].id == "mock-id"
 
@@ -915,21 +915,21 @@ async def test_login_with_multi_auth_module(mock_hass) -> None:
     )
 
     step = await manager.login_flow.async_init(("insecure_example", None))
-    assert step["type"] == data_entry_flow.FlowResultType.FORM
+    assert step["type"] is data_entry_flow.FlowResultType.FORM
 
     step = await manager.login_flow.async_configure(
         step["flow_id"], {"username": "test-user", "password": "test-pass"}
     )
 
     # After auth_provider validated, request select auth module
-    assert step["type"] == data_entry_flow.FlowResultType.FORM
+    assert step["type"] is data_entry_flow.FlowResultType.FORM
     assert step["step_id"] == "select_mfa_module"
 
     step = await manager.login_flow.async_configure(
         step["flow_id"], {"multi_factor_auth_module": "module2"}
     )
 
-    assert step["type"] == data_entry_flow.FlowResultType.FORM
+    assert step["type"] is data_entry_flow.FlowResultType.FORM
     assert step["step_id"] == "mfa"
 
     step = await manager.login_flow.async_configure(
@@ -937,7 +937,7 @@ async def test_login_with_multi_auth_module(mock_hass) -> None:
     )
 
     # Finally passed, get credential
-    assert step["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert step["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert step["result"]
     assert step["result"].id == "mock-id"
 
@@ -983,13 +983,13 @@ async def test_auth_module_expired_session(mock_hass) -> None:
     )
 
     step = await manager.login_flow.async_init(("insecure_example", None))
-    assert step["type"] == data_entry_flow.FlowResultType.FORM
+    assert step["type"] is data_entry_flow.FlowResultType.FORM
 
     step = await manager.login_flow.async_configure(
         step["flow_id"], {"username": "test-user", "password": "test-pass"}
     )
 
-    assert step["type"] == data_entry_flow.FlowResultType.FORM
+    assert step["type"] is data_entry_flow.FlowResultType.FORM
     assert step["step_id"] == "mfa"
 
     with freeze_time(dt_util.utcnow() + MFA_SESSION_EXPIRATION):
@@ -997,7 +997,7 @@ async def test_auth_module_expired_session(mock_hass) -> None:
             step["flow_id"], {"pin": "test-pin"}
         )
         # login flow abort due session timeout
-        assert step["type"] == data_entry_flow.FlowResultType.ABORT
+        assert step["type"] is data_entry_flow.FlowResultType.ABORT
         assert step["reason"] == "login_expired"
 
 

--- a/tests/components/airos/test_config_flow.py
+++ b/tests/components/airos/test_config_flow.py
@@ -231,7 +231,7 @@ async def test_reauth_flow_scenario(
             data=mock_config_entry.data,
         )
 
-    assert flow["type"] == FlowResultType.FORM
+    assert flow["type"] is FlowResultType.FORM
     assert flow["step_id"] == REAUTH_STEP
 
     fw_major = int(ap_status_fixture.host.fwversion.lstrip("v").split(".", 1)[0])
@@ -305,7 +305,7 @@ async def test_reauth_flow_scenarios(
             data=mock_config_entry.data,
         )
 
-    assert flow["type"] == FlowResultType.FORM
+    assert flow["type"] is FlowResultType.FORM
     assert flow["step_id"] == REAUTH_STEP
 
     with patch(
@@ -337,7 +337,7 @@ async def test_reauth_flow_scenarios(
             user_input={CONF_PASSWORD: NEW_PASSWORD},
         )
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
 
     updated_entry = hass.config_entries.async_get_entry(mock_config_entry.entry_id)

--- a/tests/components/airos/test_init.py
+++ b/tests/components/airos/test_init.py
@@ -284,7 +284,7 @@ async def test_setup_entry_failure(
 
     result = await hass.config_entries.async_setup(mock_config_entry.entry_id)
     assert result is False
-    assert mock_config_entry.state == state
+    assert mock_config_entry.state is state
 
 
 async def test_fetch_airos_data_auth_error(mock_airos_client: MagicMock) -> None:

--- a/tests/components/alexa_devices/test_init.py
+++ b/tests/components/alexa_devices/test_init.py
@@ -138,4 +138,4 @@ async def test_migrate_future_version_returns_false(
 
     await setup_integration(hass, config_entry)
 
-    assert config_entry.state == ConfigEntryState.MIGRATION_ERROR
+    assert config_entry.state is ConfigEntryState.MIGRATION_ERROR

--- a/tests/components/anthropic/test_conversation.py
+++ b/tests/components/anthropic/test_conversation.py
@@ -164,7 +164,7 @@ async def test_error_handling(
         hass, "hello", None, Context(), agent_id="conversation.claude_conversation"
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == "unknown", result
 
 
@@ -189,7 +189,7 @@ async def test_template_error(
         hass, "hello", None, Context(), agent_id="conversation.claude_conversation"
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == "unknown", result
 
 
@@ -230,7 +230,7 @@ async def test_template_variables(
             hass, "hello", None, context, agent_id="conversation.claude_conversation"
         )
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert (
         result.response.speech["plain"]["speech"]
         == "Okay, let me take care of that for you."
@@ -382,7 +382,7 @@ async def test_function_call(
     system_text = " ".join(block["text"] for block in system if "text" in block)
     assert "You are a voice assistant for Home Assistant." in system_text
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert (
         result.response.speech["plain"]["speech"]
         == "I have successfully called the function"
@@ -457,7 +457,7 @@ async def test_function_exception(
         agent_id=agent_id,
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert (
         result.response.speech["plain"]["speech"]
         == "There was an error calling the function"
@@ -638,7 +638,7 @@ async def test_refusal(
         agent_id="conversation.claude_conversation",
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == "unknown"
     assert (
         result.response.speech["plain"]["speech"]
@@ -670,7 +670,7 @@ async def test_stream_wrong_type(
         agent_id="conversation.claude_conversation",
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == "unknown"
     assert result.response.speech["plain"]["speech"] == "Expected a stream of messages"
 
@@ -700,7 +700,7 @@ async def test_double_system_messages(
             agent_id="conversation.claude_conversation",
         )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == "unknown"
     assert (
         result.response.speech["plain"]["speech"]

--- a/tests/components/anthropic/test_coordinator.py
+++ b/tests/components/anthropic/test_coordinator.py
@@ -42,7 +42,7 @@ async def test_auth_error_handling(
         hass, "hello", None, Context(), agent_id="conversation.claude_conversation"
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == "unknown", result
 
     await hass.async_block_till_done()
@@ -86,7 +86,7 @@ async def test_connection_error_handling(
         hass, "hello", None, Context(), agent_id="conversation.claude_conversation"
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == "unknown", result
 
     # Check new state

--- a/tests/components/axis/test_hub.py
+++ b/tests/components/axis/test_hub.py
@@ -190,7 +190,7 @@ async def test_device_trigger_reauth_flow(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
         mock_flow_init.assert_called_once()
-    assert config_entry.state == ConfigEntryState.SETUP_ERROR
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_shutdown(config_entry_data: MappingProxyType[str, Any]) -> None:
@@ -235,4 +235,4 @@ async def test_get_axis_api_errors(
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
-    assert config_entry.state == state
+    assert config_entry.state is state

--- a/tests/components/azure_data_explorer/test_config_flow.py
+++ b/tests/components/azure_data_explorer/test_config_flow.py
@@ -26,7 +26,7 @@ async def test_config_flow(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=None
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -34,7 +34,7 @@ async def test_config_flow(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> 
         BASE_CONFIG.copy(),
     )
 
-    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result2["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert (
         result2["title"]
         == "cluster.region.kusto.windows.net / test-database-name (test-table-name)"
@@ -61,7 +61,7 @@ async def test_config_flow_errors(
         context={"source": config_entries.SOURCE_USER},
         data=None,
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
     # Test error handling with error
@@ -71,7 +71,7 @@ async def test_config_flow_errors(
         result["flow_id"],
         BASE_CONFIG.copy(),
     )
-    assert result2["type"] == data_entry_flow.FlowResultType.FORM
+    assert result2["type"] is data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": expected}
 
     schema = result2["data_schema"]
@@ -112,4 +112,4 @@ async def test_config_flow_errors(
 
     await hass.async_block_till_done()
 
-    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result3["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY

--- a/tests/components/azure_data_explorer/test_config_flow.py
+++ b/tests/components/azure_data_explorer/test_config_flow.py
@@ -99,7 +99,7 @@ async def test_config_flow_errors(
 
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.FlowResultType.FORM
+    assert result2["type"] is data_entry_flow.FlowResultType.FORM
 
     # Retest error handling if error is corrected and connection is successful
 

--- a/tests/components/bayesian/test_config_flow.py
+++ b/tests/components/bayesian/test_config_flow.py
@@ -70,7 +70,7 @@ async def test_config_flow_step_user(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        assert result1["type"] == FlowResultType.CREATE_ENTRY
+        assert result1["type"] is FlowResultType.CREATE_ENTRY
         assert result1["result"].title == "Office occupied"
         assert result1["next_flow"][0] == FlowType.CONFIG_SUBENTRIES_FLOW
 
@@ -260,7 +260,7 @@ async def test_single_state_observation(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["type"] is FlowResultType.CREATE_ENTRY
         entry_id = result["result"].entry_id
         sub_flow_id = result["next_flow"][1]
 
@@ -287,7 +287,7 @@ async def test_single_state_observation(hass: HomeAssistant) -> None:
             },
         )
 
-        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["type"] is FlowResultType.CREATE_ENTRY
         await hass.async_block_till_done()
 
         config_entry = hass.config_entries.async_get_entry(entry_id)
@@ -337,7 +337,7 @@ async def test_single_numeric_state_observation(hass: HomeAssistant) -> None:
                 CONF_PRIOR: 20,
             },
         )
-        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["type"] is FlowResultType.CREATE_ENTRY
         config_entry = result["result"]
         sub_flow_id = result["next_flow"][1]
         await hass.async_block_till_done()
@@ -408,7 +408,7 @@ async def test_multi_numeric_state_observation(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["type"] is FlowResultType.CREATE_ENTRY
         config_entry = result["result"]
         sub_flow_id = result["next_flow"][1]
 
@@ -546,7 +546,7 @@ async def test_single_template_observation(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["type"] is FlowResultType.CREATE_ENTRY
         config_entry = result["result"]
         sub_flow_id = result["next_flow"][1]
 
@@ -1086,7 +1086,7 @@ async def test_invalid_configs(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
         assert result.get("errors") is None
 
-        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["type"] is FlowResultType.CREATE_ENTRY
         config_entry = result["result"]
         sub_flow_id = result["next_flow"][1]
 

--- a/tests/components/bring/test_init.py
+++ b/tests/components/bring/test_init.py
@@ -72,7 +72,7 @@ async def test_init_failure(
     """Test an initialization error on integration load."""
     mock_bring_client.login.side_effect = exception
     await setup_integration(hass, bring_config_entry)
-    assert bring_config_entry.state == status
+    assert bring_config_entry.state is status
 
     assert (
         any(

--- a/tests/components/caldav/test_init.py
+++ b/tests/components/caldav/test_init.py
@@ -67,7 +67,7 @@ async def test_client_failure(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state == expected_state
+    assert config_entry.state is expected_state
 
     flows = hass.config_entries.flow.async_progress()
     assert [flow.get("step_id") for flow in flows] == expected_flows

--- a/tests/components/casper_glow/test_init.py
+++ b/tests/components/casper_glow/test_init.py
@@ -56,7 +56,7 @@ async def test_async_unload_entry(
     result = await hass.config_entries.async_unload(config_entry.entry_id)
 
     assert result is True
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_device_info(

--- a/tests/components/climate/test_intent.py
+++ b/tests/components/climate/test_intent.py
@@ -201,7 +201,7 @@ async def test_set_temperature(
             {"temperature": {"value": 20}},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.MULTIPLE_TARGETS
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.MULTIPLE_TARGETS
 
     # Select by area explicitly (climate_2)
     response = await intent.async_handle(
@@ -211,7 +211,7 @@ async def test_set_temperature(
         {"area": {"value": bedroom_area.name}, "temperature": {"value": 20.1}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == climate_2.entity_id
     state = hass.states.get(climate_2.entity_id)
@@ -228,7 +228,7 @@ async def test_set_temperature(
         },
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.matched_states
     assert response.matched_states[0].entity_id == climate_2.entity_id
     state = hass.states.get(climate_2.entity_id)
@@ -242,7 +242,7 @@ async def test_set_temperature(
         {"floor": {"value": second_floor.name}, "temperature": {"value": 20.3}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.matched_states
     assert response.matched_states[0].entity_id == climate_2.entity_id
     state = hass.states.get(climate_2.entity_id)
@@ -259,7 +259,7 @@ async def test_set_temperature(
         },
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.matched_states
     assert response.matched_states[0].entity_id == climate_2.entity_id
     state = hass.states.get(climate_2.entity_id)
@@ -273,7 +273,7 @@ async def test_set_temperature(
         {"name": {"value": "Climate 2"}, "temperature": {"value": 20.5}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == climate_2.entity_id
     state = hass.states.get(climate_2.entity_id)
@@ -291,7 +291,7 @@ async def test_set_temperature(
 
     # Exception should contain details of what we tried to match
     assert isinstance(error.value, intent.MatchFailedError)
-    assert error.value.result.no_match_reason == intent.MatchFailedReason.AREA
+    assert error.value.result.no_match_reason is intent.MatchFailedReason.AREA
     constraints = error.value.constraints
     assert constraints.name is None
     assert constraints.area_name == office_area.name
@@ -310,7 +310,7 @@ async def test_set_temperature(
             },
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.MULTIPLE_TARGETS
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.MULTIPLE_TARGETS
 
 
 async def test_set_temperature_no_entities(
@@ -330,7 +330,7 @@ async def test_set_temperature_no_entities(
             {"temperature": {"value": 20}},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.DOMAIN
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.DOMAIN
 
 
 async def test_set_temperature_not_supported(hass: HomeAssistant) -> None:
@@ -357,4 +357,4 @@ async def test_set_temperature_not_supported(hass: HomeAssistant) -> None:
 
     # Exception should contain details of what we tried to match
     assert isinstance(error.value, intent.MatchFailedError)
-    assert error.value.result.no_match_reason == intent.MatchFailedReason.FEATURE
+    assert error.value.result.no_match_reason is intent.MatchFailedReason.FEATURE

--- a/tests/components/comelit/test_init.py
+++ b/tests/components/comelit/test_init.py
@@ -114,4 +114,4 @@ async def test_migrate_future_version_returns_false(
 
     await setup_integration(hass, config_entry)
 
-    assert config_entry.state == ConfigEntryState.MIGRATION_ERROR
+    assert config_entry.state is ConfigEntryState.MIGRATION_ERROR

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -785,7 +785,7 @@ async def test_get_progress_index(
         )
 
     for form in (form_hassio, form_user, form_reconfigure):
-        assert form["type"] == data_entry_flow.FlowResultType.FORM
+        assert form["type"] is data_entry_flow.FlowResultType.FORM
         assert form["step_id"] == "account"
 
     await ws_client.send_json({"id": 5, "type": "config_entries/flow/progress"})
@@ -961,9 +961,9 @@ async def test_get_progress_subscribe(
                 "test", context=context
             )
 
-    assert forms["bluetooth"]["type"] == data_entry_flow.FlowResultType.ABORT
+    assert forms["bluetooth"]["type"] is data_entry_flow.FlowResultType.ABORT
     for key in ("hassio", "user", "reauth", "reconfigure"):
-        assert forms[key]["type"] == data_entry_flow.FlowResultType.FORM
+        assert forms[key]["type"] is data_entry_flow.FlowResultType.FORM
         assert forms[key]["step_id"] == "account"
 
     for key in ("hassio", "user", "reauth", "reconfigure"):
@@ -1100,9 +1100,9 @@ async def test_get_progress_subscribe_in_progress(
                 "test", context=context
             )
 
-    assert forms["bluetooth"]["type"] == data_entry_flow.FlowResultType.ABORT
+    assert forms["bluetooth"]["type"] is data_entry_flow.FlowResultType.ABORT
     for key in ("hassio", "user", "reauth", "reconfigure"):
-        assert forms[key]["type"] == data_entry_flow.FlowResultType.FORM
+        assert forms[key]["type"] is data_entry_flow.FlowResultType.FORM
         assert forms[key]["step_id"] == "account"
 
     await ws_client.send_json({"id": 1, "type": "config_entries/flow/subscribe"})
@@ -1235,16 +1235,16 @@ async def test_get_progress_subscribe_in_progress_bad_flow(
                 "test", context=context
             )
 
-    assert forms["bluetooth"]["type"] == data_entry_flow.FlowResultType.ABORT
+    assert forms["bluetooth"]["type"] is data_entry_flow.FlowResultType.ABORT
     for key in ("hassio", "user", "reauth", "reconfigure"):
-        assert forms[key]["type"] == data_entry_flow.FlowResultType.FORM
+        assert forms[key]["type"] is data_entry_flow.FlowResultType.FORM
         assert forms[key]["step_id"] == "account"
 
     with mock_config_flow("test2", BadFlow):
         forms["bad"] = await hass.config_entries.flow.async_init(
             "test2", context={"source": core_ce.SOURCE_REAUTH, "entry_id": "1234"}
         )
-    assert forms["bad"]["type"] == data_entry_flow.FlowResultType.FORM
+    assert forms["bad"]["type"] is data_entry_flow.FlowResultType.FORM
     assert forms["bad"]["step_id"] == "account"
 
     await ws_client.send_json({"id": 1, "type": "config_entries/flow/subscribe"})

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -116,7 +116,7 @@ async def test_hidden_entities_skipped(
     )
 
     assert len(calls) == 0
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
 
 
@@ -135,13 +135,13 @@ async def test_exposed_domains(hass: HomeAssistant) -> None:
     result = await conversation.async_converse(
         hass, "unlock front door", None, Context(), None
     )
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
 
     result = await conversation.async_converse(
         hass, "run my script", None, Context(), None
     )
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
 
 
@@ -191,7 +191,7 @@ async def test_exposed_areas(
     )
 
     # All is well for the exposed kitchen light
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.intent is not None
     assert result.response.intent.slots["area"]["value"] == area_kitchen.id
     assert result.response.intent.slots["area"]["text"] == area_kitchen.normalized_name
@@ -202,14 +202,14 @@ async def test_exposed_areas(
     )
 
     # This should be an error because the lights in that area are not exposed
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
 
     # But we can still ask questions about the bedroom, even with no exposed entities
     result = await conversation.async_converse(
         hass, "how many lights are on in the bedroom?", None, Context(), None
     )
-    assert result.response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert result.response.response_type is intent.IntentResponseType.QUERY_ANSWER
 
 
 @pytest.mark.usefixtures("init_components")
@@ -248,7 +248,7 @@ async def test_punctuation(hass: HomeAssistant) -> None:
 
     assert len(calls) == 1
     assert calls[0].data["entity_id"][0] == "light.test_light"
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.intent is not None
     assert result.response.intent.slots["name"]["value"] == "test light"
     assert result.response.intent.slots["name"]["text"] == "test light"
@@ -326,7 +326,7 @@ async def test_unexposed_entities_skipped(
     )
 
     assert len(calls) == 1
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.intent is not None
     assert result.response.intent.slots["area"]["value"] == area_kitchen.id
     assert result.response.intent.slots["area"]["text"] == area_kitchen.normalized_name
@@ -338,7 +338,7 @@ async def test_unexposed_entities_skipped(
         hass, "how many lights are on in the kitchen", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert result.response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(result.response.matched_states) == 1
     assert result.response.matched_states[0].entity_id == exposed_light.entity_id
 
@@ -403,7 +403,7 @@ async def test_duplicated_names_resolved_with_device_area(
         assert len(calls) == 1
         assert calls[0].data["entity_id"][0] == bedroom_light.entity_id
 
-        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
         assert result.response.intent is not None
         assert result.response.intent.slots.get("name", {}).get("value") == name
         assert result.response.intent.slots.get("name", {}).get("text") == name
@@ -421,7 +421,7 @@ async def test_trigger_sentences(hass: HomeAssistant) -> None:
     unregister = manager.register_trigger(trigger_sentences, callback)
 
     result = await conversation.async_converse(hass, "Not the trigger", None, Context())
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
 
     # Using different case and including punctuation
     test_sentences = ["it's party time!", "IT IS TIME TO PARTY."]
@@ -430,7 +430,7 @@ async def test_trigger_sentences(hass: HomeAssistant) -> None:
         result = await conversation.async_converse(hass, sentence, None, Context())
         assert callback.call_count == 1
         assert callback.call_args[0][0].text == sentence
-        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE, (
+        assert result.response.response_type is intent.IntentResponseType.ACTION_DONE, (
             sentence
         )
         assert result.response.speech == {
@@ -443,7 +443,7 @@ async def test_trigger_sentences(hass: HomeAssistant) -> None:
     callback.reset_mock()
     for sentence in test_sentences:
         result = await conversation.async_converse(hass, sentence, None, Context())
-        assert result.response.response_type == intent.IntentResponseType.ERROR, (
+        assert result.response.response_type is intent.IntentResponseType.ERROR, (
             sentence
         )
 
@@ -479,7 +479,7 @@ async def test_trigger_sentence_response_translation(
         result = await conversation.async_converse(
             hass, "test sentence", None, Context()
         )
-        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
         assert result.response.speech == {
             "plain": {"speech": expected, "extra_data": None}
         }
@@ -493,7 +493,7 @@ async def test_shopping_list_add_item(hass: HomeAssistant) -> None:
     result = await conversation.async_converse(
         hass, "add apples to my shopping list", None, Context()
     )
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.speech == {
         "plain": {"speech": "Added apples", "extra_data": None}
     }
@@ -506,7 +506,7 @@ async def test_nevermind_intent(hass: HomeAssistant) -> None:
     assert result.response.intent is not None
     assert result.response.intent.intent_type == intent.INTENT_NEVERMIND
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert not result.response.speech
 
 
@@ -517,7 +517,7 @@ async def test_respond_intent(hass: HomeAssistant) -> None:
     assert result.response.intent is not None
     assert result.response.intent.intent_type == intent.INTENT_RESPOND
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.speech["plain"]["speech"] == "Hello from Home Assistant."
 
 
@@ -584,7 +584,7 @@ async def test_satellite_area_context(
         satellite_id=kitchen_satellite.entity_id,
     )
     await hass.async_block_till_done()
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.intent is not None
     assert result.response.intent.slots["area"]["value"] == area_kitchen.id
     assert result.response.intent.slots["area"]["text"] == area_kitchen.normalized_name
@@ -608,7 +608,7 @@ async def test_satellite_area_context(
         satellite_id=kitchen_satellite.entity_id,
     )
     await hass.async_block_till_done()
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.intent is not None
     assert result.response.intent.slots["area"]["value"] == area_bedroom.id
     assert result.response.intent.slots["area"]["text"] == area_bedroom.normalized_name
@@ -632,7 +632,7 @@ async def test_satellite_area_context(
         device_id=bedroom_satellite.id,
     )
     await hass.async_block_till_done()
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.intent is not None
     assert result.response.intent.slots["area"]["value"] == area_bedroom.id
     assert result.response.intent.slots["area"]["text"] == area_bedroom.normalized_name
@@ -652,7 +652,7 @@ async def test_satellite_area_context(
             hass, f"turn {command} all lights", None, Context(), None
         )
         await hass.async_block_till_done()
-        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
 
         # All lights should have been targeted
         assert {s.entity_id for s in result.response.matched_states} == {
@@ -667,7 +667,7 @@ async def test_error_no_device(hass: HomeAssistant) -> None:
         hass, "turn on missing entity", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
@@ -685,7 +685,7 @@ async def test_error_no_device_exposed(hass: HomeAssistant) -> None:
         hass, "turn on kitchen light", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
@@ -700,7 +700,7 @@ async def test_error_no_area(hass: HomeAssistant) -> None:
         hass, "turn on the lights in missing area", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
@@ -715,7 +715,7 @@ async def test_error_no_floor(hass: HomeAssistant) -> None:
         hass, "turn on all the lights on missing floor", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
@@ -734,7 +734,7 @@ async def test_error_no_device_in_area(
         hass, "turn on missing entity in the kitchen", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
@@ -754,7 +754,7 @@ async def test_error_no_device_on_floor(
         hass, "turn on missing entity on ground floor", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
@@ -809,7 +809,7 @@ async def test_error_no_device_on_floor_exposed(
             hass, "turn on test light on the ground floor", None, Context(), None
         )
 
-        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.response_type is intent.IntentResponseType.ERROR
         assert (
             result.response.error_code
             == intent.IntentResponseErrorCode.NO_VALID_TARGETS
@@ -848,7 +848,7 @@ async def test_error_no_device_in_area_exposed(
         hass, "turn on test light in the kitchen", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
@@ -877,7 +877,7 @@ async def test_error_no_domain(hass: HomeAssistant) -> None:
             hass, "turn on the fans", None, Context(), None
         )
 
-        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.response_type is intent.IntentResponseType.ERROR
         assert (
             result.response.error_code
             == intent.IntentResponseErrorCode.NO_VALID_TARGETS
@@ -912,7 +912,7 @@ async def test_error_no_domain_exposed(hass: HomeAssistant) -> None:
             hass, "turn on the fans", None, Context(), None
         )
 
-        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.response_type is intent.IntentResponseType.ERROR
         assert (
             result.response.error_code
             == intent.IntentResponseErrorCode.NO_VALID_TARGETS
@@ -931,7 +931,7 @@ async def test_error_no_domain_in_area(
         hass, "turn on the lights in the kitchen", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
@@ -967,7 +967,7 @@ async def test_error_no_domain_in_area_exposed(
         hass, "turn on the lights in the kitchen", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
@@ -991,7 +991,7 @@ async def test_error_no_domain_on_floor(
         hass, "turn on all lights on the ground floor", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
@@ -1009,7 +1009,7 @@ async def test_error_no_domain_on_floor(
         hass, "turn on all lights upstairs", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
@@ -1048,7 +1048,7 @@ async def test_error_no_domain_on_floor_exposed(
         hass, "turn on all lights on the ground floor", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
@@ -1086,7 +1086,7 @@ async def test_error_no_device_class(hass: HomeAssistant) -> None:
             hass, "open the windows", None, Context(), None
         )
 
-        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.response_type is intent.IntentResponseType.ERROR
         assert (
             result.response.error_code
             == intent.IntentResponseErrorCode.NO_VALID_TARGETS
@@ -1135,7 +1135,7 @@ async def test_error_no_device_class_exposed(hass: HomeAssistant) -> None:
             hass, "open all the windows", None, Context(), None
         )
 
-        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.response_type is intent.IntentResponseType.ERROR
         assert (
             result.response.error_code
             == intent.IntentResponseErrorCode.NO_VALID_TARGETS
@@ -1156,7 +1156,7 @@ async def test_error_no_device_class_in_area(
         hass, "open bedroom windows", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
@@ -1191,7 +1191,7 @@ async def test_error_no_device_class_in_area_exposed(
         hass, "open bedroom windows", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
@@ -1246,7 +1246,7 @@ async def test_error_no_device_class_on_floor_exposed(
             hass, "open ground floor windows", None, Context(), None
         )
 
-        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.response_type is intent.IntentResponseType.ERROR
         assert (
             result.response.error_code
             == intent.IntentResponseErrorCode.NO_VALID_TARGETS
@@ -1268,7 +1268,7 @@ async def test_error_no_intent(hass: HomeAssistant) -> None:
             hass, "do something", None, Context(), None
         )
 
-        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.response_type is intent.IntentResponseType.ERROR
         assert (
             result.response.error_code == intent.IntentResponseErrorCode.NO_INTENT_MATCH
         )
@@ -1305,7 +1305,7 @@ async def test_error_duplicate_names(
         result = await conversation.async_converse(
             hass, f"turn on {name}", None, Context(), None
         )
-        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.response_type is intent.IntentResponseType.ERROR
         assert (
             result.response.error_code
             == intent.IntentResponseErrorCode.NO_VALID_TARGETS
@@ -1319,7 +1319,7 @@ async def test_error_duplicate_names(
         result = await conversation.async_converse(
             hass, f"is {name} on?", None, Context(), None
         )
-        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.response_type is intent.IntentResponseType.ERROR
         assert (
             result.response.error_code
             == intent.IntentResponseErrorCode.NO_VALID_TARGETS
@@ -1362,7 +1362,7 @@ async def test_duplicate_names_but_one_is_exposed(
         result = await conversation.async_converse(
             hass, f"turn on {name}", None, Context(), None
         )
-        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
         assert result.response.matched_states[0].entity_id == kitchen_light_1.entity_id
 
 
@@ -1399,7 +1399,7 @@ async def test_error_duplicate_names_same_area(
         result = await conversation.async_converse(
             hass, f"turn on {name} in {area_kitchen.name}", None, Context(), None
         )
-        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.response_type is intent.IntentResponseType.ERROR
         assert (
             result.response.error_code
             == intent.IntentResponseErrorCode.NO_VALID_TARGETS
@@ -1414,7 +1414,7 @@ async def test_error_duplicate_names_same_area(
         result = await conversation.async_converse(
             hass, f"is {name} on in the {area_kitchen.name}?", None, Context(), None
         )
-        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.response_type is intent.IntentResponseType.ERROR
         assert (
             result.response.error_code
             == intent.IntentResponseErrorCode.NO_VALID_TARGETS
@@ -1464,7 +1464,7 @@ async def test_duplicate_names_same_area_but_one_is_exposed(
         result = await conversation.async_converse(
             hass, f"turn on {name} in {area_kitchen.name}", None, Context(), None
         )
-        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
         assert result.response.matched_states[0].entity_id == kitchen_light_1.entity_id
 
 
@@ -1530,20 +1530,20 @@ async def test_duplicate_names_different_areas(
         result = await conversation.async_converse(
             hass, f"turn on {name}", None, Context(), None
         )
-        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.response_type is intent.IntentResponseType.ERROR
 
         # Target kitchen light by using kitchen device
         result = await conversation.async_converse(
             hass, f"turn on {name}", None, Context(), None, device_id=device_kitchen.id
         )
-        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
         assert result.response.matched_states[0].entity_id == kitchen_light.entity_id
 
         # Target bedroom light by using bedroom device
         result = await conversation.async_converse(
             hass, f"turn on {name}", None, Context(), None, device_id=device_bedroom.id
         )
-        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
         assert result.response.matched_states[0].entity_id == bedroom_light.entity_id
 
 
@@ -1562,7 +1562,7 @@ async def test_error_wrong_state(hass: HomeAssistant) -> None:
         hass, "pause test player", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert result.response.speech["plain"]["speech"] == "Sorry, no device is playing"
 
@@ -1583,7 +1583,7 @@ async def test_error_feature_not_supported(hass: HomeAssistant) -> None:
         hass, "set test player volume to 100%", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
@@ -1615,7 +1615,7 @@ async def test_error_no_timer_support(
         hass, "set a 5 minute timer", None, Context(), None, device_id=device_id
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.FAILED_TO_HANDLE
     assert (
         result.response.speech["plain"]["speech"]
@@ -1639,7 +1639,7 @@ async def test_error_timer_not_found(hass: HomeAssistant) -> None:
         hass, "pause timer", None, Context(), None, device_id=device_id
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.FAILED_TO_HANDLE
     assert (
         result.response.speech["plain"]["speech"] == "Sorry, I couldn't find that timer"
@@ -1677,18 +1677,18 @@ async def test_error_multiple_timers_matched(
     result = await conversation.async_converse(
         hass, "set a timer for 5 minutes", None, Context(), None, device_id=device_id
     )
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
 
     result = await conversation.async_converse(
         hass, "set a timer for 5 minutes", None, Context(), None, device_id=device_id
     )
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Cannot target multiple timers
     result = await conversation.async_converse(
         hass, "cancel timer", None, Context(), None, device_id=device_id
     )
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.FAILED_TO_HANDLE
     assert (
         result.response.speech["plain"]["speech"]
@@ -1714,7 +1714,7 @@ async def test_no_states_matched_default_error(
             hass, "turn on lights in the kitchen", None, Context(), None
         )
 
-        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert result.response.response_type is intent.IntentResponseType.ERROR
         assert (
             result.response.error_code
             == intent.IntentResponseErrorCode.NO_VALID_TARGETS
@@ -1802,7 +1802,7 @@ async def test_all_domains_loaded(hass: HomeAssistant) -> None:
     )
 
     # Invalid target vs. no intent recognized
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
     assert (
         result.response.speech["plain"]["speech"]
@@ -1856,7 +1856,7 @@ async def test_same_named_entities_in_different_areas(
     await hass.async_block_till_done()
 
     assert len(calls) == 1
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.intent is not None
     assert (
         result.response.intent.slots.get("name", {}).get("value") == kitchen_light.name
@@ -1876,7 +1876,7 @@ async def test_same_named_entities_in_different_areas(
     await hass.async_block_till_done()
 
     assert len(calls) == 1
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.intent is not None
     assert (
         result.response.intent.slots.get("name", {}).get("value") == bedroom_light.name
@@ -1892,19 +1892,19 @@ async def test_same_named_entities_in_different_areas(
     result = await conversation.async_converse(
         hass, "turn on overhead light", None, Context(), None
     )
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
 
     # Querying a duplicate name should also fail
     result = await conversation.async_converse(
         hass, "is the overhead light on?", None, Context(), None
     )
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
 
     # But we can still ask questions that don't rely on the name
     result = await conversation.async_converse(
         hass, "how many lights are on?", None, Context(), None
     )
-    assert result.response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert result.response.response_type is intent.IntentResponseType.QUERY_ANSWER
 
 
 @pytest.mark.usefixtures("init_components")
@@ -1955,7 +1955,7 @@ async def test_same_aliased_entities_in_different_areas(
     await hass.async_block_till_done()
 
     assert len(calls) == 1
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.intent is not None
     assert result.response.intent.slots.get("name", {}).get("value") == "overhead light"
     assert result.response.intent.slots.get("name", {}).get("text") == "overhead light"
@@ -1971,7 +1971,7 @@ async def test_same_aliased_entities_in_different_areas(
     await hass.async_block_till_done()
 
     assert len(calls) == 1
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.intent is not None
     assert result.response.intent.slots.get("name", {}).get("value") == "overhead light"
     assert result.response.intent.slots.get("name", {}).get("text") == "overhead light"
@@ -1983,19 +1983,19 @@ async def test_same_aliased_entities_in_different_areas(
     result = await conversation.async_converse(
         hass, "turn on overhead light", None, Context(), None
     )
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
 
     # Querying a duplicate alias should also fail
     result = await conversation.async_converse(
         hass, "is the overhead light on?", None, Context(), None
     )
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
 
     # But we can still ask questions that don't rely on the alias
     result = await conversation.async_converse(
         hass, "how many lights are on?", None, Context(), None
     )
-    assert result.response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert result.response.response_type is intent.IntentResponseType.QUERY_ANSWER
 
 
 @pytest.mark.usefixtures("init_components")
@@ -2027,7 +2027,7 @@ async def test_device_id_in_handler(hass: HomeAssistant) -> None:
         Context(),
         device_id=device_id,
     )
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert handler.device_id == device_id
 
 
@@ -2070,7 +2070,7 @@ async def test_name_wildcard_lower_priority(hass: HomeAssistant) -> None:
     result = await conversation.async_converse(
         hass, "I'd like to order a stout please", None, Context(), None
     )
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert beer_handler.triggered
     assert not food_handler.triggered
 
@@ -2079,7 +2079,7 @@ async def test_name_wildcard_lower_priority(hass: HomeAssistant) -> None:
     result = await conversation.async_converse(
         hass, "I'd like to order a cookie please", None, Context(), None
     )
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert not beer_handler.triggered
     assert food_handler.triggered
 
@@ -2871,7 +2871,7 @@ async def test_query_same_name_different_areas(
     result = await conversation.async_converse(
         hass, "is the overhead light on?", None, Context(), None
     )
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
 
     # Succeeds using area from device (kitchen)
     result = await conversation.async_converse(
@@ -2882,7 +2882,7 @@ async def test_query_same_name_different_areas(
         None,
         device_id=kitchen_device.id,
     )
-    assert result.response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert result.response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(result.response.matched_states) == 1
     assert result.response.matched_states[0].entity_id == kitchen_light.entity_id
 
@@ -3059,7 +3059,7 @@ async def test_entities_names_are_not_templates(hass: HomeAssistant) -> None:
     )
 
     assert result is not None
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Not exposed
     expose_entity(hass, "light.test_light", False)
@@ -3072,7 +3072,7 @@ async def test_entities_names_are_not_templates(hass: HomeAssistant) -> None:
     )
 
     assert result is not None
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
 
 
 @pytest.mark.parametrize(
@@ -3339,7 +3339,7 @@ async def test_state_names_are_not_translated(
         result = await conversation.async_converse(
             hass, "what is the weather like?", None, Context(), None
         )
-        assert result.response.response_type == intent.IntentResponseType.QUERY_ANSWER
+        assert result.response.response_type is intent.IntentResponseType.QUERY_ANSWER
         mock_async_render.assert_called_once()
 
         assert (
@@ -3396,7 +3396,7 @@ async def test_intent_tool_call_in_chat_log(hass: HomeAssistant) -> None:
         hass, "turn on test light", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
 
     with (
         chat_session.async_get_chat_session(hass, result.conversation_id) as session,
@@ -3448,7 +3448,7 @@ async def test_trigger_tool_call_in_chat_log(hass: HomeAssistant) -> None:
         hass, trigger_sentence, None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
 
     with (
         chat_session.async_get_chat_session(hass, result.conversation_id) as session,
@@ -3486,7 +3486,7 @@ async def test_no_tool_call_on_no_intent_match(hass: HomeAssistant) -> None:
         hass, "this is a random sentence that should not match", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
 
     with (
         chat_session.async_get_chat_session(hass, result.conversation_id) as session,
@@ -3511,7 +3511,7 @@ async def test_intent_tool_call_with_error_response(hass: HomeAssistant) -> None
         hass, "turn on the non existent device", None, Context(), None
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
 
     with (

--- a/tests/components/conversation/test_default_agent_intents.py
+++ b/tests/components/conversation/test_default_agent_intents.py
@@ -88,7 +88,7 @@ async def test_cover_set_position(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "Opening"
     assert len(calls) == 1
     call = calls[0]
@@ -102,7 +102,7 @@ async def test_cover_set_position(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "Closing"
     assert len(calls) == 1
     call = calls[0]
@@ -116,7 +116,7 @@ async def test_cover_set_position(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "Position set"
     assert len(calls) == 1
     call = calls[0]
@@ -144,7 +144,7 @@ async def test_cover_device_class(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "Opening the garage"
     assert len(calls) == 1
     call = calls[0]
@@ -168,7 +168,7 @@ async def test_valve_intents(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "Opening"
     assert len(calls) == 1
     call = calls[0]
@@ -182,7 +182,7 @@ async def test_valve_intents(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "Closing"
     assert len(calls) == 1
     call = calls[0]
@@ -196,7 +196,7 @@ async def test_valve_intents(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "Position set"
     assert len(calls) == 1
     call = calls[0]
@@ -229,7 +229,7 @@ async def test_vacuum_intents(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "Started"
     assert len(calls) == 1
     call = calls[0]
@@ -243,7 +243,7 @@ async def test_vacuum_intents(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "Returning"
     assert len(calls) == 1
     call = calls[0]
@@ -275,7 +275,7 @@ async def test_media_player_intents(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "Paused"
     assert len(calls) == 1
     call = calls[0]
@@ -294,7 +294,7 @@ async def test_media_player_intents(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "Resumed"
     assert len(calls) == 1
     call = calls[0]
@@ -313,7 +313,7 @@ async def test_media_player_intents(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "Playing next"
     assert len(calls) == 1
     call = calls[0]
@@ -329,7 +329,7 @@ async def test_media_player_intents(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "Volume set"
     assert len(calls) == 1
     call = calls[0]
@@ -399,7 +399,7 @@ async def test_turn_floor_lights_on_off(
     )
 
     assert len(on_calls) == 2
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert {s.entity_id for s in result.response.matched_states} == {
         kitchen_light.entity_id,
         living_room_light.entity_id,
@@ -411,7 +411,7 @@ async def test_turn_floor_lights_on_off(
     )
 
     assert len(on_calls) == 1
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert {s.entity_id for s in result.response.matched_states} == {
         bedroom_light.entity_id
     }
@@ -422,7 +422,7 @@ async def test_turn_floor_lights_on_off(
     )
 
     assert len(off_calls) == 1
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert {s.entity_id for s in result.response.matched_states} == {
         bedroom_light.entity_id
     }
@@ -474,7 +474,7 @@ async def test_date_time(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "September 17th, 2013"
 
     result = await conversation.async_converse(
@@ -483,5 +483,5 @@ async def test_date_time(
     await hass.async_block_till_done()
 
     response = result.response
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech["plain"]["speech"] == "1:02 AM"

--- a/tests/components/cookidoo/test_init.py
+++ b/tests/components/cookidoo/test_init.py
@@ -57,7 +57,7 @@ async def test_init_failure(
     """Test an initialization error on integration load."""
     mock_cookidoo_client.login.side_effect = exception
     await setup_integration(hass, cookidoo_config_entry)
-    assert cookidoo_config_entry.state == status
+    assert cookidoo_config_entry.state is status
 
 
 @pytest.mark.parametrize(

--- a/tests/components/cover/test_intent.py
+++ b/tests/components/cover/test_intent.py
@@ -43,7 +43,7 @@ async def test_open_cover_intent(hass: HomeAssistant, slots: dict[str, Any]) -> 
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -75,7 +75,7 @@ async def test_close_cover_intent(hass: HomeAssistant, slots: dict[str, Any]) ->
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -110,7 +110,7 @@ async def test_set_cover_position(hass: HomeAssistant, slots: dict[str, Any]) ->
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN

--- a/tests/components/fan/test_intent.py
+++ b/tests/components/fan/test_intent.py
@@ -29,7 +29,7 @@ async def test_set_speed_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN

--- a/tests/components/firefly_iii/test_init.py
+++ b/tests/components/firefly_iii/test_init.py
@@ -35,4 +35,4 @@ async def test_setup_exceptions(
     """Test the _async_setup."""
     mock_firefly_client.get_about.side_effect = exception
     await setup_integration(hass, mock_config_entry)
-    assert mock_config_entry.state == expected_state
+    assert mock_config_entry.state is expected_state

--- a/tests/components/go2rtc/test_init.py
+++ b/tests/components/go2rtc/test_init.py
@@ -679,7 +679,7 @@ async def test_setup_with_retryable_setup_entry_error_custom_server(
     await hass.async_block_till_done(wait_background_tasks=True)
     config_entries = hass.config_entries.async_entries(DOMAIN)
     assert len(config_entries) == 1
-    assert config_entries[0].state == expected_config_entry_state
+    assert config_entries[0].state is expected_config_entry_state
     assert expected_log_message in caplog.text
 
 
@@ -716,7 +716,7 @@ async def test_setup_with_retryable_setup_entry_error_default_server(
     config_entries = hass.config_entries.async_entries(DOMAIN)
     assert len(config_entries) == has_go2rtc_entry
     for config_entry in config_entries:
-        assert config_entry.state == expected_config_entry_state
+        assert config_entry.state is expected_config_entry_state
     assert expected_log_message in caplog.text
 
 
@@ -750,7 +750,7 @@ async def test_setup_with_version_error(
     await hass.async_block_till_done(wait_background_tasks=True)
     config_entries = hass.config_entries.async_entries(DOMAIN)
     assert len(config_entries) == 1
-    assert config_entries[0].state == expected_config_entry_state
+    assert config_entries[0].state is expected_config_entry_state
     assert expected_log_message in caplog.text
 
 

--- a/tests/components/google_generative_ai_conversation/test_conversation.py
+++ b/tests/components/google_generative_ai_conversation/test_conversation.py
@@ -74,7 +74,7 @@ async def test_error_handling(
             Context(),
             agent_id="conversation.google_ai_conversation",
         )
-    assert result.response.response_type == intent.IntentResponseType.ERROR, result
+    assert result.response.response_type is intent.IntentResponseType.ERROR, result
     assert result.response.error_code == "unknown", result
     assert (
         result.response.as_dict()["speech"]["plain"]["speech"] == ERROR_GETTING_RESPONSE
@@ -249,7 +249,7 @@ async def test_function_call(
         agent_id=agent_id,
         device_id="test_device",
     )
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert (
         result.response.as_dict()["speech"]["plain"]["speech"]
         == "I've called the test function with the provided parameters."
@@ -356,7 +356,7 @@ async def test_google_search_tool_is_sent(
             agent_id=agent_id,
             device_id="test_device",
         )
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert (
         result.response.as_dict()["speech"]["plain"]["speech"]
         == "The last winner of the 2024 FIFA World Cup was Argentina."
@@ -406,7 +406,7 @@ async def test_blocked_response(
         device_id="test_device",
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR, result
+    assert result.response.response_type is intent.IntentResponseType.ERROR, result
     assert result.response.error_code == "unknown", result
     assert result.response.as_dict()["speech"]["plain"]["speech"] == (
         "The message got blocked due to content violations, reason: SAFETY"
@@ -450,7 +450,7 @@ async def test_empty_response(
         agent_id=agent_id,
         device_id="test_device",
     )
-    assert result.response.response_type == intent.IntentResponseType.ERROR, result
+    assert result.response.response_type is intent.IntentResponseType.ERROR, result
     assert result.response.error_code == "unknown", result
     assert result.response.as_dict()["speech"]["plain"]["speech"] == (
         "Unable to get response"
@@ -485,7 +485,7 @@ async def test_none_response(
         device_id="test_device",
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR, result
+    assert result.response.response_type is intent.IntentResponseType.ERROR, result
     assert result.response.error_code == "unknown", result
     assert result.response.as_dict()["speech"]["plain"]["speech"] == (
         "The message got blocked due to content violations, reason: unknown"
@@ -514,7 +514,7 @@ async def test_converse_error(
         agent_id="conversation.google_ai_conversation",
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR, result
+    assert result.response.response_type is intent.IntentResponseType.ERROR, result
     assert result.response.error_code == "unknown", result
     assert result.response.as_dict()["speech"]["plain"]["speech"] == (
         "Error preparing LLM API"

--- a/tests/components/home_connect/test_init.py
+++ b/tests/components/home_connect/test_init.py
@@ -178,7 +178,7 @@ async def test_token_refresh_error(
         assert not await integration_setup(client)
         await hass.async_block_till_done()
 
-    assert config_entry.state == expected_config_entry_state
+    assert config_entry.state is expected_config_entry_state
 
 
 @pytest.mark.parametrize(

--- a/tests/components/home_connect/test_init.py
+++ b/tests/components/home_connect/test_init.py
@@ -199,7 +199,7 @@ async def test_client_error(
     client_with_exception.get_home_appliances.return_value = None
     client_with_exception.get_home_appliances.side_effect = exception
     assert not await integration_setup(client_with_exception)
-    assert config_entry.state == expected_state
+    assert config_entry.state is expected_state
     assert client_with_exception.get_home_appliances.call_count == 1
 
 

--- a/tests/components/homeassistant_hardware/test_config_flow.py
+++ b/tests/components/homeassistant_hardware/test_config_flow.py
@@ -357,7 +357,7 @@ async def consume_progress_flow(
         result = await hass.config_entries.flow.async_configure(flow_id)
         flow_id = result["flow_id"]
 
-        if result["type"] != FlowResultType.SHOW_PROGRESS:
+        if result["type"] is not FlowResultType.SHOW_PROGRESS:
             break
 
         assert result["type"] is FlowResultType.SHOW_PROGRESS

--- a/tests/components/homeassistant_sky_connect/test_const.py
+++ b/tests/components/homeassistant_sky_connect/test_const.py
@@ -16,7 +16,7 @@ def test_hardware_variant(
     usb_product_name: str, expected_variant: HardwareVariant
 ) -> None:
     """Test hardware variant parsing."""
-    assert HardwareVariant.from_usb_product_name(usb_product_name) == expected_variant
+    assert HardwareVariant.from_usb_product_name(usb_product_name) is expected_variant
 
 
 def test_hardware_variant_invalid() -> None:

--- a/tests/components/homeassistant_sky_connect/test_util.py
+++ b/tests/components/homeassistant_sky_connect/test_util.py
@@ -65,7 +65,7 @@ def test_get_usb_service_info() -> None:
 
 def test_get_hardware_variant() -> None:
     """Test `get_hardware_variant` extraction."""
-    assert get_hardware_variant(SKYCONNECT_CONFIG_ENTRY) == HardwareVariant.SKYCONNECT
+    assert get_hardware_variant(SKYCONNECT_CONFIG_ENTRY) is HardwareVariant.SKYCONNECT
     assert (
-        get_hardware_variant(CONNECT_ZBT1_CONFIG_ENTRY) == HardwareVariant.CONNECT_ZBT1
+        get_hardware_variant(CONNECT_ZBT1_CONFIG_ENTRY) is HardwareVariant.CONNECT_ZBT1
     )

--- a/tests/components/html5/test_config_flow.py
+++ b/tests/components/html5/test_config_flow.py
@@ -110,7 +110,7 @@ async def test_step_user_form_invalid_key(
 
         await hass.async_block_till_done()
 
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
         assert mock_setup_entry.call_count == 0
 
         result = await hass.config_entries.flow.async_configure(

--- a/tests/components/humidifier/test_intent.py
+++ b/tests/components/humidifier/test_intent.py
@@ -263,7 +263,7 @@ async def test_intent_errors(hass: HomeAssistant) -> None:
         {"name": {"value": "Bedroom humidifier"}, "humidity": {"value": "50"}},
         assistant=conversation.DOMAIN,
     )
-    assert result.response_type == IntentResponseType.ACTION_DONE
+    assert result.response_type is IntentResponseType.ACTION_DONE
 
     result = await async_handle(
         hass,
@@ -272,7 +272,7 @@ async def test_intent_errors(hass: HomeAssistant) -> None:
         {"name": {"value": "Bedroom humidifier"}, "mode": {"value": "away"}},
         assistant=conversation.DOMAIN,
     )
-    assert result.response_type == IntentResponseType.ACTION_DONE
+    assert result.response_type is IntentResponseType.ACTION_DONE
 
     # Unexposing it should fail
     async_expose_entity(hass, conversation.DOMAIN, entity_id, False)
@@ -285,7 +285,7 @@ async def test_intent_errors(hass: HomeAssistant) -> None:
             {"name": {"value": "Bedroom humidifier"}, "humidity": {"value": "50"}},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == MatchFailedReason.ASSISTANT
+    assert err.value.result.no_match_reason is MatchFailedReason.ASSISTANT
 
     with pytest.raises(MatchFailedError) as err:
         await async_handle(
@@ -295,7 +295,7 @@ async def test_intent_errors(hass: HomeAssistant) -> None:
             {"name": {"value": "Bedroom humidifier"}, "mode": {"value": "away"}},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == MatchFailedReason.ASSISTANT
+    assert err.value.result.no_match_reason is MatchFailedReason.ASSISTANT
 
     # Expose again to test other errors
     async_expose_entity(hass, conversation.DOMAIN, entity_id, True)
@@ -328,7 +328,7 @@ async def test_intent_errors(hass: HomeAssistant) -> None:
             {"name": {"value": "does not exist"}, "humidity": {"value": "50"}},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == MatchFailedReason.NAME
+    assert err.value.result.no_match_reason is MatchFailedReason.NAME
 
     with pytest.raises(MatchFailedError) as err:
         await async_handle(
@@ -338,4 +338,4 @@ async def test_intent_errors(hass: HomeAssistant) -> None:
             {"name": {"value": "does not exist"}, "mode": {"value": "away"}},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == MatchFailedReason.NAME
+    assert err.value.result.no_match_reason is MatchFailedReason.NAME

--- a/tests/components/imap/test_config_flow.py
+++ b/tests/components/imap/test_config_flow.py
@@ -440,7 +440,7 @@ async def test_options_flow_when_connection_fails(
             result2 = await hass.config_entries.options.async_configure(
                 result["flow_id"], new_config
             )
-            assert result2["type"] == assert_result
+            assert result2["type"] is assert_result
 
             if result2.get("errors") is not None:
                 assert assert_result is FlowResultType.FORM

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -167,7 +167,7 @@ async def test_setup_config_full(
     full_config.update(config_update)
     full_config.update(config_ext)
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert entry.data == full_config
     assert issue_registry.async_get_issue(
         domain=DOMAIN,
@@ -351,7 +351,7 @@ async def test_setup_minimal_config_no_connection_keys(
 
     entry = conf_entries[0]
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert entry.data == BASE_V1_CONFIG
 
     assert not issue_registry.async_get_issue(domain=DOMAIN, issue_id="deprecated_yaml")
@@ -396,7 +396,7 @@ async def test_setup_minimal_config_with_connection_keys(
 
     entry = conf_entries[0]
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert entry.data == config_base
 
     assert issue_registry.async_get_issue(domain=DOMAIN, issue_id="deprecated_yaml")

--- a/tests/components/intent/test_init.py
+++ b/tests/components/intent/test_init.py
@@ -591,7 +591,7 @@ async def test_get_state_intent(
     )
 
     # yes
-    assert result.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert result.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert result.matched_states and (
         result.matched_states[0].entity_id == bedroom_light.entity_id
     )
@@ -611,7 +611,7 @@ async def test_get_state_intent(
     )
 
     # no, it's on
-    assert result.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert result.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert not result.matched_states
     assert result.unmatched_states and (
         result.unmatched_states[0].entity_id == kitchen_light.entity_id
@@ -628,7 +628,7 @@ async def test_get_state_intent(
         },
     )
 
-    assert result.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert result.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert result.matched_states and (
         result.matched_states[0].entity_id == kitchen_sensor.entity_id
     )
@@ -648,7 +648,7 @@ async def test_get_state_intent(
     )
 
     # yes
-    assert result.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert result.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert result.matched_states and (
         result.matched_states[0].entity_id == problem_sensor.entity_id
     )
@@ -667,7 +667,7 @@ async def test_get_state_intent(
     )
 
     # yes, 2 of them
-    assert result.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert result.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(result.matched_states) == 2 and {
         state.entity_id for state in result.matched_states
     } == {problem_sensor.entity_id, moisture_sensor.entity_id}
@@ -686,7 +686,7 @@ async def test_get_state_intent(
     )
 
     # no
-    assert result.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert result.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert not result.matched_states and not result.unmatched_states
 
     # Test unknown area failure
@@ -754,7 +754,7 @@ async def test_stop_moving_valve(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == VALVE_DOMAIN
@@ -782,7 +782,7 @@ async def test_stop_moving_cover(hass: HomeAssistant, slots: dict[str, Any]) -> 
     response = await intent.async_handle(hass, "test", intent.INTENT_STOP_MOVING, slots)
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == COVER_DOMAIN

--- a/tests/components/intent/test_temperature.py
+++ b/tests/components/intent/test_temperature.py
@@ -261,7 +261,7 @@ async def test_get_temperature(
     # Exception should contain details of what we tried to match
     assert isinstance(error.value, intent.MatchFailedError)
     assert (
-        error.value.result.no_match_reason == intent.MatchFailedReason.MULTIPLE_TARGETS
+        error.value.result.no_match_reason is intent.MatchFailedReason.MULTIPLE_TARGETS
     )
 
     # Select by area (office_temperature)
@@ -272,7 +272,7 @@ async def test_get_temperature(
         {"area": {"value": office_area.name}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == office_temperature_id
     state = response.matched_states[0]
@@ -286,7 +286,7 @@ async def test_get_temperature(
         {"preferred_area_id": {"value": attic_area.id}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == attic_temperature_id
     state = response.matched_states[0]
@@ -300,7 +300,7 @@ async def test_get_temperature(
         {"area": {"value": bedroom_area.name}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == climate_2.entity_id
     state = response.matched_states[0]
@@ -314,7 +314,7 @@ async def test_get_temperature(
         {"name": {"value": "Climate 2"}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == climate_2.entity_id
     state = response.matched_states[0]
@@ -332,7 +332,7 @@ async def test_get_temperature(
 
     # Exception should contain details of what we tried to match
     assert isinstance(error.value, intent.MatchFailedError)
-    assert error.value.result.no_match_reason == intent.MatchFailedReason.AREA
+    assert error.value.result.no_match_reason is intent.MatchFailedReason.AREA
     constraints = error.value.constraints
     assert constraints.name is None
     assert constraints.area_name == bathroom_area.name
@@ -349,7 +349,7 @@ async def test_get_temperature(
         )
 
     assert isinstance(error.value, intent.MatchFailedError)
-    assert error.value.result.no_match_reason == intent.MatchFailedReason.NAME
+    assert error.value.result.no_match_reason is intent.MatchFailedReason.NAME
     constraints = error.value.constraints
     assert constraints.name == "Does not exist"
     assert constraints.area_name is None
@@ -366,7 +366,7 @@ async def test_get_temperature(
         )
 
     assert isinstance(error.value, intent.MatchFailedError)
-    assert error.value.result.no_match_reason == intent.MatchFailedReason.AREA
+    assert error.value.result.no_match_reason is intent.MatchFailedReason.AREA
     constraints = error.value.constraints
     assert constraints.name == "Climate 1"
     assert constraints.area_name == bedroom_area.name
@@ -381,7 +381,7 @@ async def test_get_temperature(
         {"floor": {"value": first_floor.name}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == climate_1.entity_id
     state = response.matched_states[0]
@@ -395,7 +395,7 @@ async def test_get_temperature(
         {"preferred_area_id": {"value": bedroom_area.id}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == climate_2.entity_id
     state = response.matched_states[0]
@@ -409,7 +409,7 @@ async def test_get_temperature(
         {"preferred_floor_id": {"value": first_floor.floor_id}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == climate_1.entity_id
     state = response.matched_states[0]
@@ -433,7 +433,7 @@ async def test_get_temperature_no_entities(
             {},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.DOMAIN
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.DOMAIN
 
 
 async def test_not_exposed(
@@ -505,7 +505,7 @@ async def test_not_exposed(
         {},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == climate_2.entity_id
 
@@ -517,7 +517,7 @@ async def test_not_exposed(
         {"area": {"value": living_room_area.name}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == climate_2.entity_id
 
@@ -529,7 +529,7 @@ async def test_not_exposed(
         {"name": {"value": climate_2.name}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == climate_2.entity_id
 
@@ -542,7 +542,7 @@ async def test_not_exposed(
             {"name": {"value": climate_1.name}},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.ASSISTANT
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.ASSISTANT
 
     # Expose first, hide second
     async_expose_entity(hass, conversation.DOMAIN, climate_1.entity_id, True)
@@ -556,7 +556,7 @@ async def test_not_exposed(
         {},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     assert response.matched_states[0].entity_id == climate_1.entity_id
 
@@ -569,7 +569,7 @@ async def test_not_exposed(
             {"area": {"value": bedroom_area.name}},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.AREA
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.AREA
 
     # Neither are exposed
     async_expose_entity(hass, conversation.DOMAIN, climate_1.entity_id, False)
@@ -583,7 +583,7 @@ async def test_not_exposed(
             {},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.ASSISTANT
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.ASSISTANT
 
     # Should fail with area
     with pytest.raises(intent.MatchFailedError) as err:
@@ -594,7 +594,7 @@ async def test_not_exposed(
             {"area": {"value": living_room_area.name}},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.ASSISTANT
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.ASSISTANT
 
     # Should fail with both names
     for name in (climate_1.name, climate_2.name):
@@ -606,4 +606,4 @@ async def test_not_exposed(
                 {"name": {"value": name}},
                 assistant=conversation.DOMAIN,
             )
-        assert err.value.result.no_match_reason == intent.MatchFailedReason.ASSISTANT
+        assert err.value.result.no_match_reason is intent.MatchFailedReason.ASSISTANT

--- a/tests/components/intent/test_timers.py
+++ b/tests/components/intent/test_timers.py
@@ -82,7 +82,7 @@ async def test_start_finish_timer(hass: HomeAssistant, init_components) -> None:
         device_id=device_id,
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await asyncio.gather(started_event.wait(), finished_event.wait())
@@ -153,7 +153,7 @@ async def test_cancel_timer(hass: HomeAssistant, init_components) -> None:
         device_id=device_id,
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await cancelled_event.wait()
@@ -187,7 +187,7 @@ async def test_cancel_timer(hass: HomeAssistant, init_components) -> None:
         device_id=device_id,
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await cancelled_event.wait()
@@ -211,7 +211,7 @@ async def test_cancel_timer(hass: HomeAssistant, init_components) -> None:
         await started_event.wait()
 
     result = await intent.async_handle(hass, "test", intent.INTENT_CANCEL_TIMER, {})
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
 
 async def test_increase_timer(hass: HomeAssistant, init_components) -> None:
@@ -273,7 +273,7 @@ async def test_increase_timer(hass: HomeAssistant, init_components) -> None:
         device_id=device_id,
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await started_event.wait()
@@ -294,7 +294,7 @@ async def test_increase_timer(hass: HomeAssistant, init_components) -> None:
         },
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     assert not updated_event.is_set()
 
     # Add 30 seconds to the timer
@@ -313,7 +313,7 @@ async def test_increase_timer(hass: HomeAssistant, init_components) -> None:
         },
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await updated_event.wait()
@@ -326,7 +326,7 @@ async def test_increase_timer(hass: HomeAssistant, init_components) -> None:
         {"name": {"value": timer_name}},
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await cancelled_event.wait()
@@ -390,7 +390,7 @@ async def test_decrease_timer(hass: HomeAssistant, init_components) -> None:
         device_id=device_id,
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await started_event.wait()
@@ -408,7 +408,7 @@ async def test_decrease_timer(hass: HomeAssistant, init_components) -> None:
         },
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await started_event.wait()
@@ -421,7 +421,7 @@ async def test_decrease_timer(hass: HomeAssistant, init_components) -> None:
         {"name": {"value": timer_name}},
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await cancelled_event.wait()
@@ -480,7 +480,7 @@ async def test_decrease_timer_below_zero(hass: HomeAssistant, init_components) -
         device_id=device_id,
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await started_event.wait()
@@ -498,7 +498,7 @@ async def test_decrease_timer_below_zero(hass: HomeAssistant, init_components) -
         },
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await asyncio.gather(
@@ -545,7 +545,7 @@ async def test_find_timer_failed(hass: HomeAssistant, init_components) -> None:
         {"name": {"value": "pizza"}, "minutes": {"value": 5}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Right name
     result = await intent.async_handle(
@@ -554,7 +554,7 @@ async def test_find_timer_failed(hass: HomeAssistant, init_components) -> None:
         intent.INTENT_INCREASE_TIMER,
         {"name": {"value": "PIZZA "}, "minutes": {"value": 1}},
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Wrong name
     with pytest.raises(intent.IntentError):
@@ -572,7 +572,7 @@ async def test_find_timer_failed(hass: HomeAssistant, init_components) -> None:
         intent.INTENT_INCREASE_TIMER,
         {"start_minutes": {"value": 5}, "minutes": {"value": 1}},
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Wrong start time
     with pytest.raises(intent.IntentError):
@@ -645,7 +645,7 @@ async def test_disambiguation(
         {"minutes": {"value": 3}},
         device_id=device_alice_study.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Bob: set a 3 minute timer
     result = await intent.async_handle(
@@ -655,13 +655,13 @@ async def test_disambiguation(
         {"minutes": {"value": 3}},
         device_id=device_bob_kitchen_1.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Alice should hear her timer listed first
     result = await intent.async_handle(
         hass, "test", intent.INTENT_TIMER_STATUS, {}, device_id=device_alice_study.id
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 2
     assert timers[0].get(ATTR_DEVICE_ID) == device_alice_study.id
@@ -671,7 +671,7 @@ async def test_disambiguation(
     result = await intent.async_handle(
         hass, "test", intent.INTENT_TIMER_STATUS, {}, device_id=device_bob_kitchen_1.id
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 2
     assert timers[0].get(ATTR_DEVICE_ID) == device_bob_kitchen_1.id
@@ -683,7 +683,7 @@ async def test_disambiguation(
     result = await intent.async_handle(
         hass, "test", intent.INTENT_CANCEL_TIMER, {}, device_id=device_alice_study.id
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await cancelled_event.wait()
@@ -902,7 +902,7 @@ async def test_pause_unpause_timer(hass: HomeAssistant, init_components) -> None
         {"minutes": {"value": 5}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await started_event.wait()
@@ -910,7 +910,7 @@ async def test_pause_unpause_timer(hass: HomeAssistant, init_components) -> None
     # Pause the timer
     expected_active = False
     result = await intent.async_handle(hass, "test", intent.INTENT_PAUSE_TIMER, {})
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await updated_event.wait()
@@ -923,7 +923,7 @@ async def test_pause_unpause_timer(hass: HomeAssistant, init_components) -> None
     updated_event.clear()
     expected_active = True
     result = await intent.async_handle(hass, "test", intent.INTENT_UNPAUSE_TIMER, {})
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await updated_event.wait()
@@ -1065,7 +1065,7 @@ async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> 
         {"name": {"value": "pizza"}, "minutes": {"value": 10}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     result = await intent.async_handle(
         hass,
@@ -1074,7 +1074,7 @@ async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> 
         {"name": {"value": "pizza"}, "minutes": {"value": 15}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     result = await intent.async_handle(
         hass,
@@ -1083,7 +1083,7 @@ async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> 
         {"name": {"value": "cookies"}, "minutes": {"value": 20}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     result = await intent.async_handle(
         hass,
@@ -1092,7 +1092,7 @@ async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> 
         {"name": {"value": "chicken"}, "hours": {"value": 2}, "seconds": {"value": 30}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Wait for all timers to start
     async with asyncio.timeout(1):
@@ -1103,7 +1103,7 @@ async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> 
         result = await intent.async_handle(
             hass, "test", intent.INTENT_TIMER_STATUS, {}, device_id=handle_device_id
         )
-        assert result.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response_type is intent.IntentResponseType.ACTION_DONE
         timers = result.speech_slots.get("timers", [])
         assert len(timers) == 4
         assert {t.get(ATTR_NAME) for t in timers} == {"pizza", "cookies", "chicken"}
@@ -1116,7 +1116,7 @@ async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> 
         {"name": {"value": "cookies"}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 1
     assert timers[0].get(ATTR_NAME) == "cookies"
@@ -1130,7 +1130,7 @@ async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> 
         {"name": {"value": "pizza"}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 2
     assert timers[0].get(ATTR_NAME) == "pizza"
@@ -1145,7 +1145,7 @@ async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> 
         {"name": {"value": "pizza"}, "start_minutes": {"value": 10}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 1
     assert timers[0].get(ATTR_NAME) == "pizza"
@@ -1163,7 +1163,7 @@ async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> 
         },
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 1
     assert timers[0].get(ATTR_NAME) == "chicken"
@@ -1179,7 +1179,7 @@ async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> 
         {"name": {"value": "does-not-exist"}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 0
 
@@ -1195,7 +1195,7 @@ async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> 
         },
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 0
 
@@ -1252,7 +1252,7 @@ async def test_area_filter(
         {"name": {"value": "pizza"}, "minutes": {"value": 10}},
         device_id=device_kitchen.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     result = await intent.async_handle(
         hass,
@@ -1261,7 +1261,7 @@ async def test_area_filter(
         {"name": {"value": "tv"}, "minutes": {"value": 10}},
         device_id=device_living_room.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     result = await intent.async_handle(
         hass,
@@ -1270,7 +1270,7 @@ async def test_area_filter(
         {"name": {"value": "media"}, "minutes": {"value": 15}},
         device_id=device_living_room.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Wait for all timers to start
     async with asyncio.timeout(1):
@@ -1280,7 +1280,7 @@ async def test_area_filter(
     result = await intent.async_handle(
         hass, "test", intent.INTENT_TIMER_STATUS, {}, device_id=device_kitchen.id
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == num_timers
     assert {t.get(ATTR_NAME) for t in timers} == {"pizza", "tv", "media"}
@@ -1293,7 +1293,7 @@ async def test_area_filter(
         {"area": {"value": "kitchen"}},
         device_id=device_living_room.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 1
     assert timers[0].get(ATTR_NAME) == "pizza"
@@ -1306,7 +1306,7 @@ async def test_area_filter(
         {"area": {"value": "living room"}},
         device_id=device_kitchen.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 2
     assert {t.get(ATTR_NAME) for t in timers} == {"tv", "media"}
@@ -1319,7 +1319,7 @@ async def test_area_filter(
         {"area": {"value": "living room"}, "name": {"value": "tv"}},
         device_id=device_kitchen.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 1
     assert timers[0].get(ATTR_NAME) == "tv"
@@ -1332,7 +1332,7 @@ async def test_area_filter(
         {"area": {"value": "living room"}, "start_minutes": {"value": 15}},
         device_id=device_kitchen.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 1
     assert timers[0].get(ATTR_NAME) == "media"
@@ -1345,7 +1345,7 @@ async def test_area_filter(
         {"area": {"value": "does-not-exist"}},
         device_id=device_kitchen.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 0
 
@@ -1357,7 +1357,7 @@ async def test_area_filter(
         {"area": {"value": "living room"}, "start_minutes": {"value": 15}},
         device_id=device_living_room.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Cancel by area
     result = await intent.async_handle(
@@ -1367,7 +1367,7 @@ async def test_area_filter(
         {"area": {"value": "living room"}},
         device_id=device_living_room.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Get status with device missing
     with patch(
@@ -1380,7 +1380,7 @@ async def test_area_filter(
             intent.INTENT_TIMER_STATUS,
             device_id=device_kitchen.id,
         )
-        assert result.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response_type is intent.IntentResponseType.ACTION_DONE
         timers = result.speech_slots.get("timers", [])
         assert len(timers) == 1
 
@@ -1395,7 +1395,7 @@ async def test_area_filter(
             intent.INTENT_TIMER_STATUS,
             device_id=device_kitchen.id,
         )
-        assert result.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response_type is intent.IntentResponseType.ACTION_DONE
         timers = result.speech_slots.get("timers", [])
         assert len(timers) == 1
 
@@ -1457,7 +1457,7 @@ async def test_start_timer_with_conversation_command(
             conversation_agent_id=agent_id,
         )
 
-        assert result.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
         # No timer events for delayed commands
         mock_handle_timer.assert_not_called()
@@ -1500,7 +1500,7 @@ async def test_start_timer_with_sentence_trigger_validation(
             conversation_agent_id=agent_id,
         )
 
-        assert result.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
         # Verify the sentence trigger was checked
         mock_agent.async_recognize_sentence_trigger.assert_called_once()
@@ -1562,7 +1562,7 @@ async def test_start_timer_with_conversation_command_skip_validation(
         conversation_agent_id=agent_id,
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Verify timer was created successfully despite invalid command
     timer_manager = hass.data[TIMER_DATA]
@@ -1602,7 +1602,7 @@ async def test_pause_unpause_timer_disambiguate(
         {"minutes": {"value": 5}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await started_event.wait()
@@ -1611,7 +1611,7 @@ async def test_pause_unpause_timer_disambiguate(
     result = await intent.async_handle(
         hass, "test", intent.INTENT_PAUSE_TIMER, {}, device_id=device_id
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await updated_event.wait()
@@ -1625,7 +1625,7 @@ async def test_pause_unpause_timer_disambiguate(
         {"minutes": {"value": 10}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await started_event.wait()
@@ -1637,7 +1637,7 @@ async def test_pause_unpause_timer_disambiguate(
     result = await intent.async_handle(
         hass, "test", intent.INTENT_PAUSE_TIMER, {}, device_id=device_id
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await updated_event.wait()
@@ -1653,7 +1653,7 @@ async def test_pause_unpause_timer_disambiguate(
         {"start_minutes": {"value": 10}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await updated_event.wait()
@@ -1666,7 +1666,7 @@ async def test_pause_unpause_timer_disambiguate(
     result = await intent.async_handle(
         hass, "test", intent.INTENT_UNPAUSE_TIMER, {}, device_id=device_id
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
         await updated_event.wait()
@@ -1721,7 +1721,7 @@ async def test_cancel_all_timers(hass: HomeAssistant, init_components) -> None:
         {"name": {"value": "pizza"}, "minutes": {"value": 10}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     result = await intent.async_handle(
         hass,
@@ -1730,7 +1730,7 @@ async def test_cancel_all_timers(hass: HomeAssistant, init_components) -> None:
         {"name": {"value": "tv"}, "minutes": {"value": 10}},
         device_id=device_id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     result2 = await intent.async_handle(
         hass,
@@ -1739,7 +1739,7 @@ async def test_cancel_all_timers(hass: HomeAssistant, init_components) -> None:
         {"name": {"value": "media"}, "minutes": {"value": 15}},
         device_id=device_id,
     )
-    assert result2.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result2.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Wait for all timers to start
     async with asyncio.timeout(1):
@@ -1749,14 +1749,14 @@ async def test_cancel_all_timers(hass: HomeAssistant, init_components) -> None:
     result = await intent.async_handle(
         hass, "test", intent.INTENT_CANCEL_ALL_TIMERS, {}, device_id=device_id
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.speech_slots.get("canceled", 0) == 3
 
     # No timers should be running for test_device
     result = await intent.async_handle(
         hass, "test", intent.INTENT_TIMER_STATUS, {}, device_id=device_id
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 0
 
@@ -1813,7 +1813,7 @@ async def test_cancel_all_timers_area(
         {"name": {"value": "pizza"}, "minutes": {"value": 10}},
         device_id=device_kitchen.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     result = await intent.async_handle(
         hass,
@@ -1822,7 +1822,7 @@ async def test_cancel_all_timers_area(
         {"name": {"value": "tv"}, "minutes": {"value": 10}},
         device_id=device_living_room.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     result = await intent.async_handle(
         hass,
@@ -1831,7 +1831,7 @@ async def test_cancel_all_timers_area(
         {"name": {"value": "media"}, "minutes": {"value": 15}},
         device_id=device_living_room.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Wait for all timers to start
     async with asyncio.timeout(1):
@@ -1845,7 +1845,7 @@ async def test_cancel_all_timers_area(
         {"area": {"value": "kitchen"}},
         device_id=device_kitchen.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.speech_slots.get("canceled", 0) == 1
     assert result.speech_slots.get("area") == "kitchen"
 
@@ -1857,7 +1857,7 @@ async def test_cancel_all_timers_area(
         {"area": {"value": "kitchen"}},
         device_id=device_kitchen.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 0
 
@@ -1869,6 +1869,6 @@ async def test_cancel_all_timers_area(
         {"area": {"value": "living room"}},
         device_id=device_living_room.id,
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 2

--- a/tests/components/lawn_mower/test_intent.py
+++ b/tests/components/lawn_mower/test_intent.py
@@ -35,7 +35,7 @@ async def test_start_lawn_mower_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -60,7 +60,7 @@ async def test_start_lawn_mower_without_name(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -88,7 +88,7 @@ async def test_stop_lawn_mower_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -113,7 +113,7 @@ async def test_stop_lawn_mower_without_name(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN

--- a/tests/components/lcn/test_config_flow.py
+++ b/tests/components/lcn/test_config_flow.py
@@ -58,7 +58,7 @@ async def test_show_form(hass: HomeAssistant) -> None:
 
     result = await flow.async_step_user(user_input=None)
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -73,7 +73,7 @@ async def test_step_user(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": config_entries.SOURCE_USER}, data=data
         )
 
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == CONNECTION_DATA[CONF_HOST]
         assert result["data"] == {
             **CONNECTION_DATA,
@@ -94,7 +94,7 @@ async def test_step_user_existing_host(
             DOMAIN, context={"source": config_entries.SOURCE_USER}, data=config_data
         )
 
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["type"] is data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "already_configured"
 
 
@@ -121,7 +121,7 @@ async def test_step_user_error(
             DOMAIN, context={"source": config_entries.SOURCE_USER}, data=data
         )
 
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
         assert result["errors"] == errors
 
 
@@ -131,7 +131,7 @@ async def test_step_reconfigure(hass: HomeAssistant, entry: MockConfigEntry) -> 
     old_entry_data = entry.data.copy()
 
     result = await entry.start_reconfigure_flow(hass)
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reconfigure"
 
     with (
@@ -142,7 +142,7 @@ async def test_step_reconfigure(hass: HomeAssistant, entry: MockConfigEntry) -> 
             result["flow_id"],
             CONFIG_DATA.copy(),
         )
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["type"] is data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "reconfigure_successful"
 
         entry = hass.config_entries.async_get_entry(entry.entry_id)
@@ -169,7 +169,7 @@ async def test_step_reconfigure_error(
     entry.add_to_hass(hass)
 
     result = await entry.start_reconfigure_flow(hass)
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reconfigure"
 
     with patch(
@@ -181,7 +181,7 @@ async def test_step_reconfigure_error(
             CONFIG_DATA.copy(),
         )
 
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
         assert result["errors"] == errors
 
 

--- a/tests/components/lg_netcast/test_config_flow.py
+++ b/tests/components/lg_netcast/test_config_flow.py
@@ -31,7 +31,7 @@ async def test_show_form(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -52,12 +52,12 @@ async def test_manual_host(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: IP_ADDRESS}
         )
 
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "authorize"
         assert not result["errors"]
 
         result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result2["type"] == data_entry_flow.FlowResultType.FORM
+        assert result2["type"] is data_entry_flow.FlowResultType.FORM
         assert result2["step_id"] == "authorize"
         assert result2["errors"] is not None
         assert result2["errors"][CONF_ACCESS_TOKEN] == "invalid_access_token"
@@ -66,7 +66,7 @@ async def test_manual_host(hass: HomeAssistant) -> None:
             result["flow_id"], {CONF_ACCESS_TOKEN: FAKE_PIN}
         )
 
-        assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result3["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result3["title"] == FRIENDLY_NAME
         assert result3["data"] == {
             CONF_HOST: IP_ADDRESS,
@@ -84,7 +84,7 @@ async def test_manual_host_no_connection_during_authorize(hass: HomeAssistant) -
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: IP_ADDRESS}
         )
 
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["type"] is data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "cannot_connect"
 
 
@@ -97,7 +97,7 @@ async def test_manual_host_invalid_details_during_authorize(
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: IP_ADDRESS}
         )
 
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["type"] is data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "cannot_connect"
 
 
@@ -108,7 +108,7 @@ async def test_manual_host_unsuccessful_details_response(hass: HomeAssistant) ->
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: IP_ADDRESS}
         )
 
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["type"] is data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "cannot_connect"
 
 
@@ -119,7 +119,7 @@ async def test_manual_host_no_unique_id_response(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: IP_ADDRESS}
         )
 
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["type"] is data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "invalid_host"
 
 
@@ -130,7 +130,7 @@ async def test_invalid_session_id(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: IP_ADDRESS}
         )
 
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "authorize"
         assert not result["errors"]
 
@@ -138,7 +138,7 @@ async def test_invalid_session_id(hass: HomeAssistant) -> None:
             result["flow_id"], {CONF_ACCESS_TOKEN: FAKE_PIN}
         )
 
-        assert result2["type"] == data_entry_flow.FlowResultType.FORM
+        assert result2["type"] is data_entry_flow.FlowResultType.FORM
         assert result2["step_id"] == "authorize"
         assert result2["errors"] is not None
         assert result2["errors"]["base"] == "cannot_connect"
@@ -169,7 +169,7 @@ async def test_display_access_token_aborted(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: IP_ADDRESS}
         )
 
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "authorize"
         assert not result["errors"]
 

--- a/tests/components/matter/test_init.py
+++ b/tests/components/matter/test_init.py
@@ -555,7 +555,7 @@ async def test_stop_addon(
     )
     await hass.async_block_till_done()
 
-    assert entry.state == entry_state
+    assert entry.state is entry_state
     assert stop_addon.call_count == 1
     assert stop_addon.call_args == call("core_matter_server")
 

--- a/tests/components/media_player/test_intent.py
+++ b/tests/components/media_player/test_intent.py
@@ -68,7 +68,7 @@ async def test_pause_media_player_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -115,7 +115,7 @@ async def test_unpause_media_player_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -141,7 +141,7 @@ async def test_next_media_player_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -192,7 +192,7 @@ async def test_previous_media_player_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -243,7 +243,7 @@ async def test_volume_media_player_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -284,7 +284,7 @@ async def test_media_player_mute_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -325,7 +325,7 @@ async def test_media_player_unmute_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -479,7 +479,7 @@ async def test_multiple_media_players(
         {"name": {"value": "TV"}, "floor": {"value": "upstairs"}},
     )
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     assert calls[0].data == {"entity_id": bedroom_tv.entity_id}
     hass.states.async_set(bedroom_tv.entity_id, STATE_PAUSED, attributes=attributes)
@@ -494,7 +494,7 @@ async def test_multiple_media_players(
     )
 
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     assert calls[0].data == {"entity_id": living_room_tv.entity_id}
     hass.states.async_set(living_room_tv.entity_id, STATE_PAUSED, attributes=attributes)
@@ -508,7 +508,7 @@ async def test_multiple_media_players(
         {"name": {"value": "smart speaker"}, "area": {"value": "kitchen"}},
     )
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     assert calls[0].data == {"entity_id": kitchen_smart_speaker.entity_id}
     hass.states.async_set(
@@ -527,7 +527,7 @@ async def test_multiple_media_players(
         },
     )
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     assert calls[0].data == {"entity_id": living_room_smart_speaker.entity_id}
     hass.states.async_set(
@@ -543,7 +543,7 @@ async def test_multiple_media_players(
         {"floor": {"value": "upstairs"}},
     )
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 3
     assert {call.data["entity_id"] for call in calls} == {
         bedroom_tv.entity_id,
@@ -565,7 +565,7 @@ async def test_multiple_media_players(
         },
     )
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     assert calls[0].data == {"entity_id": bedroom_tv.entity_id}
     hass.states.async_set(bedroom_tv.entity_id, STATE_PAUSED, attributes=attributes)
@@ -579,7 +579,7 @@ async def test_multiple_media_players(
         {"area": {"value": "bathroom"}, "volume_level": {"value": 50}},
     )
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     assert calls[0].data == {
         "entity_id": bathroom_smart_speaker.entity_id,
@@ -599,7 +599,7 @@ async def test_multiple_media_players(
         {"floor": {"value": "ground"}},
     )
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     assert calls[0].data == {"entity_id": kitchen_smart_speaker.entity_id}
 
@@ -612,7 +612,7 @@ async def test_multiple_media_players(
         {"area": {"value": "kitchen"}},
     )
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     assert calls[0].data == {"entity_id": kitchen_smart_speaker.entity_id}
 
@@ -628,7 +628,7 @@ async def test_multiple_media_players(
         media_player_intent.INTENT_MEDIA_UNPAUSE,
     )
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     assert calls[0].data == {"entity_id": kitchen_smart_speaker.entity_id}
 
@@ -666,7 +666,7 @@ async def test_manual_pause_unpause(
         context=context,
     )
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 2
 
     hass.states.async_set(
@@ -686,7 +686,7 @@ async def test_manual_pause_unpause(
         context=context,
     )
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 2
 
     hass.states.async_set(
@@ -707,7 +707,7 @@ async def test_manual_pause_unpause(
         context=context,
     )
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     assert calls[0].data == {"entity_id": device_1.entity_id}
 
@@ -732,7 +732,7 @@ async def test_manual_pause_unpause(
         context=context,
     )
     await hass.async_block_till_done()
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     assert calls[0].data == {"entity_id": device_2.entity_id}
 
@@ -776,7 +776,7 @@ async def test_search_and_play_media_player_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Response should contain a "media" slot with the matched item.
     assert not response.speech
@@ -812,7 +812,7 @@ async def test_search_and_play_media_player_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
 
     # A search failure is indicated by no "media" slot in the response.
     assert not response.speech
@@ -928,7 +928,7 @@ async def test_search_and_play_media_player_intent_with_media_class(
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Response should contain a "media" slot with the matched item.
     assert not response.speech
@@ -1020,7 +1020,7 @@ async def test_volume_relative_media_player_intent(
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     idle_expected_volume += volume_change
     assert math.isclose(idle_entity.volume_level, idle_expected_volume)
 
@@ -1051,7 +1051,7 @@ async def test_volume_relative_media_player_intent(
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     playing_expected_volume += volume_change
     assert math.isclose(idle_entity.volume_level, idle_expected_volume)
     assert math.isclose(playing_entity.volume_level, playing_expected_volume)
@@ -1065,7 +1065,7 @@ async def test_volume_relative_media_player_intent(
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     idle_expected_volume += volume_change
     assert math.isclose(idle_entity.volume_level, idle_expected_volume)
     assert math.isclose(playing_entity.volume_level, playing_expected_volume)
@@ -1079,7 +1079,7 @@ async def test_volume_relative_media_player_intent(
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     playing_expected_volume += volume_change_int / 100
     assert math.isclose(idle_entity.volume_level, idle_expected_volume)
     assert math.isclose(playing_entity.volume_level, playing_expected_volume)

--- a/tests/components/nextcloud/test_init.py
+++ b/tests/components/nextcloud/test_init.py
@@ -92,4 +92,4 @@ async def test_setup_entry_errors(
     ):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
-        assert entry.state == expcted_entry_state
+        assert entry.state is expcted_entry_state

--- a/tests/components/ollama/test_conversation.py
+++ b/tests/components/ollama/test_conversation.py
@@ -84,7 +84,7 @@ async def test_chat(
             Message(role="user", content="test message"),
         ]
 
-        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE, (
+        assert result.response.response_type is intent.IntentResponseType.ACTION_DONE, (
             result
         )
         assert result.response.speech["plain"]["speech"] == "test response"
@@ -147,7 +147,7 @@ async def test_chat_stream(
             Message(role="user", content="test message"),
         ]
 
-        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE, (
+        assert result.response.response_type is intent.IntentResponseType.ACTION_DONE, (
             result
         )
         assert result.response.speech["plain"]["speech"] == "test response"
@@ -254,7 +254,7 @@ async def test_template_variables(
             hass, "hello", None, context, agent_id=mock_config_entry.entry_id
         )
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE, (
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE, (
         result
     )
 
@@ -357,7 +357,7 @@ async def test_function_call(
         )
 
     assert mock_chat.call_count == 2
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert (
         result.response.speech["plain"]["speech"]
         == "I have successfully called the function"
@@ -441,7 +441,7 @@ async def test_function_exception(
         )
 
     assert mock_chat.call_count == 2
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert (
         result.response.speech["plain"]["speech"]
         == "There was an error calling the function"
@@ -559,7 +559,7 @@ async def test_history_conversion(
             Message(role="user", content="test message"),
         ]
 
-        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE, (
+        assert result.response.response_type is intent.IntentResponseType.ACTION_DONE, (
             result
         )
         assert result.response.speech["plain"]["speech"] == "test response"
@@ -624,7 +624,7 @@ async def test_message_history_trimming(
                 agent_id=mock_config_entry.entry_id,
             )
             assert (
-                result.response.response_type == intent.IntentResponseType.ACTION_DONE
+                result.response.response_type is intent.IntentResponseType.ACTION_DONE
             ), result
 
         assert mock_chat.call_count == 5
@@ -725,7 +725,7 @@ async def test_message_history_unlimited(
                 agent_id=mock_config_entry.entry_id,
             )
             assert (
-                result.response.response_type == intent.IntentResponseType.ACTION_DONE
+                result.response.response_type is intent.IntentResponseType.ACTION_DONE
             ), result
 
         args = mock_chat.call_args_list
@@ -750,7 +750,7 @@ async def test_error_handling(
             hass, "hello", None, Context(), agent_id=mock_config_entry.entry_id
         )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR, result
+    assert result.response.response_type is intent.IntentResponseType.ERROR, result
     assert result.response.error_code == "unknown", result
 
 
@@ -776,7 +776,7 @@ async def test_template_error(
             hass, "hello", None, Context(), agent_id=mock_config_entry.entry_id
         )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR, result
+    assert result.response.response_type is intent.IntentResponseType.ERROR, result
     assert result.response.error_code == "unknown", result
 
 

--- a/tests/components/open_router/test_conversation.py
+++ b/tests/components/open_router/test_conversation.py
@@ -69,7 +69,7 @@ async def test_default_prompt(
         agent_id="conversation.gpt_3_5_turbo",
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert mock_chat_log.content[1:] == snapshot
     call = mock_openai_client.chat.completions.create.call_args_list[0][1]
     assert call["model"] == "openai/gpt-3.5-turbo"
@@ -136,7 +136,7 @@ async def test_empty_api_response(
         agent_id="conversation.gpt_3_5_turbo",
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
 
 
 @pytest.mark.parametrize("enable_assist", [True])
@@ -258,7 +258,7 @@ async def test_function_call(
         agent_id="conversation.gpt_3_5_turbo",
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     # Don't test the prompt, as it's not deterministic
     assert mock_chat_log.content[1:] == snapshot
     assert mock_openai_client.chat.completions.create.call_count == 2

--- a/tests/components/openai_conversation/test_conversation.py
+++ b/tests/components/openai_conversation/test_conversation.py
@@ -115,7 +115,7 @@ async def test_error_handling(
         hass, "hello", None, Context(), agent_id=mock_config_entry.entry_id
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR, result
+    assert result.response.response_type is intent.IntentResponseType.ERROR, result
     assert result.response.speech["plain"]["speech"] == message, result.response.speech
 
 
@@ -167,7 +167,7 @@ async def test_incomplete_response(
         agent_id="conversation.openai_conversation",
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR, result
+    assert result.response.response_type is intent.IntentResponseType.ERROR, result
     assert (
         result.response.speech["plain"]["speech"]
         == f"OpenAI response incomplete: {message}"
@@ -191,7 +191,7 @@ async def test_incomplete_response(
         agent_id="conversation.openai_conversation",
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR, result
+    assert result.response.response_type is intent.IntentResponseType.ERROR, result
     assert (
         result.response.speech["plain"]["speech"]
         == f"OpenAI response incomplete: {message}"
@@ -230,7 +230,7 @@ async def test_failed_response(
         agent_id="conversation.openai_conversation",
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR, result
+    assert result.response.response_type is intent.IntentResponseType.ERROR, result
     assert result.response.speech["plain"]["speech"] == message, result.response.speech
 
 
@@ -338,7 +338,7 @@ async def test_function_call(
         agent_id="conversation.openai_conversation",
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     # Don't test the prompt, as it's not deterministic
     assert mock_chat_log.content[1:] == snapshot
     assert mock_create_stream.call_args.kwargs["input"][1:] == snapshot
@@ -382,7 +382,7 @@ async def test_function_call_without_reasoning(
         agent_id="conversation.openai_conversation",
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     # Don't test the prompt, as it's not deterministic
     assert mock_chat_log.content[1:] == snapshot
 
@@ -568,7 +568,7 @@ async def test_store_responses_forwarded_for_conversation_agent(
         hass, "hello", None, Context(), agent_id=mock_config_entry.entry_id
     )
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert mock_create_stream.call_args is not None
     assert mock_create_stream.call_args.kwargs["store"] is expected_store
 
@@ -637,7 +637,7 @@ async def test_web_search(
             },
         }
     ]
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
 
     # Test follow-up message in multi-turn conversation
     mock_create_stream.return_value = [
@@ -707,7 +707,7 @@ async def test_code_interpreter(
     assert mock_create_stream.mock_calls[0][2]["tools"] == [
         {"type": "code_interpreter", "container": {"type": "auto"}}
     ]
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.speech["plain"]["speech"] == message, result.response.speech
 
     # Test follow-up message in multi-turn conversation
@@ -765,7 +765,7 @@ async def test_flex_tier_retry(
     )
 
     assert mock_create_stream.call_count == 2
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.speech["plain"]["speech"] == "How can I assist?", (
         result.response.speech
     )

--- a/tests/components/orvibo/test_config_flow.py
+++ b/tests/components/orvibo/test_config_flow.py
@@ -23,7 +23,7 @@ async def test_user_menu_display(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == FlowResultType.MENU
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "user"
     assert set(result["menu_options"]) == {"start_discovery", "edit"}
 
@@ -62,7 +62,7 @@ async def test_edit_flow_success(
         result["flow_id"], user_input
     )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == f"{DEFAULT_NAME} (192.168.1.2)"
     assert result["data"][CONF_HOST] == "192.168.1.2"
     assert result["data"][CONF_MAC] == expected_mac
@@ -113,7 +113,7 @@ async def test_edit_flow_errors(
         result["flow_id"], user_input
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"]["base"] == expected_error
 
     mock_s20.side_effect = None
@@ -124,7 +124,7 @@ async def test_edit_flow_errors(
         {CONF_HOST: "192.168.1.2", CONF_MAC: "ac:cf:23:12:34:56"},
     )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == f"{DEFAULT_NAME} (192.168.1.2)"
     assert result["data"][CONF_HOST] == "192.168.1.2"
     assert result["data"][CONF_MAC] == "ac:cf:23:12:34:56"
@@ -136,12 +136,12 @@ async def test_discovery_success(hass: HomeAssistant, mock_discover) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == FlowResultType.MENU
+    assert result["type"] is FlowResultType.MENU
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "start_discovery"}
     )
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "start_discovery"
     assert result["progress_action"] == "start_discovery"
 
@@ -149,14 +149,14 @@ async def test_discovery_success(hass: HomeAssistant, mock_discover) -> None:
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "choose_switch"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_SWITCH_LIST: "192.168.1.100"}
     )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == f"{DEFAULT_NAME} (192.168.1.100)"
     assert result["data"][CONF_HOST] == "192.168.1.100"
     assert result["data"][CONF_MAC] == "ac:cf:23:12:34:56"
@@ -181,14 +181,14 @@ async def test_discovery_no_devices(
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result["type"] == FlowResultType.MENU
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "discovery_failed"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "edit"}
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "edit"
 
     mock_s20.return_value._mac = b"\xaa\xbb\xcc\xdd\xee\xff"
@@ -198,7 +198,7 @@ async def test_discovery_no_devices(
         {CONF_HOST: "192.168.1.10", CONF_MAC: "aa:bb:cc:dd:ee:ff"},
     )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == f"{DEFAULT_NAME} (192.168.1.10)"
     assert result["data"][CONF_HOST] == "192.168.1.10"
     assert result["data"][CONF_MAC] == "aa:bb:cc:dd:ee:ff"
@@ -232,7 +232,7 @@ async def test_import_flow_success(
         DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=import_data
     )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "192.168.1.5"
     assert result["data"][CONF_MAC] == expected_mac
 
@@ -267,7 +267,7 @@ async def test_import_flow_errors(
         DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=import_data
     )
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == expected_reason
 
 
@@ -295,7 +295,7 @@ async def test_discover_skips_existing_and_invalid_mac(
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "choose_switch"
 
     schema = result["data_schema"].schema
@@ -320,11 +320,11 @@ async def test_start_discovery_shows_progress(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"next_step_id": "start_discovery"}
         )
-        assert result["type"] == FlowResultType.SHOW_PROGRESS
+        assert result["type"] is FlowResultType.SHOW_PROGRESS
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-        assert result["type"] == FlowResultType.SHOW_PROGRESS
+        assert result["type"] is FlowResultType.SHOW_PROGRESS
         assert result["progress_action"] == "start_discovery"
 
     await hass.async_block_till_done()
@@ -348,5 +348,5 @@ async def test_discovery_flow_task_exception(
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result["type"] == FlowResultType.MENU
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "discovery_failed"

--- a/tests/components/otbr/conftest.py
+++ b/tests/components/otbr/conftest.py
@@ -64,7 +64,7 @@ def mock_api_actions(
     that speak camelCase and 404 for older PascalCase OTBRs.
     """
     status = (
-        HTTPStatus.OK if key_format == KeyFormat.CAMEL_CASE else HTTPStatus.NOT_FOUND
+        HTTPStatus.OK if key_format is KeyFormat.CAMEL_CASE else HTTPStatus.NOT_FOUND
     )
     aioclient_mock.get(re.compile(r".*/api/actions$"), status=status)
 

--- a/tests/components/otbr/test_config_flow.py
+++ b/tests/components/otbr/test_config_flow.py
@@ -68,7 +68,7 @@ def _expected_dataset_body(pan_id: int, key_format: KeyFormat) -> dict[str, Any]
     python_otbr_api emits camelCase by default and rewrites to PascalCase only
     when the /api/actions probe returns 404.
     """
-    if key_format == KeyFormat.PASCAL_CASE:
+    if key_format is KeyFormat.PASCAL_CASE:
         return {
             "Channel": 15,
             "NetworkName": f"ha-thread-{pan_id:04x}",
@@ -306,7 +306,7 @@ async def test_user_flow_router_not_setup(
     assert aioclient_mock.mock_calls[-2][0] == "PUT"
     assert aioclient_mock.mock_calls[-2][1].path == "/node/dataset/active"
     body = aioclient_mock.mock_calls[-2][2]
-    pan_id = body["PanId" if key_format == KeyFormat.PASCAL_CASE else "panId"]
+    pan_id = body["PanId" if key_format is KeyFormat.PASCAL_CASE else "panId"]
     assert body == _expected_dataset_body(pan_id, key_format)
 
     assert aioclient_mock.mock_calls[-1][0] == "PUT"
@@ -731,7 +731,7 @@ async def test_hassio_discovery_flow_router_not_setup(
     assert aioclient_mock.mock_calls[-2][0] == "PUT"
     assert aioclient_mock.mock_calls[-2][1].path == "/node/dataset/active"
     body = aioclient_mock.mock_calls[-2][2]
-    pan_id = body["PanId" if key_format == KeyFormat.PASCAL_CASE else "panId"]
+    pan_id = body["PanId" if key_format is KeyFormat.PASCAL_CASE else "panId"]
     assert body == _expected_dataset_body(pan_id, key_format)
 
     assert aioclient_mock.mock_calls[-1][0] == "PUT"
@@ -850,7 +850,7 @@ async def test_hassio_discovery_flow_router_not_setup_has_preferred_2(
     assert aioclient_mock.mock_calls[-2][0] == "PUT"
     assert aioclient_mock.mock_calls[-2][1].path == "/node/dataset/active"
     body = aioclient_mock.mock_calls[-2][2]
-    pan_id = body["PanId" if key_format == KeyFormat.PASCAL_CASE else "panId"]
+    pan_id = body["PanId" if key_format is KeyFormat.PASCAL_CASE else "panId"]
     assert body == _expected_dataset_body(pan_id, key_format)
 
     assert aioclient_mock.mock_calls[-1][0] == "PUT"

--- a/tests/components/ourgroceries/test_init.py
+++ b/tests/components/ourgroceries/test_init.py
@@ -49,4 +49,4 @@ async def test_init_failure(
     ourgroceries_config_entry: MockConfigEntry | None,
 ) -> None:
     """Test an initialization error on integration load."""
-    assert ourgroceries_config_entry.state == status
+    assert ourgroceries_config_entry.state is status

--- a/tests/components/overseerr/test_init.py
+++ b/tests/components/overseerr/test_init.py
@@ -45,7 +45,7 @@ async def test_initialization_errors(
 
     await setup_integration(hass, mock_config_entry)
 
-    assert mock_config_entry.state == config_entry_state
+    assert mock_config_entry.state is config_entry_state
 
 
 async def test_device_info(

--- a/tests/components/paperless_ngx/test_init.py
+++ b/tests/components/paperless_ngx/test_init.py
@@ -79,5 +79,5 @@ async def test_setup_config_error_handling(
 
     await setup_integration(hass, mock_config_entry)
 
-    assert mock_config_entry.state == expected_state
+    assert mock_config_entry.state is expected_state
     assert mock_config_entry.error_reason_translation_key == expected_error_key

--- a/tests/components/portainer/test_init.py
+++ b/tests/components/portainer/test_init.py
@@ -52,7 +52,7 @@ async def test_setup_exceptions(
     """Test the _async_setup."""
     mock_portainer_client.get_endpoints.side_effect = exception
     await setup_integration(hass, mock_config_entry)
-    assert mock_config_entry.state == expected_state
+    assert mock_config_entry.state is expected_state
 
 
 async def test_migrations(
@@ -232,7 +232,7 @@ async def test_migration_v4_to_v5_exceptions(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.MIGRATION_ERROR
+    assert entry.state is ConfigEntryState.MIGRATION_ERROR
 
 
 async def test_device_registry(

--- a/tests/components/proxmoxve/test_init.py
+++ b/tests/components/proxmoxve/test_init.py
@@ -162,7 +162,7 @@ async def test_setup_exceptions(
     attr_to_mock.side_effect = exception
 
     await setup_integration(hass, mock_config_entry)
-    assert mock_config_entry.state == expected_state
+    assert mock_config_entry.state is expected_state
 
 
 async def test_migration_v1_to_v3(
@@ -317,7 +317,7 @@ async def test_new_vm_creates_entity(
     """Test that a VM appearing after initial load gets an entity created."""
     mock_proxmox_client._node_mock.qemu.get.return_value = []
     await setup_integration(hass, mock_config_entry)
-    assert mock_config_entry.state == ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
     initial_count = len(
         er.async_entries_for_config_entry(entity_registry, mock_config_entry.entry_id)
@@ -350,7 +350,7 @@ async def test_new_container_creates_entity(
     """Test that a container appearing after initial load gets an entity created."""
     mock_proxmox_client._node_mock.lxc.get.return_value = []
     await setup_integration(hass, mock_config_entry)
-    assert mock_config_entry.state == ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
     initial_count = len(
         er.async_entries_for_config_entry(entity_registry, mock_config_entry.entry_id)

--- a/tests/components/radio_browser/conftest.py
+++ b/tests/components/radio_browser/conftest.py
@@ -45,7 +45,7 @@ async def init_integration(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert mock_config_entry.state == ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
     return mock_config_entry
 

--- a/tests/components/radio_browser/test_media_source.py
+++ b/tests/components/radio_browser/test_media_source.py
@@ -98,7 +98,7 @@ async def test_browsing_exceptions(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-        assert mock_config_entry.state == ConfigEntryState.LOADED
+        assert mock_config_entry.state is ConfigEntryState.LOADED
 
         mock_browser.return_value.stations.side_effect = exception
         with pytest.raises(BrowseError) as exc_info:
@@ -124,7 +124,7 @@ async def test_browsing_not_ready(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-        assert mock_config_entry.state == ConfigEntryState.SETUP_RETRY
+        assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
         with pytest.raises(BrowseError) as exc_info:
             await media_source.async_browse_media(
@@ -153,7 +153,7 @@ async def test_resolve_media_exceptions(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-        assert mock_config_entry.state == ConfigEntryState.LOADED
+        assert mock_config_entry.state is ConfigEntryState.LOADED
 
         mock_browser.return_value.station.side_effect = exception
         with pytest.raises(media_source.Unresolvable) as exc_info:
@@ -179,7 +179,7 @@ async def test_resolve_media_not_ready(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-        assert mock_config_entry.state == ConfigEntryState.SETUP_RETRY
+        assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
         with pytest.raises(media_source.Unresolvable) as exc_info:
             await media_source.async_resolve_media(

--- a/tests/components/recorder/common.py
+++ b/tests/components/recorder/common.py
@@ -255,7 +255,7 @@ def assert_events_equal_without_context(event: Event, other: Event) -> None:
     """Assert that two events are equal, ignoring context."""
     assert event.data == other.data
     assert event.event_type == other.event_type
-    assert event.origin == other.origin
+    assert event.origin is other.origin
     assert event.time_fired == other.time_fired
 
 

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -133,7 +133,7 @@ async def test_failures_parametrized(
     )
     await hass.async_block_till_done()
 
-    assert config_entry.state == expected
+    assert config_entry.state is expected
 
 
 async def test_firmware_error_twice(

--- a/tests/components/roborock/conftest.py
+++ b/tests/components/roborock/conftest.py
@@ -439,7 +439,7 @@ def fake_devices_fixture() -> list[FakeDevice]:
         elif device_data.pv == "A01":
             if device_product_data.category is RoborockCategory.WET_DRY_VAC:
                 fake_device.dyad = create_dyad_trait()
-            elif device_product_data.category == RoborockCategory.WASHING_MACHINE:
+            elif device_product_data.category is RoborockCategory.WASHING_MACHINE:
                 fake_device.zeo = create_zeo_trait()
             else:
                 raise ValueError("Unknown A01 category in test HOME_DATA")

--- a/tests/components/roborock/conftest.py
+++ b/tests/components/roborock/conftest.py
@@ -437,7 +437,7 @@ def fake_devices_fixture() -> list[FakeDevice]:
                 NETWORK_INFO_BY_DEVICE[device_data.duid]
             )
         elif device_data.pv == "A01":
-            if device_product_data.category == RoborockCategory.WET_DRY_VAC:
+            if device_product_data.category is RoborockCategory.WET_DRY_VAC:
                 fake_device.dyad = create_dyad_trait()
             elif device_product_data.category == RoborockCategory.WASHING_MACHINE:
                 fake_device.zeo = create_zeo_trait()

--- a/tests/components/samsungtv/test_init.py
+++ b/tests/components/samsungtv/test_init.py
@@ -157,4 +157,4 @@ async def test_migrate_future_version_returns_false(
 
     await hass.config_entries.async_setup(entry.entry_id)
 
-    assert entry.state == ConfigEntryState.MIGRATION_ERROR
+    assert entry.state is ConfigEntryState.MIGRATION_ERROR

--- a/tests/components/satel_integra/test_init.py
+++ b/tests/components/satel_integra/test_init.py
@@ -242,4 +242,4 @@ async def test_setup_exceptions(
     """Test the client async_connect."""
     mock_satel.connect.side_effect = exception
     await setup_integration(hass, mock_config_entry)
-    assert mock_config_entry.state == expected_state
+    assert mock_config_entry.state is expected_state

--- a/tests/components/sftp_storage/test_backup.py
+++ b/tests/components/sftp_storage/test_backup.py
@@ -87,7 +87,7 @@ async def test_agents_info(
     assert (
         response["result"]
         == {"agents": [{"agent_id": "backup.local", "name": "local"}]}
-        or config_entry.state == ConfigEntryState.NOT_LOADED
+        or config_entry.state is ConfigEntryState.NOT_LOADED
     )
 
 

--- a/tests/components/shopping_list/test_init.py
+++ b/tests/components/shopping_list/test_init.py
@@ -59,7 +59,7 @@ async def test_add_item(
     assert _get_shopping_data(hass).items[0]["name"] == "beer"  # name was trimmed
 
     # Response text is now handled by default conversation agent
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert_shopping_list_data(hass, snapshot)
 
 

--- a/tests/components/shopping_list/test_intent.py
+++ b/tests/components/shopping_list/test_intent.py
@@ -24,7 +24,7 @@ async def test_complete_item_intent(hass: HomeAssistant, sl_setup) -> None:
         hass, "test", "HassShoppingListCompleteItem", {"item": {"value": "beer"}}
     )
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     completed_items = response.speech_slots.get("completed_items")
     assert len(completed_items) == 2
     assert completed_items[0]["name"] == "beer"
@@ -36,7 +36,7 @@ async def test_complete_item_intent(hass: HomeAssistant, sl_setup) -> None:
         hass, "test", "HassShoppingListCompleteItem", {"item": {"value": "beer"}}
     )
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech_slots.get("completed_items") == []
     assert _get_shopping_data(hass).items[1]["complete"]
     assert _get_shopping_data(hass).items[2]["complete"]
@@ -47,7 +47,7 @@ async def test_complete_item_intent_not_found(hass: HomeAssistant, sl_setup) -> 
     response = await intent.async_handle(
         hass, "test", "HassShoppingListCompleteItem", {"item": {"value": "beer"}}
     )
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.speech_slots.get("completed_items") == []
 
 

--- a/tests/components/sma/test_init.py
+++ b/tests/components/sma/test_init.py
@@ -55,4 +55,4 @@ async def test_setup_exceptions(
     """Test the _async_setup."""
     mock_sma_client.device_info.side_effect = exception
     await setup_integration(hass, mock_config_entry)
-    assert mock_config_entry.state == expected_state
+    assert mock_config_entry.state is expected_state

--- a/tests/components/snooz/__init__.py
+++ b/tests/components/snooz/__init__.py
@@ -88,7 +88,7 @@ class MockSnoozDevice(ParentMockSnoozDevice):
             if self._api is not None:
                 await self._api.async_disconnect()
 
-            if self.connection_status != SnoozConnectionStatus.DISCONNECTED:
+            if self.connection_status is not SnoozConnectionStatus.DISCONNECTED:
                 self._machine.device_disconnected(reason=DisconnectionReason.USER)
 
         finally:

--- a/tests/components/stt/test_init.py
+++ b/tests/components/stt/test_init.py
@@ -268,11 +268,11 @@ async def test_stream_audio_uses_enum_values(
     assert isinstance(metadata.codec, AudioCodecs)
     assert metadata.codec == AudioCodecs.PCM
     assert isinstance(metadata.bit_rate, AudioBitRates)
-    assert metadata.bit_rate == AudioBitRates.BITRATE_16
+    assert metadata.bit_rate is AudioBitRates.BITRATE_16
     assert isinstance(metadata.sample_rate, AudioSampleRates)
-    assert metadata.sample_rate == AudioSampleRates.SAMPLERATE_16000
+    assert metadata.sample_rate is AudioSampleRates.SAMPLERATE_16000
     assert isinstance(metadata.channel, AudioChannels)
-    assert metadata.channel == AudioChannels.CHANNEL_MONO
+    assert metadata.channel is AudioChannels.CHANNEL_MONO
 
 
 @pytest.mark.parametrize(

--- a/tests/components/switchbot_cloud/test_init.py
+++ b/tests/components/switchbot_cloud/test_init.py
@@ -147,7 +147,7 @@ async def test_setup_entry_fails_when_listing_devices(
     """Test error handling when list_devices in setup of entry."""
     mock_list_devices.side_effect = error
     entry = await configure_integration(hass)
-    assert entry.state == state
+    assert entry.state is state
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()

--- a/tests/components/tami4/test_init.py
+++ b/tests/components/tami4/test_init.py
@@ -46,7 +46,7 @@ async def test_init_error_raised(
     """Test init when an error is raised."""
 
     entry = await create_config_entry(hass)
-    assert entry.state == expected_state
+    assert entry.state is expected_state
 
 
 async def test_load_unload(mock_api, hass: HomeAssistant) -> None:

--- a/tests/components/telegram_bot/test_telegram_bot.py
+++ b/tests/components/telegram_bot/test_telegram_bot.py
@@ -149,7 +149,7 @@ async def test_polling_platform_init_failed(
         await hass.async_block_till_done()
 
     mock_get_me.assert_called_once()
-    assert mock_polling_config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert mock_polling_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 @pytest.mark.parametrize(

--- a/tests/components/template/conftest.py
+++ b/tests/components/template/conftest.py
@@ -164,7 +164,7 @@ async def setup_entity(
         **({"attributes": attributes} if attributes else {}),
         **(extra_config or {}),
     }
-    if style == ConfigurationStyle.MODERN:
+    if style is ConfigurationStyle.MODERN:
         await async_setup_modern_state_format(
             hass, platform_setup.domain, count, entity_config, extra_section_config
         )
@@ -200,7 +200,7 @@ async def setup_and_test_unique_id(
         {"name": "template_entity_1", **entity_config},
         {"name": "template_entity_2", **entity_config},
     ]
-    if style == ConfigurationStyle.MODERN:
+    if style is ConfigurationStyle.MODERN:
         await async_setup_modern_state_format(hass, platform_setup.domain, 1, entities)
     elif style == ConfigurationStyle.TRIGGER:
         await async_setup_modern_trigger_format(
@@ -232,7 +232,7 @@ async def setup_and_test_nested_unique_id(
         {"name": "test_b", "unique_id": "b", **(entity_config or {}), **state_config},
     ]
     extra_section_config = {"unique_id": "x"}
-    if style == ConfigurationStyle.MODERN:
+    if style is ConfigurationStyle.MODERN:
         await async_setup_modern_state_format(
             hass, platform_setup.domain, 1, entities, extra_section_config
         )

--- a/tests/components/template/conftest.py
+++ b/tests/components/template/conftest.py
@@ -168,7 +168,7 @@ async def setup_entity(
         await async_setup_modern_state_format(
             hass, platform_setup.domain, count, entity_config, extra_section_config
         )
-    elif style == ConfigurationStyle.TRIGGER:
+    elif style is ConfigurationStyle.TRIGGER:
         await async_setup_modern_trigger_format(
             hass,
             platform_setup.domain,
@@ -202,7 +202,7 @@ async def setup_and_test_unique_id(
     ]
     if style is ConfigurationStyle.MODERN:
         await async_setup_modern_state_format(hass, platform_setup.domain, 1, entities)
-    elif style == ConfigurationStyle.TRIGGER:
+    elif style is ConfigurationStyle.TRIGGER:
         await async_setup_modern_trigger_format(
             hass, platform_setup.domain, platform_setup.trigger, 1, entities
         )
@@ -236,7 +236,7 @@ async def setup_and_test_nested_unique_id(
         await async_setup_modern_state_format(
             hass, platform_setup.domain, 1, entities, extra_section_config
         )
-    elif style == ConfigurationStyle.TRIGGER:
+    elif style is ConfigurationStyle.TRIGGER:
         await async_setup_modern_trigger_format(
             hass,
             platform_setup.domain,

--- a/tests/components/todo/test_intent.py
+++ b/tests/components/todo/test_intent.py
@@ -59,7 +59,7 @@ async def test_add_item_intent(
         {ATTR_ITEM: {"value": " beer "}, "name": {"value": "list 1"}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert response.success_results[0].name == "list 1"
     assert response.success_results[0].type == intent.IntentResponseTargetType.ENTITY
     assert response.success_results[0].id == entity1.entity_id
@@ -78,7 +78,7 @@ async def test_add_item_intent(
         {ATTR_ITEM: {"value": "cheese"}, "name": {"value": "List 2"}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
 
     assert len(entity1.items) == 0
     assert len(entity2.items) == 1
@@ -93,7 +93,7 @@ async def test_add_item_intent(
         {ATTR_ITEM: {"value": "wine"}, "name": {"value": "lIST 2"}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
 
     assert len(entity1.items) == 0
     assert len(entity2.items) == 2
@@ -111,7 +111,7 @@ async def test_add_item_intent(
             {"item": {"value": "cookies"}, "name": {"value": "list 1"}},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.ASSISTANT
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.ASSISTANT
 
     # Missing list
     with pytest.raises(intent.MatchFailedError):
@@ -210,7 +210,7 @@ async def test_complete_item_intent(
         {ATTR_ITEM: {"value": "beer"}, ATTR_NAME: {"value": "list 1"}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
 
     assert len(entity1.items) == 2
     assert entity1.items[0].status == TodoItemStatus.COMPLETED
@@ -321,7 +321,7 @@ async def test_remove_item_intent(
         {ATTR_ITEM: {"value": "beer"}, ATTR_NAME: {"value": "list 1"}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
 
     # only the first matching item has been removed
     assert len(entity1.items) == 2

--- a/tests/components/tplink/test_config_flow.py
+++ b/tests/components/tplink/test_config_flow.py
@@ -2135,9 +2135,9 @@ async def test_pick_device_errors(
             {CONF_DEVICE: MAC_ADDRESS},
         )
         await hass.async_block_till_done()
-    assert result3["type"] == expected_flow
+    assert result3["type"] is expected_flow
 
-    if expected_flow != FlowResultType.ABORT:
+    if expected_flow is not FlowResultType.ABORT:
         result4 = await hass.config_entries.flow.async_configure(
             result3["flow_id"],
             user_input={

--- a/tests/components/tplink_omada/test_init.py
+++ b/tests/components/tplink_omada/test_init.py
@@ -57,7 +57,7 @@ async def test_setup_entry_login_failed_raises_configentryauthfailed(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert mock_config_entry.state == entry_state
+    assert mock_config_entry.state is entry_state
 
 
 async def test_missing_devices_removed_at_startup(

--- a/tests/components/uhoo/test_config_flow.py
+++ b/tests/components/uhoo/test_config_flow.py
@@ -74,7 +74,7 @@ async def test_user_flow_exceptions(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert not result["errors"]
 

--- a/tests/components/vacuum/test_intent.py
+++ b/tests/components/vacuum/test_intent.py
@@ -37,7 +37,7 @@ async def test_start(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -60,7 +60,7 @@ async def test_start_without_name(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -88,7 +88,7 @@ async def test_return_to_base(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -113,7 +113,7 @@ async def test_return_to_base_without_name(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -147,7 +147,7 @@ async def test_clean_area(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     assert set(calls[0].data["entity_id"]) == {vacuum_1, vacuum_2}
     assert calls[0].data["cleaning_area_id"] == [kitchen.id]
@@ -171,7 +171,7 @@ async def test_clean_area(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     assert calls[0].data == {
         "entity_id": [vacuum_1],
@@ -194,7 +194,7 @@ async def test_clean_area_no_matching_vacuum(hass: HomeAssistant) -> None:
             vacuum_intent.INTENT_VACUUM_CLEAN_AREA,
             {"area": {"value": "Kitchen"}},
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.DOMAIN
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.DOMAIN
 
     # Vacuum without CLEAN_AREA feature
     hass.states.async_set(
@@ -210,7 +210,7 @@ async def test_clean_area_no_matching_vacuum(hass: HomeAssistant) -> None:
             vacuum_intent.INTENT_VACUUM_CLEAN_AREA,
             {"area": {"value": "Kitchen"}},
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.FEATURE
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.FEATURE
 
 
 async def test_clean_area_invalid_area(hass: HomeAssistant) -> None:
@@ -230,7 +230,7 @@ async def test_clean_area_invalid_area(hass: HomeAssistant) -> None:
             vacuum_intent.INTENT_VACUUM_CLEAN_AREA,
             {"area": {"value": "Nonexistent room"}},
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.INVALID_AREA
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.INVALID_AREA
     assert err.value.result.no_match_name == "Nonexistent room"
 
 

--- a/tests/components/valve/test_intent.py
+++ b/tests/components/valve/test_intent.py
@@ -28,7 +28,7 @@ async def test_open_valve_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -49,7 +49,7 @@ async def test_close_valve_intent(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN
@@ -75,7 +75,7 @@ async def test_set_valve_position(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
     call = calls[0]
     assert call.domain == DOMAIN

--- a/tests/components/vera/common.py
+++ b/tests/components/vera/common.py
@@ -139,7 +139,7 @@ class ComponentFactory:
         self.vera_controller_class_mock.return_value = controller
 
         # Setup component through config flow.
-        if controller_config.config_source == ConfigSource.CONFIG_FLOW:
+        if controller_config.config_source is ConfigSource.CONFIG_FLOW:
             await hass.config_entries.flow.async_init(
                 DOMAIN,
                 context={"source": config_entries.SOURCE_USER},
@@ -148,7 +148,7 @@ class ComponentFactory:
             await hass.async_block_till_done()
 
         # Setup component directly from config entry.
-        if controller_config.config_source == ConfigSource.CONFIG_ENTRY:
+        if controller_config.config_source is ConfigSource.CONFIG_ENTRY:
             entry = MockConfigEntry(
                 domain=DOMAIN,
                 data=controller_config.config,

--- a/tests/components/vodafone_station/test_init.py
+++ b/tests/components/vodafone_station/test_init.py
@@ -107,4 +107,4 @@ async def test_migrate_future_version_returns_false(
 
     await setup_integration(hass, config_entry)
 
-    assert config_entry.state == ConfigEntryState.MIGRATION_ERROR
+    assert config_entry.state is ConfigEntryState.MIGRATION_ERROR

--- a/tests/components/weather/test_intent.py
+++ b/tests/components/weather/test_intent.py
@@ -37,7 +37,7 @@ async def test_get_weather(hass: HomeAssistant) -> None:
     response = await intent.async_handle(
         hass, "test", weather_intent.INTENT_GET_WEATHER, {}
     )
-    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     state = response.matched_states[0]
     assert state.entity_id == entity1.entity_id
@@ -50,7 +50,7 @@ async def test_get_weather(hass: HomeAssistant) -> None:
         {"name": {"value": "Weather 2"}},
         assistant=conversation.DOMAIN,
     )
-    assert response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert response.response_type is intent.IntentResponseType.QUERY_ANSWER
     assert len(response.matched_states) == 1
     state = response.matched_states[0]
     assert state.entity_id == entity2.entity_id
@@ -67,7 +67,7 @@ async def test_get_weather(hass: HomeAssistant) -> None:
                 {"name": {"value": name}},
                 assistant=conversation.DOMAIN,
             )
-        assert err.value.result.no_match_reason == intent.MatchFailedReason.ASSISTANT
+        assert err.value.result.no_match_reason is intent.MatchFailedReason.ASSISTANT
 
 
 async def test_get_weather_wrong_name(hass: HomeAssistant) -> None:
@@ -93,7 +93,7 @@ async def test_get_weather_wrong_name(hass: HomeAssistant) -> None:
             {"name": {"value": "not the right name"}},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.NAME
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.NAME
 
     # Empty name
     with pytest.raises(intent.InvalidSlotInfo):
@@ -121,4 +121,4 @@ async def test_get_weather_no_entities(hass: HomeAssistant) -> None:
             {},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.DOMAIN
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.DOMAIN

--- a/tests/components/wled/test_init.py
+++ b/tests/components/wled/test_init.py
@@ -93,7 +93,7 @@ async def test_migrate_entry_future_version_is_downgrade(
     await hass.async_block_till_done()
 
     assert result is False
-    assert entry.state == ConfigEntryState.MIGRATION_ERROR
+    assert entry.state is ConfigEntryState.MIGRATION_ERROR
     assert entry.version == 2
     assert entry.minor_version == 0
     assert entry.unique_id == "AABBCCDDEEFF"
@@ -110,7 +110,7 @@ async def test_migrate_entry_v1_to_1_2_no_duplicates(
     await hass.async_block_till_done()
 
     assert result is True
-    assert config_entry_v1.state == ConfigEntryState.LOADED
+    assert config_entry_v1.state is ConfigEntryState.LOADED
     assert config_entry_v1.version == 1
     assert config_entry_v1.minor_version == 2
     assert config_entry_v1.unique_id == "aabbccddeeff"
@@ -149,7 +149,7 @@ async def test_migrate_entry_v1_with_ignored_duplicates(
     await hass.async_block_till_done()
 
     assert result is True
-    assert config_entry_v1.state == ConfigEntryState.LOADED
+    assert config_entry_v1.state is ConfigEntryState.LOADED
     assert config_entry_v1.version == 1
     assert config_entry_v1.minor_version == 2
     assert config_entry_v1.unique_id == "aabbccddeeff"
@@ -181,7 +181,7 @@ async def test_migrate_entry_v1_with_non_ignored_duplicate_aborts(
     await hass.async_block_till_done()
 
     assert result is False
-    assert config_entry_v1.state == ConfigEntryState.MIGRATION_ERROR
+    assert config_entry_v1.state is ConfigEntryState.MIGRATION_ERROR
     assert config_entry_v1.version == 1
     assert config_entry_v1.minor_version == 1
     assert config_entry_v1.unique_id == "AABBCCDDEEFF"
@@ -207,7 +207,7 @@ async def test_migrate_entry_already_at_1_2_is_noop(
     await hass.async_block_till_done()
 
     assert result is True
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert entry.version == 1
     assert entry.minor_version == 2
     assert entry.unique_id == "aabbccddeeff"

--- a/tests/components/wyoming/test_conversation.py
+++ b/tests/components/wyoming/test_conversation.py
@@ -7,7 +7,7 @@ from syrupy.assertion import SnapshotAssertion
 from wyoming.asr import Transcript
 from wyoming.handle import Handled, NotHandled
 from wyoming.info import Info
-from wyoming.intent import Entity, Intent, NotRecognized
+from wyoming.intent import Entity, Intent, IntentsStart, IntentsStop, NotRecognized
 
 from homeassistant.components import conversation
 from homeassistant.components.conversation import chat_log
@@ -125,6 +125,99 @@ async def test_intent(
     }
 
 
+async def test_multiple_intents(
+    hass: HomeAssistant,
+    init_wyoming_intent: ConfigEntry,
+    mock_chat_log: MockChatLog,  # noqa: F811
+) -> None:
+    """Test when more than one intent is recognized."""
+    agent_id = "conversation.test_intent"
+    conversation_id = mock_chat_log.conversation_id
+    satellite_id = "satellite-1234"
+    device_id = "device-1234"
+
+    test_intent1 = Intent(
+        name="TestIntent1",
+        entities=[Entity(name="entity1", value="value1")],
+        text="{{ slots.slot_name }}",
+    )
+
+    test_intent2 = Intent(
+        name="TestIntent2",
+        entities=[Entity(name="entity2", value="value2")],
+        text="{{ slots.slot_name }}",
+    )
+
+    class TestIntentHandler(intent.IntentHandler):
+        """Test Intent Handler."""
+
+        def __init__(self, intent_type: str, slot_value: str) -> None:
+            """Initialize the handler."""
+            self.intent_type = intent_type
+            self._slot_value = slot_value
+
+        async def async_handle(self, intent_obj: intent.Intent):
+            """Handle the intent."""
+            response = intent_obj.create_response()
+            response.async_set_speech_slots({"slot_name": self._slot_value})
+            return response
+
+    intent.async_register(hass, TestIntentHandler("TestIntent1", "slot value 1"))
+    intent.async_register(hass, TestIntentHandler("TestIntent2", "slot value 2"))
+
+    # Send multiple intent events framed by intents-start and intents-stop.
+    client = MockAsyncTcpClient(
+        [
+            IntentsStart().event(),
+            test_intent1.event(),
+            test_intent2.event(),
+            IntentsStop().event(),
+        ]
+    )
+    with patch(
+        "homeassistant.components.wyoming.conversation.AsyncTcpClient",
+        client,
+    ):
+        result = await conversation.async_converse(
+            hass=hass,
+            text="test text",
+            conversation_id=conversation_id,
+            context=Context(),
+            language=hass.config.language,
+            agent_id=agent_id,
+            satellite_id=satellite_id,
+            device_id=device_id,
+        )
+
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
+    assert result.response.speech, "No speech"
+
+    # Speech results are joined with newlines because punctuation would be
+    # language-dependent.
+    assert (
+        result.response.speech.get("plain", {}).get("speech")
+        == "slot value 1\nslot value 2"
+    )
+
+    # Verify that chat log recorded all intents as tool calls
+    content: chat_log.AssistantContent | None = next(
+        filter(
+            lambda c: isinstance(c, chat_log.AssistantContent), mock_chat_log.content
+        ),
+        None,
+    )
+    assert content is not None, "Missing assistant content"
+    assert content.tool_calls and len(content.tool_calls) == 2
+
+    for tool_call, test_intent in zip(
+        content.tool_calls, (test_intent1, test_intent2), strict=True
+    ):
+        assert tool_call.tool_name == test_intent.name
+        assert tool_call.tool_args == {
+            e.name: {"value": e.value} for e in test_intent.entities
+        }
+
+
 async def test_intent_handle_error(
     hass: HomeAssistant, init_wyoming_intent: ConfigEntry
 ) -> None:
@@ -158,7 +251,68 @@ async def test_intent_handle_error(
         )
 
     assert result.response.response_type is intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.FAILED_TO_HANDLE
+    assert result.response.error_code is intent.IntentResponseErrorCode.FAILED_TO_HANDLE
+
+
+async def test_multiple_intents_handle_error(
+    hass: HomeAssistant,
+    init_wyoming_intent: ConfigEntry,
+    mock_chat_log: MockChatLog,  # noqa: F811
+) -> None:
+    """Test error during handling when multiple intents are recognized."""
+    agent_id = "conversation.test_intent"
+
+    test_intent_1 = Intent(name="TestIntent1", entities=[], text="success")
+    test_intent_2 = Intent(name="TestIntent2", entities=[], text="success")
+
+    class TestIntentHandler1(intent.IntentHandler):
+        """Test Intent Handler."""
+
+        intent_type = "TestIntent1"
+
+        async def async_handle(self, intent_obj: intent.Intent):
+            """Handle the intent."""
+            return intent_obj.create_response()
+
+    class TestIntentHandler2(intent.IntentHandler):
+        """Test Intent Handler."""
+
+        intent_type = "TestIntent2"
+
+        async def async_handle(self, intent_obj: intent.Intent):
+            """Handle the intent."""
+            raise intent.IntentError
+
+    intent.async_register(hass, TestIntentHandler1())
+    intent.async_register(hass, TestIntentHandler2())
+
+    with patch(
+        "homeassistant.components.wyoming.conversation.AsyncTcpClient",
+        MockAsyncTcpClient(
+            [
+                IntentsStart().event(),
+                test_intent_1.event(),
+                test_intent_2.event(),
+                IntentsStop().event(),
+            ]
+        ),
+    ):
+        result = await conversation.async_converse(
+            hass=hass,
+            text="test text",
+            conversation_id=None,
+            context=Context(),
+            language=hass.config.language,
+            agent_id=agent_id,
+        )
+
+    assert result.response.response_type is intent.IntentResponseType.ERROR
+    assert result.response.error_code is intent.IntentResponseErrorCode.FAILED_TO_HANDLE
+
+    # Ensure that no tool calls were recorded
+    assert not any(
+        isinstance(c, chat_log.AssistantContent) for c in mock_chat_log.content
+    )
 
 
 async def test_not_recognized(
@@ -244,7 +398,7 @@ async def test_not_handled(
         )
 
     assert result.response.response_type is intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.FAILED_TO_HANDLE
+    assert result.response.error_code is intent.IntentResponseErrorCode.FAILED_TO_HANDLE
     assert result.response.speech, "No speech"
     assert result.response.speech.get("plain", {}).get("speech") == "failure"
 
@@ -343,3 +497,60 @@ async def test_supported_languages_empty_means_all(
     agent = conversation.async_get_agent(hass, agent_id)
     assert agent is not None
     assert agent.supported_languages == MATCH_ALL
+
+
+async def test_intent_supports_home_control(
+    hass: HomeAssistant, intent_config_entry: ConfigEntry
+) -> None:
+    """Test that the CONTROL supported feature is always set for intent services."""
+    agent_id = "conversation.test_intent"
+
+    with patch(
+        "homeassistant.components.wyoming.data.load_wyoming_info",
+        return_value=Info(intent=INTENT_INFO.intent),
+    ):
+        await hass.config_entries.async_setup(intent_config_entry.entry_id)
+
+    agent = conversation.async_get_agent(hass, agent_id)
+    assert isinstance(agent, conversation.ConversationEntity)
+    assert agent.supported_features is not None
+    assert (
+        agent.supported_features & conversation.ConversationEntityFeature.CONTROL
+    ) == conversation.ConversationEntityFeature.CONTROL
+
+
+@pytest.mark.parametrize(
+    "supports_home_control",
+    [False, True],
+)
+async def test_handle_supports_home_control(
+    hass: HomeAssistant, intent_config_entry: ConfigEntry, supports_home_control: bool
+) -> None:
+    """Test that the CONTROL supported feature matches the Wyoming info."""
+    agent_id = "conversation.test_handle"
+
+    with (
+        patch.object(
+            HANDLE_INFO.handle[0], "supports_home_control", supports_home_control
+        ),
+        patch(
+            "homeassistant.components.wyoming.data.load_wyoming_info",
+            return_value=Info(handle=HANDLE_INFO.handle),
+        ),
+    ):
+        await hass.config_entries.async_setup(intent_config_entry.entry_id)
+
+    agent = conversation.async_get_agent(hass, agent_id)
+    assert isinstance(agent, conversation.ConversationEntity)
+    supported_features = (
+        agent.supported_features or conversation.ConversationEntityFeature(0)
+    )
+
+    control_feature = (
+        supported_features & conversation.ConversationEntityFeature.CONTROL
+    )
+
+    if supports_home_control:
+        assert control_feature == conversation.ConversationEntityFeature.CONTROL
+    else:
+        assert control_feature == conversation.ConversationEntityFeature(0)

--- a/tests/components/wyoming/test_conversation.py
+++ b/tests/components/wyoming/test_conversation.py
@@ -251,7 +251,7 @@ async def test_intent_handle_error(
         )
 
     assert result.response.response_type is intent.IntentResponseType.ERROR
-    assert result.response.error_code is intent.IntentResponseErrorCode.FAILED_TO_HANDLE
+    assert result.response.error_code == intent.IntentResponseErrorCode.FAILED_TO_HANDLE
 
 
 async def test_multiple_intents_handle_error(
@@ -307,7 +307,7 @@ async def test_multiple_intents_handle_error(
         )
 
     assert result.response.response_type is intent.IntentResponseType.ERROR
-    assert result.response.error_code is intent.IntentResponseErrorCode.FAILED_TO_HANDLE
+    assert result.response.error_code == intent.IntentResponseErrorCode.FAILED_TO_HANDLE
 
     # Ensure that no tool calls were recorded
     assert not any(
@@ -398,7 +398,7 @@ async def test_not_handled(
         )
 
     assert result.response.response_type is intent.IntentResponseType.ERROR
-    assert result.response.error_code is intent.IntentResponseErrorCode.FAILED_TO_HANDLE
+    assert result.response.error_code == intent.IntentResponseErrorCode.FAILED_TO_HANDLE
     assert result.response.speech, "No speech"
     assert result.response.speech.get("plain", {}).get("speech") == "failure"
 

--- a/tests/components/wyoming/test_conversation.py
+++ b/tests/components/wyoming/test_conversation.py
@@ -7,7 +7,7 @@ from syrupy.assertion import SnapshotAssertion
 from wyoming.asr import Transcript
 from wyoming.handle import Handled, NotHandled
 from wyoming.info import Info
-from wyoming.intent import Entity, Intent, IntentsStart, IntentsStop, NotRecognized
+from wyoming.intent import Entity, Intent, NotRecognized
 
 from homeassistant.components import conversation
 from homeassistant.components.conversation import chat_log
@@ -104,7 +104,7 @@ async def test_intent(
         "device_id": device_id,
     }
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.speech, "No speech"
     assert result.response.speech.get("plain", {}).get("speech") == "success"
     assert result.conversation_id == conversation_id
@@ -123,99 +123,6 @@ async def test_intent(
     assert tool_call.tool_args == {
         e.name: {"value": e.value} for e in test_intent.entities
     }
-
-
-async def test_multiple_intents(
-    hass: HomeAssistant,
-    init_wyoming_intent: ConfigEntry,
-    mock_chat_log: MockChatLog,  # noqa: F811
-) -> None:
-    """Test when more than one intent is recognized."""
-    agent_id = "conversation.test_intent"
-    conversation_id = mock_chat_log.conversation_id
-    satellite_id = "satellite-1234"
-    device_id = "device-1234"
-
-    test_intent1 = Intent(
-        name="TestIntent1",
-        entities=[Entity(name="entity1", value="value1")],
-        text="{{ slots.slot_name }}",
-    )
-
-    test_intent2 = Intent(
-        name="TestIntent2",
-        entities=[Entity(name="entity2", value="value2")],
-        text="{{ slots.slot_name }}",
-    )
-
-    class TestIntentHandler(intent.IntentHandler):
-        """Test Intent Handler."""
-
-        def __init__(self, intent_type: str, slot_value: str) -> None:
-            """Initialize the handler."""
-            self.intent_type = intent_type
-            self._slot_value = slot_value
-
-        async def async_handle(self, intent_obj: intent.Intent):
-            """Handle the intent."""
-            response = intent_obj.create_response()
-            response.async_set_speech_slots({"slot_name": self._slot_value})
-            return response
-
-    intent.async_register(hass, TestIntentHandler("TestIntent1", "slot value 1"))
-    intent.async_register(hass, TestIntentHandler("TestIntent2", "slot value 2"))
-
-    # Send multiple intent events framed by intents-start and intents-stop.
-    client = MockAsyncTcpClient(
-        [
-            IntentsStart().event(),
-            test_intent1.event(),
-            test_intent2.event(),
-            IntentsStop().event(),
-        ]
-    )
-    with patch(
-        "homeassistant.components.wyoming.conversation.AsyncTcpClient",
-        client,
-    ):
-        result = await conversation.async_converse(
-            hass=hass,
-            text="test text",
-            conversation_id=conversation_id,
-            context=Context(),
-            language=hass.config.language,
-            agent_id=agent_id,
-            satellite_id=satellite_id,
-            device_id=device_id,
-        )
-
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
-    assert result.response.speech, "No speech"
-
-    # Speech results are joined with newlines because punctuation would be
-    # language-dependent.
-    assert (
-        result.response.speech.get("plain", {}).get("speech")
-        == "slot value 1\nslot value 2"
-    )
-
-    # Verify that chat log recorded all intents as tool calls
-    content: chat_log.AssistantContent | None = next(
-        filter(
-            lambda c: isinstance(c, chat_log.AssistantContent), mock_chat_log.content
-        ),
-        None,
-    )
-    assert content is not None, "Missing assistant content"
-    assert content.tool_calls and len(content.tool_calls) == 2
-
-    for tool_call, test_intent in zip(
-        content.tool_calls, (test_intent1, test_intent2), strict=True
-    ):
-        assert tool_call.tool_name == test_intent.name
-        assert tool_call.tool_args == {
-            e.name: {"value": e.value} for e in test_intent.entities
-        }
 
 
 async def test_intent_handle_error(
@@ -250,69 +157,8 @@ async def test_intent_handle_error(
             agent_id=agent_id,
         )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.FAILED_TO_HANDLE
-
-
-async def test_multiple_intents_handle_error(
-    hass: HomeAssistant,
-    init_wyoming_intent: ConfigEntry,
-    mock_chat_log: MockChatLog,  # noqa: F811
-) -> None:
-    """Test error during handling when multiple intents are recognized."""
-    agent_id = "conversation.test_intent"
-
-    test_intent_1 = Intent(name="TestIntent1", entities=[], text="success")
-    test_intent_2 = Intent(name="TestIntent2", entities=[], text="success")
-
-    class TestIntentHandler1(intent.IntentHandler):
-        """Test Intent Handler."""
-
-        intent_type = "TestIntent1"
-
-        async def async_handle(self, intent_obj: intent.Intent):
-            """Handle the intent."""
-            return intent_obj.create_response()
-
-    class TestIntentHandler2(intent.IntentHandler):
-        """Test Intent Handler."""
-
-        intent_type = "TestIntent2"
-
-        async def async_handle(self, intent_obj: intent.Intent):
-            """Handle the intent."""
-            raise intent.IntentError
-
-    intent.async_register(hass, TestIntentHandler1())
-    intent.async_register(hass, TestIntentHandler2())
-
-    with patch(
-        "homeassistant.components.wyoming.conversation.AsyncTcpClient",
-        MockAsyncTcpClient(
-            [
-                IntentsStart().event(),
-                test_intent_1.event(),
-                test_intent_2.event(),
-                IntentsStop().event(),
-            ]
-        ),
-    ):
-        result = await conversation.async_converse(
-            hass=hass,
-            text="test text",
-            conversation_id=None,
-            context=Context(),
-            language=hass.config.language,
-            agent_id=agent_id,
-        )
-
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.FAILED_TO_HANDLE
-
-    # Ensure that no tool calls were recorded
-    assert not any(
-        isinstance(c, chat_log.AssistantContent) for c in mock_chat_log.content
-    )
 
 
 async def test_not_recognized(
@@ -334,7 +180,7 @@ async def test_not_recognized(
             agent_id=agent_id,
         )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_INTENT_MATCH
     assert result.response.speech, "No speech"
     assert result.response.speech.get("plain", {}).get("speech") == "failure"
@@ -372,7 +218,7 @@ async def test_handle(hass: HomeAssistant, init_wyoming_handle: ConfigEntry) -> 
         "device_id": device_id,
     }
 
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.response_type is intent.IntentResponseType.ACTION_DONE
     assert result.response.speech, "No speech"
     assert result.response.speech.get("plain", {}).get("speech") == "success"
     assert result.conversation_id == conversation_id
@@ -397,7 +243,7 @@ async def test_not_handled(
             agent_id=agent_id,
         )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.FAILED_TO_HANDLE
     assert result.response.speech, "No speech"
     assert result.response.speech.get("plain", {}).get("speech") == "failure"
@@ -422,7 +268,7 @@ async def test_connection_lost(
             agent_id=agent_id,
         )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.UNKNOWN
     assert result.response.speech, "No speech"
     assert result.response.speech.get("plain", {}).get("speech") == snapshot
@@ -451,7 +297,7 @@ async def test_oserror(
             agent_id=agent_id,
         )
 
-    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.response_type is intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.UNKNOWN
     assert result.response.speech, "No speech"
     assert result.response.speech.get("plain", {}).get("speech") == snapshot
@@ -497,60 +343,3 @@ async def test_supported_languages_empty_means_all(
     agent = conversation.async_get_agent(hass, agent_id)
     assert agent is not None
     assert agent.supported_languages == MATCH_ALL
-
-
-async def test_intent_supports_home_control(
-    hass: HomeAssistant, intent_config_entry: ConfigEntry
-) -> None:
-    """Test that the CONTROL supported feature is always set for intent services."""
-    agent_id = "conversation.test_intent"
-
-    with patch(
-        "homeassistant.components.wyoming.data.load_wyoming_info",
-        return_value=Info(intent=INTENT_INFO.intent),
-    ):
-        await hass.config_entries.async_setup(intent_config_entry.entry_id)
-
-    agent = conversation.async_get_agent(hass, agent_id)
-    assert isinstance(agent, conversation.ConversationEntity)
-    assert agent.supported_features is not None
-    assert (
-        agent.supported_features & conversation.ConversationEntityFeature.CONTROL
-    ) == conversation.ConversationEntityFeature.CONTROL
-
-
-@pytest.mark.parametrize(
-    "supports_home_control",
-    [False, True],
-)
-async def test_handle_supports_home_control(
-    hass: HomeAssistant, intent_config_entry: ConfigEntry, supports_home_control: bool
-) -> None:
-    """Test that the CONTROL supported feature matches the Wyoming info."""
-    agent_id = "conversation.test_handle"
-
-    with (
-        patch.object(
-            HANDLE_INFO.handle[0], "supports_home_control", supports_home_control
-        ),
-        patch(
-            "homeassistant.components.wyoming.data.load_wyoming_info",
-            return_value=Info(handle=HANDLE_INFO.handle),
-        ),
-    ):
-        await hass.config_entries.async_setup(intent_config_entry.entry_id)
-
-    agent = conversation.async_get_agent(hass, agent_id)
-    assert isinstance(agent, conversation.ConversationEntity)
-    supported_features = (
-        agent.supported_features or conversation.ConversationEntityFeature(0)
-    )
-
-    control_feature = (
-        supported_features & conversation.ConversationEntityFeature.CONTROL
-    )
-
-    if supports_home_control:
-        assert control_feature == conversation.ConversationEntityFeature.CONTROL
-    else:
-        assert control_feature == conversation.ConversationEntityFeature(0)

--- a/tests/components/wyoming/test_satellite.py
+++ b/tests/components/wyoming/test_satellite.py
@@ -1508,7 +1508,7 @@ async def test_timers(hass: HomeAssistant) -> None:
             device_id=device.device_id,
         )
 
-        assert result.response_type == intent_helper.IntentResponseType.ACTION_DONE
+        assert result.response_type is intent_helper.IntentResponseType.ACTION_DONE
         async with asyncio.timeout(1):
             await mock_client.timer_started_event.wait()
             timer_started = mock_client.timer_started
@@ -1530,7 +1530,7 @@ async def test_timers(hass: HomeAssistant) -> None:
             device_id=device.device_id,
         )
 
-        assert result.response_type == intent_helper.IntentResponseType.ACTION_DONE
+        assert result.response_type is intent_helper.IntentResponseType.ACTION_DONE
         async with asyncio.timeout(1):
             await mock_client.timer_updated_event.wait()
             timer_updated = mock_client.timer_updated
@@ -1548,7 +1548,7 @@ async def test_timers(hass: HomeAssistant) -> None:
             device_id=device.device_id,
         )
 
-        assert result.response_type == intent_helper.IntentResponseType.ACTION_DONE
+        assert result.response_type is intent_helper.IntentResponseType.ACTION_DONE
         async with asyncio.timeout(1):
             await mock_client.timer_updated_event.wait()
             timer_updated = mock_client.timer_updated
@@ -1570,7 +1570,7 @@ async def test_timers(hass: HomeAssistant) -> None:
             device_id=device.device_id,
         )
 
-        assert result.response_type == intent_helper.IntentResponseType.ACTION_DONE
+        assert result.response_type is intent_helper.IntentResponseType.ACTION_DONE
         async with asyncio.timeout(1):
             await mock_client.timer_updated_event.wait()
             timer_updated = mock_client.timer_updated
@@ -1592,7 +1592,7 @@ async def test_timers(hass: HomeAssistant) -> None:
             device_id=device.device_id,
         )
 
-        assert result.response_type == intent_helper.IntentResponseType.ACTION_DONE
+        assert result.response_type is intent_helper.IntentResponseType.ACTION_DONE
         async with asyncio.timeout(1):
             await mock_client.timer_updated_event.wait()
             timer_updated = mock_client.timer_updated
@@ -1609,7 +1609,7 @@ async def test_timers(hass: HomeAssistant) -> None:
             device_id=device.device_id,
         )
 
-        assert result.response_type == intent_helper.IntentResponseType.ACTION_DONE
+        assert result.response_type is intent_helper.IntentResponseType.ACTION_DONE
         async with asyncio.timeout(1):
             await mock_client.timer_cancelled_event.wait()
             timer_cancelled = mock_client.timer_cancelled
@@ -1629,7 +1629,7 @@ async def test_timers(hass: HomeAssistant) -> None:
             device_id=device.device_id,
         )
 
-        assert result.response_type == intent_helper.IntentResponseType.ACTION_DONE
+        assert result.response_type is intent_helper.IntentResponseType.ACTION_DONE
         async with asyncio.timeout(1):
             await mock_client.timer_started_event.wait()
             timer_started = mock_client.timer_started
@@ -1646,7 +1646,7 @@ async def test_timers(hass: HomeAssistant) -> None:
             device_id=device.device_id,
         )
 
-        assert result.response_type == intent_helper.IntentResponseType.ACTION_DONE
+        assert result.response_type is intent_helper.IntentResponseType.ACTION_DONE
         async with asyncio.timeout(1):
             await mock_client.timer_finished_event.wait()
             timer_finished = mock_client.timer_finished

--- a/tests/components/yale_smart_alarm/test_config_flow.py
+++ b/tests/components/yale_smart_alarm/test_config_flow.py
@@ -466,4 +466,4 @@ async def test_options_flow(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {"lock_code_digits": 4}
 
-    assert entry.state == config_entries.ConfigEntryState.LOADED
+    assert entry.state is config_entries.ConfigEntryState.LOADED

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -200,7 +200,7 @@ async def consume_progress_flow(
         result = await flow_manager.async_configure(flow_id)
         flow_id = result["flow_id"]
 
-        if result["type"] != FlowResultType.SHOW_PROGRESS:
+        if result["type"] is not FlowResultType.SHOW_PROGRESS:
             break
 
         assert result["type"] is FlowResultType.SHOW_PROGRESS

--- a/tests/components/zha/test_helpers.py
+++ b/tests/components/zha/test_helpers.py
@@ -108,11 +108,11 @@ async def test_zcl_schema_conversions(hass: HomeAssistant) -> None:
     assert isinstance(converted_data["action"], lighting.Color.ColorLoopAction)
     assert (
         converted_data["action"]
-        == lighting.Color.ColorLoopAction.Activate_from_current_hue
+        is lighting.Color.ColorLoopAction.Activate_from_current_hue
     )
 
     assert isinstance(converted_data["direction"], lighting.Color.ColorLoopDirection)
-    assert converted_data["direction"] == lighting.Color.ColorLoopDirection.Increment
+    assert converted_data["direction"] is lighting.Color.ColorLoopDirection.Increment
 
     assert isinstance(converted_data["time"], uint16_t)
     assert converted_data["time"] == 20
@@ -141,11 +141,11 @@ async def test_zcl_schema_conversions(hass: HomeAssistant) -> None:
     assert isinstance(converted_data["action"], lighting.Color.ColorLoopAction)
     assert (
         converted_data["action"]
-        == lighting.Color.ColorLoopAction.Activate_from_current_hue
+        is lighting.Color.ColorLoopAction.Activate_from_current_hue
     )
 
     assert isinstance(converted_data["direction"], lighting.Color.ColorLoopDirection)
-    assert converted_data["direction"] == lighting.Color.ColorLoopDirection.Increment
+    assert converted_data["direction"] is lighting.Color.ColorLoopDirection.Increment
 
     assert isinstance(converted_data["time"], uint16_t)
     assert converted_data["time"] == 20

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -1295,7 +1295,7 @@ async def test_stop_addon(
     )
     await hass.async_block_till_done()
 
-    assert entry.state == entry_state
+    assert entry.state is entry_state
     assert stop_addon.call_count == 1
     assert stop_addon.call_args == call("core_zwave_js")
 

--- a/tests/helpers/test_config_entry_flow.py
+++ b/tests/helpers/test_config_entry_flow.py
@@ -75,7 +75,7 @@ async def test_single_entry_allowed(
     MockConfigEntry(domain="test").add_to_hass(hass)
     result = await flow.async_step_user()
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
 
@@ -103,7 +103,7 @@ async def test_user_has_confirmation(
         "test", context={"source": config_entries.SOURCE_USER}, data={}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "confirm"
 
     progress = hass.config_entries.flow.async_progress()
@@ -116,7 +116,7 @@ async def test_user_has_confirmation(
     }
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 async def test_user_has_confirmation_async_discovery_flow(
@@ -130,7 +130,7 @@ async def test_user_has_confirmation_async_discovery_flow(
         "test", context={"source": config_entries.SOURCE_USER}, data={}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "confirm"
 
     progress = hass.config_entries.flow.async_progress()
@@ -143,7 +143,7 @@ async def test_user_has_confirmation_async_discovery_flow(
     }
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 @pytest.mark.parametrize(
@@ -236,13 +236,13 @@ async def test_multiple_discoveries(
     result = await hass.config_entries.flow.async_init(
         "test", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     # Second discovery
     result = await hass.config_entries.flow.async_init(
         "test", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
 
 
 async def test_only_one_in_progress(
@@ -255,21 +255,21 @@ async def test_only_one_in_progress(
     result = await hass.config_entries.flow.async_init(
         "test", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     # User starts flow
     result = await hass.config_entries.flow.async_init(
         "test", context={"source": config_entries.SOURCE_USER}, data={}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     # Discovery flow has not been aborted
     assert len(hass.config_entries.flow.async_progress()) == 2
 
     # Discovery should be aborted once user confirms
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert len(hass.config_entries.flow.async_progress()) == 0
 
 
@@ -283,14 +283,14 @@ async def test_import_abort_discovery(
     result = await hass.config_entries.flow.async_init(
         "test", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     # Start import flow
     result = await hass.config_entries.flow.async_init(
         "test", context={"source": config_entries.SOURCE_IMPORT}, data={}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
     # Discovery flow has been aborted
     assert len(hass.config_entries.flow.async_progress()) == 0
@@ -332,7 +332,7 @@ async def test_ignored_discoveries(
     result = await hass.config_entries.flow.async_init(
         "test", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     flow = next(
         (
@@ -354,7 +354,7 @@ async def test_ignored_discoveries(
     result = await hass.config_entries.flow.async_init(
         "test", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
 
 
 async def test_webhook_single_entry_allowed(
@@ -367,7 +367,7 @@ async def test_webhook_single_entry_allowed(
     MockConfigEntry(domain="test_single").add_to_hass(hass)
     result = await flow.async_step_user()
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
 
@@ -382,7 +382,7 @@ async def test_webhook_multiple_entries_allowed(
     hass.config.api = Mock(base_url="http://example.com")
 
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
 
 async def test_webhook_config_flow_registers_webhook(
@@ -398,7 +398,7 @@ async def test_webhook_config_flow_registers_webhook(
     )
     result = await flow.async_step_user(user_input={})
 
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"]["webhook_id"] is not None
 
 
@@ -425,7 +425,7 @@ async def test_webhook_create_cloudhook(
     result = await hass.config_entries.flow.async_init(
         "test_single", context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     with (
         patch(
@@ -447,7 +447,7 @@ async def test_webhook_create_cloudhook(
     ):
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["description_placeholders"]["webhook_url"] == "https://example.com"
     assert len(mock_create.mock_calls) == 1
     assert len(async_setup_entry.mock_calls) == 1
@@ -486,7 +486,7 @@ async def test_webhook_create_cloudhook_aborts_not_connected(
     result = await hass.config_entries.flow.async_init(
         "test_single", context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     with (
         patch(
@@ -508,7 +508,7 @@ async def test_webhook_create_cloudhook_aborts_not_connected(
     ):
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "cloud_not_connected"
 
 

--- a/tests/helpers/test_config_entry_oauth2_flow.py
+++ b/tests/helpers/test_config_entry_oauth2_flow.py
@@ -149,7 +149,7 @@ async def test_abort_if_no_implementation(
     flow = flow_handler()
     flow.hass = hass
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "missing_configuration"
 
 
@@ -171,7 +171,7 @@ async def test_abort_if_oauth_implementation_unavailable(
     flow = flow_handler()
     flow.hass = hass
     result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "oauth_implementation_unavailable"
 
 
@@ -185,7 +185,7 @@ async def test_missing_credentials_for_domain(
 
     with patch("homeassistant.loader.APPLICATION_CREDENTIALS", [TEST_DOMAIN]):
         result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "missing_credentials"
 
 
@@ -207,7 +207,7 @@ async def test_abort_if_authorization_timeout(
     ):
         result = await flow.async_step_user()
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "authorize_url_timeout"
 
 
@@ -228,7 +228,7 @@ async def test_abort_if_no_url_available(
     ):
         result = await flow.async_step_user()
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "no_url_available"
 
 
@@ -252,7 +252,7 @@ async def test_abort_if_oauth_error(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pick_implementation"
 
     # Pick implementation
@@ -268,7 +268,7 @@ async def test_abort_if_oauth_error(
         },
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
+    assert result["type"] is data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["url"] == (
         f"{AUTHORIZE_URL}?response_type=code&client_id={CLIENT_ID}"
         "&redirect_uri=https://example.com/auth/external/callback"
@@ -292,7 +292,7 @@ async def test_abort_if_oauth_error(
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "oauth_error"
 
 
@@ -313,7 +313,7 @@ async def test_abort_if_oauth_rejected(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pick_implementation"
 
     # Pick implementation
@@ -329,7 +329,7 @@ async def test_abort_if_oauth_rejected(
         },
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
+    assert result["type"] is data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["url"] == (
         f"{AUTHORIZE_URL}?response_type=code&client_id={CLIENT_ID}"
         "&redirect_uri=https://example.com/auth/external/callback"
@@ -345,7 +345,7 @@ async def test_abort_if_oauth_rejected(
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "user_rejected_authorize"
     assert result["description_placeholders"] == {"error": "access_denied"}
 
@@ -368,7 +368,7 @@ async def test_abort_on_oauth_timeout_error(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pick_implementation"
 
     # Pick implementation
@@ -384,7 +384,7 @@ async def test_abort_on_oauth_timeout_error(
         },
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
+    assert result["type"] is data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["url"] == (
         f"{AUTHORIZE_URL}?response_type=code&client_id={CLIENT_ID}"
         "&redirect_uri=https://example.com/auth/external/callback"
@@ -402,7 +402,7 @@ async def test_abort_on_oauth_timeout_error(
     ):
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "oauth_timeout"
 
 
@@ -423,7 +423,7 @@ async def test_step_discovery(
         data=data_entry_flow.BaseServiceInfo(),
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "oauth_discovery"
 
     result = await hass.config_entries.flow.async_configure(
@@ -431,7 +431,7 @@ async def test_step_discovery(
         user_input={},
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pick_implementation"
 
 
@@ -457,7 +457,7 @@ async def test_abort_discovered_multiple(
         user_input={},
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pick_implementation"
 
     result = await hass.config_entries.flow.async_init(
@@ -466,7 +466,7 @@ async def test_abort_discovered_multiple(
         data=data_entry_flow.BaseServiceInfo(),
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_in_progress"
 
 
@@ -525,7 +525,7 @@ async def test_abort_if_oauth_token_error(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pick_implementation"
 
     # Pick implementation
@@ -541,7 +541,7 @@ async def test_abort_if_oauth_token_error(
         },
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
+    assert result["type"] is data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["url"] == (
         f"{AUTHORIZE_URL}?response_type=code&client_id={CLIENT_ID}"
         "&redirect_uri=https://example.com/auth/external/callback"
@@ -566,7 +566,7 @@ async def test_abort_if_oauth_token_error(
         in caplog.text
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == error_reason
 
 
@@ -589,7 +589,7 @@ async def test_abort_if_oauth_token_closing_error(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pick_implementation"
 
     # Pick implementation
@@ -605,7 +605,7 @@ async def test_abort_if_oauth_token_closing_error(
         },
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
+    assert result["type"] is data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["url"] == (
         f"{AUTHORIZE_URL}?response_type=code&client_id={CLIENT_ID}"
         "&redirect_uri=https://example.com/auth/external/callback"
@@ -627,7 +627,7 @@ async def test_abort_if_oauth_token_closing_error(
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
     assert "Token request for oauth2_test failed (401): unknown" in caplog.text
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "oauth_unauthorized"
 
 
@@ -654,7 +654,7 @@ async def test_abort_discovered_existing_entries(
         data=data_entry_flow.BaseServiceInfo(),
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -687,7 +687,7 @@ async def test_full_flow(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pick_implementation"
 
     # Pick implementation
@@ -703,7 +703,7 @@ async def test_full_flow(
         },
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
+    assert result["type"] is data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert result["url"] == (
         f"{AUTHORIZE_URL}?response_type=code&client_id={CLIENT_ID}"
         f"&redirect_uri={expected_redirect_uri}"
@@ -1084,7 +1084,7 @@ async def test_abort_oauth_with_pkce_rejected(
     )
 
     code_challenge = local_impl_pkce.compute_code_challenge(MOCK_SECRET_TOKEN_URLSAFE)
-    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
+    assert result["type"] is data_entry_flow.FlowResultType.EXTERNAL_STEP
 
     assert result["url"].startswith(f"{AUTHORIZE_URL}?")
     assert f"client_id={CLIENT_ID}" in result["url"]
@@ -1104,7 +1104,7 @@ async def test_abort_oauth_with_pkce_rejected(
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "user_rejected_authorize"
     assert result["description_placeholders"] == {"error": "access_denied"}
 
@@ -1142,7 +1142,7 @@ async def test_oauth_with_pkce_adds_code_verifier_to_token_resolve(
     )
 
     code_challenge = local_impl_pkce.compute_code_challenge(MOCK_SECRET_TOKEN_URLSAFE)
-    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
+    assert result["type"] is data_entry_flow.FlowResultType.EXTERNAL_STEP
 
     assert result["url"].startswith(f"{AUTHORIZE_URL}?")
     assert f"client_id={CLIENT_ID}" in result["url"]

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -591,11 +591,11 @@ async def test_async_remove_no_platform(hass: HomeAssistant) -> None:
     ent.entity_id = "test.test"
     assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     ent.async_write_ha_state()
-    assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
+    assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     assert len(hass.states.async_entity_ids()) == 1
     await ent.async_remove()
     assert len(hass.states.async_entity_ids()) == 0
-    assert ent._platform_state == entity.EntityPlatformState.REMOVED
+    assert ent._platform_state is entity.EntityPlatformState.REMOVED
 
 
 async def test_async_remove_runs_callbacks(hass: HomeAssistant) -> None:
@@ -607,7 +607,7 @@ async def test_async_remove_runs_callbacks(hass: HomeAssistant) -> None:
     ent.entity_id = "test.test"
     assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
-    assert ent._platform_state == entity.EntityPlatformState.ADDED
+    assert ent._platform_state is entity.EntityPlatformState.ADDED
     ent.async_on_remove(lambda: result.append(1))
     await ent.async_remove()
     assert len(result) == 1
@@ -663,7 +663,7 @@ async def test_async_remove_twice(hass: HomeAssistant) -> None:
     await ent.async_remove()
     assert len(result) == 1
     assert len(ent.remove_calls) == 1
-    assert ent._platform_state == entity.EntityPlatformState.REMOVED
+    assert ent._platform_state is entity.EntityPlatformState.REMOVED
 
 
 async def test_set_context(hass: HomeAssistant) -> None:
@@ -1840,7 +1840,7 @@ async def test_reuse_entity_object_after_abort(
     ent.entity_id = "invalid"
     assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
-    assert ent._platform_state == entity.EntityPlatformState.REMOVED
+    assert ent._platform_state is entity.EntityPlatformState.REMOVED
     assert "Invalid entity ID: invalid" in caplog.text
     await platform.async_add_entities([ent])
     assert ent._platform_state == entity.EntityPlatformState.REMOVED
@@ -1864,7 +1864,7 @@ async def test_reuse_entity_object_after_entity_registry_remove(
     await platform.async_add_entities([ent])
     assert ent.registry_entry is entry
     assert len(hass.states.async_entity_ids()) == 1
-    assert ent._platform_state == entity.EntityPlatformState.ADDED
+    assert ent._platform_state is entity.EntityPlatformState.ADDED
 
     entity_registry.async_remove(entry.entity_id)
     await hass.async_block_till_done()
@@ -1891,7 +1891,7 @@ async def test_reuse_entity_object_after_entity_registry_disabled(
     await platform.async_add_entities([ent])
     assert ent.registry_entry is entry
     assert len(hass.states.async_entity_ids()) == 1
-    assert ent._platform_state == entity.EntityPlatformState.ADDED
+    assert ent._platform_state is entity.EntityPlatformState.ADDED
 
     entity_registry.async_update_entity(
         entry.entity_id, disabled_by=er.RegistryEntryDisabler.USER
@@ -1937,7 +1937,7 @@ async def test_change_entity_id(
     await platform.async_add_entities([ent])
     assert hass.states.get("test.test").state == STATE_UNKNOWN
     assert len(ent.added_calls) == 1
-    assert ent._platform_state == entity.EntityPlatformState.ADDED
+    assert ent._platform_state is entity.EntityPlatformState.ADDED
 
     entry = entity_registry.async_update_entity(
         entry.entity_id, new_entity_id="test.test2"
@@ -2814,7 +2814,7 @@ async def test_platform_state(
     assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
     assert hass.states.get("test.test").state == "added_to_hass"
-    assert ent._platform_state == entity.EntityPlatformState.ADDED
+    assert ent._platform_state is entity.EntityPlatformState.ADDED
 
     entry = entity_registry.async_remove(entry.entity_id)
     await hass.async_block_till_done()
@@ -2880,7 +2880,7 @@ async def test_platform_state_fail_to_add(
     assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
     assert hass.states.get("test.test") is None
-    assert ent._platform_state == entity.EntityPlatformState.ADDING
+    assert ent._platform_state is entity.EntityPlatformState.ADDING
 
     entry = entity_registry.async_remove(entry.entity_id)
     await hass.async_block_till_done()
@@ -2910,7 +2910,7 @@ async def test_platform_state_write_from_init(
     assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
     assert hass.states.get("test.unnamed_device").state == "init"
-    assert ent._platform_state == entity.EntityPlatformState.ADDED
+    assert ent._platform_state is entity.EntityPlatformState.ADDED
 
     assert len(hass.states.async_all()) == 1
 
@@ -2950,7 +2950,7 @@ async def test_platform_state_write_from_init_entity_id(
     assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
     assert hass.states.get("test.test").state == "init"
-    assert ent._platform_state == entity.EntityPlatformState.REMOVED
+    assert ent._platform_state is entity.EntityPlatformState.REMOVED
 
     assert len(hass.states.async_all()) == 1
 
@@ -3000,7 +3000,7 @@ async def test_platform_state_write_from_init_unique_id(
     assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
     assert hass.states.get("test.test").state == "init"
-    assert ent._platform_state == entity.EntityPlatformState.REMOVED
+    assert ent._platform_state is entity.EntityPlatformState.REMOVED
 
     assert len(hass.states.async_all()) == 1
 

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -589,7 +589,7 @@ async def test_async_remove_no_platform(hass: HomeAssistant) -> None:
     ent = entity.Entity()
     ent.hass = hass
     ent.entity_id = "test.test"
-    assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
+    assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     ent.async_write_ha_state()
     assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
     assert len(hass.states.async_entity_ids()) == 1
@@ -605,7 +605,7 @@ async def test_async_remove_runs_callbacks(hass: HomeAssistant) -> None:
     platform = MockEntityPlatform(hass, domain="test")
     ent = entity.Entity()
     ent.entity_id = "test.test"
-    assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
+    assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
     assert ent._platform_state == entity.EntityPlatformState.ADDED
     ent.async_on_remove(lambda: result.append(1))
@@ -658,7 +658,7 @@ async def test_async_remove_twice(hass: HomeAssistant) -> None:
     await ent.async_remove()
     assert len(result) == 1
     assert len(ent.remove_calls) == 1
-    assert ent._platform_state == entity.EntityPlatformState.REMOVED
+    assert ent._platform_state is entity.EntityPlatformState.REMOVED
 
     await ent.async_remove()
     assert len(result) == 1
@@ -1838,7 +1838,7 @@ async def test_reuse_entity_object_after_abort(
     platform = MockEntityPlatform(hass, domain="test")
     ent = entity.Entity()
     ent.entity_id = "invalid"
-    assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
+    assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
     assert ent._platform_state == entity.EntityPlatformState.REMOVED
     assert "Invalid entity ID: invalid" in caplog.text
@@ -1860,7 +1860,7 @@ async def test_reuse_entity_object_after_entity_registry_remove(
     platform = MockEntityPlatform(hass, domain="test", platform_name="test")
     ent = entity.Entity()
     ent._attr_unique_id = "5678"
-    assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
+    assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
     assert ent.registry_entry is entry
     assert len(hass.states.async_entity_ids()) == 1
@@ -1887,7 +1887,7 @@ async def test_reuse_entity_object_after_entity_registry_disabled(
     platform = MockEntityPlatform(hass, domain="test", platform_name="test")
     ent = entity.Entity()
     ent._attr_unique_id = "5678"
-    assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
+    assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
     assert ent.registry_entry is entry
     assert len(hass.states.async_entity_ids()) == 1
@@ -1933,7 +1933,7 @@ async def test_change_entity_id(
 
     platform = MockEntityPlatform(hass, domain="test")
     ent = MockEntity()
-    assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
+    assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
     assert hass.states.get("test.test").state == STATE_UNKNOWN
     assert len(ent.added_calls) == 1
@@ -2660,7 +2660,7 @@ async def test_remove_entity_registry(
     assert len(result) == 1
     assert len(ent.added_calls) == 1
     assert len(ent.remove_calls) == 1
-    assert ent._platform_state == entity.EntityPlatformState.REMOVED
+    assert ent._platform_state is entity.EntityPlatformState.REMOVED
 
     assert hass.states.get("test.test") is None
 
@@ -2811,7 +2811,7 @@ async def test_platform_state(
 
     platform = MockEntityPlatform(hass, domain="test")
     ent = MockEntity()
-    assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
+    assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
     assert hass.states.get("test.test").state == "added_to_hass"
     assert ent._platform_state == entity.EntityPlatformState.ADDED
@@ -2839,7 +2839,7 @@ async def test_platform_state_no_platform(hass: HomeAssistant) -> None:
     assert hass.states.get("test.test") is None
 
     # The attempt to write when in state NOT_ADDED should be allowed
-    assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
+    assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     ent.async_set_state("not_added")
     assert hass.states.get("test.test").state == "not_added"
 
@@ -2877,7 +2877,7 @@ async def test_platform_state_fail_to_add(
 
     platform = MockEntityPlatform(hass, domain="test")
     ent = MockEntity()
-    assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
+    assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
     assert hass.states.get("test.test") is None
     assert ent._platform_state == entity.EntityPlatformState.ADDING
@@ -2907,7 +2907,7 @@ async def test_platform_state_write_from_init(
 
     platform = MockEntityPlatform(hass, domain="test")
     ent = MockEntity(hass)
-    assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
+    assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
     assert hass.states.get("test.unnamed_device").state == "init"
     assert ent._platform_state == entity.EntityPlatformState.ADDED
@@ -2934,7 +2934,7 @@ async def test_platform_state_write_from_init_entity_id(
             self.hass = hass
             # The attempt to write when in state NOT_ADDED is not prevented because
             # the platform is not yet set
-            assert self._platform_state == entity.EntityPlatformState.NOT_ADDED
+            assert self._platform_state is entity.EntityPlatformState.NOT_ADDED
             self._attr_state = "init"
             self.async_write_ha_state()
             assert hass.states.get("test.test").state == "init"
@@ -2947,7 +2947,7 @@ async def test_platform_state_write_from_init_entity_id(
 
     platform = MockEntityPlatform(hass, domain="test")
     ent = MockEntity(hass)
-    assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
+    assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
     assert hass.states.get("test.test").state == "init"
     assert ent._platform_state == entity.EntityPlatformState.REMOVED
@@ -2984,7 +2984,7 @@ async def test_platform_state_write_from_init_unique_id(
             self.hass = hass
             # The attempt to write when in state NOT_ADDED is not prevented because
             # the platform is not yet set
-            assert self._platform_state == entity.EntityPlatformState.NOT_ADDED
+            assert self._platform_state is entity.EntityPlatformState.NOT_ADDED
             self._attr_state = "init"
             self.async_write_ha_state()
             assert hass.states.get("test.test").state == "init"
@@ -2997,7 +2997,7 @@ async def test_platform_state_write_from_init_unique_id(
 
     platform = MockEntityPlatform(hass, domain="test")
     ent = MockEntity(hass)
-    assert ent._platform_state == entity.EntityPlatformState.NOT_ADDED
+    assert ent._platform_state is entity.EntityPlatformState.NOT_ADDED
     await platform.async_add_entities([ent])
     assert hass.states.get("test.test").state == "init"
     assert ent._platform_state == entity.EntityPlatformState.REMOVED

--- a/tests/helpers/test_intent.py
+++ b/tests/helpers/test_intent.py
@@ -345,7 +345,7 @@ async def test_async_match_targets(
         states=states,
     )
     assert not result.is_match
-    assert result.no_match_reason == intent.MatchFailedReason.DUPLICATE_NAME
+    assert result.no_match_reason is intent.MatchFailedReason.DUPLICATE_NAME
     assert result.no_match_name == "bathroom light"
 
     # Works with duplicate names allowed
@@ -411,7 +411,7 @@ async def test_async_match_targets(
         states=states,
     )
     assert not result.is_match
-    assert result.no_match_reason == intent.MatchFailedReason.DUPLICATE_NAME
+    assert result.no_match_reason is intent.MatchFailedReason.DUPLICATE_NAME
 
     # Disambiguate by area name, if unique
     result = intent.async_match_targets(
@@ -432,7 +432,7 @@ async def test_async_match_targets(
         states=states,
     )
     assert not result.is_match
-    assert result.no_match_reason == intent.MatchFailedReason.DUPLICATE_NAME
+    assert result.no_match_reason is intent.MatchFailedReason.DUPLICATE_NAME
 
     # Does work if floor/area name combo is unique
     result = intent.async_match_targets(
@@ -457,7 +457,7 @@ async def test_async_match_targets(
         states=states,
     )
     assert not result.is_match
-    assert result.no_match_reason == intent.MatchFailedReason.AREA
+    assert result.no_match_reason is intent.MatchFailedReason.AREA
 
     # Check state constraint (only third floor bathroom light is on)
     result = intent.async_match_targets(
@@ -533,7 +533,7 @@ async def test_async_match_targets(
         states=states,
     )
     assert not result.is_match
-    assert result.no_match_reason == intent.MatchFailedReason.MULTIPLE_TARGETS
+    assert result.no_match_reason is intent.MatchFailedReason.MULTIPLE_TARGETS
 
     # Only one light on the ground floor
     result = intent.async_match_targets(
@@ -718,7 +718,7 @@ async def test_validate_then_run_in_background(hass: HomeAssistant) -> None:
         slots={"name": {"value": "kitchen"}},
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
 
     assert not call_done.is_set()
     await call_done.wait()
@@ -765,7 +765,7 @@ async def test_invalid_area_floor_names(hass: HomeAssistant) -> None:
             "TestType",
             slots={"area": {"value": "invalid area"}},
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.INVALID_AREA
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.INVALID_AREA
 
     with pytest.raises(intent.MatchFailedError) as err:
         await intent.async_handle(
@@ -774,7 +774,7 @@ async def test_invalid_area_floor_names(hass: HomeAssistant) -> None:
             "TestType",
             slots={"floor": {"value": "invalid floor"}},
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.INVALID_FLOOR
+    assert err.value.result.no_match_reason is intent.MatchFailedReason.INVALID_FLOOR
 
 
 async def test_service_intent_handler_required_domains(hass: HomeAssistant) -> None:
@@ -798,7 +798,7 @@ async def test_service_intent_handler_required_domains(hass: HomeAssistant) -> N
         "TestType",
         slots={"name": {"value": "kitchen"}, "domain": {"value": "light"}},
     )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(calls) == 1
 
     # Fails because the intent handler is restricted to lights only
@@ -935,7 +935,7 @@ async def test_service_handler_matched_states_uses_updated_state(
         slots={"name": {"value": "kitchen"}},
     )
 
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
     assert len(result.matched_states) == 1
     assert result.matched_states[0].entity_id == "light.kitchen"
     assert result.matched_states[0].state == "on"

--- a/tests/helpers/test_schema_config_entry_flow.py
+++ b/tests/helpers/test_schema_config_entry_flow.py
@@ -133,11 +133,11 @@ async def test_config_flow_advanced_option(
 
     # Start flow in basic mode
     result = await manager.async_init("test")
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert list(result["data_schema"].schema.keys()) == ["option1"]
 
     result = await manager.async_configure(result["flow_id"], {"option1": "blabla"})
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {}
     assert result["options"] == {
         "advanced_default": "a very reasonable default",
@@ -149,7 +149,7 @@ async def test_config_flow_advanced_option(
 
     # Start flow in advanced mode
     result = await manager.async_init("test", context={"show_advanced_options": True})
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert list(result["data_schema"].schema.keys()) == [
         "option1",
         "advanced_no_default",
@@ -159,7 +159,7 @@ async def test_config_flow_advanced_option(
     result = await manager.async_configure(
         result["flow_id"], {"advanced_no_default": "abc123", "option1": "blabla"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {}
     assert result["options"] == {
         "advanced_default": "a very reasonable default",
@@ -172,7 +172,7 @@ async def test_config_flow_advanced_option(
 
     # Start flow in advanced mode
     result = await manager.async_init("test", context={"show_advanced_options": True})
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert list(result["data_schema"].schema.keys()) == [
         "option1",
         "advanced_no_default",
@@ -187,7 +187,7 @@ async def test_config_flow_advanced_option(
             "option1": "blabla",
         },
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {}
     assert result["options"] == {
         "advanced_default": "not default",
@@ -241,13 +241,13 @@ async def test_options_flow_advanced_option(
 
     # Start flow in basic mode
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert list(result["data_schema"].schema.keys()) == ["option1"]
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {"option1": "blublu"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         "advanced_default": "not default",
         "advanced_no_default": "abc123",
@@ -261,7 +261,7 @@ async def test_options_flow_advanced_option(
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id, context={"show_advanced_options": True}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert list(result["data_schema"].schema.keys()) == [
         "option1",
         "advanced_no_default",
@@ -271,7 +271,7 @@ async def test_options_flow_advanced_option(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {"advanced_no_default": "def456", "option1": "blabla"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         "advanced_default": "a very reasonable default",
         "advanced_no_default": "def456",
@@ -285,7 +285,7 @@ async def test_options_flow_advanced_option(
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id, context={"show_advanced_options": True}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert list(result["data_schema"].schema.keys()) == [
         "option1",
         "advanced_no_default",
@@ -300,7 +300,7 @@ async def test_options_flow_advanced_option(
             "option1": "blabla",
         },
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         "advanced_default": "also not default",
         "advanced_no_default": "abc123",
@@ -528,7 +528,7 @@ async def test_suggested_values(
 
     # Start flow in basic mode, suggested values should be the existing options
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
     schema_keys: list[vol.Optional] = list(result["data_schema"].schema.keys())
     assert schema_keys == ["option1"]
@@ -538,7 +538,7 @@ async def test_suggested_values(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {"option1": "blublu"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "step_1"
     schema_keys: list[vol.Optional] = list(result["data_schema"].schema.keys())
     assert schema_keys == ["option1"]
@@ -548,7 +548,7 @@ async def test_suggested_values(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {"option1": "blabla"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "step_2"
     schema_keys: list[vol.Optional] = list(result["data_schema"].schema.keys())
     assert schema_keys == ["option1"]
@@ -558,7 +558,7 @@ async def test_suggested_values(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {"option1": "blabla"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "step_3"
     schema_keys: list[vol.Optional] = list(result["data_schema"].schema.keys())
     assert schema_keys == ["option1"]
@@ -568,7 +568,7 @@ async def test_suggested_values(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {"option1": "blabla"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "step_4"
     schema_keys: list[vol.Optional] = list(result["data_schema"].schema.keys())
     assert schema_keys == ["option1"]
@@ -578,7 +578,7 @@ async def test_suggested_values(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {"option1": "not a valid value"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "step_4"
     schema_keys: list[vol.Optional] = list(result["data_schema"].schema.keys())
     assert schema_keys == ["option1"]
@@ -588,7 +588,7 @@ async def test_suggested_values(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {"option1": "blabla"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 async def test_description_placeholders(
@@ -625,7 +625,7 @@ async def test_description_placeholders(
 
     # Start flow and check the description_placeholders is populated
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
     assert result["description_placeholders"] == {"option1": "a dynamic string"}
 
@@ -680,7 +680,7 @@ async def test_options_flow_state(hass: HomeAssistant) -> None:
 
     # Start flow in basic mode, flow state is initialised with None value
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "step_1"
 
     options_handler: SchemaOptionsFlowHandler
@@ -695,7 +695,7 @@ async def test_options_flow_state(hass: HomeAssistant) -> None:
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {"option1": "blublu"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "step_2"
 
     options_handler = hass.config_entries.options._progress[result["flow_id"]]
@@ -705,7 +705,7 @@ async def test_options_flow_state(hass: HomeAssistant) -> None:
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {"option1": "blabla"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         "idx_from_flow_state": "blublu",
         "option1": "blabla",
@@ -755,14 +755,14 @@ async def test_options_flow_omit_optional_keys(
 
     # Start flow in basic mode
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert list(result["data_schema"].schema.keys()) == [
         "optional_no_default",
         "optional_default",
     ]
 
     result = await hass.config_entries.options.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         "advanced_default": "not default",
         "advanced_no_default": "abc123",
@@ -773,7 +773,7 @@ async def test_options_flow_omit_optional_keys(
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id, context={"show_advanced_options": True}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert list(result["data_schema"].schema.keys()) == [
         "optional_no_default",
         "optional_default",
@@ -782,7 +782,7 @@ async def test_options_flow_omit_optional_keys(
     ]
 
     result = await hass.config_entries.options.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         "advanced_default": "a very reasonable default",
         "optional_default": "a very reasonable default",
@@ -849,12 +849,12 @@ async def test_options_flow_with_automatic_reload(
 
     # Start flow in basic mode
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], new_options
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
     assert len(load_entry_mock.mock_calls) == expected_loads
     assert len(unload_entry_mock.mock_calls) == expected_unloads

--- a/tests/syrupy.py
+++ b/tests/syrupy.py
@@ -366,7 +366,7 @@ def _merge_serialized_report(report: SnapshotReport, json_data: dict[str, Any]) 
     for key, selected_item in json_data["_selected_items"].items():
         if key in report.selected_items:
             status = ItemStatus(selected_item)
-            if status != ItemStatus.NOT_RUN:
+            if status is not ItemStatus.NOT_RUN:
                 report.selected_items[key] = status
         else:
             report.selected_items[key] = ItemStatus(selected_item)

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -2714,7 +2714,7 @@ async def test_subentry_flow(
         result = await manager.subentries.async_init(
             (entry.entry_id, "test"), context={"source": "user"}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
         assert entry.data == {"first": True}
         assert entry.options == {}
@@ -3403,7 +3403,7 @@ async def test_entry_reload_error(
     assert len(async_setup.mock_calls) == 0
     assert len(async_setup_entry.mock_calls) == 0
 
-    assert entry.state == state
+    assert entry.state is state
 
 
 async def test_entry_disable_succeed(
@@ -3722,7 +3722,7 @@ async def test_unique_id_existing_entry(
             "comp", context={"source": config_entries.SOURCE_USER}
         )
 
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
     entries = hass.config_entries.async_entries("comp")
     assert len(entries) == 1
@@ -4106,7 +4106,7 @@ async def test_unique_id_in_progress(
         result = await manager.flow.async_init(
             "comp", context={"source": existing_flow_source, "entry_id": entry.entry_id}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
 
         result2 = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_USER}
@@ -4145,14 +4145,14 @@ async def test_finish_flow_aborts_progress(
         result = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
 
         # Will finish and cancel other one.
         result2 = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_USER}, data={}
         )
 
-    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result2["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
     assert len(hass.config_entries.flow.async_progress()) == 0
 
@@ -4196,7 +4196,7 @@ async def test_unique_id_ignore(
         result = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
 
         result2 = await manager.flow.async_init(
             "comp",
@@ -4204,7 +4204,7 @@ async def test_unique_id_ignore(
             data={"unique_id": "mock-unique-id", "title": "Ignored Title"},
         )
 
-    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result2["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
     # assert len(hass.config_entries.flow.async_progress()) == 0
 
@@ -4267,7 +4267,7 @@ async def test_manual_add_overrides_ignored_entry(
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert entry.data["host"] == "1.1.1.1"
     assert entry.data["additional"] == "data"
     assert len(async_reload.mock_calls) == 0
@@ -4473,7 +4473,7 @@ async def test_update_discovery_keys(
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == flow_result
+    assert result["type"] is flow_result
     assert entry.data == {}
     assert entry.discovery_keys == updated_discovery_keys
     assert len(async_reload.mock_calls) == 0
@@ -4556,7 +4556,7 @@ async def test_update_discovery_keys_2(
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == flow_result
+    assert result["type"] is flow_result
     assert entry.data == {}
     assert entry.discovery_keys == updated_discovery_keys
     assert len(async_reload.mock_calls) == 0
@@ -4731,7 +4731,7 @@ async def test_partial_flows_hidden(
         # async_progress and have triggered
         # discovery notifications
         result = await init_task
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
         assert len(hass.config_entries.flow.async_progress()) == 1
 
 
@@ -4940,7 +4940,7 @@ async def test_flow_with_default_discovery(
         result = await manager.flow.async_init(
             "comp", context={"source": discovery_source[0]}, data=discovery_source[1]
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
 
         flows = hass.config_entries.flow.async_progress()
         assert len(flows) == 1
@@ -4953,7 +4953,7 @@ async def test_flow_with_default_discovery(
         result2 = await manager.flow.async_configure(
             result["flow_id"], user_input={"fake": "data"}
         )
-        assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result2["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
     assert len(hass.config_entries.flow.async_progress()) == 0
 
@@ -4989,7 +4989,7 @@ async def test_flow_with_default_discovery_with_unique_id(
         result = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_DISCOVERY}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
@@ -5016,7 +5016,7 @@ async def test_default_discovery_abort_existing_entries(
         result = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_DISCOVERY}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["type"] is data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "already_configured"
 
 
@@ -5047,13 +5047,13 @@ async def test_default_discovery_in_progress(
             context={"source": config_entries.SOURCE_DISCOVERY},
             data={"unique_id": "mock-unique-id"},
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
 
         # Second discovery without a unique ID
         result2 = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
         )
-        assert result2["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result2["type"] is data_entry_flow.FlowResultType.ABORT
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
@@ -5086,7 +5086,7 @@ async def test_default_discovery_abort_on_new_unique_flow(
         result2 = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
         )
-        assert result2["type"] == data_entry_flow.FlowResultType.FORM
+        assert result2["type"] is data_entry_flow.FlowResultType.FORM
 
         # Second discovery brings in a unique ID
         result = await manager.flow.async_init(
@@ -5094,7 +5094,7 @@ async def test_default_discovery_abort_on_new_unique_flow(
             context={"source": config_entries.SOURCE_DISCOVERY},
             data={"unique_id": "mock-unique-id"},
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
 
     # Ensure the first one is cancelled and we end up with just the last one
     flows = hass.config_entries.flow.async_progress()
@@ -5133,7 +5133,7 @@ async def test_default_discovery_abort_on_user_flow_complete(
         flow1 = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
         )
-        assert flow1["type"] == data_entry_flow.FlowResultType.FORM
+        assert flow1["type"] is data_entry_flow.FlowResultType.FORM
 
         flows = hass.config_entries.flow.async_progress()
         assert len(flows) == 1
@@ -5142,14 +5142,14 @@ async def test_default_discovery_abort_on_user_flow_complete(
         flow2 = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_USER}
         )
-        assert flow2["type"] == data_entry_flow.FlowResultType.FORM
+        assert flow2["type"] is data_entry_flow.FlowResultType.FORM
 
         flows = hass.config_entries.flow.async_progress()
         assert len(flows) == 2
 
         # Complete the manual flow
         result = await hass.config_entries.flow.async_configure(flow2["flow_id"], {})
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
     # Ensure the first flow is gone now
     flows = hass.config_entries.flow.async_progress()
@@ -5213,7 +5213,7 @@ async def test_flow_same_device_multiple_sources(
         result2 = await manager.flow.async_configure(
             flows[0]["flow_id"], user_input={"fake": "data"}
         )
-        assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result2["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
     assert len(hass.config_entries.flow.async_progress()) == 0
 
@@ -7025,7 +7025,7 @@ async def test_update_entry_and_reload(
     assert entry.unique_id == expected_unique_id
     assert entry.data == expected_data
     assert entry.options == expected_options
-    assert entry.state == config_entries.ConfigEntryState.LOADED
+    assert entry.state is config_entries.ConfigEntryState.LOADED
     if raises:
         assert isinstance(err, raises)
     else:
@@ -7167,7 +7167,7 @@ async def test_update_entry_without_reload(
     assert entry.unique_id == "5678"
     assert entry.data == {"vendor": "data2"}
     assert entry.options == {"vendor": "options2"}
-    assert entry.state == config_entries.ConfigEntryState.LOADED
+    assert entry.state is config_entries.ConfigEntryState.LOADED
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == reason
     # Assert entry is not reloaded
@@ -8028,7 +8028,7 @@ async def test_avoid_adding_second_config_entry_on_single_config_entry(
         result = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
 
         # Add a config entry
         entry = MockConfigEntry(
@@ -8044,7 +8044,7 @@ async def test_avoid_adding_second_config_entry_on_single_config_entry(
         result = await manager.flow.async_configure(
             result["flow_id"], user_input={"host": "127.0.0.1"}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["type"] is data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "single_instance_allowed"
         assert result["translation_domain"] == HOMEASSISTANT_DOMAIN
 
@@ -8112,18 +8112,18 @@ async def test_in_progress_get_canceled_when_entry_is_created(
         result = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
 
         # Will be canceled
         result2 = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_USER}
         )
-        assert result2["type"] == data_entry_flow.FlowResultType.FORM
+        assert result2["type"] is data_entry_flow.FlowResultType.FORM
 
         result = await manager.flow.async_configure(
             result["flow_id"], user_input={"host": "127.0.0.1"}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
     assert len(manager.flow.async_progress()) == 0
     assert len(manager.async_entries()) == 1
@@ -8802,7 +8802,7 @@ async def test_async_has_matching_discovery_flow(
             context={"source": config_entries.SOURCE_HOMEKIT},
             data={"properties": {"id": "aa:bb:cc:dd:ee:ff"}},
         )
-    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+    assert result["type"] is data_entry_flow.FlowResultType.SHOW_PROGRESS
     assert result["progress_action"] == "task_one"
     assert len(manager.flow.async_progress()) == 1
     assert len(manager.flow.async_progress_by_handler("test")) == 1
@@ -10128,7 +10128,7 @@ async def test_config_flow_abort_with_next_flow(hass: HomeAssistant) -> None:
             "test", context={"source": config_entries.SOURCE_USER}
         )
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "provision_successful"
     assert "next_flow" in result
     assert result["next_flow"][0] == config_entries.FlowType.CONFIG_FLOW
@@ -10246,7 +10246,7 @@ async def test_config_flow_create_entry_with_next_flow(hass: HomeAssistant) -> N
             "test", context={"source": config_entries.SOURCE_USER}
         )
 
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Test Entry"
     assert "next_flow" in result
     assert result["next_flow"][0] == config_entries.FlowType.CONFIG_FLOW
@@ -10322,7 +10322,7 @@ async def test_discovery_flow_dismiss_protected_on_configure(
                 type="_tcp.local.",
             ),
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "confirm"
 
         # Before user interaction, dismiss_protected should not be set
@@ -10331,7 +10331,7 @@ async def test_discovery_flow_dismiss_protected_on_configure(
 
         # User configures the flow
         result = await manager.flow.async_configure(result["flow_id"])
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
 
         # After user interaction, dismiss_protected should be set
         context = _get_flow_context(manager, result["flow_id"])
@@ -10341,7 +10341,7 @@ async def test_discovery_flow_dismiss_protected_on_configure(
         result = await manager.flow.async_configure(
             result["flow_id"], user_input={"fake": "data"}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 async def test_user_flow_not_dismiss_protected_on_configure(
@@ -10376,13 +10376,13 @@ async def test_user_flow_not_dismiss_protected_on_configure(
         result = await manager.flow.async_init(
             "comp", context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
 
         # User configures the flow
         result = await manager.flow.async_configure(
             result["flow_id"], user_input={"fake": "data"}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is data_entry_flow.FlowResultType.FORM
 
         # User flows should not be marked as dismiss protected
         context = _get_flow_context(manager, result["flow_id"])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -667,7 +667,7 @@ async def test_stage_shutdown_generic_error(
         assert patched_call.called
 
     assert "test_exception" in caplog.text
-    assert hass.state == ha.CoreState.stopped
+    assert hass.state is ha.CoreState.stopped
 
 
 async def test_stage_shutdown_with_exit_code(hass: HomeAssistant) -> None:
@@ -2056,12 +2056,12 @@ async def test_start_taking_too_long(caplog: pytest.LogCaptureFixture) -> None:
         with patch("asyncio.wait", return_value=(set(), {asyncio.Future()})):
             await hass.async_start()
 
-        assert hass.state == ha.CoreState.running
+        assert hass.state is ha.CoreState.running
         assert "Something is blocking Home Assistant" in caplog.text
 
     finally:
         await hass.async_stop()
-        assert hass.state == ha.CoreState.stopped
+        assert hass.state is ha.CoreState.stopped
 
 
 async def test_service_executed_with_subservices(hass: HomeAssistant) -> None:
@@ -3029,19 +3029,19 @@ def test_is_callback_check_partial() -> None:
         pass
 
     assert ha.is_callback(callback_func)
-    assert HassJob(callback_func).job_type == ha.HassJobType.Callback
+    assert HassJob(callback_func).job_type is ha.HassJobType.Callback
     assert ha.is_callback_check_partial(functools.partial(callback_func))
-    assert HassJob(functools.partial(callback_func)).job_type == ha.HassJobType.Callback
+    assert HassJob(functools.partial(callback_func)).job_type is ha.HassJobType.Callback
     assert ha.is_callback_check_partial(
         functools.partial(functools.partial(callback_func))
     )
-    assert HassJob(functools.partial(functools.partial(callback_func))).job_type == (
+    assert HassJob(functools.partial(functools.partial(callback_func))).job_type is (
         ha.HassJobType.Callback
     )
     assert not ha.is_callback_check_partial(not_callback_func)
-    assert HassJob(not_callback_func).job_type == ha.HassJobType.Executor
+    assert HassJob(not_callback_func).job_type is ha.HassJobType.Executor
     assert not ha.is_callback_check_partial(functools.partial(not_callback_func))
-    assert HassJob(functools.partial(not_callback_func)).job_type == (
+    assert HassJob(functools.partial(not_callback_func)).job_type is (
         ha.HassJobType.Executor
     )
 
@@ -3049,7 +3049,7 @@ def test_is_callback_check_partial() -> None:
     assert not ha.is_callback_check_partial(
         ha.callback(functools.partial(not_callback_func))
     )
-    assert HassJob(ha.callback(functools.partial(not_callback_func))).job_type == (
+    assert HassJob(ha.callback(functools.partial(not_callback_func))).job_type is (
         ha.HassJobType.Executor
     )
 
@@ -3066,13 +3066,13 @@ def test_hassjob_passing_job_type() -> None:
 
     assert (
         HassJob(callback_func, job_type=ha.HassJobType.Callback).job_type
-        == ha.HassJobType.Callback
+        is ha.HassJobType.Callback
     )
 
     # We should trust the job_type passed in
     assert (
         HassJob(not_callback_func, job_type=ha.HassJobType.Callback).job_type
-        == ha.HassJobType.Callback
+        is ha.HassJobType.Callback
     )
 
 

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -106,7 +106,7 @@ async def test_configure_two_steps(manager: MockFlowManager) -> None:
         form = await manager.async_configure(form["flow_id"], "INCORRECT-DATA")
 
     form = await manager.async_configure(form["flow_id"], ["SECOND-DATA"])
-    assert form["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert form["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert len(manager.async_progress()) == 0
     assert len(manager.mock_created_entries) == 1
     result = manager.mock_created_entries[0]
@@ -128,7 +128,7 @@ async def test_show_form(manager: MockFlowManager) -> None:
             )
 
     form = await manager.async_init("test")
-    assert form["type"] == data_entry_flow.FlowResultType.FORM
+    assert form["type"] is data_entry_flow.FlowResultType.FORM
     assert form["data_schema"] is schema
     assert form["errors"] == {"username": "Should be unique."}
 
@@ -183,7 +183,7 @@ async def test_form_shows_with_added_suggested_values(manager: MockFlowManager) 
             "section_1": {"full_name": "John Doe"},
         },
     )
-    assert form["type"] == data_entry_flow.FlowResultType.FORM
+    assert form["type"] is data_entry_flow.FlowResultType.FORM
     assert form["data_schema"].schema is not schema.schema
     assert form["data_schema"].schema != schema.schema
     compare_schemas(form["data_schema"], schema)
@@ -210,7 +210,7 @@ async def test_form_shows_with_added_suggested_values(manager: MockFlowManager) 
     form = await manager.async_init(
         "test",
     )
-    assert form["type"] == data_entry_flow.FlowResultType.FORM
+    assert form["type"] is data_entry_flow.FlowResultType.FORM
     assert form["data_schema"].schema is not schema.schema
     assert form["data_schema"].schema == schema.schema
     markers = list(form["data_schema"].schema)
@@ -441,16 +441,16 @@ async def test_finish_callback_change_result_type(hass: HomeAssistant) -> None:
     manager = FlowManager(hass)
 
     result = await manager.async_init("test")
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await manager.async_configure(result["flow_id"], {"count": 0})
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
     assert "result" not in result
 
     result = await manager.async_configure(result["flow_id"], {"count": 2})
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["result"] == 2
 
 
@@ -480,7 +480,7 @@ async def test_external_step(hass: HomeAssistant, manager: MockFlowManager) -> N
     )
 
     result = await manager.async_init("test")
-    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
+    assert result["type"] is data_entry_flow.FlowResultType.EXTERNAL_STEP
     assert len(manager.async_progress()) == 1
     assert len(manager.async_progress_by_handler("test")) == 1
     assert manager.async_get(result["flow_id"])["handler"] == "test"
@@ -488,7 +488,7 @@ async def test_external_step(hass: HomeAssistant, manager: MockFlowManager) -> N
     # Mimic external step
     # Called by integrations: `hass.config_entries.flow.async_configure(…)`
     result = await manager.async_configure(result["flow_id"], {"title": "Hello"})
-    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP_DONE
+    assert result["type"] is data_entry_flow.FlowResultType.EXTERNAL_STEP_DONE
 
     await hass.async_block_till_done()
     assert len(events) == 1
@@ -500,7 +500,7 @@ async def test_external_step(hass: HomeAssistant, manager: MockFlowManager) -> N
 
     # Frontend refreshes the flow
     result = await manager.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Hello"
 
 
@@ -573,7 +573,7 @@ async def test_show_progress(hass: HomeAssistant, manager: MockFlowManager) -> N
     )
 
     result = await manager.async_init("test")
-    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+    assert result["type"] is data_entry_flow.FlowResultType.SHOW_PROGRESS
     assert result["progress_action"] == "task_one"
     assert len(manager.async_progress()) == 1
     assert len(manager.async_progress_by_handler("test")) == 1
@@ -592,7 +592,7 @@ async def test_show_progress(hass: HomeAssistant, manager: MockFlowManager) -> N
 
     # Frontend refreshes the flow
     result = await manager.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+    assert result["type"] is data_entry_flow.FlowResultType.SHOW_PROGRESS
     assert result["progress_action"] == "task_two"
     assert len(progress_update_events) == 1
     assert progress_update_events[0].data == {
@@ -620,7 +620,7 @@ async def test_show_progress(hass: HomeAssistant, manager: MockFlowManager) -> N
 
     # Frontend refreshes the flow
     result = await manager.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Hello"
 
 
@@ -667,7 +667,7 @@ async def test_show_progress_error(
     )
 
     result = await manager.async_init("test")
-    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+    assert result["type"] is data_entry_flow.FlowResultType.SHOW_PROGRESS
     assert result["progress_action"] == "task"
     assert len(manager.async_progress()) == 1
     assert len(manager.async_progress_by_handler("test")) == 1
@@ -685,7 +685,7 @@ async def test_show_progress_error(
 
     # Frontend refreshes the flow
     result = await manager.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "error"
 
 
@@ -726,7 +726,7 @@ async def test_show_progress_hidden_from_frontend(
             return self.async_create_entry(title=None, data=self.data)
 
     result = await manager.async_init("test")
-    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+    assert result["type"] is data_entry_flow.FlowResultType.SHOW_PROGRESS
     assert result["progress_action"] == "task"
     assert len(manager.async_progress()) == 1
     assert len(manager.async_progress_by_handler("test")) == 1
@@ -737,7 +737,7 @@ async def test_show_progress_hidden_from_frontend(
 
     # Frontend refreshes the flow
     result = await manager.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert async_show_progress_done_called
 
 
@@ -786,7 +786,7 @@ async def test_show_progress_legacy(
     )
 
     result = await manager.async_init("test")
-    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+    assert result["type"] is data_entry_flow.FlowResultType.SHOW_PROGRESS
     assert result["progress_action"] == "task_one"
     assert len(manager.async_progress()) == 1
     assert len(manager.async_progress_by_handler("test")) == 1
@@ -795,7 +795,7 @@ async def test_show_progress_legacy(
     # Mimic task one done and moving to task two
     # Called by integrations: `hass.config_entries.flow.async_configure(…)`
     result = await manager.async_configure(result["flow_id"], {"task_finished": 1})
-    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+    assert result["type"] is data_entry_flow.FlowResultType.SHOW_PROGRESS
     assert result["progress_action"] == "task_two"
 
     await hass.async_block_till_done()
@@ -808,7 +808,7 @@ async def test_show_progress_legacy(
 
     # Frontend refreshes the flow
     result = await manager.async_configure(result["flow_id"])
-    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+    assert result["type"] is data_entry_flow.FlowResultType.SHOW_PROGRESS
     assert result["progress_action"] == "task_two"
 
     # Mimic task two done and continuing step
@@ -818,13 +818,13 @@ async def test_show_progress_legacy(
     )
     # Note: The SHOW_PROGRESS_DONE is not hidden from frontend when flows manage
     # the progress tasks themselves
-    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS_DONE
+    assert result["type"] is data_entry_flow.FlowResultType.SHOW_PROGRESS_DONE
 
     # Frontend refreshes the flow
     result = await manager.async_configure(
         result["flow_id"], {"task_finished": 2, "title": "Hello"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "Hello"
 
     await hass.async_block_till_done()
@@ -890,7 +890,7 @@ async def test_show_progress_fires_only_when_changed(
                 },
             },
         )
-        assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+        assert result["type"] is data_entry_flow.FlowResultType.SHOW_PROGRESS
         assert result["progress_action"] == progress_action
         assert (
             result["description_placeholders"]["progress"]
@@ -907,7 +907,7 @@ async def test_show_progress_fires_only_when_changed(
             }
 
     result = await manager.async_init("test")
-    assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+    assert result["type"] is data_entry_flow.FlowResultType.SHOW_PROGRESS
     assert result["progress_action"] == "task_one"
     assert len(manager.async_progress()) == 1
     assert len(manager.async_progress_by_handler("test")) == 1
@@ -939,7 +939,7 @@ async def test_abort_flow_exception_step(manager: MockFlowManager) -> None:
             raise data_entry_flow.AbortFlow("mock-reason", {"placeholder": "yo"})
 
     form = await manager.async_init("test")
-    assert form["type"] == data_entry_flow.FlowResultType.ABORT
+    assert form["type"] is data_entry_flow.FlowResultType.ABORT
     assert form["reason"] == "mock-reason"
     assert form["description_placeholders"] == {"placeholder": "yo"}
 
@@ -966,7 +966,7 @@ async def test_abort_flow_exception_finish_flow(hass: HomeAssistant) -> None:
     manager = FlowManager(hass)
 
     form = await manager.async_init("test")
-    assert form["type"] == data_entry_flow.FlowResultType.ABORT
+    assert form["type"] is data_entry_flow.FlowResultType.ABORT
     assert form["reason"] == "mock-reason"
     assert form["description_placeholders"] == {"placeholder": "yo"}
 
@@ -1058,7 +1058,7 @@ async def test_manager_abort_calls_async_flow_removed(manager: MockFlowManager) 
 
     manager.async_flow_removed = Mock()
     result = await manager.async_init("test")
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "init"
 
     manager.async_flow_removed.assert_not_called()
@@ -1109,7 +1109,7 @@ async def test_show_menu(
             return self.async_show_form(step_id="target2")
 
     result = await manager.async_init("test")
-    assert result["type"] == data_entry_flow.FlowResultType.MENU
+    assert result["type"] is data_entry_flow.FlowResultType.MENU
     assert result["menu_options"] == menu_options
     assert result["description_placeholders"] == {"name": "Paulus"}
     assert result.get("sort") == expect_sort
@@ -1121,7 +1121,7 @@ async def test_show_menu(
     result = await manager.async_configure(
         result["flow_id"], {"next_step_id": "target1"}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "target1"
 
 
@@ -1196,7 +1196,7 @@ async def test_find_flows_by_init_data_type(manager: MockFlowManager) -> None:
     bluetooth_result = await manager.async_configure(
         bluetooth_form["flow_id"], ["SECOND-DATA"]
     )
-    assert bluetooth_result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert bluetooth_result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
     assert len(manager.async_progress()) == 1
     assert len(manager.mock_created_entries) == 1
     result = manager.mock_created_entries[0]


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

<!-- No "Breaking change" section — pure semantic equivalence. -->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Mechanical codemod that replaces `==` with `is` (and `!=` with `is not`)
on every line where both operands statically resolve to the same enum
class — as identified by `mypy_plugins.enum_identity_compare` from
#171551.

**This PR covers `tests/` files only** (95 files). The corresponding
source-side codemod is in #171591.

```python
# Before:
assert result["type"] == FlowResultType.FORM   # both sides resolve to FlowResultType
# After:
assert result["type"] is FlowResultType.FORM
```

**Scope is intentionally narrow:**

- **Plain `enum.Enum` subclasses** — 100% safe, because `Enum.__eq__`
  is identity-based: `==` and `is` give the same result.
- **`homeassistant.data_entry_flow.FlowResultType`** — the only
  `StrEnum` on a curated allowlist, because HA's framework controls
  every value-assigning callsite. Reviewers have been requesting
  `assert result["type"] is FlowResultType.X` in PR reviews
  consistently for 2 years (~260 review comments across the corpus).

**What is NOT changed:**

- Other `StrEnum`/`IntEnum`/`ReprEnum` subclasses (`HVACMode`,
  `HTTPStatus`, `Platform`, `EntityCategory`, ...). Their `__eq__`
  delegates to `str`/`int` equality and accepts raw primitives —
  test fixtures and `hass.states.async_set` commonly pass the
  string. `is` would silently break those tests.
- `Flag`/`IntFlag` — bitwise `==` is idiomatic.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #171551 (plugin), #171591 (source-side codemod)
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

The codemod is independent of #171551 and of the source-side codemod
(#171591). All three can land in any order; CI on the plugin will be
fully clean only once both codemod halves land.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
