### PR TITLE
Fix `rgb_color` passed as RGBColor NamedTuple instead of plain tuple to light entity turn_on

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -241,7 +241,7 @@ def preprocess_turn_on_alternatives(
 
     if (color_name := params.pop(ATTR_COLOR_NAME, None)) is not None:
         try:
-            params[ATTR_RGB_COLOR] = color_util.color_name_to_rgb(color_name)
+            params[ATTR_RGB_COLOR] = tuple(color_util.color_name_to_rgb(color_name))
         except ValueError:
             _LOGGER.warning("Got unknown color %s, falling back to white", color_name)
             params[ATTR_RGB_COLOR] = (255, 255, 255)
@@ -464,12 +464,6 @@ def process_turn_on_params(  # noqa: C901
             params[ATTR_COLOR_TEMP_KELVIN] = color_util.color_xy_to_temperature(
                 *xy_color
             )
-
-    # Ensure rgb_color is a plain tuple. preprocess_turn_on_alternatives may have set it
-    # from color_name_to_rgb, which returns a RGBColor NamedTuple and runs after the
-    # service schema coercion (vol.Coerce(tuple)) that would otherwise normalise it.
-    if ATTR_RGB_COLOR in params:
-        params[ATTR_RGB_COLOR] = tuple(params[ATTR_RGB_COLOR])
 
     # If white is set to True, set it to the light's brightness
     # Add a warning in Home Assistant Core 2024.3 if the brightness is set to an

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -465,6 +465,12 @@ def process_turn_on_params(  # noqa: C901
                 *xy_color
             )
 
+    # Ensure rgb_color is a plain tuple. preprocess_turn_on_alternatives may have set it
+    # from color_name_to_rgb, which returns a RGBColor NamedTuple and runs after the
+    # service schema coercion (vol.Coerce(tuple)) that would otherwise normalise it.
+    if ATTR_RGB_COLOR in params:
+        params[ATTR_RGB_COLOR] = tuple(params[ATTR_RGB_COLOR])
+
     # If white is set to True, set it to the light's brightness
     # Add a warning in Home Assistant Core 2024.3 if the brightness is set to an
     # integer.

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -1734,9 +1734,9 @@ async def test_light_turn_on_rgb_color_is_plain_tuple(
     - rgb_color: RGBColor NamedTuple passed directly, converted by the schema.
     """
     entities = [
-        MockLight("Test_hs", STATE_ON, supported_color_modes=[light.ColorMode.HS]),
-        MockLight("Test_rgb", STATE_ON, supported_color_modes=[light.ColorMode.RGB]),
-        MockLight("Test_xy", STATE_ON, supported_color_modes=[light.ColorMode.XY]),
+        MockLight("Test_hs", STATE_ON, supported_color_modes={light.ColorMode.HS}),
+        MockLight("Test_rgb", STATE_ON, supported_color_modes={light.ColorMode.RGB}),
+        MockLight("Test_xy", STATE_ON, supported_color_modes={light.ColorMode.XY}),
         MockLight(
             "Test_all",
             STATE_ON,
@@ -1746,9 +1746,9 @@ async def test_light_turn_on_rgb_color_is_plain_tuple(
                 light.ColorMode.XY,
             },
         ),
-        MockLight("Test_rgbw", STATE_ON, supported_color_modes=[light.ColorMode.RGBW]),
+        MockLight("Test_rgbw", STATE_ON, supported_color_modes={light.ColorMode.RGBW}),
         MockLight(
-            "Test_rgbww", STATE_ON, supported_color_modes=[light.ColorMode.RGBWW]
+            "Test_rgbww", STATE_ON, supported_color_modes={light.ColorMode.RGBWW}
         ),
     ]
     setup_test_component_platform(hass, light.DOMAIN, entities)

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -1,5 +1,6 @@
 """The tests for the Light component."""
 
+from typing import Any
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
@@ -1708,41 +1709,49 @@ async def test_light_service_call_color_conversion(hass: HomeAssistant) -> None:
     assert data == {"brightness": 128, "color_temp_kelvin": 3451}
 
 
-async def test_light_service_call_color_conversion_named_tuple(
+@pytest.mark.parametrize(
+    "color_input",
+    [
+        pytest.param(
+            {"color_name": "maroon"},
+            id="color_name",
+        ),
+        pytest.param(
+            {"rgb_color": color_util.RGBColor(128, 0, 0)},
+            id="rgb_color_named_tuple",
+        ),
+    ],
+)
+async def test_light_turn_on_rgb_color_is_plain_tuple(
     hass: HomeAssistant,
+    color_input: dict[str, Any],
 ) -> None:
-    """Test a named tuple (RGBColor) is handled correctly."""
+    """Test that rgb_color passed to entity turn_on is always a plain tuple.
+
+    Covers two input paths that both resolve to the same RGB value (128, 0, 0):
+    - color_name: goes through color_name_to_rgb (returns RGBColor NamedTuple),
+      bypassing the service schema vol.Coerce(tuple) coercion.
+    - rgb_color: RGBColor NamedTuple passed directly, converted by the schema.
+    """
     entities = [
-        MockLight("Test_hs", STATE_ON),
-        MockLight("Test_rgb", STATE_ON),
-        MockLight("Test_xy", STATE_ON),
-        MockLight("Test_all", STATE_ON),
-        MockLight("Test_rgbw", STATE_ON),
-        MockLight("Test_rgbww", STATE_ON),
+        MockLight("Test_hs", STATE_ON, supported_color_modes=[light.ColorMode.HS]),
+        MockLight("Test_rgb", STATE_ON, supported_color_modes=[light.ColorMode.RGB]),
+        MockLight("Test_xy", STATE_ON, supported_color_modes=[light.ColorMode.XY]),
+        MockLight(
+            "Test_all",
+            STATE_ON,
+            supported_color_modes={
+                light.ColorMode.HS,
+                light.ColorMode.RGB,
+                light.ColorMode.XY,
+            },
+        ),
+        MockLight("Test_rgbw", STATE_ON, supported_color_modes=[light.ColorMode.RGBW]),
+        MockLight(
+            "Test_rgbww", STATE_ON, supported_color_modes=[light.ColorMode.RGBWW]
+        ),
     ]
     setup_test_component_platform(hass, light.DOMAIN, entities)
-
-    entity0 = entities[0]
-    entity0.supported_color_modes = {light.ColorMode.HS}
-
-    entity1 = entities[1]
-    entity1.supported_color_modes = {light.ColorMode.RGB}
-
-    entity2 = entities[2]
-    entity2.supported_color_modes = {light.ColorMode.XY}
-
-    entity3 = entities[3]
-    entity3.supported_color_modes = {
-        light.ColorMode.HS,
-        light.ColorMode.RGB,
-        light.ColorMode.XY,
-    }
-
-    entity4 = entities[4]
-    entity4.supported_color_modes = {light.ColorMode.RGBW}
-
-    entity5 = entities[5]
-    entity5.supported_color_modes = {light.ColorMode.RGBWW}
 
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -1751,30 +1760,25 @@ async def test_light_service_call_color_conversion_named_tuple(
         "light",
         "turn_on",
         {
-            "entity_id": [
-                entity0.entity_id,
-                entity1.entity_id,
-                entity2.entity_id,
-                entity3.entity_id,
-                entity4.entity_id,
-                entity5.entity_id,
-            ],
+            "entity_id": [entity.entity_id for entity in entities],
             "brightness_pct": 25,
-            "rgb_color": color_util.RGBColor(128, 0, 0),
+            **color_input,
         },
         blocking=True,
     )
-    _, data = entity0.last_call("turn_on")
+    _, data = entities[0].last_call("turn_on")
     assert data == {"brightness": 64, "hs_color": (0.0, 100.0)}
-    _, data = entity1.last_call("turn_on")
+    _, data = entities[1].last_call("turn_on")
     assert data == {"brightness": 64, "rgb_color": (128, 0, 0)}
-    _, data = entity2.last_call("turn_on")
+    assert type(data["rgb_color"]) is tuple
+    _, data = entities[2].last_call("turn_on")
     assert data == {"brightness": 64, "xy_color": (0.701, 0.299)}
-    _, data = entity3.last_call("turn_on")
+    _, data = entities[3].last_call("turn_on")
     assert data == {"brightness": 64, "rgb_color": (128, 0, 0)}
-    _, data = entity4.last_call("turn_on")
+    assert type(data["rgb_color"]) is tuple
+    _, data = entities[4].last_call("turn_on")
     assert data == {"brightness": 64, "rgbw_color": (128, 0, 0, 0)}
-    _, data = entity5.last_call("turn_on")
+    _, data = entities[5].last_call("turn_on")
     assert data == {"brightness": 64, "rgbww_color": (128, 0, 0, 0, 0)}
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`color_util.color_name_to_rgb()` returns a `RGBColor` NamedTuple (the internal `COLORS` dict stores values as `RGBColor` instances). This function is called from `preprocess_turn_on_alternatives` **after** the service schema validation, so the schema's `vol.Coerce(tuple)` coercion does not apply to this path.

For light entities that support `ColorMode.RGB`, no colour-space conversion branch in `process_turn_on_params` is triggered, so the `RGBColor` NamedTuple passes through unchanged and is received by the entity's `turn_on` method. While `RGBColor(128, 0, 0) == (128, 0, 0)` (NamedTuple inherits from tuple), the **type** differs, which can break integrations that forward the value directly to external libraries with strict type expectations (e.g. a `type(x) is tuple` check or a library that inspects `__class__`  or use serialization libraries).

**Why the bug was hard to reproduce:** entities whose `supported_color_modes` does not include `ColorMode.RGB` are not affected, because the colour conversion branches in `process_turn_on_params` unpack `*rgb_color` and pass the result to a conversion function that returns a plain tuple. For example, a WLED segment with `LightCapability.RGB_COLOR | LightCapability.WHITE_CHANNEL` maps to `ColorMode.RGBW` - the RGB value is converted to RGBW via `color_rgb_to_rgbw(*rgb_color)`, which produces a plain tuple, so the bug does not occur. Only a segment with `LightCapability.RGB_COLOR` alone (mapping to `ColorMode.RGB`) hits the unaffected code path where the NamedTuple passes through as-is.

All other code paths that write `ATTR_RGB_COLOR` to params (conversions from HS, XY, RGBW, RGBWW) already return plain tuples. The fix wraps the `color_name_to_rgb` call in `tuple()` at the single source of the problem.

The regression test is updated to:
- use `color_name` as the input (exercises the buggy path) and `rgb_color: RGBColor(...)` as the direct input (exercises the schema path), via `pytest.mark.parametrize`
- assert `type(data["rgb_color"]) is tuple` for entities supporting `ColorMode.RGB`, making the plain-tuple contract explicit

 
CC: @frenck 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/171605
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
