### PR TITLE
Enable Alert Component to be setup via the UI

### DIFF
--- a/homeassistant/components/alert/__init__.py
+++ b/homeassistant/components/alert/__init__.py
@@ -32,6 +32,7 @@ from .const import (
     CONF_NOTIFIERS,
     CONF_SKIP_FIRST,
     CONF_TITLE,
+    DATA_COMPONENT,
     DEFAULT_CAN_ACK,
     DEFAULT_SKIP_FIRST,
     DOMAIN,
@@ -126,7 +127,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     DEVELOPMENT OF THE ALERT INTEGRATION IS FROZEN.
     """
-    component = hass.data[DOMAIN] = EntityComponent[AlertEntity](LOGGER, DOMAIN, hass)
+    component = hass.data[DATA_COMPONENT] = EntityComponent[AlertEntity](
+        LOGGER, DOMAIN, hass
+    )
 
     component.async_register_entity_service(SERVICE_TURN_OFF, None, "async_turn_off")
     component.async_register_entity_service(SERVICE_TURN_ON, None, "async_turn_on")
@@ -144,7 +147,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: AlertConfigEntry) -> bool:
     """Set up an alert from a config entry."""
-    component: EntityComponent[AlertEntity] = hass.data[DOMAIN]
+    component = hass.data[DATA_COMPONENT]
     alert = _alert_from_entry(hass, entry)
     await component.async_add_entities([alert])
     entry.runtime_data = alert.entity_id
@@ -153,6 +156,5 @@ async def async_setup_entry(hass: HomeAssistant, entry: AlertConfigEntry) -> boo
 
 async def async_unload_entry(hass: HomeAssistant, entry: AlertConfigEntry) -> bool:
     """Unload a config entry."""
-    component: EntityComponent[AlertEntity] = hass.data[DOMAIN]
-    await component.async_remove_entity(entry.runtime_data)
+    await hass.data[DATA_COMPONENT].async_remove_entity(entry.runtime_data)
     return True

--- a/homeassistant/components/alert/__init__.py
+++ b/homeassistant/components/alert/__init__.py
@@ -49,8 +49,8 @@ ALERT_SCHEMA = vol.Schema(
         vol.Required(CONF_REPEAT): vol.All(
             cv.ensure_list,
             [vol.Coerce(float)],
-            # Minimum delay is 1 second = 0.016 minutes
-            [vol.Range(min=0.016)],
+            # Minimum delay is 1 second
+            [vol.Range(min=1 / 60)],
         ),
         vol.Optional(CONF_CAN_ACK, default=DEFAULT_CAN_ACK): cv.boolean,
         vol.Optional(CONF_SKIP_FIRST, default=DEFAULT_SKIP_FIRST): cv.boolean,

--- a/homeassistant/components/alert/__init__.py
+++ b/homeassistant/components/alert/__init__.py
@@ -3,8 +3,11 @@
 DEVELOPMENT OF THE ALERT INTEGRATION IS FROZEN.
 """
 
+from typing import Any
+
 import voluptuous as vol
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_ENTITY_ID,
     CONF_NAME,
@@ -18,6 +21,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.template import Template
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
@@ -34,6 +38,8 @@ from .const import (
     LOGGER,
 )
 from .entity import AlertEntity
+
+type AlertConfigEntry = ConfigEntry[str]
 
 ALERT_SCHEMA = vol.Schema(
     {
@@ -63,56 +69,90 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
+def _alert_from_yaml(
+    hass: HomeAssistant, object_id: str, cfg: dict[str, Any] | None
+) -> AlertEntity:
+    """Build an AlertEntity from a YAML alert configuration."""
+    if not cfg:
+        cfg = {}
+
+    return AlertEntity(
+        hass,
+        object_id,
+        cfg[CONF_NAME],
+        cfg[CONF_ENTITY_ID],
+        cfg[CONF_STATE],
+        cfg[CONF_REPEAT],
+        cfg[CONF_SKIP_FIRST],
+        cfg.get(CONF_ALERT_MESSAGE),
+        cfg.get(CONF_DONE_MESSAGE),
+        cfg[CONF_NOTIFIERS],
+        cfg[CONF_CAN_ACK],
+        cfg.get(CONF_TITLE),
+        cfg.get(CONF_DATA),
+    )
+
+
+def _template_from_string(hass: HomeAssistant, value: str | None) -> Template | None:
+    """Wrap an optional string in a Template attached to hass."""
+    if value is None:
+        return None
+    return Template(value, hass)
+
+
+def _alert_from_entry(hass: HomeAssistant, entry: AlertConfigEntry) -> AlertEntity:
+    """Build an AlertEntity from a config entry."""
+    options = entry.options
+    return AlertEntity(
+        hass,
+        None,
+        entry.title,
+        options[CONF_ENTITY_ID],
+        options.get(CONF_STATE, STATE_ON),
+        [float(value) for value in options[CONF_REPEAT]],
+        options.get(CONF_SKIP_FIRST, DEFAULT_SKIP_FIRST),
+        _template_from_string(hass, options.get(CONF_ALERT_MESSAGE)),
+        _template_from_string(hass, options.get(CONF_DONE_MESSAGE)),
+        list(options.get(CONF_NOTIFIERS, [])),
+        options.get(CONF_CAN_ACK, DEFAULT_CAN_ACK),
+        _template_from_string(hass, options.get(CONF_TITLE)),
+        options.get(CONF_DATA),
+        unique_id=entry.entry_id,
+    )
+
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Alert component.
 
     DEVELOPMENT OF THE ALERT INTEGRATION IS FROZEN.
     """
-    component = EntityComponent[AlertEntity](LOGGER, DOMAIN, hass)
-
-    entities: list[AlertEntity] = []
-
-    for object_id, cfg in config[DOMAIN].items():
-        if not cfg:
-            cfg = {}
-
-        name = cfg[CONF_NAME]
-        watched_entity_id = cfg[CONF_ENTITY_ID]
-        alert_state = cfg[CONF_STATE]
-        repeat = cfg[CONF_REPEAT]
-        skip_first = cfg[CONF_SKIP_FIRST]
-        message_template = cfg.get(CONF_ALERT_MESSAGE)
-        done_message_template = cfg.get(CONF_DONE_MESSAGE)
-        notifiers = cfg[CONF_NOTIFIERS]
-        can_ack = cfg[CONF_CAN_ACK]
-        title_template = cfg.get(CONF_TITLE)
-        data = cfg.get(CONF_DATA)
-
-        entities.append(
-            AlertEntity(
-                hass,
-                object_id,
-                name,
-                watched_entity_id,
-                alert_state,
-                repeat,
-                skip_first,
-                message_template,
-                done_message_template,
-                notifiers,
-                can_ack,
-                title_template,
-                data,
-            )
-        )
-
-    if not entities:
-        return False
+    component = hass.data[DOMAIN] = EntityComponent[AlertEntity](LOGGER, DOMAIN, hass)
 
     component.async_register_entity_service(SERVICE_TURN_OFF, None, "async_turn_off")
     component.async_register_entity_service(SERVICE_TURN_ON, None, "async_turn_on")
     component.async_register_entity_service(SERVICE_TOGGLE, None, "async_toggle")
 
-    await component.async_add_entities(entities)
+    yaml_entities = [
+        _alert_from_yaml(hass, object_id, cfg)
+        for object_id, cfg in config.get(DOMAIN, {}).items()
+    ]
+    if yaml_entities:
+        await component.async_add_entities(yaml_entities)
 
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: AlertConfigEntry) -> bool:
+    """Set up an alert from a config entry."""
+    component: EntityComponent[AlertEntity] = hass.data[DOMAIN]
+    alert = _alert_from_entry(hass, entry)
+    await component.async_add_entities([alert])
+    entry.runtime_data = alert.entity_id
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: AlertConfigEntry) -> bool:
+    """Unload a config entry."""
+    component: EntityComponent[AlertEntity] = hass.data[DOMAIN]
+    await component.async_remove_entity(entry.runtime_data)
     return True

--- a/homeassistant/components/alert/config_flow.py
+++ b/homeassistant/components/alert/config_flow.py
@@ -40,7 +40,7 @@ from .const import (
     DOMAIN,
 )
 
-MIN_REPEAT_MINUTES = 0.016
+MIN_REPEAT_MINUTES = 1 / 60
 
 
 async def _validate_repeat(

--- a/homeassistant/components/alert/config_flow.py
+++ b/homeassistant/components/alert/config_flow.py
@@ -1,0 +1,108 @@
+"""Config flow for the Alert integration."""
+
+from collections.abc import Mapping
+from typing import Any, cast
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_ENTITY_ID,
+    CONF_NAME,
+    CONF_REPEAT,
+    CONF_STATE,
+    STATE_ON,
+)
+from homeassistant.helpers.schema_config_entry_flow import (
+    SchemaCommonFlowHandler,
+    SchemaConfigFlowHandler,
+    SchemaFlowError,
+    SchemaFlowFormStep,
+)
+from homeassistant.helpers.selector import (
+    BooleanSelector,
+    EntitySelector,
+    ObjectSelector,
+    TemplateSelector,
+    TextSelector,
+    TextSelectorConfig,
+)
+
+from .const import (
+    CONF_ALERT_MESSAGE,
+    CONF_CAN_ACK,
+    CONF_DATA,
+    CONF_DONE_MESSAGE,
+    CONF_NOTIFIERS,
+    CONF_SKIP_FIRST,
+    CONF_TITLE,
+    DEFAULT_CAN_ACK,
+    DEFAULT_SKIP_FIRST,
+    DOMAIN,
+)
+
+MIN_REPEAT_MINUTES = 0.016
+
+
+async def _validate_repeat(
+    handler: SchemaCommonFlowHandler, user_input: dict[str, Any]
+) -> dict[str, Any]:
+    """Validate that repeat entries are floats above the minimum delay."""
+    raw_values = user_input.get(CONF_REPEAT)
+    if not raw_values:
+        raise SchemaFlowError("repeat_required")
+
+    parsed: list[float] = []
+    for value in raw_values:
+        try:
+            number = float(value)
+        except (TypeError, ValueError) as err:
+            raise SchemaFlowError("invalid_repeat") from err
+        if number < MIN_REPEAT_MINUTES:
+            raise SchemaFlowError("invalid_repeat")
+        parsed.append(number)
+
+    return {**user_input, CONF_REPEAT: parsed}
+
+
+OPTIONS_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_ENTITY_ID): EntitySelector(),
+        vol.Required(CONF_STATE, default=STATE_ON): TextSelector(),
+        vol.Required(CONF_REPEAT): TextSelector(TextSelectorConfig(multiple=True)),
+        vol.Required(CONF_CAN_ACK, default=DEFAULT_CAN_ACK): BooleanSelector(),
+        vol.Required(CONF_SKIP_FIRST, default=DEFAULT_SKIP_FIRST): BooleanSelector(),
+        vol.Optional(CONF_NOTIFIERS, default=list): TextSelector(
+            TextSelectorConfig(multiple=True)
+        ),
+        vol.Optional(CONF_TITLE): TemplateSelector(),
+        vol.Optional(CONF_ALERT_MESSAGE): TemplateSelector(),
+        vol.Optional(CONF_DONE_MESSAGE): TemplateSelector(),
+        vol.Optional(CONF_DATA): ObjectSelector(),
+    }
+)
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_NAME): TextSelector(),
+    }
+).extend(OPTIONS_SCHEMA.schema)
+
+CONFIG_FLOW = {
+    "user": SchemaFlowFormStep(CONFIG_SCHEMA, validate_user_input=_validate_repeat),
+}
+
+OPTIONS_FLOW = {
+    "init": SchemaFlowFormStep(OPTIONS_SCHEMA, validate_user_input=_validate_repeat),
+}
+
+
+class AlertConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
+    """Handle a config or options flow for Alert."""
+
+    config_flow = CONFIG_FLOW
+    options_flow = OPTIONS_FLOW
+    options_flow_reloads = True
+
+    def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
+        """Return config entry title."""
+        return cast(str, options[CONF_NAME])

--- a/homeassistant/components/alert/const.py
+++ b/homeassistant/components/alert/const.py
@@ -1,7 +1,5 @@
 """Constants for the Alert integration."""
 
-from __future__ import annotations
-
 import logging
 from typing import TYPE_CHECKING, Final
 

--- a/homeassistant/components/alert/const.py
+++ b/homeassistant/components/alert/const.py
@@ -1,9 +1,19 @@
 """Constants for the Alert integration."""
 
+from __future__ import annotations
+
 import logging
-from typing import Final
+from typing import TYPE_CHECKING, Final
+
+from homeassistant.util.hass_dict import HassKey
+
+if TYPE_CHECKING:
+    from homeassistant.helpers.entity_component import EntityComponent
+
+    from .entity import AlertEntity
 
 DOMAIN: Final = "alert"
+DATA_COMPONENT: HassKey[EntityComponent[AlertEntity]] = HassKey(DOMAIN)
 
 LOGGER = logging.getLogger(__package__)
 

--- a/homeassistant/components/alert/entity.py
+++ b/homeassistant/components/alert/entity.py
@@ -38,7 +38,7 @@ class AlertEntity(Entity):
     def __init__(
         self,
         hass: HomeAssistant,
-        entity_id: str,
+        entity_id: str | None,
         name: str,
         watched_entity_id: str,
         state: str,
@@ -49,11 +49,13 @@ class AlertEntity(Entity):
         notifiers: list[str],
         can_ack: bool,
         title_template: Template | None,
-        data: dict[Any, Any],
+        data: dict[Any, Any] | None,
+        unique_id: str | None = None,
     ) -> None:
         """Initialize the alert."""
         self.hass = hass
         self._attr_name = name
+        self._attr_unique_id = unique_id
         self._alert_state = state
         self._skip_first = skip_first
         self._data = data
@@ -72,7 +74,8 @@ class AlertEntity(Entity):
         self._ack = False
         self._cancel: Callable[[], None] | None = None
         self._send_done_message = False
-        self.entity_id = f"{DOMAIN}.{entity_id}"
+        if entity_id is not None:
+            self.entity_id = f"{DOMAIN}.{entity_id}"
 
         async_track_state_change_event(
             hass, [watched_entity_id], self.watched_entity_change

--- a/homeassistant/components/alert/manifest.json
+++ b/homeassistant/components/alert/manifest.json
@@ -3,7 +3,9 @@
   "name": "Alert",
   "after_dependencies": ["notify"],
   "codeowners": ["@home-assistant/core", "@frenck"],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/alert",
+  "integration_type": "helper",
   "iot_class": "local_push",
   "quality_scale": "internal"
 }

--- a/homeassistant/components/alert/strings.json
+++ b/homeassistant/components/alert/strings.json
@@ -1,4 +1,41 @@
 {
+  "config": {
+    "error": {
+      "invalid_repeat": "Each repeat value must be a number of minutes greater than or equal to 0.016 (one second).",
+      "repeat_required": "Provide at least one repeat interval."
+    },
+    "step": {
+      "user": {
+        "data": {
+          "can_acknowledge": "Allow acknowledging the alert",
+          "data": "Notification data",
+          "done_message": "Done message",
+          "entity_id": "Watched entity",
+          "message": "Message",
+          "name": "[%key:common::config_flow::data::name%]",
+          "notifiers": "Notifiers",
+          "repeat": "Repeat",
+          "skip_first": "Skip first notification",
+          "state": "Alert state",
+          "title": "Title"
+        },
+        "data_description": {
+          "can_acknowledge": "If enabled, the alert can be silenced.",
+          "data": "Extra data sent to the notifier service.",
+          "done_message": "Optional template rendered once the alert clears.",
+          "entity_id": "Entity whose state is monitored to trigger the alert.",
+          "message": "Optional template rendered for the notification body.",
+          "notifiers": "Notifier service names (without the `notify.` prefix) to call when the alert fires.",
+          "repeat": "Delays in minutes between repeat notifications. Minimum value is 0.016 (one second).",
+          "skip_first": "If enabled, no notification is sent immediately when the alert begins.",
+          "state": "State of the watched entity that triggers the alert.",
+          "title": "Optional template rendered for the notification title."
+        },
+        "description": "Create an alert that watches an entity's state and sends repeating notifications while the state matches.",
+        "title": "Add alert"
+      }
+    }
+  },
   "entity_component": {
     "_": {
       "name": "[%key:component::alert::title%]",
@@ -6,6 +43,41 @@
         "idle": "[%key:common::state::idle%]",
         "off": "Acknowledged",
         "on": "[%key:common::state::active%]"
+      }
+    }
+  },
+  "options": {
+    "error": {
+      "invalid_repeat": "[%key:component::alert::config::error::invalid_repeat%]",
+      "repeat_required": "[%key:component::alert::config::error::repeat_required%]"
+    },
+    "step": {
+      "init": {
+        "data": {
+          "can_acknowledge": "[%key:component::alert::config::step::user::data::can_acknowledge%]",
+          "data": "[%key:component::alert::config::step::user::data::data%]",
+          "done_message": "[%key:component::alert::config::step::user::data::done_message%]",
+          "entity_id": "[%key:component::alert::config::step::user::data::entity_id%]",
+          "message": "[%key:component::alert::config::step::user::data::message%]",
+          "notifiers": "[%key:component::alert::config::step::user::data::notifiers%]",
+          "repeat": "[%key:component::alert::config::step::user::data::repeat%]",
+          "skip_first": "[%key:component::alert::config::step::user::data::skip_first%]",
+          "state": "[%key:component::alert::config::step::user::data::state%]",
+          "title": "[%key:component::alert::config::step::user::data::title%]"
+        },
+        "data_description": {
+          "can_acknowledge": "[%key:component::alert::config::step::user::data_description::can_acknowledge%]",
+          "data": "[%key:component::alert::config::step::user::data_description::data%]",
+          "done_message": "[%key:component::alert::config::step::user::data_description::done_message%]",
+          "entity_id": "[%key:component::alert::config::step::user::data_description::entity_id%]",
+          "message": "[%key:component::alert::config::step::user::data_description::message%]",
+          "notifiers": "[%key:component::alert::config::step::user::data_description::notifiers%]",
+          "repeat": "[%key:component::alert::config::step::user::data_description::repeat%]",
+          "skip_first": "[%key:component::alert::config::step::user::data_description::skip_first%]",
+          "state": "[%key:component::alert::config::step::user::data_description::state%]",
+          "title": "[%key:component::alert::config::step::user::data_description::title%]"
+        },
+        "description": "Adjust the alert configuration."
       }
     }
   },

--- a/homeassistant/components/alert/strings.json
+++ b/homeassistant/components/alert/strings.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "error": {
-      "invalid_repeat": "Each repeat value must be a number of minutes greater than or equal to 0.016 (one second).",
+      "invalid_repeat": "Each repeat value must be a number of minutes (minimum 1 second).",
       "repeat_required": "Provide at least one repeat interval."
     },
     "step": {
@@ -26,7 +26,7 @@
           "entity_id": "Entity whose state is monitored to trigger the alert.",
           "message": "Optional template rendered for the notification body.",
           "notifiers": "Notifier service names (without the `notify.` prefix) to call when the alert fires.",
-          "repeat": "Delays in minutes between repeat notifications. Minimum value is 0.016 (one second).",
+          "repeat": "Delays in minutes between repeat notifications (minimum 1 second).",
           "skip_first": "If enabled, no notification is sent immediately when the alert begins.",
           "state": "State of the watched entity that triggers the alert.",
           "title": "Optional template rendered for the notification title."

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -5,6 +5,7 @@ To update, run python3 -m script.hassfest
 
 FLOWS = {
     "helper": [
+        "alert",
         "derivative",
         "filter",
         "generic_hygrostat",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -222,11 +222,6 @@
       "config_flow": true,
       "iot_class": "local_push"
     },
-    "alert": {
-      "integration_type": "hub",
-      "config_flow": false,
-      "iot_class": "local_push"
-    },
     "alpha_vantage": {
       "name": "Alpha Vantage",
       "integration_type": "hub",
@@ -8328,6 +8323,11 @@
     }
   },
   "helper": {
+    "alert": {
+      "integration_type": "helper",
+      "config_flow": true,
+      "iot_class": "local_push"
+    },
     "counter": {
       "integration_type": "helper",
       "config_flow": false

--- a/tests/components/alert/test_config_flow.py
+++ b/tests/components/alert/test_config_flow.py
@@ -1,0 +1,182 @@
+"""Test the Alert config flow."""
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.alert.const import DOMAIN
+from homeassistant.const import (
+    CONF_ENTITY_ID,
+    CONF_NAME,
+    CONF_REPEAT,
+    CONF_STATE,
+    STATE_IDLE,
+    STATE_ON,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+WATCHED_ENTITY = "input_boolean.watched"
+
+
+async def test_config_flow_create(hass: HomeAssistant) -> None:
+    """A user can create an alert via the config flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] is None
+
+    with patch(
+        "homeassistant.components.alert.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_NAME: "My alert",
+                CONF_ENTITY_ID: WATCHED_ENTITY,
+                CONF_STATE: STATE_ON,
+                CONF_REPEAT: ["1", "5"],
+                "can_acknowledge": True,
+                "skip_first": False,
+                "notifiers": [],
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "My alert"
+    assert result["data"] == {}
+    assert result["options"] == {
+        CONF_NAME: "My alert",
+        CONF_ENTITY_ID: WATCHED_ENTITY,
+        CONF_STATE: STATE_ON,
+        CONF_REPEAT: [1.0, 5.0],
+        "can_acknowledge": True,
+        "skip_first": False,
+        "notifiers": [],
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("repeat_input", "error"),
+    [
+        ([], "repeat_required"),
+        (["not-a-number"], "invalid_repeat"),
+        (["0.001"], "invalid_repeat"),
+    ],
+    ids=("empty", "non-numeric", "below-minimum"),
+)
+async def test_config_flow_invalid_repeat(
+    hass: HomeAssistant, repeat_input: list[str], error: str
+) -> None:
+    """Invalid repeat values surface a form error rather than creating an entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Bad alert",
+            CONF_ENTITY_ID: WATCHED_ENTITY,
+            CONF_STATE: STATE_ON,
+            CONF_REPEAT: repeat_input,
+            "can_acknowledge": True,
+            "skip_first": False,
+            "notifiers": [],
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": error}
+
+
+async def test_entity_created_from_entry(hass: HomeAssistant) -> None:
+    """An AlertEntity is added when a config entry is set up, and removed on unload."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Alarm went off",
+        data={},
+        options={
+            CONF_NAME: "Alarm went off",
+            CONF_ENTITY_ID: WATCHED_ENTITY,
+            CONF_STATE: STATE_ON,
+            CONF_REPEAT: [1.0],
+            "can_acknowledge": True,
+            "skip_first": False,
+            "notifiers": [],
+        },
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("alert.alarm_went_off")
+    assert state is not None
+    assert state.state == STATE_IDLE
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    # Entity registry keeps the entry; the entity reports unavailable after unload.
+    assert hass.states.get("alert.alarm_went_off").state == "unavailable"
+
+
+async def test_options_flow_updates_entity(hass: HomeAssistant) -> None:
+    """Editing options re-creates the entity with the new configuration."""
+    other_entity = "input_boolean.other"
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="My alert",
+        data={},
+        options={
+            CONF_NAME: "My alert",
+            CONF_ENTITY_ID: WATCHED_ENTITY,
+            CONF_STATE: STATE_ON,
+            CONF_REPEAT: [1.0],
+            "can_acknowledge": True,
+            "skip_first": False,
+            "notifiers": [],
+        },
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_ENTITY_ID: other_entity,
+            CONF_STATE: "open",
+            CONF_REPEAT: ["2"],
+            "can_acknowledge": False,
+            "skip_first": True,
+            "notifiers": ["mobile"],
+        },
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    await hass.async_block_till_done()
+
+    assert entry.options == {
+        CONF_NAME: "My alert",
+        CONF_ENTITY_ID: other_entity,
+        CONF_STATE: "open",
+        CONF_REPEAT: [2.0],
+        "can_acknowledge": False,
+        "skip_first": True,
+        "notifiers": ["mobile"],
+    }
+    # Entity_id is still derived from the unchanged entry title
+    state = hass.states.get("alert.my_alert")
+    assert state is not None
+    assert state.state == STATE_IDLE


### PR DESCRIPTION
Signed-off-by: Lukas Bachschwell <lukas@lbsfilm.at>

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Allow the alert component to be setup via the UI. While I am aware that the alert component is not maintained, this feels like a missing bit that I was reccently looking for. 
Alerts in my home might need adjustments every once in a while, which s much nicer witha UI flow

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
