### PR TITLE
Bump reolink_aio to 0.20.0: Reolink battery camera support

### DIFF
--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -20,5 +20,5 @@
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
   "quality_scale": "platinum",
-  "requirements": ["reolink-aio==0.19.1"]
+  "requirements": ["reolink-aio==0.20.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2871,7 +2871,7 @@ renault-api==0.5.10
 renson-endura-delta==1.7.2
 
 # homeassistant.components.reolink
-reolink-aio==0.19.1
+reolink-aio==0.20.0
 
 # homeassistant.components.radio_frequency
 rf-protocols==3.2.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump reolink_aio to 0.20.0, this will add support to directly connect Reolink battery cameras to Home Assistant withouth the need for a Home Hub or NVR. This uses a brand new implementation of a UDP protocol. This is initial support, so not everything will work perfectly yet and not all features of the camera will be available yet, therefore it is still recomended to use a Home Hub or NVR for Reolink battery cameras.

**UDP battery camera support:**
- [Baichuan UDP to support battery cameras #171](https://github.com/starkillerOG/reolink_aio/pull/171)
  - New `bc_connection` optional argument to main Host class
  - [Basic UDP protocol](https://github.com/starkillerOG/reolink_aio/commit/0c2f777758e639dd2f13bbe69e645774af3e9f71)
  - [Add decrypt_udp_baichuan to util](https://github.com/starkillerOG/reolink_aio/commit/7dde03614c2efc331281a453fd1c3dfb4d5d014e)
  - [Add encrypt_udp_baichuan to util](https://github.com/starkillerOG/reolink_aio/commit/ee7c390a5ada2ff512ddddb759bc331f7765a4b1)
  - [Add calc_crc to util for UDP communication](https://github.com/starkillerOG/reolink_aio/commit/1ebf40006e4b44109f2c25b17e8eaeb84558db8a)
  - [Implement offset for encrypt/decrypt_udp_baichuan](https://github.com/starkillerOG/reolink_aio/commit/00f29b719be70a26a3c43ae82cafb3a3ef6f7ea6)
  - [Split out to connection classes](https://github.com/starkillerOG/reolink_aio/commit/abf9a702d2210cf4346537f44f6a88c3c4172761)
  - [Use base send method for UDP and TCP communication](https://github.com/starkillerOG/reolink_aio/commit/1c2f03dd47ba91a12f1d53e225088b91c5deaa19)
  - [Implement UDP connection handshake](https://github.com/starkillerOG/reolink_aio/commit/99029560a4d3eb002a3e2321e91c7d5a990b0583)
  - [Initial UDP acknowledgements](https://github.com/starkillerOG/reolink_aio/commit/16c4d6c50fcb8b4ad027e22861fa20c3f85cf3c0)
  - [Implement UDP acknowledgement](https://github.com/starkillerOG/reolink_aio/commit/e26927749159d1b985d68f7a2cb3ad3297ab014e)
  - [Process UDP close message](https://github.com/starkillerOG/reolink_aio/commit/065d58157e94e443526fcd69377734e4c52eab65)
  - [Handle closing UDP connection](https://github.com/starkillerOG/reolink_aio/commit/e721ef5c4093414d68081906f109bcf259770ce0)
  - [Catch logout error for UDP disconnects](https://github.com/starkillerOG/reolink_aio/commit/83bd7a63ac862ae0c0b52196dabefd1222a0d408)
  - [Check UDP message lengths and process BC messages](https://github.com/starkillerOG/reolink_aio/commit/918cbf95300c9cec19bd9b2e1f1e10c901bbbc2c)
  - [Fix implementation of the send_seq_id and recv_seq_id](https://github.com/starkillerOG/reolink_aio/commit/13fc898652d3c46207ab9c0f4b060a3357bd4671)
  - [Implement UDP heartbeat cmd_id 234 response](https://github.com/starkillerOG/reolink_aio/commit/232b97d3594e57cd936436bf7d74302a2b55118d)
  - [Move client_id to protocol](https://github.com/starkillerOG/reolink_aio/commit/1582e2000ce35347235b2e2013495d993d47080b)
  - [Simplify UDP datagram_received](https://github.com/starkillerOG/reolink_aio/commit/d63a142cb091aab314835146eb2cedf7f7a56911)
  - [Check the UDP client_id of received messages](https://github.com/starkillerOG/reolink_aio/commit/cc2e7b02b9bdb79a694f52968a63d7d0b670d5bc)
  - [fix: fragment baichuan UDP frames #166](https://github.com/starkillerOG/reolink_aio/pull/166)
  - [retry on send_udp timeouts](https://github.com/starkillerOG/reolink_aio/commit/d4ab5c93f187c4155b4261f53bc554e21b84e774)
  - [Detect when send_udp receives wrong mess_id while waiting on it](https://github.com/starkillerOG/reolink_aio/commit/91244b512fe5d60aaf0c9723c04bcda4b99d9b9f)
  - [Move decoding of bytes out of decrypt_udp_baichuan](https://github.com/starkillerOG/reolink_aio/commit/cf564743c490fa055c558def30f0ed1758a5b45d)
  - [Detect battery support using Baichuan](https://github.com/starkillerOG/reolink_aio/commit/4a2c80da62a8bbb71e44ef5d33cc46bf234219bc)
  - [Auto detect UDP vs TCP Baichuan connection, new bc_connection argument](https://github.com/starkillerOG/reolink_aio/commit/4de7602d4502b09dcb9bd3536feee066e905f778)
  - [Add is_battery property](https://github.com/starkillerOG/reolink_aio/commit/88a29b2f5e966870ffbae132297019c0f0f20247)
  - [Close battery connection when idle for 5.0 seconds](https://github.com/starkillerOG/reolink_aio/commit/de960bfebc676950174a99f2077f504f9a2e0445)
  - [Do not wake battery camera when requesting get_states with wake=False](https://github.com/starkillerOG/reolink_aio/commit/098e81e21d056818d5cd2f5d6a615c2dd8d39af2)
  - [Add login_sucess to determine battery camera availability](https://github.com/starkillerOG/reolink_aio/commit/37176db11dc498cd38176147f2cb2be839b0de6c)
  - [Block baichuan subscriptions for battery cameras](https://github.com/starkillerOG/reolink_aio/commit/8964cd7ff06d3cd1c16a144e4193071f6b352792)

**Additions:**
- [Add 3D zoom (area zoom) support via Set3DPos/Get3DPos #159](https://github.com/starkillerOG/reolink_aio/pull/159)

**Bug fixes:**
- [protect against continues login attempts](https://github.com/starkillerOG/reolink_aio/commit/34782dbb4d15e68e5f93879c712346b67b082223)
- [Fix keyError when parsing smart AI event](https://github.com/starkillerOG/reolink_aio/commit/dd48d5c0bfefad2ea326b96983644ffb3d179505)
- [Protect against KeyError in Baichuan get_ptz_preset](https://github.com/starkillerOG/reolink_aio/commit/6cffcb6b8c0e2a3276a25b4259263a9593c748cb)
- [Make encrypt_baichuan / decrypt_baichuan compatible with non-ascii chars and allow bytes input](https://github.com/starkillerOG/reolink_aio/commit/bfc2234e552c6900296d231bdeb464f0b20d119e)
- [Fix Baichuan header lengths for non-ASCII XML](https://github.com/starkillerOG/reolink_aio/commit/6b6b559b4c50565bb14e9aeeb2a8e7bba5fc11b5)
- [Protection in case cmd_id 685 wakes a camera](https://github.com/starkillerOG/reolink_aio/commit/fcb727bb9ad6b6c67fc5e7489a218517b26b1756)
- [Check for timeout on Baichuan connection close](https://github.com/starkillerOG/reolink_aio/commit/88a2aa312132af72778384795ef410e65f92a6b2)

**Optimizations:**
- [Combine get_value_from_xml_element and get_value_from_xml](https://github.com/starkillerOG/reolink_aio/commit/9d325130842710b24a0fb3c6d24c90792d43dfa2)
- [Fix newest mypy styling](https://github.com/starkillerOG/reolink_aio/commit/ac8e51f32519d9339f42b9c57a9ee4957fca74cb)
- [comment out unused net_type](https://github.com/starkillerOG/reolink_aio/commit/b1041c4a28ad546d8603e697de33127ba78c3022)
- [RETRY_ATTEMPTS constant](https://github.com/starkillerOG/reolink_aio/commit/1a0edbf404cd7e348d3d93c4c38987a4cc4bb4f5)

**Full Changelog**: https://github.com/starkillerOG/reolink_aio/compare/0.19.1...0.20.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
