### PR TITLE
Fix OpenHome config flow crash when UDN is a list

### DIFF
--- a/homeassistant/components/openhome/config_flow.py
+++ b/homeassistant/components/openhome/config_flow.py
@@ -37,11 +37,13 @@ class OpenhomeConfigFlow(ConfigFlow, domain=DOMAIN):
             _LOGGER.debug("async_step_ssdp: Incomplete discovery, ignoring")
             return self.async_abort(reason="incomplete_discovery")
 
-        _LOGGER.debug(
-            "async_step_ssdp: setting unique id %s", discovery_info.upnp[ATTR_UPNP_UDN]
-        )
+        udn = discovery_info.upnp[ATTR_UPNP_UDN]
+        if isinstance(udn, list):
+            udn = udn[0]
 
-        await self.async_set_unique_id(discovery_info.upnp[ATTR_UPNP_UDN])
+        _LOGGER.debug("async_step_ssdp: setting unique id %s", udn)
+
+        await self.async_set_unique_id(udn)
         self._abort_if_unique_id_configured({CONF_HOST: discovery_info.ssdp_location})
 
         _LOGGER.debug(

--- a/homeassistant/components/openhome/config_flow.py
+++ b/homeassistant/components/openhome/config_flow.py
@@ -39,6 +39,8 @@ class OpenhomeConfigFlow(ConfigFlow, domain=DOMAIN):
 
         udn = discovery_info.upnp[ATTR_UPNP_UDN]
         if isinstance(udn, list):
+            if not udn:
+                return self.async_abort(reason="incomplete_discovery")
             udn = udn[0]
 
         _LOGGER.debug("async_step_ssdp: setting unique id %s", udn)

--- a/tests/components/openhome/test_config_flow.py
+++ b/tests/components/openhome/test_config_flow.py
@@ -116,3 +116,33 @@ async def test_host_updated(hass: HomeAssistant) -> None:
     assert result["reason"] == "already_configured"
 
     assert entry.data[CONF_HOST] == MOCK_SSDP_LOCATION
+
+
+async def test_ssdp_udn_as_list(hass: HomeAssistant) -> None:
+    """Test SSDP discovery when UDN is a list instead of a string.
+
+    Regression test for https://github.com/home-assistant/core/issues/171837
+    """
+    list_udn_discovery = SsdpServiceInfo(
+        ssdp_usn="usn",
+        ssdp_st="st",
+        ssdp_location=MOCK_SSDP_LOCATION,
+        upnp={
+            ATTR_UPNP_FRIENDLY_NAME: MOCK_FRIENDLY_NAME,
+            ATTR_UPNP_UDN: [MOCK_UDN, "uuid:other"],
+        },
+    )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={CONF_SOURCE: SOURCE_SSDP},
+        data=list_udn_discovery,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "confirm"
+    assert result["description_placeholders"] == {CONF_NAME: MOCK_FRIENDLY_NAME}
+
+    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["title"] == MOCK_FRIENDLY_NAME
+    assert result2["data"] == {CONF_HOST: MOCK_SSDP_LOCATION}

--- a/tests/components/openhome/test_config_flow.py
+++ b/tests/components/openhome/test_config_flow.py
@@ -146,3 +146,24 @@ async def test_ssdp_udn_as_list(hass: HomeAssistant) -> None:
     assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["title"] == MOCK_FRIENDLY_NAME
     assert result2["data"] == {CONF_HOST: MOCK_SSDP_LOCATION}
+
+
+async def test_ssdp_udn_as_empty_list(hass: HomeAssistant) -> None:
+    """Test SSDP discovery when UDN is an empty list."""
+    empty_udn_discovery = SsdpServiceInfo(
+        ssdp_usn="usn",
+        ssdp_st="st",
+        ssdp_location=MOCK_SSDP_LOCATION,
+        upnp={
+            ATTR_UPNP_FRIENDLY_NAME: MOCK_FRIENDLY_NAME,
+            ATTR_UPNP_UDN: [],
+        },
+    )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={CONF_SOURCE: SOURCE_SSDP},
+        data=empty_udn_discovery,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "incomplete_discovery"


### PR DESCRIPTION
## Proposed change

Handle the case where the UPnP UDN field in SSDP discovery data is a list instead of a string. Volumio devices broadcast as OpenHome devices via SSDP but provide the UDN as a list of strings, which causes `async_set_unique_id` to crash with `HomeAssistantError: The entry unique id [...] is not a string`. This crash happens on every HA restart for affected users.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #171837
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr