### PR TITLE
OpenGarage use explicit garage door commands

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1284,8 +1284,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/openevse/ @c00w @firstof9
 /homeassistant/components/openexchangerates/ @MartinHjelmare
 /tests/components/openexchangerates/ @MartinHjelmare
-/homeassistant/components/opengarage/ @danielhiversen
-/tests/components/opengarage/ @danielhiversen
+/homeassistant/components/opengarage/ @danielhiversen @h0tw1r3
+/tests/components/opengarage/ @danielhiversen @h0tw1r3
 /homeassistant/components/openhome/ @bazwilliams
 /tests/components/openhome/ @bazwilliams
 /homeassistant/components/openrgb/ @felipecrs

--- a/homeassistant/components/opengarage/cover.py
+++ b/homeassistant/components/opengarage/cover.py
@@ -2,6 +2,7 @@
 
 import logging
 from typing import Any, cast
+from urllib.parse import urlencode
 
 from homeassistant.components.cover import (
     CoverDeviceClass,
@@ -12,12 +13,19 @@ from homeassistant.components.cover import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .const import CONF_DEVICE_KEY
 from .coordinator import OpenGarageConfigEntry, OpenGarageDataUpdateCoordinator
 from .entity import OpenGarageEntity
 
 _LOGGER = logging.getLogger(__name__)
 
-STATES_MAP = {0: CoverState.CLOSED, 1: CoverState.OPEN}
+STATES_MAP = {
+    0: CoverState.CLOSED,
+    1: CoverState.OPEN,
+    2: CoverState.OPEN,  # stopped (partially open)
+    3: CoverState.CLOSING,
+    4: CoverState.OPENING,
+}
 
 
 async def async_setup_entry(
@@ -74,7 +82,8 @@ class OpenGarageCover(OpenGarageEntity, CoverEntity):
             return
         self._state_before_move = self._state
         self._state = CoverState.CLOSING
-        await self._push_button()
+        self.async_write_ha_state()
+        await self._push_close_button()
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
@@ -82,7 +91,8 @@ class OpenGarageCover(OpenGarageEntity, CoverEntity):
             return
         self._state_before_move = self._state
         self._state = CoverState.OPENING
-        await self._push_button()
+        self.async_write_ha_state()
+        await self._push_open_button()
 
     @callback
     def _update_attr(self) -> None:
@@ -97,18 +107,64 @@ class OpenGarageCover(OpenGarageEntity, CoverEntity):
         else:
             self._state = state
 
-    async def _push_button(self):
+    async def _push_close_button(self) -> None:
+        """Send a close command to the API."""
+        await self._push_button("close")
+
+    async def _push_open_button(self) -> None:
+        """Send an open command to the API."""
+        await self._push_button("open")
+
+    async def _push_button(self, command: str) -> None:
         """Send commands to API."""
-        result = await self.coordinator.open_garage_connection.push_button()
-        if result is None:
-            _LOGGER.error("Unable to connect to OpenGarage device")
-        if result == 1:
+        params = {
+            "dkey": self.coordinator.config_entry.data[CONF_DEVICE_KEY],
+            command: "1",
+        }
+        data = await self.coordinator.open_garage_connection._execute(  # noqa: SLF001
+            f"cc?{urlencode(params)}"
+        )
+        if not isinstance(data, dict):
+            _LOGGER.error(
+                "Unable to control %s: Invalid API response: %r", self.name, data
+            )
+            self._revert_state()
             return
 
-        if result == 2:
-            _LOGGER.error("Unable to control %s: Device key is incorrect", self.name)
-        elif result > 2:
-            _LOGGER.error("Unable to control %s: Error code %s", self.name, result)
+        result = data.get("result")
+        if isinstance(result, int):
+            if result == 1:
+                return
+
+            if result == 2:
+                _LOGGER.error(
+                    "Unable to control %s: Device key is incorrect", self.name
+                )
+            else:
+                _LOGGER.error(
+                    "Unable to control %s: Error code %s (response: %r)",
+                    self.name,
+                    result,
+                    data,
+                )
+        else:
+            _LOGGER.error(
+                "Unable to control %s: Invalid API result: %r (response: %r)",
+                self.name,
+                result,
+                data,
+            )
+
+        self._revert_state()
+
+    def _revert_state(self) -> None:
+        """Revert the optimistic state after a failed command."""
+        if self._state_before_move is None:
+            _LOGGER.warning(
+                "Unable to revert state for %s: no previous state was saved", self.name
+            )
+            return
 
         self._state = self._state_before_move
         self._state_before_move = None
+        self.async_write_ha_state()

--- a/homeassistant/components/opengarage/manifest.json
+++ b/homeassistant/components/opengarage/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "opengarage",
   "name": "OpenGarage",
-  "codeowners": ["@danielhiversen"],
+  "codeowners": ["@danielhiversen", "@h0tw1r3"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/opengarage",
   "integration_type": "device",

--- a/tests/components/opengarage/test_button.py
+++ b/tests/components/opengarage/test_button.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock
 
 from homeassistant.components import button
+from homeassistant.components.opengarage.const import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -21,6 +22,10 @@ async def test_buttons(
     entry = entity_registry.async_get("button.garage_abcdef_restart")
     assert entry
     assert entry.unique_id == "12345_restart"
+    assert (
+        entity_registry.async_get_entity_id(button.DOMAIN, DOMAIN, "12345_restart")
+        == "button.garage_abcdef_restart"
+    )
     await hass.services.async_call(
         button.DOMAIN,
         button.SERVICE_PRESS,

--- a/tests/components/opengarage/test_cover.py
+++ b/tests/components/opengarage/test_cover.py
@@ -1,0 +1,230 @@
+"""Test the OpenGarage covers."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from homeassistant.components.cover import (
+    DOMAIN as COVER_DOMAIN,
+    SERVICE_CLOSE_COVER,
+    SERVICE_OPEN_COVER,
+    CoverState,
+)
+from homeassistant.components.opengarage.const import CONF_DEVICE_KEY
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+ENTITY_ID = "cover.garage_abcdef"
+
+
+async def _setup_opengarage(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Set up the OpenGarage integration."""
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+
+@pytest.mark.parametrize(
+    ("door_state", "expected_state"),
+    [
+        pytest.param(0, CoverState.CLOSED, id="closed"),
+        pytest.param(1, CoverState.OPEN, id="open"),
+        pytest.param(2, CoverState.OPEN, id="stopped"),
+        pytest.param(3, CoverState.CLOSING, id="closing"),
+        pytest.param(4, CoverState.OPENING, id="opening"),
+        pytest.param(5, STATE_UNKNOWN, id="unknown"),
+        pytest.param(99, STATE_UNKNOWN, id="unsupported"),
+    ],
+)
+async def test_cover_door_states(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_opengarage: MagicMock,
+    door_state: int,
+    expected_state: CoverState | str,
+) -> None:
+    """Test OpenGarage door state mapping."""
+    mock_opengarage.update_state.return_value = {
+        "name": "abcdef",
+        "mac": "aa:bb:cc:dd:ee:ff",
+        "fwv": "1.2.4",
+        "door": door_state,
+    }
+
+    await _setup_opengarage(hass, mock_config_entry)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state
+    assert state.state == expected_state
+
+
+async def test_open_cover_uses_explicit_open_command(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_opengarage: MagicMock,
+) -> None:
+    """Test opening the cover uses the explicit open command."""
+    device_key = "abc123&=?/"
+    object.__setattr__(
+        mock_config_entry,
+        "data",
+        {**mock_config_entry.data, CONF_DEVICE_KEY: device_key},
+    )
+    mock_opengarage.update_state.return_value = {
+        "name": "abcdef",
+        "mac": "aa:bb:cc:dd:ee:ff",
+        "fwv": "1.2.4",
+        "door": 0,
+    }
+    mock_opengarage._execute.return_value = {"result": 1}
+
+    await _setup_opengarage(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+
+    mock_opengarage._execute.assert_awaited_once_with(
+        "cc?dkey=abc123%26%3D%3F%2F&open=1"
+    )
+    mock_opengarage.push_button.assert_not_called()
+    state = hass.states.get(ENTITY_ID)
+    assert state
+    assert state.state == CoverState.OPENING
+
+
+async def test_close_cover_uses_explicit_close_command(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_opengarage: MagicMock,
+) -> None:
+    """Test closing the cover uses the explicit close command."""
+    device_key = "abc123&=?/"
+    object.__setattr__(
+        mock_config_entry,
+        "data",
+        {**mock_config_entry.data, CONF_DEVICE_KEY: device_key},
+    )
+    mock_opengarage.update_state.return_value = {
+        "name": "abcdef",
+        "mac": "aa:bb:cc:dd:ee:ff",
+        "fwv": "1.2.4",
+        "door": 1,
+    }
+    mock_opengarage._execute.return_value = {"result": 1}
+
+    await _setup_opengarage(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_CLOSE_COVER,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+
+    mock_opengarage._execute.assert_awaited_once_with(
+        "cc?dkey=abc123%26%3D%3F%2F&close=1"
+    )
+    mock_opengarage.push_button.assert_not_called()
+    state = hass.states.get(ENTITY_ID)
+    assert state
+    assert state.state == CoverState.CLOSING
+
+
+async def test_cover_failed_command_reverts_state(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_opengarage: MagicMock,
+) -> None:
+    """Test a failed command reverts the optimistic state."""
+    mock_opengarage.update_state.return_value = {
+        "name": "abcdef",
+        "mac": "aa:bb:cc:dd:ee:ff",
+        "fwv": "1.2.4",
+        "door": 0,
+    }
+    mock_opengarage._execute.return_value = None
+
+    await _setup_opengarage(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+
+    state = hass.states.get(ENTITY_ID)
+    assert state
+    assert state.state == CoverState.CLOSED
+
+
+@pytest.mark.parametrize("result", [2, 99, "bad"])
+async def test_cover_command_error_result_reverts_state(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_opengarage: MagicMock,
+    result: int | str,
+) -> None:
+    """Test error result responses revert the optimistic state."""
+    mock_opengarage.update_state.return_value = {
+        "name": "abcdef",
+        "mac": "aa:bb:cc:dd:ee:ff",
+        "fwv": "1.2.4",
+        "door": 0,
+    }
+    mock_opengarage._execute.return_value = {"result": result}
+
+    await _setup_opengarage(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+
+    state = hass.states.get(ENTITY_ID)
+    assert state
+    assert state.state == CoverState.CLOSED
+
+
+@pytest.mark.parametrize(
+    "data",
+    [None, "bad", {"result": 2}, {"result": 99}, {"result": "bad"}],
+)
+async def test_close_cover_command_error_reverts_state(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_opengarage: MagicMock,
+    data: dict[str, int | str] | str | None,
+) -> None:
+    """Test close command error responses revert the optimistic state."""
+    mock_opengarage.update_state.return_value = {
+        "name": "abcdef",
+        "mac": "aa:bb:cc:dd:ee:ff",
+        "fwv": "1.2.4",
+        "door": 1,
+    }
+    mock_opengarage._execute.return_value = data
+
+    await _setup_opengarage(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_CLOSE_COVER,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+
+    state = hass.states.get(ENTITY_ID)
+    assert state
+    assert state.state == CoverState.OPEN


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

* Map newer door states available in latest OpenGarage firmware
* Route cover commands through explict firmware commands (see why below)
* Add targeted cover tests

Although pyOpenGarage has support for explicit open and close commands for 2 years, support was never published to pypi. Additionally, I will be building on this PR to support all of the OpenGarage firmware 2.3 features.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Addressing issue raised on the OpenGarage Firmware repository

https://github.com/OpenGarage/OpenGarage-Firmware/issues/115

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
