### PR TITLE
Add shared rainbird device lock and increase calendar timeout

### DIFF
--- a/homeassistant/components/rainbird/__init__.py
+++ b/homeassistant/components/rainbird/__init__.py
@@ -113,11 +113,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: RainbirdConfigEntry) -> 
     except RainbirdApiException as err:
         raise ConfigEntryNotReady from err
 
+    # Rain Bird devices can only handle a single request at a time. This shared
+    # lock ensures that the background coordinators do not poll the device
+    # concurrently.
+    device_lock = asyncio.Lock()
     data = RainbirdData(
         controller,
         model_info,
-        coordinator=RainbirdUpdateCoordinator(hass, entry, controller, model_info),
-        schedule_coordinator=RainbirdScheduleUpdateCoordinator(hass, entry, controller),
+        coordinator=RainbirdUpdateCoordinator(
+            hass, entry, controller, model_info, device_lock
+        ),
+        schedule_coordinator=RainbirdScheduleUpdateCoordinator(
+            hass, entry, controller, device_lock
+        ),
     )
     await data.coordinator.async_config_entry_first_refresh()
 

--- a/homeassistant/components/rainbird/coordinator.py
+++ b/homeassistant/components/rainbird/coordinator.py
@@ -25,6 +25,7 @@ UPDATE_INTERVAL = datetime.timedelta(minutes=1)
 # The calendar data requires RPCs for each program/zone, and the data rarely
 # changes, so we refresh it less often.
 CALENDAR_UPDATE_INTERVAL = datetime.timedelta(minutes=15)
+CALENDAR_TIMEOUT_SECONDS = 30
 
 # The valves state are not immediately reflected after issuing a command. We add
 # small delay to give additional time to reflect the new state.
@@ -64,6 +65,7 @@ class RainbirdUpdateCoordinator(DataUpdateCoordinator[RainbirdDeviceState]):
         config_entry: RainbirdConfigEntry,
         controller: AsyncRainbirdController,
         model_info: ModelAndVersion,
+        device_lock: asyncio.Lock,
     ) -> None:
         """Initialize RainbirdUpdateCoordinator."""
         super().__init__(
@@ -80,6 +82,7 @@ class RainbirdUpdateCoordinator(DataUpdateCoordinator[RainbirdDeviceState]):
         self._unique_id = config_entry.unique_id
         self._zones: set[int] | None = None
         self._model_info = model_info
+        self._device_lock = device_lock
 
     @property
     def controller(self) -> AsyncRainbirdController:
@@ -112,8 +115,9 @@ class RainbirdUpdateCoordinator(DataUpdateCoordinator[RainbirdDeviceState]):
     async def _async_update_data(self) -> RainbirdDeviceState:
         """Fetch data from Rain Bird device."""
         try:
-            async with asyncio.timeout(TIMEOUT_SECONDS):
-                return await self._fetch_data()
+            async with self._device_lock:
+                async with asyncio.timeout(TIMEOUT_SECONDS):
+                    return await self._fetch_data()
         except RainbirdDeviceBusyException as err:
             raise UpdateFailed("Rain Bird device is busy") from err
         except RainbirdApiException as err:
@@ -147,6 +151,7 @@ class RainbirdScheduleUpdateCoordinator(DataUpdateCoordinator[Schedule]):
         hass: HomeAssistant,
         config_entry: RainbirdConfigEntry,
         controller: AsyncRainbirdController,
+        device_lock: asyncio.Lock,
     ) -> None:
         """Initialize ZoneStateUpdateCoordinator."""
         super().__init__(
@@ -158,11 +163,13 @@ class RainbirdScheduleUpdateCoordinator(DataUpdateCoordinator[Schedule]):
             update_interval=CALENDAR_UPDATE_INTERVAL,
         )
         self._controller = controller
+        self._device_lock = device_lock
 
     async def _async_update_data(self) -> Schedule:
         """Fetch data from Rain Bird device."""
         try:
-            async with asyncio.timeout(TIMEOUT_SECONDS):
-                return await self._controller.get_schedule()
+            async with self._device_lock:
+                async with asyncio.timeout(CALENDAR_TIMEOUT_SECONDS):
+                    return await self._controller.get_schedule()
         except RainbirdApiException as err:
             raise UpdateFailed(f"Error communicating with Device: {err}") from err


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rain Bird LNK Wi-Fi modules are extremely resource-constrained and can only reliably handle a single HTTP request at a time. The background coordinators (`RainbirdUpdateCoordinator` and `RainbirdScheduleUpdateCoordinator`) run on independent update intervals and can execute overlapping requests concurrently, causing the device to return busy warnings (NAKs) or go unavailable.

This PR:
1. Instantiates a shared `asyncio.Lock()` (`device_lock`) inside the config entry's setup to prevent concurrent coordinator requests.
2. Synchronizes updates by wrapping both coordinator background update blocks in `async with self._device_lock`.
3. Increases the schedule fetch timeout from 20 to 30 seconds (`CALENDAR_TIMEOUT_SECONDS = 30`) to accommodate slower responses from certain controller models when retrieving calendar/schedule timeline data.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #169672
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
