### PR TITLE
Add tests for Overkiz siren platform

### DIFF
--- a/tests/components/overkiz/fixtures/setup/local_somfy_tahoma_v2_europe.json
+++ b/tests/components/overkiz/fixtures/setup/local_somfy_tahoma_v2_europe.json
@@ -2610,6 +2610,262 @@
       "subsystemId": 0,
       "synced": true,
       "type": 1
+    },
+    {
+      "states": [
+        {
+          "value": [],
+          "type": 11,
+          "name": "core:CommandLockLevelsState"
+        },
+        {
+          "value": "good",
+          "type": 3,
+          "name": "core:DiscreteRSSILevelState"
+        },
+        {
+          "value": 100,
+          "type": 1,
+          "name": "core:RSSILevelState"
+        },
+        {
+          "value": "off",
+          "type": 3,
+          "name": "core:OnOffState"
+        },
+        {
+          "value": "normal",
+          "type": 3,
+          "name": "core:BatteryState"
+        },
+        {
+          "value": "available",
+          "type": 3,
+          "name": "core:StatusState"
+        },
+        {
+          "value": "Siren",
+          "type": 3,
+          "name": "core:NameState"
+        },
+        {
+          "value": "standard",
+          "type": 3,
+          "name": "io:MemorizedSimpleVolumeState"
+        }
+      ],
+      "enabled": true,
+      "type": 1,
+      "synced": true,
+      "attributes": [
+        {
+          "value": "5131231A02",
+          "type": 3,
+          "name": "core:FirmwareRevision"
+        },
+        {
+          "value": "Somfy",
+          "type": 3,
+          "name": "core:Manufacturer"
+        }
+      ],
+      "deviceURL": "io://1234-5678-3293/2733989",
+      "definition": {
+        "uiClass": "Siren",
+        "states": [
+          {
+            "name": "core:NameState"
+          },
+          {
+            "name": "core:DiscreteRSSILevelState"
+          },
+          {
+            "name": "core:RSSILevelState"
+          },
+          {
+            "name": "core:CommandLockLevelsState"
+          },
+          {
+            "name": "core:AdditionalStatusState"
+          },
+          {
+            "name": "core:BatteryState"
+          },
+          {
+            "name": "io:MemorizedSimpleVolumeState"
+          },
+          {
+            "name": "core:OnOffState"
+          },
+          {
+            "name": "core:StatusState"
+          },
+          {
+            "name": "core:ManufacturerSettingsState"
+          },
+          {
+            "name": "core:ManufacturerDiagnosticsState"
+          }
+        ],
+        "widgetName": "IOSiren",
+        "commands": [
+          {
+            "nparams": 1,
+            "commandName": "setConfigState",
+            "paramsSig": "p1"
+          },
+          {
+            "nparams": 1,
+            "commandName": "unpairOneWayController",
+            "paramsSig": "p1,*p2"
+          },
+          {
+            "commandName": "unpairAllOneWayControllers",
+            "nparams": 0
+          },
+          {
+            "nparams": 1,
+            "commandName": "advancedRefresh",
+            "paramsSig": "p1,*p2"
+          },
+          {
+            "nparams": 1,
+            "commandName": "setMemorizedSimpleVolume",
+            "paramsSig": "p1"
+          },
+          {
+            "nparams": 1,
+            "commandName": "pairOneWayController",
+            "paramsSig": "p1,*p2"
+          },
+          {
+            "commandName": "getName",
+            "nparams": 0
+          },
+          {
+            "nparams": 1,
+            "commandName": "delayedStopIdentify",
+            "paramsSig": "p1"
+          },
+          {
+            "nparams": 4,
+            "commandName": "ringWithSingleSimpleSequence",
+            "paramsSig": "p1,p2,p3,p4"
+          },
+          {
+            "commandName": "unpairAllOneWayControllersAndDeleteNode",
+            "nparams": 0
+          },
+          {
+            "nparams": 8,
+            "commandName": "ringWithDoubleSimpleSequence",
+            "paramsSig": "p1,p2,p3,p4,p5,p6,p7,p8"
+          },
+          {
+            "nparams": 1,
+            "commandName": "executeManufacturerProcedure",
+            "paramsSig": "p1,*p2"
+          },
+          {
+            "nparams": 1,
+            "commandName": "writeManufacturerData",
+            "paramsSig": "p1"
+          },
+          {
+            "nparams": 1,
+            "commandName": "readManufacturerData",
+            "paramsSig": "p1"
+          },
+          {
+            "commandName": "off",
+            "nparams": 0
+          },
+          {
+            "commandName": "sendIOKey",
+            "nparams": 0
+          },
+          {
+            "nparams": 1,
+            "commandName": "wink",
+            "paramsSig": "p1"
+          },
+          {
+            "commandName": "stopIdentify",
+            "nparams": 0
+          },
+          {
+            "commandName": "startIdentify",
+            "nparams": 0
+          },
+          {
+            "nparams": 12,
+            "commandName": "ringWithThreeSimpleSequence",
+            "paramsSig": "p1,p2,p3,p4,p5,p6,p7,p8,p9,p10,p11,p12"
+          },
+          {
+            "commandName": "identify",
+            "nparams": 0
+          },
+          {
+            "nparams": 1,
+            "commandName": "setName",
+            "paramsSig": "p1"
+          },
+          {
+            "commandName": "ring",
+            "nparams": 0
+          },
+          {
+            "commandName": "stop",
+            "nparams": 0
+          },
+          {
+            "nparams": 2,
+            "commandName": "runManufacturerSettingsCommand",
+            "paramsSig": "p1,p2"
+          },
+          {
+            "commandName": "keepOneWayControllersAndDeleteNode",
+            "nparams": 0
+          },
+          {
+            "commandName": "resetLockLevels",
+            "nparams": 0
+          },
+          {
+            "nparams": 1,
+            "commandName": "removeLockLevel",
+            "paramsSig": "p1"
+          },
+          {
+            "nparams": 1,
+            "commandName": "addLockLevel",
+            "paramsSig": "p1,*p2"
+          }
+        ],
+        "type": "ACTUATOR",
+        "attributes": [
+          {
+            "name": "core:FirmwareRevision"
+          },
+          {
+            "name": "core:SupportedManufacturerProcedures"
+          },
+          {
+            "name": "core:SupportedManufacturerSettingsCommands"
+          },
+          {
+            "name": "core:SupportedReadableManufacturerData"
+          },
+          {
+            "name": "core:Manufacturer"
+          }
+        ]
+      },
+      "available": true,
+      "label": "Siren",
+      "subsystemId": 0,
+      "controllableName": "io:SomfyIndoorSimpleSirenIOComponent"
     }
   ]
 }

--- a/tests/components/overkiz/snapshots/test_siren.ambr
+++ b/tests/components/overkiz/snapshots/test_siren.ambr
@@ -1,0 +1,52 @@
+# serializer version: 1
+# name: test_siren_entities_snapshot[local_somfy_tahoma_v2_europe.json][siren.siren-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'siren',
+    'entity_category': None,
+    'entity_id': 'siren.siren',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <SirenEntityFeature: 19>,
+    'translation_key': None,
+    'unique_id': 'io://1234-5678-3293/2733989',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_siren_entities_snapshot[local_somfy_tahoma_v2_europe.json][siren.siren-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Siren',
+      'supported_features': <SirenEntityFeature: 19>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'siren.siren',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/overkiz/test_siren.py
+++ b/tests/components/overkiz/test_siren.py
@@ -1,0 +1,158 @@
+"""Tests for the Overkiz siren platform."""
+
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import patch
+
+from freezegun.api import FrozenDateTimeFactory
+from pyoverkiz.enums import EventName
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.siren import ATTR_DURATION, DOMAIN as SIREN_DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_UNAVAILABLE,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .conftest import FixtureDevice, MockOverkizClient, SetupOverkizIntegration
+from .helpers import assert_command_call, async_deliver_events, build_event
+
+from tests.common import snapshot_platform
+
+SIREN = FixtureDevice(
+    "setup/local_somfy_tahoma_v2_europe.json",
+    "io://1234-5678-3293/2733989",
+    "siren.siren",
+)
+
+SNAPSHOT_FIXTURES = [
+    SIREN,
+]
+
+
+@pytest.fixture(autouse=True)
+def fixture_platforms() -> Generator[None]:
+    """Limit platforms to siren only."""
+    with patch("homeassistant.components.overkiz.PLATFORMS", [Platform.SIREN]):
+        yield
+
+
+@pytest.mark.parametrize(
+    "device",
+    SNAPSHOT_FIXTURES,
+    ids=[Path(device.fixture).name for device in SNAPSHOT_FIXTURES],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_siren_entities_snapshot(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    device: FixtureDevice,
+) -> None:
+    """Test representative real setups via snapshot."""
+    config_entry = await setup_overkiz_integration(fixture=device.fixture)
+
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
+
+
+async def test_siren_turn_on_default_duration(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+) -> None:
+    """Test turning on the siren with default duration (2 minutes)."""
+    await setup_overkiz_integration(fixture=SIREN.fixture)
+
+    await hass.services.async_call(
+        SIREN_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: SIREN.entity_id},
+        blocking=True,
+    )
+
+    assert_command_call(
+        mock_client,
+        device_url=SIREN.device_url,
+        command_name="ringWithSingleSimpleSequence",
+        parameters=[120000, 75, 2, "memorizedVolume"],
+    )
+
+
+async def test_siren_turn_on_custom_duration(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+) -> None:
+    """Test turning on the siren with a custom duration."""
+    await setup_overkiz_integration(fixture=SIREN.fixture)
+
+    await hass.services.async_call(
+        SIREN_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: SIREN.entity_id, ATTR_DURATION: 30},
+        blocking=True,
+    )
+
+    assert_command_call(
+        mock_client,
+        device_url=SIREN.device_url,
+        command_name="ringWithSingleSimpleSequence",
+        parameters=[30000, 75, 2, "memorizedVolume"],
+    )
+
+
+async def test_siren_turn_off(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+) -> None:
+    """Test turning off the siren."""
+    await setup_overkiz_integration(fixture=SIREN.fixture)
+
+    await hass.services.async_call(
+        SIREN_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: SIREN.entity_id},
+        blocking=True,
+    )
+
+    assert_command_call(
+        mock_client,
+        device_url=SIREN.device_url,
+        command_name="off",
+    )
+
+
+async def test_siren_unavailability(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test siren becomes unavailable when device goes offline."""
+    await setup_overkiz_integration(fixture=SIREN.fixture)
+
+    state = hass.states.get(SIREN.entity_id)
+    assert state
+    assert state.state != STATE_UNAVAILABLE
+
+    await async_deliver_events(
+        hass,
+        freezer,
+        mock_client,
+        [
+            build_event(
+                EventName.DEVICE_UNAVAILABLE.value,
+                device_url=SIREN.device_url,
+            )
+        ],
+    )
+
+    assert hass.states.get(SIREN.entity_id).state == STATE_UNAVAILABLE


### PR DESCRIPTION
## Proposed change

Add tests for the Overkiz siren platform, covering the siren device type (`io:SomfyIndoorSimpleSirenIOComponent`). Tests include:
- Snapshot testing for entity state verification
- Turn on with default duration
- Turn on with custom duration
- Turn off
- Unavailability handling

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr