### PR TITLE
Deprecate device tracker TrackerEntity location_name property

### DIFF
--- a/homeassistant/components/device_tracker/entity.py
+++ b/homeassistant/components/device_tracker/entity.py
@@ -240,7 +240,7 @@ class TrackerEntity(
             )
             _LOGGER.warning(
                 (
-                    "%s::%s is overriding the deprecated location_name method on "
+                    "%s::%s is overriding the deprecated location_name property on "
                     "an instance of TrackerEntity, this will be unsupported from "
                     "Home Assistant 2027.6, please %s"
                 ),
@@ -290,7 +290,7 @@ class TrackerEntity(
                 )
                 _LOGGER.warning(
                     (
-                        "%s::%s is setting the deprecated _attr_location_name property "
+                        "%s::%s is setting the deprecated _attr_location_name attribute "
                         "on an instance of TrackerEntity, this will be unsupported from "
                         "Home Assistant 2027.6, please %s"
                     ),

--- a/homeassistant/components/device_tracker/entity.py
+++ b/homeassistant/components/device_tracker/entity.py
@@ -1,6 +1,7 @@
 """Provide functionality to keep track of devices."""
 
 import asyncio
+import logging
 from typing import TYPE_CHECKING, Any, final
 
 from propcache.api import cached_property
@@ -22,6 +23,7 @@ from homeassistant.core import (
     EventStateChangedData,
     HomeAssistant,
     State,
+    async_get_hass_or_none,
     callback,
 )
 from homeassistant.helpers import (
@@ -37,6 +39,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.entity_platform import EntityPlatform
 from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.loader import async_suggest_report_issue
 from homeassistant.util.hass_dict import HassKey
 
 from .const import (
@@ -51,6 +54,8 @@ from .const import (
     LOGGER,
     SourceType,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 DATA_KEY: HassKey[dict[str, tuple[str, str]]] = HassKey(f"{DOMAIN}_mac")
 
@@ -212,12 +217,33 @@ class TrackerEntity(
     _attr_in_zones: list[str] | None = None
     _attr_latitude: float | None = None
     _attr_location_accuracy: float = 0
+    # _attr_location_name is deprecated and will be removed in Home Assistant 2027.6
     _attr_location_name: str | None = None
     _attr_longitude: float | None = None
     _attr_source_type: SourceType = SourceType.GPS
 
     __active_zone: State | None = None
+    # If we reported setting deprecated _attr_location_name
+    __deprecated_attr_location_name_reported = False
     __in_zones: list[str] | None = None
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        """Post initialisation processing."""
+        super().__init_subclass__(**kwargs)
+        if "location_name" in cls.__dict__:
+            report_issue = async_suggest_report_issue(
+                async_get_hass_or_none(), module=cls.__module__
+            )
+            _LOGGER.warning(
+                (
+                    "%s::%s is overriding the deprecated location_name method on "
+                    "an instance of TrackerEntity, this will be unsupported from "
+                    "Home Assistant 2027.6, please %s"
+                ),
+                cls.__module__,
+                cls.__name__,
+                report_issue,
+            )
 
     @cached_property
     def should_poll(self) -> bool:
@@ -249,7 +275,27 @@ class TrackerEntity(
 
     @cached_property
     def location_name(self) -> str | None:
-        """Return a location name for the current location of the device."""
+        """Return a location name for the current location of the device.
+
+        The property is deprecated and will be removed in Home Assistant 2027.6.
+        """
+        if (location_name := self._attr_location_name) is not None:
+            if not self.__deprecated_attr_location_name_reported:
+                report_issue = async_suggest_report_issue(
+                    self.hass, module=self.__class__.__module__
+                )
+                _LOGGER.warning(
+                    (
+                        "%s::%s is setting the deprecated _attr_location_name property "
+                        "on an instance of TrackerEntity, this will be unsupported from "
+                        "Home Assistant 2027.6, please %s"
+                    ),
+                    self.__class__.__module__,
+                    self.__class__.__name__,
+                    report_issue,
+                )
+                self.__deprecated_attr_location_name_reported = True
+            return location_name
         return self._attr_location_name
 
     @cached_property

--- a/homeassistant/components/device_tracker/entity.py
+++ b/homeassistant/components/device_tracker/entity.py
@@ -231,6 +231,10 @@ class TrackerEntity(
         """Post initialisation processing."""
         super().__init_subclass__(**kwargs)
         if "location_name" in cls.__dict__:
+            if cls.__module__.startswith("homeassistant.components."):
+                # Don't ask users to report issue for built in integrations,
+                # they already have issues opened on them.
+                return
             report_issue = async_suggest_report_issue(
                 async_get_hass_or_none(), module=cls.__module__
             )

--- a/homeassistant/components/device_tracker/entity.py
+++ b/homeassistant/components/device_tracker/entity.py
@@ -217,7 +217,7 @@ class TrackerEntity(
     _attr_in_zones: list[str] | None = None
     _attr_latitude: float | None = None
     _attr_location_accuracy: float = 0
-    # _attr_location_name is deprecated and will be removed in Home Assistant 2027.6
+    # _attr_location_name is deprecated and will be removed in Home Assistant 2027.7
     _attr_location_name: str | None = None
     _attr_longitude: float | None = None
     _attr_source_type: SourceType = SourceType.GPS
@@ -242,7 +242,7 @@ class TrackerEntity(
                 (
                     "%s::%s is overriding the deprecated location_name property on "
                     "an instance of TrackerEntity, this will be unsupported from "
-                    "Home Assistant 2027.6, please %s"
+                    "Home Assistant 2027.7, please %s"
                 ),
                 cls.__module__,
                 cls.__name__,
@@ -281,7 +281,7 @@ class TrackerEntity(
     def location_name(self) -> str | None:
         """Return a location name for the current location of the device.
 
-        The property is deprecated and will be removed in Home Assistant 2027.6.
+        The property is deprecated and will be removed in Home Assistant 2027.7.
         """
         if (location_name := self._attr_location_name) is not None:
             if not self.__deprecated_attr_location_name_reported:
@@ -292,7 +292,7 @@ class TrackerEntity(
                     (
                         "%s::%s is setting the deprecated _attr_location_name attribute "
                         "on an instance of TrackerEntity, this will be unsupported from "
-                        "Home Assistant 2027.6, please %s"
+                        "Home Assistant 2027.7, please %s"
                     ),
                     self.__class__.__module__,
                     self.__class__.__name__,

--- a/homeassistant/components/device_tracker/entity.py
+++ b/homeassistant/components/device_tracker/entity.py
@@ -284,7 +284,12 @@ class TrackerEntity(
         The property is deprecated and will be removed in Home Assistant 2027.7.
         """
         if (location_name := self._attr_location_name) is not None:
-            if not self.__deprecated_attr_location_name_reported:
+            if (
+                not self.__deprecated_attr_location_name_reported
+                and not self.__class__.__module__.startswith(
+                    "homeassistant.components."
+                )
+            ):
                 report_issue = async_suggest_report_issue(
                     self.hass, module=self.__class__.__module__
                 )

--- a/tests/components/device_tracker/test_entity.py
+++ b/tests/components/device_tracker/test_entity.py
@@ -1379,6 +1379,98 @@ def test_base_tracker_entity() -> None:
         entity.state_attributes  # noqa: B018
 
 
+async def test_attr_location_name_deprecation_warning(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that setting _attr_location_name logs a deprecation warning."""
+    error_message = "is setting the deprecated _attr_location_name property"
+
+    # No warning when _attr_location_name is unset (default None)
+    entity_no_attr = TrackerEntity()
+    entity_no_attr.hass = hass
+    assert entity_no_attr.location_name is None
+    assert error_message not in caplog.text
+
+    # Warning fires when _attr_location_name has a non-None value
+    entity = TrackerEntity()
+    entity.hass = hass
+    entity._attr_location_name = "the_zone"
+    caplog.clear()
+    assert entity.location_name == "the_zone"
+    assert error_message in caplog.text
+
+    # Warning does not fire again on subsequent access for the same instance
+    caplog.clear()
+    assert entity.location_name == "the_zone"
+    assert error_message not in caplog.text
+
+    # Warning is suppressed for this instance even after the cached value is
+    # invalidated by a subsequent _attr_location_name assignment.
+    entity._attr_location_name = "another_zone"
+    caplog.clear()
+    assert entity.location_name == "another_zone"
+    assert error_message not in caplog.text
+
+    # A fresh instance warns once again
+    entity_new = TrackerEntity()
+    entity_new.hass = hass
+    entity_new._attr_location_name = "the_zone"
+    caplog.clear()
+    assert entity_new.location_name == "the_zone"
+    assert error_message in caplog.text
+
+
+def test_location_name_override_deprecation_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that overriding location_name in a subclass logs a warning."""
+    error_message = "is overriding the deprecated location_name method"
+
+    caplog.clear()
+
+    class _SubclassWithOverride(TrackerEntity):
+        @property
+        def location_name(self) -> str | None:
+            return "custom"
+
+    assert error_message in caplog.text
+    assert _SubclassWithOverride.__name__ in caplog.text
+
+    # No warning for a subclass that does not override location_name
+    caplog.clear()
+
+    class _SubclassWithoutOverride(TrackerEntity):
+        pass
+
+    assert error_message not in caplog.text
+
+
+def test_battery_level_override_deprecation_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that overriding battery_level in a subclass logs a warning."""
+    error_message = "is overriding the deprecated battery_level method"
+
+    caplog.clear()
+
+    class _SubclassWithOverride(TrackerEntity):
+        @property
+        def battery_level(self) -> int | None:
+            return 50
+
+    assert error_message in caplog.text
+    assert _SubclassWithOverride.__name__ in caplog.text
+
+    # No warning for a subclass that does not override battery_level
+    caplog.clear()
+
+    class _SubclassWithoutOverride(TrackerEntity):
+        pass
+
+    assert error_message not in caplog.text
+
+
 @pytest.mark.parametrize(
     ("mac_address", "unique_id"), [(TEST_MAC_ADDRESS, f"{TEST_MAC_ADDRESS}_yo1")]
 )

--- a/tests/components/device_tracker/test_entity.py
+++ b/tests/components/device_tracker/test_entity.py
@@ -1384,7 +1384,7 @@ async def test_attr_location_name_deprecation_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that setting _attr_location_name logs a deprecation warning."""
-    error_message = "is setting the deprecated _attr_location_name property"
+    error_message = "is setting the deprecated _attr_location_name attribute"
 
     # No warning when _attr_location_name is unset (default None)
     entity_no_attr = TrackerEntity()
@@ -1425,7 +1425,7 @@ def test_location_name_override_deprecation_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that overriding location_name in a subclass logs a warning."""
-    error_message = "is overriding the deprecated location_name method"
+    error_message = "is overriding the deprecated location_name property"
 
     caplog.clear()
 

--- a/tests/components/device_tracker/test_entity.py
+++ b/tests/components/device_tracker/test_entity.py
@@ -1446,31 +1446,6 @@ def test_location_name_override_deprecation_warning(
     assert error_message not in caplog.text
 
 
-def test_battery_level_override_deprecation_warning(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test that overriding battery_level in a subclass logs a warning."""
-    error_message = "is overriding the deprecated battery_level method"
-
-    caplog.clear()
-
-    class _SubclassWithOverride(TrackerEntity):
-        @property
-        def battery_level(self) -> int | None:
-            return 50
-
-    assert error_message in caplog.text
-    assert _SubclassWithOverride.__name__ in caplog.text
-
-    # No warning for a subclass that does not override battery_level
-    caplog.clear()
-
-    class _SubclassWithoutOverride(TrackerEntity):
-        pass
-
-    assert error_message not in caplog.text
-
-
 @pytest.mark.parametrize(
     ("mac_address", "unique_id"), [(TEST_MAC_ADDRESS, f"{TEST_MAC_ADDRESS}_yo1")]
 )

--- a/tests/components/device_tracker/test_entity.py
+++ b/tests/components/device_tracker/test_entity.py
@@ -1386,14 +1386,17 @@ async def test_attr_location_name_deprecation_warning(
     """Test that setting _attr_location_name logs a deprecation warning."""
     error_message = "is setting the deprecated _attr_location_name attribute"
 
+    class _Subclass(TrackerEntity):
+        pass
+
     # No warning when _attr_location_name is unset (default None)
-    entity_no_attr = TrackerEntity()
+    entity_no_attr = _Subclass()
     entity_no_attr.hass = hass
     assert entity_no_attr.location_name is None
     assert error_message not in caplog.text
 
     # Warning fires when _attr_location_name has a non-None value
-    entity = TrackerEntity()
+    entity = _Subclass()
     entity.hass = hass
     entity._attr_location_name = "the_zone"
     caplog.clear()
@@ -1413,7 +1416,7 @@ async def test_attr_location_name_deprecation_warning(
     assert error_message not in caplog.text
 
     # A fresh instance warns once again
-    entity_new = TrackerEntity()
+    entity_new = _Subclass()
     entity_new.hass = hass
     entity_new._attr_location_name = "the_zone"
     caplog.clear()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecate device tracker `TrackerEntity` `location_name` property as decided in https://github.com/home-assistant/architecture/discussions/1387

The following core integrations either implement the `location_name` property or set the `_attr_location_name` attribute and need to be updated:

Integrations which implement the `location_name` property:
- mobile_app
- owntracks
- tesla_fleet

Integrations which set the `_attr_location_name` attribute:
- geofency
- locative
- mqtt
- teslemetry

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/3118
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
