### PR TITLE
Add support for Deluge listen port configuration and enhance integration

### DIFF
--- a/homeassistant/components/deluge/__init__.py
+++ b/homeassistant/components/deluge/__init__.py
@@ -18,7 +18,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from .const import CONF_WEB_PORT
 from .coordinator import DelugeConfigEntry, DelugeDataUpdateCoordinator
 
-PLATFORMS = [Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [Platform.NUMBER, Platform.SENSOR, Platform.SWITCH]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/deluge/const.py
+++ b/homeassistant/components/deluge/const.py
@@ -30,8 +30,6 @@ class DelugeGetSessionStatusKeys(enum.Enum):
 
     """
 
-    DHT_DOWNLOAD_RATE = "dht_download_rate"
-    DHT_UPLOAD_RATE = "dht_upload_rate"
     DOWNLOAD_RATE = "download_rate"
     UPLOAD_RATE = "upload_rate"
 
@@ -47,7 +45,25 @@ class DelugeSensorType(enum.StrEnum):
     CURRENT_STATUS_SENSOR = "current_status"
     DOWNLOAD_SPEED_SENSOR = "download_speed"
     UPLOAD_SPEED_SENSOR = "upload_speed"
-    PROTOCOL_TRAFFIC_UPLOAD_SPEED_SENSOR = "protocol_traffic_upload_speed"
-    PROTOCOL_TRAFFIC_DOWNLOAD_SPEED_SENSOR = "protocol_traffic_download_speed"
     DOWNLOADING_COUNT_SENSOR = "downloading_count"
     SEEDING_COUNT_SENSOR = "seeding_count"
+    LISTEN_PORTS_SENSOR = "listen_ports"
+
+
+class DelugeNumberType(enum.StrEnum):
+    """Number entity types for the Deluge integration."""
+
+    LISTEN_PORT = "listen_port"
+
+
+class DelugeGetConfigValueKeys(enum.StrEnum):
+    """Keys passed into the Deluge RPC `core.get_config_value`."""
+
+    LISTEN_PORTS = "listen_ports"
+
+
+class DelugeSetConfigKeys(enum.StrEnum):
+    """Keys passed into the Deluge RPC `core.set_config`."""
+
+    LISTEN_PORTS = "listen_ports"
+    RANDOM_PORT = "random_port"

--- a/homeassistant/components/deluge/coordinator.py
+++ b/homeassistant/components/deluge/coordinator.py
@@ -13,7 +13,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import LOGGER, DelugeGetSessionStatusKeys, DelugeSensorType
+from .const import (
+    LOGGER,
+    DelugeGetConfigValueKeys,
+    DelugeGetSessionStatusKeys,
+    DelugeSensorType,
+    DelugeSetConfigKeys,
+)
 
 type DelugeConfigEntry = ConfigEntry[DelugeDataUpdateCoordinator]
 
@@ -45,9 +51,27 @@ class DelugeDataUpdateCoordinator(
             logger=LOGGER,
             config_entry=entry,
             name=entry.title,
-            update_interval=timedelta(seconds=30),
+            update_interval=timedelta(seconds=60),
         )
         self.api = api
+
+    def set_listen_port(self, port: int) -> None:
+        """Set Deluge to use one fixed listen port.
+
+        Deluge stores the incoming ports as a [start_port, end_port] list.
+        Setting both values to the same port creates a single fixed port.
+        random_port must be disabled, otherwise Deluge may ignore listen_ports.
+        """
+        if not 1 <= port <= 65535:
+            raise ValueError(f"Invalid Deluge listen port: {port}")
+
+        self.api.call(
+            "core.set_config",
+            {
+                DelugeSetConfigKeys.LISTEN_PORTS.value: [port, port],
+                DelugeSetConfigKeys.RANDOM_PORT.value: False,
+            },
+        )
 
     def _get_deluge_data(self):
         """Get the latest data from Deluge."""
@@ -63,6 +87,9 @@ class DelugeDataUpdateCoordinator(
             )
             data["torrents_status_paused"] = self.api.call(
                 "core.get_torrents_status", {}, ["paused"]
+            )
+            data["listen_ports"] = self.api.call(
+                "core.get_config_value", DelugeGetConfigValueKeys.LISTEN_PORTS.value
             )
 
         except (
@@ -89,8 +116,15 @@ class DelugeDataUpdateCoordinator(
 
         data = {}
         data[Platform.SENSOR] = {
-            k.decode(): v for k, v in deluge_data["session_status"].items()
+            (k.decode() if isinstance(k, bytes) else k): v
+            for k, v in deluge_data["session_status"].items()
         }
         data[Platform.SENSOR].update(count_states(deluge_data["torrents_status_state"]))
-        data[Platform.SWITCH] = deluge_data["torrents_status_paused"]
+        # Normalize keys to strings for the SWITCH platform
+        data[Platform.SWITCH] = {
+            k.decode(): v for k, v in deluge_data["torrents_status_paused"].items()
+        }
+        data[Platform.SENSOR][DelugeSensorType.LISTEN_PORTS_SENSOR.value] = deluge_data[
+            "listen_ports"
+        ]
         return data

--- a/homeassistant/components/deluge/entity.py
+++ b/homeassistant/components/deluge/entity.py
@@ -24,5 +24,5 @@ class DelugeEntity(CoordinatorEntity[DelugeDataUpdateCoordinator]):
             identifiers={(DOMAIN, coordinator.config_entry.entry_id)},
             manufacturer=DEFAULT_NAME,
             name=DEFAULT_NAME,
-            sw_version=coordinator.api.deluge_version,
+            sw_version=str(coordinator.api.deluge_version),
         )

--- a/homeassistant/components/deluge/number.py
+++ b/homeassistant/components/deluge/number.py
@@ -1,0 +1,79 @@
+"""Support for setting Deluge numeric configuration values."""
+
+from homeassistant.components.number import (
+    NumberEntity,
+    NumberEntityDescription,
+    NumberMode,
+)
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import DelugeNumberType, DelugeSensorType
+from .coordinator import DelugeConfigEntry, DelugeDataUpdateCoordinator
+from .entity import DelugeEntity
+
+NUMBER_TYPES: tuple[NumberEntityDescription, ...] = (
+    NumberEntityDescription(
+        key=DelugeNumberType.LISTEN_PORT.value,
+        translation_key=DelugeNumberType.LISTEN_PORT.value,
+        native_min_value=1,
+        native_max_value=65535,
+        native_step=1,
+        mode=NumberMode.BOX,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: DelugeConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Deluge number entities."""
+    async_add_entities(
+        DelugeListenPortNumber(entry.runtime_data, description)
+        for description in NUMBER_TYPES
+    )
+
+
+class DelugeListenPortNumber(DelugeEntity, NumberEntity):
+    """Representation of the configured Deluge listen port."""
+
+    entity_description: NumberEntityDescription
+
+    def __init__(
+        self,
+        coordinator: DelugeDataUpdateCoordinator,
+        description: NumberEntityDescription,
+    ) -> None:
+        """Initialize the number entity."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = (
+            f"{coordinator.config_entry.entry_id}_{description.key}_config"
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the configured listen port.
+
+        Deluge stores listen_ports as [start_port, end_port]. For setting a single
+        fixed port we use the start value as the displayed value.
+        """
+        listen_ports = self.coordinator.data[Platform.SENSOR].get(
+            DelugeSensorType.LISTEN_PORTS_SENSOR.value
+        )
+
+        if isinstance(listen_ports, list | tuple) and listen_ports:
+            return int(listen_ports[0])
+
+        return None
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the Deluge listen port."""
+        await self.hass.async_add_executor_job(
+            self.coordinator.set_listen_port,
+            int(value),
+        )
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/deluge/sensor.py
+++ b/homeassistant/components/deluge/sensor.py
@@ -20,12 +20,10 @@ from .coordinator import DelugeConfigEntry, DelugeDataUpdateCoordinator
 from .entity import DelugeEntity
 
 
-def get_state(data: dict[str, float], key: str) -> str | float:
+def get_state(data: dict[str, Any], key: str) -> str | float:
     """Get current download/upload state."""
     upload = data[DelugeGetSessionStatusKeys.UPLOAD_RATE.value]
     download = data[DelugeGetSessionStatusKeys.DOWNLOAD_RATE.value]
-    protocol_upload = data[DelugeGetSessionStatusKeys.DHT_UPLOAD_RATE.value]
-    protocol_download = data[DelugeGetSessionStatusKeys.DHT_DOWNLOAD_RATE.value]
 
     # if key is CURRENT_STATUS, we just return whether
     # we are uploading / downloading / idle
@@ -39,26 +37,31 @@ def get_state(data: dict[str, float], key: str) -> str | float:
         return STATE_IDLE
 
     # if not, return the transfer rate for the given key
-    rate = 0.0
-    if key == DelugeSensorType.DOWNLOAD_SPEED_SENSOR:
-        rate = download
-    elif key == DelugeSensorType.UPLOAD_SPEED_SENSOR:
-        rate = upload
-    elif key == DelugeSensorType.PROTOCOL_TRAFFIC_DOWNLOAD_SPEED_SENSOR:
-        rate = protocol_download
-    else:
-        rate = protocol_upload
+    rate = download if key == DelugeSensorType.DOWNLOAD_SPEED_SENSOR else upload
 
     # convert to KiB/s and round
     kb_spd = rate / 1024
     return round(kb_spd, 2 if kb_spd < 0.1 else 1)
 
 
+def format_listen_ports(data: dict[str, Any]) -> str | None:
+    """Return a user-friendly representation of Deluge listen_ports."""
+    listen_ports = data.get(DelugeSensorType.LISTEN_PORTS_SENSOR.value)
+
+    if not isinstance(listen_ports, list | tuple) or not listen_ports:
+        return None
+
+    if len(listen_ports) == 1 or listen_ports[0] == listen_ports[1]:
+        return str(listen_ports[0])
+
+    return f"{listen_ports[0]} bis {listen_ports[1]}"
+
+
 @dataclass(frozen=True)
 class DelugeSensorEntityDescription(SensorEntityDescription):
     """Class to describe a Deluge sensor."""
 
-    value: Callable[[dict[str, float]], Any] = lambda val: val
+    value: Callable[[dict[str, Any]], Any] = lambda val: val
 
 
 SENSOR_TYPES: tuple[DelugeSensorEntityDescription, ...] = (
@@ -90,26 +93,6 @@ SENSOR_TYPES: tuple[DelugeSensorEntityDescription, ...] = (
         value=lambda data: get_state(data, DelugeSensorType.UPLOAD_SPEED_SENSOR.value),
     ),
     DelugeSensorEntityDescription(
-        key=DelugeSensorType.PROTOCOL_TRAFFIC_UPLOAD_SPEED_SENSOR.value,
-        translation_key=DelugeSensorType.PROTOCOL_TRAFFIC_UPLOAD_SPEED_SENSOR.value,
-        device_class=SensorDeviceClass.DATA_RATE,
-        native_unit_of_measurement=UnitOfDataRate.KILOBYTES_PER_SECOND,
-        state_class=SensorStateClass.MEASUREMENT,
-        value=lambda data: get_state(
-            data, DelugeSensorType.PROTOCOL_TRAFFIC_UPLOAD_SPEED_SENSOR.value
-        ),
-    ),
-    DelugeSensorEntityDescription(
-        key=DelugeSensorType.PROTOCOL_TRAFFIC_DOWNLOAD_SPEED_SENSOR.value,
-        translation_key=DelugeSensorType.PROTOCOL_TRAFFIC_DOWNLOAD_SPEED_SENSOR.value,
-        device_class=SensorDeviceClass.DATA_RATE,
-        native_unit_of_measurement=UnitOfDataRate.KILOBYTES_PER_SECOND,
-        state_class=SensorStateClass.MEASUREMENT,
-        value=lambda data: get_state(
-            data, DelugeSensorType.PROTOCOL_TRAFFIC_DOWNLOAD_SPEED_SENSOR.value
-        ),
-    ),
-    DelugeSensorEntityDescription(
         key=DelugeSensorType.DOWNLOADING_COUNT_SENSOR.value,
         translation_key=DelugeSensorType.DOWNLOADING_COUNT_SENSOR.value,
         state_class=SensorStateClass.TOTAL,
@@ -120,6 +103,11 @@ SENSOR_TYPES: tuple[DelugeSensorEntityDescription, ...] = (
         translation_key=DelugeSensorType.SEEDING_COUNT_SENSOR.value,
         state_class=SensorStateClass.TOTAL,
         value=lambda data: data[DelugeSensorType.SEEDING_COUNT_SENSOR.value],
+    ),
+    DelugeSensorEntityDescription(
+        key=DelugeSensorType.LISTEN_PORTS_SENSOR.value,
+        translation_key=DelugeSensorType.LISTEN_PORTS_SENSOR.value,
+        value=format_listen_ports,
     ),
 )
 

--- a/homeassistant/components/deluge/strings.json
+++ b/homeassistant/components/deluge/strings.json
@@ -26,6 +26,11 @@
     }
   },
   "entity": {
+    "number": {
+      "listen_port": {
+        "name": "Listen port"
+      }
+    },
     "sensor": {
       "download_speed": {
         "name": "Download speed"
@@ -34,11 +39,8 @@
         "name": "Downloading count",
         "unit_of_measurement": "torrents"
       },
-      "protocol_traffic_download_speed": {
-        "name": "Protocol traffic download speed"
-      },
-      "protocol_traffic_upload_speed": {
-        "name": "Protocol traffic upload speed"
+      "listen_ports": {
+        "name": "Listen ports"
       },
       "seeding_count": {
         "name": "Seeding count",


### PR DESCRIPTION
- Introduced DelugeNumberType for listen port management.
- Added DelugeListenPortNumber entity to handle listen port settings.
- Updated existing components to support listen port functionality.
- Refactored error handling and improved data retrieval methods.
- Removed unused constants and cleaned up code for better maintainability.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
