### PR TITLE
Fix Hue device trigger crash for devices removed from bridge

### DIFF
--- a/homeassistant/components/hue/v2/device_trigger.py
+++ b/homeassistant/components/hue/v2/device_trigger.py
@@ -87,6 +87,8 @@ def async_get_triggers(
 
     # Get Hue device id from device identifier
     hue_dev_id = get_hue_device_id(device_entry)
+    if hue_dev_id is None or hue_dev_id not in api.devices:
+        return []
     # extract triggers from all button resources of this Hue device
     triggers: list[dict[str, Any]] = []
     model_id = api.devices[hue_dev_id].product_data.product_name

--- a/tests/components/hue/test_device_trigger_v2.py
+++ b/tests/components/hue/test_device_trigger_v2.py
@@ -116,3 +116,30 @@ async def test_get_triggers(
     ]
 
     assert triggers == unordered(expected_triggers)
+
+
+async def test_get_triggers_for_removed_device(
+    hass: HomeAssistant,
+    mock_bridge_v2: Mock,
+    v2_resources_test_data: JsonArrayType,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test triggers for a device removed from the bridge.
+
+    Regression test for https://github.com/home-assistant/core/issues/152937
+    """
+    await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
+    await setup_platform(
+        hass, mock_bridge_v2, [Platform.BINARY_SENSOR, Platform.SENSOR]
+    )
+
+    # Create a device entry with a Hue ID that doesn't exist on the bridge
+    orphaned_device = device_registry.async_get_or_create(
+        config_entry_id=mock_bridge_v2.config_entry.entry_id,
+        identifiers={(hue.DOMAIN, "non-existent-hue-device-id")},
+    )
+
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, orphaned_device.id
+    )
+    assert triggers == []


### PR DESCRIPTION
## Proposed change

Guard against missing Hue device IDs in the v2 device trigger handler. When a device is removed from the Hue bridge but still exists in the HA device registry, `api.devices[hue_dev_id]` raises `KeyError`, crashing device trigger retrieval. This also handles the case where `get_hue_device_id` returns `None` for non-v2 identifiers.

Now returns an empty trigger list for devices that no longer exist on the bridge.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #152937
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr