### PR TITLE
Fix ElkM1 emergency heat switch turn_off setting wrong thermostat mode

### DIFF
--- a/homeassistant/components/elkm1/switch.py
+++ b/homeassistant/components/elkm1/switch.py
@@ -78,4 +78,4 @@ class ElkThermostatEMHeat(ElkEntity, SwitchEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the output."""
-        self._elk_set(ThermostatMode.EMERGENCY_HEAT)
+        self._elk_set(ThermostatMode.HEAT)

--- a/tests/components/elkm1/test_switch.py
+++ b/tests/components/elkm1/test_switch.py
@@ -3,22 +3,25 @@
 from unittest.mock import MagicMock
 
 from elkm1_lib.const import ThermostatMode, ThermostatSetting
+from elkm1_lib.elk import Elk
+from elkm1_lib.thermostats import Thermostat
 import pytest
 
+from homeassistant.components.elkm1.models import ELKM1Data
 from homeassistant.components.elkm1.switch import ElkThermostatEMHeat
 
 
 @pytest.fixture
 def emheat_entity() -> ElkThermostatEMHeat:
     """Return an ElkThermostatEMHeat entity with mocked dependencies."""
-    element = MagicMock()
+    element = MagicMock(spec=Thermostat)
     element.name = "Downstairs"
     element.default_name.return_value = "downstairs"
     element.index = 0
 
-    elk = MagicMock()
+    elk = MagicMock(spec=Elk)
 
-    elk_data = MagicMock()
+    elk_data = MagicMock(spec=ELKM1Data)
     elk_data.mac = "aa:bb:cc:dd:ee:ff"
     elk_data.prefix = ""
     elk_data.auto_configure = True

--- a/tests/components/elkm1/test_switch.py
+++ b/tests/components/elkm1/test_switch.py
@@ -41,4 +41,6 @@ async def test_emheat_actions(
 ) -> None:
     """Test emergency heat turn on/off sets the correct thermostat mode."""
     await getattr(emheat_entity, method)()
-    emheat_entity._element.set.assert_called_once_with(ThermostatSetting.MODE, expected_mode)
+    emheat_entity._element.set.assert_called_once_with(
+        ThermostatSetting.MODE, expected_mode
+    )

--- a/tests/components/elkm1/test_switch.py
+++ b/tests/components/elkm1/test_switch.py
@@ -1,0 +1,44 @@
+"""Test the Elk-M1 switch platform."""
+
+from unittest.mock import MagicMock
+
+from elkm1_lib.const import ThermostatMode, ThermostatSetting
+import pytest
+
+from homeassistant.components.elkm1.switch import ElkThermostatEMHeat
+
+
+@pytest.fixture
+def emheat_entity() -> ElkThermostatEMHeat:
+    """Return an ElkThermostatEMHeat entity with mocked dependencies."""
+    element = MagicMock()
+    element.name = "Downstairs"
+    element.default_name.return_value = "downstairs"
+    element.index = 0
+
+    elk = MagicMock()
+
+    elk_data = MagicMock()
+    elk_data.mac = "aa:bb:cc:dd:ee:ff"
+    elk_data.prefix = ""
+    elk_data.auto_configure = True
+    elk_data.config = {"temperature_unit": "F"}
+
+    return ElkThermostatEMHeat(element, elk, elk_data)
+
+
+@pytest.mark.parametrize(
+    ("method", "expected_mode"),
+    [
+        pytest.param("async_turn_on", ThermostatMode.EMERGENCY_HEAT, id="turn_on"),
+        pytest.param("async_turn_off", ThermostatMode.HEAT, id="turn_off"),
+    ],
+)
+async def test_emheat_actions(
+    emheat_entity: ElkThermostatEMHeat,
+    method: str,
+    expected_mode: ThermostatMode,
+) -> None:
+    """Test emergency heat turn on/off sets the correct thermostat mode."""
+    await getattr(emheat_entity, method)()
+    emheat_entity._element.set.assert_called_once_with(ThermostatSetting.MODE, expected_mode)


### PR DESCRIPTION
## Proposed change

`ElkThermostatEMHeat.async_turn_off` was calling `ThermostatMode.EMERGENCY_HEAT` — identical to `async_turn_on`. This meant pressing "off" on the emergency heat switch had no effect; it just re-applied emergency heat mode.

When turning off emergency heat the thermostat should revert to `ThermostatMode.HEAT`.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [ ] I have followed the [perfect PR recommendations](https://developers.home-assistant.io/docs/review-process/#perfect-pr)
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.