### PR TITLE
Remove unnecessary intermediate variables in zeversolar diagnostics

### DIFF
--- a/homeassistant/components/zeversolar/diagnostics.py
+++ b/homeassistant/components/zeversolar/diagnostics.py
@@ -14,10 +14,9 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, config_entry: ZeversolarConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-
     data: ZeverSolarData = config_entry.runtime_data.data
 
-    payload: dict[str, Any] = {
+    return {
         "wifi_enabled": data.wifi_enabled,
         "serial_or_registry_id": data.serial_or_registry_id,
         "registry_key": data.registry_key,
@@ -33,8 +32,6 @@ async def async_get_config_entry_diagnostics(
         "meter_status": data.meter_status.value,
     }
 
-    return payload
-
 
 async def async_get_device_diagnostics(
     hass: HomeAssistant, entry: ZeversolarConfigEntry, device: DeviceEntry
@@ -42,15 +39,13 @@ async def async_get_device_diagnostics(
     """Return diagnostics for a device entry."""
     coordinator = entry.runtime_data
 
-    updateInterval = (
-        None
-        if coordinator.update_interval is None
-        else coordinator.update_interval.total_seconds()
-    )
-
     return {
         "name": coordinator.name,
         "always_update": coordinator.always_update,
         "last_update_success": coordinator.last_update_success,
-        "update_interval": updateInterval,
+        "update_interval": (
+            None
+            if coordinator.update_interval is None
+            else coordinator.update_interval.total_seconds()
+        ),
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Part of larger clean up and improvements. In this PR:
- Remove the intermediate payload variable in async_get_config_entry_diagnostics — return the dict directly
- Inline the updateInterval camelCase variable in async_get_device_diagnostics — no behaviour change, just cleaner code

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->



## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
