### PR TITLE
Refactor labs websocket API tests to use async_setup_component

### DIFF
--- a/tests/components/labs/test_websocket_api.py
+++ b/tests/components/labs/test_websocket_api.py
@@ -8,9 +8,10 @@ import pytest
 from homeassistant.components.labs import (
     EVENT_LABS_UPDATED,
     async_is_preview_feature_enabled,
-    async_setup,
 )
+from homeassistant.components.labs.const import DOMAIN
 from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
 
 from . import assert_stored_labs_data
 
@@ -48,7 +49,7 @@ async def test_websocket_list_preview_features(
     if load_integration:
         hass.config.components.add("kitchen_sink")
 
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_ws_client(hass)
@@ -68,7 +69,7 @@ async def test_websocket_update_preview_feature_enable(
     """Test enabling a preview feature via WebSocket."""
     # Load kitchen_sink integration
     hass.config.components.add("kitchen_sink")
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_ws_client(hass)
@@ -132,7 +133,7 @@ async def test_websocket_update_preview_feature_disable(
     }
 
     hass.config.components.add("kitchen_sink")
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_ws_client(hass)
@@ -164,7 +165,7 @@ async def test_websocket_update_nonexistent_feature(
     hass_storage: dict[str, Any],
 ) -> None:
     """Test updating a preview feature that doesn't exist."""
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_ws_client(hass)
@@ -193,7 +194,7 @@ async def test_websocket_update_unavailable_preview_feature(
 ) -> None:
     """Test updating a preview feature whose integration is not loaded still works."""
     # Don't load kitchen_sink integration
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_ws_client(hass)
@@ -235,7 +236,7 @@ async def test_websocket_requires_admin(
     hass_admin_user.groups = []
 
     hass.config.components.add("kitchen_sink")
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_ws_client(hass)
@@ -264,7 +265,7 @@ async def test_websocket_update_validates_enabled_parameter(
 ) -> None:
     """Test that enabled parameter must be boolean."""
     hass.config.components.add("kitchen_sink")
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_ws_client(hass)
@@ -291,7 +292,7 @@ async def test_storage_persists_preview_feature_across_calls(
 ) -> None:
     """Test that storage persists preview feature state across multiple calls."""
     hass.config.components.add("kitchen_sink")
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_ws_client(hass)
@@ -350,7 +351,7 @@ async def test_preview_feature_urls_present(
 ) -> None:
     """Test that preview features include feedback and report URLs."""
     hass.config.components.add("kitchen_sink")
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_ws_client(hass)
@@ -401,7 +402,7 @@ async def test_websocket_update_preview_feature_backup_scenarios(
 ) -> None:
     """Test various backup scenarios when updating preview features."""
     hass.config.components.add("kitchen_sink")
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_ws_client(hass)
@@ -463,7 +464,7 @@ async def test_websocket_list_multiple_enabled_features(
     }
 
     hass.config.components.add("kitchen_sink")
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_ws_client(hass)
@@ -484,7 +485,7 @@ async def test_websocket_update_rapid_toggle(
 ) -> None:
     """Test rapid toggling of a preview feature."""
     hass.config.components.add("kitchen_sink")
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_ws_client(hass)
@@ -534,7 +535,7 @@ async def test_websocket_update_same_state_idempotent(
 ) -> None:
     """Test that enabling an already-enabled feature is idempotent."""
     hass.config.components.add("kitchen_sink")
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_ws_client(hass)
@@ -572,7 +573,7 @@ async def test_websocket_list_filtered_by_loaded_components(
 ) -> None:
     """Test that list only shows features from loaded integrations."""
     # Don't load kitchen_sink - its preview feature shouldn't appear
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_ws_client(hass)
@@ -600,7 +601,7 @@ async def test_websocket_update_with_missing_required_field(
 ) -> None:
     """Test that missing required fields are rejected."""
     hass.config.components.add("kitchen_sink")
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_ws_client(hass)
@@ -625,7 +626,7 @@ async def test_websocket_event_data_structure(
 ) -> None:
     """Test that event data has correct structure."""
     hass.config.components.add("kitchen_sink")
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_ws_client(hass)
@@ -666,7 +667,7 @@ async def test_websocket_backup_timeout_handling(
 ) -> None:
     """Test handling of backup timeout/long-running backup."""
     hass.config.components.add("kitchen_sink")
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_ws_client(hass)
@@ -702,7 +703,7 @@ async def test_websocket_subscribe_feature(
 ) -> None:
     """Test subscribing to a specific preview feature."""
     hass.config.components.add("kitchen_sink")
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_ws_client(hass)
@@ -739,7 +740,7 @@ async def test_websocket_subscribe_feature_receives_updates(
 ) -> None:
     """Test that subscription receives updates when feature is toggled."""
     hass.config.components.add("kitchen_sink")
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_ws_client(hass)
@@ -793,7 +794,7 @@ async def test_websocket_subscribe_nonexistent_feature(
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test subscribing to a preview feature that doesn't exist."""
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_ws_client(hass)
@@ -821,7 +822,7 @@ async def test_websocket_subscribe_does_not_require_admin(
     hass_admin_user.groups = []
 
     hass.config.components.add("kitchen_sink")
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_ws_client(hass)
@@ -847,7 +848,7 @@ async def test_websocket_subscribe_only_receives_subscribed_feature_updates(
 ) -> None:
     """Test that subscription only receives updates for the subscribed feature."""
     hass.config.components.add("kitchen_sink")
-    assert await async_setup(hass, {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_ws_client(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactor labs websocket API tests to use async_setup_component

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #171886
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
