### PR TITLE
DNM: cache test, single test-file diff

### DIFF
--- a/tests/components/abode/test_camera.py
+++ b/tests/components/abode/test_camera.py
@@ -1,4 +1,5 @@
 """Tests for the Abode camera device."""
+# DNM: cache empirical test — touch this file to provoke a single-file cache miss.
 
 from unittest.mock import patch
 


### PR DESCRIPTION
## Proposed change

DNM (do not merge).  Empirical test for #171780.  Touches one test file in `tests/components/abode/` — the cache should report a single miss and re-collect only that file.

Expected behaviour:
- "Run split_tests.py" step prints something like `Cache: 5359 hits / 1 misses / 5360 total`
- Step finishes in a few seconds

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #171780
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr