### PR TITLE
Update rf-protocols to 4.0.0

### DIFF
--- a/homeassistant/components/novy_cooker_hood/commands.py
+++ b/homeassistant/components/novy_cooker_hood/commands.py
@@ -1,7 +1,0 @@
-"""Command names for the Novy Cooker Hood RF codes."""
-
-from typing import Final
-
-COMMAND_LIGHT: Final = "light"
-COMMAND_PLUS: Final = "plus"
-COMMAND_MINUS: Final = "minus"

--- a/homeassistant/components/novy_cooker_hood/config_flow.py
+++ b/homeassistant/components/novy_cooker_hood/config_flow.py
@@ -3,7 +3,7 @@
 import asyncio
 from typing import Any
 
-from rf_protocols.commands.novy import NovyCookerHoodCommand
+from rf_protocols.codes.novy.cooker_hood import NovyCookerHoodButton
 import voluptuous as vol
 
 from homeassistant.components.radio_frequency import (
@@ -19,7 +19,6 @@ from homeassistant.const import CONF_CODE
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er, selector
 
-from .commands import COMMAND_LIGHT
 from .const import (
     CODE_MAX,
     CODE_MIN,
@@ -128,7 +127,7 @@ class NovyCookerHoodConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Toggle the hood light on then off so it ends in its starting state."""
         assert self._transmitter_entity_id is not None
-        command = NovyCookerHoodCommand(channel=self._code, key=COMMAND_LIGHT)
+        command = NovyCookerHoodButton.LIGHT.to_command(channel=self._code)
         try:
             await async_send_command(self.hass, self._transmitter_entity_id, command)
             await asyncio.sleep(_TOGGLE_GAP)

--- a/homeassistant/components/novy_cooker_hood/config_flow.py
+++ b/homeassistant/components/novy_cooker_hood/config_flow.py
@@ -3,7 +3,7 @@
 import asyncio
 from typing import Any
 
-from rf_protocols.codes.novy.cooker_hood import get_codes_for_code
+from rf_protocols.commands.novy import NovyCookerHoodCommand
 import voluptuous as vol
 
 from homeassistant.components.radio_frequency import (
@@ -128,10 +128,8 @@ class NovyCookerHoodConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Toggle the hood light on then off so it ends in its starting state."""
         assert self._transmitter_entity_id is not None
+        command = NovyCookerHoodCommand(channel=self._code, key=COMMAND_LIGHT)
         try:
-            command = await get_codes_for_code(self._code).async_load_command(
-                COMMAND_LIGHT
-            )
             await async_send_command(self.hass, self._transmitter_entity_id, command)
             await asyncio.sleep(_TOGGLE_GAP)
             await async_send_command(self.hass, self._transmitter_entity_id, command)

--- a/homeassistant/components/novy_cooker_hood/fan.py
+++ b/homeassistant/components/novy_cooker_hood/fan.py
@@ -4,6 +4,7 @@ import asyncio
 import math
 from typing import Any
 
+from rf_protocols.codes.novy.cooker_hood import NovyCookerHoodButton
 from rf_protocols.commands.novy import NovyCookerHoodCommand
 
 from homeassistant.components.fan import ATTR_PERCENTAGE, FanEntity, FanEntityFeature
@@ -18,7 +19,6 @@ from homeassistant.util.percentage import (
     ranged_value_to_percentage,
 )
 
-from .commands import COMMAND_MINUS, COMMAND_PLUS
 from .const import SPEED_COUNT
 from .entity import NovyCookerHoodEntity
 
@@ -107,7 +107,7 @@ class NovyCookerHoodFan(NovyCookerHoodEntity, FanEntity, RestoreEntity):
     async def async_increase_speed(self, percentage_step: int | None = None) -> None:
         """Bump speed up by N hardware levels (no recalibration)."""
         steps = self._steps_from_percentage(percentage_step)
-        plus = NovyCookerHoodCommand(channel=self._code, key=COMMAND_PLUS)
+        plus = NovyCookerHoodButton.PLUS.to_command(channel=self._code)
         await self._async_send_repeated(plus, steps)
         self._level = min(SPEED_COUNT, self._level + steps)
         self.async_write_ha_state()
@@ -115,7 +115,7 @@ class NovyCookerHoodFan(NovyCookerHoodEntity, FanEntity, RestoreEntity):
     async def async_decrease_speed(self, percentage_step: int | None = None) -> None:
         """Bump speed down by N hardware levels (no recalibration)."""
         steps = self._steps_from_percentage(percentage_step)
-        minus = NovyCookerHoodCommand(channel=self._code, key=COMMAND_MINUS)
+        minus = NovyCookerHoodButton.MINUS.to_command(channel=self._code)
         await self._async_send_repeated(minus, steps)
         self._level = max(0, self._level - steps)
         self.async_write_ha_state()
@@ -129,11 +129,11 @@ class NovyCookerHoodFan(NovyCookerHoodEntity, FanEntity, RestoreEntity):
 
     async def _async_set_level(self, level: int) -> None:
         """Reset to off with `SPEED_COUNT` minus presses, then climb to level."""
-        minus = NovyCookerHoodCommand(channel=self._code, key=COMMAND_MINUS)
+        minus = NovyCookerHoodButton.MINUS.to_command(channel=self._code)
         await self._async_send_repeated(minus, SPEED_COUNT)
         if level > 0:
             await asyncio.sleep(_COMMAND_DELAY)
-            plus = NovyCookerHoodCommand(channel=self._code, key=COMMAND_PLUS)
+            plus = NovyCookerHoodButton.PLUS.to_command(channel=self._code)
             await self._async_send_repeated(plus, level)
         self._level = level
         self.async_write_ha_state()

--- a/homeassistant/components/novy_cooker_hood/fan.py
+++ b/homeassistant/components/novy_cooker_hood/fan.py
@@ -1,6 +1,5 @@
 """Fan platform for the Novy Cooker Hood (calibrated speed control)."""
 
-import asyncio
 import math
 from typing import Any
 
@@ -25,9 +24,6 @@ from .entity import NovyCookerHoodEntity
 PARALLEL_UPDATES = 1
 
 _SPEED_RANGE = (1, SPEED_COUNT)
-
-# Novy hood expects at least 150ms between RF commands
-_COMMAND_DELAY = 0.2
 
 
 async def async_setup_entry(
@@ -108,7 +104,8 @@ class NovyCookerHoodFan(NovyCookerHoodEntity, FanEntity, RestoreEntity):
         """Bump speed up by N hardware levels (no recalibration)."""
         steps = self._steps_from_percentage(percentage_step)
         plus = NovyCookerHoodButton.PLUS.to_command(channel=self._code)
-        await self._async_send_repeated(plus, steps)
+        for _ in range(steps):
+            await self._async_send(plus)
         self._level = min(SPEED_COUNT, self._level + steps)
         self.async_write_ha_state()
 
@@ -116,7 +113,8 @@ class NovyCookerHoodFan(NovyCookerHoodEntity, FanEntity, RestoreEntity):
         """Bump speed down by N hardware levels (no recalibration)."""
         steps = self._steps_from_percentage(percentage_step)
         minus = NovyCookerHoodButton.MINUS.to_command(channel=self._code)
-        await self._async_send_repeated(minus, steps)
+        for _ in range(steps):
+            await self._async_send(minus)
         self._level = max(0, self._level - steps)
         self.async_write_ha_state()
 
@@ -130,22 +128,14 @@ class NovyCookerHoodFan(NovyCookerHoodEntity, FanEntity, RestoreEntity):
     async def _async_set_level(self, level: int) -> None:
         """Reset to off with `SPEED_COUNT` minus presses, then climb to level."""
         minus = NovyCookerHoodButton.MINUS.to_command(channel=self._code)
-        await self._async_send_repeated(minus, SPEED_COUNT)
+        for _ in range(SPEED_COUNT):
+            await self._async_send(minus)
         if level > 0:
-            await asyncio.sleep(_COMMAND_DELAY)
             plus = NovyCookerHoodButton.PLUS.to_command(channel=self._code)
-            await self._async_send_repeated(plus, level)
+            for _ in range(level):
+                await self._async_send(plus)
         self._level = level
         self.async_write_ha_state()
-
-    async def _async_send_repeated(
-        self, command: NovyCookerHoodCommand, count: int
-    ) -> None:
-        """Send the same RF command N times, pausing between presses."""
-        for i in range(count):
-            if i > 0:
-                await asyncio.sleep(_COMMAND_DELAY)
-            await self._async_send(command)
 
     async def _async_send(self, command: NovyCookerHoodCommand) -> None:
         """Send a single RF command via the configured transmitter."""

--- a/homeassistant/components/novy_cooker_hood/fan.py
+++ b/homeassistant/components/novy_cooker_hood/fan.py
@@ -1,9 +1,10 @@
 """Fan platform for the Novy Cooker Hood (calibrated speed control)."""
 
+import asyncio
 import math
 from typing import Any
 
-from rf_protocols.codes.novy.cooker_hood import get_codes_for_code
+from rf_protocols.commands.novy import NovyCookerHoodCommand
 
 from homeassistant.components.fan import ATTR_PERCENTAGE, FanEntity, FanEntityFeature
 from homeassistant.components.radio_frequency import async_send_command
@@ -24,6 +25,9 @@ from .entity import NovyCookerHoodEntity
 PARALLEL_UPDATES = 1
 
 _SPEED_RANGE = (1, SPEED_COUNT)
+
+# Novy hood expects at least 150ms between RF commands
+_COMMAND_DELAY = 0.2
 
 
 async def async_setup_entry(
@@ -49,7 +53,7 @@ class NovyCookerHoodFan(NovyCookerHoodEntity, FanEntity, RestoreEntity):
     def __init__(self, entry: ConfigEntry) -> None:
         """Initialize the fan."""
         super().__init__(entry)
-        self._codes = get_codes_for_code(entry.data[CONF_CODE])
+        self._code: int = entry.data[CONF_CODE]
         self._level = 0
         self._attr_unique_id = entry.entry_id
 
@@ -103,18 +107,16 @@ class NovyCookerHoodFan(NovyCookerHoodEntity, FanEntity, RestoreEntity):
     async def async_increase_speed(self, percentage_step: int | None = None) -> None:
         """Bump speed up by N hardware levels (no recalibration)."""
         steps = self._steps_from_percentage(percentage_step)
-        plus = await self._codes.async_load_command(COMMAND_PLUS)
-        for _ in range(steps):
-            await self._async_send(plus)
+        plus = NovyCookerHoodCommand(channel=self._code, key=COMMAND_PLUS)
+        await self._async_send_repeated(plus, steps)
         self._level = min(SPEED_COUNT, self._level + steps)
         self.async_write_ha_state()
 
     async def async_decrease_speed(self, percentage_step: int | None = None) -> None:
         """Bump speed down by N hardware levels (no recalibration)."""
         steps = self._steps_from_percentage(percentage_step)
-        minus = await self._codes.async_load_command(COMMAND_MINUS)
-        for _ in range(steps):
-            await self._async_send(minus)
+        minus = NovyCookerHoodCommand(channel=self._code, key=COMMAND_MINUS)
+        await self._async_send_repeated(minus, steps)
         self._level = max(0, self._level - steps)
         self.async_write_ha_state()
 
@@ -127,17 +129,25 @@ class NovyCookerHoodFan(NovyCookerHoodEntity, FanEntity, RestoreEntity):
 
     async def _async_set_level(self, level: int) -> None:
         """Reset to off with `SPEED_COUNT` minus presses, then climb to level."""
-        minus = await self._codes.async_load_command(COMMAND_MINUS)
-        for _ in range(SPEED_COUNT):
-            await self._async_send(minus)
+        minus = NovyCookerHoodCommand(channel=self._code, key=COMMAND_MINUS)
+        await self._async_send_repeated(minus, SPEED_COUNT)
         if level > 0:
-            plus = await self._codes.async_load_command(COMMAND_PLUS)
-            for _ in range(level):
-                await self._async_send(plus)
+            await asyncio.sleep(_COMMAND_DELAY)
+            plus = NovyCookerHoodCommand(channel=self._code, key=COMMAND_PLUS)
+            await self._async_send_repeated(plus, level)
         self._level = level
         self.async_write_ha_state()
 
-    async def _async_send(self, command: Any) -> None:
+    async def _async_send_repeated(
+        self, command: NovyCookerHoodCommand, count: int
+    ) -> None:
+        """Send the same RF command N times, pausing between presses."""
+        for i in range(count):
+            if i > 0:
+                await asyncio.sleep(_COMMAND_DELAY)
+            await self._async_send(command)
+
+    async def _async_send(self, command: NovyCookerHoodCommand) -> None:
         """Send a single RF command via the configured transmitter."""
         await async_send_command(
             self.hass, self._transmitter, command, context=self._context

--- a/homeassistant/components/novy_cooker_hood/light.py
+++ b/homeassistant/components/novy_cooker_hood/light.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from rf_protocols.commands.novy import NovyCookerHoodCommand
+from rf_protocols.codes.novy.cooker_hood import NovyCookerHoodButton
 
 from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.components.radio_frequency import async_send_command
@@ -12,7 +12,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .commands import COMMAND_LIGHT
 from .entity import NovyCookerHoodEntity
 
 PARALLEL_UPDATES = 1
@@ -48,19 +47,19 @@ class NovyCookerHoodLight(NovyCookerHoodEntity, LightEntity, RestoreEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on by sending the toggle command."""
-        await self._async_send_command(COMMAND_LIGHT)
+        await self._async_send_light()
         self._attr_is_on = True
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off by sending the toggle command."""
-        await self._async_send_command(COMMAND_LIGHT)
+        await self._async_send_light()
         self._attr_is_on = False
         self.async_write_ha_state()
 
-    async def _async_send_command(self, key: str) -> None:
-        """Build the named command and send it via the configured transmitter."""
-        command = NovyCookerHoodCommand(channel=self._code, key=key)
+    async def _async_send_light(self) -> None:
+        """Send the light toggle command via the configured transmitter."""
+        command = NovyCookerHoodButton.LIGHT.to_command(channel=self._code)
         await async_send_command(
             self.hass, self._transmitter, command, context=self._context
         )

--- a/homeassistant/components/novy_cooker_hood/light.py
+++ b/homeassistant/components/novy_cooker_hood/light.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from rf_protocols.codes.novy.cooker_hood import get_codes_for_code
+from rf_protocols.commands.novy import NovyCookerHoodCommand
 
 from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.components.radio_frequency import async_send_command
@@ -37,7 +37,7 @@ class NovyCookerHoodLight(NovyCookerHoodEntity, LightEntity, RestoreEntity):
     def __init__(self, entry: ConfigEntry) -> None:
         """Initialize the light."""
         super().__init__(entry)
-        self._codes = get_codes_for_code(entry.data[CONF_CODE])
+        self._code = entry.data[CONF_CODE]
         self._attr_unique_id = entry.entry_id
 
     async def async_added_to_hass(self) -> None:
@@ -58,9 +58,9 @@ class NovyCookerHoodLight(NovyCookerHoodEntity, LightEntity, RestoreEntity):
         self._attr_is_on = False
         self.async_write_ha_state()
 
-    async def _async_send_command(self, name: str) -> None:
-        """Load the named command and send it via the configured transmitter."""
-        command = await self._codes.async_load_command(name)
+    async def _async_send_command(self, key: str) -> None:
+        """Build the named command and send it via the configured transmitter."""
+        command = NovyCookerHoodCommand(channel=self._code, key=key)
         await async_send_command(
             self.hass, self._transmitter, command, context=self._context
         )

--- a/homeassistant/components/radio_frequency/manifest.json
+++ b/homeassistant/components/radio_frequency/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/radio_frequency",
   "integration_type": "entity",
   "quality_scale": "internal",
-  "requirements": ["rf-protocols==3.2.0"]
+  "requirements": ["rf-protocols==4.0.0"]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ python-slugify==8.0.4
 PyTurboJPEG==1.8.3
 PyYAML==6.0.3
 requests==2.34.2
-rf-protocols==3.2.0
+rf-protocols==4.0.0
 securetar==2026.4.1
 SQLAlchemy==2.0.49
 standard-aifc==3.13.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2874,7 +2874,7 @@ renson-endura-delta==1.7.2
 reolink-aio==0.19.1
 
 # homeassistant.components.radio_frequency
-rf-protocols==3.2.0
+rf-protocols==4.0.0
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/tests/components/novy_cooker_hood/conftest.py
+++ b/tests/components/novy_cooker_hood/conftest.py
@@ -1,10 +1,9 @@
 """Common fixtures for the Novy Cooker Hood tests."""
 
 from collections.abc import Iterator
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
 
 import pytest
-from rf_protocols.loader import CodeCollection
 
 from homeassistant.components.novy_cooker_hood.const import CONF_TRANSMITTER, DOMAIN
 from homeassistant.const import CONF_CODE
@@ -12,36 +11,16 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry
-from tests.components.radio_frequency.common import (
-    MockRadioFrequencyCommand,
-    MockRadioFrequencyEntity,
-)
+from tests.components.radio_frequency.common import MockRadioFrequencyEntity
 
 TRANSMITTER_ENTITY_ID = "radio_frequency.test_rf_transmitter"
 
 
 @pytest.fixture(autouse=True)
-def mock_get_codes() -> Iterator[MagicMock]:
-    """Patch the bundled-codes loader so tests don't hit the filesystem."""
-    fake_collection = MagicMock(spec=CodeCollection)
-    fake_collection.async_load_command = AsyncMock(
-        side_effect=lambda name: MockRadioFrequencyCommand()
-    )
-    with (
-        patch(
-            "homeassistant.components.novy_cooker_hood.light.get_codes_for_code",
-            return_value=fake_collection,
-        ),
-        patch(
-            "homeassistant.components.novy_cooker_hood.fan.get_codes_for_code",
-            return_value=fake_collection,
-        ),
-        patch(
-            "homeassistant.components.novy_cooker_hood.config_flow.get_codes_for_code",
-            return_value=fake_collection,
-        ),
-    ):
-        yield fake_collection
+def mock_command_delay() -> Iterator[None]:
+    """Drop the inter-command delay so tests don't spend real time waiting."""
+    with patch("homeassistant.components.novy_cooker_hood.fan._COMMAND_DELAY", 0):
+        yield
 
 
 @pytest.fixture

--- a/tests/components/novy_cooker_hood/conftest.py
+++ b/tests/components/novy_cooker_hood/conftest.py
@@ -1,8 +1,5 @@
 """Common fixtures for the Novy Cooker Hood tests."""
 
-from collections.abc import Iterator
-from unittest.mock import patch
-
 import pytest
 
 from homeassistant.components.novy_cooker_hood.const import CONF_TRANSMITTER, DOMAIN
@@ -14,13 +11,6 @@ from tests.common import MockConfigEntry
 from tests.components.radio_frequency.common import MockRadioFrequencyEntity
 
 TRANSMITTER_ENTITY_ID = "radio_frequency.test_rf_transmitter"
-
-
-@pytest.fixture(autouse=True)
-def mock_command_delay() -> Iterator[None]:
-    """Drop the inter-command delay so tests don't spend real time waiting."""
-    with patch("homeassistant.components.novy_cooker_hood.fan._COMMAND_DELAY", 0):
-        yield
 
 
 @pytest.fixture

--- a/tests/components/novy_cooker_hood/test_config_flow.py
+++ b/tests/components/novy_cooker_hood/test_config_flow.py
@@ -4,8 +4,8 @@ from collections.abc import Iterator
 from unittest.mock import patch
 
 import pytest
+from rf_protocols.codes.novy.cooker_hood import NovyCookerHoodButton
 
-from homeassistant.components.novy_cooker_hood.commands import COMMAND_LIGHT
 from homeassistant.components.novy_cooker_hood.const import CONF_TRANSMITTER, DOMAIN
 from homeassistant.components.radio_frequency import DATA_COMPONENT, DOMAIN as RF_DOMAIN
 from homeassistant.config_entries import SOURCE_USER
@@ -59,7 +59,7 @@ async def test_user_flow_test_then_finish(
     assert result["step_id"] == "test_light"
     assert len(mock_rf_entity.send_command_calls) == 2
     sent = mock_rf_entity.send_command_calls[0].command
-    assert sent.key == COMMAND_LIGHT
+    assert sent.key == NovyCookerHoodButton.LIGHT.code
     assert sent.channel == 3
 
     result = await hass.config_entries.flow.async_configure(
@@ -226,7 +226,7 @@ async def test_reconfigure_updates_entry(
     assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "test_light"
     sent = mock_rf_entity.send_command_calls[-1].command
-    assert sent.key == COMMAND_LIGHT
+    assert sent.key == NovyCookerHoodButton.LIGHT.code
     assert sent.channel == 4
 
     result = await hass.config_entries.flow.async_configure(

--- a/tests/components/novy_cooker_hood/test_config_flow.py
+++ b/tests/components/novy_cooker_hood/test_config_flow.py
@@ -1,7 +1,7 @@
 """Test the Novy Hood config flow."""
 
 from collections.abc import Iterator
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -49,7 +49,6 @@ async def _start_user_flow(hass: HomeAssistant, code: str = "1") -> dict:
 
 async def test_user_flow_test_then_finish(
     hass: HomeAssistant,
-    mock_get_codes: MagicMock,
     mock_rf_entity: MockRadioFrequencyEntity,
     entity_registry: er.EntityRegistry,
 ) -> None:
@@ -58,8 +57,10 @@ async def test_user_flow_test_then_finish(
 
     assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "test_light"
-    mock_get_codes.async_load_command.assert_awaited_with(COMMAND_LIGHT)
     assert len(mock_rf_entity.send_command_calls) == 2
+    sent = mock_rf_entity.send_command_calls[0].command
+    assert sent.key == COMMAND_LIGHT
+    assert sent.channel == 3
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={"next_step_id": "finish"}
@@ -77,7 +78,6 @@ async def test_user_flow_test_then_finish(
 
 async def test_user_flow_retry_picks_different_code(
     hass: HomeAssistant,
-    mock_get_codes: MagicMock,
     mock_rf_entity: MockRadioFrequencyEntity,
     entity_registry: er.EntityRegistry,
 ) -> None:
@@ -99,9 +99,13 @@ async def test_user_flow_retry_picks_different_code(
         },
     )
     assert result["type"] is FlowResultType.MENU
-    # One load per test x two tests; two sends per test x two tests.
-    assert mock_get_codes.async_load_command.await_count == 2
     assert len(mock_rf_entity.send_command_calls) == 4
+    assert [c.command.channel for c in mock_rf_entity.send_command_calls] == [
+        1,
+        1,
+        7,
+        7,
+    ]
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={"next_step_id": "finish"}
@@ -127,7 +131,6 @@ async def test_user_flow_test_transmit_failure(
 
 async def test_recover_after_transmit_failure(
     hass: HomeAssistant,
-    mock_get_codes: MagicMock,
     mock_rf_entity: MockRadioFrequencyEntity,
 ) -> None:
     """The user can Retry from test_failed and complete the flow."""
@@ -183,7 +186,6 @@ async def test_unique_id_already_configured(
 
 async def test_same_transmitter_different_code_is_allowed(
     hass: HomeAssistant,
-    mock_get_codes: MagicMock,
     mock_config_entry: MockConfigEntry,
     mock_rf_entity: MockRadioFrequencyEntity,
     entity_registry: er.EntityRegistry,
@@ -205,7 +207,6 @@ async def test_same_transmitter_different_code_is_allowed(
 
 async def test_reconfigure_updates_entry(
     hass: HomeAssistant,
-    mock_get_codes: MagicMock,
     init_novy_cooker_hood: MockConfigEntry,
     mock_rf_entity: MockRadioFrequencyEntity,
     entity_registry: er.EntityRegistry,
@@ -224,7 +225,9 @@ async def test_reconfigure_updates_entry(
     )
     assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "test_light"
-    mock_get_codes.async_load_command.assert_awaited_with(COMMAND_LIGHT)
+    sent = mock_rf_entity.send_command_calls[-1].command
+    assert sent.key == COMMAND_LIGHT
+    assert sent.channel == 4
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={"next_step_id": "finish"}
@@ -239,7 +242,6 @@ async def test_reconfigure_updates_entry(
 
 async def test_reconfigure_frees_old_unique_id(
     hass: HomeAssistant,
-    mock_get_codes: MagicMock,
     init_novy_cooker_hood: MockConfigEntry,
     mock_rf_entity: MockRadioFrequencyEntity,
 ) -> None:
@@ -295,7 +297,6 @@ async def test_reconfigure_aborts_on_collision(
 
 async def test_reconfigure_retry_returns_to_picker(
     hass: HomeAssistant,
-    mock_get_codes: MagicMock,
     init_novy_cooker_hood: MockConfigEntry,
     mock_rf_entity: MockRadioFrequencyEntity,
 ) -> None:
@@ -326,7 +327,6 @@ async def test_no_transmitters(hass: HomeAssistant) -> None:
 
 async def test_recover_after_no_transmitters(
     hass: HomeAssistant,
-    mock_get_codes: MagicMock,
 ) -> None:
     """User can re-init the flow after the radio_frequency integration loads."""
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/novy_cooker_hood/test_light.py
+++ b/tests/components/novy_cooker_hood/test_light.py
@@ -1,11 +1,12 @@
 """Tests for the Novy Hood light platform."""
 
+from rf_protocols.codes.novy.cooker_hood import NovyCookerHoodButton
+
 from homeassistant.components.light import (
     DOMAIN as LIGHT_DOMAIN,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
-from homeassistant.components.novy_cooker_hood.commands import COMMAND_LIGHT
 from homeassistant.const import (
     ATTR_ASSUMED_STATE,
     ATTR_ENTITY_ID,
@@ -65,8 +66,8 @@ async def test_turn_on_and_off_send_light_once_each(
     assert state.state == STATE_OFF
     assert len(mock_rf_entity.send_command_calls) == 2
     assert [c.command.key for c in mock_rf_entity.send_command_calls] == [
-        COMMAND_LIGHT,
-        COMMAND_LIGHT,
+        NovyCookerHoodButton.LIGHT.code,
+        NovyCookerHoodButton.LIGHT.code,
     ]
 
 

--- a/tests/components/novy_cooker_hood/test_light.py
+++ b/tests/components/novy_cooker_hood/test_light.py
@@ -1,7 +1,5 @@
 """Tests for the Novy Hood light platform."""
 
-from unittest.mock import MagicMock, call
-
 from homeassistant.components.light import (
     DOMAIN as LIGHT_DOMAIN,
     SERVICE_TURN_OFF,
@@ -28,7 +26,6 @@ ENTITY_ID = "light.novy_cooker_hood_light"
 
 async def test_turn_on_and_off_send_light_once_each(
     hass: HomeAssistant,
-    mock_get_codes: MagicMock,
     mock_rf_entity: MockRadioFrequencyEntity,
     init_novy_cooker_hood: MockConfigEntry,
 ) -> None:
@@ -66,11 +63,11 @@ async def test_turn_on_and_off_send_light_once_each(
     state = hass.states.get(ENTITY_ID)
     assert state is not None
     assert state.state == STATE_OFF
-    assert mock_get_codes.async_load_command.await_args_list == [
-        call(COMMAND_LIGHT),
-        call(COMMAND_LIGHT),
-    ]
     assert len(mock_rf_entity.send_command_calls) == 2
+    assert [c.command.key for c in mock_rf_entity.send_command_calls] == [
+        COMMAND_LIGHT,
+        COMMAND_LIGHT,
+    ]
 
 
 async def test_restore_state(


### PR DESCRIPTION
## Proposed change

Bump `rf-protocols` from 3.2.0 to 4.0.0 and adapt the Novy Cooker Hood integration to the new API.

The library now ships a typed `NovyCookerHoodButton` enum (`MINUS`, `PLUS`, `LIGHT`, `POWER`, `AMBIENT`, …) with a `to_command(channel=...)` factory. The integration was carrying its own string constants in `commands.py` and building commands via the lower-level `NovyCookerHoodCommand(...)` constructor. That file is removed, and the enum is used directly from `fan.py`, `light.py`, and `config_flow.py`.

Release notes: https://github.com/home-assistant-libs/rf-protocols/releases/tag/4.0.0
Diff: https://github.com/home-assistant-libs/rf-protocols/compare/3.2.0...4.0.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
