### PR TITLE
Add puzzles to Lichess integration

### DIFF
--- a/homeassistant/components/lichess/icons.json
+++ b/homeassistant/components/lichess/icons.json
@@ -19,11 +19,8 @@
       "classical_rating": {
         "default": "mdi:chart-line"
       },
-      "correspondence_rating": {
-        "default": "mdi:chart-line"
-      },
       "puzzle_games": {
-        "default": "mdi:chess-pawn"
+        "default": "mdi:puzzle"
       },
       "puzzle_rating": {
         "default": "mdi:chart-line"

--- a/homeassistant/components/lichess/icons.json
+++ b/homeassistant/components/lichess/icons.json
@@ -19,6 +19,15 @@
       "classical_rating": {
         "default": "mdi:chart-line"
       },
+      "correspondence_rating": {
+        "default": "mdi:chart-line"
+      },
+      "puzzle_games": {
+        "default": "mdi:chess-pawn"
+      },
+      "puzzle_rating": {
+        "default": "mdi:chart-line"
+      },
       "rapid_games": {
         "default": "mdi:chess-pawn"
       },

--- a/homeassistant/components/lichess/sensor.py
+++ b/homeassistant/components/lichess/sensor.py
@@ -79,6 +79,28 @@ SENSORS: tuple[LichessEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda state: state.classical_games,
     ),
+    LichessEntityDescription(
+        key="correspondence_rating",
+        translation_key="correspondence_rating",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+        value_fn=lambda state: state.correspondence_rating,
+    ),
+    LichessEntityDescription(
+        key="puzzle_rating",
+        translation_key="puzzle_rating",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+        value_fn=lambda state: state.puzzle_rating,
+    ),
+    LichessEntityDescription(
+        key="puzzle_games",
+        translation_key="puzzle_games",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda state: state.puzzle_games,
+    ),
 )
 
 

--- a/homeassistant/components/lichess/sensor.py
+++ b/homeassistant/components/lichess/sensor.py
@@ -80,13 +80,6 @@ SENSORS: tuple[LichessEntityDescription, ...] = (
         value_fn=lambda state: state.classical_games,
     ),
     LichessEntityDescription(
-        key="correspondence_rating",
-        translation_key="correspondence_rating",
-        state_class=SensorStateClass.MEASUREMENT,
-        entity_registry_enabled_default=False,
-        value_fn=lambda state: state.correspondence_rating,
-    ),
-    LichessEntityDescription(
         key="puzzle_rating",
         translation_key="puzzle_rating",
         state_class=SensorStateClass.MEASUREMENT,

--- a/homeassistant/components/lichess/strings.json
+++ b/homeassistant/components/lichess/strings.json
@@ -44,7 +44,7 @@
       },
       "puzzle_games": {
         "name": "Puzzle games",
-        "unit_of_measurement": "games"
+        "unit_of_measurement": "[%key:component::lichess::entity::sensor::bullet_games::unit_of_measurement%]"
       },
       "puzzle_rating": {
         "name": "Puzzle rating"

--- a/homeassistant/components/lichess/strings.json
+++ b/homeassistant/components/lichess/strings.json
@@ -42,6 +42,16 @@
       "classical_rating": {
         "name": "Classical rating"
       },
+      "correspondence_rating": {
+        "name": "Correspondence rating"
+      },
+      "puzzle_games": {
+        "name": "Puzzle games",
+        "unit_of_measurement": "[%key:component::lichess::entity::sensor::bullet_games::unit_of_measurement%]"
+      },
+      "puzzle_rating": {
+        "name": "Puzzle rating"
+      },
       "rapid_games": {
         "name": "Rapid games",
         "unit_of_measurement": "[%key:component::lichess::entity::sensor::bullet_games::unit_of_measurement%]"

--- a/homeassistant/components/lichess/strings.json
+++ b/homeassistant/components/lichess/strings.json
@@ -42,12 +42,9 @@
       "classical_rating": {
         "name": "Classical rating"
       },
-      "correspondence_rating": {
-        "name": "Correspondence rating"
-      },
       "puzzle_games": {
         "name": "Puzzle games",
-        "unit_of_measurement": "[%key:component::lichess::entity::sensor::bullet_games::unit_of_measurement%]"
+        "unit_of_measurement": "games"
       },
       "puzzle_rating": {
         "name": "Puzzle rating"

--- a/tests/components/lichess/conftest.py
+++ b/tests/components/lichess/conftest.py
@@ -60,9 +60,12 @@ def mock_lichess_client() -> Generator[AsyncMock]:
             rapid_rating=1050,
             bullet_rating=1373,
             classical_rating=888,
+            correspondence_rating=1600,
+            puzzle_rating=2500,
             blitz_games=31,
             rapid_games=324,
             bullet_games=7,
             classical_games=1,
+            puzzle_games=50,
         )
         yield client

--- a/tests/components/lichess/conftest.py
+++ b/tests/components/lichess/conftest.py
@@ -27,7 +27,7 @@ def mock_config_entry() -> MockConfigEntry:
     return MockConfigEntry(
         domain=DOMAIN,
         title="DrNykterstein",
-        unique_id="drnykterstien",
+        unique_id="drnykterstein",
         data={CONF_API_TOKEN: "my_secret_token"},
     )
 
@@ -47,20 +47,19 @@ def mock_lichess_client() -> Generator[AsyncMock]:
     ):
         client = mock_client.return_value
         client.get_all.return_value = LichessUser(
-            id="drnykterstien",
+            id="drnykterstein",
             username="DrNykterstein",
             url="https://lichess.org/@/DrNykterstein",
             created_at=1420502920988,
             seen_at=1747342929853,
             play_time=999999,
         )
-        client.get_user_id.return_value = "drnykterstien"
+        client.get_user_id.return_value = "drnykterstein"
         client.get_statistics.return_value = LichessStatistics(
             blitz_rating=944,
             rapid_rating=1050,
             bullet_rating=1373,
             classical_rating=888,
-            correspondence_rating=1600,
             puzzle_rating=2500,
             blitz_games=31,
             rapid_games=324,

--- a/tests/components/lichess/snapshots/test_init.ambr
+++ b/tests/components/lichess/snapshots/test_init.ambr
@@ -14,7 +14,7 @@
     'identifiers': set({
       tuple(
         'lichess',
-        'drnykterstien',
+        'drnykterstein',
       ),
     }),
     'labels': set({

--- a/tests/components/lichess/snapshots/test_sensor.ambr
+++ b/tests/components/lichess/snapshots/test_sensor.ambr
@@ -34,7 +34,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'blitz_games',
-    'unique_id': 'drnykterstien.blitz_games',
+    'unique_id': 'drnykterstein.blitz_games',
     'unit_of_measurement': 'games',
   })
 # ---
@@ -88,7 +88,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'blitz_rating',
-    'unique_id': 'drnykterstien.blitz_rating',
+    'unique_id': 'drnykterstein.blitz_rating',
     'unit_of_measurement': None,
   })
 # ---
@@ -141,7 +141,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'bullet_games',
-    'unique_id': 'drnykterstien.bullet_games',
+    'unique_id': 'drnykterstein.bullet_games',
     'unit_of_measurement': 'games',
   })
 # ---
@@ -195,7 +195,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'bullet_rating',
-    'unique_id': 'drnykterstien.bullet_rating',
+    'unique_id': 'drnykterstein.bullet_rating',
     'unit_of_measurement': None,
   })
 # ---
@@ -248,7 +248,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'classical_games',
-    'unique_id': 'drnykterstien.classical_games',
+    'unique_id': 'drnykterstein.classical_games',
     'unit_of_measurement': 'games',
   })
 # ---
@@ -302,7 +302,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'classical_rating',
-    'unique_id': 'drnykterstien.classical_rating',
+    'unique_id': 'drnykterstein.classical_rating',
     'unit_of_measurement': None,
   })
 # ---
@@ -318,59 +318,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '888',
-  })
-# ---
-# name: test_all_entities[sensor.drnykterstein_correspondence_rating-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.drnykterstein_correspondence_rating',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Correspondence rating',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Correspondence rating',
-    'platform': 'lichess',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'correspondence_rating',
-    'unique_id': 'drnykterstien.correspondence_rating',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[sensor.drnykterstein_correspondence_rating-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'DrNykterstein Correspondence rating',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.drnykterstein_correspondence_rating',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '1600',
   })
 # ---
 # name: test_all_entities[sensor.drnykterstein_puzzle_games-entry]
@@ -408,7 +355,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'puzzle_games',
-    'unique_id': 'drnykterstien.puzzle_games',
+    'unique_id': 'drnykterstein.puzzle_games',
     'unit_of_measurement': 'games',
   })
 # ---
@@ -462,7 +409,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'puzzle_rating',
-    'unique_id': 'drnykterstien.puzzle_rating',
+    'unique_id': 'drnykterstein.puzzle_rating',
     'unit_of_measurement': None,
   })
 # ---
@@ -515,7 +462,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'rapid_games',
-    'unique_id': 'drnykterstien.rapid_games',
+    'unique_id': 'drnykterstein.rapid_games',
     'unit_of_measurement': 'games',
   })
 # ---
@@ -569,7 +516,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'rapid_rating',
-    'unique_id': 'drnykterstien.rapid_rating',
+    'unique_id': 'drnykterstein.rapid_rating',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/lichess/snapshots/test_sensor.ambr
+++ b/tests/components/lichess/snapshots/test_sensor.ambr
@@ -320,6 +320,166 @@
     'state': '888',
   })
 # ---
+# name: test_all_entities[sensor.drnykterstein_correspondence_rating-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.drnykterstein_correspondence_rating',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Correspondence rating',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Correspondence rating',
+    'platform': 'lichess',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'correspondence_rating',
+    'unique_id': 'drnykterstien.correspondence_rating',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.drnykterstein_correspondence_rating-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'DrNykterstein Correspondence rating',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.drnykterstein_correspondence_rating',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1600',
+  })
+# ---
+# name: test_all_entities[sensor.drnykterstein_puzzle_games-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.drnykterstein_puzzle_games',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Puzzle games',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Puzzle games',
+    'platform': 'lichess',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'puzzle_games',
+    'unique_id': 'drnykterstien.puzzle_games',
+    'unit_of_measurement': 'games',
+  })
+# ---
+# name: test_all_entities[sensor.drnykterstein_puzzle_games-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'DrNykterstein Puzzle games',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': 'games',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.drnykterstein_puzzle_games',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '50',
+  })
+# ---
+# name: test_all_entities[sensor.drnykterstein_puzzle_rating-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.drnykterstein_puzzle_rating',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Puzzle rating',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Puzzle rating',
+    'platform': 'lichess',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'puzzle_rating',
+    'unique_id': 'drnykterstien.puzzle_rating',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.drnykterstein_puzzle_rating-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'DrNykterstein Puzzle rating',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.drnykterstein_puzzle_rating',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2500',
+  })
+# ---
 # name: test_all_entities[sensor.drnykterstein_rapid_games-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/lichess/test_config_flow.py
+++ b/tests/components/lichess/test_config_flow.py
@@ -30,7 +30,7 @@ async def test_full_flow(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> No
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "DrNykterstein"
     assert result["data"] == {CONF_API_TOKEN: "my_secret_token"}
-    assert result["result"].unique_id == "drnykterstien"
+    assert result["result"].unique_id == "drnykterstein"
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/lichess/test_init.py
+++ b/tests/components/lichess/test_init.py
@@ -25,7 +25,7 @@ async def test_device(
     """Test the Lichess device."""
     await setup_integration(hass, mock_config_entry)
 
-    device = device_registry.async_get_device({(DOMAIN, "drnykterstien")})
+    device = device_registry.async_get_device({(DOMAIN, "drnykterstein")})
     assert device
     assert device == snapshot
 


### PR DESCRIPTION
## Proposed change

Surface the puzzle stats that `aiolichess.LichessStatistics` already exposes (since 1.2.0) but the integration never used. Two new sensors are added, both disabled by default so existing installations are not flooded with new entities on update:

- `sensor.<player>_puzzle_rating`
- `sensor.<player>_puzzle_games` (diagnostic)

No coordinator or dependency changes — this PR only reads fields the library already returns.

The correspondence and variant perfs (Ultra Bullet, Crazyhouse, Chess960, King of the Hill, Three-check, Antichess, Atomic, Horde, Racing Kings) ship in the companion PR #171988, which bumps `aiolichess` to 1.3.0.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (\`ruff format homeassistant tests\`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: \`python3 -m script.hassfest\`.
- [ ] New or updated dependencies have been added to \`requirements_all.txt\`.  
      Updated by running \`python3 -m script.gen_requirements_all\`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr