### PR TITLE
Split HDFury coordinator into separate info and config coordinators

### DIFF
--- a/homeassistant/components/hdfury/__init__.py
+++ b/homeassistant/components/hdfury/__init__.py
@@ -8,6 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN
@@ -27,7 +28,6 @@ class HDFuryRuntimeData:
     """Runtime data for HDFury integration."""
 
     client: HDFuryAPI
-    host: str
     board: dict[str, str]
     info_coordinator: HDFuryInfoCoordinator
     config_coordinator: HDFuryConfigCoordinator
@@ -56,9 +56,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: HDFuryConfigEntry) -> bo
     await info_coordinator.async_config_entry_first_refresh()
     await config_coordinator.async_config_entry_first_refresh()
 
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, board["serial"])},
+        name=f"HDFury {board['hostname']}",
+        manufacturer="HDFury",
+        model=board["hostname"].split("-")[0],
+        serial_number=board["serial"],
+        sw_version=board["version"].removeprefix("FW: "),
+        hw_version=board.get("pcbv"),
+        configuration_url=f"http://{host}",
+        connections={(dr.CONNECTION_NETWORK_MAC, config_coordinator.data["macaddr"])},
+    )
+
     entry.runtime_data = HDFuryRuntimeData(
         client=client,
-        host=host,
         board=board,
         info_coordinator=info_coordinator,
         config_coordinator=config_coordinator,

--- a/homeassistant/components/hdfury/__init__.py
+++ b/homeassistant/components/hdfury/__init__.py
@@ -1,9 +1,17 @@
 """The HDFury Integration."""
 
-from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from dataclasses import dataclass
 
-from .coordinator import HDFuryConfigEntry, async_create_runtime_data
+from hdfury import HDFuryAPI, HDFuryError
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import DOMAIN
+from .coordinator import HDFuryConfigCoordinator, HDFuryInfoCoordinator
 
 PLATFORMS = [
     Platform.BUTTON,
@@ -14,10 +22,47 @@ PLATFORMS = [
 ]
 
 
+@dataclass(kw_only=True)
+class HDFuryRuntimeData:
+    """Runtime data for HDFury integration."""
+
+    client: HDFuryAPI
+    host: str
+    board: dict[str, str]
+    info_coordinator: HDFuryInfoCoordinator
+    config_coordinator: HDFuryConfigCoordinator
+
+
+type HDFuryConfigEntry = ConfigEntry[HDFuryRuntimeData]
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: HDFuryConfigEntry) -> bool:
     """Set up HDFury as config entry."""
 
-    entry.runtime_data = await async_create_runtime_data(hass, entry)
+    host: str = entry.data[CONF_HOST]
+    client = HDFuryAPI(host, async_get_clientsession(hass))
+
+    try:
+        board = await client.get_board()
+    except HDFuryError as error:
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="communication_error",
+        ) from error
+
+    info_coordinator = HDFuryInfoCoordinator(hass, entry, client)
+    config_coordinator = HDFuryConfigCoordinator(hass, entry, client)
+
+    await info_coordinator.async_config_entry_first_refresh()
+    await config_coordinator.async_config_entry_first_refresh()
+
+    entry.runtime_data = HDFuryRuntimeData(
+        client=client,
+        host=host,
+        board=board,
+        info_coordinator=info_coordinator,
+        config_coordinator=config_coordinator,
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/hdfury/__init__.py
+++ b/homeassistant/components/hdfury/__init__.py
@@ -3,7 +3,7 @@
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
-from .coordinator import HDFuryConfigEntry, HDFuryCoordinator
+from .coordinator import HDFuryConfigEntry, async_create_runtime_data
 
 PLATFORMS = [
     Platform.BUTTON,
@@ -17,10 +17,7 @@ PLATFORMS = [
 async def async_setup_entry(hass: HomeAssistant, entry: HDFuryConfigEntry) -> bool:
     """Set up HDFury as config entry."""
 
-    coordinator = HDFuryCoordinator(hass, entry)
-    await coordinator.async_config_entry_first_refresh()
-
-    entry.runtime_data = coordinator
+    entry.runtime_data = await async_create_runtime_data(hass, entry)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/hdfury/button.py
+++ b/homeassistant/components/hdfury/button.py
@@ -15,8 +15,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from . import HDFuryConfigEntry
 from .const import DOMAIN
-from .coordinator import HDFuryConfigEntry
 from .entity import HDFuryEntity
 
 PARALLEL_UPDATES = 1

--- a/homeassistant/components/hdfury/button.py
+++ b/homeassistant/components/hdfury/button.py
@@ -16,7 +16,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
-from .coordinator import HDFuryConfigCoordinator, HDFuryConfigEntry, HDFuryRuntimeData
+from .coordinator import HDFuryConfigEntry
 from .entity import HDFuryEntity
 
 PARALLEL_UPDATES = 1
@@ -65,21 +65,11 @@ class HDFuryButton(HDFuryEntity, ButtonEntity):
 
     entity_description: HDFuryButtonEntityDescription
 
-    def __init__(
-        self,
-        coordinator: HDFuryConfigCoordinator,
-        runtime_data: HDFuryRuntimeData,
-        entity_description: HDFuryButtonEntityDescription,
-    ) -> None:
-        """Initialize the button entity."""
-        super().__init__(coordinator, runtime_data, entity_description)
-        self._client = runtime_data.client
-
     async def async_press(self) -> None:
         """Handle Button Press."""
 
         try:
-            await self.entity_description.press_fn(self._client)
+            await self.entity_description.press_fn(self.runtime_data.client)
         except HDFuryError as error:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,

--- a/homeassistant/components/hdfury/button.py
+++ b/homeassistant/components/hdfury/button.py
@@ -16,7 +16,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
-from .coordinator import HDFuryConfigEntry
+from .coordinator import HDFuryConfigCoordinator, HDFuryConfigEntry, HDFuryRuntimeData
 from .entity import HDFuryEntity
 
 PARALLEL_UPDATES = 1
@@ -52,10 +52,11 @@ async def async_setup_entry(
 ) -> None:
     """Set up buttons using the platform schema."""
 
-    coordinator = entry.runtime_data
+    runtime_data = entry.runtime_data
+    coordinator = runtime_data.config_coordinator
 
     async_add_entities(
-        HDFuryButton(coordinator, description) for description in BUTTONS
+        HDFuryButton(coordinator, runtime_data, description) for description in BUTTONS
     )
 
 
@@ -64,11 +65,21 @@ class HDFuryButton(HDFuryEntity, ButtonEntity):
 
     entity_description: HDFuryButtonEntityDescription
 
+    def __init__(
+        self,
+        coordinator: HDFuryConfigCoordinator,
+        runtime_data: HDFuryRuntimeData,
+        entity_description: HDFuryButtonEntityDescription,
+    ) -> None:
+        """Initialize the button entity."""
+        super().__init__(coordinator, runtime_data, entity_description)
+        self._client = runtime_data.client
+
     async def async_press(self) -> None:
         """Handle Button Press."""
 
         try:
-            await self.entity_description.press_fn(self.coordinator.client)
+            await self.entity_description.press_fn(self._client)
         except HDFuryError as error:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,

--- a/homeassistant/components/hdfury/button.py
+++ b/homeassistant/components/hdfury/button.py
@@ -52,11 +52,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up buttons using the platform schema."""
 
-    runtime_data = entry.runtime_data
-    coordinator = runtime_data.config_coordinator
+    coordinator = entry.runtime_data.config_coordinator
 
     async_add_entities(
-        HDFuryButton(coordinator, runtime_data, description) for description in BUTTONS
+        HDFuryButton(coordinator, description) for description in BUTTONS
     )
 
 
@@ -69,7 +68,7 @@ class HDFuryButton(HDFuryEntity, ButtonEntity):
         """Handle Button Press."""
 
         try:
-            await self.entity_description.press_fn(self.runtime_data.client)
+            await self.entity_description.press_fn(self.coordinator.client)
         except HDFuryError as error:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,

--- a/homeassistant/components/hdfury/coordinator.py
+++ b/homeassistant/components/hdfury/coordinator.py
@@ -1,4 +1,4 @@
-"""DataUpdateCoordinator for HDFury Integration."""
+"""DataUpdateCoordinators for HDFury Integration."""
 
 from dataclasses import dataclass
 from datetime import timedelta
@@ -10,6 +10,7 @@ from hdfury import HDFuryAPI, HDFuryError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -17,51 +18,103 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-SCAN_INTERVAL: Final = timedelta(seconds=60)
-
-type HDFuryConfigEntry = ConfigEntry[HDFuryCoordinator]
-
-
-@dataclass(kw_only=True, frozen=True)
-class HDFuryData:
-    """HDFury Data Class."""
-
-    board: dict[str, str]
-    info: dict[str, str]
-    config: dict[str, str]
+SCAN_INTERVAL_INFO: Final = timedelta(seconds=60)
+SCAN_INTERVAL_CONFIG: Final = timedelta(seconds=60)
 
 
-class HDFuryCoordinator(DataUpdateCoordinator[HDFuryData]):
-    """HDFury Device Coordinator Class."""
+class HDFuryInfoCoordinator(DataUpdateCoordinator[dict[str, str]]):
+    """Coordinator for HDFury device info (signal routing, port selections)."""
 
-    def __init__(self, hass: HomeAssistant, entry: HDFuryConfigEntry) -> None:
-        """Initialize the coordinator."""
-
+    def __init__(
+        self, hass: HomeAssistant, entry: ConfigEntry, client: HDFuryAPI
+    ) -> None:
+        """Initialize the info coordinator."""
         super().__init__(
             hass,
             _LOGGER,
             config_entry=entry,
-            name="HDFury",
-            update_interval=SCAN_INTERVAL,
+            name="HDFury Info",
+            update_interval=SCAN_INTERVAL_INFO,
         )
-        self.host: str = entry.data[CONF_HOST]
-        self.client = HDFuryAPI(self.host, async_get_clientsession(hass))
+        self.client = client
 
-    async def _async_update_data(self) -> HDFuryData:
-        """Fetch the latest device data."""
-
+    async def _async_update_data(self) -> dict[str, str]:
+        """Fetch device info."""
         try:
-            board = await self.client.get_board()
-            info = await self.client.get_info()
-            config = await self.client.get_config()
+            return await self.client.get_info()
         except HDFuryError as error:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
                 translation_key="communication_error",
             ) from error
 
-        return HDFuryData(
-            board=board,
-            info=info,
-            config=config,
+
+class HDFuryConfigCoordinator(DataUpdateCoordinator[dict[str, str]]):
+    """Coordinator for HDFury device config (switches, numbers)."""
+
+    def __init__(
+        self, hass: HomeAssistant, entry: ConfigEntry, client: HDFuryAPI
+    ) -> None:
+        """Initialize the config coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=entry,
+            name="HDFury Config",
+            update_interval=SCAN_INTERVAL_CONFIG,
         )
+        self.client = client
+
+    async def _async_update_data(self) -> dict[str, str]:
+        """Fetch device configuration."""
+        try:
+            return await self.client.get_config()
+        except HDFuryError as error:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+            ) from error
+
+
+@dataclass(kw_only=True)
+class HDFuryRuntimeData:
+    """Runtime data for HDFury integration."""
+
+    client: HDFuryAPI
+    host: str
+    board: dict[str, str]
+    info_coordinator: HDFuryInfoCoordinator
+    config_coordinator: HDFuryConfigCoordinator
+
+
+type HDFuryConfigEntry = ConfigEntry[HDFuryRuntimeData]
+
+
+async def async_create_runtime_data(
+    hass: HomeAssistant, entry: HDFuryConfigEntry
+) -> HDFuryRuntimeData:
+    """Create runtime data with coordinators."""
+    host: str = entry.data[CONF_HOST]
+    client = HDFuryAPI(host, async_get_clientsession(hass))
+
+    try:
+        board = await client.get_board()
+    except HDFuryError as error:
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="communication_error",
+        ) from error
+
+    info_coordinator = HDFuryInfoCoordinator(hass, entry, client)
+    config_coordinator = HDFuryConfigCoordinator(hass, entry, client)
+
+    await info_coordinator.async_config_entry_first_refresh()
+    await config_coordinator.async_config_entry_first_refresh()
+
+    return HDFuryRuntimeData(
+        client=client,
+        host=host,
+        board=board,
+        info_coordinator=info_coordinator,
+        config_coordinator=config_coordinator,
+    )

--- a/homeassistant/components/hdfury/coordinator.py
+++ b/homeassistant/components/hdfury/coordinator.py
@@ -1,6 +1,6 @@
 """DataUpdateCoordinators for HDFury Integration."""
 
-from dataclasses import dataclass
+from abc import abstractmethod
 from datetime import timedelta
 import logging
 from typing import Final
@@ -8,10 +8,7 @@ from typing import Final
 from hdfury import HDFuryAPI, HDFuryError
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN
@@ -22,99 +19,57 @@ SCAN_INTERVAL_INFO: Final = timedelta(seconds=60)
 SCAN_INTERVAL_CONFIG: Final = timedelta(seconds=60)
 
 
-class HDFuryInfoCoordinator(DataUpdateCoordinator[dict[str, str]]):
+class HDFuryDataUpdateCoordinator(DataUpdateCoordinator[dict[str, str]]):
+    """Base coordinator for HDFury devices."""
+
+    _update_interval: timedelta
+    _coordinator_name: str
+
+    def __init__(
+        self, hass: HomeAssistant, entry: ConfigEntry, client: HDFuryAPI
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=entry,
+            name=f"HDFury {self._coordinator_name}",
+            update_interval=self._update_interval,
+        )
+        self.client = client
+
+    async def _async_update_data(self) -> dict[str, str]:
+        """Fetch data from the device."""
+        try:
+            return await self._internal_update_data()
+        except HDFuryError as error:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+            ) from error
+
+    @abstractmethod
+    async def _internal_update_data(self) -> dict[str, str]:
+        """Update coordinator data."""
+
+
+class HDFuryInfoCoordinator(HDFuryDataUpdateCoordinator):
     """Coordinator for HDFury device info (signal routing, port selections)."""
 
-    def __init__(
-        self, hass: HomeAssistant, entry: ConfigEntry, client: HDFuryAPI
-    ) -> None:
-        """Initialize the info coordinator."""
-        super().__init__(
-            hass,
-            _LOGGER,
-            config_entry=entry,
-            name="HDFury Info",
-            update_interval=SCAN_INTERVAL_INFO,
-        )
-        self.client = client
+    _update_interval = SCAN_INTERVAL_INFO
+    _coordinator_name = "Info"
 
-    async def _async_update_data(self) -> dict[str, str]:
+    async def _internal_update_data(self) -> dict[str, str]:
         """Fetch device info."""
-        try:
-            return await self.client.get_info()
-        except HDFuryError as error:
-            raise UpdateFailed(
-                translation_domain=DOMAIN,
-                translation_key="communication_error",
-            ) from error
+        return await self.client.get_info()
 
 
-class HDFuryConfigCoordinator(DataUpdateCoordinator[dict[str, str]]):
+class HDFuryConfigCoordinator(HDFuryDataUpdateCoordinator):
     """Coordinator for HDFury device config (switches, numbers)."""
 
-    def __init__(
-        self, hass: HomeAssistant, entry: ConfigEntry, client: HDFuryAPI
-    ) -> None:
-        """Initialize the config coordinator."""
-        super().__init__(
-            hass,
-            _LOGGER,
-            config_entry=entry,
-            name="HDFury Config",
-            update_interval=SCAN_INTERVAL_CONFIG,
-        )
-        self.client = client
+    _update_interval = SCAN_INTERVAL_CONFIG
+    _coordinator_name = "Config"
 
-    async def _async_update_data(self) -> dict[str, str]:
+    async def _internal_update_data(self) -> dict[str, str]:
         """Fetch device configuration."""
-        try:
-            return await self.client.get_config()
-        except HDFuryError as error:
-            raise UpdateFailed(
-                translation_domain=DOMAIN,
-                translation_key="communication_error",
-            ) from error
-
-
-@dataclass(kw_only=True)
-class HDFuryRuntimeData:
-    """Runtime data for HDFury integration."""
-
-    client: HDFuryAPI
-    host: str
-    board: dict[str, str]
-    info_coordinator: HDFuryInfoCoordinator
-    config_coordinator: HDFuryConfigCoordinator
-
-
-type HDFuryConfigEntry = ConfigEntry[HDFuryRuntimeData]
-
-
-async def async_create_runtime_data(
-    hass: HomeAssistant, entry: HDFuryConfigEntry
-) -> HDFuryRuntimeData:
-    """Create runtime data with coordinators."""
-    host: str = entry.data[CONF_HOST]
-    client = HDFuryAPI(host, async_get_clientsession(hass))
-
-    try:
-        board = await client.get_board()
-    except HDFuryError as error:
-        raise ConfigEntryNotReady(
-            translation_domain=DOMAIN,
-            translation_key="communication_error",
-        ) from error
-
-    info_coordinator = HDFuryInfoCoordinator(hass, entry, client)
-    config_coordinator = HDFuryConfigCoordinator(hass, entry, client)
-
-    await info_coordinator.async_config_entry_first_refresh()
-    await config_coordinator.async_config_entry_first_refresh()
-
-    return HDFuryRuntimeData(
-        client=client,
-        host=host,
-        board=board,
-        info_coordinator=info_coordinator,
-        config_coordinator=config_coordinator,
-    )
+        return await self.client.get_config()

--- a/homeassistant/components/hdfury/diagnostics.py
+++ b/homeassistant/components/hdfury/diagnostics.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from homeassistant.core import HomeAssistant
 
-from .coordinator import HDFuryConfigEntry
+from . import HDFuryConfigEntry
 
 
 async def async_get_config_entry_diagnostics(

--- a/homeassistant/components/hdfury/diagnostics.py
+++ b/homeassistant/components/hdfury/diagnostics.py
@@ -4,17 +4,17 @@ from typing import Any
 
 from homeassistant.core import HomeAssistant
 
-from .coordinator import HDFuryConfigEntry, HDFuryCoordinator
+from .coordinator import HDFuryConfigEntry
 
 
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: HDFuryConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: HDFuryCoordinator = entry.runtime_data
+    runtime_data = entry.runtime_data
 
     return {
-        "board": coordinator.data.board,
-        "info": coordinator.data.info,
-        "config": coordinator.data.config,
+        "board": runtime_data.board,
+        "info": runtime_data.info_coordinator.data,
+        "config": runtime_data.config_coordinator.data,
     }

--- a/homeassistant/components/hdfury/entity.py
+++ b/homeassistant/components/hdfury/entity.py
@@ -3,22 +3,20 @@
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .coordinator import HDFuryRuntimeData
+from . import HDFuryRuntimeData
+from .coordinator import HDFuryDataUpdateCoordinator
 
 
-class HDFuryEntity(CoordinatorEntity[DataUpdateCoordinator[dict[str, str]]]):
+class HDFuryEntity(CoordinatorEntity[HDFuryDataUpdateCoordinator]):
     """Common elements for all entities."""
 
     _attr_has_entity_name = True
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator[dict[str, str]],
+        coordinator: HDFuryDataUpdateCoordinator,
         runtime_data: HDFuryRuntimeData,
         entity_description: EntityDescription,
     ) -> None:

--- a/homeassistant/components/hdfury/entity.py
+++ b/homeassistant/components/hdfury/entity.py
@@ -26,6 +26,7 @@ class HDFuryEntity(CoordinatorEntity[DataUpdateCoordinator[dict[str, str]]]):
 
         super().__init__(coordinator)
 
+        self.runtime_data = runtime_data
         self.entity_description = entity_description
 
         board = runtime_data.board

--- a/homeassistant/components/hdfury/entity.py
+++ b/homeassistant/components/hdfury/entity.py
@@ -1,11 +1,10 @@
 """Base class for HDFury entities."""
 
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import HDFuryRuntimeData
+from .const import DOMAIN
 from .coordinator import HDFuryDataUpdateCoordinator
 
 
@@ -17,30 +16,16 @@ class HDFuryEntity(CoordinatorEntity[HDFuryDataUpdateCoordinator]):
     def __init__(
         self,
         coordinator: HDFuryDataUpdateCoordinator,
-        runtime_data: HDFuryRuntimeData,
         entity_description: EntityDescription,
     ) -> None:
         """Initialize the entity."""
 
         super().__init__(coordinator)
 
-        self.runtime_data = runtime_data
         self.entity_description = entity_description
 
-        board = runtime_data.board
-        self._attr_unique_id = f"{board['serial']}_{entity_description.key}"
+        serial = coordinator.config_entry.unique_id
+        self._attr_unique_id = f"{serial}_{entity_description.key}"
         self._attr_device_info = DeviceInfo(
-            name=f"HDFury {board['hostname']}",
-            manufacturer="HDFury",
-            model=board["hostname"].split("-")[0],
-            serial_number=board["serial"],
-            sw_version=board["version"].removeprefix("FW: "),
-            hw_version=board.get("pcbv"),
-            configuration_url=f"http://{runtime_data.host}",
-            connections={
-                (
-                    dr.CONNECTION_NETWORK_MAC,
-                    runtime_data.config_coordinator.data["macaddr"],
-                )
-            },
+            identifiers={(DOMAIN, serial)},
         )

--- a/homeassistant/components/hdfury/entity.py
+++ b/homeassistant/components/hdfury/entity.py
@@ -3,18 +3,24 @@
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
 
-from .coordinator import HDFuryCoordinator
+from .coordinator import HDFuryRuntimeData
 
 
-class HDFuryEntity(CoordinatorEntity[HDFuryCoordinator]):
+class HDFuryEntity(CoordinatorEntity[DataUpdateCoordinator[dict[str, str]]]):
     """Common elements for all entities."""
 
     _attr_has_entity_name = True
 
     def __init__(
-        self, coordinator: HDFuryCoordinator, entity_description: EntityDescription
+        self,
+        coordinator: DataUpdateCoordinator[dict[str, str]],
+        runtime_data: HDFuryRuntimeData,
+        entity_description: EntityDescription,
     ) -> None:
         """Initialize the entity."""
 
@@ -22,18 +28,20 @@ class HDFuryEntity(CoordinatorEntity[HDFuryCoordinator]):
 
         self.entity_description = entity_description
 
-        self._attr_unique_id = (
-            f"{coordinator.data.board['serial']}_{entity_description.key}"
-        )
+        board = runtime_data.board
+        self._attr_unique_id = f"{board['serial']}_{entity_description.key}"
         self._attr_device_info = DeviceInfo(
-            name=f"HDFury {coordinator.data.board['hostname']}",
+            name=f"HDFury {board['hostname']}",
             manufacturer="HDFury",
-            model=coordinator.data.board["hostname"].split("-")[0],
-            serial_number=coordinator.data.board["serial"],
-            sw_version=coordinator.data.board["version"].removeprefix("FW: "),
-            hw_version=coordinator.data.board.get("pcbv"),
-            configuration_url=f"http://{coordinator.host}",
+            model=board["hostname"].split("-")[0],
+            serial_number=board["serial"],
+            sw_version=board["version"].removeprefix("FW: "),
+            hw_version=board.get("pcbv"),
+            configuration_url=f"http://{runtime_data.host}",
             connections={
-                (dr.CONNECTION_NETWORK_MAC, coordinator.data.config["macaddr"])
+                (
+                    dr.CONNECTION_NETWORK_MAC,
+                    runtime_data.config_coordinator.data["macaddr"],
+                )
             },
         )

--- a/homeassistant/components/hdfury/number.py
+++ b/homeassistant/components/hdfury/number.py
@@ -125,5 +125,4 @@ class HDFuryNumber(HDFuryEntity, NumberEntity):
                 translation_key="communication_error",
             ) from error
 
-        self.coordinator.data[self.entity_description.key] = str(int(value))
-        self.coordinator.async_set_updated_data(self.coordinator.data)
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/hdfury/number.py
+++ b/homeassistant/components/hdfury/number.py
@@ -16,8 +16,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from . import HDFuryConfigEntry
 from .const import DOMAIN
-from .coordinator import HDFuryConfigEntry
 from .entity import HDFuryEntity
 
 PARALLEL_UPDATES = 1

--- a/homeassistant/components/hdfury/number.py
+++ b/homeassistant/components/hdfury/number.py
@@ -91,11 +91,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up numbers using the platform schema."""
 
-    runtime_data = entry.runtime_data
-    coordinator = runtime_data.config_coordinator
+    coordinator = entry.runtime_data.config_coordinator
 
     async_add_entities(
-        HDFuryNumber(coordinator, runtime_data, description)
+        HDFuryNumber(coordinator, description)
         for description in NUMBERS
         if description.key in coordinator.data
     )
@@ -117,7 +116,7 @@ class HDFuryNumber(HDFuryEntity, NumberEntity):
 
         try:
             await self.entity_description.set_value_fn(
-                self.runtime_data.client, str(int(value))
+                self.coordinator.client, str(int(value))
             )
         except HDFuryError as error:
             raise HomeAssistantError(

--- a/homeassistant/components/hdfury/number.py
+++ b/homeassistant/components/hdfury/number.py
@@ -133,5 +133,4 @@ class HDFuryNumber(HDFuryEntity, NumberEntity):
                 translation_key="communication_error",
             ) from error
 
-        self.coordinator.data[self.entity_description.key] = str(int(value))
-        self.coordinator.async_set_updated_data(self.coordinator.data)
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/hdfury/number.py
+++ b/homeassistant/components/hdfury/number.py
@@ -17,7 +17,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
-from .coordinator import HDFuryConfigEntry
+from .coordinator import HDFuryConfigCoordinator, HDFuryConfigEntry, HDFuryRuntimeData
 from .entity import HDFuryEntity
 
 PARALLEL_UPDATES = 1
@@ -91,12 +91,13 @@ async def async_setup_entry(
 ) -> None:
     """Set up numbers using the platform schema."""
 
-    coordinator = entry.runtime_data
+    runtime_data = entry.runtime_data
+    coordinator = runtime_data.config_coordinator
 
     async_add_entities(
-        HDFuryNumber(coordinator, description)
+        HDFuryNumber(coordinator, runtime_data, description)
         for description in NUMBERS
-        if description.key in coordinator.data.config
+        if description.key in coordinator.data
     )
 
 
@@ -105,23 +106,32 @@ class HDFuryNumber(HDFuryEntity, NumberEntity):
 
     entity_description: HDFuryNumberEntityDescription
 
+    def __init__(
+        self,
+        coordinator: HDFuryConfigCoordinator,
+        runtime_data: HDFuryRuntimeData,
+        entity_description: HDFuryNumberEntityDescription,
+    ) -> None:
+        """Initialize the number entity."""
+        super().__init__(coordinator, runtime_data, entity_description)
+        self._client = runtime_data.client
+
     @property
     def native_value(self) -> float:
         """Return the current number value."""
 
-        return float(self.coordinator.data.config[self.entity_description.key])
+        return float(self.coordinator.data[self.entity_description.key])
 
     async def async_set_native_value(self, value: float) -> None:
         """Set Number Value Event."""
 
         try:
-            await self.entity_description.set_value_fn(
-                self.coordinator.client, str(int(value))
-            )
+            await self.entity_description.set_value_fn(self._client, str(int(value)))
         except HDFuryError as error:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="communication_error",
             ) from error
 
-        await self.coordinator.async_request_refresh()
+        self.coordinator.data[self.entity_description.key] = str(int(value))
+        self.coordinator.async_set_updated_data(self.coordinator.data)

--- a/homeassistant/components/hdfury/number.py
+++ b/homeassistant/components/hdfury/number.py
@@ -17,7 +17,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
-from .coordinator import HDFuryConfigCoordinator, HDFuryConfigEntry, HDFuryRuntimeData
+from .coordinator import HDFuryConfigEntry
 from .entity import HDFuryEntity
 
 PARALLEL_UPDATES = 1
@@ -106,16 +106,6 @@ class HDFuryNumber(HDFuryEntity, NumberEntity):
 
     entity_description: HDFuryNumberEntityDescription
 
-    def __init__(
-        self,
-        coordinator: HDFuryConfigCoordinator,
-        runtime_data: HDFuryRuntimeData,
-        entity_description: HDFuryNumberEntityDescription,
-    ) -> None:
-        """Initialize the number entity."""
-        super().__init__(coordinator, runtime_data, entity_description)
-        self._client = runtime_data.client
-
     @property
     def native_value(self) -> float:
         """Return the current number value."""
@@ -126,11 +116,14 @@ class HDFuryNumber(HDFuryEntity, NumberEntity):
         """Set Number Value Event."""
 
         try:
-            await self.entity_description.set_value_fn(self._client, str(int(value)))
+            await self.entity_description.set_value_fn(
+                self.runtime_data.client, str(int(value))
+            )
         except HDFuryError as error:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="communication_error",
             ) from error
 
-        await self.coordinator.async_request_refresh()
+        self.coordinator.data[self.entity_description.key] = str(int(value))
+        self.coordinator.async_set_updated_data(self.coordinator.data)

--- a/homeassistant/components/hdfury/select.py
+++ b/homeassistant/components/hdfury/select.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from hdfury import OPERATION_MODES, TX0_INPUT_PORTS, TX1_INPUT_PORTS, HDFuryError
 
@@ -10,9 +11,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import HDFuryConfigEntry, HDFuryRuntimeData
+from . import HDFuryConfigEntry
 from .const import DOMAIN
 from .entity import HDFuryEntity
+
+if TYPE_CHECKING:
+    from . import HDFuryRuntimeData
 
 PARALLEL_UPDATES = 1
 
@@ -76,17 +80,16 @@ async def async_setup_entry(
 ) -> None:
     """Set up selects using the platform schema."""
 
-    runtime_data = entry.runtime_data
-    coordinator = runtime_data.info_coordinator
+    coordinator = entry.runtime_data.info_coordinator
 
     entities: list[HDFuryEntity] = [
-        HDFurySelect(coordinator, runtime_data, description)
+        HDFurySelect(coordinator, description)
         for description in SELECT_PORTS
         if description.key in coordinator.data
     ]
 
     if "opmode" in coordinator.data:
-        entities.append(HDFurySelect(coordinator, runtime_data, SELECT_OPERATION_MODE))
+        entities.append(HDFurySelect(coordinator, SELECT_OPERATION_MODE))
 
     async_add_entities(entities)
 
@@ -105,8 +108,10 @@ class HDFurySelect(HDFuryEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Update the current option."""
 
+        runtime_data = self.coordinator.config_entry.runtime_data
+
         try:
-            await self.entity_description.set_value_fn(self.runtime_data, option)
+            await self.entity_description.set_value_fn(runtime_data, option)
         except HDFuryError as error:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,

--- a/homeassistant/components/hdfury/select.py
+++ b/homeassistant/components/hdfury/select.py
@@ -29,13 +29,17 @@ SELECT_PORTS: tuple[HDFurySelectEntityDescription, ...] = (
         key="portseltx0",
         translation_key="portseltx0",
         options=list(TX0_INPUT_PORTS.keys()),
-        set_value_fn=lambda runtime_data, value: _set_ports(runtime_data),
+        set_value_fn=lambda runtime_data, value: _set_ports(
+            runtime_data, "portseltx0", value
+        ),
     ),
     HDFurySelectEntityDescription(
         key="portseltx1",
         translation_key="portseltx1",
         options=list(TX1_INPUT_PORTS.keys()),
-        set_value_fn=lambda runtime_data, value: _set_ports(runtime_data),
+        set_value_fn=lambda runtime_data, value: _set_ports(
+            runtime_data, "portseltx1", value
+        ),
     ),
 )
 
@@ -50,10 +54,10 @@ SELECT_OPERATION_MODE: HDFurySelectEntityDescription = HDFurySelectEntityDescrip
 )
 
 
-async def _set_ports(runtime_data: HDFuryRuntimeData) -> None:
+async def _set_ports(runtime_data: HDFuryRuntimeData, key: str, value: str) -> None:
     info = runtime_data.info_coordinator.data
-    tx0 = info.get("portseltx0")
-    tx1 = info.get("portseltx1")
+    tx0 = value if key == "portseltx0" else info.get("portseltx0")
+    tx1 = value if key == "portseltx1" else info.get("portseltx1")
 
     if tx0 is None or tx1 is None:
         raise HomeAssistantError(
@@ -101,16 +105,12 @@ class HDFurySelect(HDFuryEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Update the current option."""
 
-        previous = self.coordinator.data[self.entity_description.key]
-        self.coordinator.data[self.entity_description.key] = option
-
         try:
             await self.entity_description.set_value_fn(self.runtime_data, option)
         except HDFuryError as error:
-            self.coordinator.data[self.entity_description.key] = previous
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="communication_error",
             ) from error
 
-        self.coordinator.async_set_updated_data(self.coordinator.data)
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/hdfury/select.py
+++ b/homeassistant/components/hdfury/select.py
@@ -10,8 +10,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from . import HDFuryConfigEntry, HDFuryRuntimeData
 from .const import DOMAIN
-from .coordinator import HDFuryConfigEntry, HDFuryRuntimeData
 from .entity import HDFuryEntity
 
 PARALLEL_UPDATES = 1

--- a/homeassistant/components/hdfury/select.py
+++ b/homeassistant/components/hdfury/select.py
@@ -11,7 +11,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
-from .coordinator import HDFuryConfigEntry, HDFuryCoordinator
+from .coordinator import HDFuryConfigEntry, HDFuryInfoCoordinator, HDFuryRuntimeData
 from .entity import HDFuryEntity
 
 PARALLEL_UPDATES = 1
@@ -21,7 +21,7 @@ PARALLEL_UPDATES = 1
 class HDFurySelectEntityDescription(SelectEntityDescription):
     """Description for HDFury select entities."""
 
-    set_value_fn: Callable[[HDFuryCoordinator, str], Awaitable[None]]
+    set_value_fn: Callable[[HDFuryRuntimeData, str], Awaitable[None]]
 
 
 SELECT_PORTS: tuple[HDFurySelectEntityDescription, ...] = (
@@ -29,13 +29,13 @@ SELECT_PORTS: tuple[HDFurySelectEntityDescription, ...] = (
         key="portseltx0",
         translation_key="portseltx0",
         options=list(TX0_INPUT_PORTS.keys()),
-        set_value_fn=lambda coordinator, value: _set_ports(coordinator),
+        set_value_fn=lambda runtime_data, value: _set_ports(runtime_data),
     ),
     HDFurySelectEntityDescription(
         key="portseltx1",
         translation_key="portseltx1",
         options=list(TX1_INPUT_PORTS.keys()),
-        set_value_fn=lambda coordinator, value: _set_ports(coordinator),
+        set_value_fn=lambda runtime_data, value: _set_ports(runtime_data),
     ),
 )
 
@@ -44,15 +44,16 @@ SELECT_OPERATION_MODE: HDFurySelectEntityDescription = HDFurySelectEntityDescrip
     key="opmode",
     translation_key="opmode",
     options=list(OPERATION_MODES.keys()),
-    set_value_fn=lambda coordinator, value: coordinator.client.set_operation_mode(
+    set_value_fn=lambda runtime_data, value: runtime_data.client.set_operation_mode(
         value
     ),
 )
 
 
-async def _set_ports(coordinator: HDFuryCoordinator) -> None:
-    tx0 = coordinator.data.info.get("portseltx0")
-    tx1 = coordinator.data.info.get("portseltx1")
+async def _set_ports(runtime_data: HDFuryRuntimeData) -> None:
+    info = runtime_data.info_coordinator.data
+    tx0 = info.get("portseltx0")
+    tx1 = info.get("portseltx1")
 
     if tx0 is None or tx1 is None:
         raise HomeAssistantError(
@@ -61,7 +62,7 @@ async def _set_ports(coordinator: HDFuryCoordinator) -> None:
             translation_placeholders={"details": f"tx0={tx0}, tx1={tx1}"},
         )
 
-    await coordinator.client.set_port_selection(tx0, tx1)
+    await runtime_data.client.set_port_selection(tx0, tx1)
 
 
 async def async_setup_entry(
@@ -71,17 +72,17 @@ async def async_setup_entry(
 ) -> None:
     """Set up selects using the platform schema."""
 
-    coordinator = entry.runtime_data
+    runtime_data = entry.runtime_data
+    coordinator = runtime_data.info_coordinator
 
     entities: list[HDFuryEntity] = [
-        HDFurySelect(coordinator, description)
+        HDFurySelect(coordinator, runtime_data, description)
         for description in SELECT_PORTS
-        if description.key in coordinator.data.info
+        if description.key in coordinator.data
     ]
 
-    # Add OPMODE select if present
-    if "opmode" in coordinator.data.info:
-        entities.append(HDFurySelect(coordinator, SELECT_OPERATION_MODE))
+    if "opmode" in coordinator.data:
+        entities.append(HDFurySelect(coordinator, runtime_data, SELECT_OPERATION_MODE))
 
     async_add_entities(entities)
 
@@ -90,27 +91,37 @@ class HDFurySelect(HDFuryEntity, SelectEntity):
     """HDFury Select Class."""
 
     entity_description: HDFurySelectEntityDescription
+    _runtime_data: HDFuryRuntimeData
+
+    def __init__(
+        self,
+        coordinator: HDFuryInfoCoordinator,
+        runtime_data: HDFuryRuntimeData,
+        entity_description: HDFurySelectEntityDescription,
+    ) -> None:
+        """Initialize the select entity."""
+        super().__init__(coordinator, runtime_data, entity_description)
+        self._runtime_data = runtime_data
 
     @property
     def current_option(self) -> str:
         """Return the current option."""
 
-        return self.coordinator.data.info[self.entity_description.key]
+        return self.coordinator.data[self.entity_description.key]
 
     async def async_select_option(self, option: str) -> None:
         """Update the current option."""
 
-        # Update local data first
-        self.coordinator.data.info[self.entity_description.key] = option
+        previous = self.coordinator.data[self.entity_description.key]
+        self.coordinator.data[self.entity_description.key] = option
 
-        # Send command to device
         try:
-            await self.entity_description.set_value_fn(self.coordinator, option)
+            await self.entity_description.set_value_fn(self._runtime_data, option)
         except HDFuryError as error:
+            self.coordinator.data[self.entity_description.key] = previous
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="communication_error",
             ) from error
 
-        # Trigger HA coordinator refresh
-        await self.coordinator.async_request_refresh()
+        self.coordinator.async_set_updated_data(self.coordinator.data)

--- a/homeassistant/components/hdfury/select.py
+++ b/homeassistant/components/hdfury/select.py
@@ -11,7 +11,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
-from .coordinator import HDFuryConfigEntry, HDFuryInfoCoordinator, HDFuryRuntimeData
+from .coordinator import HDFuryConfigEntry, HDFuryRuntimeData
 from .entity import HDFuryEntity
 
 PARALLEL_UPDATES = 1
@@ -29,17 +29,13 @@ SELECT_PORTS: tuple[HDFurySelectEntityDescription, ...] = (
         key="portseltx0",
         translation_key="portseltx0",
         options=list(TX0_INPUT_PORTS.keys()),
-        set_value_fn=lambda runtime_data, value: _set_ports(
-            runtime_data, "portseltx0", value
-        ),
+        set_value_fn=lambda runtime_data, value: _set_ports(runtime_data),
     ),
     HDFurySelectEntityDescription(
         key="portseltx1",
         translation_key="portseltx1",
         options=list(TX1_INPUT_PORTS.keys()),
-        set_value_fn=lambda runtime_data, value: _set_ports(
-            runtime_data, "portseltx1", value
-        ),
+        set_value_fn=lambda runtime_data, value: _set_ports(runtime_data),
     ),
 )
 
@@ -54,12 +50,10 @@ SELECT_OPERATION_MODE: HDFurySelectEntityDescription = HDFurySelectEntityDescrip
 )
 
 
-async def _set_ports(
-    runtime_data: HDFuryRuntimeData, changed_key: str, new_value: str
-) -> None:
+async def _set_ports(runtime_data: HDFuryRuntimeData) -> None:
     info = runtime_data.info_coordinator.data
-    tx0 = new_value if changed_key == "portseltx0" else info.get("portseltx0")
-    tx1 = new_value if changed_key == "portseltx1" else info.get("portseltx1")
+    tx0 = info.get("portseltx0")
+    tx1 = info.get("portseltx1")
 
     if tx0 is None or tx1 is None:
         raise HomeAssistantError(
@@ -97,17 +91,6 @@ class HDFurySelect(HDFuryEntity, SelectEntity):
     """HDFury Select Class."""
 
     entity_description: HDFurySelectEntityDescription
-    _runtime_data: HDFuryRuntimeData
-
-    def __init__(
-        self,
-        coordinator: HDFuryInfoCoordinator,
-        runtime_data: HDFuryRuntimeData,
-        entity_description: HDFurySelectEntityDescription,
-    ) -> None:
-        """Initialize the select entity."""
-        super().__init__(coordinator, runtime_data, entity_description)
-        self._runtime_data = runtime_data
 
     @property
     def current_option(self) -> str:
@@ -118,12 +101,16 @@ class HDFurySelect(HDFuryEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Update the current option."""
 
+        previous = self.coordinator.data[self.entity_description.key]
+        self.coordinator.data[self.entity_description.key] = option
+
         try:
-            await self.entity_description.set_value_fn(self._runtime_data, option)
+            await self.entity_description.set_value_fn(self.runtime_data, option)
         except HDFuryError as error:
+            self.coordinator.data[self.entity_description.key] = previous
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="communication_error",
             ) from error
 
-        await self.coordinator.async_request_refresh()
+        self.coordinator.async_set_updated_data(self.coordinator.data)

--- a/homeassistant/components/hdfury/select.py
+++ b/homeassistant/components/hdfury/select.py
@@ -29,13 +29,17 @@ SELECT_PORTS: tuple[HDFurySelectEntityDescription, ...] = (
         key="portseltx0",
         translation_key="portseltx0",
         options=list(TX0_INPUT_PORTS.keys()),
-        set_value_fn=lambda runtime_data, value: _set_ports(runtime_data),
+        set_value_fn=lambda runtime_data, value: _set_ports(
+            runtime_data, "portseltx0", value
+        ),
     ),
     HDFurySelectEntityDescription(
         key="portseltx1",
         translation_key="portseltx1",
         options=list(TX1_INPUT_PORTS.keys()),
-        set_value_fn=lambda runtime_data, value: _set_ports(runtime_data),
+        set_value_fn=lambda runtime_data, value: _set_ports(
+            runtime_data, "portseltx1", value
+        ),
     ),
 )
 
@@ -50,10 +54,12 @@ SELECT_OPERATION_MODE: HDFurySelectEntityDescription = HDFurySelectEntityDescrip
 )
 
 
-async def _set_ports(runtime_data: HDFuryRuntimeData) -> None:
+async def _set_ports(
+    runtime_data: HDFuryRuntimeData, changed_key: str, new_value: str
+) -> None:
     info = runtime_data.info_coordinator.data
-    tx0 = info.get("portseltx0")
-    tx1 = info.get("portseltx1")
+    tx0 = new_value if changed_key == "portseltx0" else info.get("portseltx0")
+    tx1 = new_value if changed_key == "portseltx1" else info.get("portseltx1")
 
     if tx0 is None or tx1 is None:
         raise HomeAssistantError(
@@ -112,16 +118,12 @@ class HDFurySelect(HDFuryEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Update the current option."""
 
-        previous = self.coordinator.data[self.entity_description.key]
-        self.coordinator.data[self.entity_description.key] = option
-
         try:
             await self.entity_description.set_value_fn(self._runtime_data, option)
         except HDFuryError as error:
-            self.coordinator.data[self.entity_description.key] = previous
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="communication_error",
             ) from error
 
-        self.coordinator.async_set_updated_data(self.coordinator.data)
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/hdfury/sensor.py
+++ b/homeassistant/components/hdfury/sensor.py
@@ -5,7 +5,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .coordinator import HDFuryConfigEntry
+from . import HDFuryConfigEntry
 from .entity import HDFuryEntity
 
 PARALLEL_UPDATES = 0

--- a/homeassistant/components/hdfury/sensor.py
+++ b/homeassistant/components/hdfury/sensor.py
@@ -102,11 +102,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up sensors using the platform schema."""
 
-    runtime_data = entry.runtime_data
-    coordinator = runtime_data.info_coordinator
+    coordinator = entry.runtime_data.info_coordinator
 
     async_add_entities(
-        HDFurySensor(coordinator, runtime_data, description)
+        HDFurySensor(coordinator, description)
         for description in SENSORS
         if description.key in coordinator.data
     )

--- a/homeassistant/components/hdfury/sensor.py
+++ b/homeassistant/components/hdfury/sensor.py
@@ -102,12 +102,13 @@ async def async_setup_entry(
 ) -> None:
     """Set up sensors using the platform schema."""
 
-    coordinator = entry.runtime_data
+    runtime_data = entry.runtime_data
+    coordinator = runtime_data.info_coordinator
 
     async_add_entities(
-        HDFurySensor(coordinator, description)
+        HDFurySensor(coordinator, runtime_data, description)
         for description in SENSORS
-        if description.key in coordinator.data.info
+        if description.key in coordinator.data
     )
 
 
@@ -120,4 +121,4 @@ class HDFurySensor(HDFuryEntity, SensorEntity):
     def native_value(self) -> str:
         """Set Sensor Value."""
 
-        return self.coordinator.data.info[self.entity_description.key]
+        return self.coordinator.data[self.entity_description.key]

--- a/homeassistant/components/hdfury/switch.py
+++ b/homeassistant/components/hdfury/switch.py
@@ -183,8 +183,7 @@ class HDFurySwitch(HDFuryEntity, SwitchEntity):
                 translation_key="communication_error",
             ) from error
 
-        self.coordinator.data[self.entity_description.key] = "1"
-        self.coordinator.async_set_updated_data(self.coordinator.data)
+        await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Handle Switch Off Event."""
@@ -197,5 +196,4 @@ class HDFurySwitch(HDFuryEntity, SwitchEntity):
                 translation_key="communication_error",
             ) from error
 
-        self.coordinator.data[self.entity_description.key] = "0"
-        self.coordinator.async_set_updated_data(self.coordinator.data)
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/hdfury/switch.py
+++ b/homeassistant/components/hdfury/switch.py
@@ -13,7 +13,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
-from .coordinator import HDFuryConfigCoordinator, HDFuryConfigEntry, HDFuryRuntimeData
+from .coordinator import HDFuryConfigEntry
 from .entity import HDFuryEntity
 
 PARALLEL_UPDATES = 1
@@ -156,16 +156,6 @@ class HDFurySwitch(HDFuryEntity, SwitchEntity):
 
     entity_description: HDFurySwitchEntityDescription
 
-    def __init__(
-        self,
-        coordinator: HDFuryConfigCoordinator,
-        runtime_data: HDFuryRuntimeData,
-        entity_description: HDFurySwitchEntityDescription,
-    ) -> None:
-        """Initialize the switch entity."""
-        super().__init__(coordinator, runtime_data, entity_description)
-        self._client = runtime_data.client
-
     @property
     def is_on(self) -> bool:
         """Set Switch State."""
@@ -176,24 +166,26 @@ class HDFurySwitch(HDFuryEntity, SwitchEntity):
         """Handle Switch On Event."""
 
         try:
-            await self.entity_description.set_value_fn(self._client, "on")
+            await self.entity_description.set_value_fn(self.runtime_data.client, "on")
         except HDFuryError as error:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="communication_error",
             ) from error
 
-        await self.coordinator.async_request_refresh()
+        self.coordinator.data[self.entity_description.key] = "1"
+        self.coordinator.async_set_updated_data(self.coordinator.data)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Handle Switch Off Event."""
 
         try:
-            await self.entity_description.set_value_fn(self._client, "off")
+            await self.entity_description.set_value_fn(self.runtime_data.client, "off")
         except HDFuryError as error:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="communication_error",
             ) from error
 
-        await self.coordinator.async_request_refresh()
+        self.coordinator.data[self.entity_description.key] = "0"
+        self.coordinator.async_set_updated_data(self.coordinator.data)

--- a/homeassistant/components/hdfury/switch.py
+++ b/homeassistant/components/hdfury/switch.py
@@ -173,8 +173,7 @@ class HDFurySwitch(HDFuryEntity, SwitchEntity):
                 translation_key="communication_error",
             ) from error
 
-        self.coordinator.data[self.entity_description.key] = "1"
-        self.coordinator.async_set_updated_data(self.coordinator.data)
+        await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Handle Switch Off Event."""
@@ -187,5 +186,4 @@ class HDFurySwitch(HDFuryEntity, SwitchEntity):
                 translation_key="communication_error",
             ) from error
 
-        self.coordinator.data[self.entity_description.key] = "0"
-        self.coordinator.async_set_updated_data(self.coordinator.data)
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/hdfury/switch.py
+++ b/homeassistant/components/hdfury/switch.py
@@ -12,8 +12,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from . import HDFuryConfigEntry
 from .const import DOMAIN
-from .coordinator import HDFuryConfigEntry
 from .entity import HDFuryEntity
 
 PARALLEL_UPDATES = 1

--- a/homeassistant/components/hdfury/switch.py
+++ b/homeassistant/components/hdfury/switch.py
@@ -141,11 +141,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up switches using the platform schema."""
 
-    runtime_data = entry.runtime_data
-    coordinator = runtime_data.config_coordinator
+    coordinator = entry.runtime_data.config_coordinator
 
     async_add_entities(
-        HDFurySwitch(coordinator, runtime_data, description)
+        HDFurySwitch(coordinator, description)
         for description in SWITCHES
         if description.key in coordinator.data
     )
@@ -166,7 +165,7 @@ class HDFurySwitch(HDFuryEntity, SwitchEntity):
         """Handle Switch On Event."""
 
         try:
-            await self.entity_description.set_value_fn(self.runtime_data.client, "on")
+            await self.entity_description.set_value_fn(self.coordinator.client, "on")
         except HDFuryError as error:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
@@ -179,7 +178,7 @@ class HDFurySwitch(HDFuryEntity, SwitchEntity):
         """Handle Switch Off Event."""
 
         try:
-            await self.entity_description.set_value_fn(self.runtime_data.client, "off")
+            await self.entity_description.set_value_fn(self.coordinator.client, "off")
         except HDFuryError as error:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,

--- a/homeassistant/components/hdfury/switch.py
+++ b/homeassistant/components/hdfury/switch.py
@@ -13,7 +13,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
-from .coordinator import HDFuryConfigEntry
+from .coordinator import HDFuryConfigCoordinator, HDFuryConfigEntry, HDFuryRuntimeData
 from .entity import HDFuryEntity
 
 PARALLEL_UPDATES = 1
@@ -141,12 +141,13 @@ async def async_setup_entry(
 ) -> None:
     """Set up switches using the platform schema."""
 
-    coordinator = entry.runtime_data
+    runtime_data = entry.runtime_data
+    coordinator = runtime_data.config_coordinator
 
     async_add_entities(
-        HDFurySwitch(coordinator, description)
+        HDFurySwitch(coordinator, runtime_data, description)
         for description in SWITCHES
-        if description.key in coordinator.data.config
+        if description.key in coordinator.data
     )
 
 
@@ -155,34 +156,46 @@ class HDFurySwitch(HDFuryEntity, SwitchEntity):
 
     entity_description: HDFurySwitchEntityDescription
 
+    def __init__(
+        self,
+        coordinator: HDFuryConfigCoordinator,
+        runtime_data: HDFuryRuntimeData,
+        entity_description: HDFurySwitchEntityDescription,
+    ) -> None:
+        """Initialize the switch entity."""
+        super().__init__(coordinator, runtime_data, entity_description)
+        self._client = runtime_data.client
+
     @property
     def is_on(self) -> bool:
         """Set Switch State."""
 
-        return self.coordinator.data.config.get(self.entity_description.key) == "1"
+        return self.coordinator.data.get(self.entity_description.key) == "1"
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Handle Switch On Event."""
 
         try:
-            await self.entity_description.set_value_fn(self.coordinator.client, "on")
+            await self.entity_description.set_value_fn(self._client, "on")
         except HDFuryError as error:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="communication_error",
             ) from error
 
-        await self.coordinator.async_request_refresh()
+        self.coordinator.data[self.entity_description.key] = "1"
+        self.coordinator.async_set_updated_data(self.coordinator.data)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Handle Switch Off Event."""
 
         try:
-            await self.entity_description.set_value_fn(self.coordinator.client, "off")
+            await self.entity_description.set_value_fn(self._client, "off")
         except HDFuryError as error:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="communication_error",
             ) from error
 
-        await self.coordinator.async_request_refresh()
+        self.coordinator.data[self.entity_description.key] = "0"
+        self.coordinator.async_set_updated_data(self.coordinator.data)

--- a/tests/components/hdfury/conftest.py
+++ b/tests/components/hdfury/conftest.py
@@ -44,7 +44,7 @@ def mock_hdfury_client() -> Generator[AsyncMock]:
             autospec=True,
         ) as mock_cf_client,
         patch(
-            "homeassistant.components.hdfury.coordinator.HDFuryAPI",
+            "homeassistant.components.hdfury.HDFuryAPI",
             autospec=True,
         ) as mock_coord_client,
     ):

--- a/tests/components/hdfury/test_init.py
+++ b/tests/components/hdfury/test_init.py
@@ -1,0 +1,25 @@
+"""Tests for the HDFury integration init."""
+
+from unittest.mock import AsyncMock
+
+from hdfury import HDFuryError
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+
+
+async def test_setup_entry_board_fetch_failure(
+    hass: HomeAssistant,
+    mock_hdfury_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test setup retries when board data fetch fails."""
+    mock_hdfury_client.get_board.side_effect = HDFuryError()
+
+    await setup_integration(hass, mock_config_entry, [])
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/hdfury/test_number.py
+++ b/tests/components/hdfury/test_number.py
@@ -66,6 +66,9 @@ async def test_number_set_value(
 
     getattr(mock_hdfury_client, method).assert_awaited_once_with("50")
 
+    state = hass.states.get(entity_id)
+    assert state.state == "50.0"
+
 
 @pytest.mark.parametrize(
     ("entity_id", "method"),
@@ -123,7 +126,7 @@ async def test_number_entities_unavailable_on_error(
 
     await setup_integration(hass, mock_config_entry, [Platform.NUMBER])
 
-    mock_hdfury_client.get_info.side_effect = HDFuryError()
+    mock_hdfury_client.get_config.side_effect = HDFuryError()
 
     freezer.tick(timedelta(seconds=61))
     async_fire_time_changed(hass)

--- a/tests/components/hdfury/test_number.py
+++ b/tests/components/hdfury/test_number.py
@@ -66,9 +66,6 @@ async def test_number_set_value(
 
     getattr(mock_hdfury_client, method).assert_awaited_once_with("50")
 
-    state = hass.states.get(entity_id)
-    assert state.state == "50.0"
-
 
 @pytest.mark.parametrize(
     ("entity_id", "method"),

--- a/tests/components/hdfury/test_select.py
+++ b/tests/components/hdfury/test_select.py
@@ -57,10 +57,10 @@ async def test_select_operation_mode(
 
 
 @pytest.mark.parametrize(
-    ("entity_id", "expected_tx0", "expected_tx1"),
+    ("entity_id"),
     [
-        ("select.hdfury_vrroom_02_port_select_tx0", "1", "4"),
-        ("select.hdfury_vrroom_02_port_select_tx1", "0", "1"),
+        ("select.hdfury_vrroom_02_port_select_tx0"),
+        ("select.hdfury_vrroom_02_port_select_tx1"),
     ],
 )
 async def test_select_tx_ports(
@@ -68,8 +68,6 @@ async def test_select_tx_ports(
     mock_hdfury_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
     entity_id: str,
-    expected_tx0: str,
-    expected_tx1: str,
 ) -> None:
     """Test selecting TX ports."""
 
@@ -85,9 +83,7 @@ async def test_select_tx_ports(
         blocking=True,
     )
 
-    mock_hdfury_client.set_port_selection.assert_awaited_once_with(
-        expected_tx0, expected_tx1
-    )
+    mock_hdfury_client.set_port_selection.assert_awaited()
 
 
 async def test_select_operation_mode_error(

--- a/tests/components/hdfury/test_select.py
+++ b/tests/components/hdfury/test_select.py
@@ -55,15 +55,12 @@ async def test_select_operation_mode(
 
     mock_hdfury_client.set_operation_mode.assert_awaited_once_with("1")
 
-    state = hass.states.get("select.hdfury_vrroom_02_operation_mode")
-    assert state.state == "1"
-
 
 @pytest.mark.parametrize(
-    ("entity_id"),
+    ("entity_id", "expected_tx0", "expected_tx1"),
     [
-        ("select.hdfury_vrroom_02_port_select_tx0"),
-        ("select.hdfury_vrroom_02_port_select_tx1"),
+        ("select.hdfury_vrroom_02_port_select_tx0", "1", "4"),
+        ("select.hdfury_vrroom_02_port_select_tx1", "0", "1"),
     ],
 )
 async def test_select_tx_ports(
@@ -71,6 +68,8 @@ async def test_select_tx_ports(
     mock_hdfury_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
     entity_id: str,
+    expected_tx0: str,
+    expected_tx1: str,
 ) -> None:
     """Test selecting TX ports."""
 
@@ -86,10 +85,9 @@ async def test_select_tx_ports(
         blocking=True,
     )
 
-    mock_hdfury_client.set_port_selection.assert_awaited()
-
-    state = hass.states.get(entity_id)
-    assert state.state == "1"
+    mock_hdfury_client.set_port_selection.assert_awaited_once_with(
+        expected_tx0, expected_tx1
+    )
 
 
 async def test_select_operation_mode_error(

--- a/tests/components/hdfury/test_select.py
+++ b/tests/components/hdfury/test_select.py
@@ -55,6 +55,9 @@ async def test_select_operation_mode(
 
     mock_hdfury_client.set_operation_mode.assert_awaited_once_with("1")
 
+    state = hass.states.get("select.hdfury_vrroom_02_operation_mode")
+    assert state.state == "1"
+
 
 @pytest.mark.parametrize(
     ("entity_id"),
@@ -84,6 +87,9 @@ async def test_select_tx_ports(
     )
 
     mock_hdfury_client.set_port_selection.assert_awaited()
+
+    state = hass.states.get(entity_id)
+    assert state.state == "1"
 
 
 async def test_select_operation_mode_error(

--- a/tests/components/hdfury/test_switch.py
+++ b/tests/components/hdfury/test_switch.py
@@ -39,26 +39,48 @@ async def test_switch_entities(
 
 
 @pytest.mark.parametrize(
-    ("entity_id", "method", "service"),
+    ("entity_id", "method", "service", "expected_state"),
     [
-        ("switch.hdfury_vrroom_02_cec", "set_cec", SERVICE_TURN_ON),
-        ("switch.hdfury_vrroom_02_cec", "set_cec", SERVICE_TURN_OFF),
+        ("switch.hdfury_vrroom_02_cec", "set_cec", SERVICE_TURN_ON, "on"),
+        ("switch.hdfury_vrroom_02_cec", "set_cec", SERVICE_TURN_OFF, "off"),
         (
             "switch.hdfury_vrroom_02_auto_switch_inputs",
             "set_auto_switch_inputs",
             SERVICE_TURN_ON,
+            "on",
         ),
         (
             "switch.hdfury_vrroom_02_auto_switch_inputs",
             "set_auto_switch_inputs",
             SERVICE_TURN_OFF,
+            "off",
         ),
-        ("switch.hdfury_vrroom_02_oled_display", "set_oled", SERVICE_TURN_ON),
-        ("switch.hdfury_vrroom_02_oled_display", "set_oled", SERVICE_TURN_OFF),
-        ("switch.hdfury_vrroom_02_tx0_force_5v", "set_tx0_force_5v", SERVICE_TURN_ON),
-        ("switch.hdfury_vrroom_02_tx0_force_5v", "set_tx0_force_5v", SERVICE_TURN_OFF),
-        ("switch.hdfury_vrroom_02_tx1_force_5v", "set_tx1_force_5v", SERVICE_TURN_ON),
-        ("switch.hdfury_vrroom_02_tx1_force_5v", "set_tx1_force_5v", SERVICE_TURN_OFF),
+        ("switch.hdfury_vrroom_02_oled_display", "set_oled", SERVICE_TURN_ON, "on"),
+        ("switch.hdfury_vrroom_02_oled_display", "set_oled", SERVICE_TURN_OFF, "off"),
+        (
+            "switch.hdfury_vrroom_02_tx0_force_5v",
+            "set_tx0_force_5v",
+            SERVICE_TURN_ON,
+            "on",
+        ),
+        (
+            "switch.hdfury_vrroom_02_tx0_force_5v",
+            "set_tx0_force_5v",
+            SERVICE_TURN_OFF,
+            "off",
+        ),
+        (
+            "switch.hdfury_vrroom_02_tx1_force_5v",
+            "set_tx1_force_5v",
+            SERVICE_TURN_ON,
+            "on",
+        ),
+        (
+            "switch.hdfury_vrroom_02_tx1_force_5v",
+            "set_tx1_force_5v",
+            SERVICE_TURN_OFF,
+            "off",
+        ),
     ],
 )
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -69,6 +91,7 @@ async def test_switch_turn_on_off(
     entity_id: str,
     method: str,
     service: str,
+    expected_state: str,
 ) -> None:
     """Test turning device switches on and off."""
 
@@ -82,6 +105,9 @@ async def test_switch_turn_on_off(
     )
 
     getattr(mock_hdfury_client, method).assert_awaited_once()
+
+    state = hass.states.get(entity_id)
+    assert state.state == expected_state
 
 
 @pytest.mark.parametrize(
@@ -126,7 +152,7 @@ async def test_switch_entities_unavailable_on_error(
 
     await setup_integration(hass, mock_config_entry, [Platform.SWITCH])
 
-    mock_hdfury_client.get_info.side_effect = HDFuryError()
+    mock_hdfury_client.get_config.side_effect = HDFuryError()
 
     freezer.tick(timedelta(seconds=61))
     async_fire_time_changed(hass)

--- a/tests/components/hdfury/test_switch.py
+++ b/tests/components/hdfury/test_switch.py
@@ -39,48 +39,26 @@ async def test_switch_entities(
 
 
 @pytest.mark.parametrize(
-    ("entity_id", "method", "service", "expected_state"),
+    ("entity_id", "method", "service"),
     [
-        ("switch.hdfury_vrroom_02_cec", "set_cec", SERVICE_TURN_ON, "on"),
-        ("switch.hdfury_vrroom_02_cec", "set_cec", SERVICE_TURN_OFF, "off"),
+        ("switch.hdfury_vrroom_02_cec", "set_cec", SERVICE_TURN_ON),
+        ("switch.hdfury_vrroom_02_cec", "set_cec", SERVICE_TURN_OFF),
         (
             "switch.hdfury_vrroom_02_auto_switch_inputs",
             "set_auto_switch_inputs",
             SERVICE_TURN_ON,
-            "on",
         ),
         (
             "switch.hdfury_vrroom_02_auto_switch_inputs",
             "set_auto_switch_inputs",
             SERVICE_TURN_OFF,
-            "off",
         ),
-        ("switch.hdfury_vrroom_02_oled_display", "set_oled", SERVICE_TURN_ON, "on"),
-        ("switch.hdfury_vrroom_02_oled_display", "set_oled", SERVICE_TURN_OFF, "off"),
-        (
-            "switch.hdfury_vrroom_02_tx0_force_5v",
-            "set_tx0_force_5v",
-            SERVICE_TURN_ON,
-            "on",
-        ),
-        (
-            "switch.hdfury_vrroom_02_tx0_force_5v",
-            "set_tx0_force_5v",
-            SERVICE_TURN_OFF,
-            "off",
-        ),
-        (
-            "switch.hdfury_vrroom_02_tx1_force_5v",
-            "set_tx1_force_5v",
-            SERVICE_TURN_ON,
-            "on",
-        ),
-        (
-            "switch.hdfury_vrroom_02_tx1_force_5v",
-            "set_tx1_force_5v",
-            SERVICE_TURN_OFF,
-            "off",
-        ),
+        ("switch.hdfury_vrroom_02_oled_display", "set_oled", SERVICE_TURN_ON),
+        ("switch.hdfury_vrroom_02_oled_display", "set_oled", SERVICE_TURN_OFF),
+        ("switch.hdfury_vrroom_02_tx0_force_5v", "set_tx0_force_5v", SERVICE_TURN_ON),
+        ("switch.hdfury_vrroom_02_tx0_force_5v", "set_tx0_force_5v", SERVICE_TURN_OFF),
+        ("switch.hdfury_vrroom_02_tx1_force_5v", "set_tx1_force_5v", SERVICE_TURN_ON),
+        ("switch.hdfury_vrroom_02_tx1_force_5v", "set_tx1_force_5v", SERVICE_TURN_OFF),
     ],
 )
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -91,7 +69,6 @@ async def test_switch_turn_on_off(
     entity_id: str,
     method: str,
     service: str,
-    expected_state: str,
 ) -> None:
     """Test turning device switches on and off."""
 
@@ -105,9 +82,6 @@ async def test_switch_turn_on_off(
     )
 
     getattr(mock_hdfury_client, method).assert_awaited_once()
-
-    state = hass.states.get(entity_id)
-    assert state.state == expected_state
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change

Split the single `HDFuryCoordinator` into two specialized coordinators to reduce the number of HTTP requests per polling cycle and prevent overwhelming the device's embedded web server.

**Architecture changes:**

- **`HDFuryInfoCoordinator`** — polls device info (signal routing, port selections) used by sensors and selects. Makes 1 HTTP request per cycle.
- **`HDFuryConfigCoordinator`** — polls device config (switch states, number values) used by switches and numbers. Makes 2 HTTP requests per cycle (config + CEC pages).
- **Board data** — fetched once at setup since it rarely changes (firmware version, serial, hostname). Raises `ConfigEntryNotReady` on failure.
- **`HDFuryRuntimeData`** — new dataclass storing the shared client, board data, and both coordinators as `entry.runtime_data`.
- **Entity base** — updated to accept `runtime_data` for device info construction while entities subscribe to updates from their specific coordinator.

Previously the single coordinator made 4 sequential HTTP requests every 60 seconds (`get_board` + `get_info` + `get_config` which fetches 2 pages). Now each coordinator only fetches what its entities need, and board data isn't polled at all after setup.

A complementary fix to add global request debouncing in the underlying library has been submitted at glenndehaan/python-hdfury#4.

## Type of change

- Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR is related to issue: N/A
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [x] I have followed the [perfect PR recommendations](https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr)
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests](https://github.com/home-assistant/core/pulls) in this repository.
