### PR TITLE
Add API version sensor to HomeWizard

### DIFF
--- a/homeassistant/components/homewizard/icons.json
+++ b/homeassistant/components/homewizard/icons.json
@@ -15,6 +15,9 @@
       "any_power_fail_count": {
         "default": "mdi:transmission-tower-off"
       },
+      "api_version": {
+        "default": "mdi:api"
+      },
       "cycles": {
         "default": "mdi:battery-sync-outline"
       },

--- a/homeassistant/components/homewizard/sensor.py
+++ b/homeassistant/components/homewizard/sensor.py
@@ -657,6 +657,16 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
             )
         ),
     ),
+    HomeWizardSensorEntityDescription(
+        key="api_version",
+        translation_key="api_version",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        has_fn=(
+            lambda data: data.device is not None and data.device.api_version is not None
+        ),
+        value_fn=lambda data: data.device.api_version,
+    ),
 )
 
 

--- a/homeassistant/components/homewizard/strings.json
+++ b/homeassistant/components/homewizard/strings.json
@@ -105,6 +105,9 @@
       "any_power_fail_count": {
         "name": "Power failures detected"
       },
+      "api_version": {
+        "name": "API version"
+      },
       "cycles": {
         "name": "Battery cycles"
       },

--- a/tests/components/homewizard/test_sensor.py
+++ b/tests/components/homewizard/test_sensor.py
@@ -346,6 +346,7 @@ async def test_sensors(
         (
             "HWE-P1",
             [
+                "sensor.device_api_version",
                 "sensor.device_current_phase_1",
                 "sensor.device_current_phase_2",
                 "sensor.device_current_phase_3",
@@ -359,6 +360,7 @@ async def test_sensors(
         (
             "HWE-P1-unused-exports",
             [
+                "sensor.device_api_version",
                 "sensor.device_energy_export_tariff_1",
                 "sensor.device_energy_export_tariff_2",
                 "sensor.device_energy_export_tariff_3",
@@ -369,24 +371,28 @@ async def test_sensors(
         (
             "HWE-SKT-11",
             [
+                "sensor.device_api_version",
                 "sensor.device_wi_fi_strength",
             ],
         ),
         (
             "HWE-SKT-21",
             [
+                "sensor.device_api_version",
                 "sensor.device_wi_fi_strength",
             ],
         ),
         (
             "HWE-WTR",
             [
+                "sensor.device_api_version",
                 "sensor.device_wi_fi_strength",
             ],
         ),
         (
             "SDM230",
             [
+                "sensor.device_api_version",
                 "sensor.device_apparent_power",
                 "sensor.device_current",
                 "sensor.device_frequency",
@@ -399,6 +405,7 @@ async def test_sensors(
         (
             "SDM630",
             [
+                "sensor.device_api_version",
                 "sensor.device_apparent_power_phase_1",
                 "sensor.device_apparent_power_phase_2",
                 "sensor.device_apparent_power_phase_3",
@@ -424,6 +431,7 @@ async def test_sensors(
         (
             "HWE-KWH1",
             [
+                "sensor.device_api_version",
                 "sensor.device_apparent_power",
                 "sensor.device_current",
                 "sensor.device_frequency",
@@ -436,6 +444,7 @@ async def test_sensors(
         (
             "HWE-KWH3",
             [
+                "sensor.device_api_version",
                 "sensor.device_apparent_power_phase_1",
                 "sensor.device_apparent_power_phase_2",
                 "sensor.device_apparent_power_phase_3",
@@ -461,6 +470,7 @@ async def test_sensors(
         (
             "HWE-BAT",
             [
+                "sensor.device_api_version",
                 "sensor.device_current",
                 "sensor.device_frequency",
                 "sensor.device_uptime",
@@ -480,6 +490,23 @@ async def test_disabled_by_default_sensors(
         assert (entry := entity_registry.async_get(entity_id))
         assert entry.disabled
         assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+
+
+@pytest.mark.parametrize("device_fixture", ["HWE-P1"])
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_api_version_sensor_enabled(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_homewizardenergy: MagicMock,
+) -> None:
+    """Test api_version sensor state when enabled."""
+    entity_id = "sensor.device_api_version"
+
+    assert (state := hass.states.get(entity_id))
+    assert state.state == mock_homewizardenergy.combined.return_value.device.api_version
+
+    assert (entry := entity_registry.async_get(entity_id))
+    assert entry.disabled_by is None
 
 
 @pytest.mark.parametrize("exception", [RequestError])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
HomeWizard devices API are versioned, and due to the release schedule not all devices are updated to the latest version at the same time.

This sensor helps with ‘debugging’ when users are missing features.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45512
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr