### PR TITLE
Fix WLED light.turn_on with color_name failing on serialization

### DIFF
--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -254,10 +254,10 @@ class WLEDSegmentLight(WLEDEntity, LightEntity):
         }
 
         if ATTR_RGB_COLOR in kwargs:
-            data[ATTR_COLOR_PRIMARY] = kwargs[ATTR_RGB_COLOR]
+            data[ATTR_COLOR_PRIMARY] = tuple(kwargs[ATTR_RGB_COLOR])
 
         if ATTR_RGBW_COLOR in kwargs:
-            data[ATTR_COLOR_PRIMARY] = kwargs[ATTR_RGBW_COLOR]
+            data[ATTR_COLOR_PRIMARY] = tuple(kwargs[ATTR_RGBW_COLOR])
 
         if ATTR_COLOR_TEMP_KELVIN in kwargs:
             data[ATTR_CCT] = kelvin_to_255(


### PR DESCRIPTION
## Proposed change

Convert color tuples to plain tuples before passing them to the WLED library. The light platform passes `RGBColor` and `RGBWColor` NamedTuples from color conversion, which the WLED library (since v0.22.0) cannot serialize with `orjson`. `orjson` does not auto-convert NamedTuples to arrays like `json.dumps` does.

This fixes `light.turn_on` with `color_name` (and potentially other color attributes) failing with `TypeError: Type is not JSON serializable: RGBColor`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #171605
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr