### PR TITLE
(Re) add missing WeatherFlow UDP sensors

### DIFF
--- a/homeassistant/components/weatherflow/icons.json
+++ b/homeassistant/components/weatherflow/icons.json
@@ -15,6 +15,15 @@
       "lightning_count": {
         "default": "mdi:lightning-bolt"
       },
+      "lightning_strike_last_distance": {
+        "default": "mdi:lightning-bolt"
+      },
+      "lightning_strike_last_energy": {
+        "default": "mdi:lightning-bolt"
+      },
+      "lightning_strike_last_epoch": {
+        "default": "mdi:lightning-bolt"
+      },
       "precipitation_type": {
         "default": "mdi:weather-rainy"
       },

--- a/homeassistant/components/weatherflow/sensor.py
+++ b/homeassistant/components/weatherflow/sensor.py
@@ -10,6 +10,7 @@ from pyweatherflowudp.const import EVENT_RAPID_WIND
 from pyweatherflowudp.device import (
     EVENT_OBSERVATION,
     EVENT_STATUS_UPDATE,
+    EVENT_STRIKE,
     WeatherFlowDevice,
     WeatherFlowSensorDevice,
 )
@@ -60,12 +61,13 @@ class WeatherFlowSensorEntityDescription(SensorEntityDescription):
 
     raw_data_conv_fn: Callable[[Any], datetime | StateType]
 
+    device_attr: str | None = None
     event_subscriptions: list[str] = field(default_factory=lambda: [EVENT_OBSERVATION])
     imperial_suggested_unit: str | None = None
 
     def get_native_value(self, device: WeatherFlowDevice) -> datetime | StateType:
         """Return the parsed sensor value."""
-        if (raw_sensor_data := getattr(device, self.key)) is None:
+        if (raw_sensor_data := getattr(device, self.device_attr or self.key)) is None:
             return None
         return self.raw_data_conv_fn(raw_sensor_data)
 
@@ -152,6 +154,33 @@ SENSORS: tuple[WeatherFlowSensorEntityDescription, ...] = (
         translation_key="lightning_count",
         state_class=SensorStateClass.TOTAL,
         raw_data_conv_fn=lambda raw_data: raw_data,
+    ),
+    WeatherFlowSensorEntityDescription(
+        key="lightning_strike_last_distance",
+        device_attr="last_lightning_strike_event",
+        translation_key="lightning_strike_last_distance",
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.DISTANCE,
+        native_unit_of_measurement=UnitOfLength.KILOMETERS,
+        suggested_display_precision=2,
+        event_subscriptions=[EVENT_STRIKE],
+        raw_data_conv_fn=lambda raw_data: raw_data.distance.magnitude,
+    ),
+    WeatherFlowSensorEntityDescription(
+        key="lightning_strike_last_energy",
+        device_attr="last_lightning_strike_event",
+        translation_key="lightning_strike_last_energy",
+        state_class=SensorStateClass.MEASUREMENT,
+        event_subscriptions=[EVENT_STRIKE],
+        raw_data_conv_fn=lambda raw_data: raw_data.energy,
+    ),
+    WeatherFlowSensorEntityDescription(
+        key="lightning_strike_last_epoch",
+        device_attr="last_lightning_strike_event",
+        translation_key="lightning_strike_last_epoch",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        event_subscriptions=[EVENT_STRIKE],
+        raw_data_conv_fn=lambda raw_data: raw_data.timestamp,
     ),
     WeatherFlowSensorEntityDescription(
         key="precipitation_type",
@@ -310,7 +339,7 @@ async def async_setup_entry(
                 is_metric=(hass.config.units == METRIC_SYSTEM),
             )
             for description in SENSORS
-            if hasattr(device, description.key)
+            if hasattr(device, description.device_attr or description.key)
         ]
 
         async_add_entities(sensors)

--- a/homeassistant/components/weatherflow/strings.json
+++ b/homeassistant/components/weatherflow/strings.json
@@ -48,6 +48,15 @@
       "lightning_count": {
         "name": "Lightning count"
       },
+      "lightning_strike_last_distance": {
+        "name": "Lightning last distance"
+      },
+      "lightning_strike_last_energy": {
+        "name": "Lightning last energy"
+      },
+      "lightning_strike_last_epoch": {
+        "name": "Lightning last strike"
+      },
       "precipitation_type": {
         "name": "Precipitation type",
         "state": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Well, I've learned my lesson on that one. I originally had a PR open: https://github.com/home-assistant/core/pull/169580 but I forgot about it and deleted my fork. So here it is again...exact same changes

Add missing lightning strike sensors to the local WeatherFlow UDP integration.

The underlying `pyweatherflowudp` library already parses `evt_strike` UDP events, including timestamp, distance, and energy. This PR exposes those parsed values as Home Assistant sensors:

- Lightning last distance
- Lightning last energy
- Lightning last strike

This brings the local UDP integration closer to parity with the WeatherFlow Cloud integration for last lightning strike data.

PR generated with Codex 5.5, but I understand the code and have tried to align it with the WF Cloud integration and HA best practices.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45168
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository. 

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr