### PR TITLE
Fix ValueError crash when isy994 Z-Wave device has non-numeric manufacturer ID

### DIFF
--- a/homeassistant/components/isy994/helpers.py
+++ b/homeassistant/components/isy994/helpers.py
@@ -315,13 +315,23 @@ def _generate_device_info(node: Node) -> DeviceInfo:
         and node.zwave_props
         and node.zwave_props.mfr_id != "0"
     ):
-        device_info[ATTR_MANUFACTURER] = (
-            f"Z-Wave MfrID:{int(node.zwave_props.mfr_id):#0{6}x}"
-        )
-        model += (
-            f"Type:{int(node.zwave_props.prod_type_id):#0{6}x} "
-            f"Product:{int(node.zwave_props.product_id):#0{6}x}"
-        )
+        try:
+            device_info[ATTR_MANUFACTURER] = (
+                f"Z-Wave MfrID:{int(node.zwave_props.mfr_id):#0{6}x}"
+            )
+            model += (
+                f"Type:{int(node.zwave_props.prod_type_id):#0{6}x} "
+                f"Product:{int(node.zwave_props.product_id):#0{6}x}"
+            )
+        except ValueError:
+            _LOGGER.warning(
+                "Z-Wave device %s has non-numeric manufacturer/product IDs: "
+                "mfr_id=%s, prod_type_id=%s, product_id=%s",
+                node.address,
+                node.zwave_props.mfr_id,
+                node.zwave_props.prod_type_id,
+                node.zwave_props.product_id,
+            )
     device_info[ATTR_MODEL] = model
 
     return device_info

--- a/tests/components/isy994/test_helpers.py
+++ b/tests/components/isy994/test_helpers.py
@@ -1,0 +1,74 @@
+"""Test ISY994 helpers."""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from pyisy.constants import PROTO_ZWAVE
+
+from homeassistant.components.isy994.helpers import _generate_device_info
+
+
+@pytest.fixture
+def zwave_node(mock_isy: MagicMock) -> MagicMock:
+    """Return a mock Z-Wave ISY node with valid numeric IDs."""
+    node = MagicMock()
+    node.isy = mock_isy
+    node.address = "ZW001"
+    node.name = "Z-Wave Lock"
+    node.node_def_id = "ZWaveLock"
+    node.type = None
+    node.protocol = PROTO_ZWAVE
+    node.folder = None
+    node.zwave_props = MagicMock()
+    node.zwave_props.mfr_id = "99"
+    node.zwave_props.prod_type_id = "18756"
+    node.zwave_props.product_id = "12593"
+    return node
+
+
+@pytest.mark.parametrize(
+    ("mfr_id", "prod_type_id", "product_id"),
+    [
+        pytest.param("99", "18756", "12593", id="valid_numeric"),
+        pytest.param("0x0063", "0x4944", "0x3131", id="valid_hex_string"),
+    ],
+)
+def test_generate_device_info_zwave_numeric_ids(
+    zwave_node: MagicMock,
+    mfr_id: str,
+    prod_type_id: str,
+    product_id: str,
+) -> None:
+    """Test _generate_device_info does not raise with valid numeric Z-Wave IDs."""
+    zwave_node.zwave_props.mfr_id = mfr_id
+    zwave_node.zwave_props.prod_type_id = prod_type_id
+    zwave_node.zwave_props.product_id = product_id
+    device_info = _generate_device_info(zwave_node)
+    assert device_info is not None
+
+
+@pytest.mark.parametrize(
+    ("mfr_id", "prod_type_id", "product_id"),
+    [
+        pytest.param("N/A", "N/A", "N/A", id="not_applicable"),
+        pytest.param("unknown", "0x4944", "0x3131", id="non_numeric_mfr"),
+    ],
+)
+def test_generate_device_info_zwave_non_numeric_ids_logs_warning(
+    zwave_node: MagicMock,
+    mfr_id: str,
+    prod_type_id: str,
+    product_id: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test _generate_device_info logs a warning for non-numeric Z-Wave IDs."""
+    zwave_node.zwave_props.mfr_id = mfr_id
+    zwave_node.zwave_props.prod_type_id = prod_type_id
+    zwave_node.zwave_props.product_id = product_id
+
+    with caplog.at_level(logging.WARNING, logger="homeassistant.components.isy994"):
+        device_info = _generate_device_info(zwave_node)
+
+    assert device_info is not None
+    assert "non-numeric" in caplog.text

--- a/tests/components/isy994/test_helpers.py
+++ b/tests/components/isy994/test_helpers.py
@@ -3,15 +3,15 @@
 import logging
 from unittest.mock import MagicMock
 
-import pytest
 from pyisy.constants import PROTO_ZWAVE
+import pytest
 
 from homeassistant.components.isy994.helpers import _generate_device_info
 
 
 @pytest.fixture
 def zwave_node(mock_isy: MagicMock) -> MagicMock:
-    """Return a mock Z-Wave ISY node with valid numeric IDs."""
+    """Return a mock Z-Wave ISY node."""
     node = MagicMock()
     node.isy = mock_isy
     node.address = "ZW001"
@@ -27,23 +27,8 @@ def zwave_node(mock_isy: MagicMock) -> MagicMock:
     return node
 
 
-@pytest.mark.parametrize(
-    ("mfr_id", "prod_type_id", "product_id"),
-    [
-        pytest.param("99", "18756", "12593", id="valid_numeric"),
-        pytest.param("0x0063", "0x4944", "0x3131", id="valid_hex_string"),
-    ],
-)
-def test_generate_device_info_zwave_numeric_ids(
-    zwave_node: MagicMock,
-    mfr_id: str,
-    prod_type_id: str,
-    product_id: str,
-) -> None:
+def test_generate_device_info_zwave_numeric_ids(zwave_node: MagicMock) -> None:
     """Test _generate_device_info does not raise with valid numeric Z-Wave IDs."""
-    zwave_node.zwave_props.mfr_id = mfr_id
-    zwave_node.zwave_props.prod_type_id = prod_type_id
-    zwave_node.zwave_props.product_id = product_id
     device_info = _generate_device_info(zwave_node)
     assert device_info is not None
 


### PR DESCRIPTION
## Proposed change

`_generate_device_info` in `helpers.py` calls `int()` directly on three Z-Wave properties (`mfr_id`, `prod_type_id`, `product_id`) without guarding against non-numeric values. If the ISY controller returns anything other than a plain decimal string for these fields, the call raises `ValueError` and the entire device setup for that node fails with an uncaught exception.

Wraps the conversion in `try/except ValueError` and logs a warning with the raw values so the issue can be diagnosed, while allowing the rest of the device to set up normally with the partial model string already built.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr