### PR TITLE
Update strings.json to align with HomeWizard app

### DIFF
--- a/homeassistant/components/homewizard/strings.json
+++ b/homeassistant/components/homewizard/strings.json
@@ -61,13 +61,13 @@
     },
     "select": {
       "battery_group_mode": {
-        "name": "Battery group mode",
+        "name": "Battery group charging strategy",
         "state": {
           "standby": "Standby",
-          "to_full": "Manual charge mode",
-          "zero": "Zero mode",
-          "zero_charge_only": "Zero mode (charge only)",
-          "zero_discharge_only": "Zero mode (discharge only)"
+          "to_full": "One-time full charge",
+          "zero": "Net zero",
+          "zero_charge_only": "Net zero (charge only)",
+          "zero_discharge_only": "Net zero (discharge only)"
         }
       }
     },

--- a/tests/components/homewizard/snapshots/test_select.ambr
+++ b/tests/components/homewizard/snapshots/test_select.ambr
@@ -1,8 +1,8 @@
 # serializer version: 1
-# name: test_select_entity_snapshots[HWE-P1-select.device_battery_group_mode]
+# name: test_select_entity_snapshots[HWE-P1-select.device_battery_group_charging_strategy]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Device Battery group mode',
+      'friendly_name': 'Device Battery group charging strategy',
       'options': list([
         'standby',
         'to_full',
@@ -10,14 +10,14 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'select.device_battery_group_mode',
+    'entity_id': 'select.device_battery_group_charging_strategy',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'zero',
   })
 # ---
-# name: test_select_entity_snapshots[HWE-P1-select.device_battery_group_mode].1
+# name: test_select_entity_snapshots[HWE-P1-select.device_battery_group_charging_strategy].1
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -37,7 +37,7 @@
     'disabled_by': None,
     'domain': 'select',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'select.device_battery_group_mode',
+    'entity_id': 'select.device_battery_group_charging_strategy',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -45,12 +45,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Battery group mode',
+    'object_id_base': 'Battery group charging strategy',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Battery group mode',
+    'original_name': 'Battery group charging strategy',
     'platform': 'homewizard',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -60,7 +60,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_select_entity_snapshots[HWE-P1-select.device_battery_group_mode].2
+# name: test_select_entity_snapshots[HWE-P1-select.device_battery_group_charging_strategy].2
   DeviceRegistryEntrySnapshot({
     'area_id': None,
     'config_entries': <ANY>,

--- a/tests/components/homewizard/test_select.py
+++ b/tests/components/homewizard/test_select.py
@@ -33,31 +33,31 @@ pytestmark = [
         (
             "HWE-WTR",
             [
-                "select.device_battery_group_mode",
+                "select.device_battery_group_charging_strategy",
             ],
         ),
         (
             "SDM230",
             [
-                "select.device_battery_group_mode",
+                "select.device_battery_group_charging_strategy",
             ],
         ),
         (
             "SDM630",
             [
-                "select.device_battery_group_mode",
+                "select.device_battery_group_charging_strategy",
             ],
         ),
         (
             "HWE-KWH1",
             [
-                "select.device_battery_group_mode",
+                "select.device_battery_group_charging_strategy",
             ],
         ),
         (
             "HWE-KWH3",
             [
-                "select.device_battery_group_mode",
+                "select.device_battery_group_charging_strategy",
             ],
         ),
     ],
@@ -74,7 +74,7 @@ async def test_entities_not_created_for_device(
 @pytest.mark.parametrize(
     ("device_fixture", "entity_id"),
     [
-        ("HWE-P1", "select.device_battery_group_mode"),
+        ("HWE-P1", "select.device_battery_group_charging_strategy"),
     ],
 )
 async def test_select_entity_snapshots(
@@ -101,17 +101,22 @@ async def test_select_entity_snapshots(
     [
         (
             "HWE-P1",
-            "select.device_battery_group_mode",
+            "select.device_battery_group_charging_strategy",
             "standby",
             Batteries.Mode.STANDBY,
         ),
         (
             "HWE-P1",
-            "select.device_battery_group_mode",
+            "select.device_battery_group_charging_strategy",
             "to_full",
             Batteries.Mode.TO_FULL,
         ),
-        ("HWE-P1", "select.device_battery_group_mode", "zero", Batteries.Mode.ZERO),
+        (
+            "HWE-P1",
+            "select.device_battery_group_charging_strategy",
+            "zero",
+            Batteries.Mode.ZERO,
+        ),
     ],
 )
 async def test_select_set_option(
@@ -137,9 +142,9 @@ async def test_select_set_option(
 @pytest.mark.parametrize(
     ("device_fixture", "entity_id", "option"),
     [
-        ("HWE-P1", "select.device_battery_group_mode", "zero"),
-        ("HWE-P1", "select.device_battery_group_mode", "standby"),
-        ("HWE-P1", "select.device_battery_group_mode", "to_full"),
+        ("HWE-P1", "select.device_battery_group_charging_strategy", "zero"),
+        ("HWE-P1", "select.device_battery_group_charging_strategy", "standby"),
+        ("HWE-P1", "select.device_battery_group_charging_strategy", "to_full"),
     ],
 )
 async def test_select_request_error(
@@ -168,7 +173,7 @@ async def test_select_request_error(
 @pytest.mark.parametrize(
     ("device_fixture", "entity_id", "option"),
     [
-        ("HWE-P1", "select.device_battery_group_mode", "to_full"),
+        ("HWE-P1", "select.device_battery_group_charging_strategy", "to_full"),
     ],
 )
 async def test_select_unauthorized_error(
@@ -203,7 +208,7 @@ async def test_select_unauthorized_error(
 @pytest.mark.parametrize(
     ("entity_id", "method"),
     [
-        ("select.device_battery_group_mode", "combined"),
+        ("select.device_battery_group_charging_strategy", "combined"),
     ],
 )
 async def test_select_unreachable(
@@ -226,7 +231,7 @@ async def test_select_unreachable(
 @pytest.mark.parametrize(
     ("device_fixture", "entity_id"),
     [
-        ("HWE-P1", "select.device_battery_group_mode"),
+        ("HWE-P1", "select.device_battery_group_charging_strategy"),
     ],
 )
 async def test_select_multiple_state_changes(
@@ -275,7 +280,7 @@ async def test_select_multiple_state_changes(
         (
             "HWE-P1-no-batteries",
             [
-                "select.device_battery_group_mode",
+                "select.device_battery_group_charging_strategy",
             ],
         ),
     ],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

Align the battery mode strings with how they're called in the HomeWizard app.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45513
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
