### PR TITLE
Daikin: implement dynamic temperature limits for climate entities

### DIFF
--- a/homeassistant/components/daikin/climate.py
+++ b/homeassistant/components/daikin/climate.py
@@ -260,6 +260,23 @@ class DaikinClimate(DaikinEntity, ClimateEntity):
         """Return the temperature we try to reach."""
         return self.device.target_temperature
 
+    @property
+    def min_temp(self) -> float:
+        """Return the minimum temperature based on current mode."""
+        if self.hvac_mode == HVACMode.COOL:
+            return 18.0  # 64°F for cooling
+        if self.hvac_mode == HVACMode.HEAT:
+            # Allow 10C/50F to support Daikin's Leave Home anti-freeze mode
+            return 10.0
+        return 16.0  # Standard fallback
+
+    @property
+    def max_temp(self) -> float:
+        """Return the maximum temperature based on current mode."""
+        if self.hvac_mode == HVACMode.HEAT:
+            return 30.0  # 86°F maximum for heating
+        return 32.0  # 90°F maximum for cooling
+
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         await self._set(kwargs)

--- a/tests/components/daikin/test_climate.py
+++ b/tests/components/daikin/test_climate.py
@@ -1,0 +1,80 @@
+"""Tests for Daikin climate entities."""
+
+import pytest
+
+from homeassistant.components.climate import (
+    ATTR_MAX_TEMP,
+    ATTR_MIN_TEMP,
+    DOMAIN as CLIMATE_DOMAIN,
+    HVACMode,
+)
+from homeassistant.components.daikin.const import DOMAIN, KEY_MAC
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .conftest import ZoneDevice, configure_zone_device
+
+from tests.common import MockConfigEntry
+
+HOST = "127.0.0.1"
+
+
+async def _async_setup_daikin(
+    hass: HomeAssistant, zone_device: ZoneDevice
+) -> MockConfigEntry:
+    """Set up a Daikin config entry with a mocked library device."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=zone_device.mac,
+        data={CONF_HOST: HOST, KEY_MAC: zone_device.mac},
+    )
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    return config_entry
+
+
+@pytest.mark.parametrize(
+    ("daikin_mode", "hvac_mode", "expected_min", "expected_max"),
+    [
+        pytest.param("cool", HVACMode.COOL, 18.0, 32.0, id="cooling_limits"),
+        pytest.param("hot", HVACMode.HEAT, 10.0, 30.0, id="heating_limits"),
+        pytest.param("auto", HVACMode.HEAT_COOL, 16.0, 32.0, id="auto_limits"),
+        pytest.param("dry", HVACMode.DRY, 16.0, 32.0, id="dry_limits"),
+        pytest.param("fan", HVACMode.FAN_ONLY, 16.0, 32.0, id="fan_only_limits"),
+        pytest.param("off", HVACMode.OFF, 16.0, 32.0, id="off_limits"),
+    ],
+)
+async def test_daikin_climate_dynamic_temperature_limits(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    zone_device: ZoneDevice,
+    daikin_mode: str,
+    hvac_mode: HVACMode,
+    expected_min: float,
+    expected_max: float,
+) -> None:
+    """Test that DaikinClimate reports dynamic min_temp and max_temp based on HVAC mode."""
+    configure_zone_device(
+        zone_device,
+        zones=[["Living", "1", 22]],
+        mode=daikin_mode,
+    )
+
+    await _async_setup_daikin(hass, zone_device)
+
+    entity_id = entity_registry.async_get_entity_id(
+        CLIMATE_DOMAIN,
+        DOMAIN,
+        zone_device.mac,
+    )
+    assert entity_id is not None
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == hvac_mode
+    assert state.attributes[ATTR_MIN_TEMP] == expected_min
+    assert state.attributes[ATTR_MAX_TEMP] == expected_max


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
In the unlikely event that users depend on being able to send out-of-range setpoints to climate entities from the Daikin integration, these setpoints will now be out-of-range and may return errors rather than just being silently thrown away and ignored by the device interface. This doesn't feel breaking to me, but https://xkcd.com/1172/.

## Proposed change
The range of temperatures allowed for setpoints by the integration, previously defaulted to a range that exceeded the values that would be accepted by the head units. These out-of-range values are silently ignored.

This creates a confusing situation for users where they will adjust the thermostat to a value that looks like it should be accepted, only to have it silently thrown away.

Silently ignoring configurations that appear to be in-range also breaks automations that depend on these ranges to adjust the setpoints for desired proportional temperature control behavior (e.g. RoomMind).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
