### PR TITLE
Add in_zones property to mobile_app device tracker

### DIFF
--- a/homeassistant/components/mobile_app/device_tracker.py
+++ b/homeassistant/components/mobile_app/device_tracker.py
@@ -10,10 +10,12 @@ import voluptuous as vol
 from homeassistant.components.device_tracker import (
     ATTR_BATTERY,
     ATTR_GPS,
+    ATTR_IN_ZONES,
     ATTR_LOCATION_NAME,
     TrackerEntity,
 )
 from homeassistant.components.zone import (
+    DOMAIN as ZONE_DOMAIN,
     ENTITY_ID_FORMAT as ZONE_ENTITY_ID_FORMAT,
     HOME_ZONE,
 )
@@ -59,6 +61,7 @@ LOCATION_UPDATE_SCHEMA = vol.All(
             vol.Optional(ATTR_ALTITUDE): vol.Coerce(float),
             vol.Optional(ATTR_COURSE): cv.positive_int,
             vol.Optional(ATTR_VERTICAL_ACCURACY): cv.positive_int,
+            vol.Optional(ATTR_IN_ZONES): cv.entities_domain(ZONE_DOMAIN),
         },
     ),
 )
@@ -127,6 +130,11 @@ class MobileAppEntity(TrackerEntity, RestoreEntity):
         return attrs
 
     @property
+    def in_zones(self) -> list[str] | None:
+        """Return the zones the device is currently in."""
+        return self._data.get(ATTR_IN_ZONES)
+
+    @property
     def location_accuracy(self) -> float:
         """Return the gps accuracy of the device."""
         return self._data.get(ATTR_GPS_ACCURACY, 0)
@@ -150,6 +158,11 @@ class MobileAppEntity(TrackerEntity, RestoreEntity):
     @property
     def location_name(self) -> str | None:
         """Return a location name for the current location of the device."""
+        if ATTR_IN_ZONES in self._data:
+            # New app sends in_zones as well as location_name. Prioritize in_zones
+            # and only use location_name for backwards compatibility with old
+            # app versions.
+            return None
         if location_name := self._data.get(ATTR_LOCATION_NAME):
             if location_name == HOME_ZONE:
                 return STATE_HOME

--- a/tests/components/mobile_app/test_device_tracker.py
+++ b/tests/components/mobile_app/test_device_tracker.py
@@ -138,6 +138,51 @@ async def setup_zone(hass: HomeAssistant) -> None:
             },
             "School",
         ),
+        # Send in_zones only - first zone determines state
+        (
+            {"in_zones": ["zone.home"]},
+            {"in_zones": ["zone.home"]},
+            "home",
+        ),
+        (
+            {"in_zones": ["zone.office"]},
+            {"in_zones": ["zone.office"]},
+            "Office",
+        ),
+        (
+            {"in_zones": ["zone.home", "zone.office"]},
+            {"in_zones": ["zone.home", "zone.office"]},
+            "home",
+        ),
+        # Empty in_zones list - not_home
+        (
+            {"in_zones": []},
+            {"in_zones": []},
+            "not_home",
+        ),
+        # in_zones + location_name: in_zones wins, location_name ignored
+        (
+            {"in_zones": ["zone.office"], "location_name": "home"},
+            {"in_zones": ["zone.office"]},
+            "Office",
+        ),
+        # in_zones with empty list still suppresses location_name
+        (
+            {"in_zones": [], "location_name": "home"},
+            {"in_zones": []},
+            "not_home",
+        ),
+        # in_zones + gps: gps wins, in_zones recomputed from coordinates
+        (
+            {"gps": [10, 20], "in_zones": ["zone.school"]},
+            {
+                "latitude": 10,
+                "longitude": 20,
+                "gps_accuracy": 30,
+                "in_zones": ["zone.home"],
+            },
+            "home",
+        ),
     ],
 )
 async def test_sending_location(
@@ -341,6 +386,32 @@ async def test_restoring_location(
                 }
             },
         ),
+        # in_zones only
+        (
+            {"in_zones": ["zone.office"]},
+            "Office",
+            {
+                "friendly_name": "Test 1",
+                "source_type": "gps",
+                "battery_level": 40,
+                "altitude": 50.0,
+                "course": 60,
+                "speed": 70,
+                "vertical_accuracy": 80,
+                "in_zones": ["zone.office"],
+            },
+            {
+                "data": {
+                    "gps_accuracy": 30,
+                    "battery": 40,
+                    "altitude": 50.0,
+                    "course": 60,
+                    "speed": 70,
+                    "vertical_accuracy": 80,
+                    "in_zones": ["zone.office"],
+                }
+            },
+        ),
     ],
 )
 async def test_saving_state(
@@ -451,6 +522,42 @@ async def test_saving_state(
                 "course": 60,
                 "speed": 70,
                 "vertical_accuracy": 80,
+                "in_zones": [],
+            },
+        ),
+        # Last update was an in_zones list (no coords)
+        (
+            {
+                "in_zones": ["zone.office"],
+                "battery": 40,
+                "altitude": 50.0,
+                "course": 60,
+                "speed": 70,
+                "vertical_accuracy": 80,
+            },
+            "Office",
+            {
+                "friendly_name": "Test 1",
+                "source_type": "gps",
+                "battery_level": 40,
+                "altitude": 50.0,
+                "course": 60,
+                "speed": 70,
+                "vertical_accuracy": 80,
+                "in_zones": ["zone.office"],
+            },
+        ),
+        # Empty in_zones list - not_home
+        (
+            {
+                "in_zones": [],
+                "battery": 40,
+            },
+            "not_home",
+            {
+                "friendly_name": "Test 1",
+                "source_type": "gps",
+                "battery_level": 40,
                 "in_zones": [],
             },
         ),
@@ -602,6 +709,8 @@ async def test_restoring_state_legacy_fallback(
         {"battery": -1},
         # gps_accuracy rejected by cv.positive_float
         {"gps_accuracy": "not-a-number"},
+        # in_zones contains a non-zone entity_id
+        {"in_zones": ["sensor.foo"]},
     ],
 )
 async def test_restoring_state_invalid_extra_data(

--- a/tests/components/mobile_app/test_webhook.py
+++ b/tests/components/mobile_app/test_webhook.py
@@ -833,6 +833,99 @@ async def test_webhook_update_location_with_location_name(
     assert state.state == STATE_NOT_HOME
 
 
+async def test_webhook_update_location_with_in_zones(
+    hass: HomeAssistant,
+    create_registrations: tuple[dict[str, Any], dict[str, Any]],
+    webhook_client: TestClient,
+) -> None:
+    """Test that in_zones can be set via the update_location webhook."""
+    with patch(
+        "homeassistant.config.load_yaml_config_file",
+        autospec=True,
+        return_value={
+            ZONE_DOMAIN: [
+                {
+                    "name": "zone_name",
+                    "latitude": 1.23,
+                    "longitude": -4.56,
+                    "radius": 200,
+                    "icon": "mdi:test-tube",
+                },
+            ]
+        },
+    ):
+        await hass.services.async_call(ZONE_DOMAIN, "reload", blocking=True)
+
+    resp = await webhook_client.post(
+        f"/api/webhook/{create_registrations[1]['webhook_id']}",
+        json={
+            "type": "update_location",
+            "data": {"in_zones": ["zone.zone_name"]},
+        },
+    )
+
+    assert resp.status == HTTPStatus.OK
+
+    state = hass.states.get("device_tracker.test_1_2")
+    assert state is not None
+    assert state.state == "zone_name"
+    assert state.attributes["in_zones"] == ["zone.zone_name"]
+
+    # Empty list reports not_home
+    resp = await webhook_client.post(
+        f"/api/webhook/{create_registrations[1]['webhook_id']}",
+        json={
+            "type": "update_location",
+            "data": {"in_zones": []},
+        },
+    )
+
+    assert resp.status == HTTPStatus.OK
+
+    state = hass.states.get("device_tracker.test_1_2")
+    assert state is not None
+    assert state.state == STATE_NOT_HOME
+    assert state.attributes["in_zones"] == []
+
+
+async def test_webhook_update_location_in_zones_rejects_non_zone_entity(
+    hass: HomeAssistant,
+    create_registrations: tuple[dict[str, Any], dict[str, Any]],
+    webhook_client: TestClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that in_zones rejects entity_ids outside the zone domain."""
+    # First, set a valid state so we can verify it isn't overwritten by the
+    # rejected payload.
+    resp = await webhook_client.post(
+        f"/api/webhook/{create_registrations[1]['webhook_id']}",
+        json={
+            "type": "update_location",
+            "data": {"location_name": STATE_HOME},
+        },
+    )
+    assert resp.status == HTTPStatus.OK
+    state = hass.states.get("device_tracker.test_1_2")
+    assert state is not None
+    assert state.state == STATE_HOME
+
+    # Send a payload with an invalid in_zones entry; the webhook responds OK
+    # but the payload is dropped.
+    resp = await webhook_client.post(
+        f"/api/webhook/{create_registrations[1]['webhook_id']}",
+        json={
+            "type": "update_location",
+            "data": {"in_zones": ["sensor.not_a_zone"]},
+        },
+    )
+    assert resp.status == HTTPStatus.OK
+    assert "Received invalid webhook payload" in caplog.text
+
+    state = hass.states.get("device_tracker.test_1_2")
+    assert state is not None
+    assert state.state == STATE_HOME
+
+
 async def test_webhook_enable_encryption(
     hass: HomeAssistant,
     create_registrations: tuple[dict[str, Any], dict[str, Any]],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `in_zones` property to `mobile_app` device tracker

A new optional field `in_zones` is added to the `update_location` webhook data. If `in_zones` is present in the `update_location` data, the `location_name` field is ignored.

The Android and iOS companion apps need to be updated to populate the `in_zones` field.
- Android companion app PR: https://github.com/home-assistant/android/pull/6879
- iOS companion app PR:

Note: Depends on, and at the time of opening this PR includes commits from, https://github.com/home-assistant/core/pull/171765

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
