### PR TITLE
DNM: cache test, conftest change full bust

### DIFF
--- a/tests/components/abode/conftest.py
+++ b/tests/components/abode/conftest.py
@@ -1,4 +1,5 @@
 """Configuration for Abode tests."""
+# DNM: cache empirical test — touch this conftest to provoke a full cache bust.
 
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch


### PR DESCRIPTION
## Proposed change

DNM (do not merge).  Empirical test for #171780.  Touches `tests/components/abode/conftest.py` — the conftest_hash should drift and the cache should fully bust, falling back to a full collect.

Expected behaviour:
- "Run split_tests.py" step prints `Cache: 0 hits / 5360 misses / 5360 total`
- Step takes similar time to the parent PR (#171772), no regression on cold path

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #171780
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr