### PR TITLE
Use discovered Axis name for config entry title and device name

### DIFF
--- a/homeassistant/components/axis/config_flow.py
+++ b/homeassistant/components/axis/config_flow.py
@@ -8,7 +8,6 @@ from urllib.parse import urlsplit
 import voluptuous as vol
 
 from homeassistant.config_entries import (
-    SOURCE_IGNORE,
     SOURCE_REAUTH,
     SOURCE_RECONFIGURE,
     ConfigEntry,
@@ -139,31 +138,15 @@ class AxisFlowHandler(ConfigFlow, domain=DOMAIN):
     async def _create_entry(self, serial: str) -> ConfigFlowResult:
         """Create entry for device.
 
-        Use the discovered device name when available, otherwise generate a name
-        to be used as a prefix for device entities.
+        Use the discovered device name when available.
         """
         if (title_placeholders := self.context.get("title_placeholders")) is not None:
             name = title_placeholders[CONF_NAME]
-            title = name
         else:
-            model = self.config[CONF_MODEL]
-            same_model = [
-                entry.data[CONF_NAME]
-                for entry in self.hass.config_entries.async_entries(DOMAIN)
-                if entry.source != SOURCE_IGNORE and entry.data[CONF_MODEL] == model
-            ]
-
-            name = model
-            for idx in range(len(same_model) + 1):
-                name = f"{model} {idx}"
-                if name not in same_model:
-                    break
-
-            title = f"{model} - {serial}"
-
+            name = f"{self.config[CONF_MODEL]} - {serial}"
         self.config[CONF_NAME] = name
 
-        return self.async_create_entry(title=title, data=self.config)
+        return self.async_create_entry(title=name, data=self.config)
 
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/axis/config_flow.py
+++ b/homeassistant/components/axis/config_flow.py
@@ -139,28 +139,31 @@ class AxisFlowHandler(ConfigFlow, domain=DOMAIN):
     async def _create_entry(self, serial: str) -> ConfigFlowResult:
         """Create entry for device.
 
-        Generate a name to be used as a prefix for device entities.
+        Use the discovered device name when available, otherwise generate a name
+        to be used as a prefix for device entities.
         """
         model = self.config[CONF_MODEL]
-        same_model = [
-            entry.data[CONF_NAME]
-            for entry in self.hass.config_entries.async_entries(DOMAIN)
-            if entry.source != SOURCE_IGNORE and entry.data[CONF_MODEL] == model
-        ]
+        title_placeholders = self.context.get("title_placeholders")
 
-        name = model
-        for idx in range(len(same_model) + 1):
-            name = f"{model} {idx}"
-            if name not in same_model:
-                break
+        if title_placeholders is not None:
+            name = title_placeholders[CONF_NAME]
+            title = name
+        else:
+            same_model = [
+                entry.data[CONF_NAME]
+                for entry in self.hass.config_entries.async_entries(DOMAIN)
+                if entry.source != SOURCE_IGNORE and entry.data[CONF_MODEL] == model
+            ]
+
+            name = model
+            for idx in range(len(same_model) + 1):
+                name = f"{model} {idx}"
+                if name not in same_model:
+                    break
+
+            title = f"{model} - {serial}"
 
         self.config[CONF_NAME] = name
-
-        title_placeholders = self.context.get("title_placeholders")
-        if title_placeholders is not None:
-            title = title_placeholders[CONF_NAME] or f"{model} - {serial}"
-        else:
-            title = f"{model} - {serial}"
 
         return self.async_create_entry(title=title, data=self.config)
 

--- a/homeassistant/components/axis/config_flow.py
+++ b/homeassistant/components/axis/config_flow.py
@@ -142,13 +142,11 @@ class AxisFlowHandler(ConfigFlow, domain=DOMAIN):
         Use the discovered device name when available, otherwise generate a name
         to be used as a prefix for device entities.
         """
-        model = self.config[CONF_MODEL]
-        title_placeholders = self.context.get("title_placeholders")
-
-        if title_placeholders is not None:
+        if (title_placeholders := self.context.get("title_placeholders")) is not None:
             name = title_placeholders[CONF_NAME]
             title = name
         else:
+            model = self.config[CONF_MODEL]
             same_model = [
                 entry.data[CONF_NAME]
                 for entry in self.hass.config_entries.async_entries(DOMAIN)

--- a/homeassistant/components/axis/config_flow.py
+++ b/homeassistant/components/axis/config_flow.py
@@ -156,7 +156,12 @@ class AxisFlowHandler(ConfigFlow, domain=DOMAIN):
 
         self.config[CONF_NAME] = name
 
-        title = f"{model} - {serial}"
+        title_placeholders = self.context.get("title_placeholders")
+        if title_placeholders is not None:
+            title = title_placeholders[CONF_NAME] or f"{model} - {serial}"
+        else:
+            title = f"{model} - {serial}"
+
         return self.async_create_entry(title=title, data=self.config)
 
     async def async_step_reconfigure(

--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -374,10 +374,10 @@ async def test_discovery_flow(
         CONF_PASSWORD: "pass",
         CONF_PORT: 80,
         CONF_MODEL: "M1065-LW",
-        CONF_NAME: "M1065-LW 0",
+        CONF_NAME: expected_title,
     }
 
-    assert result["data"][CONF_NAME] == "M1065-LW 0"
+    assert result["data"][CONF_NAME] == expected_title
 
 
 @pytest.mark.parametrize(

--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -266,7 +266,7 @@ async def test_reconfiguration_flow_update_configuration(
 
 
 @pytest.mark.parametrize(
-    ("source", "discovery_info"),
+    ("source", "discovery_info", "expected_title"),
     [
         (
             SOURCE_DHCP,
@@ -275,6 +275,7 @@ async def test_reconfiguration_flow_update_configuration(
                 ip=DEFAULT_HOST,
                 macaddress=DHCP_FORMATTED_MAC,
             ),
+            f"axis-{MAC}",
         ),
         (
             SOURCE_SSDP,
@@ -314,6 +315,7 @@ async def test_reconfiguration_flow_update_configuration(
                     "presentationURL": f"http://{DEFAULT_HOST}:80/",
                 },
             ),
+            f"AXIS M1065-LW - {MAC}",
         ),
         (
             SOURCE_ZEROCONF,
@@ -329,6 +331,7 @@ async def test_reconfiguration_flow_update_configuration(
                     "macaddress": MAC,
                 },
             ),
+            f"AXIS M1065-LW - {MAC}",
         ),
     ],
 )
@@ -337,6 +340,7 @@ async def test_discovery_flow(
     hass: HomeAssistant,
     source: str,
     discovery_info: BaseServiceInfo,
+    expected_title: str,
 ) -> None:
     """Test the different discovery flows for new devices work."""
     result = await hass.config_entries.flow.async_init(
@@ -362,7 +366,7 @@ async def test_discovery_flow(
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == f"M1065-LW - {MAC}"
+    assert result["title"] == expected_title
     assert result["data"] == {
         CONF_PROTOCOL: "http",
         CONF_HOST: "1.2.3.4",

--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -73,7 +73,7 @@ async def test_flow_manual_configuration(hass: HomeAssistant) -> None:
         CONF_PASSWORD: "pass",
         CONF_PORT: 80,
         CONF_MODEL: "M1065-LW",
-        CONF_NAME: "M1065-LW 0",
+        CONF_NAME: f"M1065-LW - {MAC}",
     }
 
 
@@ -189,10 +189,10 @@ async def test_flow_create_entry_multiple_existing_entries_of_same_model(
         CONF_PASSWORD: "pass",
         CONF_PORT: 80,
         CONF_MODEL: "M1065-LW",
-        CONF_NAME: "M1065-LW 2",
+        CONF_NAME: f"M1065-LW - {MAC}",
     }
 
-    assert result["data"][CONF_NAME] == "M1065-LW 2"
+    assert result["data"][CONF_NAME] == f"M1065-LW - {MAC}"
 
 
 async def test_reauth_flow_update_configuration(


### PR DESCRIPTION
## Proposed change

When Axis devices are discovered, the config entry now uses the discovered device name as its title instead of the model/serial fallback. The entity-prefix naming logic remains unchanged.

This keeps the discovery flow title aligned with the name that Axis already exposes via DHCP, SSDP, or Zeroconf, while preserving the existing manual-setup title behavior.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/