### PR TITLE
Map ViCare hvac_action to compressor phase for cooling support

### DIFF
--- a/homeassistant/components/vicare/climate.py
+++ b/homeassistant/components/vicare/climate.py
@@ -200,27 +200,38 @@ class ViCareClimate(ViCareEntity, ClimateEntity):
             # Resolve the current hvac action from the underlying heat
             # source. Burners (boilers) only heat; compressors (heat pumps)
             # expose a `phase` ("heating" / "cooling" / "off" / ...) on top
-            # of the active flag.
-            self._current_action = HVACAction.IDLE
+            # of the active flag. Collect per-source flags first, then map
+            # to a single HVACAction so the result is independent of
+            # iteration order: cooling takes precedence over heating, which
+            # takes precedence over idle.
+            heating_active = False
+            cooling_active = False
             with suppress(PyViCareNotSupportedFeatureError):
                 for burner in get_burners(self._device):
                     if burner.getActive():
-                        self._current_action = HVACAction.HEATING
+                        heating_active = True
 
             with suppress(PyViCareNotSupportedFeatureError):
                 for compressor in get_compressors(self._device):
                     if not compressor.getActive():
                         continue
                     phase = None
-                    with suppress(PyViCareNotSupportedFeatureError, KeyError):
+                    with suppress(PyViCareNotSupportedFeatureError):
                         phase = compressor.getPhase()
                     if phase == "cooling":
-                        self._current_action = HVACAction.COOLING
+                        cooling_active = True
                     elif phase == "heating" or phase is None:
-                        # Fall back to HEATING when the device reports
-                        # active without a recognisable phase, matching
-                        # the pre-cooling-support behaviour.
-                        self._current_action = HVACAction.HEATING
+                        # Phase is unset on hybrid devices that do not
+                        # expose it: fall back to HEATING to match the
+                        # pre-cooling-support behaviour.
+                        heating_active = True
+
+            if cooling_active:
+                self._current_action = HVACAction.COOLING
+            elif heating_active:
+                self._current_action = HVACAction.HEATING
+            else:
+                self._current_action = HVACAction.IDLE
 
     @property
     def hvac_mode(self) -> HVACMode | None:

--- a/homeassistant/components/vicare/climate.py
+++ b/homeassistant/components/vicare/climate.py
@@ -127,7 +127,7 @@ class ViCareClimate(ViCareEntity, ClimateEntity):
     _attr_max_temp = VICARE_TEMP_HEATING_MAX
     _attr_target_temperature_step = PRECISION_WHOLE
     _attr_translation_key = "heating"
-    _current_action: bool | None = None
+    _current_action: HVACAction | None = None
     _current_mode: str | None = None
     _current_program: str | None = None
 
@@ -197,17 +197,30 @@ class ViCareClimate(ViCareEntity, ClimateEntity):
             with suppress(PyViCareNotSupportedFeatureError):
                 self._attributes["vicare_modes"] = self._api.getModes()
 
-            self._current_action = False
-            # Update the specific device attributes
+            # Resolve the current hvac action from the underlying heat
+            # source. Burners (boilers) only heat; compressors (heat pumps)
+            # expose a `phase` ("heating" / "cooling" / "off" / ...) on top
+            # of the active flag.
+            self._current_action = HVACAction.IDLE
             with suppress(PyViCareNotSupportedFeatureError):
                 for burner in get_burners(self._device):
-                    self._current_action = self._current_action or burner.getActive()
+                    if burner.getActive():
+                        self._current_action = HVACAction.HEATING
 
             with suppress(PyViCareNotSupportedFeatureError):
                 for compressor in get_compressors(self._device):
-                    self._current_action = (
-                        self._current_action or compressor.getActive()
-                    )
+                    if not compressor.getActive():
+                        continue
+                    phase = None
+                    with suppress(PyViCareNotSupportedFeatureError, KeyError):
+                        phase = compressor.getPhase()
+                    if phase == "cooling":
+                        self._current_action = HVACAction.COOLING
+                    elif phase == "heating" or phase is None:
+                        # Fall back to HEATING when the device reports
+                        # active without a recognisable phase, matching
+                        # the pre-cooling-support behaviour.
+                        self._current_action = HVACAction.HEATING
 
     @property
     def hvac_mode(self) -> HVACMode | None:
@@ -257,9 +270,7 @@ class ViCareClimate(ViCareEntity, ClimateEntity):
     @property
     def hvac_action(self) -> HVACAction:
         """Return the current hvac action."""
-        if self._current_action:
-            return HVACAction.HEATING
-        return HVACAction.IDLE
+        return self._current_action or HVACAction.IDLE
 
     def set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperatures."""

--- a/tests/components/vicare/test_climate.py
+++ b/tests/components/vicare/test_climate.py
@@ -1,13 +1,15 @@
 """Test ViCare climate entity."""
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
+from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.climate import ATTR_HVAC_ACTION, HVACAction
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import entity_component, entity_registry as er
 
 from . import MODULE, setup_integration
 from .conftest import Fixture, MockPyViCare
@@ -39,3 +41,73 @@ async def test_all_entities(
         await setup_integration(hass, mock_config_entry)
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("phase", "active", "expected_action"),
+    [
+        ("heating", True, HVACAction.HEATING),
+        ("cooling", True, HVACAction.COOLING),
+        ("off", False, HVACAction.IDLE),
+        ("ready", False, HVACAction.IDLE),
+        # Active compressor without a recognisable phase falls back to
+        # HEATING (matches the pre-cooling-support behaviour for hybrid
+        # devices that may not expose the phase property).
+        (None, True, HVACAction.HEATING),
+    ],
+)
+async def test_hvac_action_compressor_phase(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    phase: str | None,
+    active: bool,
+    expected_action: HVACAction,
+) -> None:
+    """hvac_action follows compressor.getPhase for heat pumps.
+
+    Regression test for #171849: previously the entity reported HEATING
+    whenever any compressor was active, even during cooling mode.
+    """
+    fixtures: list[Fixture] = [
+        Fixture({"type:boiler"}, "vicare/Vitodens300W.json"),
+    ]
+    mock_compressor = Mock()
+    mock_compressor.getActive.return_value = active
+    if phase is None:
+        mock_compressor.getPhase.side_effect = PyViCareNotSupportedFeatureError("phase")
+    else:
+        mock_compressor.getPhase.return_value = phase
+
+    with (
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.OAuth2Session.async_ensure_token_valid",
+        ),
+        patch(
+            f"{MODULE}._setup_vicare_api",
+            return_value=MockPyViCare(fixtures).as_vicare_data(),
+        ),
+        patch(f"{MODULE}.PLATFORMS", [Platform.CLIMATE]),
+        patch(
+            "homeassistant.components.vicare.climate.get_compressors",
+            return_value=[mock_compressor],
+        ),
+        patch(
+            "homeassistant.components.vicare.climate.get_burners",
+            return_value=[],
+        ),
+    ):
+        await setup_integration(hass, mock_config_entry)
+        # Force a refresh while the get_compressors/get_burners patches
+        # are still active so the entity's update() picks up the mock.
+        component: entity_component.EntityComponent = hass.data["climate"]
+        for entity in component.entities:
+            await entity.async_update_ha_state(force_refresh=True)
+
+    climate_states = [
+        state
+        for state in hass.states.async_all("climate")
+        if state.attributes.get(ATTR_HVAC_ACTION) is not None
+    ]
+    assert climate_states, "no climate entity exposed hvac_action"
+    for state in climate_states:
+        assert state.attributes[ATTR_HVAC_ACTION] == expected_action

--- a/tests/components/vicare/test_climate.py
+++ b/tests/components/vicare/test_climate.py
@@ -111,3 +111,57 @@ async def test_hvac_action_compressor_phase(
     assert climate_states, "no climate entity exposed hvac_action"
     for state in climate_states:
         assert state.attributes[ATTR_HVAC_ACTION] == expected_action
+
+
+async def test_hvac_action_multi_compressor_cooling_takes_precedence(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Cooling on any compressor must win over heating/unknown on another.
+
+    Regression guard for the order-dependent bug raised on #171945: with
+    one compressor reporting `cooling` and a second compressor active
+    without a recognisable phase, the result must be COOLING regardless
+    of iteration order.
+    """
+    fixtures: list[Fixture] = [
+        Fixture({"type:boiler"}, "vicare/Vitodens300W.json"),
+    ]
+    cooling_compressor = Mock()
+    cooling_compressor.getActive.return_value = True
+    cooling_compressor.getPhase.return_value = "cooling"
+    unknown_compressor = Mock()
+    unknown_compressor.getActive.return_value = True
+    unknown_compressor.getPhase.side_effect = PyViCareNotSupportedFeatureError("phase")
+
+    with (
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.OAuth2Session.async_ensure_token_valid",
+        ),
+        patch(
+            f"{MODULE}._setup_vicare_api",
+            return_value=MockPyViCare(fixtures).as_vicare_data(),
+        ),
+        patch(f"{MODULE}.PLATFORMS", [Platform.CLIMATE]),
+        patch(
+            "homeassistant.components.vicare.climate.get_compressors",
+            return_value=[unknown_compressor, cooling_compressor],
+        ),
+        patch(
+            "homeassistant.components.vicare.climate.get_burners",
+            return_value=[],
+        ),
+    ):
+        await setup_integration(hass, mock_config_entry)
+        component: entity_component.EntityComponent = hass.data["climate"]
+        for entity in component.entities:
+            await entity.async_update_ha_state(force_refresh=True)
+
+    climate_states = [
+        state
+        for state in hass.states.async_all("climate")
+        if state.attributes.get(ATTR_HVAC_ACTION) is not None
+    ]
+    assert climate_states, "no climate entity exposed hvac_action"
+    for state in climate_states:
+        assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.COOLING


### PR DESCRIPTION
## Proposed change

The ViCare climate entity reported `hvac_action: heating` whenever any compressor was active, so heat pumps in cooling mode (Vitocal 200S et al.) showed the wrong action even though `hvac_mode` was already correct.

PyViCare's `compressor.getPhase()` exposes the `"heating"` / `"cooling"` / `"off"` / `"ready"` discriminator (cloud feature `heating.compressors.0.phase`). The integration already has it plumbed (the user noted it surfaces as `sensor.vicare_compressor_phase`); only the climate entity's `hvac_action` ignored it. Consume the phase string in `_current_action` resolution:

| state | `hvac_action` |
|---|---|
| burner active | HEATING |
| compressor active + `phase == "heating"` | HEATING |
| compressor active + `phase == "cooling"` | COOLING |
| compressor active + phase missing / unsupported | HEATING (fallback for hybrid devices that may not expose phase) |
| nothing active | IDLE |

Phase values confirmed on a real Vitocal 200S (CU401B S) via diagnostics dumps attached to #171849: `cooling` during active cooling, `heating` during active heating, `off` when idle.

Parametrized test mocks `get_compressors` / `get_burners` and forces a refresh inside the patch block, covering all five branches.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #171849
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: \`python3 -m script.hassfest\`.
- [ ] New or updated dependencies have been added to \`requirements_all.txt\`.
      Updated by running \`python3 -m script.gen_requirements_all\`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr