### PR TITLE
Fix Lutron Caseta battery sensor crash on unsupported devices

### DIFF
--- a/homeassistant/components/lutron_caseta/binary_sensor.py
+++ b/homeassistant/components/lutron_caseta/binary_sensor.py
@@ -3,7 +3,7 @@
 from datetime import timedelta
 from typing import Any
 
-from pylutron_caseta import OCCUPANCY_GROUP_OCCUPIED
+from pylutron_caseta import OCCUPANCY_GROUP_OCCUPIED, BridgeResponseError
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -131,7 +131,11 @@ class LutronCasetaBatterySensor(LutronCasetaEntity, BinarySensorEntity):
 
     async def async_update(self) -> None:
         """Fetch the latest battery status from the bridge."""
-        status = await self._smartbridge.get_battery_status(self.device_id)
+        try:
+            status = await self._smartbridge.get_battery_status(self.device_id)
+        except BridgeResponseError:
+            self._attr_is_on = None
+            return
         normalized_status = status.strip().casefold() if status else None
         if normalized_status == BATTERY_STATUS_LOW:
             self._attr_is_on = True

--- a/tests/components/lutron_caseta/test_binary_sensor.py
+++ b/tests/components/lutron_caseta/test_binary_sensor.py
@@ -1,9 +1,10 @@
 """Tests for the Lutron Caseta binary sensors."""
 
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
+from pylutron_caseta import BridgeResponseError
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.lutron_caseta.binary_sensor import SCAN_INTERVAL
@@ -118,3 +119,32 @@ async def test_battery_sensor_updates_on_schedule(
     assert unknown_state is not None
     assert unknown_state.state == STATE_UNKNOWN
     assert instance.get_battery_status.await_count == 3
+
+
+async def test_battery_sensor_handles_bridge_response_error(
+    hass: HomeAssistant,
+) -> None:
+    """Test battery sensor handles BridgeResponseError gracefully.
+
+    Regression test for https://github.com/home-assistant/core/issues/169965
+    """
+    instance = MockBridge()
+
+    def factory(*args: Any, **kwargs: Any) -> MockBridge:
+        """Return the mock bridge instance."""
+        return instance
+
+    mock_response = MagicMock()
+    mock_response.Header.StatusCode = "404 NotFound"
+    instance.get_battery_status = AsyncMock(
+        side_effect=BridgeResponseError(mock_response)
+    )
+
+    await async_setup_integration(hass, factory)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(
+        "binary_sensor.basement_bedroom_basement_bedroom_left_shade_battery"
+    )
+    assert state is not None
+    assert state.state == STATE_UNKNOWN


### PR DESCRIPTION
## Proposed change

Handle `BridgeResponseError` in the Lutron Caseta battery sensor's `async_update`. Radio RA3 cover devices can return a 404 for the battery status endpoint, which raises `BridgeResponseError` and crashes entity setup since `update_before_add=True` is used.

The battery sensor now catches the error and sets the state to unknown, allowing the entity to be created without crashing.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #169965
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr