### PR TITLE
Bump python-izone to 1.2.10

### DIFF
--- a/homeassistant/components/izone/manifest.json
+++ b/homeassistant/components/izone/manifest.json
@@ -10,5 +10,5 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["pizone"],
-  "requirements": ["python-izone==1.2.9"]
+  "requirements": ["python-izone==1.2.10"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2644,7 +2644,7 @@ python-homewizard-energy==10.1.0
 python-hpilo==4.4.3
 
 # homeassistant.components.izone
-python-izone==1.2.9
+python-izone==1.2.10
 
 # homeassistant.components.joaoapps_join
 python-join-api==0.0.9

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -170,7 +170,6 @@ FORBIDDEN_PACKAGE_EXCEPTIONS: dict[str, dict[str, set[str]]] = {
     "imeon_inverter": {"imeon-inverter-api": {"async-timeout"}},
     "ipp": {"pyipp": {"backoff"}},
     "iqvia": {"pyiqvia": {"backoff"}},
-    "izone": {"python-izone": {"async-timeout"}},
     "kef": {"aiokef": {"async-timeout"}},
     "kodi": {"jsonrpc-websocket": {"async-timeout"}},
     "lametric": {"demetriek": {"backoff"}},


### PR DESCRIPTION
## Proposed change

Bump the `python-izone` dependency for the iZone integration from 1.2.9 to 1.2.10.

Version 1.2.10 adds `fetch_controller(uid, timeout)` and `fetch_controllers(timeout)` async methods to `DiscoveryService`, moving triggered discovery deduplication and timeout logic into the library. It also removes `async-timeout` as a transitive dependency, so the `FORBIDDEN_PACKAGE_EXCEPTIONS` entry for izone is removed at the same time.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

### Dependency update: `python-izone` 1.2.9 → 1.2.10

- [PyPI](https://pypi.org/project/python-izone/1.2.10/)
- [Release notes / compare](https://github.com/Swamp-Ig/pizone/releases/tag/v1.2.10)

#### What's changed in 1.2.10

**New features**
- Added `fetch_controller(uid, timeout)` and `fetch_controllers(timeout)` async methods to `DiscoveryService`, moving triggered discovery deduplication and timeout logic into the library.

**Changes**
- Updated to Python 3.14; `async-timeout` is no longer a dependency — the `FORBIDDEN_PACKAGE_EXCEPTIONS` entry for izone is removed in this PR.
- Improved `Controller` internals: split out `DatagramProtocol` and `Listener` interfaces.
- Updated typing annotations throughout.
- Improved test coverage.
- Updated GitHub Actions workflows and minor code cleanups.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io

