### PR TITLE
DNM: cache test, conftest + manifest = full bust

### DIFF
--- a/homeassistant/components/cloud/manifest.json
+++ b/homeassistant/components/cloud/manifest.json
@@ -12,7 +12,7 @@
   "documentation": "https://www.home-assistant.io/integrations/cloud",
   "integration_type": "system",
   "iot_class": "cloud_push",
-  "loggers": ["acme", "hass_nabucasa", "snitun"],
+  "loggers": ["acme", "snitun", "hass_nabucasa"],
   "requirements": ["hass-nabucasa==2.2.0", "openai==2.21.0"],
   "single_config_entry": true
 }

--- a/tests/components/cloud/conftest.py
+++ b/tests/components/cloud/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for cloud tests."""
+# DNM: empirical test of split_tests cache full-bust path.
 
 from collections.abc import AsyncGenerator, Callable, Coroutine, Generator
 from pathlib import Path


### PR DESCRIPTION
## Proposed change

DNM (do not merge).  Empirical test for #171780.

Touches both `tests/components/cloud/conftest.py` and `homeassistant/components/cloud/manifest.json`.  The manifest change makes cloud a "core component" change, which flips `CORE_ANY=true` and triggers the full-suite path (so the `Split tests for full run` job actually runs).  The conftest edit then makes the cache's `conftest_hash` drift, so the cache should fully bust.

Expected behaviour in the `Run split_tests.py` step:
- `Cache: 0 hits / NNNN misses / NNNN total`
- Step time on par with the parent PR (no warm-cache savings)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #171780

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr