### PR TITLE
Bump bleak, habluetooth, and bleak-retry-connector for BlueZ backend fix

### DIFF
--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -16,7 +16,7 @@
   "quality_scale": "internal",
   "requirements": [
     "bleak==3.0.2",
-    "bleak-retry-connector==4.6.0",
+    "bleak-retry-connector==4.6.1",
     "bluetooth-adapters==2.1.0",
     "bluetooth-auto-recovery==1.5.3",
     "bluetooth-data-tools==1.29.18",

--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -15,7 +15,7 @@
   ],
   "quality_scale": "internal",
   "requirements": [
-    "bleak==2.1.1",
+    "bleak==3.0.2",
     "bleak-retry-connector==4.6.0",
     "bluetooth-adapters==2.1.0",
     "bluetooth-auto-recovery==1.5.3",

--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -21,6 +21,6 @@
     "bluetooth-auto-recovery==1.5.3",
     "bluetooth-data-tools==1.29.18",
     "dbus-fast==5.0.3",
-    "habluetooth==6.7.2"
+    "habluetooth==6.7.3"
   ]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -21,7 +21,7 @@ av==16.0.1
 awesomeversion==25.8.0
 bcrypt==5.0.0
 bleak-retry-connector==4.6.0
-bleak==2.1.1
+bleak==3.0.2
 bluetooth-adapters==2.1.0
 bluetooth-auto-recovery==1.5.3
 bluetooth-data-tools==1.29.18

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -35,7 +35,7 @@ file-read-backwards==2.0.0
 fnv-hash-fast==2.0.3
 go2rtc-client==0.4.0
 ha-ffmpeg==3.2.2
-habluetooth==6.7.2
+habluetooth==6.7.3
 hass-nabucasa==2.2.0
 hassil==3.5.0
 home-assistant-bluetooth==2.0.0

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -20,7 +20,7 @@ audioop-lts==0.2.2
 av==16.0.1
 awesomeversion==25.8.0
 bcrypt==5.0.0
-bleak-retry-connector==4.6.0
+bleak-retry-connector==4.6.1
 bleak==3.0.2
 bluetooth-adapters==2.1.0
 bluetooth-auto-recovery==1.5.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -654,7 +654,7 @@ bizkaibus==0.1.1
 bleak-esphome==3.9.1
 
 # homeassistant.components.bluetooth
-bleak-retry-connector==4.6.0
+bleak-retry-connector==4.6.1
 
 # homeassistant.components.bluetooth
 bleak==3.0.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1210,7 +1210,7 @@ ha-xthings-cloud==1.0.5
 habiticalib==0.4.7
 
 # homeassistant.components.bluetooth
-habluetooth==6.7.2
+habluetooth==6.7.3
 
 # homeassistant.components.hanna
 hanna-cloud==0.0.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -654,7 +654,7 @@ bleak-esphome==3.9.1
 bleak-retry-connector==4.6.0
 
 # homeassistant.components.bluetooth
-bleak==2.1.1
+bleak==3.0.2
 
 # homeassistant.components.blebox
 blebox-uniapi==2.5.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps:
- bleak 2.1.1 to 3.0.2
- habluetooth 6.7.2 to 6.7.3
- bleak-retry-connector 4.6.0 to 4.6.1

All three have to land together. bleak 3.0 made `bluez` a required keyword-only argument on `BleakClientBlueZDBus.__init__`; habluetooth's `HaBleakClientWrapper` bypasses `BleakClient.__init__` and constructs the backend client directly, so the default supplied by the high-level constructor never reaches the backend, and any local Linux BLE connection raises `TypeError: BleakClientBlueZDBus.__init__() missing 1 required keyword-only argument: 'bluez'`. habluetooth 6.7.3 fixes the wrapper to pass `bluez={}` explicitly, and it depends on bleak-retry-connector>=4.6.1 which pulls 4.6.1 in.

Verified locally; `tests/components/bluetooth/test_models.py::test_wrapped_bleak_client_local_adapter_only` failed before the habluetooth bump and passes after.

Changelogs:
- bleak: https://github.com/hbldh/bleak/blob/develop/CHANGELOG.rst
- habluetooth: https://github.com/Bluetooth-Devices/habluetooth/releases/tag/v6.7.3
- bleak-retry-connector: https://github.com/Bluetooth-Devices/bleak-retry-connector/releases/tag/v4.6.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr