### PR TITLE
Bump python-ecobee-api to 0.4.0

### DIFF
--- a/homeassistant/components/ecobee/manifest.json
+++ b/homeassistant/components/ecobee/manifest.json
@@ -10,7 +10,7 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "loggers": ["pyecobee"],
-  "requirements": ["python-ecobee-api==0.3.2"],
+  "requirements": ["python-ecobee-api==0.4.0"],
   "single_config_entry": true,
   "zeroconf": [
     {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2614,7 +2614,7 @@ python-dropbox-api==0.1.3
 python-duco-connectivity==0.5.0
 
 # homeassistant.components.ecobee
-python-ecobee-api==0.3.2
+python-ecobee-api==0.4.0
 
 # homeassistant.components.etherscan
 python-etherscan-api==0.0.3


### PR DESCRIPTION
## Proposed change

Bumps `python-ecobee-api` from `0.3.2` to `0.4.0`.

The 0.4.0 release replaces the legacy username/password implicit grant with OAuth2 authorization code + PKCE and `offline_access`, so the library now stores a real `refresh_token` and uses `grant_type=refresh_token` for steady-state refreshes (no more repeated password POSTs on every refresh). It also exposes a new `EcobeeAuthMfaRequiredError` carrying an opaque `MfaChallenge` so callers can complete MFA-gated logins.

This PR is the library bump only, per [the splitting request on home-assistant/core#172101](https://github.com/home-assistant/core/pull/172101#pullrequestreview-3424044636). The integration-side changes (MFA / reauth / new exception handling) live in [home-assistant/core#172101](https://github.com/home-assistant/core/pull/172101) and will be rebased onto this PR once it lands.

Upstream library changelog: https://github.com/nkgilley/python-ecobee-api/releases/tag/0.4.0

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is unrelated to existing issues
- This PR is unrelated to existing discussions
- Companion docs PR: not needed for a library bump

## Checklist

- [x] The code change is tested and works locally
- [x] Local tests pass: tested by running #172101 against this dep
- [x] No new dependencies introduced — only an existing dependency version bump
- [x] No additional configuration required for end users on the existing username/password setup path with this bump alone (integration code in #172101 handles the new MFA paths)