### PR TITLE
Fix hardcoded exception strings in uptimerobot

### DIFF
--- a/homeassistant/components/uptimerobot/__init__.py
+++ b/homeassistant/components/uptimerobot/__init__.py
@@ -7,7 +7,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import PLATFORMS
+from .const import DOMAIN, PLATFORMS
 from .coordinator import UptimeRobotConfigEntry, UptimeRobotDataUpdateCoordinator
 
 
@@ -17,7 +17,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: UptimeRobotConfigEntry) 
     if key.startswith(("ur", "m")):
         # pylint: disable-next=home-assistant-exception-not-translated
         raise ConfigEntryAuthFailed(
-            "Wrong API key type detected, use the 'main' API key"
+            translation_domain=DOMAIN,
+            translation_key="api_key_wrong_type",
         )
     uptime_robot_api = UptimeRobot(key, async_get_clientsession(hass))
 

--- a/homeassistant/components/uptimerobot/__init__.py
+++ b/homeassistant/components/uptimerobot/__init__.py
@@ -15,7 +15,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: UptimeRobotConfigEntry) 
     """Set up UptimeRobot from a config entry."""
     key: str = entry.data[CONF_API_KEY]
     if key.startswith(("ur", "m")):
-        # pylint: disable-next=home-assistant-exception-not-translated
         raise ConfigEntryAuthFailed(
             translation_domain=DOMAIN,
             translation_key="api_key_wrong_type",

--- a/homeassistant/components/uptimerobot/coordinator.py
+++ b/homeassistant/components/uptimerobot/coordinator.py
@@ -55,7 +55,7 @@ class UptimeRobotDataUpdateCoordinator(
         except UptimeRobotException as exception:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
-                translation_key="api_exception",
+                translation_key="api_generic_exception",
                 translation_placeholders={"error": "Generic UptimeRobot exception"},
             ) from exception
 

--- a/homeassistant/components/uptimerobot/coordinator.py
+++ b/homeassistant/components/uptimerobot/coordinator.py
@@ -49,10 +49,17 @@ class UptimeRobotDataUpdateCoordinator(
             response = await self.api.async_get_monitors()
         except UptimeRobotAuthenticationException as exception:
             # pylint: disable-next=home-assistant-exception-not-translated
-            raise ConfigEntryAuthFailed(exception) from exception
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="api_authentication_exception",
+            ) from exception
         except UptimeRobotException as exception:
             # pylint: disable-next=home-assistant-exception-not-translated
-            raise UpdateFailed(exception) from exception
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="api_exception",
+                translation_placeholders={"error": "Generic UptimeRobot exception"},
+            ) from exception
 
         if TYPE_CHECKING:
             assert isinstance(response.data, list)

--- a/homeassistant/components/uptimerobot/coordinator.py
+++ b/homeassistant/components/uptimerobot/coordinator.py
@@ -48,13 +48,11 @@ class UptimeRobotDataUpdateCoordinator(
         try:
             response = await self.api.async_get_monitors()
         except UptimeRobotAuthenticationException as exception:
-            # pylint: disable-next=home-assistant-exception-not-translated
             raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN,
                 translation_key="api_authentication_exception",
             ) from exception
         except UptimeRobotException as exception:
-            # pylint: disable-next=home-assistant-exception-not-translated
             raise UpdateFailed(
                 translation_domain=DOMAIN,
                 translation_key="api_exception",

--- a/homeassistant/components/uptimerobot/strings.json
+++ b/homeassistant/components/uptimerobot/strings.json
@@ -60,11 +60,14 @@
     "api_authentication_exception": {
       "message": "API authentication failed, please check your API key"
     },
-    "api_exception": {
-      "message": "Could not turn on/off monitoring: {error}"
+    "api_generic_exception": {
+      "message": "API error: {error}"
     },
     "api_key_wrong_type": {
       "message": "Wrong API key type detected, use the 'main' API key"
+    },
+    "api_switch_exception": {
+      "message": "Could not turn on/off monitoring: {error}"
     }
   }
 }

--- a/homeassistant/components/uptimerobot/strings.json
+++ b/homeassistant/components/uptimerobot/strings.json
@@ -57,8 +57,14 @@
     }
   },
   "exceptions": {
+    "api_authentication_exception": {
+      "message": "API authentication failed, please check your API key"
+    },
     "api_exception": {
       "message": "Could not turn on/off monitoring: {error}"
+    },
+    "api_key_wrong_type": {
+      "message": "Wrong API key type detected, use the 'main' API key"
     }
   }
 }

--- a/homeassistant/components/uptimerobot/utils.py
+++ b/homeassistant/components/uptimerobot/utils.py
@@ -33,7 +33,7 @@ def uptimerobot_api_call[_T: UptimeRobotEntity, **_P](
         except UptimeRobotException as exception:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
-                translation_key="api_exception",
+                translation_key="api_switch_exception",
                 translation_placeholders={"error": "Generic UptimeRobot exception"},
             ) from exception
 

--- a/tests/components/uptimerobot/test_init.py
+++ b/tests/components/uptimerobot/test_init.py
@@ -45,7 +45,10 @@ async def test_reauthentication_trigger_in_setup(
     flows = hass.config_entries.flow.async_progress()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
-    assert mock_config_entry.reason == "could not authenticate"
+    assert (
+        mock_config_entry.reason
+        == "API authentication failed, please check your API key"
+    )
 
     assert len(flows) == 1
     flow = flows[0]

--- a/tests/components/uptimerobot/test_switch.py
+++ b/tests/components/uptimerobot/test_switch.py
@@ -158,7 +158,7 @@ async def test_action_execution_failure(hass: HomeAssistant) -> None:
         )
 
     assert exc_info.value.translation_domain == "uptimerobot"
-    assert exc_info.value.translation_key == "api_exception"
+    assert exc_info.value.translation_key == "api_switch_exception"
     assert exc_info.value.translation_placeholders == {
         "error": "Generic UptimeRobot exception"
     }
@@ -186,7 +186,7 @@ async def test_switch_api_failure(hass: HomeAssistant) -> None:
         )
 
     assert exc_info.value.translation_domain == "uptimerobot"
-    assert exc_info.value.translation_key == "api_exception"
+    assert exc_info.value.translation_key == "api_switch_exception"
     assert exc_info.value.translation_placeholders == {
         "error": "Generic UptimeRobot exception"
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix hardcoded exception strings in uptimerobot, found in <https://github.com/home-assistant/epics/issues/71>

Note: Used the same message already used in the integration. Will need a tweak in future: <https://github.com/home-assistant/architecture/discussions/1397>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #171511 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
