### PR TITLE
Replace duplicate constants in xthings_cloud with homeassistant.const imports

### DIFF
--- a/homeassistant/components/xthings_cloud/__init__.py
+++ b/homeassistant/components/xthings_cloud/__init__.py
@@ -2,10 +2,11 @@
 
 from ha_xthings_cloud import XthingsCloudApiClient
 
+from homeassistant.const import CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import CONF_TOKEN, PLATFORMS
+from .const import PLATFORMS
 from .coordinator import XthingsCloudConfigEntry, XthingsCloudCoordinator
 
 

--- a/homeassistant/components/xthings_cloud/config_flow.py
+++ b/homeassistant/components/xthings_cloud/config_flow.py
@@ -10,17 +10,11 @@ from ha_xthings_cloud import (
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_TOKEN
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.instance_id import async_get as async_get_instance_id
 
-from .const import (
-    CONF_EMAIL,
-    CONF_PASSWORD,
-    CONF_REFRESH_TOKEN,
-    CONF_TOKEN,
-    DOMAIN,
-    LOGGER,
-)
+from .const import CONF_REFRESH_TOKEN, DOMAIN, LOGGER
 
 ERROR_CODE_MAP: dict[int, str] = {
     20001: "token_invalid",

--- a/homeassistant/components/xthings_cloud/const.py
+++ b/homeassistant/components/xthings_cloud/const.py
@@ -7,15 +7,7 @@ from homeassistant.const import Platform
 DOMAIN = "xthings_cloud"
 LOGGER = logging.getLogger(__package__)
 
-# pylint: disable-next=home-assistant-duplicate-const
-CONF_EMAIL = "email"
-# pylint: disable-next=home-assistant-duplicate-const
-CONF_PASSWORD = "password"
-# pylint: disable-next=home-assistant-duplicate-const
-CONF_TOKEN = "token"
 CONF_REFRESH_TOKEN = "refresh_token"
-# pylint: disable-next=home-assistant-duplicate-const
-CONF_CLIENT_ID = "client_id"
 CONF_INSTANCE_ID = "instance_id"
 
 # Polling interval (seconds)

--- a/homeassistant/components/xthings_cloud/coordinator.py
+++ b/homeassistant/components/xthings_cloud/coordinator.py
@@ -11,12 +11,13 @@ from ha_xthings_cloud import (
 )
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import CONF_REFRESH_TOKEN, CONF_TOKEN, DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER
+from .const import CONF_REFRESH_TOKEN, DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER
 
 type XthingsCloudConfigEntry = ConfigEntry[XthingsCloudCoordinator]
 

--- a/tests/components/xthings_cloud/conftest.py
+++ b/tests/components/xthings_cloud/conftest.py
@@ -5,12 +5,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from homeassistant.components.xthings_cloud.const import (
-    CONF_EMAIL,
-    CONF_REFRESH_TOKEN,
-    CONF_TOKEN,
-    DOMAIN,
-)
+from homeassistant.components.xthings_cloud.const import CONF_REFRESH_TOKEN, DOMAIN
+from homeassistant.const import CONF_EMAIL, CONF_TOKEN
 
 from .const import MOCK_EMAIL, MOCK_REFRESH_TOKEN, MOCK_TOKEN, MOCK_USER_ID
 

--- a/tests/components/xthings_cloud/test_config_flow.py
+++ b/tests/components/xthings_cloud/test_config_flow.py
@@ -5,14 +5,9 @@ from unittest.mock import AsyncMock
 from ha_xthings_cloud import XthingsCloudApiError, XthingsCloudAuthError
 import pytest
 
-from homeassistant.components.xthings_cloud.const import (
-    CONF_EMAIL,
-    CONF_PASSWORD,
-    CONF_REFRESH_TOKEN,
-    CONF_TOKEN,
-    DOMAIN,
-)
+from homeassistant.components.xthings_cloud.const import CONF_REFRESH_TOKEN, DOMAIN
 from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
none

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The `xthings_cloud` integration defines constants that already exist in `homeassistant.const` with the same name and value.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #171345
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
