### PR TITLE
Improve tests of trigger variables

### DIFF
--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -150,6 +150,15 @@ class _MockTrigger(Trigger):
         return self._hass.bus.async_listen("mock_trigger_fire", _on_event)
 
 
+_BASE_DATA_TEMPLATE = {
+    "name": "{{ name }}",
+    "via_event": "{{ via_event }}",
+    "trigger_id": "{{ trigger.id }}",
+    "trigger_idx": "{{ trigger.idx }}",
+    "trigger_platform": "{{ trigger.platform }}",
+    "trigger_description": "{{ trigger.description }}",
+    "this_entity_id": "{{ this.entity_id }}",
+}
 _LEGACY_TRIGGER = {"platform": "event", "event_type": "test_event"}
 _LEGACY_PER_TRIGGER_VARS = {
     "name": "Paulus",
@@ -173,23 +182,6 @@ _MODERN_PER_TRIGGER_VARS = {
     "name": "Paulus",
     "via_event": "{{ trigger.entity_id }}",
 }
-_BASE_DATA_TEMPLATE = {
-    "name": "{{ name }}",
-    "via_event": "{{ via_event }}",
-    "trigger_id": "{{ trigger.id }}",
-    "trigger_idx": "{{ trigger.idx }}",
-    "trigger_platform": "{{ trigger.platform }}",
-    "trigger_description": "{{ trigger.description }}",
-    "this_entity_id": "{{ this.entity_id }}",
-}
-_MOCK_DATA_TEMPLATE = {
-    **_BASE_DATA_TEMPLATE,
-    "top_level_extra": "{{ extra_var | default('NOT_AT_TOP_LEVEL') }}",
-    "trigger_extra_var": "{{ trigger.extra_var }}",
-    "trigger_rendered_option": "{{ trigger.rendered_option }}",
-    "automation_in_action": "{{ automation_var }}",
-    "per_trigger_in_action": "{{ per_trigger_var }}",
-}
 _MODERN_EXPECTED = {
     "name": "Paulus",
     "via_event": "event.foo",
@@ -198,6 +190,14 @@ _MODERN_EXPECTED = {
     "trigger_platform": "event.received",
     "trigger_description": "state of event.foo",
     "this_entity_id": "automation.automation_0",
+}
+_MOCK_DATA_TEMPLATE = {
+    **_BASE_DATA_TEMPLATE,
+    "top_level_extra": "{{ extra_var | default('NOT_AT_TOP_LEVEL') }}",
+    "trigger_extra_var": "{{ trigger.extra_var }}",
+    "trigger_rendered_option": "{{ trigger.rendered_option }}",
+    "automation_in_action": "{{ automation_var }}",
+    "per_trigger_in_action": "{{ per_trigger_var }}",
 }
 _MOCK_EXPECTED = {
     "name": "Paulus",

--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -46,6 +46,7 @@ from homeassistant.helpers.automation import (
     DomainSpec,
     move_top_level_schema_fields_to_options,
 )
+from homeassistant.helpers.template import Template
 from homeassistant.helpers.trigger import (
     ATTR_BEHAVIOR,
     BEHAVIOR_ANY,
@@ -103,35 +104,275 @@ async def test_trigger_subtype(hass: HomeAssistant) -> None:
         assert integration_mock.call_args == call(hass, "test")
 
 
-async def test_trigger_variables(
-    hass: HomeAssistant, service_calls: list[ServiceCall]
-) -> None:
-    """Test trigger variables."""
-    assert await async_setup_component(
-        hass,
-        "automation",
-        {
-            "automation": {
+class _MockTrigger(Trigger):
+    """Mock modern trigger demonstrating variable-handling.
+
+    Fires when the bus event ``mock_trigger_fire`` is observed, emitting
+    an ``extra_var`` in the extra_trigger_payload and a ``rendered_option``
+    field containing the result of rendering a config-supplied template
+    against the variables the Trigger class has access to at attach time
+    — which is none.
+    """
+
+    @classmethod
+    async def async_validate_config(
+        cls, hass: HomeAssistant, config: ConfigType
+    ) -> ConfigType:
+        """Validate config."""
+        return config
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Initialize the mock trigger."""
+        super().__init__(hass, config)
+        self._options = config.options or {}
+
+    async def async_attach_runner(
+        self, run_action: TriggerActionRunner
+    ) -> CALLBACK_TYPE:
+        """Attach the trigger to a bus event."""
+        raw_template = self._options.get("option_template")
+        if raw_template is not None:
+            rendered_option = Template(raw_template, self._hass).async_render({})
+        else:
+            rendered_option = "<no_template>"
+
+        @callback
+        def _on_event(event: Any) -> None:
+            run_action(
+                {
+                    "extra_var": "from_extra_payload",
+                    "rendered_option": rendered_option,
+                },
+                "mock fired",
+                event.context,
+            )
+
+        return self._hass.bus.async_listen("mock_trigger_fire", _on_event)
+
+
+_LEGACY_TRIGGER = {"platform": "event", "event_type": "test_event"}
+_LEGACY_PER_TRIGGER_VARS = {
+    "name": "Paulus",
+    "via_event": "{{ trigger.event.event_type }}",
+}
+_LEGACY_EXPECTED = {
+    "name": "Paulus",
+    "via_event": "test_event",
+    "trigger_id": 0,
+    "trigger_idx": 0,
+    "trigger_platform": "event",
+    "trigger_description": "event 'test_event'",
+    "this_entity_id": "automation.automation_0",
+}
+_MODERN_TRIGGER = {
+    "platform": "event.received",
+    "target": {"entity_id": "event.foo"},
+    "options": {"event_type": ["button_press"]},
+}
+_MODERN_PER_TRIGGER_VARS = {
+    "name": "Paulus",
+    "via_event": "{{ trigger.entity_id }}",
+}
+_BASE_DATA_TEMPLATE = {
+    "name": "{{ name }}",
+    "via_event": "{{ via_event }}",
+    "trigger_id": "{{ trigger.id }}",
+    "trigger_idx": "{{ trigger.idx }}",
+    "trigger_platform": "{{ trigger.platform }}",
+    "trigger_description": "{{ trigger.description }}",
+    "this_entity_id": "{{ this.entity_id }}",
+}
+_MOCK_DATA_TEMPLATE = {
+    **_BASE_DATA_TEMPLATE,
+    "top_level_extra": "{{ extra_var | default('NOT_AT_TOP_LEVEL') }}",
+    "trigger_extra_var": "{{ trigger.extra_var }}",
+    "trigger_rendered_option": "{{ trigger.rendered_option }}",
+    "automation_in_action": "{{ automation_var }}",
+    "per_trigger_in_action": "{{ per_trigger_var }}",
+}
+_MODERN_EXPECTED = {
+    "name": "Paulus",
+    "via_event": "event.foo",
+    "trigger_id": 0,
+    "trigger_idx": 0,
+    "trigger_platform": "event.received",
+    "trigger_description": "state of event.foo",
+    "this_entity_id": "automation.automation_0",
+}
+_MOCK_EXPECTED = {
+    "name": "Paulus",
+    "via_event": "from_extra_payload",
+    "trigger_id": 0,
+    "trigger_idx": 0,
+    "trigger_platform": "mock_templated_trigger",
+    "trigger_description": "mock fired",
+    "this_entity_id": "automation.automation_0",
+    # New variables emitted by the trigger are wrapped in the
+    # trigger dict and not to top level
+    "top_level_extra": "NOT_AT_TOP_LEVEL",
+    "trigger_extra_var": "from_extra_payload",
+    # Variables injected by the user (typically an automation) and per
+    # trigger variables are not visible to the trigger
+    # Note: It's a documented feature that per trigger variables are
+    # not meant to be consumed by the trigger
+    "trigger_rendered_option": ("automation=NOT_VISIBLE per_trigger=NOT_VISIBLE"),
+    "automation_in_action": "automation_value",
+    "per_trigger_in_action": "per_trigger_value",
+}
+
+
+@pytest.mark.parametrize(
+    ("automation_extra", "data_template", "expected_data"),
+    [
+        pytest.param(
+            {"trigger": {**_LEGACY_TRIGGER, "variables": _LEGACY_PER_TRIGGER_VARS}},
+            _BASE_DATA_TEMPLATE,
+            _LEGACY_EXPECTED,
+            id="legacy_per_trigger_only",
+        ),
+        pytest.param(
+            {
+                "trigger_variables": {"name": "Global", "via_event": "ignored"},
+                "trigger": {**_LEGACY_TRIGGER, "variables": _LEGACY_PER_TRIGGER_VARS},
+            },
+            _BASE_DATA_TEMPLATE,
+            _LEGACY_EXPECTED,
+            id="legacy_per_trigger_overrides_automation_trigger_variables",
+        ),
+        pytest.param(
+            {
+                "variables": {
+                    "name": "Global",
+                    "via_event": "{{ trigger.event.event_type }}",
+                },
+                "trigger": {**_LEGACY_TRIGGER, "variables": {"name": "Paulus"}},
+            },
+            _BASE_DATA_TEMPLATE,
+            _LEGACY_EXPECTED,
+            id="legacy_per_trigger_overrides_automation_variables",
+        ),
+        pytest.param(
+            {
                 "trigger": {
-                    "platform": "event",
-                    "event_type": "test_event",
+                    **_LEGACY_TRIGGER,
+                    "variables": {**_LEGACY_PER_TRIGGER_VARS, "trigger": "ignored"},
+                },
+            },
+            _BASE_DATA_TEMPLATE,
+            _LEGACY_EXPECTED,
+            id="legacy_per_trigger_cannot_shadow_trigger_payload",
+        ),
+        pytest.param(
+            {"trigger": {**_MODERN_TRIGGER, "variables": _MODERN_PER_TRIGGER_VARS}},
+            _BASE_DATA_TEMPLATE,
+            _MODERN_EXPECTED,
+            id="modern_per_trigger_only",
+        ),
+        pytest.param(
+            {
+                "trigger_variables": {"name": "Global", "via_event": "ignored"},
+                "trigger": {**_MODERN_TRIGGER, "variables": _MODERN_PER_TRIGGER_VARS},
+            },
+            _BASE_DATA_TEMPLATE,
+            _MODERN_EXPECTED,
+            id="modern_per_trigger_overrides_automation_trigger_variables",
+        ),
+        pytest.param(
+            {
+                "variables": {
+                    "name": "Global",
+                    "via_event": "{{ trigger.entity_id }}",
+                },
+                "trigger": {**_MODERN_TRIGGER, "variables": {"name": "Paulus"}},
+            },
+            _BASE_DATA_TEMPLATE,
+            _MODERN_EXPECTED,
+            id="modern_per_trigger_overrides_automation_variables",
+        ),
+        pytest.param(
+            {
+                "trigger": {
+                    **_MODERN_TRIGGER,
+                    "variables": {**_MODERN_PER_TRIGGER_VARS, "trigger": "ignored"},
+                },
+            },
+            _BASE_DATA_TEMPLATE,
+            _MODERN_EXPECTED,
+            id="modern_per_trigger_cannot_shadow_trigger_payload",
+        ),
+        pytest.param(
+            {
+                "trigger_variables": {"automation_var": "automation_value"},
+                "trigger": {
+                    "platform": "mock_templated_trigger",
+                    "options": {
+                        "option_template": (
+                            "automation={{ automation_var | default('NOT_VISIBLE') }}"
+                            " per_trigger="
+                            "{{ per_trigger_var | default('NOT_VISIBLE') }}"
+                        ),
+                    },
                     "variables": {
                         "name": "Paulus",
-                        "via_event": "{{ trigger.event.event_type }}",
+                        "via_event": "{{ trigger.extra_var }}",
+                        "per_trigger_var": "per_trigger_value",
                     },
                 },
-                "action": {
-                    "service": "test.automation",
-                    "data_template": {"hello": "{{ name }} + {{ via_event }}"},
-                },
-            }
-        },
+            },
+            _MOCK_DATA_TEMPLATE,
+            _MOCK_EXPECTED,
+            id="mock_modern_payload_contract",
+        ),
+    ],
+)
+async def test_trigger_variables(
+    hass: HomeAssistant,
+    service_calls: list[ServiceCall],
+    automation_extra: dict[str, Any],
+    data_template: dict[str, Any],
+    expected_data: dict[str, Any],
+) -> None:
+    """Test trigger variables and their precedence over other variable sources."""
+    hass.states.async_set("event.foo", STATE_UNKNOWN, {"event_type": "button_press"})
+
+    async def async_get_triggers(hass: HomeAssistant) -> dict[str, type[Trigger]]:
+        return {"_": _MockTrigger}
+
+    mock_integration(hass, MockModule("mock_templated_trigger"))
+    mock_platform(
+        hass,
+        "mock_templated_trigger.trigger",
+        Mock(async_get_triggers=async_get_triggers),
     )
 
+    with patch(
+        "homeassistant.components.labs.async_is_preview_feature_enabled",
+        return_value=True,
+    ):
+        assert await async_setup_component(
+            hass,
+            "automation",
+            {
+                "automation": {
+                    **automation_extra,
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": data_template,
+                    },
+                }
+            },
+        )
+
     hass.bus.async_fire("test_event")
+    hass.states.async_set(
+        "event.foo",
+        "2026-05-21T12:00:00+00:00",
+        {"event_type": "button_press"},
+    )
+    hass.bus.async_fire("mock_trigger_fire")
     await hass.async_block_till_done()
     assert len(service_calls) == 1
-    assert service_calls[0].data["hello"] == "Paulus + test_event"
+    assert service_calls[0].data == expected_data
 
 
 async def test_if_disabled_trigger_not_firing(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve tests of trigger variables:
- Trigger variables can be injected by the user the main case for this is `trigger_variables` in automations, per trigger via `variables` for each trigger and also set by triggers. Test the priority of those, i.e. which shadows which
- Explicitly test which variables are visible to triggers, for legacy and modern triggers

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
