### PR TITLE
Implement entity available for battery cameras

### DIFF
--- a/homeassistant/components/reolink/entity.py
+++ b/homeassistant/components/reolink/entity.py
@@ -96,6 +96,13 @@ class ReolinkHostCoordinatorEntity(CoordinatorEntity[ReolinkCoordinator]):
         if self.entity_description.always_available:
             return True
 
+        if self._host.api.is_battery:
+            return (
+                self._host.api.baichuan.login_sucess
+                and not self._host.api.baichuan.privacy_mode()
+                and super().available
+            )
+
         return (
             self._host.api.session_active
             and not self._host.api.baichuan.privacy_mode()

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -93,6 +93,7 @@ def _init_host_mock(host_mock: MagicMock) -> None:
     host_mock.update_firmware = AsyncMock()
     host_mock.is_nvr = True
     host_mock.is_hub = False
+    host_mock.is_battery = False
     host_mock.mac_address = TEST_MAC
     host_mock.uid = TEST_UID
     host_mock.onvif_enabled = True
@@ -162,6 +163,7 @@ def _init_host_mock(host_mock: MagicMock) -> None:
     # Disable tcp push by default for tests
     host_mock.baichuan.port = TEST_BC_PORT
     host_mock.baichuan.events_active = False
+    host_mock.baichuan.login_sucess = True
     host_mock.baichuan.subscribe_events = AsyncMock()
     host_mock.baichuan.unsubscribe_events = AsyncMock()
     host_mock.baichuan.check_subscribe_events = AsyncMock()

--- a/tests/components/reolink/test_entity.py
+++ b/tests/components/reolink/test_entity.py
@@ -1,0 +1,41 @@
+"""Test the Reolink entity file."""
+
+from unittest.mock import MagicMock, patch
+
+from freezegun.api import FrozenDateTimeFactory
+
+from homeassistant.components.reolink.coordinator import DEVICE_UPDATE_INTERVAL_MIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant
+
+from .conftest import TEST_CAM_NAME
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def test_battery_available(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    config_entry: MockConfigEntry,
+    reolink_host: MagicMock,
+) -> None:
+    """Test available property of a entity from a Reolink battery camera."""
+    reolink_host.volume.return_value = 80
+    reolink_host.is_battery = True
+
+    with patch("homeassistant.components.reolink.PLATFORMS", [Platform.NUMBER]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    entity_id = f"{Platform.NUMBER}.{TEST_CAM_NAME}_volume"
+
+    assert hass.states.get(entity_id).state == "80"
+
+    reolink_host.baichuan.login_sucess = False
+    freezer.tick(2 * DEVICE_UPDATE_INTERVAL_MIN)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Battery camera support is new in HA 2026.6.0.

Implement entity available for battery cameras.
Since battery cameras sleep in-between updates, the connect is dropped and would otherwise be reported as unavailable.
This looks if the last login was succesfull to determine if the entities are available.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
