### PR TITLE
Migrate analytics integration to config entry setup

### DIFF
--- a/homeassistant/components/analytics/__init__.py
+++ b/homeassistant/components/analytics/__init__.py
@@ -85,7 +85,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Analytics from a config entry."""
-    snapshots_url = hass.data.get(_DATA_SNAPSHOTS_URL)
+    snapshots_url = hass.data[_DATA_SNAPSHOTS_URL]
     analytics = Analytics(hass, snapshots_url)
 
     try:
@@ -120,13 +120,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(async_at_started(hass, start_schedule))
 
     hass.data[DATA_COMPONENT] = analytics
-    return True
-
-
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload an Analytics config entry."""
-    analytics = hass.data.pop(DATA_COMPONENT)
-    analytics.cancel_scheduled()
     return True
 
 

--- a/homeassistant/components/analytics/__init__.py
+++ b/homeassistant/components/analytics/__init__.py
@@ -5,8 +5,12 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant.components import labs, websocket_api
-from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.components.hassio import HassioNotReadyError
+from homeassistant.config_entries import SOURCE_SYSTEM, ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import discovery_flow
+from homeassistant.helpers.start import async_at_started
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.hass_dict import HassKey
 
@@ -49,6 +53,7 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 DATA_COMPONENT: HassKey[Analytics] = HassKey(DOMAIN)
+_DATA_SNAPSHOTS_URL: HassKey[str | None] = HassKey(f"{DOMAIN}_snapshots_url")
 
 LABS_SNAPSHOT_FEATURE = "snapshots"
 
@@ -57,18 +62,39 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the analytics integration."""
     analytics_config = config.get(DOMAIN, {})
 
+    snapshots_url: str | None = None
     if CONF_SNAPSHOTS_URL in analytics_config:
         await labs.async_update_preview_feature(
             hass, DOMAIN, LABS_SNAPSHOT_FEATURE, enabled=True
         )
         snapshots_url = analytics_config[CONF_SNAPSHOTS_URL]
-    else:
-        snapshots_url = None
 
+    hass.data[_DATA_SNAPSHOTS_URL] = snapshots_url
+
+    discovery_flow.async_create_flow(
+        hass, DOMAIN, context={"source": SOURCE_SYSTEM}, data={}
+    )
+
+    websocket_api.async_register_command(hass, websocket_analytics)
+    websocket_api.async_register_command(hass, websocket_analytics_preferences)
+
+    hass.http.register_view(AnalyticsDevicesView)
+
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Analytics from a config entry."""
+    snapshots_url = hass.data.get(_DATA_SNAPSHOTS_URL)
     analytics = Analytics(hass, snapshots_url)
 
-    # Load stored data
-    await analytics.load()
+    try:
+        await analytics.load()
+    except HassioNotReadyError as err:
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="supervisor_not_ready",
+        ) from err
 
     started = False
 
@@ -80,23 +106,27 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         if started:
             await analytics.async_schedule()
 
-    async def start_schedule(_event: Event) -> None:
-        """Start the send schedule after the started event."""
+    async def start_schedule(hass: HomeAssistant) -> None:
+        """Start the send schedule once Home Assistant has started."""
         nonlocal started
         started = True
         await analytics.async_schedule()
 
-    labs.async_subscribe_preview_feature(
-        hass, DOMAIN, LABS_SNAPSHOT_FEATURE, _async_handle_labs_update
+    entry.async_on_unload(
+        labs.async_subscribe_preview_feature(
+            hass, DOMAIN, LABS_SNAPSHOT_FEATURE, _async_handle_labs_update
+        )
     )
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, start_schedule)
-
-    websocket_api.async_register_command(hass, websocket_analytics)
-    websocket_api.async_register_command(hass, websocket_analytics_preferences)
-
-    hass.http.register_view(AnalyticsDevicesView)
+    entry.async_on_unload(async_at_started(hass, start_schedule))
 
     hass.data[DATA_COMPONENT] = analytics
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload an Analytics config entry."""
+    analytics = hass.data.pop(DATA_COMPONENT)
+    analytics.cancel_scheduled()
     return True
 
 
@@ -109,7 +139,9 @@ def websocket_analytics(
     msg: dict[str, Any],
 ) -> None:
     """Return analytics preferences."""
-    analytics = hass.data[DATA_COMPONENT]
+    if (analytics := hass.data.get(DATA_COMPONENT)) is None:
+        connection.send_error(msg["id"], websocket_api.ERR_NOT_FOUND, "Not loaded")
+        return
     connection.send_result(
         msg["id"],
         {ATTR_PREFERENCES: analytics.preferences, ATTR_ONBOARDED: analytics.onboarded},
@@ -130,8 +162,10 @@ async def websocket_analytics_preferences(
     msg: dict[str, Any],
 ) -> None:
     """Update analytics preferences."""
+    if (analytics := hass.data.get(DATA_COMPONENT)) is None:
+        connection.send_error(msg["id"], websocket_api.ERR_NOT_FOUND, "Not loaded")
+        return
     preferences = msg[ATTR_PREFERENCES]
-    analytics = hass.data[DATA_COMPONENT]
 
     await analytics.save_preferences(preferences)
     await analytics.async_schedule()

--- a/homeassistant/components/analytics/__init__.py
+++ b/homeassistant/components/analytics/__init__.py
@@ -112,12 +112,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         started = True
         await analytics.async_schedule()
 
-    entry.async_on_unload(
-        labs.async_subscribe_preview_feature(
-            hass, DOMAIN, LABS_SNAPSHOT_FEATURE, _async_handle_labs_update
-        )
+    labs.async_subscribe_preview_feature(
+        hass, DOMAIN, LABS_SNAPSHOT_FEATURE, _async_handle_labs_update
     )
-    entry.async_on_unload(async_at_started(hass, start_schedule))
+    async_at_started(hass, start_schedule)
 
     hass.data[DATA_COMPONENT] = analytics
     return True

--- a/homeassistant/components/analytics/analytics.py
+++ b/homeassistant/components/analytics/analytics.py
@@ -299,12 +299,8 @@ class Analytics:
             self._data = AnalyticsData.from_dict(stored)
 
         if self.supervisor and not self.onboarded:
-            # This may raise HassioNotReadyError if Supervisor was unreachable
-            # during setup of the Supervisor integration. That will fail setup
-            # of this integration. However there is no better option at this time
-            # since we need to get the diagnostic setting from Supervisor to correctly
-            # setup this integration and we can't raise ConfigEntryNotReady to
-            # trigger a retry from async_setup.
+            # This may raise HassioNotReadyError if Supervisor was unreachable.
+            # The caller is responsible for handling this and triggering a retry.
             supervisor_info = hassio.get_supervisor_info(self._hass)
 
             # User have not configured analytics, get this setting from the supervisor
@@ -349,8 +345,7 @@ class Analytics:
             await self._save()
 
         if self.supervisor:
-            # get_supervisor_info was called during setup so we can't get here
-            # if it raised. The others may raise HassioNotReadyError if only some
+            # The others may raise HassioNotReadyError if only some
             # data was successfully fetched from Supervisor
             supervisor_info = hassio.get_supervisor_info(hass)
             with contextlib.suppress(hassio.HassioNotReadyError):
@@ -629,6 +624,16 @@ class Analytics:
                 url,
                 err,
             )
+
+    @callback
+    def cancel_scheduled(self) -> None:
+        """Cancel all scheduled analytics tasks."""
+        if self._basic_scheduled is not None:
+            self._basic_scheduled()
+            self._basic_scheduled = None
+        if self._snapshot_scheduled is not None:
+            self._snapshot_scheduled()
+            self._snapshot_scheduled = None
 
     async def async_schedule(self) -> None:
         """Schedule analytics."""

--- a/homeassistant/components/analytics/analytics.py
+++ b/homeassistant/components/analytics/analytics.py
@@ -626,16 +626,6 @@ class Analytics:
                 err,
             )
 
-    @callback
-    def cancel_scheduled(self) -> None:
-        """Cancel all scheduled analytics tasks."""
-        if self._basic_scheduled is not None:
-            self._basic_scheduled()
-            self._basic_scheduled = None
-        if self._snapshot_scheduled is not None:
-            self._snapshot_scheduled()
-            self._snapshot_scheduled = None
-
     async def async_schedule(self) -> None:
         """Schedule analytics."""
         if not self.onboarded:

--- a/homeassistant/components/analytics/analytics.py
+++ b/homeassistant/components/analytics/analytics.py
@@ -345,9 +345,10 @@ class Analytics:
             await self._save()
 
         if self.supervisor:
-            # The others may raise HassioNotReadyError if only some
-            # data was successfully fetched from Supervisor
-            supervisor_info = hassio.get_supervisor_info(hass)
+            # Try to pull Supervisor information, but don't fail if some or all
+            # of it is unavailable due to setup failures in the hassio integration.
+            with contextlib.suppress(hassio.HassioNotReadyError):
+                supervisor_info = hassio.get_supervisor_info(hass)
             with contextlib.suppress(hassio.HassioNotReadyError):
                 operating_system_info = hassio.get_os_info(hass)
             with contextlib.suppress(hassio.HassioNotReadyError):

--- a/homeassistant/components/analytics/config_flow.py
+++ b/homeassistant/components/analytics/config_flow.py
@@ -16,4 +16,4 @@ class AnalyticsConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-        return self.async_create_entry(title="Analytics", data=user_input or {})
+        return self.async_create_entry(title="Analytics", data={})

--- a/homeassistant/components/analytics/config_flow.py
+++ b/homeassistant/components/analytics/config_flow.py
@@ -1,0 +1,19 @@
+"""Config flow for Analytics integration."""
+
+from typing import Any
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+
+from .const import DOMAIN
+
+
+class AnalyticsConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Analytics."""
+
+    VERSION = 1
+
+    async def async_step_system(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        return self.async_create_entry(title="Analytics", data=user_input or {})

--- a/homeassistant/components/analytics/manifest.json
+++ b/homeassistant/components/analytics/manifest.json
@@ -4,6 +4,7 @@
   "after_dependencies": ["energy", "hassio", "recorder"],
   "codeowners": ["@home-assistant/core"],
   "config_flow": true,
+  "single_config_entry": true,
   "dependencies": ["api", "websocket_api", "http"],
   "documentation": "https://www.home-assistant.io/integrations/analytics",
   "integration_type": "system",

--- a/homeassistant/components/analytics/manifest.json
+++ b/homeassistant/components/analytics/manifest.json
@@ -4,7 +4,6 @@
   "after_dependencies": ["energy", "hassio", "recorder"],
   "codeowners": ["@home-assistant/core"],
   "config_flow": true,
-  "single_config_entry": true,
   "dependencies": ["api", "websocket_api", "http"],
   "documentation": "https://www.home-assistant.io/integrations/analytics",
   "integration_type": "system",
@@ -16,5 +15,6 @@
       "report_issue_url": "https://github.com/OHF-Device-Database/device-database/issues/new"
     }
   },
-  "quality_scale": "internal"
+  "quality_scale": "internal",
+  "single_config_entry": true
 }

--- a/homeassistant/components/analytics/manifest.json
+++ b/homeassistant/components/analytics/manifest.json
@@ -3,7 +3,6 @@
   "name": "Analytics",
   "after_dependencies": ["energy", "hassio", "recorder"],
   "codeowners": ["@home-assistant/core"],
-  "config_flow": true,
   "dependencies": ["api", "websocket_api", "http"],
   "documentation": "https://www.home-assistant.io/integrations/analytics",
   "integration_type": "system",

--- a/homeassistant/components/analytics/manifest.json
+++ b/homeassistant/components/analytics/manifest.json
@@ -3,6 +3,7 @@
   "name": "Analytics",
   "after_dependencies": ["energy", "hassio", "recorder"],
   "codeowners": ["@home-assistant/core"],
+  "config_flow": true,
   "dependencies": ["api", "websocket_api", "http"],
   "documentation": "https://www.home-assistant.io/integrations/analytics",
   "integration_type": "system",

--- a/homeassistant/components/analytics/strings.json
+++ b/homeassistant/components/analytics/strings.json
@@ -1,4 +1,9 @@
 {
+  "exceptions": {
+    "supervisor_not_ready": {
+      "message": "Supervisor was not ready during setup, will retry"
+    }
+  },
   "preview_features": {
     "snapshots": {
       "description": "We're creating the [Open Home Foundation Device Database](https://www.home-assistant.io/blog/2026/02/02/about-device-database/): a free, open source community-powered resource to help users find practical information about how smart home devices perform in real installations.\n\nYou can help us build it by opting in to share anonymized data about your devices. This data will only ever include device-specific details (like model or manufacturer) – never personally identifying information (like the names you assign).\n\nFind out how we process your data (should you choose to contribute) in our [Data Use Statement](https://www.openhomefoundation.org/device-database-data-use-statement).",

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -59,6 +59,7 @@ FLOWS = {
         "amberelectric",
         "ambient_network",
         "ambient_station",
+        "analytics",
         "analytics_insights",
         "android_ip_webcam",
         "androidtv",

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -59,7 +59,6 @@ FLOWS = {
         "amberelectric",
         "ambient_network",
         "ambient_station",
-        "analytics",
         "analytics_insights",
         "android_ip_webcam",
         "androidtv",

--- a/tests/components/analytics/test_init.py
+++ b/tests/components/analytics/test_init.py
@@ -155,9 +155,15 @@ async def test_unload_entry(
     assert len(aioclient_mock.mock_calls) == 1
 
 
+@pytest.mark.parametrize(
+    ("ws_type", "ws_options"),
+    [("analytics", {}), ("analytics/preferences", {"preferences": {"base": True}})],
+)
 async def test_websocket_not_loaded(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
+    ws_type: str,
+    ws_options: dict[str, Any],
 ) -> None:
     """Test websocket returns error when analytics entry failed to load."""
     with (
@@ -174,35 +180,7 @@ async def test_websocket_not_loaded(
         await hass.async_block_till_done()
 
     ws_client = await hass_ws_client(hass)
-    await ws_client.send_json_auto_id({"type": "analytics"})
-    response = await ws_client.receive_json()
-
-    assert not response["success"]
-    assert response["error"]["code"] == "not_found"
-
-
-async def test_websocket_preferences_not_loaded(
-    hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
-) -> None:
-    """Test preferences websocket returns error when analytics entry failed to load."""
-    with (
-        patch(
-            "homeassistant.components.analytics.analytics.is_hassio",
-            return_value=True,
-        ),
-        patch(
-            "homeassistant.components.hassio.get_supervisor_info",
-            side_effect=HassioNotReadyError,
-        ),
-    ):
-        assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
-        await hass.async_block_till_done()
-
-    ws_client = await hass_ws_client(hass)
-    await ws_client.send_json_auto_id(
-        {"type": "analytics/preferences", "preferences": {"base": True}}
-    )
+    await ws_client.send_json_auto_id({"type": ws_type} | ws_options)
     response = await ws_client.receive_json()
 
     assert not response["success"]

--- a/tests/components/analytics/test_init.py
+++ b/tests/components/analytics/test_init.py
@@ -6,15 +6,18 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.analytics import LABS_SNAPSHOT_FEATURE
+from homeassistant.components.analytics import CONF_SNAPSHOTS_URL, LABS_SNAPSHOT_FEATURE
 from homeassistant.components.analytics.const import (
     BASIC_ENDPOINT_URL,
+    BASIC_ENDPOINT_URL_DEV,
     DOMAIN,
     SNAPSHOT_DEFAULT_URL,
     SNAPSHOT_URL_PATH,
     STORAGE_KEY,
 )
+from homeassistant.components.hassio import HassioNotReadyError
 from homeassistant.components.labs import async_update_preview_feature
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -35,6 +38,175 @@ async def test_setup(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert DOMAIN in hass.data
+
+
+async def test_setup_with_snapshots_url(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    hass_ws_client: WebSocketGenerator,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test setup with snapshots_url in YAML config sends snapshots to that URL."""
+    custom_url = "https://custom-snapshot-endpoint.example.com"
+    snapshot_endpoint = custom_url + SNAPSHOT_URL_PATH
+    aioclient_mock.post(snapshot_endpoint, status=200, json={})
+
+    with patch(
+        "homeassistant.components.analytics.analytics._async_snapshot_payload",
+        return_value={"mock": {}},
+    ):
+        assert await async_setup_component(hass, "labs", {})
+        assert await async_setup_component(
+            hass, DOMAIN, {DOMAIN: {CONF_SNAPSHOTS_URL: custom_url}}
+        )
+        await hass.async_block_till_done()
+
+        ws_client = await hass_ws_client(hass)
+        await ws_client.send_json_auto_id(
+            {"type": "analytics/preferences", "preferences": {"snapshots": True}}
+        )
+        assert (await ws_client.receive_json())["success"]
+
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=25))
+        await hass.async_block_till_done()
+
+    assert any(str(call[1]) == snapshot_endpoint for call in aioclient_mock.mock_calls)
+
+
+async def test_setup_entry_supervisor_not_ready(hass: HomeAssistant) -> None:
+    """Test that HassioNotReadyError raises ConfigEntryNotReady."""
+    with (
+        patch(
+            "homeassistant.components.analytics.analytics.is_hassio",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.hassio.get_supervisor_info",
+            side_effect=HassioNotReadyError,
+        ),
+    ):
+        assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_schedule_starts_and_sends_analytics(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    hass_ws_client: WebSocketGenerator,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test that the analytics schedule fires and sends analytics after time travel."""
+    aioclient_mock.post(BASIC_ENDPOINT_URL, status=200)
+    aioclient_mock.post(BASIC_ENDPOINT_URL_DEV, status=200)
+
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+    await hass.async_block_till_done()
+
+    ws_client = await hass_ws_client(hass)
+    with patch("homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION):
+        await ws_client.send_json_auto_id(
+            {"type": "analytics/preferences", "preferences": {"base": True}}
+        )
+        assert (await ws_client.receive_json())["success"]
+
+        assert len(aioclient_mock.mock_calls) == 0
+
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=901))
+        await hass.async_block_till_done()
+
+    assert len(aioclient_mock.mock_calls) == 1
+
+
+async def test_unload_entry(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    hass_ws_client: WebSocketGenerator,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test that unloading the config entry stops the analytics schedule."""
+    aioclient_mock.post(BASIC_ENDPOINT_URL, status=200)
+    aioclient_mock.post(BASIC_ENDPOINT_URL_DEV, status=200)
+
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+    await hass.async_block_till_done()
+
+    ws_client = await hass_ws_client(hass)
+    with patch("homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION):
+        await ws_client.send_json_auto_id(
+            {"type": "analytics/preferences", "preferences": {"base": True}}
+        )
+        await ws_client.receive_json()
+
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=901))
+        await hass.async_block_till_done()
+
+    assert len(aioclient_mock.mock_calls) == 1
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(days=2))
+    await hass.async_block_till_done()
+
+    assert len(aioclient_mock.mock_calls) == 1
+
+
+async def test_websocket_not_loaded(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test websocket returns error when analytics entry failed to load."""
+    with (
+        patch(
+            "homeassistant.components.analytics.analytics.is_hassio",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.hassio.get_supervisor_info",
+            side_effect=HassioNotReadyError,
+        ),
+    ):
+        assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json_auto_id({"type": "analytics"})
+    response = await ws_client.receive_json()
+
+    assert not response["success"]
+    assert response["error"]["code"] == "not_found"
+
+
+async def test_websocket_preferences_not_loaded(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test preferences websocket returns error when analytics entry failed to load."""
+    with (
+        patch(
+            "homeassistant.components.analytics.analytics.is_hassio",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.hassio.get_supervisor_info",
+            side_effect=HassioNotReadyError,
+        ),
+    ):
+        assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json_auto_id(
+        {"type": "analytics/preferences", "preferences": {"base": True}}
+    )
+    response = await ws_client.receive_json()
+
+    assert not response["success"]
+    assert response["error"]["code"] == "not_found"
 
 
 @pytest.mark.usefixtures("mock_snapshot_payload")

--- a/tests/components/analytics/test_init.py
+++ b/tests/components/analytics/test_init.py
@@ -120,41 +120,6 @@ async def test_schedule_starts_and_sends_analytics(
     assert len(aioclient_mock.mock_calls) == 1
 
 
-async def test_unload_entry(
-    hass: HomeAssistant,
-    hass_storage: dict[str, Any],
-    hass_ws_client: WebSocketGenerator,
-    aioclient_mock: AiohttpClientMocker,
-) -> None:
-    """Test that unloading the config entry stops the analytics schedule."""
-    aioclient_mock.post(BASIC_ENDPOINT_URL, status=200)
-    aioclient_mock.post(BASIC_ENDPOINT_URL_DEV, status=200)
-
-    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
-    await hass.async_block_till_done()
-
-    ws_client = await hass_ws_client(hass)
-    with patch("homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION):
-        await ws_client.send_json_auto_id(
-            {"type": "analytics/preferences", "preferences": {"base": True}}
-        )
-        await ws_client.receive_json()
-
-        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=901))
-        await hass.async_block_till_done()
-
-    assert len(aioclient_mock.mock_calls) == 1
-
-    entry = hass.config_entries.async_entries(DOMAIN)[0]
-    await hass.config_entries.async_unload(entry.entry_id)
-    await hass.async_block_till_done()
-
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(days=2))
-    await hass.async_block_till_done()
-
-    assert len(aioclient_mock.mock_calls) == 1
-
-
 @pytest.mark.parametrize(
     ("ws_type", "ws_options"),
     [("analytics", {}), ("analytics/preferences", {"preferences": {"base": True}})],


### PR DESCRIPTION
## Breaking change


## Proposed change

Migrates the `analytics` integration from a pure `async_setup` setup to a config entry based setup, following the same pattern used by `hassio` and `backup`.

**What changed:**
- Added `config_flow.py` with a minimal system config flow (auto-created, no user interaction)
- `async_setup` is now lightweight: reads YAML config, enables the labs feature if `snapshots_url` is set, stores the URL via `hass.data` for `async_setup_entry` to consume, and fires the discovery flow
- `async_setup_entry` does all the heavy work: creates the `Analytics` instance, loads stored data, sets up listeners and the analytics schedule
- Websocket commands and the HTTP view are registered in `async_setup` (once, not per entry reload/setup retry) and guard against the entry not being loaded with `ERR_NOT_FOUND`
- `async_listen_once(EVENT_HOMEASSISTANT_STARTED)` replaced with `async_at_started` so the schedule starts immediately when HA is already running (e.g. if `ConfigEntryNotReady` forced a late start)
- `HassioNotReadyError` from `Analytics.load()` now raises `ConfigEntryNotReady` with a translation key so setup is retried cleanly
- The hidden `snapshots_url` YAML option (added in #156984 as a developer escape hatch) is deliberately **not** migrated to config entry data to avoid exposing it via an options flow — leaving it as a YAML-only dev option for now pending more info from the original PR author

**Note on `snapshots_url`:** This is a hidden YAML-only developer option to override the snapshot analytics endpoint. It was intentionally not migrated to a config entry option to avoid exposing it in the UI. If the codeowners feel it should be dropped entirely or handled differently, happy to adjust.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr