### PR TITLE
Expose Assist VAD timing settings

### DIFF
--- a/homeassistant/components/assist_pipeline/__init__.py
+++ b/homeassistant/components/assist_pipeline/__init__.py
@@ -23,6 +23,7 @@ from .const import (
     SAMPLES_PER_CHUNK,
 )
 from .error import PipelineNotFound
+from .number import VadSilenceSecondsNumber, VadTimeoutSecondsNumber
 from .pipeline import (
     AudioSettings,
     Pipeline,
@@ -39,7 +40,6 @@ from .pipeline import (
     async_setup_pipeline_store,
     async_update_pipeline,
 )
-from .number import VadSilenceSecondsNumber, VadTimeoutSecondsNumber
 from .select import AssistPipelineSelect, VadSensitivitySelect
 from .vad import VadSensitivity
 from .websocket_api import async_register_websocket_api
@@ -58,9 +58,9 @@ __all__ = (
     "PipelineEvent",
     "PipelineEventType",
     "PipelineNotFound",
-    "VadSilenceSecondsNumber",
     "VadSensitivity",
     "VadSensitivitySelect",
+    "VadSilenceSecondsNumber",
     "VadTimeoutSecondsNumber",
     "WakeWordSettings",
     "async_create_default_pipeline",

--- a/homeassistant/components/assist_pipeline/__init__.py
+++ b/homeassistant/components/assist_pipeline/__init__.py
@@ -39,6 +39,7 @@ from .pipeline import (
     async_setup_pipeline_store,
     async_update_pipeline,
 )
+from .number import VadSilenceSecondsNumber, VadTimeoutSecondsNumber
 from .select import AssistPipelineSelect, VadSensitivitySelect
 from .vad import VadSensitivity
 from .websocket_api import async_register_websocket_api
@@ -57,8 +58,10 @@ __all__ = (
     "PipelineEvent",
     "PipelineEventType",
     "PipelineNotFound",
+    "VadSilenceSecondsNumber",
     "VadSensitivity",
     "VadSensitivitySelect",
+    "VadTimeoutSecondsNumber",
     "WakeWordSettings",
     "async_create_default_pipeline",
     "async_get_pipelines",

--- a/homeassistant/components/assist_pipeline/number.py
+++ b/homeassistant/components/assist_pipeline/number.py
@@ -1,0 +1,98 @@
+"""Number entities for assist pipeline settings."""
+
+from typing import Final
+
+from homeassistant.components.number import (
+    NumberEntityDescription,
+    NumberMode,
+    RestoreNumber,
+)
+from homeassistant.const import EntityCategory, UnitOfTime
+from homeassistant.core import HomeAssistant
+
+from .vad import DEFAULT_VAD_SILENCE_SECONDS, DEFAULT_VAD_TIMEOUT_SECONDS
+
+MIN_VAD_SILENCE_SECONDS: Final = 0.1
+MAX_VAD_SILENCE_SECONDS: Final = 5.0
+MIN_VAD_TIMEOUT_SECONDS: Final = 1.0
+MAX_VAD_TIMEOUT_SECONDS: Final = 120.0
+
+
+class VadSilenceSecondsNumber(RestoreNumber):
+    """Entity to represent VAD end-of-speech silence seconds."""
+
+    entity_description = NumberEntityDescription(
+        key="vad_silence_seconds",
+        translation_key="vad_silence_seconds",
+        entity_category=EntityCategory.CONFIG,
+    )
+    _attr_should_poll = False
+    _attr_native_min_value = MIN_VAD_SILENCE_SECONDS
+    _attr_native_max_value = MAX_VAD_SILENCE_SECONDS
+    _attr_native_step = 0.1
+    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
+    _attr_mode = NumberMode.BOX
+    _attr_native_value = DEFAULT_VAD_SILENCE_SECONDS
+
+    def __init__(self, hass: HomeAssistant, unique_id_prefix: str) -> None:
+        """Initialize a VAD silence seconds number."""
+        self._attr_unique_id = f"{unique_id_prefix}-vad_silence_seconds"
+        self.hass = hass
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to Home Assistant."""
+        await super().async_added_to_hass()
+        await self._async_restore_native_value()
+
+    async def _async_restore_native_value(self) -> None:
+        """Restore the last native value."""
+        last_number_data = await self.async_get_last_number_data()
+        if last_number_data is not None and last_number_data.native_value is not None:
+            await self.async_set_native_value(last_number_data.native_value)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set new value."""
+        self._attr_native_value = float(
+            max(MIN_VAD_SILENCE_SECONDS, min(MAX_VAD_SILENCE_SECONDS, value))
+        )
+        self.async_write_ha_state()
+
+
+class VadTimeoutSecondsNumber(RestoreNumber):
+    """Entity to represent VAD command timeout seconds."""
+
+    entity_description = NumberEntityDescription(
+        key="vad_timeout_seconds",
+        translation_key="vad_timeout_seconds",
+        entity_category=EntityCategory.CONFIG,
+    )
+    _attr_should_poll = False
+    _attr_native_min_value = MIN_VAD_TIMEOUT_SECONDS
+    _attr_native_max_value = MAX_VAD_TIMEOUT_SECONDS
+    _attr_native_step = 1.0
+    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
+    _attr_mode = NumberMode.BOX
+    _attr_native_value = DEFAULT_VAD_TIMEOUT_SECONDS
+
+    def __init__(self, hass: HomeAssistant, unique_id_prefix: str) -> None:
+        """Initialize a VAD timeout seconds number."""
+        self._attr_unique_id = f"{unique_id_prefix}-vad_timeout_seconds"
+        self.hass = hass
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to Home Assistant."""
+        await super().async_added_to_hass()
+        await self._async_restore_native_value()
+
+    async def _async_restore_native_value(self) -> None:
+        """Restore the last native value."""
+        last_number_data = await self.async_get_last_number_data()
+        if last_number_data is not None and last_number_data.native_value is not None:
+            await self.async_set_native_value(last_number_data.native_value)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set new value."""
+        self._attr_native_value = float(
+            max(MIN_VAD_TIMEOUT_SECONDS, min(MAX_VAD_TIMEOUT_SECONDS, value))
+        )
+        self.async_write_ha_state()

--- a/homeassistant/components/assist_pipeline/number.py
+++ b/homeassistant/components/assist_pipeline/number.py
@@ -18,7 +18,37 @@ MIN_VAD_TIMEOUT_SECONDS: Final = 1.0
 MAX_VAD_TIMEOUT_SECONDS: Final = 120.0
 
 
-class VadSilenceSecondsNumber(RestoreNumber):
+class _VadTimingNumber(RestoreNumber):
+    """Base entity for VAD timing settings."""
+
+    _attr_native_max_value: float
+    _attr_native_min_value: float
+    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
+    _attr_should_poll = False
+    _attr_mode = NumberMode.BOX
+
+    def __init__(self, hass: HomeAssistant, unique_id_prefix: str) -> None:
+        """Initialize a VAD timing number."""
+        self._attr_unique_id = f"{unique_id_prefix}-{self.entity_description.key}"
+        self.hass = hass
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to Home Assistant."""
+        await super().async_added_to_hass()
+
+        last_number_data = await self.async_get_last_number_data()
+        if last_number_data is not None and last_number_data.native_value is not None:
+            await self.async_set_native_value(last_number_data.native_value)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set new value."""
+        self._attr_native_value = float(
+            max(self._attr_native_min_value, min(self._attr_native_max_value, value))
+        )
+        self.async_write_ha_state()
+
+
+class VadSilenceSecondsNumber(_VadTimingNumber):
     """Entity to represent VAD end-of-speech silence seconds."""
 
     entity_description = NumberEntityDescription(
@@ -26,39 +56,13 @@ class VadSilenceSecondsNumber(RestoreNumber):
         translation_key="vad_silence_seconds",
         entity_category=EntityCategory.CONFIG,
     )
-    _attr_should_poll = False
     _attr_native_min_value = MIN_VAD_SILENCE_SECONDS
     _attr_native_max_value = MAX_VAD_SILENCE_SECONDS
     _attr_native_step = 0.1
-    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
-    _attr_mode = NumberMode.BOX
     _attr_native_value = DEFAULT_VAD_SILENCE_SECONDS
 
-    def __init__(self, hass: HomeAssistant, unique_id_prefix: str) -> None:
-        """Initialize a VAD silence seconds number."""
-        self._attr_unique_id = f"{unique_id_prefix}-vad_silence_seconds"
-        self.hass = hass
 
-    async def async_added_to_hass(self) -> None:
-        """When entity is added to Home Assistant."""
-        await super().async_added_to_hass()
-        await self._async_restore_native_value()
-
-    async def _async_restore_native_value(self) -> None:
-        """Restore the last native value."""
-        last_number_data = await self.async_get_last_number_data()
-        if last_number_data is not None and last_number_data.native_value is not None:
-            await self.async_set_native_value(last_number_data.native_value)
-
-    async def async_set_native_value(self, value: float) -> None:
-        """Set new value."""
-        self._attr_native_value = float(
-            max(MIN_VAD_SILENCE_SECONDS, min(MAX_VAD_SILENCE_SECONDS, value))
-        )
-        self.async_write_ha_state()
-
-
-class VadTimeoutSecondsNumber(RestoreNumber):
+class VadTimeoutSecondsNumber(_VadTimingNumber):
     """Entity to represent VAD command timeout seconds."""
 
     entity_description = NumberEntityDescription(
@@ -66,33 +70,7 @@ class VadTimeoutSecondsNumber(RestoreNumber):
         translation_key="vad_timeout_seconds",
         entity_category=EntityCategory.CONFIG,
     )
-    _attr_should_poll = False
     _attr_native_min_value = MIN_VAD_TIMEOUT_SECONDS
     _attr_native_max_value = MAX_VAD_TIMEOUT_SECONDS
     _attr_native_step = 1.0
-    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
-    _attr_mode = NumberMode.BOX
     _attr_native_value = DEFAULT_VAD_TIMEOUT_SECONDS
-
-    def __init__(self, hass: HomeAssistant, unique_id_prefix: str) -> None:
-        """Initialize a VAD timeout seconds number."""
-        self._attr_unique_id = f"{unique_id_prefix}-vad_timeout_seconds"
-        self.hass = hass
-
-    async def async_added_to_hass(self) -> None:
-        """When entity is added to Home Assistant."""
-        await super().async_added_to_hass()
-        await self._async_restore_native_value()
-
-    async def _async_restore_native_value(self) -> None:
-        """Restore the last native value."""
-        last_number_data = await self.async_get_last_number_data()
-        if last_number_data is not None and last_number_data.native_value is not None:
-            await self.async_set_native_value(last_number_data.native_value)
-
-    async def async_set_native_value(self, value: float) -> None:
-        """Set new value."""
-        self._attr_native_value = float(
-            max(MIN_VAD_TIMEOUT_SECONDS, min(MAX_VAD_TIMEOUT_SECONDS, value))
-        )
-        self.async_write_ha_state()

--- a/homeassistant/components/assist_pipeline/number.py
+++ b/homeassistant/components/assist_pipeline/number.py
@@ -1,7 +1,5 @@
 """Number entities for assist pipeline settings."""
 
-from typing import Final
-
 from homeassistant.components.number import (
     NumberEntityDescription,
     NumberMode,
@@ -10,12 +8,14 @@ from homeassistant.components.number import (
 from homeassistant.const import EntityCategory, UnitOfTime
 from homeassistant.core import HomeAssistant
 
-from .vad import DEFAULT_VAD_SILENCE_SECONDS, DEFAULT_VAD_TIMEOUT_SECONDS
-
-MIN_VAD_SILENCE_SECONDS: Final = 0.1
-MAX_VAD_SILENCE_SECONDS: Final = 5.0
-MIN_VAD_TIMEOUT_SECONDS: Final = 1.0
-MAX_VAD_TIMEOUT_SECONDS: Final = 120.0
+from .vad import (
+    DEFAULT_VAD_SILENCE_SECONDS,
+    DEFAULT_VAD_TIMEOUT_SECONDS,
+    MAX_VAD_SILENCE_SECONDS,
+    MAX_VAD_TIMEOUT_SECONDS,
+    MIN_VAD_SILENCE_SECONDS,
+    MIN_VAD_TIMEOUT_SECONDS,
+)
 
 
 class _VadTimingNumber(RestoreNumber):

--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -81,7 +81,14 @@ from .error import (
     WakeWordDetectionError,
     WakeWordTimeoutError,
 )
-from .vad import AudioBuffer, VoiceActivityTimeout, VoiceCommandSegmenter, chunk_samples
+from .vad import (
+    DEFAULT_VAD_SILENCE_SECONDS,
+    DEFAULT_VAD_TIMEOUT_SECONDS,
+    AudioBuffer,
+    VoiceActivityTimeout,
+    VoiceCommandSegmenter,
+    chunk_samples,
+)
 
 if TYPE_CHECKING:
     from hassil.recognize import RecognizeResult
@@ -519,8 +526,11 @@ class AudioSettings:
     is_vad_enabled: bool = True
     """True if VAD is used to determine the end of the voice command."""
 
-    silence_seconds: float = 0.7
+    silence_seconds: float = DEFAULT_VAD_SILENCE_SECONDS
     """Seconds of silence after voice command has ended."""
+
+    timeout_seconds: float = DEFAULT_VAD_TIMEOUT_SECONDS
+    """Maximum number of seconds before end-of-speech detection times out."""
 
     def __post_init__(self) -> None:
         """Verify settings post-initialization."""
@@ -529,6 +539,12 @@ class AudioSettings:
 
         if (self.auto_gain_dbfs < 0) or (self.auto_gain_dbfs > 31):
             raise ValueError("auto_gain_dbfs must be in [0, 31]")
+
+        if self.silence_seconds <= 0:
+            raise ValueError("silence_seconds must be greater than 0")
+
+        if self.timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be greater than 0")
 
     @property
     def needs_processor(self) -> bool:
@@ -952,7 +968,8 @@ class PipelineRun:
                 and self.stt_provider.audio_processing.requires_external_vad
             ):
                 stt_vad = VoiceCommandSegmenter(
-                    silence_seconds=self.audio_settings.silence_seconds
+                    silence_seconds=self.audio_settings.silence_seconds,
+                    timeout_seconds=self.audio_settings.timeout_seconds,
                 )
 
             result = await self.stt_provider.async_process_audio_stream(

--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -545,9 +545,7 @@ class AudioSettings:
             raise ValueError("auto_gain_dbfs must be in [0, 31]")
 
         if not (
-            MIN_VAD_SILENCE_SECONDS
-            <= self.silence_seconds
-            <= MAX_VAD_SILENCE_SECONDS
+            MIN_VAD_SILENCE_SECONDS <= self.silence_seconds <= MAX_VAD_SILENCE_SECONDS
         ):
             raise ValueError(
                 "silence_seconds must be in "
@@ -555,9 +553,7 @@ class AudioSettings:
             )
 
         if not (
-            MIN_VAD_TIMEOUT_SECONDS
-            <= self.timeout_seconds
-            <= MAX_VAD_TIMEOUT_SECONDS
+            MIN_VAD_TIMEOUT_SECONDS <= self.timeout_seconds <= MAX_VAD_TIMEOUT_SECONDS
         ):
             raise ValueError(
                 "timeout_seconds must be in "

--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -84,6 +84,10 @@ from .error import (
 from .vad import (
     DEFAULT_VAD_SILENCE_SECONDS,
     DEFAULT_VAD_TIMEOUT_SECONDS,
+    MAX_VAD_SILENCE_SECONDS,
+    MAX_VAD_TIMEOUT_SECONDS,
+    MIN_VAD_SILENCE_SECONDS,
+    MIN_VAD_TIMEOUT_SECONDS,
     AudioBuffer,
     VoiceActivityTimeout,
     VoiceCommandSegmenter,
@@ -540,11 +544,25 @@ class AudioSettings:
         if (self.auto_gain_dbfs < 0) or (self.auto_gain_dbfs > 31):
             raise ValueError("auto_gain_dbfs must be in [0, 31]")
 
-        if self.silence_seconds <= 0:
-            raise ValueError("silence_seconds must be greater than 0")
+        if not (
+            MIN_VAD_SILENCE_SECONDS
+            <= self.silence_seconds
+            <= MAX_VAD_SILENCE_SECONDS
+        ):
+            raise ValueError(
+                "silence_seconds must be in "
+                f"[{MIN_VAD_SILENCE_SECONDS}, {MAX_VAD_SILENCE_SECONDS}]"
+            )
 
-        if self.timeout_seconds <= 0:
-            raise ValueError("timeout_seconds must be greater than 0")
+        if not (
+            MIN_VAD_TIMEOUT_SECONDS
+            <= self.timeout_seconds
+            <= MAX_VAD_TIMEOUT_SECONDS
+        ):
+            raise ValueError(
+                "timeout_seconds must be in "
+                f"[{MIN_VAD_TIMEOUT_SECONDS}, {MAX_VAD_TIMEOUT_SECONDS}]"
+            )
 
     @property
     def needs_processor(self) -> bool:

--- a/homeassistant/components/assist_pipeline/strings.json
+++ b/homeassistant/components/assist_pipeline/strings.json
@@ -5,6 +5,14 @@
         "name": "Assist in progress"
       }
     },
+    "number": {
+      "vad_silence_seconds": {
+        "name": "Finished speaking silence"
+      },
+      "vad_timeout_seconds": {
+        "name": "Finished speaking timeout"
+      }
+    },
     "select": {
       "pipeline": {
         "name": "Assistant",

--- a/homeassistant/components/assist_pipeline/vad.py
+++ b/homeassistant/components/assist_pipeline/vad.py
@@ -9,6 +9,9 @@ from .const import SAMPLE_CHANNELS, SAMPLE_RATE, SAMPLE_WIDTH
 
 _LOGGER = logging.getLogger(__name__)
 
+DEFAULT_VAD_SILENCE_SECONDS = 0.7
+DEFAULT_VAD_TIMEOUT_SECONDS = 15.0
+
 
 class VadSensitivity(StrEnum):
     """How quickly the end of a voice command is detected."""
@@ -27,7 +30,7 @@ class VadSensitivity(StrEnum):
         if sensitivity == VadSensitivity.AGGRESSIVE:
             return 0.25
 
-        return 0.7
+        return DEFAULT_VAD_SILENCE_SECONDS
 
 
 class AudioBuffer:
@@ -79,10 +82,10 @@ class VoiceCommandSegmenter:
     command_seconds: float = 1.0
     """Minimum number of seconds for a voice command."""
 
-    silence_seconds: float = 0.7
+    silence_seconds: float = DEFAULT_VAD_SILENCE_SECONDS
     """Seconds of silence after voice command has ended."""
 
-    timeout_seconds: float = 15.0
+    timeout_seconds: float = DEFAULT_VAD_TIMEOUT_SECONDS
     """Maximum number of seconds before stopping with timeout=True."""
 
     reset_seconds: float = 1.0

--- a/homeassistant/components/assist_pipeline/vad.py
+++ b/homeassistant/components/assist_pipeline/vad.py
@@ -4,6 +4,7 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from enum import StrEnum
 import logging
+from typing import Final
 
 from .const import SAMPLE_CHANNELS, SAMPLE_RATE, SAMPLE_WIDTH
 
@@ -11,6 +12,10 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_VAD_SILENCE_SECONDS = 0.7
 DEFAULT_VAD_TIMEOUT_SECONDS = 15.0
+MIN_VAD_SILENCE_SECONDS: Final = 0.1
+MAX_VAD_SILENCE_SECONDS: Final = 5.0
+MIN_VAD_TIMEOUT_SECONDS: Final = 1.0
+MAX_VAD_TIMEOUT_SECONDS: Final = 120.0
 
 
 class VadSensitivity(StrEnum):

--- a/homeassistant/components/assist_pipeline/websocket_api.py
+++ b/homeassistant/components/assist_pipeline/websocket_api.py
@@ -43,6 +43,7 @@ from .pipeline import (
     WakeWordSettings,
     async_get_pipeline,
 )
+from .vad import DEFAULT_VAD_SILENCE_SECONDS, DEFAULT_VAD_TIMEOUT_SECONDS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -96,6 +97,14 @@ def async_register_websocket_api(hass: HomeAssistant) -> None:
                             vol.Optional("volume_multiplier"): float,
                             # Advanced use cases/testing
                             vol.Optional("no_vad"): bool,
+                            vol.Optional("vad_silence_seconds"): vol.All(
+                                vol.Coerce(float),
+                                vol.Range(min=0, min_included=False),
+                            ),
+                            vol.Optional("vad_timeout_seconds"): vol.All(
+                                vol.Coerce(float),
+                                vol.Range(min=0, min_included=False),
+                            ),
                         }
                     },
                     extra=vol.ALLOW_EXTRA,
@@ -105,6 +114,14 @@ def async_register_websocket_api(hass: HomeAssistant) -> None:
                         vol.Required("input"): {
                             vol.Required("sample_rate"): int,
                             vol.Optional("wake_word_phrase"): str,
+                            vol.Optional("vad_silence_seconds"): vol.All(
+                                vol.Coerce(float),
+                                vol.Range(min=0, min_included=False),
+                            ),
+                            vol.Optional("vad_timeout_seconds"): vol.All(
+                                vol.Coerce(float),
+                                vol.Range(min=0, min_included=False),
+                            ),
                         }
                     },
                     extra=vol.ALLOW_EXTRA,
@@ -213,6 +230,12 @@ async def websocket_run(
             auto_gain_dbfs=msg_input.get("auto_gain_dbfs", 0),
             volume_multiplier=msg_input.get("volume_multiplier", 1.0),
             is_vad_enabled=not msg_input.get("no_vad", False),
+            silence_seconds=msg_input.get(
+                "vad_silence_seconds", DEFAULT_VAD_SILENCE_SECONDS
+            ),
+            timeout_seconds=msg_input.get(
+                "vad_timeout_seconds", DEFAULT_VAD_TIMEOUT_SECONDS
+            ),
         )
     elif start_stage == PipelineStage.INTENT:
         # Input to conversation agent

--- a/homeassistant/components/assist_pipeline/websocket_api.py
+++ b/homeassistant/components/assist_pipeline/websocket_api.py
@@ -30,12 +30,6 @@ from .const import (
     SAMPLE_WIDTH,
 )
 from .error import PipelineNotFound
-from .number import (
-    MAX_VAD_SILENCE_SECONDS,
-    MAX_VAD_TIMEOUT_SECONDS,
-    MIN_VAD_SILENCE_SECONDS,
-    MIN_VAD_TIMEOUT_SECONDS,
-)
 from .pipeline import (
     KEY_ASSIST_PIPELINE,
     AudioSettings,
@@ -49,7 +43,14 @@ from .pipeline import (
     WakeWordSettings,
     async_get_pipeline,
 )
-from .vad import DEFAULT_VAD_SILENCE_SECONDS, DEFAULT_VAD_TIMEOUT_SECONDS
+from .vad import (
+    DEFAULT_VAD_SILENCE_SECONDS,
+    DEFAULT_VAD_TIMEOUT_SECONDS,
+    MAX_VAD_SILENCE_SECONDS,
+    MAX_VAD_TIMEOUT_SECONDS,
+    MIN_VAD_SILENCE_SECONDS,
+    MIN_VAD_TIMEOUT_SECONDS,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/assist_pipeline/websocket_api.py
+++ b/homeassistant/components/assist_pipeline/websocket_api.py
@@ -30,6 +30,12 @@ from .const import (
     SAMPLE_WIDTH,
 )
 from .error import PipelineNotFound
+from .number import (
+    MAX_VAD_SILENCE_SECONDS,
+    MAX_VAD_TIMEOUT_SECONDS,
+    MIN_VAD_SILENCE_SECONDS,
+    MIN_VAD_TIMEOUT_SECONDS,
+)
 from .pipeline import (
     KEY_ASSIST_PIPELINE,
     AudioSettings,
@@ -99,11 +105,17 @@ def async_register_websocket_api(hass: HomeAssistant) -> None:
                             vol.Optional("no_vad"): bool,
                             vol.Optional("vad_silence_seconds"): vol.All(
                                 vol.Coerce(float),
-                                vol.Range(min=0, min_included=False),
+                                vol.Range(
+                                    min=MIN_VAD_SILENCE_SECONDS,
+                                    max=MAX_VAD_SILENCE_SECONDS,
+                                ),
                             ),
                             vol.Optional("vad_timeout_seconds"): vol.All(
                                 vol.Coerce(float),
-                                vol.Range(min=0, min_included=False),
+                                vol.Range(
+                                    min=MIN_VAD_TIMEOUT_SECONDS,
+                                    max=MAX_VAD_TIMEOUT_SECONDS,
+                                ),
                             ),
                         }
                     },
@@ -116,11 +128,17 @@ def async_register_websocket_api(hass: HomeAssistant) -> None:
                             vol.Optional("wake_word_phrase"): str,
                             vol.Optional("vad_silence_seconds"): vol.All(
                                 vol.Coerce(float),
-                                vol.Range(min=0, min_included=False),
+                                vol.Range(
+                                    min=MIN_VAD_SILENCE_SECONDS,
+                                    max=MAX_VAD_SILENCE_SECONDS,
+                                ),
                             ),
                             vol.Optional("vad_timeout_seconds"): vol.All(
                                 vol.Coerce(float),
-                                vol.Range(min=0, min_included=False),
+                                vol.Range(
+                                    min=MIN_VAD_TIMEOUT_SECONDS,
+                                    max=MAX_VAD_TIMEOUT_SECONDS,
+                                ),
                             ),
                         }
                     },

--- a/homeassistant/components/assist_satellite/entity.py
+++ b/homeassistant/components/assist_satellite/entity.py
@@ -677,12 +677,14 @@ class AssistSatelliteEntity(entity.Entity):
     def _resolve_float_state(self, entity_id: str, name: str) -> float:
         """Resolve float value from entity state."""
         if (state := self.hass.states.get(entity_id)) is None:
-            raise RuntimeError(f"{name} entity not found")
+            raise RuntimeError(f"{name} entity not found: {entity_id}")
 
         try:
             return float(state.state)
         except ValueError as err:
-            raise RuntimeError(f"{name} entity state is not a number") from err
+            raise RuntimeError(
+                f"{name} entity state is not a number: {entity_id}={state.state!r}"
+            ) from err
 
     async def _resolve_announcement_media_id(
         self,

--- a/homeassistant/components/assist_satellite/entity.py
+++ b/homeassistant/components/assist_satellite/entity.py
@@ -27,6 +27,7 @@ from homeassistant.components.assist_pipeline import (
     vad,
 )
 from homeassistant.components.media_player import async_process_play_media_url
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import Context, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import chat_session, entity
@@ -657,9 +658,12 @@ class AssistSatelliteEntity(entity.Entity):
     def _resolve_vad_silence_seconds(self) -> float:
         """Resolve VAD silence seconds from number entity or legacy select entity."""
         if vad_silence_seconds_entity_id := self.vad_silence_seconds_entity_id:
-            return self._resolve_float_state(
-                vad_silence_seconds_entity_id, "VAD silence seconds"
-            )
+            if (
+                vad_silence_seconds := self._resolve_float_state(
+                    vad_silence_seconds_entity_id, "VAD silence seconds"
+                )
+            ) is not None:
+                return vad_silence_seconds
 
         return self._resolve_vad_sensitivity()
 
@@ -667,17 +671,23 @@ class AssistSatelliteEntity(entity.Entity):
     def _resolve_vad_timeout_seconds(self) -> float:
         """Resolve VAD timeout seconds from number entity."""
         if vad_timeout_seconds_entity_id := self.vad_timeout_seconds_entity_id:
-            return self._resolve_float_state(
-                vad_timeout_seconds_entity_id, "VAD timeout seconds"
-            )
+            if (
+                vad_timeout_seconds := self._resolve_float_state(
+                    vad_timeout_seconds_entity_id, "VAD timeout seconds"
+                )
+            ) is not None:
+                return vad_timeout_seconds
 
         return vad.DEFAULT_VAD_TIMEOUT_SECONDS
 
     @callback
-    def _resolve_float_state(self, entity_id: str, name: str) -> float:
+    def _resolve_float_state(self, entity_id: str, name: str) -> float | None:
         """Resolve float value from entity state."""
         if (state := self.hass.states.get(entity_id)) is None:
             raise RuntimeError(f"{name} entity not found: {entity_id}")
+
+        if state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+            return None
 
         try:
             return float(state.state)

--- a/homeassistant/components/assist_satellite/entity.py
+++ b/homeassistant/components/assist_satellite/entity.py
@@ -131,6 +131,8 @@ class AssistSatelliteEntity(entity.Entity):
     _attr_supported_features = AssistSatelliteEntityFeature(0)
     _attr_pipeline_entity_id: str | None = None
     _attr_vad_sensitivity_entity_id: str | None = None
+    _attr_vad_silence_seconds_entity_id: str | None = None
+    _attr_vad_timeout_seconds_entity_id: str | None = None
 
     _conversation_id: str | None = None
 
@@ -159,6 +161,16 @@ class AssistSatelliteEntity(entity.Entity):
     def vad_sensitivity_entity_id(self) -> str | None:
         """Entity ID of the VAD sensitivity to use for the next conversation."""
         return self._attr_vad_sensitivity_entity_id
+
+    @property
+    def vad_silence_seconds_entity_id(self) -> str | None:
+        """Entity ID of the VAD silence seconds to use for the next conversation."""
+        return self._attr_vad_silence_seconds_entity_id
+
+    @property
+    def vad_timeout_seconds_entity_id(self) -> str | None:
+        """Entity ID of the VAD timeout seconds to use for the next conversation."""
+        return self._attr_vad_timeout_seconds_entity_id
 
     @property
     def tts_options(self) -> dict[str, Any] | None:
@@ -528,7 +540,8 @@ class AssistSatelliteEntity(entity.Entity):
                         tts_audio_output=self.tts_options,
                         wake_word_phrase=wake_word_phrase,
                         audio_settings=AudioSettings(
-                            silence_seconds=self._resolve_vad_sensitivity()
+                            silence_seconds=self._resolve_vad_silence_seconds(),
+                            timeout_seconds=self._resolve_vad_timeout_seconds(),
                         ),
                         start_stage=start_stage,
                         end_stage=end_stage,
@@ -639,6 +652,37 @@ class AssistSatelliteEntity(entity.Entity):
             vad_sensitivity = vad.VadSensitivity(vad_sensitivity_state.state)
 
         return vad.VadSensitivity.to_seconds(vad_sensitivity)
+
+    @callback
+    def _resolve_vad_silence_seconds(self) -> float:
+        """Resolve VAD silence seconds from number entity or legacy select entity."""
+        if vad_silence_seconds_entity_id := self.vad_silence_seconds_entity_id:
+            return self._resolve_float_state(
+                vad_silence_seconds_entity_id, "VAD silence seconds"
+            )
+
+        return self._resolve_vad_sensitivity()
+
+    @callback
+    def _resolve_vad_timeout_seconds(self) -> float:
+        """Resolve VAD timeout seconds from number entity."""
+        if vad_timeout_seconds_entity_id := self.vad_timeout_seconds_entity_id:
+            return self._resolve_float_state(
+                vad_timeout_seconds_entity_id, "VAD timeout seconds"
+            )
+
+        return vad.DEFAULT_VAD_TIMEOUT_SECONDS
+
+    @callback
+    def _resolve_float_state(self, entity_id: str, name: str) -> float:
+        """Resolve float value from entity state."""
+        if (state := self.hass.states.get(entity_id)) is None:
+            raise RuntimeError(f"{name} entity not found")
+
+        try:
+            return float(state.state)
+        except ValueError as err:
+            raise RuntimeError(f"{name} entity state is not a number") from err
 
     async def _resolve_announcement_media_id(
         self,

--- a/homeassistant/components/esphome/assist_satellite.py
+++ b/homeassistant/components/esphome/assist_satellite.py
@@ -173,14 +173,14 @@ class EsphomeAssistSatellite(
         self._active_audio_channel = 0
         self._has_multi_channel_audio = False
 
-    def _get_entity_id(self, suffix: str) -> str | None:
+    def _get_entity_id(self, platform: Platform, suffix: str) -> str | None:
         """Return the entity id for pipeline select, etc."""
         if self._entry_data.device_info is None:
             return None
 
         ent_reg = er.async_get(self.hass)
         return ent_reg.async_get_entity_id(
-            Platform.SELECT,
+            platform,
             DOMAIN,
             f"{self._entry_data.device_info.mac_address}-{suffix}",
         )
@@ -193,17 +193,27 @@ class EsphomeAssistSatellite(
     def get_pipeline_entity(self, index: int) -> str | None:
         """Return the entity ID of a pipeline by index."""
         id_suffix = "" if index < 1 else f"_{index + 1}"
-        return self._get_entity_id(f"pipeline{id_suffix}")
+        return self._get_entity_id(Platform.SELECT, f"pipeline{id_suffix}")
 
     def get_wake_word_entity(self, index: int) -> str | None:
         """Return the entity ID of a wake word by index."""
         id_suffix = "" if index < 1 else f"_{index + 1}"
-        return self._get_entity_id(f"wake_word{id_suffix}")
+        return self._get_entity_id(Platform.SELECT, f"wake_word{id_suffix}")
 
     @property
     def vad_sensitivity_entity_id(self) -> str | None:
         """Return the entity ID of the VAD sensitivity for the next conversation."""
-        return self._get_entity_id("vad_sensitivity")
+        return self._get_entity_id(Platform.SELECT, "vad_sensitivity")
+
+    @property
+    def vad_silence_seconds_entity_id(self) -> str | None:
+        """Return the VAD silence seconds entity ID for the next conversation."""
+        return self._get_entity_id(Platform.NUMBER, "vad_silence_seconds")
+
+    @property
+    def vad_timeout_seconds_entity_id(self) -> str | None:
+        """Return the VAD timeout seconds entity ID for the next conversation."""
+        return self._get_entity_id(Platform.NUMBER, "vad_timeout_seconds")
 
     @callback
     def async_get_configuration(

--- a/homeassistant/components/esphome/number.py
+++ b/homeassistant/components/esphome/number.py
@@ -1,7 +1,5 @@
 """Support for esphome numbers."""
 
-from functools import partial
-
 from aioesphomeapi import (
     EntityInfo,
     NumberInfo,
@@ -9,16 +7,23 @@ from aioesphomeapi import (
     NumberState,
 )
 
+from homeassistant.components.assist_pipeline import (
+    VadSilenceSecondsNumber,
+    VadTimeoutSecondsNumber,
+)
 from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util.enum import try_parse_enum
 
 from .entity import (
+    EsphomeAssistEntity,
     EsphomeEntity,
     convert_api_error_ha_error,
     esphome_float_state_property,
     platform_async_setup_entry,
 )
+from .entry_data import ESPHomeConfigEntry, RuntimeEntryData
 from .enum_mapper import EsphomeEnumMapper
 
 PARALLEL_UPDATES = 0
@@ -30,6 +35,34 @@ NUMBER_MODES: EsphomeEnumMapper[EsphomeNumberMode, NumberMode] = EsphomeEnumMapp
         EsphomeNumberMode.SLIDER: NumberMode.SLIDER,
     }
 )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ESPHomeConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up esphome numbers based on a config entry."""
+    await platform_async_setup_entry(
+        hass,
+        entry,
+        async_add_entities,
+        info_type=NumberInfo,
+        entity_type=EsphomeNumber,
+        state_type=NumberState,
+    )
+
+    entry_data = entry.runtime_data
+    assert entry_data.device_info is not None
+    if entry_data.device_info.voice_assistant_feature_flags_compat(
+        entry_data.api_version
+    ):
+        async_add_entities(
+            [
+                EsphomeVadSilenceSecondsNumber(hass, entry_data),
+                EsphomeVadTimeoutSecondsNumber(hass, entry_data),
+            ]
+        )
 
 
 class EsphomeNumber(EsphomeEntity[NumberInfo, NumberState], NumberEntity):
@@ -70,9 +103,29 @@ class EsphomeNumber(EsphomeEntity[NumberInfo, NumberState], NumberEntity):
         )
 
 
-async_setup_entry = partial(
-    platform_async_setup_entry,
-    info_type=NumberInfo,
-    entity_type=EsphomeNumber,
-    state_type=NumberState,
-)
+class EsphomeVadSilenceSecondsNumber(EsphomeAssistEntity, VadSilenceSecondsNumber):
+    """VAD silence seconds for ESPHome devices."""
+
+    def __init__(self, hass: HomeAssistant, entry_data: RuntimeEntryData) -> None:
+        """Initialize a VAD silence seconds number."""
+        EsphomeAssistEntity.__init__(self, entry_data)
+        VadSilenceSecondsNumber.__init__(self, hass, self._device_info.mac_address)
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to Home Assistant."""
+        await EsphomeAssistEntity.async_added_to_hass(self)
+        await self._async_restore_native_value()
+
+
+class EsphomeVadTimeoutSecondsNumber(EsphomeAssistEntity, VadTimeoutSecondsNumber):
+    """VAD timeout seconds for ESPHome devices."""
+
+    def __init__(self, hass: HomeAssistant, entry_data: RuntimeEntryData) -> None:
+        """Initialize a VAD timeout seconds number."""
+        EsphomeAssistEntity.__init__(self, entry_data)
+        VadTimeoutSecondsNumber.__init__(self, hass, self._device_info.mac_address)
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to Home Assistant."""
+        await EsphomeAssistEntity.async_added_to_hass(self)
+        await self._async_restore_native_value()

--- a/homeassistant/components/esphome/number.py
+++ b/homeassistant/components/esphome/number.py
@@ -111,11 +111,6 @@ class EsphomeVadSilenceSecondsNumber(EsphomeAssistEntity, VadSilenceSecondsNumbe
         EsphomeAssistEntity.__init__(self, entry_data)
         VadSilenceSecondsNumber.__init__(self, hass, self._device_info.mac_address)
 
-    async def async_added_to_hass(self) -> None:
-        """When entity is added to Home Assistant."""
-        await EsphomeAssistEntity.async_added_to_hass(self)
-        await self._async_restore_native_value()
-
 
 class EsphomeVadTimeoutSecondsNumber(EsphomeAssistEntity, VadTimeoutSecondsNumber):
     """VAD timeout seconds for ESPHome devices."""
@@ -124,8 +119,3 @@ class EsphomeVadTimeoutSecondsNumber(EsphomeAssistEntity, VadTimeoutSecondsNumbe
         """Initialize a VAD timeout seconds number."""
         EsphomeAssistEntity.__init__(self, entry_data)
         VadTimeoutSecondsNumber.__init__(self, hass, self._device_info.mac_address)
-
-    async def async_added_to_hass(self) -> None:
-        """When entity is added to Home Assistant."""
-        await EsphomeAssistEntity.async_added_to_hass(self)
-        await self._async_restore_native_value()

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -20,10 +20,10 @@
       "service_received": "Action received"
     },
     "error": {
-      "connection_error": "Unable to connect to the ESPHome device. Make sure the device’s YAML configuration includes an `api` section.",
+      "connection_error": "Unable to connect to the ESPHome device. Make sure the device?s YAML configuration includes an `api` section.",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "invalid_psk": "The encryption key is invalid. Make sure it matches the value in the device’s YAML configuration under `api -> encryption -> key`.",
-      "requires_encryption_key": "The ESPHome device requires an encryption key. Enter the key defined in the device’s YAML configuration under `api -> encryption -> key`.",
+      "invalid_psk": "The encryption key is invalid. Make sure it matches the value in the device?s YAML configuration under `api -> encryption -> key`.",
+      "requires_encryption_key": "The ESPHome device requires an encryption key. Enter the key defined in the device?s YAML configuration under `api -> encryption -> key`.",
       "resolve_error": "Unable to resolve the address of the ESPHome device. If this issue continues, consider setting a static IP address."
     },
     "flow_title": "{name}",
@@ -87,6 +87,14 @@
     "assist_satellite": {
       "assist_satellite": {
         "name": "[%key:component::assist_satellite::entity_component::_::name%]"
+      }
+    },
+    "number": {
+      "vad_silence_seconds": {
+        "name": "[%key:component::assist_pipeline::entity::number::vad_silence_seconds::name%]"
+      },
+      "vad_timeout_seconds": {
+        "name": "[%key:component::assist_pipeline::entity::number::vad_timeout_seconds::name%]"
       }
     },
     "climate": {

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -20,10 +20,10 @@
       "service_received": "Action received"
     },
     "error": {
-      "connection_error": "Unable to connect to the ESPHome device. Make sure the device?s YAML configuration includes an `api` section.",
+      "connection_error": "Unable to connect to the ESPHome device. Make sure the device’s YAML configuration includes an `api` section.",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "invalid_psk": "The encryption key is invalid. Make sure it matches the value in the device?s YAML configuration under `api -> encryption -> key`.",
-      "requires_encryption_key": "The ESPHome device requires an encryption key. Enter the key defined in the device?s YAML configuration under `api -> encryption -> key`.",
+      "invalid_psk": "The encryption key is invalid. Make sure it matches the value in the device’s YAML configuration under `api -> encryption -> key`.",
+      "requires_encryption_key": "The ESPHome device requires an encryption key. Enter the key defined in the device’s YAML configuration under `api -> encryption -> key`.",
       "resolve_error": "Unable to resolve the address of the ESPHome device. If this issue continues, consider setting a static IP address."
     },
     "flow_title": "{name}",
@@ -89,14 +89,6 @@
         "name": "[%key:component::assist_satellite::entity_component::_::name%]"
       }
     },
-    "number": {
-      "vad_silence_seconds": {
-        "name": "[%key:component::assist_pipeline::entity::number::vad_silence_seconds::name%]"
-      },
-      "vad_timeout_seconds": {
-        "name": "[%key:component::assist_pipeline::entity::number::vad_timeout_seconds::name%]"
-      }
-    },
     "climate": {
       "climate": {
         "state_attributes": {
@@ -106,6 +98,14 @@
             }
           }
         }
+      }
+    },
+    "number": {
+      "vad_silence_seconds": {
+        "name": "[%key:component::assist_pipeline::entity::number::vad_silence_seconds::name%]"
+      },
+      "vad_timeout_seconds": {
+        "name": "[%key:component::assist_pipeline::entity::number::vad_timeout_seconds::name%]"
       }
     },
     "select": {

--- a/homeassistant/components/voip/__init__.py
+++ b/homeassistant/components/voip/__init__.py
@@ -21,6 +21,7 @@ from .voip import HassVoipDatagramProtocol
 PLATFORMS = (
     Platform.ASSIST_SATELLITE,
     Platform.BINARY_SENSOR,
+    Platform.NUMBER,
     Platform.SELECT,
     Platform.SWITCH,
 )

--- a/homeassistant/components/voip/assist_satellite.py
+++ b/homeassistant/components/voip/assist_satellite.py
@@ -148,6 +148,16 @@ class VoipAssistSatellite(VoIPEntity, AssistSatelliteEntity, RtpDatagramProtocol
         return self.voip_device.get_vad_sensitivity_entity_id(self.hass)
 
     @property
+    def vad_silence_seconds_entity_id(self) -> str | None:
+        """Return the VAD silence seconds entity ID for next conversation."""
+        return self.voip_device.get_vad_silence_seconds_entity_id(self.hass)
+
+    @property
+    def vad_timeout_seconds_entity_id(self) -> str | None:
+        """Return the VAD timeout seconds entity ID for next conversation."""
+        return self.voip_device.get_vad_timeout_seconds_entity_id(self.hass)
+
+    @property
     def tts_options(self) -> dict[str, Any] | None:
         """Options passed for text-to-speech."""
         return {

--- a/homeassistant/components/voip/devices.py
+++ b/homeassistant/components/voip/devices.py
@@ -76,6 +76,20 @@ class VoIPDevice:
             "select", DOMAIN, f"{self.voip_id}-vad_sensitivity"
         )
 
+    def get_vad_silence_seconds_entity_id(self, hass: HomeAssistant) -> str | None:
+        """Return entity id for VAD silence seconds."""
+        ent_reg = er.async_get(hass)
+        return ent_reg.async_get_entity_id(
+            "number", DOMAIN, f"{self.voip_id}-vad_silence_seconds"
+        )
+
+    def get_vad_timeout_seconds_entity_id(self, hass: HomeAssistant) -> str | None:
+        """Return entity id for VAD timeout seconds."""
+        ent_reg = er.async_get(hass)
+        return ent_reg.async_get_entity_id(
+            "number", DOMAIN, f"{self.voip_id}-vad_timeout_seconds"
+        )
+
 
 class VoIPDevices:
     """Class to store devices."""

--- a/homeassistant/components/voip/number.py
+++ b/homeassistant/components/voip/number.py
@@ -1,0 +1,68 @@
+"""Number entities for VoIP integration."""
+
+from homeassistant.components.assist_pipeline import (
+    VadSilenceSecondsNumber,
+    VadTimeoutSecondsNumber,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import VoipConfigEntry
+from .devices import VoIPDevice
+from .entity import VoIPEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: VoipConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up VoIP number entities."""
+    domain_data = config_entry.runtime_data.domain_data
+
+    @callback
+    def async_add_device(device: VoIPDevice) -> None:
+        """Add device."""
+        async_add_entities(
+            [
+                VoipVadSilenceSecondsNumber(hass, device),
+                VoipVadTimeoutSecondsNumber(hass, device),
+            ]
+        )
+
+    domain_data.devices.async_add_new_device_listener(async_add_device)
+
+    entities: list[VoIPEntity] = []
+    for device in domain_data.devices:
+        entities.append(VoipVadSilenceSecondsNumber(hass, device))
+        entities.append(VoipVadTimeoutSecondsNumber(hass, device))
+
+    async_add_entities(entities)
+
+
+class VoipVadSilenceSecondsNumber(VoIPEntity, VadSilenceSecondsNumber):
+    """VAD silence seconds for VoIP devices."""
+
+    def __init__(self, hass: HomeAssistant, device: VoIPDevice) -> None:
+        """Initialize a VAD silence seconds number."""
+        VoIPEntity.__init__(self, device)
+        VadSilenceSecondsNumber.__init__(self, hass, device.voip_id)
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to Home Assistant."""
+        await super().async_added_to_hass()
+        await self._async_restore_native_value()
+
+
+class VoipVadTimeoutSecondsNumber(VoIPEntity, VadTimeoutSecondsNumber):
+    """VAD timeout seconds for VoIP devices."""
+
+    def __init__(self, hass: HomeAssistant, device: VoIPDevice) -> None:
+        """Initialize a VAD timeout seconds number."""
+        VoIPEntity.__init__(self, device)
+        VadTimeoutSecondsNumber.__init__(self, hass, device.voip_id)
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to Home Assistant."""
+        await super().async_added_to_hass()
+        await self._async_restore_native_value()

--- a/homeassistant/components/voip/number.py
+++ b/homeassistant/components/voip/number.py
@@ -48,11 +48,6 @@ class VoipVadSilenceSecondsNumber(VoIPEntity, VadSilenceSecondsNumber):
         VoIPEntity.__init__(self, device)
         VadSilenceSecondsNumber.__init__(self, hass, device.voip_id)
 
-    async def async_added_to_hass(self) -> None:
-        """When entity is added to Home Assistant."""
-        await super().async_added_to_hass()
-        await self._async_restore_native_value()
-
 
 class VoipVadTimeoutSecondsNumber(VoIPEntity, VadTimeoutSecondsNumber):
     """VAD timeout seconds for VoIP devices."""
@@ -61,8 +56,3 @@ class VoipVadTimeoutSecondsNumber(VoIPEntity, VadTimeoutSecondsNumber):
         """Initialize a VAD timeout seconds number."""
         VoIPEntity.__init__(self, device)
         VadTimeoutSecondsNumber.__init__(self, hass, device.voip_id)
-
-    async def async_added_to_hass(self) -> None:
-        """When entity is added to Home Assistant."""
-        await super().async_added_to_hass()
-        await self._async_restore_native_value()

--- a/homeassistant/components/voip/strings.json
+++ b/homeassistant/components/voip/strings.json
@@ -15,6 +15,14 @@
         "name": "Call in progress"
       }
     },
+    "number": {
+      "vad_silence_seconds": {
+        "name": "[%key:component::assist_pipeline::entity::number::vad_silence_seconds::name%]"
+      },
+      "vad_timeout_seconds": {
+        "name": "[%key:component::assist_pipeline::entity::number::vad_timeout_seconds::name%]"
+      }
+    },
     "select": {
       "pipeline": {
         "name": "[%key:component::assist_pipeline::entity::select::pipeline::name%]",

--- a/homeassistant/components/wyoming/assist_satellite.py
+++ b/homeassistant/components/wyoming/assist_satellite.py
@@ -144,6 +144,16 @@ class WyomingAssistSatellite(WyomingSatelliteEntity, AssistSatelliteEntity):
         return self.device.get_vad_sensitivity_entity_id(self.hass)
 
     @property
+    def vad_silence_seconds_entity_id(self) -> str | None:
+        """Return the VAD silence seconds entity ID for next conversation."""
+        return self.device.get_vad_silence_seconds_entity_id(self.hass)
+
+    @property
+    def vad_timeout_seconds_entity_id(self) -> str | None:
+        """Return the VAD timeout seconds entity ID for next conversation."""
+        return self.device.get_vad_timeout_seconds_entity_id(self.hass)
+
+    @property
     def tts_options(self) -> dict[str, Any] | None:
         """Options passed for text-to-speech."""
         return {
@@ -179,7 +189,7 @@ class WyomingAssistSatellite(WyomingSatelliteEntity, AssistSatelliteEntity):
     def on_pipeline_event(self, event: PipelineEvent) -> None:
         """Set state based on pipeline stage."""
         if event.type == assist_pipeline.PipelineEventType.RUN_END:
-            # Pipeline run is complete — always update bookkeeping state
+            # Pipeline run is complete ? always update bookkeeping state
             # even after a disconnect so follow-up reconnects don't retain
             # stale _is_pipeline_running / _pipeline_ended_event state.
             self._is_pipeline_running = False

--- a/homeassistant/components/wyoming/assist_satellite.py
+++ b/homeassistant/components/wyoming/assist_satellite.py
@@ -189,7 +189,7 @@ class WyomingAssistSatellite(WyomingSatelliteEntity, AssistSatelliteEntity):
     def on_pipeline_event(self, event: PipelineEvent) -> None:
         """Set state based on pipeline stage."""
         if event.type == assist_pipeline.PipelineEventType.RUN_END:
-            # Pipeline run is complete ? always update bookkeeping state
+            # Pipeline run is complete — always update bookkeeping state
             # even after a disconnect so follow-up reconnects don't retain
             # stale _is_pipeline_running / _pipeline_ended_event state.
             self._is_pipeline_running = False

--- a/homeassistant/components/wyoming/devices.py
+++ b/homeassistant/components/wyoming/devices.py
@@ -155,3 +155,17 @@ class SatelliteDevice:
         return ent_reg.async_get_entity_id(
             "select", DOMAIN, f"{self.satellite_id}-vad_sensitivity"
         )
+
+    def get_vad_silence_seconds_entity_id(self, hass: HomeAssistant) -> str | None:
+        """Return entity id for VAD silence seconds."""
+        ent_reg = er.async_get(hass)
+        return ent_reg.async_get_entity_id(
+            "number", DOMAIN, f"{self.satellite_id}-vad_silence_seconds"
+        )
+
+    def get_vad_timeout_seconds_entity_id(self, hass: HomeAssistant) -> str | None:
+        """Return entity id for VAD timeout seconds."""
+        ent_reg = er.async_get(hass)
+        return ent_reg.async_get_entity_id(
+            "number", DOMAIN, f"{self.satellite_id}-vad_timeout_seconds"
+        )

--- a/homeassistant/components/wyoming/number.py
+++ b/homeassistant/components/wyoming/number.py
@@ -112,11 +112,6 @@ class WyomingSatelliteVadSilenceSecondsNumber(
         WyomingSatelliteEntity.__init__(self, device)
         VadSilenceSecondsNumber.__init__(self, hass, device.satellite_id)
 
-    async def async_added_to_hass(self) -> None:
-        """When entity is added to Home Assistant."""
-        await super().async_added_to_hass()
-        await self._async_restore_native_value()
-
 
 class WyomingSatelliteVadTimeoutSecondsNumber(
     WyomingSatelliteEntity, VadTimeoutSecondsNumber
@@ -127,8 +122,3 @@ class WyomingSatelliteVadTimeoutSecondsNumber(
         """Initialize a VAD timeout seconds number."""
         WyomingSatelliteEntity.__init__(self, device)
         VadTimeoutSecondsNumber.__init__(self, hass, device.satellite_id)
-
-    async def async_added_to_hass(self) -> None:
-        """When entity is added to Home Assistant."""
-        await super().async_added_to_hass()
-        await self._async_restore_native_value()

--- a/homeassistant/components/wyoming/number.py
+++ b/homeassistant/components/wyoming/number.py
@@ -2,11 +2,16 @@
 
 from typing import Final
 
+from homeassistant.components.assist_pipeline import (
+    VadSilenceSecondsNumber,
+    VadTimeoutSecondsNumber,
+)
 from homeassistant.components.number import NumberEntityDescription, RestoreNumber
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .devices import SatelliteDevice
 from .entity import WyomingSatelliteEntity
 from .models import WyomingConfigEntry
 
@@ -30,6 +35,8 @@ async def async_setup_entry(
         [
             WyomingSatelliteAutoGainNumber(item.device),
             WyomingSatelliteVolumeMultiplierNumber(item.device),
+            WyomingSatelliteVadSilenceSecondsNumber(hass, item.device),
+            WyomingSatelliteVadTimeoutSecondsNumber(hass, item.device),
         ]
     )
 
@@ -93,3 +100,35 @@ class WyomingSatelliteVolumeMultiplierNumber(WyomingSatelliteEntity, RestoreNumb
         )
         self.async_write_ha_state()
         self._device.set_volume_multiplier(self._attr_native_value)
+
+
+class WyomingSatelliteVadSilenceSecondsNumber(
+    WyomingSatelliteEntity, VadSilenceSecondsNumber
+):
+    """VAD silence seconds for Wyoming satellites."""
+
+    def __init__(self, hass: HomeAssistant, device: SatelliteDevice) -> None:
+        """Initialize a VAD silence seconds number."""
+        WyomingSatelliteEntity.__init__(self, device)
+        VadSilenceSecondsNumber.__init__(self, hass, device.satellite_id)
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to Home Assistant."""
+        await super().async_added_to_hass()
+        await self._async_restore_native_value()
+
+
+class WyomingSatelliteVadTimeoutSecondsNumber(
+    WyomingSatelliteEntity, VadTimeoutSecondsNumber
+):
+    """VAD timeout seconds for Wyoming satellites."""
+
+    def __init__(self, hass: HomeAssistant, device: SatelliteDevice) -> None:
+        """Initialize a VAD timeout seconds number."""
+        WyomingSatelliteEntity.__init__(self, device)
+        VadTimeoutSecondsNumber.__init__(self, hass, device.satellite_id)
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to Home Assistant."""
+        await super().async_added_to_hass()
+        await self._async_restore_native_value()

--- a/homeassistant/components/wyoming/strings.json
+++ b/homeassistant/components/wyoming/strings.json
@@ -34,6 +34,12 @@
       "auto_gain": {
         "name": "Auto gain"
       },
+      "vad_silence_seconds": {
+        "name": "[%key:component::assist_pipeline::entity::number::vad_silence_seconds::name%]"
+      },
+      "vad_timeout_seconds": {
+        "name": "[%key:component::assist_pipeline::entity::number::vad_timeout_seconds::name%]"
+      },
       "volume_multiplier": {
         "name": "Mic volume"
       }

--- a/tests/components/assist_pipeline/test_pipeline.py
+++ b/tests/components/assist_pipeline/test_pipeline.py
@@ -26,6 +26,7 @@ from homeassistant.components.assist_pipeline.const import (
     DOMAIN,
 )
 from homeassistant.components.assist_pipeline.pipeline import (
+    AudioSettings,
     STORAGE_KEY,
     STORAGE_VERSION,
     STORAGE_VERSION_MINOR,
@@ -39,6 +40,10 @@ from homeassistant.components.assist_pipeline.pipeline import (
     async_get_pipeline,
     async_get_pipelines,
     async_update_pipeline,
+)
+from homeassistant.components.assist_pipeline.vad import (
+    DEFAULT_VAD_SILENCE_SECONDS,
+    DEFAULT_VAD_TIMEOUT_SECONDS,
 )
 from homeassistant.const import ATTR_FRIENDLY_NAME, MATCH_ALL
 from homeassistant.core import Context, HomeAssistant
@@ -64,6 +69,29 @@ from .conftest import (
 
 from tests.common import MockConfigEntry, async_mock_service, flush_store
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
+
+
+def test_audio_settings_vad_timing_defaults() -> None:
+    """Test default VAD timing settings."""
+    settings = AudioSettings()
+
+    assert settings.silence_seconds == DEFAULT_VAD_SILENCE_SECONDS
+    assert settings.timeout_seconds == DEFAULT_VAD_TIMEOUT_SECONDS
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error"),
+    [
+        ({"silence_seconds": 0}, "silence_seconds must be greater than 0"),
+        ({"timeout_seconds": 0}, "timeout_seconds must be greater than 0"),
+    ],
+)
+def test_audio_settings_vad_timing_validation(
+    kwargs: dict[str, float], error: str
+) -> None:
+    """Test VAD timing settings validation."""
+    with pytest.raises(ValueError, match=error):
+        AudioSettings(**kwargs)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/assist_pipeline/test_pipeline.py
+++ b/tests/components/assist_pipeline/test_pipeline.py
@@ -26,10 +26,10 @@ from homeassistant.components.assist_pipeline.const import (
     DOMAIN,
 )
 from homeassistant.components.assist_pipeline.pipeline import (
-    AudioSettings,
     STORAGE_KEY,
     STORAGE_VERSION,
     STORAGE_VERSION_MINOR,
+    AudioSettings,
     Pipeline,
     PipelineData,
     PipelineEventType,

--- a/tests/components/assist_pipeline/test_pipeline.py
+++ b/tests/components/assist_pipeline/test_pipeline.py
@@ -44,6 +44,10 @@ from homeassistant.components.assist_pipeline.pipeline import (
 from homeassistant.components.assist_pipeline.vad import (
     DEFAULT_VAD_SILENCE_SECONDS,
     DEFAULT_VAD_TIMEOUT_SECONDS,
+    MAX_VAD_SILENCE_SECONDS,
+    MAX_VAD_TIMEOUT_SECONDS,
+    MIN_VAD_SILENCE_SECONDS,
+    MIN_VAD_TIMEOUT_SECONDS,
 )
 from homeassistant.const import ATTR_FRIENDLY_NAME, MATCH_ALL
 from homeassistant.core import Context, HomeAssistant
@@ -82,8 +86,22 @@ def test_audio_settings_vad_timing_defaults() -> None:
 @pytest.mark.parametrize(
     ("kwargs", "error"),
     [
-        ({"silence_seconds": 0}, "silence_seconds must be greater than 0"),
-        ({"timeout_seconds": 0}, "timeout_seconds must be greater than 0"),
+        (
+            {"silence_seconds": MIN_VAD_SILENCE_SECONDS - 0.1},
+            "silence_seconds must be in",
+        ),
+        (
+            {"silence_seconds": MAX_VAD_SILENCE_SECONDS + 0.1},
+            "silence_seconds must be in",
+        ),
+        (
+            {"timeout_seconds": MIN_VAD_TIMEOUT_SECONDS - 0.1},
+            "timeout_seconds must be in",
+        ),
+        (
+            {"timeout_seconds": MAX_VAD_TIMEOUT_SECONDS + 0.1},
+            "timeout_seconds must be in",
+        ),
     ],
 )
 def test_audio_settings_vad_timing_validation(

--- a/tests/components/assist_pipeline/test_vad.py
+++ b/tests/components/assist_pipeline/test_vad.py
@@ -4,11 +4,21 @@ import itertools as it
 
 from homeassistant.components.assist_pipeline.vad import (
     AudioBuffer,
+    DEFAULT_VAD_SILENCE_SECONDS,
+    DEFAULT_VAD_TIMEOUT_SECONDS,
     VoiceCommandSegmenter,
     chunk_samples,
 )
 
 _ONE_SECOND = 1.0
+
+
+def test_defaults() -> None:
+    """Test default VAD timing."""
+    segmenter = VoiceCommandSegmenter()
+
+    assert segmenter.silence_seconds == DEFAULT_VAD_SILENCE_SECONDS
+    assert segmenter.timeout_seconds == DEFAULT_VAD_TIMEOUT_SECONDS
 
 
 def test_silence() -> None:

--- a/tests/components/assist_pipeline/test_vad.py
+++ b/tests/components/assist_pipeline/test_vad.py
@@ -3,9 +3,9 @@
 import itertools as it
 
 from homeassistant.components.assist_pipeline.vad import (
-    AudioBuffer,
     DEFAULT_VAD_SILENCE_SECONDS,
     DEFAULT_VAD_TIMEOUT_SECONDS,
+    AudioBuffer,
     VoiceCommandSegmenter,
     chunk_samples,
 )

--- a/tests/components/assist_pipeline/test_websocket.py
+++ b/tests/components/assist_pipeline/test_websocket.py
@@ -1764,6 +1764,8 @@ async def test_audio_pipeline_with_enhancements(
                     "noise_suppression_level": 2,
                     "auto_gain_dbfs": 15,
                     "volume_multiplier": 2.0,
+                    "vad_silence_seconds": 1.5,
+                    "vad_timeout_seconds": 30,
                 },
             }
         )


### PR DESCRIPTION
## Proposed change
Adds numeric VAD silence and timeout settings for Assist voice input.

## Type of change
- [x] New feature (which adds functionality to an existing integration)

## Additional information
Related: #122177, #122182, #122962.
Docs: home-assistant/home-assistant.io#45551.

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr