### PR TITLE
Handle connection error in Waze Travel Time

### DIFF
--- a/homeassistant/components/waze_travel_time/coordinator.py
+++ b/homeassistant/components/waze_travel_time/coordinator.py
@@ -150,7 +150,7 @@ async def async_get_travel_times(
 
     except WRCError as exp:
         raise UpdateFailed(f"Error on retrieving data: {exp}") from exp
-    except httpx.ConnectError as exp:
+    except httpx.RequestError as exp:
         raise UpdateFailed(f"Connection error: {exp}") from exp
 
     else:

--- a/homeassistant/components/waze_travel_time/coordinator.py
+++ b/homeassistant/components/waze_travel_time/coordinator.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 import logging
 from typing import Literal
 
+import httpx
 from pywaze.route_calculator import CalcRoutesResponse, WazeRouteCalculator, WRCError
 
 from homeassistant.config_entries import ConfigEntry
@@ -149,6 +150,8 @@ async def async_get_travel_times(
 
     except WRCError as exp:
         raise UpdateFailed(f"Error on retrieving data: {exp}") from exp
+    except httpx.ConnectError as exp:
+        raise UpdateFailed(f"Connection error: {exp}") from exp
 
     else:
         return filtered_routes

--- a/tests/components/waze_travel_time/test_sensor.py
+++ b/tests/components/waze_travel_time/test_sensor.py
@@ -1,5 +1,6 @@
 """Test Waze Travel Time sensors."""
 
+import httpx
 import pytest
 from pywaze.route_calculator import WRCError
 
@@ -31,6 +32,13 @@ from tests.common import MockConfigEntry
 def mock_update_wrcerror_fixture(mock_update):
     """Mock an update to the sensor failed with WRCError."""
     mock_update.side_effect = WRCError("test")
+    return mock_update
+
+
+@pytest.fixture(name="mock_update_connect_error")
+def mock_update_connect_error_fixture(mock_update):
+    """Mock an update to the sensor failed with httpx.ConnectError."""
+    mock_update.side_effect = httpx.ConnectError("[Errno -3] Try again")
     return mock_update
 
 
@@ -160,3 +168,23 @@ async def test_sensor_failed_wrcerror(
 
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
     assert "Error on retrieving data: " in caplog.text
+
+
+@pytest.mark.usefixtures("mock_update_connect_error")
+async def test_sensor_failed_connect_error(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that sensor update fails with log message on connection error."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG,
+        options=DEFAULT_OPTIONS,
+        entry_id="test",
+        version=WazeConfigFlow.VERSION,
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert "Connection error: " in caplog.text

--- a/tests/components/waze_travel_time/test_sensor.py
+++ b/tests/components/waze_travel_time/test_sensor.py
@@ -150,11 +150,26 @@ async def test_excl_filter(hass: HomeAssistant) -> None:
     assert hass.states.get("sensor.waze_travel_time").attributes["distance"] == 300
 
 
-@pytest.mark.usefixtures("mock_update_wrcerror")
-async def test_sensor_failed_wrcerror(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+@pytest.mark.parametrize(
+    ("error_fixture", "log_message"),
+    [
+        pytest.param(
+            "mock_update_wrcerror", "Error on retrieving data: ", id="wrcerror"
+        ),
+        pytest.param(
+            "mock_update_connect_error", "Connection error: ", id="connect_error"
+        ),
+    ],
+)
+async def test_sensor_failed(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    error_fixture: str,
+    log_message: str,
+    request: pytest.FixtureRequest,
 ) -> None:
     """Test that sensor update fails with log message."""
+    request.getfixturevalue(error_fixture)
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data=MOCK_CONFIG,
@@ -167,24 +182,4 @@ async def test_sensor_failed_wrcerror(
     await hass.async_block_till_done()
 
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
-    assert "Error on retrieving data: " in caplog.text
-
-
-@pytest.mark.usefixtures("mock_update_connect_error")
-async def test_sensor_failed_connect_error(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Test that sensor update fails with log message on connection error."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data=MOCK_CONFIG,
-        options=DEFAULT_OPTIONS,
-        entry_id="test",
-        version=WazeConfigFlow.VERSION,
-    )
-    config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert config_entry.state is ConfigEntryState.SETUP_RETRY
-    assert "Connection error: " in caplog.text
+    assert log_message in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

```
2026-05-24 12:09:36.234 ERROR (MainThread) [homeassistant.components.waze_travel_time.coordinator] Unexpected error fetching waze_travel_time data
Traceback (most recent call last):
  File "/usr/local/lib/python3.14/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
    yield
  File "/usr/local/lib/python3.14/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
    resp = await self._pool.handle_async_request(req)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
    raise exc from None
  File "/usr/local/lib/python3.14/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
    response = await connection.handle_async_request(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        pool_request.request
        ^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/local/lib/python3.14/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
    raise exc
  File "/usr/local/lib/python3.14/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
    stream = await self._connect(request)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/httpcore/_async/connection.py", line 124, in _connect
    stream = await self._network_backend.connect_tcp(**kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
    return await self._backend.connect_tcp(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
    )
    ^
  File "/usr/local/lib/python3.14/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
    with map_exceptions(exc_map):
  File "/usr/local/lib/python3.14/contextlib.py", line 162, in __exit__
    self.gen.throw(value)
    ~~~~~~~~~~~~~~^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
    raise to_exc(exc) from exc
httpcore.ConnectError: [Errno -3] Try again

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 433, in _async_refresh
    self.data = await self._async_update_data()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/waze_travel_time/coordinator.py", line 222, in _async_update_data
    routes = await async_get_travel_times(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<13 lines>...
    )
    ^
  File "/usr/src/homeassistant/homeassistant/components/waze_travel_time/coordinator.py", line 73, in async_get_travel_times
    routes = await client.calc_routes(
             ^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<10 lines>...
    )
    ^
  File "/usr/local/lib/python3.14/site-packages/pywaze/route_calculator.py", line 324, in calc_routes
    routes = await self.get_routes(
             ^^^^^^^^^^^^^^^^^^^^^^
    ...<8 lines>...
    )
  File "/usr/local/lib/python3.14/site-packages/pywaze/route_calculator.py", line 214, in get_routes
    response: httpx.Response = await self.client.get(
                               ^^^^^^^^^^^^^^^^^^^^^^
    ...<4 lines>...
    )
    ^
  File "/usr/local/lib/python3.14/site-packages/httpx/_client.py", line 1768, in get
    return await self.request(
           ^^^^^^^^^^^^^^^^^^^
    ...<9 lines>...
    )
    ^
  File "/usr/local/lib/python3.14/site-packages/httpx/_client.py", line 1540, in request
    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/httpx/_client.py", line 1629, in send
    response = await self._send_handling_auth(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<4 lines>...
    )
    ^
  File "/usr/local/lib/python3.14/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
    response = await self._send_handling_redirects(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<3 lines>...
    )
    ^
  File "/usr/local/lib/python3.14/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
    response = await self._send_single_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/httpx/_client.py", line 1730, in _send_single_request
    response = await transport.handle_async_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
    with map_httpcore_exceptions():
         ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.14/contextlib.py", line 162, in __exit__
    self.gen.throw(value)
    ~~~~~~~~~~~~~~^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
    raise mapped_exc(message) from exc
httpx.ConnectError: [Errno -3] Try again
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
