### PR TITLE
Clean up should_expose in google assistant

### DIFF
--- a/homeassistant/components/cloud/google_config.py
+++ b/homeassistant/components/cloud/google_config.py
@@ -275,9 +275,13 @@ class CloudGoogleConfig(AbstractConfig):
             )
         )
 
-    def should_expose(self, state: State) -> bool:
-        """If a state object should be exposed."""
-        return self._should_expose_entity_id(state.entity_id)
+    def should_expose(self, entity_id: str) -> bool:
+        """If an entity should be exposed."""
+        entity_filter: EntityFilter = self._config[CONF_FILTER]
+        if not entity_filter.empty_filter:
+            return entity_filter(entity_id)
+
+        return async_should_expose(self.hass, CLOUD_GOOGLE, entity_id)
 
     def _should_expose_legacy(self, entity_id: str) -> bool:
         """If an entity ID should be exposed."""
@@ -307,14 +311,6 @@ class CloudGoogleConfig(AbstractConfig):
             and split_entity_id(entity_id)[0] in default_expose
             and _supported_legacy(self.hass, entity_id)
         )
-
-    def _should_expose_entity_id(self, entity_id: str) -> bool:
-        """If an entity should be exposed."""
-        entity_filter: EntityFilter = self._config[CONF_FILTER]
-        if not entity_filter.empty_filter:
-            return entity_filter(entity_id)
-
-        return async_should_expose(self.hass, CLOUD_GOOGLE, entity_id)
 
     @property
     def agent_user_id(self) -> str:
@@ -467,7 +463,7 @@ class CloudGoogleConfig(AbstractConfig):
 
         entity_id = event.data["entity_id"]
 
-        if not self._should_expose_entity_id(entity_id):
+        if not self.should_expose(entity_id):
             return
 
         self.async_schedule_google_sync_all()
@@ -490,8 +486,7 @@ class CloudGoogleConfig(AbstractConfig):
 
         # Check if any exposed entity uses the device area
         if not any(
-            entity_entry.area_id is None
-            and self._should_expose_entity_id(entity_entry.entity_id)
+            entity_entry.area_id is None and self.should_expose(entity_entry.entity_id)
             for entity_entry in er.async_entries_for_device(
                 er.async_get(self.hass), event.data["device_id"]
             )

--- a/homeassistant/components/google_assistant/helpers.py
+++ b/homeassistant/components/google_assistant/helpers.py
@@ -185,7 +185,7 @@ class AbstractConfig(ABC):
         """
 
     @abstractmethod
-    def should_expose(self, state) -> bool:
+    def should_expose(self, entity_id: str) -> bool:
         """Return if entity should be exposed."""
 
     @abstractmethod
@@ -532,7 +532,7 @@ class GoogleEntity:
 
     def __repr__(self) -> str:
         """Return the representation."""
-        return f"<GoogleEntity {self.state.entity_id}: {self.state.name}>"
+        return f"<GoogleEntity {self.entity_id}: {self.state.name}>"
 
     @callback
     def traits(self) -> list[trait._Trait]:
@@ -549,7 +549,7 @@ class GoogleEntity:
     @callback
     def should_expose(self):
         """If entity should be exposed."""
-        return self.config.should_expose(self.state)
+        return self.config.should_expose(self.entity_id)
 
     @callback
     def should_expose_local(self) -> bool:
@@ -733,7 +733,7 @@ class GoogleEntity:
         if not executed:
             raise SmartHomeError(
                 ERR_FUNCTION_NOT_SUPPORTED,
-                f"Unable to execute {command} for {self.state.entity_id}",
+                f"Unable to execute {command} for {self.entity_id}",
             )
 
     @callback

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -12,7 +12,7 @@ import jwt
 
 from homeassistant.components import webhook
 from homeassistant.components.http import KEY_HASS, HomeAssistantView
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant, callback, split_entity_id
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -157,17 +157,13 @@ class GoogleConfig(AbstractConfig):
 
         return None
 
-    def should_expose(self, state) -> bool:
+    def should_expose(self, entity_id: str) -> bool:
         """Return if entity should be exposed."""
         expose_by_default = self._config.get(CONF_EXPOSE_BY_DEFAULT)
         exposed_domains = self._config.get(CONF_EXPOSED_DOMAINS)
 
-        if state.attributes.get("view") is not None:
-            # Ignore entities that are views
-            return False
-
         entity_registry = er.async_get(self.hass)
-        registry_entry = entity_registry.async_get(state.entity_id)
+        registry_entry = entity_registry.async_get(entity_id)
         if registry_entry:
             auxiliary_entity = (
                 registry_entry.entity_category is not None
@@ -176,10 +172,10 @@ class GoogleConfig(AbstractConfig):
         else:
             auxiliary_entity = False
 
-        explicit_expose = self.entity_config.get(state.entity_id, {}).get(CONF_EXPOSE)
+        explicit_expose = self.entity_config.get(entity_id, {}).get(CONF_EXPOSE)
 
         domain_exposed_by_default = (
-            expose_by_default and state.domain in exposed_domains
+            expose_by_default and split_entity_id(entity_id)[0] in exposed_domains
         )
 
         # Expose an entity by default if the entity's domain is exposed by default

--- a/homeassistant/components/google_assistant/report_state.py
+++ b/homeassistant/components/google_assistant/report_state.py
@@ -73,7 +73,7 @@ def async_enable_report_state(
         return bool(
             hass.is_running
             and (new_state := data["new_state"])
-            and google_config.should_expose(new_state)
+            and google_config.should_expose(new_state.entity_id)
             and async_get_google_entity_if_supported_cached(
                 hass, google_config, new_state
             )

--- a/tests/components/cloud/test_client.py
+++ b/tests/components/cloud/test_client.py
@@ -377,14 +377,13 @@ async def test_google_config_expose_entity(
     )
 
     cloud_client = hass.data[DATA_CLOUD].client
-    state = State(entity_entry.entity_id, "on")
     gconf = await cloud_client.get_google_config()
 
-    assert gconf.should_expose(state)
+    assert gconf.should_expose(entity_entry.entity_id)
 
     async_expose_entity(hass, "cloud.google_assistant", entity_entry.entity_id, False)
 
-    assert not gconf.should_expose(state)
+    assert not gconf.should_expose(entity_entry.entity_id)
 
 
 @pytest.mark.usefixtures("mock_cloud_setup", "mock_cloud_login")

--- a/tests/components/cloud/test_google_config.py
+++ b/tests/components/cloud/test_google_config.py
@@ -27,7 +27,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STARTED,
     EntityCategory,
 )
-from homeassistant.core import CoreState, HomeAssistant, State
+from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
@@ -431,32 +431,24 @@ async def test_google_config_expose_entity_prefs(
     expose_new(hass, True)
     expose_entity(hass, entity_entry5.entity_id, False)
 
-    state = State("light.kitchen", "on")
-    state_config = State(entity_entry1.entity_id, "on")
-    state_diagnostic = State(entity_entry2.entity_id, "on")
-    state_hidden_integration = State(entity_entry3.entity_id, "on")
-    state_hidden_user = State(entity_entry4.entity_id, "on")
-    state_not_exposed = State(entity_entry5.entity_id, "on")
-    state_exposed_default = State(entity_entry6.entity_id, "on")
-
     # an entity which is not in the entity registry can be exposed
     expose_entity(hass, "light.kitchen", True)
-    assert mock_conf.should_expose(state)
+    assert mock_conf.should_expose("light.kitchen")
     # categorized and hidden entities should not be exposed
-    assert not mock_conf.should_expose(state_config)
-    assert not mock_conf.should_expose(state_diagnostic)
-    assert not mock_conf.should_expose(state_hidden_integration)
-    assert not mock_conf.should_expose(state_hidden_user)
+    assert not mock_conf.should_expose(entity_entry1.entity_id)
+    assert not mock_conf.should_expose(entity_entry2.entity_id)
+    assert not mock_conf.should_expose(entity_entry3.entity_id)
+    assert not mock_conf.should_expose(entity_entry4.entity_id)
     # this has been hidden
-    assert not mock_conf.should_expose(state_not_exposed)
+    assert not mock_conf.should_expose(entity_entry5.entity_id)
     # exposed by default
-    assert mock_conf.should_expose(state_exposed_default)
+    assert mock_conf.should_expose(entity_entry6.entity_id)
 
     expose_entity(hass, entity_entry5.entity_id, True)
-    assert mock_conf.should_expose(state_not_exposed)
+    assert mock_conf.should_expose(entity_entry5.entity_id)
 
     expose_entity(hass, entity_entry5.entity_id, None)
-    assert not mock_conf.should_expose(state_not_exposed)
+    assert not mock_conf.should_expose(entity_entry5.entity_id)
 
 
 @pytest.mark.usefixtures("mock_expired_cloud_login")

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -60,9 +60,9 @@ class MockConfig(http.GoogleConfig):
         """Get agent user ID making request."""
         return context.user_id
 
-    def should_expose(self, state):
+    def should_expose(self, entity_id):
         """Expose it all."""
-        return self._should_expose is None or self._should_expose(state)
+        return self._should_expose is None or self._should_expose(entity_id)
 
     @property
     def should_report_state(self):

--- a/tests/components/google_assistant/test_http.py
+++ b/tests/components/google_assistant/test_http.py
@@ -14,7 +14,6 @@ import pytest
 
 from homeassistant.components.google_assistant import GOOGLE_ASSISTANT_SCHEMA
 from homeassistant.components.google_assistant.const import (
-    DOMAIN,
     EVENT_COMMAND_RECEIVED,
     HOMEGRAPH_TOKEN_URL,
     REPORT_STATE_BASE_URL,
@@ -29,7 +28,7 @@ from homeassistant.components.google_assistant.http import (
     async_get_users,
 )
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STARTED
-from homeassistant.core import CoreState, HomeAssistant, State
+from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -342,25 +341,6 @@ async def test_secure_device_pin_config(hass: HomeAssistant) -> None:
     config = GoogleConfig(hass, secure_config)
 
     assert config.secure_devices_pin == secure_pin
-
-
-async def test_should_expose(hass: HomeAssistant) -> None:
-    """Test the google config should expose method."""
-    config = GoogleConfig(hass, DUMMY_CONFIG)
-    await config.async_initialize()
-
-    with patch.object(config, "async_call_homegraph_api"):
-        # Wait for google_assistant.helpers.async_initialize.sync_google to be called
-        await hass.async_block_till_done()
-
-    assert (
-        config.should_expose(State(DOMAIN + ".mock", "mock", {"view": "not None"}))
-        is False
-    )
-
-    with patch.object(config, "async_call_homegraph_api"):
-        # Wait for google_assistant.helpers.async_initialize.sync_google to be called
-        await hass.async_block_till_done()
 
 
 async def test_missing_service_account(hass: HomeAssistant) -> None:

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -84,7 +84,7 @@ def registries(
 async def test_async_handle_message(hass: HomeAssistant) -> None:
     """Test the async handle message method."""
     config = MockConfig(
-        should_expose=lambda state: state.entity_id != "light.not_expose",
+        should_expose=lambda entity_id: entity_id != "light.not_expose",
         entity_config={
             "light.demo_light": {
                 const.CONF_ROOM_HINT: "Living Room",
@@ -172,7 +172,7 @@ async def test_sync_message(hass: HomeAssistant, registries) -> None:
     hass.states.async_set("light.not_expose", "on")
 
     config = MockConfig(
-        should_expose=lambda state: state.entity_id != "light.not_expose",
+        should_expose=lambda entity_id: entity_id != "light.not_expose",
         entity_config={
             "light.demo_light": {
                 const.CONF_ROOM_HINT: "Living Room",
@@ -1392,7 +1392,7 @@ async def test_reachable_devices(hass: HomeAssistant) -> None:
     hass.states.async_set("lock.has_2fa", "on")
 
     config = MockConfig(
-        should_expose=lambda state: state.entity_id != "light.not_expose",
+        should_expose=lambda entity_id: entity_id != "light.not_expose",
     )
 
     user_agent_id = "mock-user-id"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Clean up `should_expose` in google assistant.

Remove `view` attribute handling, obsolete since #32021.
Remove unneeded `_should_expose_entity_id` helper method.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
