### PR TITLE
Fix three HEOS bugs: setup connection leak, stale favorites, schema typo

### DIFF
--- a/homeassistant/components/heos/coordinator.py
+++ b/homeassistant/components/heos/coordinator.py
@@ -107,7 +107,6 @@ class HeosCoordinator(DataUpdateCoordinator[None]):
             await self.heos.get_players()
         except HeosError as error:
             _LOGGER.debug("Unexpected error retrieving players", exc_info=True)
-            await self.heos.disconnect()
             raise ConfigEntryNotReady(
                 translation_domain=DOMAIN, translation_key="unable_to_get_players"
             ) from error

--- a/homeassistant/components/heos/coordinator.py
+++ b/homeassistant/components/heos/coordinator.py
@@ -107,6 +107,7 @@ class HeosCoordinator(DataUpdateCoordinator[None]):
             await self.heos.get_players()
         except HeosError as error:
             _LOGGER.debug("Unexpected error retrieving players", exc_info=True)
+            await self.heos.disconnect()
             raise ConfigEntryNotReady(
                 translation_domain=DOMAIN, translation_key="unable_to_get_players"
             ) from error
@@ -240,6 +241,7 @@ class HeosCoordinator(DataUpdateCoordinator[None]):
     async def _async_update_sources(self) -> None:
         """Build source list for entities."""
         self._source_list.clear()
+        self._favorites = {}
         # Get favorites only if reportedly signed in.
         if self.heos.is_signed_in:
             try:

--- a/homeassistant/components/heos/services.py
+++ b/homeassistant/components/heos/services.py
@@ -90,7 +90,7 @@ REMOVE_FROM_QUEUE_SCHEMA: Final[VolDictType] = {
 GROUP_VOLUME_SET_SCHEMA: Final[VolDictType] = {
     vol.Required(ATTR_MEDIA_VOLUME_LEVEL): cv.small_float
 }
-MOVE_QEUEUE_ITEM_SCHEMA: Final[VolDictType] = {
+MOVE_QUEUE_ITEM_SCHEMA: Final[VolDictType] = {
     vol.Required(ATTR_QUEUE_IDS): vol.All(
         cv.ensure_list,
         [vol.All(vol.Coerce(int), vol.Range(min=1, max=1000))],
@@ -110,7 +110,7 @@ MEDIA_PLAYER_ENTITY_SERVICES: Final = (
         SERVICE_REMOVE_FROM_QUEUE, "async_remove_from_queue", REMOVE_FROM_QUEUE_SCHEMA
     ),
     EntityServiceDescription(
-        SERVICE_MOVE_QUEUE_ITEM, "async_move_queue_item", MOVE_QEUEUE_ITEM_SCHEMA
+        SERVICE_MOVE_QUEUE_ITEM, "async_move_queue_item", MOVE_QUEUE_ITEM_SCHEMA
     ),
     # Group volume services
     EntityServiceDescription(


### PR DESCRIPTION
## Proposed change

Three bugs in the HEOS coordinator and services:

**1. Connection leak on setup failure (`coordinator.py`)**

`async_setup` calls `heos.connect()` then `heos.get_players()`. If `get_players()` raises `HeosError`, `ConfigEntryNotReady` was raised without disconnecting first. With `auto_reconnect=True` set on the `Heos` object, the abandoned connection kept attempting to reconnect in the background indefinitely. On each HA retry of the setup, a new `HeosCoordinator` and `Heos` object are created and the old leaked connection is never cleaned up.

Fix: call `await self.heos.disconnect()` before raising `ConfigEntryNotReady`.

**2. Stale favorites on refresh failure (`coordinator.py`)**

`_async_update_sources` clears `_source_list` at the start of each refresh, but `self._favorites` was only updated on success. If `get_favorites()` raised `HeosError`, `_favorites` retained its previous value. The stale dict was then used by `async_get_current_source` and `async_get_favorite_index`, potentially resolving favorite names to wrong station indices if the server-side favorites had changed.

Fix: reset `self._favorites = {}` alongside the `_source_list` clear.

**3. Schema constant typo (`services.py`)**

`MOVE_QEUEUE_ITEM_SCHEMA` had a double "QUE" in the name. Renamed to `MOVE_QUEUE_ITEM_SCHEMA`.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [ ] I have followed the [perfect PR recommendations](https://developers.home-assistant.io/docs/review-process/#perfect-pr)
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.