### PR TITLE
Fix ISY994 Z-Wave aux properties duplicated in entity state attributes

### DIFF
--- a/homeassistant/components/isy994/entity.py
+++ b/homeassistant/components/isy994/entity.py
@@ -113,9 +113,10 @@ class ISYNodeEntity(ISYEntity):
         """
         attrs = self._attrs
         node = self._node
-        # Insteon aux_properties are now their own sensors
-        # so we no longer need to add them to the attributes
-        if node.protocol != PROTO_INSTEON and hasattr(node, "aux_properties"):
+        # Insteon and Z-Wave aux_properties are their own sensor entities
+        if node.protocol not in (PROTO_INSTEON, PROTO_ZWAVE) and hasattr(
+            node, "aux_properties"
+        ):
             for name, value in self._node.aux_properties.items():
                 attr_name = COMMAND_FRIENDLY_NAME.get(name, name)
                 attrs[attr_name] = str(value.formatted).lower()

--- a/tests/components/isy994/test_entity.py
+++ b/tests/components/isy994/test_entity.py
@@ -1,0 +1,38 @@
+"""Test ISY994 entity base classes."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from pyisy.constants import PROTO_INSTEON, PROTO_ZWAVE
+
+from homeassistant.components.isy994.entity import ISYNodeEntity
+
+
+@pytest.mark.parametrize(
+    ("protocol", "expected_in_attrs"),
+    [
+        pytest.param(PROTO_INSTEON, False, id="insteon_excluded"),
+        pytest.param(PROTO_ZWAVE, False, id="zwave_excluded"),
+        pytest.param("zigbee", True, id="other_included"),
+    ],
+)
+def test_extra_state_attributes_aux_properties_by_protocol(
+    protocol: str,
+    expected_in_attrs: bool,
+) -> None:
+    """Test that aux_properties are excluded for Insteon and Z-Wave nodes."""
+    mock_prop = MagicMock()
+    mock_prop.formatted = "test_value"
+
+    node = MagicMock()
+    node.name = "Test Node"
+    node.isy.uuid = "test-uuid"
+    node.address = "test-address"
+    node.protocol = protocol
+    node.aux_properties = {"FAKE_PROP": mock_prop}
+    node.parent_node = MagicMock()  # not None, so has_entity_name stays False
+
+    entity = ISYNodeEntity(node)
+    attrs = entity.extra_state_attributes
+
+    assert ("FAKE_PROP" in attrs) == expected_in_attrs

--- a/tests/components/isy994/test_entity.py
+++ b/tests/components/isy994/test_entity.py
@@ -2,8 +2,8 @@
 
 from unittest.mock import MagicMock
 
-import pytest
 from pyisy.constants import PROTO_INSTEON, PROTO_ZWAVE
+import pytest
 
 from homeassistant.components.isy994.entity import ISYNodeEntity
 


### PR DESCRIPTION
## Proposed change

After Z-Wave aux properties were added as dedicated sensor entities (via the `_categorize_nodes` fix), `ISYNodeEntity.extra_state_attributes` still included them because the exclusion condition only checked for `PROTO_INSTEON`.

The condition `if node.protocol != PROTO_INSTEON` passes for Z-Wave nodes, so Z-Wave aux properties would appear both as dedicated sensor entities and as raw state attributes on the parent entity — duplicated data.

Fix: change the condition to `not in (PROTO_INSTEON, PROTO_ZWAVE)`.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [ ] I have followed the [perfect PR recommendations](https://developers.home-assistant.io/docs/review-process/#perfect-pr)
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.