### PR TITLE
Cap concurrent CalDAV requests to prevent thread-pool starvation

### DIFF
--- a/homeassistant/components/caldav/__init__.py
+++ b/homeassistant/components/caldav/__init__.py
@@ -1,5 +1,7 @@
 """The caldav component."""
 
+import asyncio
+from dataclasses import dataclass
 import logging
 
 import caldav
@@ -18,8 +20,18 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 
 from .const import TIMEOUT
+from .coordinator import MAX_CONCURRENT_REQUESTS, close_idle_connections
 
-type CalDavConfigEntry = ConfigEntry[caldav.DAVClient]
+
+@dataclass
+class CalDavRuntimeData:
+    """Runtime data shared between caldav platforms."""
+
+    client: caldav.DAVClient
+    request_semaphore: asyncio.Semaphore
+
+
+type CalDavConfigEntry = ConfigEntry[CalDavRuntimeData]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -52,7 +64,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: CalDavConfigEntry) -> bo
     except DAVError as err:
         raise ConfigEntryNotReady("CalDAV client error") from err
 
-    entry.runtime_data = client
+    entry.runtime_data = CalDavRuntimeData(
+        client=client,
+        request_semaphore=asyncio.Semaphore(MAX_CONCURRENT_REQUESTS),
+    )
+
+    async def _close_client_session() -> None:
+        """Tear down the underlying HTTP session at entry unload.
+
+        ``session.close()`` is synchronous and can block on socket teardown,
+        so dispatch it to the executor rather than running on the event loop.
+        """
+        await hass.async_add_executor_job(close_idle_connections, client)
+
+    entry.async_on_unload(_close_client_session)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/caldav/__init__.py
+++ b/homeassistant/components/caldav/__init__.py
@@ -20,7 +20,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 
 from .const import TIMEOUT
-from .coordinator import MAX_CONCURRENT_REQUESTS, close_idle_connections
+from .coordinator import MAX_CONCURRENT_REQUESTS, close_client_session
 
 
 @dataclass
@@ -69,15 +69,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: CalDavConfigEntry) -> bo
         request_semaphore=asyncio.Semaphore(MAX_CONCURRENT_REQUESTS),
     )
 
-    async def _close_client_session() -> None:
+    async def _close_session() -> None:
         """Tear down the underlying HTTP session at entry unload.
 
         ``session.close()`` is synchronous and can block on socket teardown,
         so dispatch it to the executor rather than running on the event loop.
         """
-        await hass.async_add_executor_job(close_idle_connections, client)
+        await hass.async_add_executor_job(close_client_session, client)
 
-    entry.async_on_unload(_close_client_session)
+    entry.async_on_unload(_close_session)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -159,7 +159,9 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the CalDav calendar platform for a config entry."""
-    calendars = await async_get_calendars(hass, entry.runtime_data, SUPPORTED_COMPONENT)
+    calendars = await async_get_calendars(
+        hass, entry.runtime_data.client, SUPPORTED_COMPONENT
+    )
     async_add_entities(
         (
             WebDavCalendarEntity(

--- a/homeassistant/components/caldav/coordinator.py
+++ b/homeassistant/components/caldav/coordinator.py
@@ -1,5 +1,6 @@
 """Data update coordinator for caldav."""
 
+import asyncio
 from datetime import date, datetime, time, timedelta
 from functools import partial
 import logging
@@ -22,6 +23,30 @@ _LOGGER = logging.getLogger(__name__)
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=15)
 OFFSET = "!!"
+
+# Cap concurrent CalDAV requests across all calendar/todo entities.
+# When a user has many calendars (e.g. an iCloud account with 30+ shared
+# calendars), every entity firing its first refresh in parallel at boot
+# saturates the HA thread pool and leaves sockets in CLOSE_WAIT against
+# Cloudflare-fronted CalDAV endpoints. Capping at 4 keeps overall throughput
+# high (each request takes <1 s in steady state) while preventing pool
+# exhaustion regardless of how many calendars are configured.
+MAX_CONCURRENT_REQUESTS = 4
+REQUEST_SEMAPHORE = asyncio.Semaphore(MAX_CONCURRENT_REQUESTS)
+
+
+def close_idle_connections(client: caldav.DAVClient | None) -> None:
+    """Drop urllib3 idle connections after each request.
+
+    Prevents CLOSE_WAIT sockets from accumulating between polls when the
+    server (e.g. iCloud via Cloudflare) closes the connection silently and
+    urllib3 doesn't notice until the next use. requests.Session stays usable
+    — new pools are created lazily on next call.
+    """
+    if client is None:
+        return
+    if session := getattr(client, "session", None):
+        session.close()
 
 
 class CalDavUpdateCoordinator(DataUpdateCoordinator[CalendarEvent | None]):
@@ -55,15 +80,19 @@ class CalDavUpdateCoordinator(DataUpdateCoordinator[CalendarEvent | None]):
     ) -> list[CalendarEvent]:
         """Get all events in a specific time frame."""
         # Get event list from the current calendar
-        vevent_list = await hass.async_add_executor_job(
-            partial(
-                self.calendar.search,
-                start=start_date,
-                end=end_date,
-                event=True,
-                expand=True,
-            )
-        )
+        try:
+            async with REQUEST_SEMAPHORE:
+                vevent_list = await hass.async_add_executor_job(
+                    partial(
+                        self.calendar.search,
+                        start=start_date,
+                        end=end_date,
+                        event=True,
+                        expand=True,
+                    )
+                )
+        finally:
+            close_idle_connections(self.calendar.client)
         event_list = []
         for event in vevent_list:
             if not hasattr(event.instance, "vevent"):
@@ -97,15 +126,19 @@ class CalDavUpdateCoordinator(DataUpdateCoordinator[CalendarEvent | None]):
 
         # We have to retrieve the results for the whole day as the server
         # won't return events that have already started
-        results = await self.hass.async_add_executor_job(
-            partial(
-                self.calendar.search,
-                start=start_of_today,
-                end=start_of_tomorrow,
-                event=True,
-                expand=True,
-            ),
-        )
+        try:
+            async with REQUEST_SEMAPHORE:
+                results = await self.hass.async_add_executor_job(
+                    partial(
+                        self.calendar.search,
+                        start=start_of_today,
+                        end=start_of_tomorrow,
+                        event=True,
+                        expand=True,
+                    ),
+                )
+        finally:
+            close_idle_connections(self.calendar.client)
 
         # Create new events for each recurrence of an event that happens today.
         # For recurring events, some servers return the original

--- a/homeassistant/components/caldav/coordinator.py
+++ b/homeassistant/components/caldav/coordinator.py
@@ -1,6 +1,7 @@
 """Data update coordinator for caldav."""
 
 import asyncio
+import contextlib
 from datetime import date, datetime, time, timedelta
 from functools import partial
 import logging
@@ -24,24 +25,27 @@ _LOGGER = logging.getLogger(__name__)
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=15)
 OFFSET = "!!"
 
-# Cap concurrent CalDAV requests across all calendar/todo entities.
-# When a user has many calendars (e.g. an iCloud account with 30+ shared
-# calendars), every entity firing its first refresh in parallel at boot
-# saturates the HA thread pool and leaves sockets in CLOSE_WAIT against
-# Cloudflare-fronted CalDAV endpoints. Capping at 4 keeps overall throughput
-# high (each request takes <1 s in steady state) while preventing pool
-# exhaustion regardless of how many calendars are configured.
+# Cap concurrent CalDAV requests per config entry, shared between this
+# entry's calendar and todo entities. When a user has many calendars
+# (e.g. an iCloud account with 30+ shared calendars), every entity firing
+# its first refresh in parallel at boot saturates the HA thread pool.
+# Capping at 4 keeps overall throughput high (each request takes <1 s in
+# steady state) while preventing pool exhaustion regardless of how many
+# calendars are configured. The semaphore is created per entry in
+# ``__init__.async_setup_entry`` so a slow account cannot delay updates
+# for an unrelated account.
 MAX_CONCURRENT_REQUESTS = 4
-REQUEST_SEMAPHORE = asyncio.Semaphore(MAX_CONCURRENT_REQUESTS)
 
 
 def close_idle_connections(client: caldav.DAVClient | None) -> None:
-    """Drop urllib3 idle connections after each request.
+    """Close the DAVClient's HTTP session.
 
-    Prevents CLOSE_WAIT sockets from accumulating between polls when the
-    server (e.g. iCloud via Cloudflare) closes the connection silently and
-    urllib3 doesn't notice until the next use. requests.Session stays usable
-    — new pools are created lazily on next call.
+    caldav 2.1.0+ uses ``niquests`` with ``multiplexed=True`` (HTTP/2), so a
+    single ``Session`` object handles all requests for the client across the
+    entry's lifetime. This helper tears down the pooled sockets cleanly on
+    entry unload rather than waiting for the remote peer (or the OS) to
+    time them out — at which point the integration is already gone and
+    cannot recover them.
     """
     if client is None:
         return
@@ -74,25 +78,32 @@ class CalDavUpdateCoordinator(DataUpdateCoordinator[CalendarEvent | None]):
         self.include_all_day = include_all_day
         self.search = search
         self.offset: timedelta | None = None
+        # Per-entry semaphore (None for legacy YAML coordinators with no entry).
+        self._request_semaphore: asyncio.Semaphore | None = (
+            entry.runtime_data.request_semaphore if entry is not None else None
+        )
+
+    def _semaphore_ctx(self) -> contextlib.AbstractAsyncContextManager[None]:
+        """Return the per-entry semaphore, or a no-op for legacy YAML coordinators."""
+        if self._request_semaphore is None:
+            return contextlib.nullcontext()
+        return self._request_semaphore
 
     async def async_get_events(
         self, hass: HomeAssistant, start_date: datetime, end_date: datetime
     ) -> list[CalendarEvent]:
         """Get all events in a specific time frame."""
         # Get event list from the current calendar
-        try:
-            async with REQUEST_SEMAPHORE:
-                vevent_list = await hass.async_add_executor_job(
-                    partial(
-                        self.calendar.search,
-                        start=start_date,
-                        end=end_date,
-                        event=True,
-                        expand=True,
-                    )
+        async with self._semaphore_ctx():
+            vevent_list = await hass.async_add_executor_job(
+                partial(
+                    self.calendar.search,
+                    start=start_date,
+                    end=end_date,
+                    event=True,
+                    expand=True,
                 )
-        finally:
-            close_idle_connections(self.calendar.client)
+            )
         event_list = []
         for event in vevent_list:
             if not hasattr(event.instance, "vevent"):
@@ -126,19 +137,16 @@ class CalDavUpdateCoordinator(DataUpdateCoordinator[CalendarEvent | None]):
 
         # We have to retrieve the results for the whole day as the server
         # won't return events that have already started
-        try:
-            async with REQUEST_SEMAPHORE:
-                results = await self.hass.async_add_executor_job(
-                    partial(
-                        self.calendar.search,
-                        start=start_of_today,
-                        end=start_of_tomorrow,
-                        event=True,
-                        expand=True,
-                    ),
-                )
-        finally:
-            close_idle_connections(self.calendar.client)
+        async with self._semaphore_ctx():
+            results = await self.hass.async_add_executor_job(
+                partial(
+                    self.calendar.search,
+                    start=start_of_today,
+                    end=start_of_tomorrow,
+                    event=True,
+                    expand=True,
+                ),
+            )
 
         # Create new events for each recurrence of an event that happens today.
         # For recurring events, some servers return the original

--- a/homeassistant/components/caldav/coordinator.py
+++ b/homeassistant/components/caldav/coordinator.py
@@ -37,7 +37,7 @@ OFFSET = "!!"
 MAX_CONCURRENT_REQUESTS = 4
 
 
-def close_client_session(client: caldav.DAVClient | None) -> None:
+def close_client_session(client: caldav.DAVClient) -> None:
     """Close the DAVClient's HTTP session.
 
     caldav 2.1.0+ uses ``niquests`` with ``multiplexed=True`` (HTTP/2), so a
@@ -47,8 +47,6 @@ def close_client_session(client: caldav.DAVClient | None) -> None:
     time them out — at which point the integration is already gone and
     cannot recover them.
     """
-    if client is None:
-        return
     if session := getattr(client, "session", None):
         session.close()
 

--- a/homeassistant/components/caldav/coordinator.py
+++ b/homeassistant/components/caldav/coordinator.py
@@ -37,7 +37,7 @@ OFFSET = "!!"
 MAX_CONCURRENT_REQUESTS = 4
 
 
-def close_idle_connections(client: caldav.DAVClient | None) -> None:
+def close_client_session(client: caldav.DAVClient | None) -> None:
     """Close the DAVClient's HTTP session.
 
     caldav 2.1.0+ uses ``niquests`` with ``multiplexed=True`` (HTTP/2), so a

--- a/homeassistant/components/caldav/todo.py
+++ b/homeassistant/components/caldav/todo.py
@@ -23,7 +23,6 @@ from homeassistant.util import dt as dt_util
 
 from . import CalDavConfigEntry
 from .api import async_get_calendars, get_attr_value
-from .coordinator import REQUEST_SEMAPHORE, close_idle_connections
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,12 +47,15 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the CalDav todo platform for a config entry."""
-    calendars = await async_get_calendars(hass, entry.runtime_data, SUPPORTED_COMPONENT)
+    calendars = await async_get_calendars(
+        hass, entry.runtime_data.client, SUPPORTED_COMPONENT
+    )
     async_add_entities(
         (
             WebDavTodoListEntity(
                 calendar,
                 entry.entry_id,
+                entry.runtime_data.request_semaphore,
             )
             for calendar in calendars
         ),
@@ -101,25 +103,28 @@ class WebDavTodoListEntity(TodoListEntity):
         | TodoListEntityFeature.SET_DESCRIPTION_ON_ITEM
     )
 
-    def __init__(self, calendar: caldav.Calendar, config_entry_id: str) -> None:
+    def __init__(
+        self,
+        calendar: caldav.Calendar,
+        config_entry_id: str,
+        request_semaphore: asyncio.Semaphore,
+    ) -> None:
         """Initialize WebDavTodoListEntity."""
         self._calendar = calendar
         self._attr_name = (calendar.name or "Unknown").capitalize()
         self._attr_unique_id = f"{config_entry_id}-{calendar.id}"
+        self._request_semaphore = request_semaphore
 
     async def async_update(self) -> None:
         """Update To-do list entity state."""
-        try:
-            async with REQUEST_SEMAPHORE:
-                results = await self.hass.async_add_executor_job(
-                    partial(
-                        self._calendar.search,
-                        todo=True,
-                        include_completed=True,
-                    )
+        async with self._request_semaphore:
+            results = await self.hass.async_add_executor_job(
+                partial(
+                    self._calendar.search,
+                    todo=True,
+                    include_completed=True,
                 )
-        finally:
-            close_idle_connections(self._calendar.client)
+            )
         self._attr_todo_items = [
             todo_item
             for resource in results

--- a/homeassistant/components/caldav/todo.py
+++ b/homeassistant/components/caldav/todo.py
@@ -23,6 +23,7 @@ from homeassistant.util import dt as dt_util
 
 from . import CalDavConfigEntry
 from .api import async_get_calendars, get_attr_value
+from .coordinator import REQUEST_SEMAPHORE, close_idle_connections
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -108,13 +109,17 @@ class WebDavTodoListEntity(TodoListEntity):
 
     async def async_update(self) -> None:
         """Update To-do list entity state."""
-        results = await self.hass.async_add_executor_job(
-            partial(
-                self._calendar.search,
-                todo=True,
-                include_completed=True,
-            )
-        )
+        try:
+            async with REQUEST_SEMAPHORE:
+                results = await self.hass.async_add_executor_job(
+                    partial(
+                        self._calendar.search,
+                        todo=True,
+                        include_completed=True,
+                    )
+                )
+        finally:
+            close_idle_connections(self._calendar.client)
         self._attr_todo_items = [
             todo_item
             for resource in results

--- a/tests/components/caldav/test_coordinator.py
+++ b/tests/components/caldav/test_coordinator.py
@@ -1,6 +1,7 @@
 """Tests for the CalDAV coordinator concurrency cap and unload-time cleanup."""
 
 import asyncio
+import contextlib
 from unittest.mock import MagicMock
 
 import pytest
@@ -9,7 +10,7 @@ from homeassistant.components.caldav import CalDavRuntimeData
 from homeassistant.components.caldav.coordinator import (
     MAX_CONCURRENT_REQUESTS,
     CalDavUpdateCoordinator,
-    close_idle_connections,
+    close_client_session,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
@@ -115,26 +116,69 @@ async def test_concurrent_searches_are_capped(
         await asyncio.gather(*tasks, return_exceptions=True)
 
 
-async def test_per_entry_semaphores_are_independent(hass: HomeAssistant) -> None:
-    """Each config entry owns its own semaphore.
+async def test_per_entry_semaphores_are_independent(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A saturated semaphore on entry A does not block entry B.
 
-    A slow account must not delay updates for an unrelated account, which is
-    only true when the semaphore is per-entry rather than process-global.
+    The whole point of moving from a module-global semaphore to a per-entry
+    one is that a slow account cannot delay updates for an unrelated
+    account. Verify the observable behavior — entry B's search completes
+    while entry A's search is held off by an externally-saturated semaphore.
     """
-    sem_a = asyncio.Semaphore(MAX_CONCURRENT_REQUESTS)
-    sem_b = asyncio.Semaphore(MAX_CONCURRENT_REQUESTS)
-
+    release_b = asyncio.Event()
     cal_a = MagicMock()
     cal_a.name = "a"
     cal_b = MagicMock()
     cal_b.name = "b"
 
+    async def fake_executor_job(func, *_args, **_kwargs):
+        # Route by the partial's underlying calendar.search reference so the
+        # test can keep entry B's job pending until it explicitly releases it,
+        # while entry A's job must never reach the executor at all (its
+        # semaphore is fully saturated by the test).
+        bound = getattr(func, "func", None)
+        if bound is cal_b.search:
+            await release_b.wait()
+            return []
+        if bound is cal_a.search:
+            pytest.fail("Entry A reached the executor despite saturated semaphore")
+        return []
+
+    monkeypatch.setattr(hass, "async_add_executor_job", fake_executor_job)
+
+    sem_a = asyncio.Semaphore(MAX_CONCURRENT_REQUESTS)
+    sem_b = asyncio.Semaphore(MAX_CONCURRENT_REQUESTS)
+
+    # Saturate sem_a externally so coord_a is fully blocked at acquisition.
+    for _ in range(MAX_CONCURRENT_REQUESTS):
+        await sem_a.acquire()
+
     coord_a = _build_coordinator(hass, cal_a, sem_a)
     coord_b = _build_coordinator(hass, cal_b, sem_b)
 
-    assert coord_a._request_semaphore is sem_a
-    assert coord_b._request_semaphore is sem_b
-    assert coord_a._request_semaphore is not coord_b._request_semaphore
+    now = dt_util.now()
+    task_a = asyncio.create_task(coord_a.async_get_events(hass, now, now))
+    task_b = asyncio.create_task(coord_b.async_get_events(hass, now, now))
+
+    try:
+        # B can complete: its semaphore has permits and the executor releases.
+        release_b.set()
+        await asyncio.wait_for(task_b, timeout=5.0)
+
+        # Give the loop ticks so that if sem_a were shared, A would have
+        # raced past acquisition by now. It must not.
+        for _ in range(50):
+            await asyncio.sleep(0)
+
+        assert not task_a.done(), (
+            "Entry A's task completed despite sem_a being saturated — "
+            "the semaphore is not actually per-entry"
+        )
+    finally:
+        task_a.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task_a
 
 
 async def test_legacy_yaml_coordinator_has_no_semaphore(
@@ -150,19 +194,19 @@ async def test_legacy_yaml_coordinator_has_no_semaphore(
     await coordinator.async_get_events(hass, now, now)
 
 
-def test_close_idle_connections_handles_no_session() -> None:
+def test_close_client_session_handles_no_session() -> None:
     """Helper is a no-op when the DAVClient has no ``session`` attribute yet."""
     client = MagicMock(spec=[])  # no `session` attr
-    close_idle_connections(client)  # must not raise
+    close_client_session(client)  # must not raise
 
 
-def test_close_idle_connections_handles_none() -> None:
+def test_close_client_session_handles_none() -> None:
     """Helper is a no-op when given ``None`` (e.g. setup never completed)."""
-    close_idle_connections(None)
+    close_client_session(None)
 
 
-def test_close_idle_connections_calls_session_close() -> None:
+def test_close_client_session_calls_session_close() -> None:
     """Helper closes the underlying niquests Session exactly once."""
     client = MagicMock()
-    close_idle_connections(client)
+    close_client_session(client)
     client.session.close.assert_called_once()

--- a/tests/components/caldav/test_coordinator.py
+++ b/tests/components/caldav/test_coordinator.py
@@ -1,0 +1,142 @@
+"""Tests for the CalDAV coordinator concurrency cap."""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from homeassistant.components.caldav.coordinator import (
+    MAX_CONCURRENT_REQUESTS,
+    REQUEST_SEMAPHORE,
+    CalDavUpdateCoordinator,
+    close_idle_connections,
+)
+from homeassistant.components.caldav.todo import (
+    REQUEST_SEMAPHORE as TODO_REQUEST_SEMAPHORE,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+
+
+def _build_coordinator(
+    hass: HomeAssistant, calendar: MagicMock
+) -> CalDavUpdateCoordinator:
+    """Build a coordinator suitable for direct unit testing."""
+    return CalDavUpdateCoordinator(
+        hass=hass,
+        entry=None,
+        calendar=calendar,
+        days=1,
+        include_all_day=True,
+        search=None,
+    )
+
+
+async def test_concurrent_searches_are_capped(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Many concurrent refreshes must not exceed MAX_CONCURRENT_REQUESTS in-flight searches.
+
+    Regression test for thread-pool starvation seen on instances with many
+    calendars (e.g. iCloud accounts with 30+ shared calendars): without the
+    cap, every coordinator fires its first refresh in parallel at boot and
+    saturates the executor.
+
+    Replaces ``hass.async_add_executor_job`` with a coroutine so that
+    concurrency tracking and the release barrier stay on the event loop —
+    blocking real executor threads inside a per-test timeout window is
+    fragile and can starve the worker's thread pool.
+    """
+    in_flight = 0
+    peak = 0
+    enter_event = asyncio.Event()
+    release_event = asyncio.Event()
+
+    async def fake_executor_job(_func, *_args, **_kwargs):
+        nonlocal in_flight, peak
+        in_flight += 1
+        peak = max(peak, in_flight)
+        if in_flight >= MAX_CONCURRENT_REQUESTS:
+            enter_event.set()
+        try:
+            await release_event.wait()
+            return []
+        finally:
+            in_flight -= 1
+
+    monkeypatch.setattr(hass, "async_add_executor_job", fake_executor_job)
+
+    num_calendars = 20
+    coordinators: list[CalDavUpdateCoordinator] = []
+    for idx in range(num_calendars):
+        calendar = MagicMock()
+        calendar.name = f"cal-{idx}"
+        calendar.client = MagicMock(session=MagicMock())
+        coordinators.append(_build_coordinator(hass, calendar))
+
+    now = dt_util.now()
+    tasks = [
+        asyncio.create_task(c.async_get_events(hass, now, now)) for c in coordinators
+    ]
+
+    # The semaphore must let exactly MAX_CONCURRENT_REQUESTS pass and block
+    # the rest on `__aenter__`.
+    await asyncio.wait_for(enter_event.wait(), timeout=5.0)
+
+    # Give the loop additional ticks so any over-cap searches would have
+    # had time to start. A correctly-capped semaphore will keep them blocked.
+    for _ in range(50):
+        await asyncio.sleep(0)
+
+    assert peak == MAX_CONCURRENT_REQUESTS, (
+        f"semaphore failed to cap concurrency: peak={peak} "
+        f"(expected {MAX_CONCURRENT_REQUESTS})"
+    )
+
+    release_event.set()
+    await asyncio.gather(*tasks)
+
+
+async def test_request_semaphore_module_singleton() -> None:
+    """The semaphore is a module-level singleton shared by every entity."""
+    assert isinstance(REQUEST_SEMAPHORE, asyncio.Semaphore)
+    # Calendar coordinator and todo entity must reference the *same* object,
+    # otherwise the cap wouldn't be global across both platforms.
+    assert REQUEST_SEMAPHORE is TODO_REQUEST_SEMAPHORE
+
+
+async def test_search_closes_idle_connections(hass: HomeAssistant) -> None:
+    """After each search, idle urllib3 connections are dropped to prevent CLOSE_WAIT buildup."""
+    calendar = MagicMock()
+    calendar.name = "cal"
+    session = MagicMock()
+    calendar.client = MagicMock(session=session)
+    calendar.search = MagicMock(return_value=[])
+
+    coordinator = _build_coordinator(hass, calendar)
+    now = dt_util.now()
+    await coordinator.async_get_events(hass, now, now)
+
+    session.close.assert_called_once()
+
+
+async def test_search_closes_idle_connections_on_error(hass: HomeAssistant) -> None:
+    """Idle connections are still closed when the search itself raises."""
+    calendar = MagicMock()
+    calendar.name = "cal"
+    session = MagicMock()
+    calendar.client = MagicMock(session=session)
+    calendar.search = MagicMock(side_effect=RuntimeError("boom"))
+
+    coordinator = _build_coordinator(hass, calendar)
+    now = dt_util.now()
+    with pytest.raises(RuntimeError):
+        await coordinator.async_get_events(hass, now, now)
+
+    session.close.assert_called_once()
+
+
+def test_close_idle_connections_handles_no_session() -> None:
+    """Helper is a no-op when the DAVClient has no ``session`` attribute yet."""
+    client = MagicMock(spec=[])  # no `session` attr
+    close_idle_connections(client)  # must not raise

--- a/tests/components/caldav/test_coordinator.py
+++ b/tests/components/caldav/test_coordinator.py
@@ -184,12 +184,15 @@ async def test_per_entry_semaphores_are_independent(
 async def test_legacy_yaml_coordinator_has_no_semaphore(
     hass: HomeAssistant,
 ) -> None:
-    """Coordinators created from YAML config (no entry) skip the per-entry cap."""
+    """Coordinators created from YAML config (no entry) skip the per-entry cap.
+
+    Observable behavior: ``async_get_events`` completes without raising even
+    though no per-entry semaphore is wired up. If the coordinator tried to
+    enter ``None`` as an async context manager, this would error.
+    """
     calendar = MagicMock()
     calendar.search = MagicMock(return_value=[])
     coordinator = _build_coordinator(hass, calendar, semaphore=None)
-    assert coordinator._request_semaphore is None
-    # Search still completes without raising even without a semaphore.
     now = dt_util.now()
     await coordinator.async_get_events(hass, now, now)
 
@@ -198,11 +201,6 @@ def test_close_client_session_handles_no_session() -> None:
     """Helper is a no-op when the DAVClient has no ``session`` attribute yet."""
     client = MagicMock(spec=[])  # no `session` attr
     close_client_session(client)  # must not raise
-
-
-def test_close_client_session_handles_none() -> None:
-    """Helper is a no-op when given ``None`` (e.g. setup never completed)."""
-    close_client_session(None)
 
 
 def test_close_client_session_calls_session_close() -> None:

--- a/tests/components/caldav/test_coordinator.py
+++ b/tests/components/caldav/test_coordinator.py
@@ -1,30 +1,41 @@
-"""Tests for the CalDAV coordinator concurrency cap."""
+"""Tests for the CalDAV coordinator concurrency cap and unload-time cleanup."""
 
 import asyncio
 from unittest.mock import MagicMock
 
 import pytest
 
+from homeassistant.components.caldav import CalDavRuntimeData
 from homeassistant.components.caldav.coordinator import (
     MAX_CONCURRENT_REQUESTS,
-    REQUEST_SEMAPHORE,
     CalDavUpdateCoordinator,
     close_idle_connections,
-)
-from homeassistant.components.caldav.todo import (
-    REQUEST_SEMAPHORE as TODO_REQUEST_SEMAPHORE,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
 
 def _build_coordinator(
-    hass: HomeAssistant, calendar: MagicMock
+    hass: HomeAssistant,
+    calendar: MagicMock,
+    semaphore: asyncio.Semaphore | None,
 ) -> CalDavUpdateCoordinator:
-    """Build a coordinator suitable for direct unit testing."""
+    """Build a coordinator suitable for direct unit testing.
+
+    Passing ``semaphore=None`` exercises the legacy-YAML code path where no
+    config entry (and therefore no per-entry semaphore) exists.
+    """
+    if semaphore is None:
+        entry = None
+    else:
+        entry = MagicMock()
+        entry.runtime_data = CalDavRuntimeData(
+            client=MagicMock(),
+            request_semaphore=semaphore,
+        )
     return CalDavUpdateCoordinator(
         hass=hass,
-        entry=None,
+        entry=entry,
         calendar=calendar,
         days=1,
         include_all_day=True,
@@ -35,17 +46,17 @@ def _build_coordinator(
 async def test_concurrent_searches_are_capped(
     hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Many concurrent refreshes must not exceed MAX_CONCURRENT_REQUESTS in-flight searches.
+    """A per-entry semaphore caps in-flight searches at MAX_CONCURRENT_REQUESTS.
 
     Regression test for thread-pool starvation seen on instances with many
     calendars (e.g. iCloud accounts with 30+ shared calendars): without the
     cap, every coordinator fires its first refresh in parallel at boot and
     saturates the executor.
 
-    Replaces ``hass.async_add_executor_job`` with a coroutine so that
-    concurrency tracking and the release barrier stay on the event loop —
-    blocking real executor threads inside a per-test timeout window is
-    fragile and can starve the worker's thread pool.
+    Replaces ``hass.async_add_executor_job`` with a coroutine so concurrency
+    tracking and the release barrier stay on the event loop — blocking real
+    executor threads inside a per-test timeout window is fragile and can
+    starve the worker's thread pool.
     """
     in_flight = 0
     peak = 0
@@ -66,77 +77,92 @@ async def test_concurrent_searches_are_capped(
 
     monkeypatch.setattr(hass, "async_add_executor_job", fake_executor_job)
 
+    # Single per-entry semaphore shared across this test's coordinators —
+    # constructed locally so the test is isolated from any other CalDAV
+    # tests sharing the same pytest worker.
+    semaphore = asyncio.Semaphore(MAX_CONCURRENT_REQUESTS)
+
     num_calendars = 20
     coordinators: list[CalDavUpdateCoordinator] = []
     for idx in range(num_calendars):
         calendar = MagicMock()
         calendar.name = f"cal-{idx}"
-        calendar.client = MagicMock(session=MagicMock())
-        coordinators.append(_build_coordinator(hass, calendar))
+        coordinators.append(_build_coordinator(hass, calendar, semaphore))
 
     now = dt_util.now()
     tasks = [
         asyncio.create_task(c.async_get_events(hass, now, now)) for c in coordinators
     ]
 
-    # The semaphore must let exactly MAX_CONCURRENT_REQUESTS pass and block
-    # the rest on `__aenter__`.
-    await asyncio.wait_for(enter_event.wait(), timeout=5.0)
+    try:
+        # The semaphore must let exactly MAX_CONCURRENT_REQUESTS pass and
+        # block the rest on ``__aenter__``.
+        await asyncio.wait_for(enter_event.wait(), timeout=5.0)
 
-    # Give the loop additional ticks so any over-cap searches would have
-    # had time to start. A correctly-capped semaphore will keep them blocked.
-    for _ in range(50):
-        await asyncio.sleep(0)
+        # Give the loop additional ticks so any over-cap searches would have
+        # had time to start. A correctly-capped semaphore keeps them blocked.
+        for _ in range(50):
+            await asyncio.sleep(0)
 
-    assert peak == MAX_CONCURRENT_REQUESTS, (
-        f"semaphore failed to cap concurrency: peak={peak} "
-        f"(expected {MAX_CONCURRENT_REQUESTS})"
-    )
-
-    release_event.set()
-    await asyncio.gather(*tasks)
-
-
-async def test_request_semaphore_module_singleton() -> None:
-    """The semaphore is a module-level singleton shared by every entity."""
-    assert isinstance(REQUEST_SEMAPHORE, asyncio.Semaphore)
-    # Calendar coordinator and todo entity must reference the *same* object,
-    # otherwise the cap wouldn't be global across both platforms.
-    assert REQUEST_SEMAPHORE is TODO_REQUEST_SEMAPHORE
+        assert peak == MAX_CONCURRENT_REQUESTS, (
+            f"semaphore failed to cap concurrency: peak={peak} "
+            f"(expected {MAX_CONCURRENT_REQUESTS})"
+        )
+    finally:
+        # Always release waiters and gather tasks so a failed assertion
+        # cannot leak pending tasks or wedge the test worker.
+        release_event.set()
+        await asyncio.gather(*tasks, return_exceptions=True)
 
 
-async def test_search_closes_idle_connections(hass: HomeAssistant) -> None:
-    """After each search, idle urllib3 connections are dropped to prevent CLOSE_WAIT buildup."""
+async def test_per_entry_semaphores_are_independent(hass: HomeAssistant) -> None:
+    """Each config entry owns its own semaphore.
+
+    A slow account must not delay updates for an unrelated account, which is
+    only true when the semaphore is per-entry rather than process-global.
+    """
+    sem_a = asyncio.Semaphore(MAX_CONCURRENT_REQUESTS)
+    sem_b = asyncio.Semaphore(MAX_CONCURRENT_REQUESTS)
+
+    cal_a = MagicMock()
+    cal_a.name = "a"
+    cal_b = MagicMock()
+    cal_b.name = "b"
+
+    coord_a = _build_coordinator(hass, cal_a, sem_a)
+    coord_b = _build_coordinator(hass, cal_b, sem_b)
+
+    assert coord_a._request_semaphore is sem_a
+    assert coord_b._request_semaphore is sem_b
+    assert coord_a._request_semaphore is not coord_b._request_semaphore
+
+
+async def test_legacy_yaml_coordinator_has_no_semaphore(
+    hass: HomeAssistant,
+) -> None:
+    """Coordinators created from YAML config (no entry) skip the per-entry cap."""
     calendar = MagicMock()
-    calendar.name = "cal"
-    session = MagicMock()
-    calendar.client = MagicMock(session=session)
     calendar.search = MagicMock(return_value=[])
-
-    coordinator = _build_coordinator(hass, calendar)
+    coordinator = _build_coordinator(hass, calendar, semaphore=None)
+    assert coordinator._request_semaphore is None
+    # Search still completes without raising even without a semaphore.
     now = dt_util.now()
     await coordinator.async_get_events(hass, now, now)
-
-    session.close.assert_called_once()
-
-
-async def test_search_closes_idle_connections_on_error(hass: HomeAssistant) -> None:
-    """Idle connections are still closed when the search itself raises."""
-    calendar = MagicMock()
-    calendar.name = "cal"
-    session = MagicMock()
-    calendar.client = MagicMock(session=session)
-    calendar.search = MagicMock(side_effect=RuntimeError("boom"))
-
-    coordinator = _build_coordinator(hass, calendar)
-    now = dt_util.now()
-    with pytest.raises(RuntimeError):
-        await coordinator.async_get_events(hass, now, now)
-
-    session.close.assert_called_once()
 
 
 def test_close_idle_connections_handles_no_session() -> None:
     """Helper is a no-op when the DAVClient has no ``session`` attribute yet."""
     client = MagicMock(spec=[])  # no `session` attr
     close_idle_connections(client)  # must not raise
+
+
+def test_close_idle_connections_handles_none() -> None:
+    """Helper is a no-op when given ``None`` (e.g. setup never completed)."""
+    close_idle_connections(None)
+
+
+def test_close_idle_connections_calls_session_close() -> None:
+    """Helper closes the underlying niquests Session exactly once."""
+    client = MagicMock()
+    close_idle_connections(client)
+    client.session.close.assert_called_once()

--- a/tests/components/caldav/test_coordinator.py
+++ b/tests/components/caldav/test_coordinator.py
@@ -127,21 +127,27 @@ async def test_per_entry_semaphores_are_independent(
     while entry A's search is held off by an externally-saturated semaphore.
     """
     release_b = asyncio.Event()
+    # Use explicit sentinel callables for search rather than relying on
+    # MagicMock's auto-generated child-mock caching for identity routing.
+    search_a = MagicMock(name="search_a")
+    search_b = MagicMock(name="search_b")
     cal_a = MagicMock()
     cal_a.name = "a"
+    cal_a.search = search_a
     cal_b = MagicMock()
     cal_b.name = "b"
+    cal_b.search = search_b
 
     async def fake_executor_job(func, *_args, **_kwargs):
-        # Route by the partial's underlying calendar.search reference so the
-        # test can keep entry B's job pending until it explicitly releases it,
+        # Route by the partial's underlying ``calendar.search`` reference. The
+        # test keeps entry B's job pending until it explicitly releases it,
         # while entry A's job must never reach the executor at all (its
         # semaphore is fully saturated by the test).
         bound = getattr(func, "func", None)
-        if bound is cal_b.search:
+        if bound is search_b:
             await release_b.wait()
             return []
-        if bound is cal_a.search:
+        if bound is search_a:
             pytest.fail("Entry A reached the executor despite saturated semaphore")
         return []
 
@@ -195,6 +201,11 @@ async def test_legacy_yaml_coordinator_has_no_semaphore(
     coordinator = _build_coordinator(hass, calendar, semaphore=None)
     now = dt_util.now()
     await coordinator.async_get_events(hass, now, now)
+    # The search executor job is dispatched only if the coordinator's
+    # ``_semaphore_ctx`` returned an async-enterable object (``nullcontext``
+    # for the no-entry path). If it had returned ``None``, ``async with``
+    # would have raised before reaching this call.
+    calendar.search.assert_called_once()
 
 
 def test_close_client_session_handles_no_session() -> None:

--- a/tests/components/caldav/test_init.py
+++ b/tests/components/caldav/test_init.py
@@ -1,6 +1,6 @@
 """Unit tests for the CalDav integration."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from caldav.lib.error import AuthorizationError, DAVError
 import pytest
@@ -32,6 +32,35 @@ async def test_load_unload(
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     assert config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_session_closes_on_unload(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Underlying HTTP session is torn down when the config entry unloads.
+
+    Regression guard for the lifecycle change that moved socket cleanup from
+    per-request ``finally`` blocks to a single ``entry.async_on_unload``
+    hook. Multiple in-flight requests share one ``DAVClient.session`` (caldav
+    2.1.0+ uses niquests with HTTP/2 multiplexing), so closing the session
+    between requests races with concurrent searches; closing it only at
+    unload avoids that hazard.
+    """
+    session = MagicMock()
+    with patch(
+        "homeassistant.components.caldav.config_flow.caldav.DAVClient"
+    ) as mock_client:
+        mock_client.return_value.session = session
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        assert config_entry.state is ConfigEntryState.LOADED
+        session.close.assert_not_called()
+
+        assert await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
+    session.close.assert_called_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/components/caldav/test_init.py
+++ b/tests/components/caldav/test_init.py
@@ -1,5 +1,6 @@
 """Unit tests for the CalDav integration."""
 
+import threading
 from unittest.mock import MagicMock, patch
 
 from caldav.lib.error import AuthorizationError, DAVError
@@ -38,19 +39,35 @@ async def test_session_closes_on_unload(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
 ) -> None:
-    """Underlying HTTP session is torn down when the config entry unloads.
+    """Underlying HTTP session is torn down off-loop when the entry unloads.
 
-    Regression guard for the lifecycle change that moved socket cleanup from
-    per-request ``finally`` blocks to a single ``entry.async_on_unload``
-    hook. Multiple in-flight requests share one ``DAVClient.session`` (caldav
-    2.1.0+ uses niquests with HTTP/2 multiplexing), so closing the session
-    between requests races with concurrent searches; closing it only at
-    unload avoids that hazard.
+    Two guarantees in one test:
+
+    1. Lifecycle: the session is closed exactly once, only at unload.
+       Closing between requests races with concurrent searches because
+       caldav 2.1.0+ multiplexes all requests over a single niquests
+       ``Session`` (HTTP/2), so cleanup must happen after all platforms have
+       torn down.
+    2. Threading: ``session.close()`` is synchronous and can block on
+       socket teardown, so the production code dispatches it via the
+       executor. Capture the thread the close runs on and assert it is
+       *not* the event-loop thread, to lock that in.
     """
+    close_thread: threading.Thread | None = None
+    event_loop_thread = threading.current_thread()
+
+    def record_thread() -> None:
+        nonlocal close_thread
+        close_thread = threading.current_thread()
+
     session = MagicMock()
-    with patch(
-        "homeassistant.components.caldav.config_flow.caldav.DAVClient"
-    ) as mock_client:
+    session.close.side_effect = record_thread
+
+    # Patch ``DAVClient`` on the third-party ``caldav`` package as it is
+    # imported by ``homeassistant.components.caldav.__init__`` — that is the
+    # module that constructs the client and registers the unload hook whose
+    # ``session.close()`` we are verifying.
+    with patch("homeassistant.components.caldav.caldav.DAVClient") as mock_client:
         mock_client.return_value.session = session
         await hass.config_entries.async_setup(config_entry.entry_id)
         assert config_entry.state is ConfigEntryState.LOADED
@@ -61,6 +78,11 @@ async def test_session_closes_on_unload(
 
     assert config_entry.state is ConfigEntryState.NOT_LOADED
     session.close.assert_called_once()
+    assert close_thread is not None
+    assert close_thread is not event_loop_thread, (
+        "session.close() ran on the event-loop thread — the executor offload "
+        "in async_setup_entry has regressed and a blocking close will stall HA"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change

When a CalDAV config entry has many calendars — most commonly an iCloud account with 30+ personal and shared calendars — every `CalendarEntity` and `TodoListEntity` fires its first refresh in parallel during setup. Each `caldav.Calendar.search()` call ties up an executor thread for several seconds, which at boot is enough to saturate Home Assistant's executor and leave the rest of the instance (UI, automations, unrelated polling integrations) stalled until the wave subsides.

This PR introduces a small `asyncio.Semaphore` shared across all CalDAV entities to cap concurrent in-flight searches at 4, plus a best-effort `session.close()` after each search to drop urllib3 connections that some servers (notably iCloud via Cloudflare) silently close between polls.

### Evidence from a real instance

49 calendars (mixed personal + shared, all on iCloud). Symptoms reproduced on every restart prior to this patch:

- thread pool: 62/64 busy, 380 queued
- 49 threads stuck inside `caldav.davclient.report` simultaneously
- 57 `CLOSE_WAIT` sockets visible in `ss -tn` to `104.18.97.x` / `104.18.98.x` (Cloudflare-fronted iCloud endpoints)
- UI unresponsive, light automations triggering 90-120 s late, deCONZ updates skipped

After this patch (same instance, same calendars):

- thread pool: 2-5 busy, 0 queued
- event-loop lag stable at < 1 ms
- automations fire on the expected boundary

### Why a semaphore (and why 4)

A single CalDAV search is generally < 1 s end-to-end, so 4 concurrent in-flight requests still drains 30+ calendars within ~10 s — the cap is invisible in steady state. The benefit is bounded executor usage: even with 100 configured calendars, only 4 executor threads can be in `report`-state at once, leaving headroom for every other integration. The constant lives at module scope to keep state per-process rather than per-entity, since the contention is on a single executor.

### Why force-close the session

`urllib3` relies on `select()` on a 0-timeout to detect stale keep-alive connections. Cloudflare-fronted iCloud endpoints close connections silently between polls (15-min cadence is long enough that the server tier rotates). The probe misses the close, the next request reuses a dead socket, and the connection ends up in `CLOSE_WAIT` until the kernel times it out — minutes later, sometimes hours. Across 49 calendars × 4 polls/hour the buildup is significant. `requests.Session.close()` only closes the adapter pools; the session itself remains usable and new pools are created lazily on the next call, so this costs ~one extra TCP handshake per 15-min poll cycle in exchange for clean socket state.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #163188 (a different failure mode of the same upstream — `niquests` connection abort under load — but stems from the same pattern of many concurrent requests to iCloud).
- Tested on a production HA OS instance for 12+ hours post-patch with 49 iCloud calendars; thread-pool depth stays at 2-5 / 64, no `CLOSE_WAIT` accumulation observed in `ss -tn`.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/development_submitting/