### PR TITLE
Make service response optional for Habitica integration

### DIFF
--- a/homeassistant/components/habitica/services.py
+++ b/homeassistant/components/habitica/services.py
@@ -303,7 +303,7 @@ async def _cast_skill(call: ServiceCall) -> ServiceResponse:
         ) from e
     else:
         await coordinator.async_request_refresh()
-        return asdict(response.data)
+        return asdict(response.data) if call.return_response is True else None
 
 
 async def _manage_quests(call: ServiceCall) -> ServiceResponse:
@@ -353,7 +353,7 @@ async def _manage_quests(call: ServiceCall) -> ServiceResponse:
             translation_placeholders={"reason": str(e)},
         ) from e
     else:
-        return asdict(response.data)
+        return asdict(response.data) if call.return_response is True else None
 
 
 async def _score_task(call: ServiceCall) -> ServiceResponse:
@@ -418,7 +418,7 @@ async def _score_task(call: ServiceCall) -> ServiceResponse:
         ) from e
     else:
         await coordinator.async_request_refresh()
-        return asdict(response.data)
+        return asdict(response.data) if call.return_response is True else None
 
 
 async def _transformation(call: ServiceCall) -> ServiceResponse:
@@ -503,7 +503,7 @@ async def _transformation(call: ServiceCall) -> ServiceResponse:
             translation_placeholders={"reason": str(e)},
         ) from e
     else:
-        return asdict(response.data)
+        return asdict(response.data) if call.return_response is True else None
 
 
 async def _get_tasks(call: ServiceCall) -> ServiceResponse:
@@ -839,7 +839,11 @@ async def _create_or_update_task(call: ServiceCall) -> ServiceResponse:  # noqa:
             translation_placeholders={"reason": str(e)},
         ) from e
     else:
-        return response.data.to_dict(omit_none=True)
+        return (
+            response.data.to_dict(omit_none=True)
+            if call.return_response is True
+            else None
+        )
 
 
 @callback
@@ -859,7 +863,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
             service_name,
             _manage_quests,
             schema=SERVICE_MANAGE_QUEST_SCHEMA,
-            supports_response=SupportsResponse.ONLY,
+            supports_response=SupportsResponse.OPTIONAL,
         )
 
     for service_name in (
@@ -873,7 +877,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
             service_name,
             _create_or_update_task,
             schema=SERVICE_UPDATE_TASK_SCHEMA,
-            supports_response=SupportsResponse.ONLY,
+            supports_response=SupportsResponse.OPTIONAL,
         )
     for service_name in (
         SERVICE_CREATE_DAILY,
@@ -886,7 +890,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
             service_name,
             _create_or_update_task,
             schema=SERVICE_CREATE_TASK_SCHEMA,
-            supports_response=SupportsResponse.ONLY,
+            supports_response=SupportsResponse.OPTIONAL,
         )
 
     hass.services.async_register(
@@ -894,7 +898,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
         SERVICE_CAST_SKILL,
         _cast_skill,
         schema=SERVICE_CAST_SKILL_SCHEMA,
-        supports_response=SupportsResponse.ONLY,
+        supports_response=SupportsResponse.OPTIONAL,
     )
 
     hass.services.async_register(
@@ -902,14 +906,14 @@ def async_setup_services(hass: HomeAssistant) -> None:
         SERVICE_SCORE_HABIT,
         _score_task,
         schema=SERVICE_SCORE_TASK_SCHEMA,
-        supports_response=SupportsResponse.ONLY,
+        supports_response=SupportsResponse.OPTIONAL,
     )
     hass.services.async_register(
         DOMAIN,
         SERVICE_SCORE_REWARD,
         _score_task,
         schema=SERVICE_SCORE_TASK_SCHEMA,
-        supports_response=SupportsResponse.ONLY,
+        supports_response=SupportsResponse.OPTIONAL,
     )
 
     hass.services.async_register(
@@ -917,7 +921,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
         SERVICE_TRANSFORMATION,
         _transformation,
         schema=SERVICE_TRANSFORMATION_SCHEMA,
-        supports_response=SupportsResponse.ONLY,
+        supports_response=SupportsResponse.OPTIONAL,
     )
     hass.services.async_register(
         DOMAIN,


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Make service responses optional for all actions except the get tasks action for easier automation

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
