### PR TITLE
Add notify entity to System Bridge integration

### DIFF
--- a/homeassistant/components/system_bridge/__init__.py
+++ b/homeassistant/components/system_bridge/__init__.py
@@ -215,12 +215,9 @@ async def async_setup_entry(
 
     entry.runtime_data = coordinator
 
-    # Set up all platforms except notify
-    await hass.config_entries.async_forward_entry_setups(
-        entry, [platform for platform in PLATFORMS if platform != Platform.NOTIFY]
-    )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    # Set up notify platform
+    # Set up legacy notify platform
     hass.async_create_task(
         discovery.async_load_platform(
             hass,

--- a/homeassistant/components/system_bridge/entity.py
+++ b/homeassistant/components/system_bridge/entity.py
@@ -17,13 +17,13 @@ class SystemBridgeEntity(CoordinatorEntity[SystemBridgeDataUpdateCoordinator]):
         self,
         coordinator: SystemBridgeDataUpdateCoordinator,
         api_port: int,
-        key: str,
+        key: str | None = None,
     ) -> None:
         """Initialize the System Bridge entity."""
         super().__init__(coordinator)
 
         self._hostname = coordinator.data.system.hostname
-        self._key = f"{self._hostname}_{key}"
+        self._key = f"{self._hostname}_{key}" if key is not None else self._hostname
         self._configuration_url = (
             f"http://{self._hostname}:{api_port}/app/settings.html"
         )

--- a/homeassistant/components/system_bridge/notify.py
+++ b/homeassistant/components/system_bridge/notify.py
@@ -54,7 +54,9 @@ class SystemBridgeNotifyEntity(SystemBridgeEntity, NotifyEntity):
 
     async def async_send_message(self, message: str, title: str | None = None) -> None:
         """Send a message via notify.send_message action."""
-        notification = Notification(message=message, title=title or ATTR_TITLE_DEFAULT)
+        notification = Notification(
+            message=message, title=ATTR_TITLE_DEFAULT if title is None else title
+        )
         try:
             await self.coordinator.websocket_client.send_notification(notification)
         except ConnectionClosedException as e:

--- a/homeassistant/components/system_bridge/notify.py
+++ b/homeassistant/components/system_bridge/notify.py
@@ -3,6 +3,7 @@
 import logging
 from typing import Any
 
+from systembridgeconnector.exceptions import ConnectionClosedException
 from systembridgeconnector.models.notification import Notification
 
 from homeassistant.components.notify import (
@@ -10,12 +11,18 @@ from homeassistant.components.notify import (
     ATTR_TITLE,
     ATTR_TITLE_DEFAULT,
     BaseNotificationService,
+    NotifyEntity,
+    NotifyEntityFeature,
 )
-from homeassistant.const import ATTR_ICON, CONF_ENTITY_ID
+from homeassistant.const import ATTR_ICON, CONF_ENTITY_ID, CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
+from .const import DOMAIN
 from .coordinator import SystemBridgeConfigEntry, SystemBridgeDataUpdateCoordinator
+from .entity import SystemBridgeEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,6 +30,42 @@ ATTR_ACTIONS = "actions"
 ATTR_AUDIO = "audio"
 ATTR_IMAGE = "image"
 ATTR_TIMEOUT = "timeout"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: SystemBridgeConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the notification entity platform."""
+
+    coordinator = config_entry.runtime_data
+
+    async_add_entities(
+        [SystemBridgeNotifyEntity(coordinator, config_entry.data[CONF_PORT])]
+    )
+
+
+class SystemBridgeNotifyEntity(SystemBridgeEntity, NotifyEntity):
+    """Representation of a notification entity."""
+
+    _attr_supported_features = NotifyEntityFeature.TITLE
+    _attr_name = None
+
+    async def async_send_message(self, message: str, title: str | None = None) -> None:
+        """Send a message via notify.send_message action."""
+        notification = Notification(message=message, title=title or ATTR_TITLE_DEFAULT)
+        try:
+            await self.coordinator.websocket_client.send_notification(notification)
+        except ConnectionClosedException as e:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="send_message_failed",
+                translation_placeholders={
+                    "title": self.coordinator.config_entry.title,
+                    "host": self.coordinator.config_entry.data[CONF_HOST],
+                },
+            ) from e
 
 
 async def async_get_service(

--- a/homeassistant/components/system_bridge/strings.json
+++ b/homeassistant/components/system_bridge/strings.json
@@ -115,7 +115,7 @@
       "message": "Could not find process with ID {id}."
     },
     "send_message_failed": {
-      "message": "Failed to send message to {title} ({host}) due to a connection error."
+      "message": "Failed to send message to {title} ({host}) due to a connection error"
     },
     "timeout": {
       "message": "A timeout occurred for {title} ({host})"

--- a/homeassistant/components/system_bridge/strings.json
+++ b/homeassistant/components/system_bridge/strings.json
@@ -114,6 +114,9 @@
     "process_not_found": {
       "message": "Could not find process with ID {id}."
     },
+    "send_message_failed": {
+      "message": "Sending message to {title} ({host}) failed due to a connection error"
+    },
     "timeout": {
       "message": "A timeout occurred for {title} ({host})"
     },

--- a/homeassistant/components/system_bridge/strings.json
+++ b/homeassistant/components/system_bridge/strings.json
@@ -115,7 +115,7 @@
       "message": "Could not find process with ID {id}."
     },
     "send_message_failed": {
-      "message": "Sending message to {title} ({host}) failed due to a connection error"
+      "message": "Failed to send message to {title} ({host}) due to a connection error."
     },
     "timeout": {
       "message": "A timeout occurred for {title} ({host})"

--- a/tests/components/system_bridge/snapshots/test_notify.ambr
+++ b/tests/components/system_bridge/snapshots/test_notify.ambr
@@ -1,0 +1,52 @@
+# serializer version: 1
+# name: test_notify_platform[notify.hostname-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'notify',
+    'entity_category': None,
+    'entity_id': 'notify.hostname',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'system_bridge',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <NotifyEntityFeature: 1>,
+    'translation_key': None,
+    'unique_id': 'hostname',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_notify_platform[notify.hostname-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'hostname',
+      'supported_features': <NotifyEntityFeature: 1>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'notify.hostname',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/system_bridge/test_notify.py
+++ b/tests/components/system_bridge/test_notify.py
@@ -1,0 +1,126 @@
+"""Tests for the System Bridgy notify platform."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+from systembridgeconnector.exceptions import ConnectionClosedException
+from systembridgeconnector.models.notification import Notification
+
+from homeassistant.components.notify import (
+    ATTR_MESSAGE,
+    ATTR_TITLE,
+    DOMAIN as NOTIFY_DOMAIN,
+    SERVICE_SEND_MESSAGE,
+)
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.fixture(autouse=True)
+def notify_only() -> Generator[None]:
+    """Enable only the notify platform."""
+    with patch(
+        "homeassistant.components.system_bridge.PLATFORMS",
+        [Platform.NOTIFY],
+    ):
+        yield
+
+
+@pytest.mark.usefixtures("mock_version", "mock_websocket_client")
+async def test_notify_platform(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test setup of the notify platform."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.usefixtures("mock_version")
+@pytest.mark.freeze_time("2009-02-13T23:31:30.000Z")
+async def test_send_message(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_websocket_client: AsyncMock,
+) -> None:
+    """Test sending a message."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    state = hass.states.get("notify.hostname")
+    assert state
+    assert state.state == STATE_UNKNOWN
+
+    await hass.services.async_call(
+        NOTIFY_DOMAIN,
+        SERVICE_SEND_MESSAGE,
+        {
+            ATTR_ENTITY_ID: "notify.hostname",
+            ATTR_MESSAGE: "World",
+            ATTR_TITLE: "Hello",
+        },
+        blocking=True,
+    )
+
+    state = hass.states.get("notify.hostname")
+    assert state
+    assert state.state == "2009-02-13T23:31:30+00:00"
+
+    mock_websocket_client.send_notification.assert_awaited_once_with(
+        Notification(title="Hello", message="World")
+    )
+
+
+@pytest.mark.usefixtures("mock_version")
+@pytest.mark.freeze_time("2009-02-13T23:31:30.000Z")
+async def test_send_message_exception(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_websocket_client: AsyncMock,
+) -> None:
+    """Test sending a message with exception."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    mock_websocket_client.send_notification.side_effect = ConnectionClosedException
+
+    with pytest.raises(HomeAssistantError) as e:
+        await hass.services.async_call(
+            NOTIFY_DOMAIN,
+            SERVICE_SEND_MESSAGE,
+            {
+                ATTR_ENTITY_ID: "notify.hostname",
+                ATTR_MESSAGE: "World",
+                ATTR_TITLE: "Hello",
+            },
+            blocking=True,
+        )
+
+    mock_websocket_client.send_notification.assert_awaited_once_with(
+        Notification(title="Hello", message="World")
+    )
+    assert e.value.translation_key == "send_message_failed"
+    assert e.value.translation_placeholders == {
+        "title": "TestSystem",
+        "host": "127.0.0.1",
+    }

--- a/tests/components/system_bridge/test_notify.py
+++ b/tests/components/system_bridge/test_notify.py
@@ -1,4 +1,4 @@
-"""Tests for the System Bridgy notify platform."""
+"""Tests for the System Bridge notify platform."""
 
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Adds a notify entity to the System Bridge integration

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45496
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
