### PR TITLE
Fix missing Z-Wave power monitoring sensors in isy994 integration

### DIFF
--- a/homeassistant/components/isy994/helpers.py
+++ b/homeassistant/components/isy994/helpers.py
@@ -357,7 +357,7 @@ def _categorize_nodes(
             isy_data.nodes[ISY_GROUP_PLATFORM].append(node)
             continue
 
-        if node.protocol == PROTO_INSTEON:
+        if node.protocol in (PROTO_INSTEON, PROTO_ZWAVE):
             for control in node.aux_properties:
                 if control in SKIP_AUX_PROPS:
                     continue


### PR DESCRIPTION
## Proposed change

Z-Wave power-monitoring devices (smart plugs, metering switches, etc.) expose wattage (`CPW`), energy (`TPW`), voltage (`CV`), and current (`CC`) as aux properties on their ISY node. These values appear correctly in the ISY admin console but never surface as entities in Home Assistant.

The root cause: `_categorize_nodes` in `helpers.py` only collects aux properties for `PROTO_INSTEON` nodes:

```python
if node.protocol == PROTO_INSTEON:
    for control in node.aux_properties:
        if control in SKIP_AUX_PROPS:
            continue
        isy_data.aux_properties[Platform.SENSOR].append((node, control))
```

Z-Wave aux properties are silently dropped. The fix extends the condition to also include `PROTO_ZWAVE` nodes.

The existing safety filters prevent sensor noise:
- `SKIP_AUX_PROPS` (`ST`, `ERR`, `OL`, `RR`, `BUSY`) excludes internal status/control properties
- `AUX_DISABLED_BY_DEFAULT_MATCH = ["GV", "DO"]` in `sensor.py` marks general-purpose and digital output properties as disabled by default
- `ISY_CONTROL_TO_DEVICE_CLASS` and `UOM_TO_DEVICE_CLASS` in `sensor.py` already map the Z-Wave power controls (`CPW`→POWER, `TPW`→ENERGY, `CV`→VOLTAGE, `CC`→CURRENT, etc.) to the correct HA sensor device classes and units

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #156827
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr