### PR TITLE
Fix incorrect type annotations in isy994 entity base classes

### DIFF
--- a/homeassistant/components/isy994/entity.py
+++ b/homeassistant/components/isy994/entity.py
@@ -181,7 +181,9 @@ class ISYProgramEntity(ISYEntity):
     _status: Program
     _node: Program
 
-    def __init__(self, name: str, status: Program, actions: Program | None = None) -> None:
+    def __init__(
+        self, name: str, status: Program, actions: Program | None = None
+    ) -> None:
         """Initialize the ISY program-based entity."""
         super().__init__(status)
         self._attr_name = name

--- a/homeassistant/components/isy994/entity.py
+++ b/homeassistant/components/isy994/entity.py
@@ -181,7 +181,7 @@ class ISYProgramEntity(ISYEntity):
     _status: Program
     _node: Program
 
-    def __init__(self, name: str, status: Program, actions: Program = None) -> None:
+    def __init__(self, name: str, status: Program, actions: Program | None = None) -> None:
         """Initialize the ISY program-based entity."""
         super().__init__(status)
         self._attr_name = name
@@ -237,8 +237,8 @@ class ISYAuxControlEntity(Entity):
         self._attr_has_entity_name = node.address == node.primary_node
         self._attr_unique_id = unique_id
         self._attr_device_info = device_info
-        self._change_handler: EventListener = None
-        self._availability_handler: EventListener = None
+        self._change_handler: EventListener | None = None
+        self._availability_handler: EventListener | None = None
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to the node control change events."""

--- a/tests/components/isy994/test_entity.py
+++ b/tests/components/isy994/test_entity.py
@@ -1,0 +1,52 @@
+"""Test ISY994 entity base classes."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.components.isy994.entity import ISYAuxControlEntity, ISYProgramEntity
+from homeassistant.components.select import SelectEntityDescription
+from homeassistant.const import EntityCategory
+
+
+def _make_mock_node() -> MagicMock:
+    """Return a minimal mock ISY node."""
+    node = MagicMock()
+    node.name = "Test Node"
+    node.isy.uuid = "test-uuid"
+    node.address = "test-address"
+    node.primary_node = "test-address"
+    return node
+
+
+def _make_mock_status() -> MagicMock:
+    """Return a minimal mock ISY program status."""
+    status = MagicMock()
+    status.name = "Test Program"
+    status.isy.uuid = "test-uuid"
+    status.address = "test-address"
+    return status
+
+
+def test_program_entity_init_with_none_actions() -> None:
+    """Test ISYProgramEntity accepts None for the optional actions parameter."""
+    status = _make_mock_status()
+    entity = ISYProgramEntity("Test", status, None)
+    assert entity._actions is None
+
+
+def test_aux_control_entity_init_sets_handlers_to_none() -> None:
+    """Test ISYAuxControlEntity.__init__ initialises handler attributes to None."""
+    node = _make_mock_node()
+    description = SelectEntityDescription(
+        key="test_key",
+        entity_category=EntityCategory.CONFIG,
+        options=["a", "b"],
+    )
+    entity = ISYAuxControlEntity(
+        node=node,
+        control="ST",
+        unique_id="test-uuid_test-address_ST",
+        description=description,
+        device_info=None,
+    )
+    assert entity._change_handler is None
+    assert entity._availability_handler is None


### PR DESCRIPTION
## Proposed change

Two type annotation fixes in `entity.py`:

1. **`ISYProgramEntity.__init__`**: `actions` parameter was typed as `Program` but defaults to `None`. Changed to `Program | None`.

2. **`ISYAuxControlEntity`**: `_change_handler` and `_availability_handler` instance attributes were annotated as `EventListener` but initialised to `None`. Changed to `EventListener | None`, consistent with the same fields in the `ISYEntity` base class.

Both would be caught by mypy/pyright as type errors.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr