### PR TITLE
Change default Bluetooth scanning mode to Auto

### DIFF
--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -79,11 +79,13 @@ from .const import (
     BLUETOOTH_DISCOVERY_COOLDOWN_SECONDS,
     CONF_ADAPTER,
     CONF_DETAILS,
+    CONF_MODE,
     CONF_PASSIVE,
     CONF_SOURCE_CONFIG_ENTRY_ID,
     CONF_SOURCE_DEVICE_ID,
     CONF_SOURCE_DOMAIN,
     CONF_SOURCE_MODEL,
+    DEFAULT_MODE,
     DOMAIN,
     FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
     LINUX_FIRMWARE_LOAD_FALLBACK_SECONDS,
@@ -387,9 +389,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady(
             f"Bluetooth adapter {adapter} with address {address} not found"
         )
-    passive = entry.options.get(CONF_PASSIVE)
     adapters = await manager.async_get_bluetooth_adapters()
-    mode = BluetoothScanningMode.PASSIVE if passive else BluetoothScanningMode.ACTIVE
+    if (mode_value := entry.options.get(CONF_MODE)) is not None:
+        mode = BluetoothScanningMode(mode_value)
+    elif (legacy_passive := entry.options.get(CONF_PASSIVE)) is True:
+        mode = BluetoothScanningMode.PASSIVE
+    elif legacy_passive is False:
+        mode = BluetoothScanningMode.ACTIVE
+    else:
+        mode = BluetoothScanningMode(DEFAULT_MODE)
     scanner = HaScanner(mode, adapter, address)
     scanner.async_setup()
     details = adapters[adapter]

--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -11,6 +11,7 @@ from bluetooth_adapters import (
     ADAPTER_CONNECTION_SLOTS,
     ADAPTER_HW_VERSION,
     ADAPTER_MANUFACTURER,
+    ADAPTER_PASSIVE_SCAN,
     ADAPTER_SW_VERSION,
     DEFAULT_ADDRESS,
     DEFAULT_CONNECTION_SLOTS,
@@ -390,6 +391,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             f"Bluetooth adapter {adapter} with address {address} not found"
         )
     adapters = await manager.async_get_bluetooth_adapters()
+    details = adapters[adapter]
     if (mode_value := entry.options.get(CONF_MODE)) is not None:
         mode = BluetoothScanningMode(mode_value)
     elif (legacy_passive := entry.options.get(CONF_PASSIVE)) is True:
@@ -398,9 +400,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         mode = BluetoothScanningMode.ACTIVE
     else:
         mode = BluetoothScanningMode(DEFAULT_MODE)
+    # AUTO starts the scanner in passive mode and lets the manager promote
+    # it to active on demand; that only works on adapters that actually
+    # support passive scanning. Fall back to ACTIVE on adapters that don't
+    # (old BlueZ, etc.) so we don't regress them from the historical default.
+    if mode is BluetoothScanningMode.AUTO and not details[ADAPTER_PASSIVE_SCAN]:
+        mode = BluetoothScanningMode.ACTIVE
     scanner = HaScanner(mode, adapter, address)
     scanner.async_setup()
-    details = adapters[adapter]
     if entry.title == address:
         hass.config_entries.async_update_entry(
             entry, title=adapter_title(adapter, details)

--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -1,6 +1,5 @@
 """The bluetooth integration."""
 
-from collections.abc import Mapping
 import datetime
 import logging
 import platform
@@ -81,13 +80,10 @@ from .const import (
     BLUETOOTH_DISCOVERY_COOLDOWN_SECONDS,
     CONF_ADAPTER,
     CONF_DETAILS,
-    CONF_MODE,
-    CONF_PASSIVE,
     CONF_SOURCE_CONFIG_ENTRY_ID,
     CONF_SOURCE_DEVICE_ID,
     CONF_SOURCE_DOMAIN,
     CONF_SOURCE_MODEL,
-    DEFAULT_MODE,
     DOMAIN,
     FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
     LINUX_FIRMWARE_LOAD_FALLBACK_SECONDS,
@@ -97,7 +93,7 @@ from .manager import HomeAssistantBluetoothManager
 from .match import BluetoothCallbackMatcher, IntegrationMatcher
 from .models import BluetoothCallback, BluetoothChange
 from .storage import BluetoothStorage
-from .util import adapter_title
+from .util import adapter_title, resolve_scanning_mode
 
 if TYPE_CHECKING:
     from homeassistant.helpers.typing import ConfigType
@@ -348,21 +344,6 @@ async def async_update_device(
         device_registry.async_update_device(device_entry.id, **kwargs)
 
 
-def _async_resolve_scanning_mode(options: Mapping[str, Any]) -> BluetoothScanningMode:
-    """Resolve CONF_MODE, falling back to legacy CONF_PASSIVE or DEFAULT_MODE."""
-    if (mode_value := options.get(CONF_MODE)) is not None:
-        try:
-            return BluetoothScanningMode(mode_value)
-        except ValueError:
-            _LOGGER.warning("Unknown bluetooth scanning mode %r", mode_value)
-            return BluetoothScanningMode(DEFAULT_MODE)
-    if (legacy_passive := options.get(CONF_PASSIVE)) is True:
-        return BluetoothScanningMode.PASSIVE
-    if legacy_passive is False:
-        return BluetoothScanningMode.ACTIVE
-    return BluetoothScanningMode(DEFAULT_MODE)
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a config entry for a bluetooth scanner."""
     if source_entry_id := entry.data.get(CONF_SOURCE_CONFIG_ENTRY_ID):
@@ -408,7 +389,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
     adapters = await manager.async_get_bluetooth_adapters()
     details = adapters[adapter]
-    mode = _async_resolve_scanning_mode(entry.options)
+    mode = resolve_scanning_mode(entry.options)
     # AUTO needs passive scanning support to flip on demand; without it
     # the scanner would start passive on hardware that can't do passive.
     if mode is BluetoothScanningMode.AUTO and not details.get(ADAPTER_PASSIVE_SCAN):

--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -349,21 +349,12 @@ async def async_update_device(
 
 
 def _async_resolve_scanning_mode(options: Mapping[str, Any]) -> BluetoothScanningMode:
-    """Resolve the scanning mode from saved options.
-
-    CONF_MODE wins; otherwise the legacy CONF_PASSIVE boolean is honored;
-    otherwise the new AUTO default is used. An unrecognized CONF_MODE
-    string falls back to DEFAULT_MODE so a malformed value never aborts
-    setup.
-    """
+    """Resolve CONF_MODE, falling back to legacy CONF_PASSIVE or DEFAULT_MODE."""
     if (mode_value := options.get(CONF_MODE)) is not None:
         try:
             return BluetoothScanningMode(mode_value)
         except ValueError:
-            _LOGGER.warning(
-                "Unknown bluetooth scanning mode %r in options; using default",
-                mode_value,
-            )
+            _LOGGER.warning("Unknown bluetooth scanning mode %r", mode_value)
             return BluetoothScanningMode(DEFAULT_MODE)
     if (legacy_passive := options.get(CONF_PASSIVE)) is True:
         return BluetoothScanningMode.PASSIVE
@@ -418,11 +409,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     adapters = await manager.async_get_bluetooth_adapters()
     details = adapters[adapter]
     mode = _async_resolve_scanning_mode(entry.options)
-    # AUTO starts the scanner in passive mode and lets the manager promote
-    # it to active on demand; that only works on adapters that actually
-    # support passive scanning. Fall back to ACTIVE on adapters that don't
-    # (old BlueZ, etc.) so we don't regress them from the historical default.
-    if mode is BluetoothScanningMode.AUTO and not details[ADAPTER_PASSIVE_SCAN]:
+    # AUTO needs passive scanning support to flip on demand; without it
+    # the scanner would start passive on hardware that can't do passive.
+    if mode is BluetoothScanningMode.AUTO and not details.get(ADAPTER_PASSIVE_SCAN):
         mode = BluetoothScanningMode.ACTIVE
     scanner = HaScanner(mode, adapter, address)
     scanner.async_setup()

--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -1,5 +1,6 @@
 """The bluetooth integration."""
 
+from collections.abc import Mapping
 import datetime
 import logging
 import platform
@@ -347,6 +348,30 @@ async def async_update_device(
         device_registry.async_update_device(device_entry.id, **kwargs)
 
 
+def _async_resolve_scanning_mode(options: Mapping[str, Any]) -> BluetoothScanningMode:
+    """Resolve the scanning mode from saved options.
+
+    CONF_MODE wins; otherwise the legacy CONF_PASSIVE boolean is honored;
+    otherwise the new AUTO default is used. An unrecognized CONF_MODE
+    string falls back to DEFAULT_MODE so a malformed value never aborts
+    setup.
+    """
+    if (mode_value := options.get(CONF_MODE)) is not None:
+        try:
+            return BluetoothScanningMode(mode_value)
+        except ValueError:
+            _LOGGER.warning(
+                "Unknown bluetooth scanning mode %r in options; using default",
+                mode_value,
+            )
+            return BluetoothScanningMode(DEFAULT_MODE)
+    if (legacy_passive := options.get(CONF_PASSIVE)) is True:
+        return BluetoothScanningMode.PASSIVE
+    if legacy_passive is False:
+        return BluetoothScanningMode.ACTIVE
+    return BluetoothScanningMode(DEFAULT_MODE)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a config entry for a bluetooth scanner."""
     if source_entry_id := entry.data.get(CONF_SOURCE_CONFIG_ENTRY_ID):
@@ -392,14 +417,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
     adapters = await manager.async_get_bluetooth_adapters()
     details = adapters[adapter]
-    if (mode_value := entry.options.get(CONF_MODE)) is not None:
-        mode = BluetoothScanningMode(mode_value)
-    elif (legacy_passive := entry.options.get(CONF_PASSIVE)) is True:
-        mode = BluetoothScanningMode.PASSIVE
-    elif legacy_passive is False:
-        mode = BluetoothScanningMode.ACTIVE
-    else:
-        mode = BluetoothScanningMode(DEFAULT_MODE)
+    mode = _async_resolve_scanning_mode(entry.options)
     # AUTO starts the scanner in passive mode and lets the manager promote
     # it to active on demand; that only works on adapters that actually
     # support passive scanning. Fall back to ACTIVE on adapters that don't

--- a/homeassistant/components/bluetooth/config_flow.py
+++ b/homeassistant/components/bluetooth/config_flow.py
@@ -50,6 +50,7 @@ from .const import (
 )
 from .util import adapter_title
 
+_VALID_MODE_VALUES = {mode.value for mode in BluetoothScanningMode}
 _MODE_SELECTOR = SelectSelector(
     SelectSelectorConfig(
         options=[
@@ -72,7 +73,8 @@ async def _options_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
     flip a deliberately-chosen mode.
     """
     options = handler.options
-    if (current := options.get(CONF_MODE)) is None:
+    current = options.get(CONF_MODE)
+    if current is None or current not in _VALID_MODE_VALUES:
         legacy_passive = options.get(CONF_PASSIVE)
         if legacy_passive is True:
             current = BluetoothScanningMode.PASSIVE.value

--- a/homeassistant/components/bluetooth/config_flow.py
+++ b/homeassistant/components/bluetooth/config_flow.py
@@ -45,12 +45,10 @@ from .const import (
     CONF_SOURCE_DEVICE_ID,
     CONF_SOURCE_DOMAIN,
     CONF_SOURCE_MODEL,
-    DEFAULT_MODE,
     DOMAIN,
 )
-from .util import adapter_title
+from .util import adapter_title, resolve_scanning_mode
 
-_VALID_MODE_VALUES = {mode.value for mode in BluetoothScanningMode}
 _MODE_SELECTOR = SelectSelector(
     SelectSelectorConfig(
         options=[
@@ -66,16 +64,7 @@ _MODE_SELECTOR = SelectSelector(
 
 async def _options_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
     """Build the options schema with the saved mode as the default."""
-    options = handler.options
-    current = options.get(CONF_MODE)
-    if current is None or current not in _VALID_MODE_VALUES:
-        legacy_passive = options.get(CONF_PASSIVE)
-        if legacy_passive is True:
-            current = BluetoothScanningMode.PASSIVE.value
-        elif legacy_passive is False:
-            current = BluetoothScanningMode.ACTIVE.value
-        else:
-            current = DEFAULT_MODE
+    current = resolve_scanning_mode(handler.options).value
     return vol.Schema({vol.Required(CONF_MODE, default=current): _MODE_SELECTOR})
 
 

--- a/homeassistant/components/bluetooth/config_flow.py
+++ b/homeassistant/components/bluetooth/config_flow.py
@@ -12,7 +12,7 @@ from bluetooth_adapters import (
     adapter_model,
     get_adapters,
 )
-from habluetooth import get_manager
+from habluetooth import BluetoothScanningMode, get_manager
 import voluptuous as vol
 
 from homeassistant.components import onboarding
@@ -24,31 +24,61 @@ from homeassistant.config_entries import (
 )
 from homeassistant.core import callback
 from homeassistant.helpers.schema_config_entry_flow import (
+    SchemaCommonFlowHandler,
     SchemaFlowFormStep,
     SchemaOptionsFlowHandler,
+)
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
 )
 from homeassistant.helpers.typing import DiscoveryInfoType
 
 from .const import (
     CONF_ADAPTER,
     CONF_DETAILS,
+    CONF_MODE,
     CONF_PASSIVE,
     CONF_SOURCE,
     CONF_SOURCE_CONFIG_ENTRY_ID,
     CONF_SOURCE_DEVICE_ID,
     CONF_SOURCE_DOMAIN,
     CONF_SOURCE_MODEL,
+    DEFAULT_MODE,
     DOMAIN,
 )
 from .util import adapter_title
 
 OPTIONS_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_PASSIVE, default=False): bool,
+        vol.Required(CONF_MODE, default=DEFAULT_MODE): SelectSelector(
+            SelectSelectorConfig(
+                options=[
+                    BluetoothScanningMode.AUTO.value,
+                    BluetoothScanningMode.ACTIVE.value,
+                    BluetoothScanningMode.PASSIVE.value,
+                ],
+                translation_key="mode",
+                mode=SelectSelectorMode.DROPDOWN,
+            )
+        ),
     }
 )
+
+
+async def _validate_options(
+    handler: SchemaCommonFlowHandler, user_input: dict[str, Any]
+) -> dict[str, Any]:
+    """Mirror CONF_MODE into the legacy CONF_PASSIVE option so a downgrade still works."""
+    user_input[CONF_PASSIVE] = (
+        user_input[CONF_MODE] == BluetoothScanningMode.PASSIVE.value
+    )
+    return user_input
+
+
 OPTIONS_FLOW = {
-    "init": SchemaFlowFormStep(OPTIONS_SCHEMA),
+    "init": SchemaFlowFormStep(OPTIONS_SCHEMA, validate_user_input=_validate_options),
 }
 
 

--- a/homeassistant/components/bluetooth/config_flow.py
+++ b/homeassistant/components/bluetooth/config_flow.py
@@ -65,13 +65,7 @@ _MODE_SELECTOR = SelectSelector(
 
 
 async def _options_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
-    """Build the options schema with the current mode as the default.
-
-    Existing installs may only have the legacy CONF_PASSIVE boolean and no
-    CONF_MODE; deriving the form default from both keeps the saved choice
-    visible so opening Configure and clicking Submit does not silently
-    flip a deliberately-chosen mode.
-    """
+    """Build the options schema with the saved mode as the default."""
     options = handler.options
     current = options.get(CONF_MODE)
     if current is None or current not in _VALID_MODE_VALUES:
@@ -88,7 +82,7 @@ async def _options_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
 async def _validate_options(
     handler: SchemaCommonFlowHandler, user_input: dict[str, Any]
 ) -> dict[str, Any]:
-    """Mirror CONF_MODE into the legacy CONF_PASSIVE option so a downgrade still works."""
+    """Mirror CONF_MODE into the legacy CONF_PASSIVE for downgrade safety."""
     user_input[CONF_PASSIVE] = (
         user_input[CONF_MODE] == BluetoothScanningMode.PASSIVE.value
     )

--- a/homeassistant/components/bluetooth/config_flow.py
+++ b/homeassistant/components/bluetooth/config_flow.py
@@ -50,21 +50,37 @@ from .const import (
 )
 from .util import adapter_title
 
-OPTIONS_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_MODE, default=DEFAULT_MODE): SelectSelector(
-            SelectSelectorConfig(
-                options=[
-                    BluetoothScanningMode.AUTO.value,
-                    BluetoothScanningMode.ACTIVE.value,
-                    BluetoothScanningMode.PASSIVE.value,
-                ],
-                translation_key="mode",
-                mode=SelectSelectorMode.DROPDOWN,
-            )
-        ),
-    }
+_MODE_SELECTOR = SelectSelector(
+    SelectSelectorConfig(
+        options=[
+            BluetoothScanningMode.AUTO.value,
+            BluetoothScanningMode.ACTIVE.value,
+            BluetoothScanningMode.PASSIVE.value,
+        ],
+        translation_key="mode",
+        mode=SelectSelectorMode.DROPDOWN,
+    )
 )
+
+
+async def _options_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
+    """Build the options schema with the current mode as the default.
+
+    Existing installs may only have the legacy CONF_PASSIVE boolean and no
+    CONF_MODE; deriving the form default from both keeps the saved choice
+    visible so opening Configure and clicking Submit does not silently
+    flip a deliberately-chosen mode.
+    """
+    options = handler.options
+    if (current := options.get(CONF_MODE)) is None:
+        legacy_passive = options.get(CONF_PASSIVE)
+        if legacy_passive is True:
+            current = BluetoothScanningMode.PASSIVE.value
+        elif legacy_passive is False:
+            current = BluetoothScanningMode.ACTIVE.value
+        else:
+            current = DEFAULT_MODE
+    return vol.Schema({vol.Required(CONF_MODE, default=current): _MODE_SELECTOR})
 
 
 async def _validate_options(
@@ -78,7 +94,7 @@ async def _validate_options(
 
 
 OPTIONS_FLOW = {
-    "init": SchemaFlowFormStep(OPTIONS_SCHEMA, validate_user_input=_validate_options),
+    "init": SchemaFlowFormStep(_options_schema, validate_user_input=_validate_options),
 }
 
 

--- a/homeassistant/components/bluetooth/const.py
+++ b/homeassistant/components/bluetooth/const.py
@@ -7,13 +7,20 @@ from habluetooth import (  # noqa: F401
     FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
     SCANNER_WATCHDOG_INTERVAL,
     SCANNER_WATCHDOG_TIMEOUT,
+    BluetoothScanningMode,
 )
+
+from homeassistant.const import CONF_MODE  # noqa: F401
 
 DOMAIN = "bluetooth"
 
 CONF_ADAPTER = "adapter"
 CONF_DETAILS = "details"
+# CONF_PASSIVE is the legacy boolean option; we keep writing it alongside
+# CONF_MODE so a downgrade to a pre-AUTO release reads a sensible value.
 CONF_PASSIVE = "passive"
+
+DEFAULT_MODE = BluetoothScanningMode.AUTO.value
 
 
 # pylint: disable-next=home-assistant-duplicate-const

--- a/homeassistant/components/bluetooth/strings.json
+++ b/homeassistant/components/bluetooth/strings.json
@@ -48,8 +48,20 @@
     "step": {
       "init": {
         "data": {
-          "passive": "Passive scanning"
+          "mode": "Scanning mode"
+        },
+        "data_description": {
+          "mode": "Auto is recommended for most setups. It saves battery on your Bluetooth devices while still catching new devices and updates quickly."
         }
+      }
+    }
+  },
+  "selector": {
+    "mode": {
+      "options": {
+        "active": "Active (uses more device battery, fastest updates)",
+        "auto": "Auto (recommended, saves device battery)",
+        "passive": "Passive (lowest device battery use, some details may be missing)"
       }
     }
   }

--- a/homeassistant/components/bluetooth/util.py
+++ b/homeassistant/components/bluetooth/util.py
@@ -1,5 +1,9 @@
 """The bluetooth integration utilities."""
 
+from collections.abc import Mapping
+import logging
+from typing import Any
+
 from bluetooth_adapters import (
     ADAPTER_ADDRESS,
     ADAPTER_MANUFACTURER,
@@ -9,13 +13,31 @@ from bluetooth_adapters import (
     adapter_unique_name,
 )
 from bluetooth_data_tools import monotonic_time_coarse
-from habluetooth import get_manager
+from habluetooth import BluetoothScanningMode, get_manager
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 
+from .const import CONF_MODE, CONF_PASSIVE, DEFAULT_MODE
 from .models import BluetoothServiceInfoBleak
 from .storage import BluetoothStorage
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def resolve_scanning_mode(options: Mapping[str, Any]) -> BluetoothScanningMode:
+    """Resolve CONF_MODE, falling back to legacy CONF_PASSIVE or DEFAULT_MODE."""
+    if (mode_value := options.get(CONF_MODE)) is not None:
+        try:
+            return BluetoothScanningMode(mode_value)
+        except ValueError:
+            _LOGGER.warning("Unknown bluetooth scanning mode %r", mode_value)
+            return BluetoothScanningMode(DEFAULT_MODE)
+    if (legacy_passive := options.get(CONF_PASSIVE)) is True:
+        return BluetoothScanningMode.PASSIVE
+    if legacy_passive is False:
+        return BluetoothScanningMode.ACTIVE
+    return BluetoothScanningMode(DEFAULT_MODE)
 
 
 class InvalidConfigEntryID(HomeAssistantError):

--- a/homeassistant/components/bluetooth/util.py
+++ b/homeassistant/components/bluetooth/util.py
@@ -30,7 +30,7 @@ def resolve_scanning_mode(options: Mapping[str, Any]) -> BluetoothScanningMode:
     if (mode_value := options.get(CONF_MODE)) is not None:
         try:
             return BluetoothScanningMode(mode_value)
-        except ValueError:
+        except TypeError, ValueError:
             _LOGGER.warning("Unknown bluetooth scanning mode %r", mode_value)
             return BluetoothScanningMode(DEFAULT_MODE)
     if (legacy_passive := options.get(CONF_PASSIVE)) is True:

--- a/tests/components/bluetooth/test_config_flow.py
+++ b/tests/components/bluetooth/test_config_flow.py
@@ -10,7 +10,7 @@ from homeassistant.components.bluetooth import HaBluetoothConnector
 from homeassistant.components.bluetooth.const import (
     CONF_ADAPTER,
     CONF_DETAILS,
-    CONF_PASSIVE,
+    CONF_MODE,
     CONF_SOURCE,
     CONF_SOURCE_CONFIG_ENTRY_ID,
     CONF_SOURCE_DEVICE_ID,
@@ -347,10 +347,11 @@ async def test_async_step_integration_discovery_already_exists(
     assert result["reason"] == "already_configured"
 
 
+@pytest.mark.parametrize("mode", ["auto", "active", "passive"])
 @pytest.mark.usefixtures(
     "one_adapter", "mock_bleak_scanner_start", "mock_bluetooth_adapters"
 )
-async def test_options_flow_linux(hass: HomeAssistant) -> None:
+async def test_options_flow_linux(hass: HomeAssistant, mode: str) -> None:
     """Test options on Linux."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -370,32 +371,12 @@ async def test_options_flow_linux(hass: HomeAssistant) -> None:
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input={
-            CONF_PASSIVE: True,
-        },
+        user_input={CONF_MODE: mode},
     )
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["data"][CONF_PASSIVE] is True
-
-    # Verify we can change it to False
-
-    result = await hass.config_entries.options.async_init(entry.entry_id)
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "init"
-    assert result["errors"] is None
-
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input={
-            CONF_PASSIVE: False,
-        },
-    )
-    await hass.async_block_till_done()
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["data"][CONF_PASSIVE] is False
+    assert result["data"][CONF_MODE] == mode
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 

--- a/tests/components/bluetooth/test_config_flow.py
+++ b/tests/components/bluetooth/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test the bluetooth config flow."""
 
+from typing import Any
 from unittest.mock import patch
 
 from bluetooth_adapters import DEFAULT_ADDRESS, AdapterDetails
@@ -11,6 +12,7 @@ from homeassistant.components.bluetooth.const import (
     CONF_ADAPTER,
     CONF_DETAILS,
     CONF_MODE,
+    CONF_PASSIVE,
     CONF_SOURCE,
     CONF_SOURCE_CONFIG_ENTRY_ID,
     CONF_SOURCE_DEVICE_ID,
@@ -377,6 +379,44 @@ async def test_options_flow_linux(hass: HomeAssistant, mode: str) -> None:
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_MODE] == mode
+    assert result["data"][CONF_PASSIVE] is (mode == "passive")
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+@pytest.mark.parametrize(
+    ("options", "expected_default"),
+    [
+        ({}, "auto"),
+        ({CONF_PASSIVE: True}, "passive"),
+        ({CONF_PASSIVE: False}, "active"),
+        ({CONF_MODE: "passive"}, "passive"),
+    ],
+    ids=["fresh", "legacy_passive_true", "legacy_passive_false", "explicit_mode"],
+)
+@pytest.mark.usefixtures(
+    "one_adapter", "mock_bleak_scanner_start", "mock_bluetooth_adapters"
+)
+async def test_options_flow_default_reflects_existing_options(
+    hass: HomeAssistant, options: dict[str, Any], expected_default: str
+) -> None:
+    """Options form preselects the current mode, including legacy CONF_PASSIVE."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+        options=options,
+        unique_id="00:00:00:00:00:01",
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    schema = result["data_schema"].schema
+    mode_key = next(k for k in schema if k == CONF_MODE)
+    assert mode_key.default() == expected_default
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 

--- a/tests/components/bluetooth/test_diagnostics.py
+++ b/tests/components/bluetooth/test_diagnostics.py
@@ -198,11 +198,11 @@ async def test_diagnostics(
                         "type": "HaScanner",
                         "current_mode": {
                             "__type": "<enum 'BluetoothScanningMode'>",
-                            "repr": "<BluetoothScanningMode.ACTIVE: 'active'>",
+                            "repr": "<BluetoothScanningMode.AUTO: 'auto'>",
                         },
                         "requested_mode": {
                             "__type": "<enum 'BluetoothScanningMode'>",
-                            "repr": "<BluetoothScanningMode.ACTIVE: 'active'>",
+                            "repr": "<BluetoothScanningMode.AUTO: 'auto'>",
                         },
                     },
                     {
@@ -239,11 +239,11 @@ async def test_diagnostics(
                         "type": "FakeHaScanner",
                         "current_mode": {
                             "__type": "<enum 'BluetoothScanningMode'>",
-                            "repr": "<BluetoothScanningMode.ACTIVE: 'active'>",
+                            "repr": "<BluetoothScanningMode.AUTO: 'auto'>",
                         },
                         "requested_mode": {
                             "__type": "<enum 'BluetoothScanningMode'>",
-                            "repr": "<BluetoothScanningMode.ACTIVE: 'active'>",
+                            "repr": "<BluetoothScanningMode.AUTO: 'auto'>",
                         },
                     },
                 ],
@@ -439,11 +439,11 @@ async def test_diagnostics_macos(
                         "type": "FakeHaScanner",
                         "current_mode": {
                             "__type": "<enum 'BluetoothScanningMode'>",
-                            "repr": "<BluetoothScanningMode.ACTIVE: 'active'>",
+                            "repr": "<BluetoothScanningMode.AUTO: 'auto'>",
                         },
                         "requested_mode": {
                             "__type": "<enum 'BluetoothScanningMode'>",
-                            "repr": "<BluetoothScanningMode.ACTIVE: 'active'>",
+                            "repr": "<BluetoothScanningMode.AUTO: 'auto'>",
                         },
                     }
                 ],
@@ -633,11 +633,11 @@ async def test_diagnostics_remote_adapter(
                         "type": "HaScanner",
                         "current_mode": {
                             "__type": "<enum 'BluetoothScanningMode'>",
-                            "repr": "<BluetoothScanningMode.ACTIVE: 'active'>",
+                            "repr": "<BluetoothScanningMode.AUTO: 'auto'>",
                         },
                         "requested_mode": {
                             "__type": "<enum 'BluetoothScanningMode'>",
-                            "repr": "<BluetoothScanningMode.ACTIVE: 'active'>",
+                            "repr": "<BluetoothScanningMode.AUTO: 'auto'>",
                         },
                     },
                     {

--- a/tests/components/bluetooth/test_diagnostics.py
+++ b/tests/components/bluetooth/test_diagnostics.py
@@ -198,11 +198,11 @@ async def test_diagnostics(
                         "type": "HaScanner",
                         "current_mode": {
                             "__type": "<enum 'BluetoothScanningMode'>",
-                            "repr": "<BluetoothScanningMode.AUTO: 'auto'>",
+                            "repr": "<BluetoothScanningMode.ACTIVE: 'active'>",
                         },
                         "requested_mode": {
                             "__type": "<enum 'BluetoothScanningMode'>",
-                            "repr": "<BluetoothScanningMode.AUTO: 'auto'>",
+                            "repr": "<BluetoothScanningMode.ACTIVE: 'active'>",
                         },
                     },
                     {
@@ -439,11 +439,11 @@ async def test_diagnostics_macos(
                         "type": "FakeHaScanner",
                         "current_mode": {
                             "__type": "<enum 'BluetoothScanningMode'>",
-                            "repr": "<BluetoothScanningMode.AUTO: 'auto'>",
+                            "repr": "<BluetoothScanningMode.ACTIVE: 'active'>",
                         },
                         "requested_mode": {
                             "__type": "<enum 'BluetoothScanningMode'>",
-                            "repr": "<BluetoothScanningMode.AUTO: 'auto'>",
+                            "repr": "<BluetoothScanningMode.ACTIVE: 'active'>",
                         },
                     }
                 ],
@@ -633,11 +633,11 @@ async def test_diagnostics_remote_adapter(
                         "type": "HaScanner",
                         "current_mode": {
                             "__type": "<enum 'BluetoothScanningMode'>",
-                            "repr": "<BluetoothScanningMode.AUTO: 'auto'>",
+                            "repr": "<BluetoothScanningMode.ACTIVE: 'active'>",
                         },
                         "requested_mode": {
                             "__type": "<enum 'BluetoothScanningMode'>",
-                            "repr": "<BluetoothScanningMode.AUTO: 'auto'>",
+                            "repr": "<BluetoothScanningMode.ACTIVE: 'active'>",
                         },
                     },
                     {

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -26,7 +26,7 @@ from homeassistant.components.bluetooth import (
 )
 from homeassistant.components.bluetooth.const import (
     BLUETOOTH_DISCOVERY_COOLDOWN_SECONDS,
-    CONF_PASSIVE,
+    CONF_MODE,
     CONF_SOURCE,
     CONF_SOURCE_CONFIG_ENTRY_ID,
     CONF_SOURCE_DOMAIN,
@@ -103,7 +103,7 @@ async def test_setup_and_stop_passive(
     entry = MockConfigEntry(
         domain=bluetooth.DOMAIN,
         data={},
-        options={CONF_PASSIVE: True},
+        options={CONF_MODE: "passive"},
         unique_id="00:00:00:00:00:01",
     )
     entry.add_to_hass(hass)

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -163,11 +163,11 @@ async def test_setup_and_stop_old_bluez(
     mock_bleak_scanner_start: MagicMock,
     one_adapter_old_bluez: None,
 ) -> None:
-    """Test we and setup and stop the scanner the passive scanner with older bluez."""
+    """Default AUTO falls back to active on adapters without passive scan support."""
     entry = MockConfigEntry(
         domain=bluetooth.DOMAIN,
         data={},
-        options={CONF_MODE: "active"},
+        options={},
         unique_id="00:00:00:00:00:01",
     )
     entry.add_to_hass(hass)

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -107,7 +107,7 @@ async def test_setup_and_stop_passive(
     mock_bleak_scanner_start: MagicMock,
     options: dict[str, Any],
 ) -> None:
-    """Test we and setup and stop the scanner the passive scanner.
+    """Test we set up and stop the scanner in passive mode.
 
     Covers both the new CONF_MODE key and the legacy CONF_PASSIVE boolean
     so the fallback path in async_setup_entry stays exercised.

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -27,6 +27,7 @@ from homeassistant.components.bluetooth import (
 from homeassistant.components.bluetooth.const import (
     BLUETOOTH_DISCOVERY_COOLDOWN_SECONDS,
     CONF_MODE,
+    CONF_PASSIVE,
     CONF_SOURCE,
     CONF_SOURCE_CONFIG_ENTRY_ID,
     CONF_SOURCE_DOMAIN,
@@ -95,15 +96,26 @@ async def test_setup_and_stop(
     assert len(mock_bleak_scanner_start.mock_calls) == 1
 
 
+@pytest.mark.parametrize(
+    "options",
+    [{CONF_MODE: "passive"}, {CONF_PASSIVE: True}],
+    ids=["mode_passive", "legacy_passive_true"],
+)
 @pytest.mark.usefixtures("one_adapter")
 async def test_setup_and_stop_passive(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    options: dict[str, Any],
 ) -> None:
-    """Test we and setup and stop the scanner the passive scanner."""
+    """Test we and setup and stop the scanner the passive scanner.
+
+    Covers both the new CONF_MODE key and the legacy CONF_PASSIVE boolean
+    so the fallback path in async_setup_entry stays exercised.
+    """
     entry = MockConfigEntry(
         domain=bluetooth.DOMAIN,
         data={},
-        options={CONF_MODE: "passive"},
+        options=options,
         unique_id="00:00:00:00:00:01",
     )
     entry.add_to_hass(hass)
@@ -155,7 +167,7 @@ async def test_setup_and_stop_old_bluez(
     entry = MockConfigEntry(
         domain=bluetooth.DOMAIN,
         data={},
-        options={},
+        options={CONF_MODE: "active"},
         unique_id="00:00:00:00:00:01",
     )
     entry.add_to_hass(hass)

--- a/tests/components/bluetooth/test_websocket_api.py
+++ b/tests/components/bluetooth/test_websocket_api.py
@@ -467,8 +467,8 @@ async def test_subscribe_scanner_state(
     assert response["event"] == {
         "source": "00:00:00:00:00:01",
         "adapter": "hci0",
-        "current_mode": "active",
-        "requested_mode": "active",
+        "current_mode": "auto",
+        "requested_mode": "auto",
     }
 
     # Register a new scanner

--- a/tests/components/bluetooth/test_websocket_api.py
+++ b/tests/components/bluetooth/test_websocket_api.py
@@ -461,14 +461,14 @@ async def test_subscribe_scanner_state(
         response = await client.receive_json()
     assert response["success"]
 
-    # Should receive initial state for existing scanner
+    # hci0 has passive_scan=False so AUTO falls back to ACTIVE.
     async with asyncio.timeout(1):
         response = await client.receive_json()
     assert response["event"] == {
         "source": "00:00:00:00:00:01",
         "adapter": "hci0",
-        "current_mode": "auto",
-        "requested_mode": "auto",
+        "current_mode": "active",
+        "requested_mode": "active",
     }
 
     # Register a new scanner


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The default Bluetooth scanning mode is now Auto. In most setups this reduces scan related battery drain on your Bluetooth devices by about 95 to 96 percent while still discovering devices and updates quickly.

If you have trouble finding devices after upgrading, open the Bluetooth integration, pick your adapter, click Configure, and switch the scanning mode to Active to restore the previous behavior.

If you previously selected Passive and it works for you, no action is needed; if you previously selected Passive and have trouble finding devices, switching to Auto is recommended.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Replaces the Passive on, off toggle in the adapter options with a select that offers Auto, Active, Passive. Auto starts the scanner in passive mode and lets habluetooth promote it to active on demand for per device active windows and a periodic rediscovery sweep, so devices that need active scans still work. CONF_PASSIVE is still written alongside the new CONF_MODE key so a downgrade keeps reading a sensible value.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45540
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

