### PR TITLE
Update aiolichess to 1.3.0

### DIFF
--- a/homeassistant/components/lichess/manifest.json
+++ b/homeassistant/components/lichess/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "quality_scale": "bronze",
-  "requirements": ["aiolichess==1.2.0"]
+  "requirements": ["aiolichess==1.3.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -309,7 +309,7 @@ aiokef==0.2.16
 aiokem==1.0.1
 
 # homeassistant.components.lichess
-aiolichess==1.2.0
+aiolichess==1.3.0
 
 # homeassistant.components.lifx
 aiolifx-effects==0.3.2


### PR DESCRIPTION
## Proposed change

Bumps the `aiolichess` dependency from 1.2.0 to 1.3.0. No integration code or test changes — this is purely the library version bump.

1.3.0 extends `LichessStatistics` with rating and games-played fields for every perf returned by `/api/account`: Ultra Bullet, `correspondence_games` (rating already existed), Chess960, Crazyhouse, Antichess, Atomic, Horde, King of the Hill, Racing Kings, and Three-check. The integration will start surfacing those fields as new sensors in a follow-up PR (split from this one per @joostlek's review on #171988).

Diff: https://github.com/aryanhasgithub/aiolichess/compare/v1.2.0...v1.3.0

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (\`ruff format homeassistant tests\`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: \`python3 -m script.hassfest\`.
- [x] New or updated dependencies have been added to \`requirements_all.txt\`.  
      Updated by running \`python3 -m script.gen_requirements_all\`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr