### PR TITLE
feat(lg_thinq): add missing AC entity mappings (wind strength, job mode, rotation switches)

### DIFF
--- a/homeassistant/components/lg_thinq/select.py
+++ b/homeassistant/components/lg_thinq/select.py
@@ -84,6 +84,8 @@ OPERATION_SELECT_DESC: dict[ThinQProperty, SelectEntityDescription] = {
 DEVICE_TYPE_SELECT_MAP: dict[DeviceType, tuple[SelectEntityDescription, ...]] = {
     DeviceType.AIR_CONDITIONER: (
         SELECT_DESC[ThinQProperty.MONITORING_ENABLED],
+        AIR_FLOW_SELECT_DESC[ThinQProperty.WIND_STRENGTH],
+        SELECT_DESC[ThinQProperty.CURRENT_JOB_MODE],
         OPERATION_SELECT_DESC[ThinQProperty.AIR_CLEAN_OPERATION_MODE],
     ),
     DeviceType.AIR_PURIFIER_FAN: (

--- a/homeassistant/components/lg_thinq/switch.py
+++ b/homeassistant/components/lg_thinq/switch.py
@@ -44,7 +44,21 @@ DEVICE_TYPE_SWITCH_MAP: dict[DeviceType, tuple[ThinQSwitchEntityDescription, ...
             key=ThinQProperty.AIR_CON_OPERATION_MODE,
             translation_key="operation_power",
             entity_category=EntityCategory.CONFIG,
+            ThinQSwitchEntityDescription(
+            key=ThinQProperty.WIND_ROTATE_UP_DOWN,
+            translation_key=ThinQProperty.WIND_ROTATE_UP_DOWN,
+            on_key="true",
+            off_key="false",
+            entity_category=EntityCategory.CONFIG,
         ),
+        ThinQSwitchEntityDescription(
+            key=ThinQProperty.WIND_ROTATE_LEFT_RIGHT,
+            translation_key=ThinQProperty.WIND_ROTATE_LEFT_RIGHT,
+            on_key="true",
+            off_key="false",
+            entity_category=EntityCategory.CONFIG,
+        ),
+    ),
         ThinQSwitchEntityDescription(
             key=ThinQProperty.DISPLAY_LIGHT,
             translation_key=ThinQProperty.DISPLAY_LIGHT,


### PR DESCRIPTION
## Breaking change

_Not applicable — this PR only adds new optional entities. Existing functionality is unchanged._

## Proposed change

Adds four missing entity mappings for LG ThinQ air conditioners (e.g. model `RAC_056905_WW`) that expose these properties via the ThinQ Connect API but were not yet mapped in the integration:

- **`WIND_STRENGTH`** → `select` entity (fan speed: LOW / MID / HIGH)
- **`CURRENT_JOB_MODE`** → `select` entity (operation mode: COOL / AIR_DRY / AIR_CLEAN)
- **`WIND_ROTATE_UP_DOWN`** → `switch` entity (vertical swing)
- **`WIND_ROTATE_LEFT_RIGHT`** → `switch` entity (horizontal swing)

### Changes

- `select.py`: added `AIR_FLOW_SELECT_DESC[ThinQProperty.WIND_STRENGTH]` and `SELECT_DESC[ThinQProperty.CURRENT_JOB_MODE]` to `DEVICE_TYPE_SELECT_MAP[DeviceType.AIR_CONDITIONER]`
- `switch.py`: added `ThinQSwitchEntityDescription` entries for `WIND_ROTATE_UP_DOWN` and `WIND_ROTATE_LEFT_RIGHT` to `DEVICE_TYPE_SWITCH_MAP[DeviceType.AIR_CONDITIONER]`

All four properties already have full support in the `thinqconnect` SDK and existing descriptor dictionaries — this PR only wires them up for the `AIR_CONDITIONER` device type.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr