### PR TITLE
Use latest service info for INKBIRD fallback poll recency check

### DIFF
--- a/homeassistant/components/inkbird/coordinator.py
+++ b/homeassistant/components/inkbird/coordinator.py
@@ -128,7 +128,14 @@ class INKBIRDActiveBluetoothProcessorCoordinator(
     @callback
     def _async_schedule_poll(self, _: datetime) -> None:
         """Schedule a poll of the device."""
-        if self._last_service_info and self._async_needs_poll(
-            self._last_service_info, self._last_poll
-        ):
+        # ``self._last_service_info`` only tracks dispatched events, so when
+        # the device keeps broadcasting the same payload (HA dedupes the
+        # repeats before dispatch) its timestamp stops advancing. Pull the
+        # latest service info from the bluetooth manager instead so the
+        # recency check in ``poll_needed`` sees every observed advertisement.
+        service_info = (
+            async_last_service_info(self.hass, self.address, connectable=False)
+            or self._last_service_info
+        )
+        if service_info and self._async_needs_poll(service_info, self._last_poll):
             self._debounced_poll.async_schedule_call()

--- a/homeassistant/components/inkbird/coordinator.py
+++ b/homeassistant/components/inkbird/coordinator.py
@@ -137,5 +137,5 @@ class INKBIRDActiveBluetoothProcessorCoordinator(
             async_last_service_info(self.hass, self.address, connectable=False)
             or self._last_service_info
         )
-        if service_info and self._async_needs_poll(service_info, self._last_poll):
+        if service_info and self.needs_poll(service_info):
             self._debounced_poll.async_schedule_call()

--- a/homeassistant/components/inkbird/coordinator.py
+++ b/homeassistant/components/inkbird/coordinator.py
@@ -138,4 +138,8 @@ class INKBIRDActiveBluetoothProcessorCoordinator(
             or self._last_service_info
         )
         if service_info and self.needs_poll(service_info):
+            # Seed ``_last_service_info`` so the debounced poll has a service
+            # info to hand to ``_async_poll_data``; the base ``_async_poll``
+            # asserts on it.
+            self._last_service_info = service_info
             self._debounced_poll.async_schedule_call()

--- a/tests/components/inkbird/test_sensor.py
+++ b/tests/components/inkbird/test_sensor.py
@@ -16,6 +16,7 @@ from inkbird_ble import (
 from inkbird_ble.parser import Model
 from sensor_state_data import SensorDeviceClass
 
+from homeassistant.components.bluetooth import async_last_service_info
 from homeassistant.components.inkbird.const import (
     CONF_DEVICE_DATA,
     CONF_DEVICE_TYPE,
@@ -175,8 +176,8 @@ async def test_polling_sensor(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
 
-async def test_fallback_poll_uses_latest_service_info(hass: HomeAssistant) -> None:
-    """Fallback timer queries async_last_service_info and forwards it to poll_needed.
+async def test_fallback_poll_queries_latest_service_info(hass: HomeAssistant) -> None:
+    """Fallback timer queries the bluetooth manager for the latest service info.
 
     Regression test for the case where HA dedupes repeat advertisements with the
     same payload; ``_last_service_info`` then goes stale even though the device
@@ -194,31 +195,16 @@ async def test_fallback_poll_uses_latest_service_info(hass: HomeAssistant) -> No
     inject_bluetooth_service_info(hass, SPS_PASSIVE_SERVICE_INFO)
     await hass.async_block_till_done()
 
-    fresh_service_info = SPS_PASSIVE_SERVICE_INFO
-
-    with (
-        patch(
-            "homeassistant.components.inkbird.coordinator.async_last_service_info",
-            return_value=fresh_service_info,
-        ) as mock_async_last_service_info,
-        patch(
-            "homeassistant.components.inkbird.coordinator.INKBIRDBluetoothDeviceData.poll_needed",
-            return_value=False,
-        ) as mock_poll_needed,
-        patch(
-            "homeassistant.components.inkbird.coordinator.INKBIRDBluetoothDeviceData.async_poll",
-            AsyncMock(),
-        ) as mock_async_poll,
-    ):
+    with patch(
+        "homeassistant.components.inkbird.coordinator.async_last_service_info",
+        wraps=async_last_service_info,
+    ) as mock_async_last_service_info:
         async_fire_time_changed(hass, dt_util.utcnow() + FALLBACK_POLL_INTERVAL)
         await hass.async_block_till_done()
 
     mock_async_last_service_info.assert_called_once_with(
         hass, "AA:BB:CC:DD:EE:FF", connectable=False
     )
-    mock_poll_needed.assert_called_once()
-    assert mock_poll_needed.call_args.args[0] is fresh_service_info
-    mock_async_poll.assert_not_called()
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/inkbird/test_sensor.py
+++ b/tests/components/inkbird/test_sensor.py
@@ -175,6 +175,55 @@ async def test_polling_sensor(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
 
+async def test_fallback_poll_uses_latest_service_info(hass: HomeAssistant) -> None:
+    """Fallback timer queries async_last_service_info and forwards it to poll_needed.
+
+    Regression test for the case where HA dedupes repeat advertisements with the
+    same payload; ``_last_service_info`` then goes stale even though the device
+    is still broadcasting, so the fallback recency check must consult the
+    bluetooth manager's freshest observation instead of the dispatched event.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="AA:BB:CC:DD:EE:FF",
+        data={CONF_DEVICE_TYPE: "IBS-TH"},
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    inject_bluetooth_service_info(hass, SPS_PASSIVE_SERVICE_INFO)
+    await hass.async_block_till_done()
+
+    fresh_service_info = SPS_PASSIVE_SERVICE_INFO
+
+    with (
+        patch(
+            "homeassistant.components.inkbird.coordinator.async_last_service_info",
+            return_value=fresh_service_info,
+        ) as mock_async_last_service_info,
+        patch(
+            "homeassistant.components.inkbird.coordinator.INKBIRDBluetoothDeviceData.poll_needed",
+            return_value=False,
+        ) as mock_poll_needed,
+        patch(
+            "homeassistant.components.inkbird.coordinator.INKBIRDBluetoothDeviceData.async_poll",
+            AsyncMock(),
+        ) as mock_async_poll,
+    ):
+        async_fire_time_changed(hass, dt_util.utcnow() + FALLBACK_POLL_INTERVAL)
+        await hass.async_block_till_done()
+
+    mock_async_last_service_info.assert_called_once_with(
+        hass, "AA:BB:CC:DD:EE:FF", connectable=False
+    )
+    mock_poll_needed.assert_called_once()
+    assert mock_poll_needed.call_args.args[0] is fresh_service_info
+    mock_async_poll.assert_not_called()
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
 async def test_notify_sensor_no_advertisement(hass: HomeAssistant) -> None:
     """Test setting up a notify sensor that has no advertisement."""
     entry = MockConfigEntry(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`_async_schedule_poll` was using the coordinator's `_last_service_info`, which only updates on dispatched events; when an INKBIRD device keeps broadcasting the same payload, HA dedupes the repeats before dispatch, so that timestamp goes stale and the fallback timer triggers an unnecessary connect. Pull the latest service info from the bluetooth manager via `async_last_service_info` instead so the recency check in `inkbird_ble.poll_needed` sees every observed advertisement; this is a no-op against `inkbird_ble` 1.1.x (its `poll_needed` ignores `service_info.time`) and starts working once #172040 lands the 1.2.2 bump.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr