### PR TITLE
Filter unsupported soundbar devices for SamsungTV

### DIFF
--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -537,6 +537,12 @@ class SamsungTVConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle a flow initialized by zeroconf discovery."""
         LOGGER.debug("Samsung device found via ZEROCONF: %s", discovery_info)
+        if "Soundbar" in discovery_info.name:
+            LOGGER.debug(
+                "Ignoring Samsung Soundbar found via Zeroconf: %s", discovery_info
+            )
+            return self.async_abort(reason="not_supported")
+
         self._mac = format_mac(discovery_info.properties["deviceid"])
         self._host = discovery_info.host
         self._async_start_discovery_with_mac_address()

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -1,6 +1,7 @@
 """Tests for Samsung TV config flow."""
 
 from copy import deepcopy
+import dataclasses
 from ipaddress import ip_address
 import socket
 from unittest.mock import ANY, AsyncMock, Mock, call, patch
@@ -1035,6 +1036,20 @@ async def test_zeroconf(hass: HomeAssistant) -> None:
     assert result["data"][CONF_MODEL] == "82GXARRS"
     assert result["data"][CONF_PORT] == 8002
     assert result["result"].unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
+
+
+async def test_zeroconf_ignores_soundbar_by_name(hass: HomeAssistant) -> None:
+    """Test zeroconf flow aborts early when the service name contains 'Soundbar'."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=dataclasses.replace(
+            MOCK_ZEROCONF_DATA, name="Q-Series Soundbar._airplay._tcp.local."
+        ),
+    )
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == RESULT_NOT_SUPPORTED
 
 
 @pytest.mark.usefixtures("remote_websocket", "remote_encrypted_websocket_failing")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Zeroconf example:

`
2026-05-24 16:26:39.071 DEBUG (MainThread) [homeassistant.components.samsungtv] Samsung device found via ZEROCONF: ZeroconfServiceInfo(ip_address=ZeroconfIPv4Address('192.168.0.185'), ip_addresses=[ZeroconfIPv4Address('192.168.0.185'), ZeroconfIPv6Address('fe80::b2f2:f6ff:fe53:5b11'), ZeroconfIPv6Address('fe80::b2f2:f6ff:fe53:5b11%2'), ZeroconfIPv6Address('2001:470:1f07:af0:b2f2:f6ff:fe53:5b11'), ZeroconfIPv6Address('2001:470:1f07:af0:b574:6e54:a568:b499'), ZeroconfIPv6Address('2001:470:8f62:0:b2f2:f6ff:fe53:5b11'), ZeroconfIPv6Address('2001:470:8f62:0:b574:6e54:a568:b499'), ZeroconfIPv6Address('fd40:1eef:5174:0:b2f2:f6ff:fe53:5b11'), ZeroconfIPv6Address('fd40:1eef:5174:0:b574:6e54:a568:b499')], port=40129, hostname='Samsung.local.', type='_airplay._tcp.local.', name='Q-Series Soundbar._airplay._tcp.local.', properties={'acl': '0', 'deviceid': 'B0:F2:F6:53:5B:11', 'features': '0xC05F8A00,0x1C340', 'rsf': '0x4', 'fv': 'p20.SAT-MT8532DFWWC-0090-1100.4', 'flags': '0x4', 'model': 'HW-Q990F', 'manufacturer': 'Samsung', 'serialNumber': xxxxxxxx, 'protovers': '1.1', 'srcvers': '366.0', 'pi': 'B0:F2:F6:53:5B:11', 'gid': 'B0:F2:F6:53:5B:11', 'gcgl': '0', 'pk': '03dc1e6bc0d81ea4c26348beebe1c3e69dfe16a7dacc7c487779dca75ea36fa3'})
`

We already filter out non TV here:
https://github.com/home-assistant/core/blob/5c73ad0310361b2076e6efd8208e82acbc3b2121/homeassistant/components/samsungtv/config_flow.py#L236

but it's too late in the process when zeroconf kick in.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170287
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
