### PR TITLE
Fix ZBT-2 hardware page crash when entry data is missing VID

### DIFF
--- a/homeassistant/components/homeassistant_connect_zbt2/hardware.py
+++ b/homeassistant/components/homeassistant_connect_zbt2/hardware.py
@@ -19,7 +19,9 @@ EXPECTED_ENTRY_VERSION = (
 @callback
 def async_info(hass: HomeAssistant) -> list[HardwareInfo]:
     """Return board info."""
-    entries = hass.config_entries.async_entries(DOMAIN)
+    entries = hass.config_entries.async_entries(
+        DOMAIN, include_ignore=False, include_disabled=False
+    )
     return [
         HardwareInfo(
             board=None,
@@ -37,5 +39,4 @@ def async_info(hass: HomeAssistant) -> list[HardwareInfo]:
         for entry in entries
         # Ignore unmigrated config entries in the hardware page
         if (entry.version, entry.minor_version) == EXPECTED_ENTRY_VERSION
-        and VID in entry.data
     ]

--- a/homeassistant/components/homeassistant_connect_zbt2/hardware.py
+++ b/homeassistant/components/homeassistant_connect_zbt2/hardware.py
@@ -37,4 +37,5 @@ def async_info(hass: HomeAssistant) -> list[HardwareInfo]:
         for entry in entries
         # Ignore unmigrated config entries in the hardware page
         if (entry.version, entry.minor_version) == EXPECTED_ENTRY_VERSION
+        and VID in entry.data
     ]

--- a/tests/components/homeassistant_connect_zbt2/test_hardware.py
+++ b/tests/components/homeassistant_connect_zbt2/test_hardware.py
@@ -2,6 +2,7 @@
 
 from homeassistant.components.homeassistant_connect_zbt2.const import DOMAIN
 from homeassistant.components.usb import DOMAIN as USB_DOMAIN
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -53,6 +54,69 @@ async def test_hardware_info(
             {
                 "board": None,
                 "config_entries": [config_entry.entry_id],
+                "dongle": {
+                    "vid": "303A",
+                    "pid": "4001",
+                    "serial_number": "80B54EEFAE18",
+                    "manufacturer": "Nabu Casa",
+                    "description": "ZBT-2",
+                },
+                "name": "Home Assistant Connect ZBT-2",
+                "url": "https://support.nabucasa.com/hc/en-us/categories/24734620813469-Home-Assistant-Connect-ZBT-1",
+            }
+        ]
+    }
+
+
+async def test_hardware_info_ignored_entry(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, addon_store_info
+) -> None:
+    """Test ignored discovery entries don't crash hardware info.
+
+    Regression test for https://github.com/home-assistant/core/issues/170270
+    """
+    assert await async_setup_component(hass, USB_DOMAIN, {})
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+
+    # Setup the normal entry so the hardware platform is loaded
+    normal_entry = MockConfigEntry(
+        data=CONFIG_ENTRY_DATA,
+        domain=DOMAIN,
+        options={},
+        title="Home Assistant Connect ZBT-2",
+        unique_id="normal_1",
+        version=1,
+        minor_version=1,
+    )
+    normal_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(normal_entry.entry_id)
+
+    # Setup an ignored config entry without USB data
+    ignored_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={},
+        title="Home Assistant Connect ZBT-2",
+        unique_id="ignored_1",
+        version=1,
+        minor_version=2,
+        source="ignore",
+    )
+    ignored_entry.add_to_hass(hass)
+    assert ignored_entry.state is ConfigEntryState.NOT_LOADED
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json({"id": 1, "type": "hardware/info"})
+    msg = await client.receive_json()
+
+    assert msg["id"] == 1
+    assert msg["success"]
+    assert msg["result"] == {
+        "hardware": [
+            {
+                "board": None,
+                "config_entries": [normal_entry.entry_id],
                 "dongle": {
                     "vid": "303A",
                     "pid": "4001",


### PR DESCRIPTION
## Proposed change

Skip config entries that are missing USB data keys (`VID`, `PID`, etc.) in the ZBT-2 hardware info callback. The migration from config entry version 1.1 to 1.2 bumps the version but does not add the USB data keys if they are missing. This causes a `KeyError: 'vid'` crash when the hardware page tries to render device info, surfaced as "Unknown error" in the websocket API.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #170270
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr