### PR TITLE
Fix ISY994 select walrus operator precedence for aux control index UOM

### DIFF
--- a/homeassistant/components/isy994/select.py
+++ b/homeassistant/components/isy994/select.py
@@ -74,7 +74,7 @@ async def async_setup_entry(
             options = RAMP_RATE_OPTIONS
         elif control == CMD_BACKLIGHT:
             options = BACKLIGHT_INDEX
-        elif uom := node.aux_properties[control].uom == UOM_INDEX:
+        elif (uom := node.aux_properties[control].uom) == UOM_INDEX:
             if options_dict := UOM_TO_STATES.get(uom):
                 options = list(options_dict.values())
 

--- a/tests/components/isy994/test_select.py
+++ b/tests/components/isy994/test_select.py
@@ -1,0 +1,51 @@
+"""Test the ISY994 select platform."""
+
+from unittest.mock import MagicMock, patch
+
+from homeassistant.components.isy994.const import UOM_INDEX
+from homeassistant.components.isy994.select import (
+    ISYAuxControlIndexSelectEntity,
+    async_setup_entry,
+)
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+
+async def test_setup_entry_index_uom_creates_entity_with_options(
+    hass: HomeAssistant,
+) -> None:
+    """Test that an aux control with UOM_INDEX creates an entity with correct options."""
+    control = "ST"
+    fake_options = {"0": "Off", "1": "On"}
+
+    mock_prop = MagicMock()
+    mock_prop.uom = UOM_INDEX
+
+    node = MagicMock()
+    node.address = "test_addr"
+    node.primary_node = "test_addr"
+    node.name = "Test Node"
+    node.uom = UOM_INDEX
+    node.aux_properties = {control: mock_prop}
+
+    mock_isy_data = MagicMock()
+    mock_isy_data.aux_properties = {Platform.SELECT: [(node, control)]}
+    mock_isy_data.devices = {}
+    mock_isy_data.uid_base.return_value = "uuid_test_addr"
+
+    mock_entry = MagicMock()
+    mock_entry.runtime_data = mock_isy_data
+
+    add_entities = MagicMock()
+
+    with patch(
+        "homeassistant.components.isy994.select.UOM_TO_STATES",
+        {UOM_INDEX: fake_options},
+    ):
+        await async_setup_entry(hass, mock_entry, add_entities)
+
+    add_entities.assert_called_once()
+    entities = add_entities.call_args[0][0]
+    assert len(entities) == 1
+    assert isinstance(entities[0], ISYAuxControlIndexSelectEntity)
+    assert entities[0].entity_description.options == list(fake_options.values())


### PR DESCRIPTION
## Proposed change

In `select.py`, the expression used to detect index-type UOM aux controls had a Python operator precedence bug:

```python
# Before (buggy):
elif uom := node.aux_properties[control].uom == UOM_INDEX:
```

The walrus operator `:=` has lower precedence than `==`, so `uom` was assigned the result of the boolean comparison (`True` or `False`) rather than the UOM string. `UOM_TO_STATES.get(True)` always returns `None`, so `options` was always an empty list, and `ISYAuxControlIndexSelectEntity` was never created for any aux control with an index-type UOM.

Fix: add parentheses to capture the UOM string first:

```python
# After (correct):
elif (uom := node.aux_properties[control].uom) == UOM_INDEX:
```

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [ ] I have followed the [perfect PR recommendations](https://developers.home-assistant.io/docs/review-process/#perfect-pr)
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.