### PR TITLE
Fix two HEOS bugs: host set construction and missing error decorator

### DIFF
--- a/homeassistant/components/heos/config_flow.py
+++ b/homeassistant/components/heos/config_flow.py
@@ -116,7 +116,7 @@ async def _validate_auth(
 
 def _get_current_hosts(entry: HeosConfigEntry) -> set[str]:
     """Get a set of current hosts from the entry."""
-    hosts = set(entry.data[CONF_HOST])
+    hosts = {entry.data[CONF_HOST]}
     if hasattr(entry, "runtime_data"):
         hosts.update(
             player.ip_address

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -473,6 +473,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                 await self.coordinator.heos.set_group(new_members)
                 return
 
+    @catch_action_error("remove from queue")
     async def async_remove_from_queue(self, queue_ids: list[int]) -> None:
         """Remove items from the queue."""
         await self._player.remove_from_queue(queue_ids)


### PR DESCRIPTION
## Proposed change

Two bugs in the HEOS integration:

**1. `config_flow.py` — `set(string)` produces a set of characters**

`_get_current_hosts` built the hosts set with `set(entry.data[CONF_HOST])`. Since `CONF_HOST` is a plain string (e.g. `"192.168.1.100"`), iterating it produces individual characters: `{'1', '9', '2', '.', ...}`. This set was used to exclude known hosts from re-discovery, so the comparison against IP address strings would never match.

Fix: `{entry.data[CONF_HOST]}` (set literal wrapping the string).

**2. `media_player.py` — `async_remove_from_queue` missing `@catch_action_error`**

Every other player action method uses `@catch_action_error` to convert `HeosError`/`ValueError` into `HomeAssistantError`. `async_remove_from_queue` was the sole exception, leaving errors unhandled and propagating as unexpected exceptions.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [ ] I have followed the [perfect PR recommendations](https://developers.home-assistant.io/docs/review-process/#perfect-pr)
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.