### PR TITLE
Use AlarmControlPanelEntityFeature from aioesphomeapi in esphome

### DIFF
--- a/homeassistant/components/esphome/alarm_control_panel.py
+++ b/homeassistant/components/esphome/alarm_control_panel.py
@@ -90,7 +90,8 @@ class EsphomeAlarmControlPanel(
         )
         flags = AlarmControlPanelEntityFeature(0)
         for esp_flag in esp_flags:
-            flags |= _FEATURES[esp_flag]
+            if (flag := _FEATURES.get(esp_flag)) is not None:
+                flags |= flag
         self._attr_supported_features = flags
         self._attr_code_format = (
             CodeFormat.NUMBER if static_info.requires_code else None

--- a/homeassistant/components/esphome/alarm_control_panel.py
+++ b/homeassistant/components/esphome/alarm_control_panel.py
@@ -4,10 +4,10 @@ from functools import partial
 
 from aioesphomeapi import (
     AlarmControlPanelCommand,
+    AlarmControlPanelEntityFeature as ESPHomeAlarmControlPanelEntityFeature,
     AlarmControlPanelEntityState as ESPHomeAlarmControlPanelEntityState,
     AlarmControlPanelInfo,
     AlarmControlPanelState as ESPHomeAlarmControlPanelState,
-    APIIntEnum,
     EntityInfo,
 )
 
@@ -50,16 +50,28 @@ _ESPHOME_ACP_STATE_TO_HASS_STATE: EsphomeEnumMapper[
     }
 )
 
-
-class EspHomeACPFeatures(APIIntEnum):
-    """ESPHome AlarmControlPanel feature numbers."""
-
-    ARM_HOME = 1
-    ARM_AWAY = 2
-    ARM_NIGHT = 4
-    TRIGGER = 8
-    ARM_CUSTOM_BYPASS = 16
-    ARM_VACATION = 32
+_FEATURES: dict[
+    ESPHomeAlarmControlPanelEntityFeature, AlarmControlPanelEntityFeature
+] = {
+    ESPHomeAlarmControlPanelEntityFeature.ARM_HOME: (
+        AlarmControlPanelEntityFeature.ARM_HOME
+    ),
+    ESPHomeAlarmControlPanelEntityFeature.ARM_AWAY: (
+        AlarmControlPanelEntityFeature.ARM_AWAY
+    ),
+    ESPHomeAlarmControlPanelEntityFeature.ARM_NIGHT: (
+        AlarmControlPanelEntityFeature.ARM_NIGHT
+    ),
+    ESPHomeAlarmControlPanelEntityFeature.TRIGGER: (
+        AlarmControlPanelEntityFeature.TRIGGER
+    ),
+    ESPHomeAlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS: (
+        AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS
+    ),
+    ESPHomeAlarmControlPanelEntityFeature.ARM_VACATION: (
+        AlarmControlPanelEntityFeature.ARM_VACATION
+    ),
+}
 
 
 class EsphomeAlarmControlPanel(
@@ -73,20 +85,13 @@ class EsphomeAlarmControlPanel(
         """Set attrs from static info."""
         super()._on_static_info_update(static_info)
         static_info = self._static_info
-        feature = 0
-        if static_info.supported_features & EspHomeACPFeatures.ARM_HOME:
-            feature |= AlarmControlPanelEntityFeature.ARM_HOME
-        if static_info.supported_features & EspHomeACPFeatures.ARM_AWAY:
-            feature |= AlarmControlPanelEntityFeature.ARM_AWAY
-        if static_info.supported_features & EspHomeACPFeatures.ARM_NIGHT:
-            feature |= AlarmControlPanelEntityFeature.ARM_NIGHT
-        if static_info.supported_features & EspHomeACPFeatures.TRIGGER:
-            feature |= AlarmControlPanelEntityFeature.TRIGGER
-        if static_info.supported_features & EspHomeACPFeatures.ARM_CUSTOM_BYPASS:
-            feature |= AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS
-        if static_info.supported_features & EspHomeACPFeatures.ARM_VACATION:
-            feature |= AlarmControlPanelEntityFeature.ARM_VACATION
-        self._attr_supported_features = AlarmControlPanelEntityFeature(feature)
+        esp_flags = ESPHomeAlarmControlPanelEntityFeature(
+            static_info.supported_features
+        )
+        flags = AlarmControlPanelEntityFeature(0)
+        for esp_flag in esp_flags:
+            flags |= _FEATURES[esp_flag]
+        self._attr_supported_features = flags
         self._attr_code_format = (
             CodeFormat.NUMBER if static_info.requires_code else None
         )

--- a/tests/components/esphome/test_alarm_control_panel.py
+++ b/tests/components/esphome/test_alarm_control_panel.py
@@ -4,6 +4,7 @@ from unittest.mock import call
 
 from aioesphomeapi import (
     AlarmControlPanelCommand,
+    AlarmControlPanelEntityFeature as ESPHomeAlarmControlPanelEntityFeature,
     AlarmControlPanelEntityState as ESPHomeAlarmEntityState,
     AlarmControlPanelInfo,
     AlarmControlPanelState as ESPHomeAlarmState,
@@ -22,7 +23,6 @@ from homeassistant.components.alarm_control_panel import (
     SERVICE_ALARM_TRIGGER,
     AlarmControlPanelState,
 )
-from homeassistant.components.esphome.alarm_control_panel import EspHomeACPFeatures
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 
@@ -40,12 +40,12 @@ async def test_generic_alarm_control_panel_requires_code(
             object_id="myalarm_control_panel",
             key=1,
             name="my alarm_control_panel",
-            supported_features=EspHomeACPFeatures.ARM_AWAY
-            | EspHomeACPFeatures.ARM_CUSTOM_BYPASS
-            | EspHomeACPFeatures.ARM_HOME
-            | EspHomeACPFeatures.ARM_NIGHT
-            | EspHomeACPFeatures.ARM_VACATION
-            | EspHomeACPFeatures.TRIGGER,
+            supported_features=ESPHomeAlarmControlPanelEntityFeature.ARM_AWAY
+            | ESPHomeAlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS
+            | ESPHomeAlarmControlPanelEntityFeature.ARM_HOME
+            | ESPHomeAlarmControlPanelEntityFeature.ARM_NIGHT
+            | ESPHomeAlarmControlPanelEntityFeature.ARM_VACATION
+            | ESPHomeAlarmControlPanelEntityFeature.TRIGGER,
             requires_code=True,
             requires_code_to_arm=True,
         )
@@ -172,12 +172,12 @@ async def test_generic_alarm_control_panel_no_code(
             object_id="myalarm_control_panel",
             key=1,
             name="my alarm_control_panel",
-            supported_features=EspHomeACPFeatures.ARM_AWAY
-            | EspHomeACPFeatures.ARM_CUSTOM_BYPASS
-            | EspHomeACPFeatures.ARM_HOME
-            | EspHomeACPFeatures.ARM_NIGHT
-            | EspHomeACPFeatures.ARM_VACATION
-            | EspHomeACPFeatures.TRIGGER,
+            supported_features=ESPHomeAlarmControlPanelEntityFeature.ARM_AWAY
+            | ESPHomeAlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS
+            | ESPHomeAlarmControlPanelEntityFeature.ARM_HOME
+            | ESPHomeAlarmControlPanelEntityFeature.ARM_NIGHT
+            | ESPHomeAlarmControlPanelEntityFeature.ARM_VACATION
+            | ESPHomeAlarmControlPanelEntityFeature.TRIGGER,
             requires_code=False,
             requires_code_to_arm=False,
         )
@@ -217,12 +217,12 @@ async def test_generic_alarm_control_panel_missing_state(
             object_id="myalarm_control_panel",
             key=1,
             name="my alarm_control_panel",
-            supported_features=EspHomeACPFeatures.ARM_AWAY
-            | EspHomeACPFeatures.ARM_CUSTOM_BYPASS
-            | EspHomeACPFeatures.ARM_HOME
-            | EspHomeACPFeatures.ARM_NIGHT
-            | EspHomeACPFeatures.ARM_VACATION
-            | EspHomeACPFeatures.TRIGGER,
+            supported_features=ESPHomeAlarmControlPanelEntityFeature.ARM_AWAY
+            | ESPHomeAlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS
+            | ESPHomeAlarmControlPanelEntityFeature.ARM_HOME
+            | ESPHomeAlarmControlPanelEntityFeature.ARM_NIGHT
+            | ESPHomeAlarmControlPanelEntityFeature.ARM_VACATION
+            | ESPHomeAlarmControlPanelEntityFeature.TRIGGER,
             requires_code=False,
             requires_code_to_arm=False,
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

aioesphomeapi 45.1.0 ships an ``AlarmControlPanelEntityFeature`` ``IntFlag`` (https://github.com/esphome/aioesphomeapi/pull/1732), so drop the duplicate ``EspHomeACPFeatures`` ``APIIntEnum`` defined in this integration and use the library one instead. While here, switch the feature decode to the iterate the ``IntFlag`` plus dict lookup pattern already used by the esphome media_player platform.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr