### PR TITLE
Fix invalid MDI icon references

### DIFF
--- a/homeassistant/components/alarmdecoder/icons.json
+++ b/homeassistant/components/alarmdecoder/icons.json
@@ -11,7 +11,7 @@
       "service": "mdi:dialpad"
     },
     "alarm_toggle_chime": {
-      "service": "mdi:abc"
+      "service": "mdi:bell-ring"
     }
   }
 }

--- a/homeassistant/components/currencylayer/sensor.py
+++ b/homeassistant/components/currencylayer/sensor.py
@@ -61,7 +61,7 @@ class CurrencylayerSensor(SensorEntity):
     """Implementing the Currencylayer sensor."""
 
     _attr_attribution = "Data provided by currencylayer.com"
-    _attr_icon = "mdi:currency"
+    _attr_icon = "mdi:currency-usd"
 
     def __init__(self, rest: CurrencylayerData, base: str, quote: str) -> None:
         """Initialize the sensor."""

--- a/homeassistant/components/evohome/icons.json
+++ b/homeassistant/components/evohome/icons.json
@@ -23,7 +23,7 @@
       "service": "mdi:refresh"
     },
     "set_dhw_override": {
-      "service": "mdi:water-heater"
+      "service": "mdi:water-boiler"
     },
     "set_system_mode": {
       "service": "mdi:pencil"

--- a/homeassistant/components/fing/utils.py
+++ b/homeassistant/components/fing/utils.py
@@ -16,7 +16,7 @@ class DeviceType(Enum):
     GAME_CONSOLE = "mdi:nintendo-game-boy"
     STREAMING_DONGLE = "mdi:cast"
     LOUDSPEAKER = SOUND_SYSTEM = STB = SATELLITE = MUSIC = "mdi:speaker"
-    DISC_PLAYER = "mdi:disk-player"
+    DISC_PLAYER = "mdi:disc-player"
     REMOTE_CONTROL = "mdi:remote-tv"
     RADIO = "mdi:radio"
     PHOTO_CAMERA = PHOTOS = "mdi:camera"

--- a/homeassistant/components/fumis/icons.json
+++ b/homeassistant/components/fumis/icons.json
@@ -2,7 +2,7 @@
   "entity": {
     "button": {
       "sync_clock": {
-        "default": "mdi:clock-sync"
+        "default": "mdi:clock-check"
       }
     },
     "number": {

--- a/homeassistant/components/jewish_calendar/icons.json
+++ b/homeassistant/components/jewish_calendar/icons.json
@@ -1,7 +1,7 @@
 {
   "entity": {
     "binary_sensor": {
-      "erev_shabbat_hag": { "default": "mdi:candle-light" },
+      "erev_shabbat_hag": { "default": "mdi:candle" },
       "issur_melacha_in_effect": { "default": "mdi:power-plug-off" },
       "motzei_shabbat_hag": { "default": "mdi:fire" }
     },

--- a/homeassistant/components/keba/icons.json
+++ b/homeassistant/components/keba/icons.json
@@ -7,7 +7,7 @@
       "service": "mdi:lock-open"
     },
     "disable": {
-      "service": "mdi:fash-off"
+      "service": "mdi:flash-off"
     },
     "enable": {
       "service": "mdi:flash"

--- a/homeassistant/components/liebherr/icons.json
+++ b/homeassistant/components/liebherr/icons.json
@@ -28,25 +28,25 @@
       "ice_maker": {
         "default": "mdi:cube-outline",
         "state": {
-          "off": "mdi:cube-outline-off"
+          "off": "mdi:cube-off-outline"
         }
       },
       "ice_maker_bottom_zone": {
         "default": "mdi:cube-outline",
         "state": {
-          "off": "mdi:cube-outline-off"
+          "off": "mdi:cube-off-outline"
         }
       },
       "ice_maker_middle_zone": {
         "default": "mdi:cube-outline",
         "state": {
-          "off": "mdi:cube-outline-off"
+          "off": "mdi:cube-off-outline"
         }
       },
       "ice_maker_top_zone": {
         "default": "mdi:cube-outline",
         "state": {
-          "off": "mdi:cube-outline-off"
+          "off": "mdi:cube-off-outline"
         }
       }
     },

--- a/homeassistant/components/matter/icons.json
+++ b/homeassistant/components/matter/icons.json
@@ -102,7 +102,7 @@
         "default": "mdi:home-lightning-bolt"
       },
       "eve_weather_trend": {
-        "default": "mdi:weather",
+        "default": "mdi:weather-cloudy",
         "state": {
           "cloudy": "mdi:weather-cloudy",
           "rainy": "mdi:weather-rainy",

--- a/homeassistant/components/rainmachine/icons.json
+++ b/homeassistant/components/rainmachine/icons.json
@@ -29,29 +29,29 @@
       }
     },
     "sensor": {
-      "translation_key_0": {
-        "default": "mdi:abc"
+      "flow_sensor_clicks_cubic_meter": {
+        "default": "mdi:water-pump"
       },
-      "translation_key_1": {
-        "default": "mdi:abc"
+      "flow_sensor_consumed_liters": {
+        "default": "mdi:water-pump"
       },
-      "translation_key_2": {
-        "default": "mdi:abc"
+      "flow_sensor_leak_clicks": {
+        "default": "mdi:pipe-leak"
       },
-      "translation_key_3": {
-        "default": "mdi:abc"
+      "flow_sensor_leak_volume": {
+        "default": "mdi:pipe-leak"
       },
-      "translation_key_4": {
-        "default": "mdi:abc"
+      "flow_sensor_start_index": {
+        "default": "mdi:water-pump"
       },
-      "translation_key_5": {
-        "default": "mdi:abc"
+      "flow_sensor_watering_clicks": {
+        "default": "mdi:water-pump"
       },
-      "translation_key_6": {
-        "default": "mdi:abc"
+      "last_leak_detected": {
+        "default": "mdi:pipe-leak"
       },
-      "translation_key_7": {
-        "default": "mdi:abc"
+      "rain_sensor_rain_start": {
+        "default": "mdi:weather-pouring"
       }
     },
     "switch": {

--- a/homeassistant/components/teslemetry/icons.json
+++ b/homeassistant/components/teslemetry/icons.json
@@ -497,7 +497,7 @@
         "default": "mdi:battery-clock"
       },
       "forward_collision_warning": {
-        "default": "mdi:car-crash",
+        "default": "mdi:car-emergency",
         "state": {
           "average": "mdi:alert-circle",
           "early": "mdi:alert-octagon",
@@ -634,7 +634,7 @@
         "default": "mdi:key"
       },
       "pedal_position": {
-        "default": "mdi:pedestal"
+        "default": "mdi:gauge"
       },
       "powershare_hours_left": {
         "default": "mdi:clock-time-eight-outline"
@@ -794,7 +794,7 @@
       "service": "mdi:calendar-plus"
     },
     "add_precondition_schedule": {
-      "service": "mdi:hvac-outline"
+      "service": "mdi:hvac"
     },
     "navigation_gps_request": {
       "service": "mdi:crosshairs-gps"
@@ -803,7 +803,7 @@
       "service": "mdi:calendar-minus"
     },
     "remove_precondition_schedule": {
-      "service": "mdi:hvac-off-outline"
+      "service": "mdi:hvac-off"
     },
     "set_scheduled_charging": {
       "service": "mdi:timeline-clock-outline"

--- a/homeassistant/components/weatherflow_cloud/icons.json
+++ b/homeassistant/components/weatherflow_cloud/icons.json
@@ -68,7 +68,7 @@
         "state": {
           "lightning": "mdi:weather-lightning-rainy",
           "rain": "mdi:weather-rainy",
-          "rain_snow": "mdi:weather-snoy-rainy",
+          "rain_snow": "mdi:weather-snowy-rainy",
           "snow": "mdi:weather-snowy"
         }
       },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix 15 invalid MDI icon references across 12 integrations. These icons either don't exist in the Material Design Icons set or contain typos, causing broken/missing icons in the UI.

**Python code fixes (2):**
- `currencylayer`: `mdi:currency` -> `mdi:currency-usd`
- `fing`: `mdi:disk-player` -> `mdi:disc-player` (typo)

**icons.json fixes (13):**
- `alarmdecoder`: `mdi:abc` -> `mdi:bell-ring`
- `evohome`: `mdi:water-heater` -> `mdi:water-boiler`
- `fumis`: `mdi:clock-sync` -> `mdi:clock-check`
- `jewish_calendar`: `mdi:candle-light` -> `mdi:candle`
- `keba`: `mdi:fash-off` -> `mdi:flash-off` (typo)
- `liebherr`: `mdi:cube-outline-off` -> `mdi:cube-off-outline` (wrong order)
- `matter`: `mdi:weather` -> `mdi:weather-cloudy` (incomplete name)
- `rainmachine`: `mdi:abc` -> proper icons per sensor type
- `teslemetry`: `mdi:car-crash` -> `mdi:car-emergency`, `mdi:hvac-off-outline` -> `mdi:hvac-off`, `mdi:hvac-outline` -> `mdi:hvac`, `mdi:pedestal` -> `mdi:gauge`
- `weatherflow_cloud`: `mdi:weather-snoy-rainy` -> `mdi:weather-snowy-rainy` (typo)

Detected by a new pylint MDI icon validation rule introduced in #171824.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr