### PR TITLE
Fix ISY994 ISYFanProgramEntity turn_on/turn_off calling wrong program branches

### DIFF
--- a/homeassistant/components/isy994/fan.py
+++ b/homeassistant/components/isy994/fan.py
@@ -118,8 +118,8 @@ class ISYFanProgramEntity(ISYProgramEntity, FanEntity):
         return bool(self._node.status != 0)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Send the turn on command to ISY fan program."""
-        if not await self._actions.run_then():
+        """Send the turn off command to ISY fan program."""
+        if not await self._actions.run_else():
             _LOGGER.error("Unable to turn off the fan")
 
     async def async_turn_on(
@@ -128,6 +128,6 @@ class ISYFanProgramEntity(ISYProgramEntity, FanEntity):
         preset_mode: str | None = None,
         **kwargs: Any,
     ) -> None:
-        """Send the turn off command to ISY fan program."""
-        if not await self._actions.run_else():
+        """Send the turn on command to ISY fan program."""
+        if not await self._actions.run_then():
             _LOGGER.error("Unable to turn on the fan")

--- a/tests/components/isy994/test_fan.py
+++ b/tests/components/isy994/test_fan.py
@@ -1,0 +1,36 @@
+"""Test the ISY994 fan platform."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from homeassistant.components.isy994.fan import ISYFanProgramEntity
+
+
+@pytest.mark.parametrize(
+    ("method", "expected_call", "unexpected_call"),
+    [
+        pytest.param("async_turn_on", "run_then", "run_else", id="turn_on"),
+        pytest.param("async_turn_off", "run_else", "run_then", id="turn_off"),
+    ],
+)
+async def test_fan_program_actions(
+    method: str,
+    expected_call: str,
+    unexpected_call: str,
+) -> None:
+    """Test ISYFanProgramEntity turn on/off calls correct program run method."""
+    status = MagicMock()
+    status.name = "Test Fan Program"
+    status.isy.uuid = "test-uuid"
+    status.address = "test-address"
+
+    actions = MagicMock()
+    actions.run_then = AsyncMock(return_value=True)
+    actions.run_else = AsyncMock(return_value=True)
+
+    entity = ISYFanProgramEntity("Test Fan Program", status, actions)
+    await getattr(entity, method)()
+
+    getattr(actions, expected_call).assert_called_once()
+    getattr(actions, unexpected_call).assert_not_called()


### PR DESCRIPTION
## Proposed change

`ISYFanProgramEntity.async_turn_on` was calling `run_else()` and `async_turn_off` was calling `run_then()` — exactly backwards. The docstrings were also swapped.

The correct mapping (consistent with `ISYSwitchProgramEntity`) is:
- `async_turn_on` → `run_then()`
- `async_turn_off` → `run_else()`

This means any user with an ISY fan program entity would find that pressing "on" ran the "else" branch of their program and pressing "off" ran the "then" branch — the opposite of what they configured.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- Related to how ISY programs use `run_then` as the "on/true" action and `run_else` as the "off/false" action, which is the same convention used correctly in `ISYSwitchProgramEntity`, `ISYCoverProgramEntity`, and `ISYLockProgramEntity`.

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [ ] I have followed the [perfect PR recommendations](https://developers.home-assistant.io/docs/review-process/#perfect-pr)
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.