### PR TITLE
Add override decorator to components F to G

### DIFF
--- a/homeassistant/components/faa_delays/binary_sensor.py
+++ b/homeassistant/components/faa_delays/binary_sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from faadelays import Airport
 
@@ -122,11 +122,13 @@ class FAABinarySensor(CoordinatorEntity[FAADataUpdateCoordinator], BinarySensorE
         )
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return the status of the sensor."""
         return self.entity_description.is_on_fn(self.coordinator.data)
 
     @property
+    @override
     def extra_state_attributes(self) -> Mapping[str, Any]:
         """Return attributes for sensor."""
         return self.entity_description.extra_state_attributes_fn(self.coordinator.data)

--- a/homeassistant/components/faa_delays/config_flow.py
+++ b/homeassistant/components/faa_delays/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for FAA Delays integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiohttp import ClientConnectionError
 import faadelays
@@ -23,6 +23,7 @@ class FAADelaysConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/faa_delays/coordinator.py
+++ b/homeassistant/components/faa_delays/coordinator.py
@@ -3,6 +3,7 @@
 import asyncio
 from datetime import timedelta
 import logging
+from typing import override
 
 from aiohttp import ClientConnectionError
 from faadelays import Airport
@@ -34,6 +35,7 @@ class FAADataUpdateCoordinator(DataUpdateCoordinator[Airport]):
         self.session = aiohttp_client.async_get_clientsession(hass)
         self.data = Airport(code, self.session)
 
+    @override
     async def _async_update_data(self) -> Airport:
         try:
             async with asyncio.timeout(10):

--- a/homeassistant/components/facebook/notify.py
+++ b/homeassistant/components/facebook/notify.py
@@ -3,7 +3,7 @@
 from http import HTTPStatus
 import json
 import logging
-from typing import Any
+from typing import Any, override
 
 import requests
 import voluptuous as vol
@@ -45,6 +45,7 @@ class FacebookNotificationService(BaseNotificationService):
         """Initialize the service."""
         self.page_access_token = access_token
 
+    @override
     def send_message(self, message: str = "", **kwargs: Any) -> None:
         """Send some message."""
         payload = {"access_token": self.page_access_token}

--- a/homeassistant/components/fail2ban/sensor.py
+++ b/homeassistant/components/fail2ban/sensor.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 import logging
 import os
 import re
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -70,16 +70,19 @@ class BanSensor(SensorEntity):
         _LOGGER.debug("Setting up jail %s", self.jail)
 
     @property
+    @override
     def name(self):
         """Return the name of the sensor."""
         return self._name
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the fail2ban sensor."""
         return self.ban_dict
 
     @property
+    @override
     def native_value(self):
         """Return the most recently banned IP Address."""
         return self.last_ban

--- a/homeassistant/components/familyhub/camera.py
+++ b/homeassistant/components/familyhub/camera.py
@@ -1,5 +1,7 @@
 """Family Hub camera for Samsung Refrigerators."""
 
+from typing import override
+
 from pyfamilyhublocal import FamilyHubCam
 import voluptuous as vol
 
@@ -50,6 +52,7 @@ class FamilyHubCamera(Camera):
         self._name = name
         self.family_hub_cam = family_hub_cam
 
+    @override
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
@@ -57,6 +60,7 @@ class FamilyHubCamera(Camera):
         return await self.family_hub_cam.async_get_cam_image()
 
     @property
+    @override
     def name(self):
         """Return the name of this camera."""
         return self._name

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -5,7 +5,7 @@ from enum import IntFlag
 import functools as ft
 import logging
 import math
-from typing import Any, final
+from typing import Any, final, override
 
 from propcache.api import cached_property
 import voluptuous as vol
@@ -288,6 +288,7 @@ class FanEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         """Set the direction of the fan."""
         await self.hass.async_add_executor_job(self.set_direction, direction)
 
+    @override
     def turn_on(
         self,
         percentage: int | None = None,
@@ -309,6 +310,7 @@ class FanEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
             self._valid_preset_mode_or_raise(preset_mode)
         await self.async_turn_on(percentage, preset_mode, **kwargs)
 
+    @override
     async def async_turn_on(
         self,
         percentage: int | None = None,
@@ -334,6 +336,7 @@ class FanEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         await self.hass.async_add_executor_job(self.oscillate, oscillating)
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the entity is on."""
         return (
@@ -366,6 +369,7 @@ class FanEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         return self._attr_oscillating
 
     @property
+    @override
     def capability_attributes(self) -> dict[str, list[str] | None]:
         """Return capability attributes."""
         attrs = {}
@@ -381,6 +385,7 @@ class FanEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
 
     @final
     @property
+    @override
     def state_attributes(self) -> dict[str, float | str | None]:
         """Return optional state attributes."""
         data: dict[str, float | str | None] = {}
@@ -404,6 +409,7 @@ class FanEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         return data
 
     @cached_property
+    @override
     def supported_features(self) -> FanEntityFeature:
         """Flag supported features."""
         return self._attr_supported_features

--- a/homeassistant/components/fastdotcom/config_flow.py
+++ b/homeassistant/components/fastdotcom/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for Fast.com integration."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 
@@ -12,6 +12,7 @@ class FastdotcomConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/fastdotcom/coordinator.py
+++ b/homeassistant/components/fastdotcom/coordinator.py
@@ -1,6 +1,7 @@
 """DataUpdateCoordinator for the Fast.com integration."""
 
 from datetime import timedelta
+from typing import override
 
 from fastdotcom import fast_com
 
@@ -26,6 +27,7 @@ class FastdotcomDataUpdateCoordinator(DataUpdateCoordinator[dict[str, float] | N
             update_interval=timedelta(hours=DEFAULT_INTERVAL),
         )
 
+    @override
     async def _async_update_data(self) -> dict[str, float] | None:
         """Run an executor job to retrieve Fast.com data."""
         try:

--- a/homeassistant/components/fastdotcom/sensor.py
+++ b/homeassistant/components/fastdotcom/sensor.py
@@ -1,5 +1,7 @@
 """Support for Fast.com internet speed testing sensor."""
 
+from typing import override
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -47,6 +49,7 @@ class SpeedtestSensor(CoordinatorEntity[FastdotcomDataUpdateCoordinator], Sensor
         )
 
     @property
+    @override
     def native_value(
         self,
     ) -> float | None:

--- a/homeassistant/components/feedreader/config_flow.py
+++ b/homeassistant/components/feedreader/config_flow.py
@@ -2,7 +2,7 @@
 
 import html
 import logging
-from typing import Any
+from typing import Any, override
 import urllib.error
 
 import feedparser
@@ -44,6 +44,7 @@ class FeedReaderConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> FeedReaderOptionsFlowHandler:
@@ -73,6 +74,7 @@ class FeedReaderConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/feedreader/coordinator.py
+++ b/homeassistant/components/feedreader/coordinator.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import html
 from logging import getLogger
 from time import gmtime, struct_time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 from urllib.error import URLError
 
 import feedparser
@@ -121,6 +121,7 @@ class FeedReaderCoordinator(
         self.feed_version = feedparser.api.SUPPORTED_VERSIONS.get(feed["version"])
         self._feed = feed
 
+    @override
     async def _async_update_data(self) -> list[feedparser.FeedParserDict] | None:
         """Update the feed and publish new entries to the event bus."""
         assert self._feed is not None

--- a/homeassistant/components/feedreader/event.py
+++ b/homeassistant/components/feedreader/event.py
@@ -2,6 +2,7 @@
 
 import html
 import logging
+from typing import override
 
 from feedparser import FeedParserDict
 
@@ -62,6 +63,7 @@ class FeedReaderEvent(CoordinatorEntity[FeedReaderCoordinator], EventEntity):
         )
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         if (data := self.coordinator.data) is None or not data:

--- a/homeassistant/components/ffmpeg/__init__.py
+++ b/homeassistant/components/ffmpeg/__init__.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import re
+from typing import override
 
 from haffmpeg.core import HAFFmpeg
 from haffmpeg.tools import IMAGE_JPEG, FFVersion, ImageFrame
@@ -150,6 +151,7 @@ class FFmpegBase[_HAFFmpegT: HAFFmpeg](Entity):  # pylint: disable=home-assistan
         self.ffmpeg = ffmpeg
         self.initial_state = initial_state
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register dispatcher & events.
 
@@ -175,6 +177,7 @@ class FFmpegBase[_HAFFmpegT: HAFFmpeg](Entity):  # pylint: disable=home-assistan
         self._async_register_events()
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return self.ffmpeg.is_running

--- a/homeassistant/components/ffmpeg/camera.py
+++ b/homeassistant/components/ffmpeg/camera.py
@@ -1,6 +1,6 @@
 """Support for Cameras with FFmpeg as decoder."""
 
-from typing import Any
+from typing import Any, override
 
 from aiohttp import web
 from haffmpeg.camera import CameraMjpeg
@@ -63,10 +63,12 @@ class FFmpegCamera(Camera):
         self._input: str = config[CONF_INPUT]
         self._extra_arguments: str = config[CONF_EXTRA_ARGUMENTS]
 
+    @override
     async def stream_source(self) -> str:
         """Return the stream source."""
         return self._input.split(" ")[-1]
 
+    @override
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
@@ -78,6 +80,7 @@ class FFmpegCamera(Camera):
             extra_cmd=self._extra_arguments,
         )
 
+    @override
     async def handle_async_mjpeg_stream(
         self, request: web.Request
     ) -> web.StreamResponse:
@@ -98,6 +101,7 @@ class FFmpegCamera(Camera):
             await stream.close()
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of this camera."""
         return self._name

--- a/homeassistant/components/ffmpeg_motion/binary_sensor.py
+++ b/homeassistant/components/ffmpeg_motion/binary_sensor.py
@@ -1,6 +1,6 @@
 """Provides a binary sensor which is a collection of ffmpeg tools."""
 
-from typing import Any
+from typing import Any, override
 
 from haffmpeg.core import HAFFmpeg
 import haffmpeg.sensor as ffmpeg_sensor
@@ -86,11 +86,13 @@ class FFmpegBinarySensor[_HAFFmpegT: HAFFmpeg](
         self.async_write_ha_state()
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         return self._state
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the entity."""
         return self._name
@@ -106,6 +108,7 @@ class FFmpegMotion(FFmpegBinarySensor[ffmpeg_sensor.SensorMotion]):
         ffmpeg = ffmpeg_sensor.SensorMotion(manager.binary, self._async_callback)
         super().__init__(ffmpeg, config)
 
+    @override
     async def _async_start_ffmpeg(self, entity_ids: list[str] | None) -> None:
         """Start a FFmpeg instance.
 
@@ -129,6 +132,7 @@ class FFmpegMotion(FFmpegBinarySensor[ffmpeg_sensor.SensorMotion]):
         )
 
     @property
+    @override
     def device_class(self) -> BinarySensorDeviceClass:
         """Return the class of this sensor, from DEVICE_CLASSES."""
         return BinarySensorDeviceClass.MOTION

--- a/homeassistant/components/ffmpeg_noise/binary_sensor.py
+++ b/homeassistant/components/ffmpeg_noise/binary_sensor.py
@@ -1,6 +1,6 @@
 """Provides a binary sensor which is a collection of ffmpeg tools."""
 
-from typing import Any
+from typing import Any, override
 
 import haffmpeg.sensor as ffmpeg_sensor
 import voluptuous as vol
@@ -74,6 +74,7 @@ class FFmpegNoise(FFmpegBinarySensor[ffmpeg_sensor.SensorNoise]):
         ffmpeg = ffmpeg_sensor.SensorNoise(manager.binary, self._async_callback)
         super().__init__(ffmpeg, config)
 
+    @override
     async def _async_start_ffmpeg(self, entity_ids: list[str] | None) -> None:
         """Start a FFmpeg instance.
 
@@ -95,6 +96,7 @@ class FFmpegNoise(FFmpegBinarySensor[ffmpeg_sensor.SensorNoise]):
         )
 
     @property
+    @override
     def device_class(self) -> BinarySensorDeviceClass:
         """Return the class of this sensor, from DEVICE_CLASSES."""
         return BinarySensorDeviceClass.SOUND

--- a/homeassistant/components/fibaro/binary_sensor.py
+++ b/homeassistant/components/fibaro/binary_sensor.py
@@ -1,7 +1,7 @@
 """Support for Fibaro binary sensors."""
 
 from collections.abc import Mapping
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyfibaro.fibaro_device import DeviceModel
 
@@ -73,10 +73,12 @@ class FibaroBinarySensor(FibaroEntity, BinarySensorEntity):
             self._attr_icon = SENSOR_TYPES[self._fibaro_sensor_type][1]
 
     @property
+    @override
     def extra_state_attributes(self) -> Mapping[str, Any]:
         """Return the extra state attributes of the device."""
         return {**super().extra_state_attributes, **self._own_extra_state_attributes}
 
+    @override
     def update(self) -> None:
         """Get the latest data and update the state."""
         super().update()

--- a/homeassistant/components/fibaro/climate.py
+++ b/homeassistant/components/fibaro/climate.py
@@ -2,7 +2,7 @@
 
 from contextlib import suppress
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyfibaro.fibaro_device import DeviceModel
 
@@ -209,6 +209,7 @@ class FibaroThermostat(FibaroEntity, ClimateEntity):
                 ClimateEntityFeature.TURN_OFF | ClimateEntityFeature.TURN_ON
             )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity is added to hass."""
         _LOGGER.debug(
@@ -234,6 +235,7 @@ class FibaroThermostat(FibaroEntity, ClimateEntity):
                 self.controller.register(device.fibaro_id, self._update_callback)
 
     @property
+    @override
     def fan_mode(self) -> str | None:
         """Return the fan setting."""
         if not self._fan_mode_device:
@@ -241,6 +243,7 @@ class FibaroThermostat(FibaroEntity, ClimateEntity):
         mode = self._fan_mode_device.mode
         return FANMODES[mode]
 
+    @override
     def set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
         if not self._fan_mode_device:
@@ -262,6 +265,7 @@ class FibaroThermostat(FibaroEntity, ClimateEntity):
         return device.mode
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode | None:
         """Return hvac operation ie. heat, cool, idle."""
         fibaro_operation_mode = self.fibaro_op_mode
@@ -274,6 +278,7 @@ class FibaroThermostat(FibaroEntity, ClimateEntity):
             return OPMODES_HVAC[fibaro_operation_mode]
         return None
 
+    @override
     def set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target operation mode."""
         if not self._op_mode_device:
@@ -292,6 +297,7 @@ class FibaroThermostat(FibaroEntity, ClimateEntity):
             device.execute_action("setMode", [HA_OPMODES_HVAC[hvac_mode]])
 
     @property
+    @override
     def hvac_action(self) -> HVACAction | None:
         """Return the current running hvac operation if supported."""
         if not self._op_mode_device:
@@ -305,6 +311,7 @@ class FibaroThermostat(FibaroEntity, ClimateEntity):
         return None
 
     @property
+    @override
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., home, away, temp.
 
@@ -327,6 +334,7 @@ class FibaroThermostat(FibaroEntity, ClimateEntity):
             return None
         return OPMODES_PRESET[mode]
 
+    @override
     def set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         if self._op_mode_device is None:
@@ -344,6 +352,7 @@ class FibaroThermostat(FibaroEntity, ClimateEntity):
             )
 
     @property
+    @override
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         if self._temp_sensor_device:
@@ -354,6 +363,7 @@ class FibaroThermostat(FibaroEntity, ClimateEntity):
         return None
 
     @property
+    @override
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
         if self._target_temp_device:
@@ -363,6 +373,7 @@ class FibaroThermostat(FibaroEntity, ClimateEntity):
             return device.target_level
         return None
 
+    @override
     def set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperatures."""
         temperature = kwargs.get(ATTR_TEMPERATURE)

--- a/homeassistant/components/fibaro/config_flow.py
+++ b/homeassistant/components/fibaro/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyfibaro.fibaro_client import FibaroAuthenticationFailed, FibaroConnectFailed
 from slugify import slugify
@@ -62,6 +62,7 @@ class FibaroConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/fibaro/cover.py
+++ b/homeassistant/components/fibaro/cover.py
@@ -1,6 +1,6 @@
 """Support for Fibaro cover - curtains, rollershutters etc."""
 
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyfibaro.fibaro_device import DeviceModel
 
@@ -56,6 +56,7 @@ class PositionableFibaroCover(FibaroEntity, CoverEntity):
             return 100
         return position
 
+    @override
     def update(self) -> None:
         """Update the state."""
         super().update()
@@ -75,30 +76,37 @@ class PositionableFibaroCover(FibaroEntity, CoverEntity):
             closed = self.current_cover_position == 0
         self._attr_is_closed = closed
 
+    @override
     def set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
         self.set_level(cast(int, kwargs.get(ATTR_POSITION)))
 
+    @override
     def set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Move the slats to a specific position."""
         self.set_level2(cast(int, kwargs.get(ATTR_TILT_POSITION)))
 
+    @override
     def open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         self.action("open")
 
+    @override
     def close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
         self.action("close")
 
+    @override
     def open_cover_tilt(self, **kwargs: Any) -> None:
         """Open the cover tilt."""
         self.set_level2(100)
 
+    @override
     def close_cover_tilt(self, **kwargs: Any) -> None:
         """Close the cover."""
         self.set_level2(0)
 
+    @override
     def stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         self.action("stop")
@@ -124,6 +132,7 @@ class FibaroCover(FibaroEntity, CoverEntity):
         if "stopSlats" in self.fibaro_device.actions:
             self._attr_supported_features |= CoverEntityFeature.STOP_TILT
 
+    @override
     def update(self) -> None:
         """Update the state."""
         super().update()
@@ -138,26 +147,32 @@ class FibaroCover(FibaroEntity, CoverEntity):
             closed = device_state == "closed"
         self._attr_is_closed = closed
 
+    @override
     def open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         self.action("open")
 
+    @override
     def close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
         self.action("close")
 
+    @override
     def stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         self.action("stop")
 
+    @override
     def open_cover_tilt(self, **kwargs: Any) -> None:
         """Open the cover slats."""
         self.action("rotateSlatsUp")
 
+    @override
     def close_cover_tilt(self, **kwargs: Any) -> None:
         """Close the cover slats."""
         self.action("rotateSlatsDown")
 
+    @override
     def stop_cover_tilt(self, **kwargs: Any) -> None:
         """Stop the cover slats turning."""
         self.action("stopSlats")

--- a/homeassistant/components/fibaro/entity.py
+++ b/homeassistant/components/fibaro/entity.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyfibaro.fibaro_device import DeviceModel
 
@@ -32,6 +32,7 @@ class FibaroEntity(Entity):
         if not fibaro_device.visible:
             self._attr_entity_registry_visible_default = False
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity is added to hass."""
         self.async_on_remove(
@@ -100,6 +101,7 @@ class FibaroEntity(Entity):
         return self.fibaro_device.value.bool_value(False)
 
     @property
+    @override
     def extra_state_attributes(self) -> Mapping[str, Any]:
         """Return the state attributes of the device."""
         attr = {"fibaro_id": self.fibaro_device.fibaro_id}

--- a/homeassistant/components/fibaro/event.py
+++ b/homeassistant/components/fibaro/event.py
@@ -1,5 +1,7 @@
 """Support for Fibaro event entities."""
 
+from typing import override
+
 from pyfibaro.fibaro_device import DeviceModel, SceneEvent
 from pyfibaro.fibaro_state_resolver import FibaroEvent
 
@@ -53,6 +55,7 @@ class FibaroEventEntity(FibaroEntity, EventEntity):
         self._attr_event_types = scene_event.key_event_types
         self._attr_unique_id = f"{fibaro_device.unique_id_str}.{key_id}"
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity is added to hass."""
         await super().async_added_to_hass()

--- a/homeassistant/components/fibaro/light.py
+++ b/homeassistant/components/fibaro/light.py
@@ -1,7 +1,7 @@
 """Support for Fibaro lights."""
 
 from contextlib import suppress
-from typing import Any
+from typing import Any, override
 
 from pyfibaro.fibaro_device import DeviceModel
 
@@ -100,6 +100,7 @@ class FibaroLight(FibaroEntity, LightEntity):
         super().__init__(fibaro_device)
         self.entity_id = ENTITY_ID_FORMAT.format(self.ha_id)
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
         if ATTR_BRIGHTNESS in kwargs:
@@ -124,10 +125,12 @@ class FibaroLight(FibaroEntity, LightEntity):
         # The simplest case is left for last. No dimming, just switch on
         self.call_turn_on()
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         self.call_turn_off()
 
+    @override
     def update(self) -> None:
         """Update the state."""
         super().update()

--- a/homeassistant/components/fibaro/lock.py
+++ b/homeassistant/components/fibaro/lock.py
@@ -1,6 +1,6 @@
 """Support for Fibaro locks."""
 
-from typing import Any
+from typing import Any, override
 
 from pyfibaro.fibaro_device import DeviceModel
 
@@ -34,16 +34,19 @@ class FibaroLock(FibaroEntity, LockEntity):
         super().__init__(fibaro_device)
         self.entity_id = ENTITY_ID_FORMAT.format(self.ha_id)
 
+    @override
     def lock(self, **kwargs: Any) -> None:
         """Lock the device."""
         self.action("secure")
         self._attr_is_locked = True
 
+    @override
     def unlock(self, **kwargs: Any) -> None:
         """Unlock the device."""
         self.action("unsecure")  # codespell:ignore unsecure
         self._attr_is_locked = False
 
+    @override
     def update(self) -> None:
         """Update device state."""
         super().update()

--- a/homeassistant/components/fibaro/scene.py
+++ b/homeassistant/components/fibaro/scene.py
@@ -1,6 +1,6 @@
 """Support for Fibaro scenes."""
 
-from typing import Any
+from typing import Any, override
 
 from pyfibaro.fibaro_scene import SceneModel
 
@@ -50,6 +50,7 @@ class FibaroScene(Scene):
             identifiers={(DOMAIN, controller.hub_serial)}
         )
 
+    @override
     def activate(self, **kwargs: Any) -> None:
         """Activate the scene."""
         self._fibaro_scene.start()

--- a/homeassistant/components/fibaro/sensor.py
+++ b/homeassistant/components/fibaro/sensor.py
@@ -1,6 +1,7 @@
 """Support for Fibaro sensors."""
 
 from contextlib import suppress
+from typing import override
 
 from pyfibaro.fibaro_device import DeviceModel
 
@@ -156,6 +157,7 @@ class FibaroSensor(FibaroEntity, SensorEntity):
                     fibaro_device.unit, fibaro_device.unit
                 )
 
+    @override
     def update(self) -> None:
         """Update the state."""
         super().update()
@@ -181,6 +183,7 @@ class FibaroAdditionalSensor(FibaroEntity, SensorEntity):
         self._attr_name = f"{fibaro_device.friendly_name} {entity_description.name}"
         self._attr_unique_id = f"{fibaro_device.unique_id_str}_{entity_description.key}"
 
+    @override
     def update(self) -> None:
         """Update the state."""
         super().update()

--- a/homeassistant/components/fibaro/switch.py
+++ b/homeassistant/components/fibaro/switch.py
@@ -1,6 +1,6 @@
 """Support for Fibaro switches."""
 
-from typing import Any
+from typing import Any, override
 
 from pyfibaro.fibaro_device import DeviceModel
 
@@ -34,16 +34,19 @@ class FibaroSwitch(FibaroEntity, SwitchEntity):
         super().__init__(fibaro_device)
         self.entity_id = ENTITY_ID_FORMAT.format(self.ha_id)
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Turn device on."""
         self.call_turn_on()
         self._attr_is_on = True
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Turn device off."""
         self.call_turn_off()
         self._attr_is_on = False
 
+    @override
     def update(self) -> None:
         """Update device state."""
         super().update()

--- a/homeassistant/components/fido/sensor.py
+++ b/homeassistant/components/fido/sensor.py
@@ -6,7 +6,7 @@ https://www.fido.ca/pages/#/my-account/wireless
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyfido import FidoClient
 from pyfido.client import PyFidoError
@@ -225,6 +225,7 @@ class FidoSensor(SensorEntity):
         self._attr_name = f"{name} {number} {description.name}"
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the sensor."""
         return {"number": self._number}

--- a/homeassistant/components/file/config_flow.py
+++ b/homeassistant/components/file/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for file integration."""
 
 from copy import deepcopy
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -71,6 +71,7 @@ class FileConfigFlowHandler(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> FileOptionsFlowHandler:
@@ -83,6 +84,7 @@ class FileConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             self.hass.config.is_allowed_path, file_path
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/file/notify.py
+++ b/homeassistant/components/file/notify.py
@@ -1,7 +1,7 @@
 """Support for file notification."""
 
 import os
-from typing import Any, TextIO
+from typing import Any, TextIO, override
 
 from homeassistant.components.notify import (
     ATTR_TITLE_DEFAULT,
@@ -42,6 +42,7 @@ class FileNotifyEntity(NotifyEntity):
         self._attr_name = config.get(CONF_NAME, DEFAULT_NAME)
         self._attr_unique_id = unique_id
 
+    @override
     def send_message(self, message: str, title: str | None = None) -> None:
         """Send a message to a file."""
         file: TextIO

--- a/homeassistant/components/filesize/config_flow.py
+++ b/homeassistant/components/filesize/config_flow.py
@@ -2,7 +2,7 @@
 
 import logging
 import pathlib
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -38,6 +38,7 @@ class FilesizeConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/filesize/coordinator.py
+++ b/homeassistant/components/filesize/coordinator.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 import logging
 import os
 import pathlib
+from typing import override
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_FILE_PATH
@@ -55,10 +56,12 @@ class FileSizeCoordinator(DataUpdateCoordinator[dict[str, int | float | datetime
         except OSError as error:
             raise UpdateFailed(f"Can not retrieve file statistics {error}") from error
 
+    @override
     async def _async_setup(self) -> None:
         """Set up path."""
         self.path = await self.hass.async_add_executor_job(self._get_full_path)
 
+    @override
     async def _async_update_data(self) -> dict[str, float | int | datetime]:
         """Fetch file information."""
         statinfo = await self.hass.async_add_executor_job(self._update)

--- a/homeassistant/components/filesize/sensor.py
+++ b/homeassistant/components/filesize/sensor.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 import logging
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -89,6 +90,7 @@ class FilesizeEntity(CoordinatorEntity[FileSizeCoordinator], SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> float | int | datetime:
         """Return the value of the sensor."""
         value: float | int | datetime = self.coordinator.data[

--- a/homeassistant/components/filter/config_flow.py
+++ b/homeassistant/components/filter/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for filter."""
 
 from collections.abc import Mapping
-from typing import Any, cast
+from typing import Any, cast, override
 
 import voluptuous as vol
 
@@ -246,6 +246,7 @@ class FilterConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
     options_flow = OPTIONS_FLOW
     options_flow_reloads = True
 
+    @override
     def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
         """Return config entry title."""
         return cast(str, options[CONF_NAME])

--- a/homeassistant/components/filter/sensor.py
+++ b/homeassistant/components/filter/sensor.py
@@ -8,7 +8,7 @@ from functools import partial
 import logging
 from numbers import Number
 import statistics
-from typing import Any, cast
+from typing import Any, cast, override
 
 import voluptuous as vol
 
@@ -323,6 +323,7 @@ class SensorFilter(SensorEntity):
         if update_ha:
             self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
 
@@ -399,6 +400,7 @@ class SensorFilter(SensorEntity):
         self.async_on_remove(async_at_started(self.hass, _async_hass_started))
 
     @property
+    @override
     def native_value(self) -> datetime | StateType:
         """Return the state of the sensor."""
         if self._state is not None and self.device_class == SensorDeviceClass.TIMESTAMP:
@@ -426,10 +428,12 @@ class FilterState:
             value = round(float(self.state), precision)
             self.state = int(value) if precision == 0 else value
 
+    @override
     def __str__(self) -> str:
         """Return state as the string representation of FilterState."""
         return str(self.state)
 
+    @override
     def __repr__(self) -> str:
         """Return timestamp and state as the representation of FilterState."""
         return f"{self.timestamp} : {self.state}"
@@ -545,6 +549,7 @@ class RangeFilter(Filter, SensorEntity):
         self._upper_bound = upper_bound
         self._stats_internal: Counter = Counter()
 
+    @override
     def _filter_state(self, new_state: FilterState) -> FilterState:
         """Implement the range filter."""
 
@@ -602,6 +607,7 @@ class OutlierFilter(Filter, SensorEntity):
         self._stats_internal: Counter = Counter()
         self._store_raw = True
 
+    @override
     def _filter_state(self, new_state: FilterState) -> FilterState:
         """Implement the outlier filter."""
 
@@ -644,6 +650,7 @@ class LowPassFilter(Filter, SensorEntity):
         )
         self._time_constant = time_constant
 
+    @override
     def _filter_state(self, new_state: FilterState) -> FilterState:
         """Implement the low pass filter."""
 
@@ -694,6 +701,7 @@ class TimeSMAFilter(Filter, SensorEntity):
             else:
                 return
 
+    @override
     def _filter_state(self, new_state: FilterState) -> FilterState:
         """Implement the Simple Moving Average filter."""
 
@@ -731,6 +739,7 @@ class ThrottleFilter(Filter, SensorEntity):
         )
         self._only_numbers = False
 
+    @override
     def _filter_state(self, new_state: FilterState) -> FilterState:
         """Implement the throttle filter."""
         if not self.states or len(self.states) == self.states.maxlen:
@@ -760,6 +769,7 @@ class TimeThrottleFilter(Filter, SensorEntity):
         self._last_emitted_at: datetime | None = None
         self._only_numbers = False
 
+    @override
     def _filter_state(self, new_state: FilterState) -> FilterState:
         """Implement the filter."""
         window_start = new_state.timestamp - self._time_window

--- a/homeassistant/components/fing/config_flow.py
+++ b/homeassistant/components/fing/config_flow.py
@@ -2,7 +2,7 @@
 
 from contextlib import suppress
 import logging
-from typing import Any
+from typing import Any, override
 
 from fing_agent_api import FingAgent
 import httpx
@@ -22,6 +22,7 @@ class FingConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/fing/coordinator.py
+++ b/homeassistant/components/fing/coordinator.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass, field
 from datetime import timedelta
 import logging
+from typing import override
 
 from fing_agent_api import FingAgent
 from fing_agent_api.models import AgentInfoResponse, Device
@@ -51,6 +52,7 @@ class FingDataUpdateCoordinator(DataUpdateCoordinator[FingDataObject]):
             config_entry=config_entry,
         )
 
+    @override
     async def _async_update_data(self) -> FingDataObject:
         """Fetch data from Fing Agent."""
         device_response = None

--- a/homeassistant/components/fing/device_tracker.py
+++ b/homeassistant/components/fing/device_tracker.py
@@ -1,5 +1,7 @@
 """Platform for Device tracker integration."""
 
+from typing import override
+
 from fing_agent_api.models import Device
 
 from homeassistant.components.device_tracker import ScannerEntity
@@ -77,21 +79,25 @@ class FingTrackedDevice(CoordinatorEntity[FingDataUpdateCoordinator], ScannerEnt
         self._attr_icon = get_icon_from_type(self._device.type)
 
     @property
+    @override
     def is_connected(self) -> bool:
         """Return true if the device is connected to the network."""
         return self._device.active
 
     @property
+    @override
     def ip_address(self) -> str | None:
         """Return the primary ip address of the device."""
         return self._device.ip[0] if self._device.ip else None
 
     @property
+    @override
     def entity_registry_enabled_default(self) -> bool:
         """Enable entity by default."""
         return True
 
     @property
+    @override
     def unique_id(self) -> str | None:
         """Return the unique ID of the entity."""
         return self._attr_unique_id
@@ -110,6 +116,7 @@ class FingTrackedDevice(CoordinatorEntity[FingDataUpdateCoordinator], ScannerEnt
         )
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         updated_device_data = self.coordinator.data.devices.get(self._device.mac)

--- a/homeassistant/components/fints/sensor.py
+++ b/homeassistant/components/fints/sensor.py
@@ -3,7 +3,7 @@
 from collections import namedtuple
 from datetime import timedelta
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from fints.client import FinTS3PinTanClient
 from fints.models import SEPAAccount
@@ -276,6 +276,7 @@ class FinTsHoldingsAccount(SensorEntity):
         self._attr_native_value = sum(h.total_value for h in self._holdings)
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Additional attributes of the sensor.
 

--- a/homeassistant/components/firefly_iii/config_flow.py
+++ b/homeassistant/components/firefly_iii/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyfirefly import (
     Firefly,
@@ -58,6 +58,7 @@ class FireflyConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/firefly_iii/coordinator.py
+++ b/homeassistant/components/firefly_iii/coordinator.py
@@ -4,6 +4,7 @@ import asyncio
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
+from typing import override
 
 from aiohttp import CookieJar
 from pyfirefly import (
@@ -66,6 +67,7 @@ class FireflyDataUpdateCoordinator(DataUpdateCoordinator[FireflyCoordinatorData]
             ),
         )
 
+    @override
     async def _async_setup(self) -> None:
         """Set up the coordinator."""
         try:
@@ -89,6 +91,7 @@ class FireflyDataUpdateCoordinator(DataUpdateCoordinator[FireflyCoordinatorData]
                 translation_placeholders={"error": repr(err)},
             ) from err
 
+    @override
     async def _async_update_data(self) -> FireflyCoordinatorData:
         """Fetch data from Firefly III API."""
         now = datetime.now()  # pylint: disable=home-assistant-enforce-naive-now

--- a/homeassistant/components/firefly_iii/sensor.py
+++ b/homeassistant/components/firefly_iii/sensor.py
@@ -1,5 +1,7 @@
 """Sensor platform for Firefly III integration."""
 
+from typing import override
+
 from pyfirefly.models import Account, Budget, Category
 
 from homeassistant.components.sensor import (
@@ -93,6 +95,7 @@ class FireflyAccountBalanceSensor(FireflyAccountBaseEntity, SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return current account balance."""
         return self._account.attributes.current_balance
@@ -106,6 +109,7 @@ class FireflyAccountRoleSensor(FireflyAccountBaseEntity, SensorEntity):
     _attr_entity_registry_enabled_default = True
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return account role."""
 
@@ -140,6 +144,7 @@ class FireflyAccountTypeSensor(FireflyAccountBaseEntity, SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return account type."""
         return self._account.attributes.type
@@ -165,6 +170,7 @@ class FireflyCategorySensor(FireflyCategoryBaseEntity, SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return net spent+earned value for this category in the period."""
         spent_items = self._category.attributes.spent or []
@@ -196,6 +202,7 @@ class FireflyBudgetSensor(FireflyBudgetBaseEntity, SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return spent value for this budget in the period."""
         spent_items = self._budget.attributes.spent or []

--- a/homeassistant/components/fireservicerota/binary_sensor.py
+++ b/homeassistant/components/fireservicerota/binary_sensor.py
@@ -1,6 +1,6 @@
 """Binary Sensor platform for FireServiceRota integration."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -48,11 +48,13 @@ class ResponseBinarySensor(
         self._attr_unique_id = f"{entry.unique_id}_Duty"
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return the state of the binary sensor."""
         return self._client.on_duty
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return available attributes for binary sensor."""
         attr: dict[str, Any] = {}

--- a/homeassistant/components/fireservicerota/config_flow.py
+++ b/homeassistant/components/fireservicerota/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for FireServiceRota."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 from pyfireservicerota import FireServiceRota, InvalidAuthError
 import voluptuous as vol
@@ -34,6 +34,7 @@ class FireServiceRotaFlowHandler(ConfigFlow, domain=DOMAIN):
         self._existing_entry: dict[str, Any] | None = None
         self._description_placeholders: dict[str, str] | None = None
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/fireservicerota/coordinator.py
+++ b/homeassistant/components/fireservicerota/coordinator.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyfireservicerota import (
     ExpiredTokenError,
@@ -52,6 +52,7 @@ class FireServiceUpdateCoordinator(DataUpdateCoordinator[dict | None]):
 
         self.client = client
 
+    @override
     async def _async_update_data(self) -> dict | None:
         """Get the latest availability data."""
         return await self.client.async_update()

--- a/homeassistant/components/fireservicerota/sensor.py
+++ b/homeassistant/components/fireservicerota/sensor.py
@@ -1,7 +1,7 @@
 """Sensor platform for FireServiceRota integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.core import HomeAssistant, callback
@@ -41,6 +41,7 @@ class IncidentsSensor(RestoreEntity, SensorEntity):
         self._state_attributes: dict[str, Any] = {}
 
     @property
+    @override
     def icon(self) -> str:
         """Return the icon to use in the frontend."""
         if (
@@ -52,11 +53,13 @@ class IncidentsSensor(RestoreEntity, SensorEntity):
         return "mdi:fire-truck"
 
     @property
+    @override
     def native_value(self) -> str | None:
         """Return the state of the sensor."""
         return self._state
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return available attributes for sensor."""
         attr: dict[str, Any] = {}
@@ -92,6 +95,7 @@ class IncidentsSensor(RestoreEntity, SensorEntity):
 
         return attr
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Run when about to be added to hass."""
         await super().async_added_to_hass()

--- a/homeassistant/components/fireservicerota/switch.py
+++ b/homeassistant/components/fireservicerota/switch.py
@@ -1,7 +1,7 @@
 """Switch platform for FireServiceRota integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
@@ -55,6 +55,7 @@ class ResponseSwitch(SwitchEntity):
         self._state_icon = None
 
     @property
+    @override
     def icon(self) -> str:
         """Return the icon to use in the frontend."""
         if self._state_icon == "acknowledged":
@@ -65,16 +66,19 @@ class ResponseSwitch(SwitchEntity):
         return "mdi:forum"
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Get the assumed state of the switch."""
         return self._state
 
     @property
+    @override
     def available(self) -> bool:
         """Return if switch is available."""
         return self._client.on_duty
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return available attributes for switch."""
         attr: dict[str, Any] = {}
@@ -98,10 +102,12 @@ class ResponseSwitch(SwitchEntity):
             if key in data
         }
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Send Acknowledge response status."""
         await self.async_set_response(True)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Send Reject response status."""
         await self.async_set_response(False)
@@ -117,6 +123,7 @@ class ResponseSwitch(SwitchEntity):
         await self._client.async_set_response(value)
         self.client_update()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register update callback."""
         self.async_on_remove(

--- a/homeassistant/components/firmata/binary_sensor.py
+++ b/homeassistant/components/firmata/binary_sensor.py
@@ -1,6 +1,7 @@
 """Support for Firmata binary sensor input."""
 
 import logging
+from typing import override
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.const import CONF_NAME, CONF_PIN
@@ -47,15 +48,18 @@ async def async_setup_entry(
 class FirmataBinarySensor(FirmataPinEntity, BinarySensorEntity):
     """Representation of a binary sensor on a Firmata board."""
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Set up a binary sensor."""
         await self._api.start_pin(self.async_write_ha_state)
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Stop reporting a binary sensor."""
         await self._api.stop_pin()
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if binary sensor is on."""
         return self._api.is_on

--- a/homeassistant/components/firmata/light.py
+++ b/homeassistant/components/firmata/light.py
@@ -1,7 +1,7 @@
 """Support for Firmata light output."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
 from homeassistant.config_entries import ConfigEntry
@@ -68,20 +68,24 @@ class FirmataLight(FirmataPinEntity, LightEntity):
         # Default first turn on to max
         self._last_on_level = 255
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Set up a light."""
         await self._api.start_pin()
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if light is on."""
         return self._api.state > 0
 
     @property
+    @override
     def brightness(self) -> int:
         """Return the brightness of the light."""
         return self._api.state
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on light."""
         level = kwargs.get(ATTR_BRIGHTNESS, self._last_on_level)
@@ -89,6 +93,7 @@ class FirmataLight(FirmataPinEntity, LightEntity):
         self.async_write_ha_state()
         self._last_on_level = level
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off light."""
         await self._api.set_level(0)

--- a/homeassistant/components/firmata/sensor.py
+++ b/homeassistant/components/firmata/sensor.py
@@ -1,6 +1,7 @@
 """Support for Firmata sensor input."""
 
 import logging
+from typing import override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import CONF_NAME, CONF_PIN
@@ -47,15 +48,18 @@ async def async_setup_entry(
 class FirmataSensor(FirmataPinEntity, SensorEntity):
     """Representation of a sensor on a Firmata board."""
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Set up a sensor."""
         await self._api.start_pin(self.async_write_ha_state)
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Stop reporting a sensor."""
         await self._api.stop_pin()
 
     @property
+    @override
     def native_value(self) -> int:
         """Return sensor state."""
         return self._api.state

--- a/homeassistant/components/firmata/switch.py
+++ b/homeassistant/components/firmata/switch.py
@@ -1,7 +1,7 @@
 """Support for Firmata switch output."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.const import CONF_NAME, CONF_PIN
@@ -49,20 +49,24 @@ async def async_setup_entry(
 class FirmataSwitch(FirmataPinEntity, SwitchEntity):
     """Representation of a switch on a Firmata board."""
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Set up a switch."""
         await self._api.start_pin()
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if switch is on."""
         return self._api.is_on
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on switch."""
         await self._api.turn_on()
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off switch."""
         await self._api.turn_off()

--- a/homeassistant/components/fish_audio/config_flow.py
+++ b/homeassistant/components/fish_audio/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for the Fish Audio integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from fishaudio import AsyncFishAudio
 from fishaudio.exceptions import AuthenticationError, FishAudioError
@@ -168,6 +168,7 @@ class FishAudioConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize the config flow."""
         self.client = None
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -218,6 +219,7 @@ class FishAudioConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @classmethod
     @callback
+    @override
     def async_get_supported_subentry_types(
         cls, config_entry: ConfigEntry
     ) -> dict[str, type]:

--- a/homeassistant/components/fish_audio/tts.py
+++ b/homeassistant/components/fish_audio/tts.py
@@ -1,7 +1,7 @@
 """TTS platform for the Fish Audio integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from fishaudio.exceptions import APIError, RateLimitError
 
@@ -70,15 +70,18 @@ class FishAudioTTSEntity(TextToSpeechEntity):
         )
 
     @property
+    @override
     def default_language(self) -> str:
         """Return the default language."""
         return "en"
 
     @property
+    @override
     def supported_languages(self) -> list[str]:
         """Return a list of supported languages."""
         return TTS_SUPPORTED_LANGUAGES
 
+    @override
     async def async_get_tts_audio(
         self,
         message: str,

--- a/homeassistant/components/fitbit/api.py
+++ b/homeassistant/components/fitbit/api.py
@@ -3,7 +3,7 @@
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from fitbit import Fitbit
 from fitbit.exceptions import HTTPException, HTTPUnauthorized
@@ -177,6 +177,7 @@ class OAuthFitbitApi(FitbitApi):
         super().__init__(hass, unit_system)
         self._oauth_session = oauth_session
 
+    @override
     async def async_get_access_token(self) -> dict[str, Any]:
         """Return a valid access token for the Fitbit API."""
         await self._oauth_session.async_ensure_token_valid()
@@ -198,6 +199,7 @@ class ConfigFlowFitbitApi(FitbitApi):
         super().__init__(hass)
         self._token = token
 
+    @override
     async def async_get_access_token(self) -> dict[str, Any]:
         """Return the token for the Fitbit API."""
         return self._token

--- a/homeassistant/components/fitbit/application_credentials.py
+++ b/homeassistant/components/fitbit/application_credentials.py
@@ -7,7 +7,7 @@ details on Fitbit authorization.
 import base64
 from http import HTTPStatus
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 import aiohttp
 
@@ -33,6 +33,7 @@ class FitbitOAuth2Implementation(AuthImplementation):
     Authorization header.
     """
 
+    @override
     async def async_resolve_external_data(self, external_data: dict[str, Any]) -> dict:
         """Resolve the authorization code to tokens."""
         return await self._post(
@@ -43,6 +44,7 @@ class FitbitOAuth2Implementation(AuthImplementation):
             }
         )
 
+    @override
     async def _token_request(self, data: dict) -> dict:
         """Make a token request."""
         return await self._post(

--- a/homeassistant/components/fitbit/config_flow.py
+++ b/homeassistant/components/fitbit/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
 from homeassistant.const import CONF_TOKEN
@@ -23,11 +23,13 @@ class OAuth2FlowHandler(
     DOMAIN = DOMAIN
 
     @property
+    @override
     def logger(self) -> logging.Logger:
         """Return logger."""
         return logging.getLogger(__name__)
 
     @property
+    @override
     def extra_authorize_data(self) -> dict[str, str]:
         """Extra data that needs to be appended to the authorize url."""
         return {
@@ -49,6 +51,7 @@ class OAuth2FlowHandler(
             return self.async_show_form(step_id="reauth_confirm")
         return await self.async_step_user()
 
+    @override
     async def async_step_creation(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -67,6 +70,7 @@ class OAuth2FlowHandler(
             _LOGGER.error("Failed to create Fitbit credentials: %s", err)
             return self.async_abort(reason="cannot_connect")
 
+    @override
     async def async_oauth_create_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
         """Create an entry for the flow, or update existing entry."""
 

--- a/homeassistant/components/fitbit/coordinator.py
+++ b/homeassistant/components/fitbit/coordinator.py
@@ -4,7 +4,7 @@ import asyncio
 from dataclasses import dataclass
 import datetime
 import logging
-from typing import Final
+from typing import Final, override
 
 from fitbit_web_api.models.device import Device
 
@@ -42,6 +42,7 @@ class FitbitDeviceCoordinator(DataUpdateCoordinator[dict[str, Device]]):
         )
         self._api = api
 
+    @override
     async def _async_update_data(self) -> dict[str, Device]:
         """Fetch data from API endpoint."""
         async with asyncio.timeout(TIMEOUT):

--- a/homeassistant/components/fitbit/sensor.py
+++ b/homeassistant/components/fitbit/sensor.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 import datetime
 import logging
-from typing import Any, Final, cast
+from typing import Any, Final, cast, override
 
 from fitbit_web_api.models.device import Device
 
@@ -638,6 +638,7 @@ class FitbitSensor(SensorEntity):
             self._attr_available = True
             self._attr_native_value = self.entity_description.value_fn(result)
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
@@ -677,6 +678,7 @@ class FitbitBatterySensor(CoordinatorEntity[FitbitDeviceCoordinator], SensorEnti
             self._attr_entity_registry_enabled_default = True
 
     @property
+    @override
     def icon(self) -> str | None:
         """Icon to use in the frontend, if any."""
         if self.device.battery is not None and (
@@ -686,6 +688,7 @@ class FitbitBatterySensor(CoordinatorEntity[FitbitDeviceCoordinator], SensorEnti
         return self.entity_description.icon
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, str | None]:
         """Return the state attributes."""
         return {
@@ -693,12 +696,14 @@ class FitbitBatterySensor(CoordinatorEntity[FitbitDeviceCoordinator], SensorEnti
             "type": self.device.type.lower() if self.device.type is not None else None,
         }
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass update state from existing coordinator data."""
         await super().async_added_to_hass()
         self._handle_coordinator_update()
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self.device = self.coordinator.data[cast(str, self.device.id)]
@@ -733,12 +738,14 @@ class FitbitBatteryLevelSensor(
             model=device.device_version,
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass update state from existing coordinator data."""
         await super().async_added_to_hass()
         self._handle_coordinator_update()
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self.device = self.coordinator.data[cast(str, self.device.id)]

--- a/homeassistant/components/fivem/binary_sensor.py
+++ b/homeassistant/components/fivem/binary_sensor.py
@@ -1,6 +1,7 @@
 """The FiveM binary sensor platform."""
 
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -50,6 +51,7 @@ class FiveMSensorEntity(FiveMEntity, BinarySensorEntity):
     entity_description: FiveMBinarySensorEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the state of the sensor."""
         return self.coordinator.data[self.entity_description.key]

--- a/homeassistant/components/fivem/config_flow.py
+++ b/homeassistant/components/fivem/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for FiveM integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from fivem import FiveM, FiveMServerOfflineError
 import voluptuous as vol
@@ -40,6 +40,7 @@ class FiveMConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/fivem/coordinator.py
+++ b/homeassistant/components/fivem/coordinator.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from fivem import FiveM, FiveMServerOfflineError
 
@@ -58,6 +58,7 @@ class FiveMDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.version = info["version"]
         self.game_name = info["vars"]["gamename"]
 
+    @override
     async def _async_update_data(self) -> dict[str, Any]:
         """Get server data from 3rd party library and update properties."""
         try:

--- a/homeassistant/components/fivem/entity.py
+++ b/homeassistant/components/fivem/entity.py
@@ -3,7 +3,7 @@
 from collections.abc import Mapping
 from dataclasses import dataclass
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
@@ -48,6 +48,7 @@ class FiveMEntity(CoordinatorEntity[FiveMDataUpdateCoordinator]):
         )
 
     @property
+    @override
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """Return the extra attributes of the sensor."""
         if self.entity_description.extra_attrs is None:

--- a/homeassistant/components/fivem/sensor.py
+++ b/homeassistant/components/fivem/sensor.py
@@ -1,6 +1,7 @@
 """The FiveM sensor platform."""
 
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.core import HomeAssistant
@@ -67,6 +68,7 @@ class FiveMSensorEntity(FiveMEntity, SensorEntity):
     entity_description: FiveMSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         return self.coordinator.data[self.entity_description.key]

--- a/homeassistant/components/fixer/sensor.py
+++ b/homeassistant/components/fixer/sensor.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from fixerio import Fixerio
 from fixerio.exceptions import FixerioException
@@ -73,21 +73,25 @@ class ExchangeRateSensor(SensorEntity):
         self._state = None
 
     @property
+    @override
     def name(self):
         """Return the name of the sensor."""
         return self._name
 
     @property
+    @override
     def native_unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
         return self._target
 
     @property
+    @override
     def native_value(self):
         """Return the state of the sensor."""
         return self._state
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the state attributes."""
         if self.data.rate is not None:

--- a/homeassistant/components/fjaraskupan/binary_sensor.py
+++ b/homeassistant/components/fjaraskupan/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from fjaraskupan import Device
 
@@ -85,6 +86,7 @@ class BinarySensor(CoordinatorEntity[FjaraskupanCoordinator], BinarySensorEntity
         self._attr_device_info = device_info
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         if data := self.coordinator.data:

--- a/homeassistant/components/fjaraskupan/coordinator.py
+++ b/homeassistant/components/fjaraskupan/coordinator.py
@@ -4,6 +4,7 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager, contextmanager
 from datetime import timedelta
 import logging
+from typing import override
 
 from fjaraskupan import (
     Device,
@@ -87,6 +88,7 @@ class FjaraskupanCoordinator(DataUpdateCoordinator[State]):
             update_interval=timedelta(seconds=120),
         )
 
+    @override
     async def _async_refresh(
         self,
         log_failures: bool = True,
@@ -102,6 +104,7 @@ class FjaraskupanCoordinator(DataUpdateCoordinator[State]):
             raise_on_entry_error=raise_on_entry_error,
         )
 
+    @override
     async def _async_update_data(self) -> State:
         """Handle an explicit update request."""
         if self._refresh_was_scheduled:

--- a/homeassistant/components/fjaraskupan/fan.py
+++ b/homeassistant/components/fjaraskupan/fan.py
@@ -1,6 +1,6 @@
 """Support for Fjäråskupan fans."""
 
-from typing import Any
+from typing import Any, override
 
 from fjaraskupan import (
     COMMAND_AFTERCOOKINGTIMERAUTO,
@@ -86,6 +86,7 @@ class Fan(CoordinatorEntity[FjaraskupanCoordinator], FanEntity):
         self._preset_mode = PRESET_MODE_NORMAL
         self._update_from_device_data(coordinator.data)
 
+    @override
     async def async_set_percentage(self, percentage: int) -> None:
         """Set speed."""
 
@@ -101,6 +102,7 @@ class Fan(CoordinatorEntity[FjaraskupanCoordinator], FanEntity):
                 )
                 await device.send_fan_speed(int(new_speed))
 
+    @override
     async def async_turn_on(
         self,
         percentage: int | None = None,
@@ -133,38 +135,45 @@ class Fan(CoordinatorEntity[FjaraskupanCoordinator], FanEntity):
             elif preset_mode == PRESET_MODE_AFTER_COOKING_AUTO:
                 await device.send_after_cooking(0)
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         command = PRESET_TO_COMMAND[preset_mode]
         async with self.coordinator.async_connect_and_update() as device:
             await device.send_command(command)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         async with self.coordinator.async_connect_and_update() as device:
             await device.send_command(COMMAND_STOP_FAN)
 
     @property
+    @override
     def speed_count(self) -> int:
         """Return the number of speeds the fan supports."""
         return len(ORDERED_NAMED_FAN_SPEEDS)
 
     @property
+    @override
     def percentage(self) -> int | None:
         """Return the current speed."""
         return self._percentage
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if fan is on."""
         return self._percentage != 0
 
     @property
+    @override
     def preset_mode(self) -> str | None:
         """Return the current preset mode."""
         return self._preset_mode
 
     @property
+    @override
     def preset_modes(self) -> list[str] | None:
         """Return a list of available preset modes."""
         return PRESET_MODES
@@ -191,6 +200,7 @@ class Fan(CoordinatorEntity[FjaraskupanCoordinator], FanEntity):
             self._preset_mode = PRESET_MODE_NORMAL
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle data update."""
 

--- a/homeassistant/components/fjaraskupan/light.py
+++ b/homeassistant/components/fjaraskupan/light.py
@@ -1,6 +1,6 @@
 """Support for lights."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
 from homeassistant.core import HomeAssistant
@@ -44,6 +44,7 @@ class Light(CoordinatorEntity[FjaraskupanCoordinator], LightEntity):
         self._attr_unique_id = coordinator.device.address
         self._attr_device_info = device_info
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
         async with self.coordinator.async_connect_and_update() as device:
@@ -52,6 +53,7 @@ class Light(CoordinatorEntity[FjaraskupanCoordinator], LightEntity):
             else:
                 await device.send_dim(100)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         if self.is_on:
@@ -59,6 +61,7 @@ class Light(CoordinatorEntity[FjaraskupanCoordinator], LightEntity):
                 await device.send_dim(0)
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return True if entity is on."""
         if data := self.coordinator.data:
@@ -66,6 +69,7 @@ class Light(CoordinatorEntity[FjaraskupanCoordinator], LightEntity):
         return False
 
     @property
+    @override
     def brightness(self) -> int | None:
         """Return the brightness of this light between 0..255."""
         if data := self.coordinator.data:

--- a/homeassistant/components/fjaraskupan/number.py
+++ b/homeassistant/components/fjaraskupan/number.py
@@ -1,5 +1,7 @@
 """Support for sensors."""
 
+from typing import override
+
 from homeassistant.components.number import NumberEntity
 from homeassistant.const import EntityCategory, UnitOfTime
 from homeassistant.core import HomeAssistant
@@ -50,12 +52,14 @@ class PeriodicVentingTime(CoordinatorEntity[FjaraskupanCoordinator], NumberEntit
         self._attr_device_info = device_info
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the entity value to represent the entity state."""
         if data := self.coordinator.data:
             return data.periodic_venting
         return None
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
         async with self.coordinator.async_connect_and_update() as device:

--- a/homeassistant/components/fjaraskupan/sensor.py
+++ b/homeassistant/components/fjaraskupan/sensor.py
@@ -1,5 +1,7 @@
 """Support for sensors."""
 
+from typing import override
+
 from fjaraskupan import Device
 
 from homeassistant.components.sensor import (
@@ -54,6 +56,7 @@ class RssiSensor(CoordinatorEntity[FjaraskupanCoordinator], SensorEntity):
         self._attr_device_info = device_info
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the value reported by the sensor."""
         if data := self.coordinator.data:

--- a/homeassistant/components/flexit/climate.py
+++ b/homeassistant/components/flexit/climate.py
@@ -1,7 +1,7 @@
 """Platform for Flexit AC units with CI66 Modbus adapter."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -140,6 +140,7 @@ class Flexit(ClimateEntity):
             self._attr_hvac_action = HVACAction.OFF
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return device specific state attributes."""
         return {
@@ -152,6 +153,7 @@ class Flexit(ClimateEntity):
             "outdoor_air_temp": self._outdoor_air_temp,
         }
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         if (target_temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
@@ -163,6 +165,7 @@ class Flexit(ClimateEntity):
         else:
             _LOGGER.error("Modbus error setting target temperature to Flexit")
 
+    @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new fan mode."""
         if self.fan_modes and await self._async_write_int16_to_register(

--- a/homeassistant/components/flexit_bacnet/binary_sensor.py
+++ b/homeassistant/components/flexit_bacnet/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from flexit_bacnet import FlexitBACnet
 
@@ -70,6 +71,7 @@ class FlexitBinarySensor(FlexitEntity, BinarySensorEntity):
         )
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return value of binary sensor."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/flexit_bacnet/climate.py
+++ b/homeassistant/components/flexit_bacnet/climate.py
@@ -1,7 +1,7 @@
 """The Flexit Nordic (BACnet) integration."""
 
 import asyncio.exceptions
-from typing import Any
+from typing import Any, override
 
 from flexit_bacnet import (
     OPERATION_MODE_FIREPLACE,
@@ -86,6 +86,7 @@ class FlexitClimateEntity(FlexitEntity, ClimateEntity):
         self._attr_unique_id = coordinator.device.serial_number
 
     @property
+    @override
     def hvac_action(self) -> HVACAction | None:
         """Return current HVAC action."""
         if self.device.electric_heater:
@@ -93,11 +94,13 @@ class FlexitClimateEntity(FlexitEntity, ClimateEntity):
         return HVACAction.FAN
 
     @property
+    @override
     def current_temperature(self) -> float:
         """Return the current temperature."""
         return self.device.room_temperature
 
     @property
+    @override
     def target_temperature(self) -> float:
         """Return the temperature we try to reach."""
         if self.device.ventilation_mode == VENTILATION_MODE_AWAY:
@@ -105,6 +108,7 @@ class FlexitClimateEntity(FlexitEntity, ClimateEntity):
 
         return self.device.air_temp_setpoint_home
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
@@ -131,6 +135,7 @@ class FlexitClimateEntity(FlexitEntity, ClimateEntity):
             await self.coordinator.async_refresh()
 
     @property
+    @override
     def preset_mode(self) -> str:
         """Return the current preset mode, e.g., home, away, temp.
 
@@ -138,6 +143,7 @@ class FlexitClimateEntity(FlexitEntity, ClimateEntity):
         """
         return OPERATION_TO_PRESET_MODE_MAP[self.device.operation_mode]
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         try:
@@ -169,6 +175,7 @@ class FlexitClimateEntity(FlexitEntity, ClimateEntity):
             await self.coordinator.async_refresh()
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode."""
         if self.device.operation_mode == OPERATION_MODE_OFF:
@@ -176,6 +183,7 @@ class FlexitClimateEntity(FlexitEntity, ClimateEntity):
 
         return HVACMode.FAN_ONLY
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         try:

--- a/homeassistant/components/flexit_bacnet/config_flow.py
+++ b/homeassistant/components/flexit_bacnet/config_flow.py
@@ -2,7 +2,7 @@
 
 import asyncio.exceptions
 import logging
-from typing import Any
+from typing import Any, override
 
 from flexit_bacnet import FlexitBACnet
 from flexit_bacnet.bacnet import DecodingError
@@ -30,6 +30,7 @@ class FlexitBacnetConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/flexit_bacnet/coordinator.py
+++ b/homeassistant/components/flexit_bacnet/coordinator.py
@@ -3,6 +3,7 @@
 import asyncio.exceptions
 from datetime import timedelta
 import logging
+from typing import override
 
 from flexit_bacnet import FlexitBACnet
 from flexit_bacnet.bacnet import DecodingError
@@ -40,6 +41,7 @@ class FlexitCoordinator(DataUpdateCoordinator[FlexitBACnet]):
             self.config_entry.data[CONF_DEVICE_ID],
         )
 
+    @override
     async def _async_update_data(self) -> FlexitBACnet:
         """Fetch data from the device."""
 

--- a/homeassistant/components/flexit_bacnet/number.py
+++ b/homeassistant/components/flexit_bacnet/number.py
@@ -3,6 +3,7 @@
 import asyncio.exceptions
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import override
 
 from flexit_bacnet import FlexitBACnet
 from flexit_bacnet.bacnet import DecodingError
@@ -229,20 +230,24 @@ class FlexitNumber(FlexitEntity, NumberEntity):
         )
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the state of the number."""
         return self.entity_description.native_value_fn(self.coordinator.device)
 
     @property
+    @override
     def native_max_value(self) -> float:
         """Return the native max value of the number."""
         return self.entity_description.native_max_value_fn(self.coordinator.device)
 
     @property
+    @override
     def native_min_value(self) -> float:
         """Return the native min value of the number."""
         return self.entity_description.native_min_value_fn(self.coordinator.device)
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         set_native_value_fn = self.entity_description.set_native_value_fn(

--- a/homeassistant/components/flexit_bacnet/sensor.py
+++ b/homeassistant/components/flexit_bacnet/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from flexit_bacnet import FlexitBACnet
 
@@ -189,6 +190,7 @@ class FlexitSensor(FlexitEntity, SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return value of sensor."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/flexit_bacnet/switch.py
+++ b/homeassistant/components/flexit_bacnet/switch.py
@@ -3,7 +3,7 @@
 import asyncio.exceptions
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from flexit_bacnet import FlexitBACnet
 from flexit_bacnet.bacnet import DecodingError
@@ -130,10 +130,12 @@ class FlexitSwitch(FlexitEntity, SwitchEntity):
         )
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return value of the switch."""
         return self.entity_description.is_on_fn(self.coordinator.data)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn switch on."""
         try:
@@ -149,6 +151,7 @@ class FlexitSwitch(FlexitEntity, SwitchEntity):
         finally:
             await self.coordinator.async_refresh()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn switch off."""
         try:

--- a/homeassistant/components/flipr/binary_sensor.py
+++ b/homeassistant/components/flipr/binary_sensor.py
@@ -1,5 +1,7 @@
 """Support for Flipr binary sensors."""
 
+from typing import override
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -45,6 +47,7 @@ class FliprBinarySensor(FliprEntity, BinarySensorEntity):
     """Representation of Flipr binary sensors."""
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the binary sensor is on in case of a Problem is detected."""
         return self.coordinator.data[self.entity_description.key] in (

--- a/homeassistant/components/flipr/config_flow.py
+++ b/homeassistant/components/flipr/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Flipr integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from flipr_api import FliprAPIRestClient
 from requests.exceptions import HTTPError, Timeout
@@ -27,6 +27,7 @@ class FliprConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 2
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/flipr/coordinator.py
+++ b/homeassistant/components/flipr/coordinator.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from flipr_api import FliprAPIRestClient
 from flipr_api.exceptions import FliprError
@@ -54,6 +54,7 @@ class BaseDataUpdateCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
 class FliprDataUpdateCoordinator(BaseDataUpdateCoordinator[dict[str, Any]]):
     """Class to hold Flipr data retrieval."""
 
+    @override
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from API endpoint."""
         try:
@@ -69,6 +70,7 @@ class FliprDataUpdateCoordinator(BaseDataUpdateCoordinator[dict[str, Any]]):
 class FliprHubDataUpdateCoordinator(BaseDataUpdateCoordinator[dict[str, Any]]):
     """Class to hold Flipr hub data retrieval."""
 
+    @override
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from API endpoint."""
         try:

--- a/homeassistant/components/flipr/select.py
+++ b/homeassistant/components/flipr/select.py
@@ -1,6 +1,7 @@
 """Select platform for the Flipr's Hub."""
 
 import logging
+from typing import override
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.core import HomeAssistant
@@ -39,11 +40,13 @@ class FliprHubSelect(FliprEntity, SelectEntity):
     """Select representing Hub mode."""
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return current select option."""
         _LOGGER.debug("coordinator data = %s", self.coordinator.data)
         return self.coordinator.data["mode"]
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Select new mode for Hub."""
         _LOGGER.debug("Changing mode of %s to %s", self.device_id, option)

--- a/homeassistant/components/flipr/sensor.py
+++ b/homeassistant/components/flipr/sensor.py
@@ -1,5 +1,7 @@
 """Sensor platform for the Flipr's pool_sensor."""
 
+from typing import override
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -71,6 +73,7 @@ class FliprSensor(FliprEntity, SensorEntity):
     """Sensor representing FliprSensor data."""
 
     @property
+    @override
     def native_value(self) -> str:
         """State of the sensor."""
         return self.coordinator.data[self.entity_description.key]

--- a/homeassistant/components/flipr/switch.py
+++ b/homeassistant/components/flipr/switch.py
@@ -1,7 +1,7 @@
 """Switch platform for the Flipr's Hub."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.core import HomeAssistant
@@ -39,11 +39,13 @@ class FliprHubSwitch(FliprEntity, SwitchEntity):
     """Switch representing Hub state."""
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return state of the switch."""
         _LOGGER.debug("coordinator data = %s", self.coordinator.data)
         return self.coordinator.data["state"]
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
         _LOGGER.debug("Switching off %s", self.device_id)
@@ -55,6 +57,7 @@ class FliprHubSwitch(FliprEntity, SwitchEntity):
         _LOGGER.debug("New hub infos are %s", data)
         self.coordinator.async_set_updated_data(data)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
         _LOGGER.debug("Switching on %s", self.device_id)

--- a/homeassistant/components/flo/binary_sensor.py
+++ b/homeassistant/components/flo/binary_sensor.py
@@ -1,6 +1,6 @@
 """Support for Flo Water Monitor binary sensors."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -49,11 +49,13 @@ class FloPendingAlertsBinarySensor(FloEntity, BinarySensorEntity):
         super().__init__("pending_system_alerts", device)
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the Flo device has pending alerts."""
         return self._device.has_alerts
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         if not self._device.has_alerts:
@@ -76,6 +78,7 @@ class FloWaterDetectedBinarySensor(FloEntity, BinarySensorEntity):
         super().__init__("water_detected", device)
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the Flo device is detecting water."""
         return self._device.water_detected

--- a/homeassistant/components/flo/config_flow.py
+++ b/homeassistant/components/flo/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for flo integration."""
 
-from typing import Any
+from typing import Any, override
 
 from aioflo import async_get_api
 from aioflo.errors import RequestError
@@ -38,6 +38,7 @@ class FloConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/flo/coordinator.py
+++ b/homeassistant/components/flo/coordinator.py
@@ -3,7 +3,7 @@
 import asyncio
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Any, override
 
 from aioflo.api import API
 from aioflo.errors import RequestError
@@ -57,6 +57,7 @@ class FloDeviceDataUpdateCoordinator(DataUpdateCoordinator):
             update_interval=timedelta(seconds=60),
         )
 
+    @override
     async def _async_update_data(self):
         """Update data via library."""
         try:

--- a/homeassistant/components/flo/entity.py
+++ b/homeassistant/components/flo/entity.py
@@ -1,5 +1,7 @@
 """Base entity class for Flo entities."""
 
+from typing import override
+
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity import Entity
 
@@ -25,6 +27,7 @@ class FloEntity(Entity):
         self._device: FloDeviceDataUpdateCoordinator = device
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return a device description for device registry."""
         return DeviceInfo(
@@ -38,6 +41,7 @@ class FloEntity(Entity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if device is available."""
         return self._device.available
@@ -46,6 +50,7 @@ class FloEntity(Entity):
         """Update Flo entity."""
         await self._device.async_request_refresh()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         self.async_on_remove(self._device.async_add_listener(self.async_write_ha_state))

--- a/homeassistant/components/flo/sensor.py
+++ b/homeassistant/components/flo/sensor.py
@@ -1,5 +1,7 @@
 """Support for Flo Water Monitor sensors."""
 
+from typing import override
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -62,6 +64,7 @@ class FloDailyUsageSensor(FloEntity, SensorEntity):
         super().__init__("daily_consumption", device)
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the current daily usage."""
         if self._device.consumption_today is None:
@@ -79,6 +82,7 @@ class FloSystemModeSensor(FloEntity, SensorEntity):
         super().__init__("current_system_mode", device)
 
     @property
+    @override
     def native_value(self) -> str | None:
         """Return the current system mode."""
         if not self._device.current_system_mode:
@@ -99,6 +103,7 @@ class FloCurrentFlowRateSensor(FloEntity, SensorEntity):
         super().__init__("current_flow_rate", device)
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the current flow rate."""
         if self._device.current_flow_rate is None:
@@ -120,6 +125,7 @@ class FloTemperatureSensor(FloEntity, SensorEntity):
             self._attr_translation_key = "water_temperature"
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the current temperature."""
         if self._device.temperature is None:
@@ -139,6 +145,7 @@ class FloHumiditySensor(FloEntity, SensorEntity):
         super().__init__("humidity", device)
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the current humidity."""
         if self._device.humidity is None:
@@ -159,6 +166,7 @@ class FloPressureSensor(FloEntity, SensorEntity):
         super().__init__("water_pressure", device)
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the current water pressure."""
         if self._device.current_psi is None:
@@ -178,6 +186,7 @@ class FloBatterySensor(FloEntity, SensorEntity):
         super().__init__("battery", device)
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the current battery level."""
         return self._device.battery_level

--- a/homeassistant/components/flo/switch.py
+++ b/homeassistant/components/flo/switch.py
@@ -1,6 +1,6 @@
 """Switch representing the shutoff valve for the Flo by Moen integration."""
 
-from typing import Any
+from typing import Any, override
 
 from aioflo.location import SLEEP_MINUTE_OPTIONS, SYSTEM_MODE_HOME, SYSTEM_REVERT_MODES
 import voluptuous as vol
@@ -69,12 +69,14 @@ class FloSwitch(FloEntity, SwitchEntity):
         super().__init__("shutoff_valve", device)
         self._attr_is_on = device.last_known_valve_state == "open"
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Open the valve."""
         await self._device.api_client.device.open_valve(self._device.id)
         self._attr_is_on = True
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Close the valve."""
         await self._device.api_client.device.close_valve(self._device.id)
@@ -87,6 +89,7 @@ class FloSwitch(FloEntity, SwitchEntity):
         self._attr_is_on = self._device.last_known_valve_state == "open"
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()

--- a/homeassistant/components/flock/notify.py
+++ b/homeassistant/components/flock/notify.py
@@ -3,7 +3,7 @@
 import asyncio
 from http import HTTPStatus
 import logging
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -46,6 +46,7 @@ class FlockNotificationService(BaseNotificationService):
         self._url = url
         self._session = session
 
+    @override
     async def async_send_message(self, message: str, **kwargs: Any) -> None:
         """Send the message to the user."""
         payload = {"text": message}

--- a/homeassistant/components/flume/binary_sensor.py
+++ b/homeassistant/components/flume/binary_sensor.py
@@ -1,6 +1,7 @@
 """Flume binary sensors."""
 
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -123,6 +124,7 @@ class FlumeNotificationBinarySensor(
     entity_description: FlumeBinarySensorEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return on state."""
         return bool(
@@ -145,6 +147,7 @@ class FlumeConnectionBinarySensor(
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return connection status."""
         return bool(

--- a/homeassistant/components/flume/config_flow.py
+++ b/homeassistant/components/flume/config_flow.py
@@ -3,7 +3,7 @@
 from collections.abc import Mapping
 import logging
 import os
-from typing import Any
+from typing import Any, override
 
 from pyflume import FlumeAuth, FlumeDeviceList
 from requests.exceptions import RequestException
@@ -91,6 +91,7 @@ class FlumeConfigFlow(ConfigFlow, domain=DOMAIN):
         """Init flume config flow."""
         self._reauth_unique_id: str | None = None
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/flume/coordinator.py
+++ b/homeassistant/components/flume/coordinator.py
@@ -1,7 +1,7 @@
 """The IntelliFire integration."""
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 import pyflume
 from pyflume import FlumeAuth, FlumeData, FlumeDeviceList
@@ -55,6 +55,7 @@ class FlumeDeviceDataUpdateCoordinator(DataUpdateCoordinator[None]):
 
         self.flume_device = flume_device
 
+    @override
     async def _async_update_data(self) -> None:
         """Get the latest data from the Flume."""
         try:
@@ -99,6 +100,7 @@ class FlumeDeviceConnectionUpdateCoordinator(DataUpdateCoordinator[None]):
         }
         _LOGGER.debug("Connectivity %s", self.connected)
 
+    @override
     async def _async_update_data(self) -> None:
         """Update the device list."""
         try:
@@ -152,6 +154,7 @@ class FlumeNotificationDataUpdateCoordinator(DataUpdateCoordinator[None]):
 
         self.active_notifications_by_device = active_notifications_by_device
 
+    @override
     async def _async_update_data(self) -> None:
         """Update data."""
         _LOGGER.debug("Updating Flume Notification")

--- a/homeassistant/components/flume/entity.py
+++ b/homeassistant/components/flume/entity.py
@@ -1,5 +1,7 @@
 """Platform for shared base classes for sensors."""
 
+from typing import override
+
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -50,6 +52,7 @@ class FlumeEntity[
             configuration_url="https://portal.flumewater.com",
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Request an update when added."""
         await super().async_added_to_hass()

--- a/homeassistant/components/flume/sensor.py
+++ b/homeassistant/components/flume/sensor.py
@@ -1,6 +1,6 @@
 """Sensor for displaying the number of result from Flume."""
 
-from typing import Any
+from typing import Any, override
 
 from pyflume import FlumeAuth, FlumeData
 from requests import Session
@@ -157,6 +157,7 @@ class FlumeSensor(FlumeEntity[FlumeDeviceDataUpdateCoordinator], SensorEntity):
     """Representation of the Flume sensor."""
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         sensor_key = self.entity_description.key

--- a/homeassistant/components/fluss/button.py
+++ b/homeassistant/components/fluss/button.py
@@ -1,5 +1,7 @@
 """Support for Fluss Devices."""
 
+from typing import override
+
 from homeassistant.components.button import ButtonEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -32,10 +34,12 @@ class FlussButton(FlussEntity, ButtonEntity):
     _attr_name = None
 
     @property
+    @override
     def available(self) -> bool:
         """Return True only when the device is online."""
         return super().available and self.device["internetConnected"]
 
+    @override
     async def async_press(self) -> None:
         """Handle the button press."""
         try:

--- a/homeassistant/components/fluss/config_flow.py
+++ b/homeassistant/components/fluss/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Fluss+ integration."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 from fluss_api import (
     FlussApiClient,
@@ -38,6 +38,7 @@ class FlussConfigFlow(ConfigFlow, domain=DOMAIN):
             errors["base"] = "unknown"
         return errors
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/fluss/coordinator.py
+++ b/homeassistant/components/fluss/coordinator.py
@@ -1,7 +1,7 @@
 """DataUpdateCoordinator for Fluss+ integration."""
 
 import asyncio
-from typing import Any
+from typing import Any, override
 
 from fluss_api import (
     FlussApiClient,
@@ -55,6 +55,7 @@ class FlussDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             raise UpdateFailed(f"Error fetching Fluss device status: {err}") from err
         return response["status"]
 
+    @override
     async def _async_update_data(self) -> dict[str, dict[str, Any]]:
         """Fetch Fluss+ devices and merge per-device status."""
         try:

--- a/homeassistant/components/fluss/cover.py
+++ b/homeassistant/components/fluss/cover.py
@@ -1,6 +1,6 @@
 """Cover platform for Fluss+ devices that report an open/closed status."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.cover import (
     CoverDeviceClass,
@@ -54,11 +54,13 @@ class FlussCover(FlussEntity, CoverEntity):
     _attr_supported_features = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
 
     @property
+    @override
     def available(self) -> bool:
         """Return True only when the device is online."""
         return super().available and self.device["internetConnected"]
 
     @property
+    @override
     def is_closed(self) -> bool | None:
         """Return whether the cover is closed."""
         status = self.device.get("openCloseStatus")
@@ -68,6 +70,7 @@ class FlussCover(FlussEntity, CoverEntity):
             return False
         return None
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         try:
@@ -78,6 +81,7 @@ class FlussCover(FlussEntity, CoverEntity):
             ) from err
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
         try:

--- a/homeassistant/components/fluss/entity.py
+++ b/homeassistant/components/fluss/entity.py
@@ -1,5 +1,7 @@
 """Base entities for the Fluss+ integration."""
 
+from typing import override
+
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -29,6 +31,7 @@ class FlussEntity(CoordinatorEntity[FlussDataUpdateCoordinator]):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return if the device is available."""
         return super().available and self.device_id in self.coordinator.data

--- a/homeassistant/components/flux/switch.py
+++ b/homeassistant/components/flux/switch.py
@@ -5,7 +5,7 @@ The idea was taken from https://github.com/KpaBap/hue-flux/
 
 import datetime
 import logging
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -216,27 +216,32 @@ class FluxSwitch(SwitchEntity, RestoreEntity):
         self.unsub_tracker = None
 
     @property
+    @override
     def name(self):
         """Return the name of the device if any."""
         return self._name
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if switch is on."""
         return self.unsub_tracker is not None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity about to be added to hass."""
         last_state = await self.async_get_last_state()
         if last_state and last_state.state == STATE_ON:
             await self.async_turn_on()
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from hass."""
         if self.unsub_tracker:
             self.unsub_tracker()
         return await super().async_will_remove_from_hass()
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on flux."""
         if self.is_on:
@@ -253,6 +258,7 @@ class FluxSwitch(SwitchEntity, RestoreEntity):
 
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off flux."""
         if self.is_on:

--- a/homeassistant/components/flux_led/button.py
+++ b/homeassistant/components/flux_led/button.py
@@ -1,5 +1,7 @@
 """Support for Magic home button."""
 
+from typing import override
+
 from flux_led.aio import AIOWifiLedBulb
 from flux_led.protocol import RemoteConfig
 
@@ -64,6 +66,7 @@ class FluxButton(FluxBaseEntity, ButtonEntity):
         base_unique_id = entry.unique_id or entry.entry_id
         self._attr_unique_id = f"{base_unique_id}_{description.key}"
 
+    @override
     async def async_press(self) -> None:
         """Send out a command."""
         if self.entity_description.key == _RESTART_KEY:

--- a/homeassistant/components/flux_led/config_flow.py
+++ b/homeassistant/components/flux_led/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Flux LED/MagicLight."""
 
 import contextlib
-from typing import Any, Self, cast
+from typing import Any, Self, cast, override
 
 from flux_led.const import (
     ATTR_ID,
@@ -69,12 +69,14 @@ class FluxLedConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: FluxLedConfigEntry,
     ) -> FluxLedOptionsFlow:
         """Get the options flow for the Flux LED component."""
         return FluxLedOptionsFlow()
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:
@@ -94,6 +96,7 @@ class FluxLedConfigFlow(ConfigFlow, domain=DOMAIN):
         )
         return await self._async_handle_discovery()
 
+    @override
     async def async_step_integration_discovery(
         self, discovery_info: DiscoveryInfoType
     ) -> ConfigFlowResult:
@@ -174,6 +177,7 @@ class FluxLedConfigFlow(ConfigFlow, domain=DOMAIN):
                 await self._async_set_discovered_mac(device, True)
         return await self.async_step_discovery_confirm()
 
+    @override
     def is_matching(self, other_flow: Self) -> bool:
         """Return True if other_flow is matching this flow."""
         return other_flow.host == self.host
@@ -216,6 +220,7 @@ class FluxLedConfigFlow(ConfigFlow, domain=DOMAIN):
             data=data,
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/flux_led/coordinator.py
+++ b/homeassistant/components/flux_led/coordinator.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import Final
+from typing import Final, override
 
 from flux_led.aio import AIOWifiLedBulb
 
@@ -47,6 +47,7 @@ class FluxLedUpdateCoordinator(DataUpdateCoordinator[None]):
             always_update=False,
         )
 
+    @override
     async def _async_update_data(self) -> None:
         """Fetch all device and sensor data from api."""
         try:

--- a/homeassistant/components/flux_led/entity.py
+++ b/homeassistant/components/flux_led/entity.py
@@ -1,7 +1,7 @@
 """Support for Magic Home lights."""
 
 from abc import abstractmethod
-from typing import Any
+from typing import Any, override
 
 from flux_led.aiodevice import AIOWifiLedBulb
 
@@ -97,17 +97,20 @@ class FluxEntity(CoordinatorEntity[FluxLedUpdateCoordinator]):
             await self._device.async_turn_on()
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, str]:
         """Return the attributes."""
         return {"ip_address": self._device.ipaddr}
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         if self.coordinator.last_update_success != self._responding:
             self.async_write_ha_state()
         self._responding = self.coordinator.last_update_success
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
         self.async_on_remove(

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -2,7 +2,7 @@
 
 import ast
 import logging
-from typing import Any, Final
+from typing import Any, Final, override
 
 from flux_led.const import MultiColorEffects
 from flux_led.protocol import MusicMode
@@ -209,31 +209,37 @@ class FluxLight(
         self._custom_effect_transition = custom_effect_transition
 
     @property
+    @override
     def brightness(self) -> int:
         """Return the brightness of this light between 0..255."""
         return self._device.brightness
 
     @property
+    @override
     def color_temp_kelvin(self) -> int:
         """Return the kelvin value of this light."""
         return self._device.color_temp
 
     @property
+    @override
     def rgb_color(self) -> tuple[int, int, int]:
         """Return the rgb color value."""
         return self._device.rgb_unscaled
 
     @property
+    @override
     def rgbw_color(self) -> tuple[int, int, int, int]:
         """Return the rgbw color value."""
         return self._device.rgbw
 
     @property
+    @override
     def rgbww_color(self) -> tuple[int, int, int, int, int]:
         """Return the rgbww aka rgbcw color value."""
         return self._device.rgbcw
 
     @property
+    @override
     def color_mode(self) -> ColorMode:
         """Return the color mode of the light."""
         return _flux_color_mode_to_hass(
@@ -241,10 +247,12 @@ class FluxLight(
         )
 
     @property
+    @override
     def effect(self) -> str | None:
         """Return the current effect."""
         return self._device.effect
 
+    @override
     async def _async_turn_on(self, **kwargs: Any) -> None:
         """Turn the specified or all lights on."""
         if self._device.requires_turn_on or not kwargs:

--- a/homeassistant/components/flux_led/number.py
+++ b/homeassistant/components/flux_led/number.py
@@ -3,7 +3,7 @@
 from abc import abstractmethod
 from collections.abc import Coroutine
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from flux_led.protocol import (
     MUSIC_PIXELS_MAX,
@@ -89,10 +89,12 @@ class FluxSpeedNumber(
     _attr_translation_key = "effect_speed"
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the effect speed."""
         return cast(float, self._device.speed)
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set the flux speed value."""
         current_effect = self._device.effect
@@ -130,6 +132,7 @@ class FluxConfigNumber(
         self._debouncer: Debouncer[Coroutine[Any, Any, None]] | None = None
         self._pending_value: int | None = None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Set up the debouncer when adding to hass."""
         self._debouncer = Debouncer(
@@ -141,6 +144,7 @@ class FluxConfigNumber(
         )
         await super().async_added_to_hass()
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set the value."""
         self._pending_value = int(value)
@@ -173,6 +177,7 @@ class FluxPixelsPerSegmentNumber(FluxConfigNumber):
     _attr_translation_key = "pixels_per_segment"
 
     @property
+    @override
     def native_max_value(self) -> int:
         """Return the max value."""
         return min(
@@ -180,11 +185,13 @@ class FluxPixelsPerSegmentNumber(FluxConfigNumber):
         )
 
     @property
+    @override
     def native_value(self) -> int:
         """Return the pixels per segment."""
         assert self._device.pixels_per_segment is not None
         return self._device.pixels_per_segment
 
+    @override
     async def _async_set_native_value(self) -> None:
         """Set the pixels per segment."""
         assert self._pending_value is not None
@@ -199,6 +206,7 @@ class FluxSegmentsNumber(FluxConfigNumber):
     _attr_translation_key = "segments"
 
     @property
+    @override
     def native_max_value(self) -> int:
         """Return the max value."""
         assert self._device.pixels_per_segment is not None
@@ -207,11 +215,13 @@ class FluxSegmentsNumber(FluxConfigNumber):
         )
 
     @property
+    @override
     def native_value(self) -> int:
         """Return the segments."""
         assert self._device.segments is not None
         return self._device.segments
 
+    @override
     async def _async_set_native_value(self) -> None:
         """Set the segments."""
         assert self._pending_value is not None
@@ -222,6 +232,7 @@ class FluxMusicNumber(FluxConfigNumber):
     """A number that is only available if the base pixels do not fit in music mode."""
 
     @property
+    @override
     def available(self) -> bool:
         """Return if music pixels per segment can be set."""
         return super().available and not self._pixels_and_segments_fit_in_music_mode()
@@ -233,6 +244,7 @@ class FluxMusicPixelsPerSegmentNumber(FluxMusicNumber):
     _attr_translation_key = "music_pixels_per_segment"
 
     @property
+    @override
     def native_max_value(self) -> int:
         """Return the max value."""
         assert self._device.music_segments is not None
@@ -242,11 +254,13 @@ class FluxMusicPixelsPerSegmentNumber(FluxMusicNumber):
         )
 
     @property
+    @override
     def native_value(self) -> int:
         """Return the music pixels per segment."""
         assert self._device.music_pixels_per_segment is not None
         return self._device.music_pixels_per_segment
 
+    @override
     async def _async_set_native_value(self) -> None:
         """Set the music pixels per segment."""
         assert self._pending_value is not None
@@ -261,6 +275,7 @@ class FluxMusicSegmentsNumber(FluxMusicNumber):
     _attr_translation_key = "music_segments"
 
     @property
+    @override
     def native_max_value(self) -> int:
         """Return the max value."""
         assert self._device.pixels_per_segment is not None
@@ -270,11 +285,13 @@ class FluxMusicSegmentsNumber(FluxMusicNumber):
         )
 
     @property
+    @override
     def native_value(self) -> int:
         """Return the music segments."""
         assert self._device.music_segments is not None
         return self._device.music_segments
 
+    @override
     async def _async_set_native_value(self) -> None:
         """Set the music segments."""
         assert self._pending_value is not None

--- a/homeassistant/components/flux_led/select.py
+++ b/homeassistant/components/flux_led/select.py
@@ -1,6 +1,7 @@
 """Support for Magic Home select."""
 
 import asyncio
+from typing import override
 
 from flux_led.aio import AIOWifiLedBulb
 from flux_led.base_device import DeviceType
@@ -108,6 +109,7 @@ class FluxPowerStateSelect(FluxConfigAtStartSelect, SelectEntity):
         assert restore_states.channel1 is not None
         self._attr_current_option = _human_readable_option(restore_states.channel1.name)
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the power state."""
         await self._device.async_set_power_restore(
@@ -123,16 +125,19 @@ class FluxICTypeSelect(FluxConfigSelect):
     _attr_translation_key = "ic_type"
 
     @property
+    @override
     def options(self) -> list[str]:
         """Return the available ic types."""
         assert self._device.ic_types is not None
         return self._device.ic_types
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the current ic type."""
         return self._device.ic_type
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the ic type."""
         await self._device.async_set_device_config(ic_type=option)
@@ -145,16 +150,19 @@ class FluxWiringsSelect(FluxConfigSelect):
     _attr_translation_key = "wiring"
 
     @property
+    @override
     def options(self) -> list[str]:
         """Return the available wiring options based on the strip protocol."""
         assert self._device.wirings is not None
         return self._device.wirings
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the current wiring."""
         return self._device.wiring
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the wiring."""
         await self._device.async_set_device_config(wiring=option)
@@ -166,16 +174,19 @@ class FluxOperatingModesSelect(FluxConfigSelect):
     _attr_translation_key = "operating_mode"
 
     @property
+    @override
     def options(self) -> list[str]:
         """Return the current operating mode."""
         assert self._device.operating_modes is not None
         return self._device.operating_modes
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the current operating mode."""
         return self._device.operating_mode
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the ic type."""
         await self._device.async_set_device_config(operating_mode=option)
@@ -202,11 +213,13 @@ class FluxRemoteConfigSelect(FluxConfigSelect):
         self._attr_options = list(self._name_to_state)
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the current remote config."""
         assert self._device.remote_config is not None
         return _human_readable_option(self._device.remote_config.name)
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the remote config setting."""
         remote_config: RemoteConfig = self._name_to_state[option]
@@ -231,6 +244,7 @@ class FluxWhiteChannelSelect(FluxConfigAtStartSelect):
         self._attr_unique_id = f"{base_unique_id}_white_channel"
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the current white channel type."""
         return _human_readable_option(
@@ -239,6 +253,7 @@ class FluxWhiteChannelSelect(FluxConfigAtStartSelect):
             )
         )
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the white channel type."""
         self.hass.config_entries.async_update_entry(

--- a/homeassistant/components/flux_led/sensor.py
+++ b/homeassistant/components/flux_led/sensor.py
@@ -1,5 +1,7 @@
 """Support for Magic Home sensors."""
 
+from typing import override
+
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
@@ -35,6 +37,7 @@ class FluxPairedRemotes(FluxEntity, SensorEntity):
     _attr_translation_key = "paired_remotes"
 
     @property
+    @override
     def native_value(self) -> int:
         """Return the number of paired remotes."""
         assert self._device.paired_remotes is not None

--- a/homeassistant/components/flux_led/switch.py
+++ b/homeassistant/components/flux_led/switch.py
@@ -1,6 +1,6 @@
 """Support for Magic Home switches."""
 
-from typing import Any
+from typing import Any, override
 
 from flux_led import DeviceType
 from flux_led.aio import AIOWifiLedBulb
@@ -51,6 +51,7 @@ class FluxSwitch(
 
     _attr_name = None
 
+    @override
     async def _async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         if not self.is_on:
@@ -73,6 +74,7 @@ class FluxRemoteAccessSwitch(FluxBaseEntity, SwitchEntity):
         base_unique_id = entry.unique_id or entry.entry_id
         self._attr_unique_id = f"{base_unique_id}_remote_access"
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the remote access on."""
         await self._device.async_enable_remote_access(
@@ -90,12 +92,14 @@ class FluxRemoteAccessSwitch(FluxBaseEntity, SwitchEntity):
         )
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the remote access off."""
         await self._device.async_disable_remote_access()
         await self._async_update_entry(False)
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if remote access is enabled."""
         return bool(self.entry.data[CONF_REMOTE_ACCESS_ENABLED])
@@ -106,6 +110,7 @@ class FluxMusicSwitch(FluxEntity, SwitchEntity):
 
     _attr_translation_key = "music"
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the microphone on."""
         await self._async_ensure_device_on()
@@ -113,6 +118,7 @@ class FluxMusicSwitch(FluxEntity, SwitchEntity):
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the microphone off."""
         await self._device.async_set_levels(*self._device.rgb, brightness=255)
@@ -120,6 +126,7 @@ class FluxMusicSwitch(FluxEntity, SwitchEntity):
         await self.coordinator.async_request_refresh()
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if microphone is is on."""
         return self._device.is_on and self._device.effect == MODE_MUSIC

--- a/homeassistant/components/folder_watcher/__init__.py
+++ b/homeassistant/components/folder_watcher/__init__.py
@@ -2,7 +2,7 @@
 
 import logging
 import os
-from typing import cast
+from typing import cast, override
 
 from watchdog.events import (
     DirCreatedEvent,
@@ -103,22 +103,27 @@ class EventHandler(PatternMatchingEventHandler):
             signal = f"folder_watcher-{self.entry_id}"
             dispatcher_send(self.hass, signal, event.event_type, fireable)
 
+    @override
     def on_modified(self, event: DirModifiedEvent | FileModifiedEvent) -> None:
         """File modified."""
         self.process(event)
 
+    @override
     def on_moved(self, event: DirMovedEvent | FileMovedEvent) -> None:
         """File moved."""
         self.process(event, moved=True)
 
+    @override
     def on_created(self, event: DirCreatedEvent | FileCreatedEvent) -> None:
         """File created."""
         self.process(event)
 
+    @override
     def on_deleted(self, event: DirDeletedEvent | FileDeletedEvent) -> None:
         """File deleted."""
         self.process(event)
 
+    @override
     def on_closed(self, event: FileClosedEvent) -> None:
         """File closed."""
         self.process(event)

--- a/homeassistant/components/folder_watcher/config_flow.py
+++ b/homeassistant/components/folder_watcher/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import os
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -74,11 +74,13 @@ class FolderWatcherConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
     config_flow = CONFIG_FLOW
     options_flow = OPTIONS_FLOW
 
+    @override
     def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
         """Return config entry title."""
         return f"Folder Watcher {options[CONF_FOLDER]}"
 
     @callback
+    @override
     def async_create_entry(
         self, data: Mapping[str, Any], **kwargs: Any
     ) -> ConfigFlowResult:

--- a/homeassistant/components/folder_watcher/event.py
+++ b/homeassistant/components/folder_watcher/event.py
@@ -1,6 +1,6 @@
 """Support for Folder watcher event entities."""
 
-from typing import Any
+from typing import Any, override
 
 from watchdog.events import (
     EVENT_TYPE_CLOSED,
@@ -64,6 +64,7 @@ class FolderWatcherEventEntity(EventEntity):
         self._trigger_event(event, _extra)
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
         await super().async_added_to_hass()

--- a/homeassistant/components/foobot/sensor.py
+++ b/homeassistant/components/foobot/sensor.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 import aiohttp
 from foobot_async import FoobotClient
@@ -145,6 +145,7 @@ class FoobotSensor(SensorEntity):
         self._attr_unique_id = f"{device['uuid']}_{description.key}"
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the state of the device."""
         return self.foobot_data.data.get(self.entity_description.key)

--- a/homeassistant/components/forecast_solar/config_flow.py
+++ b/homeassistant/components/forecast_solar/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Forecast.Solar integration."""
 
 import re
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -72,6 +72,7 @@ class ForecastSolarFlowHandler(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> ForecastSolarOptionFlowHandler:
@@ -80,12 +81,14 @@ class ForecastSolarFlowHandler(ConfigFlow, domain=DOMAIN):
 
     @classmethod
     @callback
+    @override
     def async_get_supported_subentry_types(
         cls, config_entry: ConfigEntry
     ) -> dict[str, type[ConfigSubentryFlow]]:
         """Return subentries supported by this handler."""
         return {SUBENTRY_TYPE_PLANE: PlaneSubentryFlowHandler}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/forecast_solar/coordinator.py
+++ b/homeassistant/components/forecast_solar/coordinator.py
@@ -1,6 +1,7 @@
 """DataUpdateCoordinator for the Forecast.Solar integration."""
 
 from datetime import timedelta
+from typing import override
 
 from forecast_solar import Estimate, ForecastSolar, ForecastSolarConnectionError, Plane
 
@@ -88,6 +89,7 @@ class ForecastSolarDataUpdateCoordinator(DataUpdateCoordinator[Estimate]):
             update_interval=update_interval,
         )
 
+    @override
     async def _async_update_data(self) -> Estimate:
         """Fetch Forecast.Solar estimates."""
         try:

--- a/homeassistant/components/forecast_solar/sensor.py
+++ b/homeassistant/components/forecast_solar/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Any, override
 
 from forecast_solar.models import Estimate
 
@@ -181,6 +181,7 @@ class ForecastSolarSensorEntity(
         )
 
     @property
+    @override
     def native_value(self) -> datetime | StateType:
         """Return the state of the sensor."""
         if self.entity_description.state is None:

--- a/homeassistant/components/forked_daapd/config_flow.py
+++ b/homeassistant/components/forked_daapd/config_flow.py
@@ -2,7 +2,7 @@
 
 from contextlib import suppress
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyforked_daapd import ForkedDaapdAPI
 import voluptuous as vol
@@ -110,6 +110,7 @@ class ForkedDaapdFlowHandler(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ForkedDaapdConfigEntry,
     ) -> ForkedDaapdOptionsFlowHandler:
@@ -130,6 +131,7 @@ class ForkedDaapdFlowHandler(ConfigFlow, domain=DOMAIN):
         )
         return validate_result
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -159,6 +161,7 @@ class ForkedDaapdFlowHandler(ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=vol.Schema(DATA_SCHEMA_DICT), errors={}
         )
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/forked_daapd/media_player.py
+++ b/homeassistant/components/forked_daapd/media_player.py
@@ -3,7 +3,7 @@
 import asyncio
 from collections import defaultdict
 import logging
-from typing import Any
+from typing import Any, override
 
 from pylibrespot_java import LibrespotJavaAPI
 
@@ -129,6 +129,7 @@ class ForkedDaapdZone(MediaPlayerEntity):
         self._available = True
         self._entry_id = entry_id
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Use lifecycle hooks."""
         self.async_on_remove(
@@ -150,10 +151,12 @@ class ForkedDaapdZone(MediaPlayerEntity):
         self.async_write_ha_state()
 
     @property
+    @override
     def unique_id(self):
         """Return unique ID."""
         return f"{self._entry_id}-{self._output_id}"
 
+    @override
     async def async_toggle(self) -> None:
         """Toggle the power on the zone."""
         if self.state == MediaPlayerState.OFF:
@@ -162,24 +165,29 @@ class ForkedDaapdZone(MediaPlayerEntity):
             await self.async_turn_off()
 
     @property
+    @override
     def available(self) -> bool:
         """Return whether the zone is available."""
         return self._available
 
+    @override
     async def async_turn_on(self) -> None:
         """Enable the output."""
         await self._api.change_output(self._output_id, selected=True)
 
+    @override
     async def async_turn_off(self) -> None:
         """Disable the output."""
         await self._api.change_output(self._output_id, selected=False)
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the zone."""
         return f"{FD_NAME} output ({self._output['name']})"
 
     @property
+    @override
     def state(self) -> MediaPlayerState:
         """State of the zone."""
         if self._output["selected"]:
@@ -187,15 +195,18 @@ class ForkedDaapdZone(MediaPlayerEntity):
         return MediaPlayerState.OFF
 
     @property
+    @override
     def volume_level(self):
         """Volume level of the media player (0..1)."""
         return self._output["volume"] / 100
 
     @property
+    @override
     def is_volume_muted(self) -> bool:
         """Boolean if volume is currently muted."""
         return self._output["volume"] == 0
 
+    @override
     async def async_mute_volume(self, mute: bool) -> None:
         """Mute the volume."""
         if mute:
@@ -207,11 +218,13 @@ class ForkedDaapdZone(MediaPlayerEntity):
             target_volume = self._last_volume  # restore volume level
         await self.async_set_volume_level(volume=target_volume)
 
+    @override
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume - input range [0,1]."""
         await self._api.set_volume(volume=volume * 100, output_id=self._output_id)
 
     @property
+    @override
     def supported_features(self) -> MediaPlayerEntityFeature:
         """Flag media player features that are supported."""
         return SUPPORTED_FEATURES_ZONE
@@ -257,6 +270,7 @@ class ForkedDaapdMaster(MediaPlayerEntity):
         self._source = SOURCE_NAME_DEFAULT
         self._max_playlists = None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Use lifecycle hooks."""
         self.async_on_remove(
@@ -391,15 +405,18 @@ class ForkedDaapdMaster(MediaPlayerEntity):
             self._track_info = defaultdict(str)
 
     @property
+    @override
     def unique_id(self) -> str:
         """Return unique ID."""
         return self._entry_id
 
     @property
+    @override
     def available(self) -> bool:
         """Return whether the master is available."""
         return self._available
 
+    @override
     async def async_turn_on(self) -> None:
         """Restore the last on outputs state."""
         # restore state
@@ -421,6 +438,7 @@ class ForkedDaapdMaster(MediaPlayerEntity):
                 [output["id"] for output in self._outputs]
             )
 
+    @override
     async def async_turn_off(self) -> None:
         """Pause player and store outputs state."""
         await self.async_media_pause()
@@ -428,6 +446,7 @@ class ForkedDaapdMaster(MediaPlayerEntity):
         if any(output["selected"] for output in self._outputs):
             await self.api.set_enabled_outputs([])
 
+    @override
     async def async_toggle(self) -> None:
         """Toggle the power on the device.
 
@@ -440,11 +459,13 @@ class ForkedDaapdMaster(MediaPlayerEntity):
             await self.async_turn_off()
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the device."""
         return f"{FD_NAME} server"
 
     @property
+    @override
     def state(self) -> MediaPlayerState | None:
         """State of the player."""
         if self._player["state"] == "play":
@@ -458,16 +479,19 @@ class ForkedDaapdMaster(MediaPlayerEntity):
         return None
 
     @property
+    @override
     def volume_level(self):
         """Volume level of the media player (0..1)."""
         return self._player["volume"] / 100
 
     @property
+    @override
     def is_volume_muted(self):
         """Boolean if volume is currently muted."""
         return self._player["volume"] == 0
 
     @property
+    @override
     def media_content_id(self) -> str | None:
         """Content ID of current playing media."""
         if (item_id := self._player["item_id"]) == 0:
@@ -475,26 +499,31 @@ class ForkedDaapdMaster(MediaPlayerEntity):
         return str(item_id)
 
     @property
+    @override
     def media_content_type(self):
         """Content type of current playing media."""
         return self._track_info["media_kind"]
 
     @property
+    @override
     def media_duration(self):
         """Duration of current playing media in seconds."""
         return self._player["item_length_ms"] / 1000
 
     @property
+    @override
     def media_position(self):
         """Position of current playing media in seconds."""
         return self._player["item_progress_ms"] / 1000
 
     @property
+    @override
     def media_position_updated_at(self):
         """When was the position of the current playing media valid."""
         return self._player_last_updated
 
     @property
+    @override
     def media_title(self):
         """Title of current playing media."""
         # Use album field when data_kind is url
@@ -504,11 +533,13 @@ class ForkedDaapdMaster(MediaPlayerEntity):
         return self._track_info["title"]
 
     @property
+    @override
     def media_artist(self):
         """Artist of current playing media, music track only."""
         return self._track_info["artist"]
 
     @property
+    @override
     def media_album_name(self):
         """Album name of current playing media, music track only."""
         # Use title field when data_kind is url
@@ -518,35 +549,42 @@ class ForkedDaapdMaster(MediaPlayerEntity):
         return self._track_info["album"]
 
     @property
+    @override
     def media_album_artist(self):
         """Album artist of current playing media, music track only."""
         return self._track_info["album_artist"]
 
     @property
+    @override
     def media_track(self):
         """Track number of current playing media, music track only."""
         return self._track_info["track_number"]
 
     @property
+    @override
     def shuffle(self):
         """Boolean if shuffle is enabled."""
         return self._player["shuffle"]
 
     @property
+    @override
     def supported_features(self) -> MediaPlayerEntityFeature:
         """Flag media player features that are supported."""
         return SUPPORTED_FEATURES
 
     @property
+    @override
     def source(self):
         """Name of the current input source."""
         return self._source
 
     @property
+    @override
     def source_list(self):
         """List of available input sources."""
         return [*self._sources_uris]
 
+    @override
     async def async_mute_volume(self, mute: bool) -> None:
         """Mute the volume."""
         if mute:
@@ -558,10 +596,12 @@ class ForkedDaapdMaster(MediaPlayerEntity):
             target_volume = self._last_volume  # restore volume level
         await self.api.set_volume(volume=target_volume * 100)
 
+    @override
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume - input range [0,1]."""
         await self.api.set_volume(volume=volume * 100)
 
+    @override
     async def async_media_play(self) -> None:
         """Start playback."""
         if self._use_pipe_control():
@@ -569,6 +609,7 @@ class ForkedDaapdMaster(MediaPlayerEntity):
         else:
             await self.api.start_playback()
 
+    @override
     async def async_media_pause(self) -> None:
         """Pause playback."""
         if self._use_pipe_control():
@@ -576,6 +617,7 @@ class ForkedDaapdMaster(MediaPlayerEntity):
         else:
             await self.api.pause_playback()
 
+    @override
     async def async_media_stop(self) -> None:
         """Stop playback."""
         if self._use_pipe_control():
@@ -583,6 +625,7 @@ class ForkedDaapdMaster(MediaPlayerEntity):
         else:
             await self.api.stop_playback()
 
+    @override
     async def async_media_previous_track(self) -> None:
         """Skip to previous track."""
         if self._use_pipe_control():
@@ -592,6 +635,7 @@ class ForkedDaapdMaster(MediaPlayerEntity):
         else:
             await self.api.previous_track()
 
+    @override
     async def async_media_next_track(self) -> None:
         """Skip to next track."""
         if self._use_pipe_control():
@@ -599,19 +643,23 @@ class ForkedDaapdMaster(MediaPlayerEntity):
         else:
             await self.api.next_track()
 
+    @override
     async def async_media_seek(self, position: float) -> None:
         """Seek to position."""
         await self.api.seek(position_ms=position * 1000)
 
+    @override
     async def async_clear_playlist(self) -> None:
         """Clear playlist."""
         await self.api.clear_queue()
 
+    @override
     async def async_set_shuffle(self, shuffle: bool) -> None:
         """Enable/disable shuffle mode."""
         await self.api.shuffle(shuffle)
 
     @property
+    @override
     def media_image_url(self):
         """Image url of current playing media."""
         if url := self._track_info.get("artwork_url"):
@@ -645,6 +693,7 @@ class ForkedDaapdMaster(MediaPlayerEntity):
             self._pause_requested = False
         self._paused_event.clear()
 
+    @override
     async def async_play_media(
         self, media_type: MediaType | str, media_id: str, **kwargs: Any
     ) -> None:
@@ -776,6 +825,7 @@ class ForkedDaapdMaster(MediaPlayerEntity):
         if saved_state != MediaPlayerState.PLAYING:
             await self.async_media_stop()
 
+    @override
     async def async_select_source(self, source: str) -> None:
         """Change source.
 
@@ -811,6 +861,7 @@ class ForkedDaapdMaster(MediaPlayerEntity):
             return
         _LOGGER.warning("No pipe control available for %s", pipe_name)
 
+    @override
     async def async_browse_media(
         self,
         media_content_type: MediaType | str | None = None,
@@ -848,6 +899,7 @@ class ForkedDaapdMaster(MediaPlayerEntity):
         # media_content_type should only be None if media_content_id is None
         return await get_owntone_content(self, media_content_id)
 
+    @override
     async def async_get_browse_image(
         self,
         media_content_type: MediaType | str,

--- a/homeassistant/components/fortios/device_tracker.py
+++ b/homeassistant/components/fortios/device_tracker.py
@@ -4,7 +4,7 @@ This FortiOS integration provides a device_tracker platform.
 """
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from awesomeversion import AwesomeVersion
 from fortiosapi import FortiOSAPI
@@ -100,11 +100,13 @@ class FortiOSDeviceScanner(DeviceScanner):
             except KeyError as kex:
                 _LOGGER.error("Key not found in clients: %s", kex)
 
+    @override
     def scan_devices(self):
         """Scan for new devices and return a list with found device IDs."""
         self.update()
         return self._clients
 
+    @override
     def get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""
         _LOGGER.debug("Getting name of device %s", device)

--- a/homeassistant/components/foscam/camera.py
+++ b/homeassistant/components/foscam/camera.py
@@ -1,6 +1,7 @@
 """Component providing basic support for Foscam IP cameras."""
 
 import asyncio
+from typing import override
 from urllib.parse import quote
 
 import voluptuous as vol
@@ -109,6 +110,7 @@ class HassFoscamCamera(FoscamEntity, Camera):
         if self._rtsp_port:
             self._attr_supported_features = CameraEntityFeature.STREAM
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Handle entity addition to hass."""
         # Get motion detection status
@@ -136,6 +138,7 @@ class HassFoscamCamera(FoscamEntity, Camera):
         else:
             self._attr_motion_detection_enabled = response == 1
 
+    @override
     def camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
@@ -148,6 +151,7 @@ class HassFoscamCamera(FoscamEntity, Camera):
 
         return response
 
+    @override
     async def stream_source(self) -> str | None:
         """Return the stream source."""
         if self._rtsp_port:
@@ -157,6 +161,7 @@ class HassFoscamCamera(FoscamEntity, Camera):
 
         return None
 
+    @override
     def enable_motion_detection(self) -> None:
         """Enable motion detection in camera."""
         try:
@@ -183,6 +188,7 @@ class HassFoscamCamera(FoscamEntity, Camera):
                 self.name,
             )
 
+    @override
     def disable_motion_detection(self) -> None:
         """Disable motion detection."""
         try:

--- a/homeassistant/components/foscam/config_flow.py
+++ b/homeassistant/components/foscam/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for foscam integration."""
 
-from typing import Any
+from typing import Any, override
 
 from libpyfoscamcgi import FoscamCamera
 from libpyfoscamcgi.foscamcgi import (
@@ -92,6 +92,7 @@ class FoscamConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_create_entry(title=name, data=data)
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/foscam/coordinator.py
+++ b/homeassistant/components/foscam/coordinator.py
@@ -3,6 +3,7 @@
 import asyncio
 from dataclasses import dataclass
 from datetime import timedelta
+from typing import override
 
 from libpyfoscamcgi import FoscamCamera
 
@@ -206,6 +207,7 @@ class FoscamCoordinator(DataUpdateCoordinator[FoscamDeviceInfo]):
             is_human_detection_on=is_human_detection_on_val,
         )
 
+    @override
     async def _async_update_data(self) -> FoscamDeviceInfo:
         """Fetch data from API endpoint."""
         async with asyncio.timeout(10):

--- a/homeassistant/components/foscam/number.py
+++ b/homeassistant/components/foscam/number.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from libpyfoscamcgi import FoscamCamera
 
@@ -78,10 +78,12 @@ class FoscamVolumeNumberEntity(FoscamEntity, NumberEntity):
         self._attr_unique_id = f"{entry_id}_{description.key}"
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the current value."""
         return self.entity_description.native_value_fn(self.coordinator)
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set the value."""
         await self.hass.async_add_executor_job(

--- a/homeassistant/components/foscam/switch.py
+++ b/homeassistant/components/foscam/switch.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from libpyfoscamcgi import FoscamCamera
 
@@ -188,10 +188,12 @@ class FoscamGenericSwitch(FoscamEntity, SwitchEntity):
         self._attr_unique_id = f"{entry_id}_{description.key}"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the state of the switch."""
         return self.entity_description.native_value_fn(self.coordinator.data)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the entity."""
         self.hass.async_add_executor_job(
@@ -199,6 +201,7 @@ class FoscamGenericSwitch(FoscamEntity, SwitchEntity):
         )
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the entity."""
         self.hass.async_add_executor_job(

--- a/homeassistant/components/free_mobile/notify.py
+++ b/homeassistant/components/free_mobile/notify.py
@@ -2,7 +2,7 @@
 
 from http import HTTPStatus
 import logging
-from typing import Any
+from typing import Any, override
 
 from freesms import FreeClient
 import voluptuous as vol
@@ -39,6 +39,7 @@ class FreeSMSNotificationService(BaseNotificationService):
         """Initialize the service."""
         self.free_client = FreeClient(username, access_token)
 
+    @override
     def send_message(self, message: str = "", **kwargs: Any) -> None:
         """Send a message to the Free Mobile user cell."""
         resp = self.free_client.send_sms(message)

--- a/homeassistant/components/freebox/alarm_control_panel.py
+++ b/homeassistant/components/freebox/alarm_control_panel.py
@@ -1,6 +1,6 @@
 """Support for Freebox alarms."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntity,
@@ -77,18 +77,22 @@ class FreeboxAlarm(FreeboxHomeEntity, AlarmControlPanelEntity):
             | AlarmControlPanelEntityFeature.TRIGGER
         )
 
+    @override
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
         await self.set_home_endpoint_value(self._command_disarm)
 
+    @override
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
         await self.set_home_endpoint_value(self._command_arm_away)
 
+    @override
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
         await self.set_home_endpoint_value(self._command_arm_home)
 
+    @override
     async def async_alarm_trigger(self, code: str | None = None) -> None:
         """Send alarm trigger command."""
         await self.set_home_endpoint_value(self._command_trigger)

--- a/homeassistant/components/freebox/binary_sensor.py
+++ b/homeassistant/components/freebox/binary_sensor.py
@@ -1,7 +1,7 @@
 """Support for Freebox devices (Freebox v6 and Freebox mini 4K)."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -85,6 +85,7 @@ class FreeboxHomeBinarySensor(FreeboxHomeEntity, BinarySensorEntity):
             self.get_value("signal", self._endpoint_name)
         )
 
+    @override
     async def async_update_signal(self) -> None:
         """Update name & state."""
         self._attr_is_on = self._edit_state(
@@ -169,6 +170,7 @@ class FreeboxRaidDegradedSensor(BinarySensorEntity):
         self._raid = self._router.raids[self._raid["id"]]
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if degraded."""
         return self._raid["degraded"]
@@ -179,6 +181,7 @@ class FreeboxRaidDegradedSensor(BinarySensorEntity):
         self.async_update_state()
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register state update callback."""
         self.async_update_state()

--- a/homeassistant/components/freebox/button.py
+++ b/homeassistant/components/freebox/button.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.button import (
     ButtonDeviceClass,
@@ -66,6 +67,7 @@ class FreeboxButton(ButtonEntity):
         self._attr_device_info = router.device_info
         self._attr_unique_id = f"{router.mac} {description.key}"
 
+    @override
     async def async_press(self) -> None:
         """Press the button."""
         await self.entity_description.async_press(self._router)

--- a/homeassistant/components/freebox/camera.py
+++ b/homeassistant/components/freebox/camera.py
@@ -1,6 +1,6 @@
 """Support for Freebox cameras."""
 
-from typing import Any
+from typing import Any, override
 
 from aiohttp import web
 from haffmpeg.camera import CameraMjpeg
@@ -84,10 +84,12 @@ class FreeboxCamera(FreeboxHomeEntity, Camera):
         self._attr_extra_state_attributes = {}
         self.update_node(node)
 
+    @override
     async def stream_source(self) -> str:
         """Return the stream source."""
         return self._input.split(" ")[-1]
 
+    @override
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
@@ -99,6 +101,7 @@ class FreeboxCamera(FreeboxHomeEntity, Camera):
             extra_cmd=_FFMPEG_ARGUMENTS,
         )
 
+    @override
     async def handle_async_mjpeg_stream(
         self, request: web.Request
     ) -> web.StreamResponse:
@@ -117,16 +120,19 @@ class FreeboxCamera(FreeboxHomeEntity, Camera):
         finally:
             await stream.close()
 
+    @override
     async def async_enable_motion_detection(self) -> None:
         """Enable motion detection in the camera."""
         if await self.set_home_endpoint_value(self._command_motion_detection, True):
             self._attr_motion_detection_enabled = True
 
+    @override
     async def async_disable_motion_detection(self) -> None:
         """Disable motion detection in camera."""
         if await self.set_home_endpoint_value(self._command_motion_detection, False):
             self._attr_motion_detection_enabled = False
 
+    @override
     async def async_update_signal(self) -> None:
         """Update the camera node."""
         self.update_node(self._router.home_devices[self._id])

--- a/homeassistant/components/freebox/config_flow.py
+++ b/homeassistant/components/freebox/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow to configure the Freebox integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from freebox_api.exceptions import AuthorizationError, HttpRequestError
 import voluptuous as vol
@@ -25,6 +25,7 @@ class FreeboxFlowHandler(ConfigFlow, domain=DOMAIN):
         """Initialize config flow."""
         self._data: dict[str, Any] = {}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -100,6 +101,7 @@ class FreeboxFlowHandler(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(step_id="link", errors=errors)
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/freebox/device_tracker.py
+++ b/homeassistant/components/freebox/device_tracker.py
@@ -1,7 +1,7 @@
 """Support for Freebox devices (Freebox v6 and Freebox mini 4K)."""
 
 from datetime import datetime
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.device_tracker import ScannerEntity
 from homeassistant.core import HomeAssistant, callback
@@ -86,16 +86,19 @@ class FreeboxDevice(ScannerEntity):
             self._attr_extra_state_attributes = device["attrs"]
 
     @property
+    @override
     def mac_address(self) -> str:
         """Return a unique ID."""
         return self._mac
 
     @property
+    @override
     def name(self) -> str:
         """Return the name."""
         return self._name
 
     @property
+    @override
     def is_connected(self) -> bool:
         """Return true if the device is connected to the network."""
         return self._active
@@ -106,6 +109,7 @@ class FreeboxDevice(ScannerEntity):
         self.async_update_state()
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register state update callback."""
         self.async_update_state()

--- a/homeassistant/components/freebox/entity.py
+++ b/homeassistant/components/freebox/entity.py
@@ -1,7 +1,7 @@
 """Support for Freebox base features."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -104,6 +104,7 @@ class FreeboxHomeEntity(Entity):
             return None
         return node["id"]
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register state update callback."""
         self.async_on_remove(

--- a/homeassistant/components/freebox/sensor.py
+++ b/homeassistant/components/freebox/sensor.py
@@ -1,7 +1,7 @@
 """Support for Freebox devices (Freebox v6 and Freebox mini 4K)."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -153,6 +153,7 @@ class FreeboxSensor(SensorEntity):
         self.async_update_state()
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register state update callback."""
         self.async_update_state()
@@ -176,6 +177,7 @@ class FreeboxCallSensor(FreeboxSensor):
         self._call_list_for_type: list[dict[str, Any]] = []
 
     @callback
+    @override
     def async_update_state(self) -> None:
         """Update the Freebox call sensor."""
         self._call_list_for_type = []
@@ -189,6 +191,7 @@ class FreeboxCallSensor(FreeboxSensor):
         self._attr_native_value = len(self._call_list_for_type)
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return device specific state attributes."""
         return {
@@ -228,6 +231,7 @@ class FreeboxDiskSensor(FreeboxSensor):
         )
 
     @callback
+    @override
     def async_update_state(self) -> None:
         """Update the Freebox disk sensor."""
         value = None
@@ -245,6 +249,7 @@ class FreeboxBatterySensor(FreeboxHomeEntity, SensorEntity):
     _attr_native_unit_of_measurement = PERCENTAGE
 
     @property
+    @override
     def native_value(self) -> int:
         """Return the current state of the device."""
         return self.get_value("signal", "battery")

--- a/homeassistant/components/freebox/switch.py
+++ b/homeassistant/components/freebox/switch.py
@@ -1,7 +1,7 @@
 """Support for Freebox Delta, Revolution and Mini 4K."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from freebox_api.exceptions import InsufficientPermissionsError
 
@@ -60,10 +60,12 @@ class FreeboxSwitch(SwitchEntity):
                 " settings. Please refer to documentation"
             )
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self._async_set_state(True)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self._async_set_state(False)

--- a/homeassistant/components/freedompro/binary_sensor.py
+++ b/homeassistant/components/freedompro/binary_sensor.py
@@ -1,6 +1,6 @@
 """Support for Freedompro binary_sensor."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -69,6 +69,7 @@ class Device(CoordinatorEntity[FreedomproDataUpdateCoordinator], BinarySensorEnt
         self._attr_device_class = DEVICE_CLASS_MAP[device["type"]]
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         device = next(
@@ -84,6 +85,7 @@ class Device(CoordinatorEntity[FreedomproDataUpdateCoordinator], BinarySensorEnt
             self._attr_is_on = state[DEVICE_KEY_MAP[self._type]]
         super()._handle_coordinator_update()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()

--- a/homeassistant/components/freedompro/climate.py
+++ b/homeassistant/components/freedompro/climate.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiohttp.client import ClientSession
 from pyfreedompro import put_state
@@ -96,6 +96,7 @@ class Device(CoordinatorEntity[FreedomproDataUpdateCoordinator], ClimateEntity):
         )
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         device = next(
@@ -116,11 +117,13 @@ class Device(CoordinatorEntity[FreedomproDataUpdateCoordinator], ClimateEntity):
                 self._attr_hvac_mode = HVAC_MAP[state["heatingCoolingState"]]
         super()._handle_coordinator_update()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
         self._handle_coordinator_update()
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Async function to set mode to climate."""
 
@@ -133,6 +136,7 @@ class Device(CoordinatorEntity[FreedomproDataUpdateCoordinator], ClimateEntity):
         )
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Async function to set temperature to climate."""
         payload = {}

--- a/homeassistant/components/freedompro/config_flow.py
+++ b/homeassistant/components/freedompro/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow to configure Freedompro."""
 
-from typing import Any
+from typing import Any, override
 
 from pyfreedompro import get_list
 import voluptuous as vol
@@ -48,6 +48,7 @@ class FreedomProConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/freedompro/coordinator.py
+++ b/homeassistant/components/freedompro/coordinator.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyfreedompro import get_list, get_states
 
@@ -38,6 +38,7 @@ class FreedomproDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]
             update_interval=update_interval,
         )
 
+    @override
     async def _async_update_data(self):
         if self._devices is None:
             result = await get_list(

--- a/homeassistant/components/freedompro/cover.py
+++ b/homeassistant/components/freedompro/cover.py
@@ -1,7 +1,7 @@
 """Support for Freedompro cover."""
 
 import json
-from typing import Any
+from typing import Any, override
 
 from pyfreedompro import put_state
 
@@ -83,6 +83,7 @@ class Device(CoordinatorEntity[FreedomproDataUpdateCoordinator], CoverEntity):
         self._attr_device_class = DEVICE_CLASS_MAP[device["type"]]
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         device = next(
@@ -103,19 +104,23 @@ class Device(CoordinatorEntity[FreedomproDataUpdateCoordinator], CoverEntity):
                     self._attr_is_closed = False
         super()._handle_coordinator_update()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
         self._handle_coordinator_update()
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         await self.async_set_cover_position(position=100)
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
         await self.async_set_cover_position(position=0)
 
+    @override
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Async function to set position to cover."""
         payload = {"position": kwargs[ATTR_POSITION]}

--- a/homeassistant/components/freedompro/fan.py
+++ b/homeassistant/components/freedompro/fan.py
@@ -1,7 +1,7 @@
 """Support for Freedompro fan."""
 
 import json
-from typing import Any
+from typing import Any, override
 
 from pyfreedompro import put_state
 
@@ -68,11 +68,13 @@ class FreedomproFan(CoordinatorEntity[FreedomproDataUpdateCoordinator], FanEntit
             self._attr_supported_features |= FanEntityFeature.SET_SPEED
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return True if entity is on."""
         return self._attr_is_on
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         device = next(
@@ -90,11 +92,13 @@ class FreedomproFan(CoordinatorEntity[FreedomproDataUpdateCoordinator], FanEntit
                 self._attr_percentage = state["rotationSpeed"]
         super()._handle_coordinator_update()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
         self._handle_coordinator_update()
 
+    @override
     async def async_turn_on(
         self,
         percentage: int | None = None,
@@ -111,6 +115,7 @@ class FreedomproFan(CoordinatorEntity[FreedomproDataUpdateCoordinator], FanEntit
         )
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Async function to turn off the fan."""
         payload = {"on": False}
@@ -122,6 +127,7 @@ class FreedomproFan(CoordinatorEntity[FreedomproDataUpdateCoordinator], FanEntit
         )
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""
         payload = {"rotationSpeed": percentage}

--- a/homeassistant/components/freedompro/light.py
+++ b/homeassistant/components/freedompro/light.py
@@ -1,7 +1,7 @@
 """Support for Freedompro light."""
 
 import json
-from typing import Any
+from typing import Any, override
 
 from pyfreedompro import put_state
 
@@ -72,6 +72,7 @@ class Device(CoordinatorEntity[FreedomproDataUpdateCoordinator], LightEntity):
         self._attr_supported_color_modes = {color_mode}
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         device = next(
@@ -92,11 +93,13 @@ class Device(CoordinatorEntity[FreedomproDataUpdateCoordinator], LightEntity):
                 self._attr_hs_color = (state["hue"], state["saturation"])
         super()._handle_coordinator_update()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
         self._handle_coordinator_update()
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Async function to set on to light."""
         payload: dict[str, Any] = {"on": True}
@@ -113,6 +116,7 @@ class Device(CoordinatorEntity[FreedomproDataUpdateCoordinator], LightEntity):
         )
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Async function to set off to light."""
         payload = {"on": False}

--- a/homeassistant/components/freedompro/lock.py
+++ b/homeassistant/components/freedompro/lock.py
@@ -1,7 +1,7 @@
 """Support for Freedompro lock."""
 
 import json
-from typing import Any
+from typing import Any, override
 
 from pyfreedompro import put_state
 
@@ -63,6 +63,7 @@ class Device(CoordinatorEntity[FreedomproDataUpdateCoordinator], LockEntity):
         )
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         device = next(
@@ -82,11 +83,13 @@ class Device(CoordinatorEntity[FreedomproDataUpdateCoordinator], LockEntity):
                     self._attr_is_locked = False
         super()._handle_coordinator_update()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
         self._handle_coordinator_update()
 
+    @override
     async def async_lock(self, **kwargs: Any) -> None:
         """Async function to lock the lock."""
         payload = {"lock": 1}
@@ -98,6 +101,7 @@ class Device(CoordinatorEntity[FreedomproDataUpdateCoordinator], LockEntity):
         )
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_unlock(self, **kwargs: Any) -> None:
         """Async function to unlock the lock."""
         payload = {"lock": 0}

--- a/homeassistant/components/freedompro/sensor.py
+++ b/homeassistant/components/freedompro/sensor.py
@@ -1,6 +1,6 @@
 """Support for Freedompro sensor."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -80,6 +80,7 @@ class Device(CoordinatorEntity[FreedomproDataUpdateCoordinator], SensorEntity):
         self._attr_native_value = 0
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         device = next(
@@ -95,6 +96,7 @@ class Device(CoordinatorEntity[FreedomproDataUpdateCoordinator], SensorEntity):
             self._attr_native_value = state[DEVICE_KEY_MAP[self._type]]
         super()._handle_coordinator_update()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()

--- a/homeassistant/components/freedompro/switch.py
+++ b/homeassistant/components/freedompro/switch.py
@@ -1,7 +1,7 @@
 """Support for Freedompro switch."""
 
 import json
-from typing import Any
+from typing import Any, override
 
 from pyfreedompro import put_state
 
@@ -61,6 +61,7 @@ class Device(CoordinatorEntity[FreedomproDataUpdateCoordinator], SwitchEntity):
         self._attr_is_on = False
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         device = next(
@@ -77,11 +78,13 @@ class Device(CoordinatorEntity[FreedomproDataUpdateCoordinator], SwitchEntity):
                 self._attr_is_on = state["on"]
         super()._handle_coordinator_update()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
         self._handle_coordinator_update()
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Async function to set on to switch."""
         payload = {"on": True}
@@ -93,6 +96,7 @@ class Device(CoordinatorEntity[FreedomproDataUpdateCoordinator], SwitchEntity):
         )
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Async function to set off to switch."""
         payload = {"on": False}

--- a/homeassistant/components/freshr/config_flow.py
+++ b/homeassistant/components/freshr/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for the Fresh-r integration."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 from aiohttp import ClientError
 from pyfreshr import FreshrClient
@@ -42,6 +42,7 @@ class FreshrFlowHandler(ConfigFlow, domain=DOMAIN):
             return "unknown"
         return None
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/freshr/coordinator.py
+++ b/homeassistant/components/freshr/coordinator.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from datetime import timedelta
+from typing import override
 
 from aiohttp import ClientError
 from pyfreshr import FreshrClient
@@ -55,6 +56,7 @@ class FreshrDevicesCoordinator(DataUpdateCoordinator[dict[str, DeviceSummary]]):
         )
         self.client = FreshrClient(session=async_create_clientsession(hass))
 
+    @override
     async def _async_update_data(self) -> dict[str, DeviceSummary]:
         """Fetch the list of devices from the Fresh-r API."""
         username = self.config_entry.data[CONF_USERNAME]
@@ -128,6 +130,7 @@ class FreshrReadingsCoordinator(DataUpdateCoordinator[DeviceReadings]):
         """Return the device ID."""
         return self._device.id
 
+    @override
     async def _async_update_data(self) -> DeviceReadings:
         """Fetch current readings for this device from the Fresh-r API."""
         try:

--- a/homeassistant/components/freshr/sensor.py
+++ b/homeassistant/components/freshr/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from pyfreshr.models import DeviceReadings, DeviceType
 
@@ -150,6 +151,7 @@ class FreshrSensor(FreshrEntity, SensorEntity):
         self._attr_unique_id = f"{coordinator.device_id}_{description.key}"
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the value from coordinator data."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/fressnapf_tracker/binary_sensor.py
+++ b/homeassistant/components/fressnapf_tracker/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from fressnapftracker import Tracker
 
@@ -60,6 +61,7 @@ class FressnapfTrackerBinarySensor(FressnapfTrackerEntity, BinarySensorEntity):
     entity_description: FressnapfTrackerBinarySensorDescription
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return True if the binary sensor is on."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/fressnapf_tracker/config_flow.py
+++ b/homeassistant/components/fressnapf_tracker/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from fressnapftracker import (
     AuthClient,
@@ -96,6 +96,7 @@ class FressnapfTrackerConfigFlow(ConfigFlow, domain=DOMAIN):
             return errors, verification_response.user_token.access_token
         return errors, None
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/fressnapf_tracker/coordinator.py
+++ b/homeassistant/components/fressnapf_tracker/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from fressnapftracker import (
     ApiClient,
@@ -52,6 +53,7 @@ class FressnapfTrackerDataUpdateCoordinator(DataUpdateCoordinator[Tracker]):
         )
         self.data = initial_data
 
+    @override
     async def _async_update_data(self) -> Tracker:
         try:
             return await self.client.get_tracker()

--- a/homeassistant/components/fressnapf_tracker/device_tracker.py
+++ b/homeassistant/components/fressnapf_tracker/device_tracker.py
@@ -1,5 +1,7 @@
 """Device tracker platform for fressnapf_tracker."""
 
+from typing import override
+
 from homeassistant.components.device_tracker import TrackerEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -37,16 +39,19 @@ class FressnapfTrackerDeviceTracker(FressnapfTrackerBaseEntity, TrackerEntity):
         self._attr_unique_id = coordinator.device.serialnumber
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return super().available and self.coordinator.data.position is not None
 
     @property
+    @override
     def entity_picture(self) -> str | None:
         """Return the entity picture url."""
         return self.coordinator.data.icon
 
     @property
+    @override
     def latitude(self) -> float | None:
         """Return latitude value of the device."""
         if self.coordinator.data.position is not None:
@@ -54,6 +59,7 @@ class FressnapfTrackerDeviceTracker(FressnapfTrackerBaseEntity, TrackerEntity):
         return None
 
     @property
+    @override
     def longitude(self) -> float | None:
         """Return longitude value of the device."""
         if self.coordinator.data.position is not None:
@@ -61,6 +67,7 @@ class FressnapfTrackerDeviceTracker(FressnapfTrackerBaseEntity, TrackerEntity):
         return None
 
     @property
+    @override
     def location_accuracy(self) -> float:
         """Return the location accuracy of the device.
 

--- a/homeassistant/components/fressnapf_tracker/light.py
+++ b/homeassistant/components/fressnapf_tracker/light.py
@@ -1,6 +1,6 @@
 """Light platform for fressnapf_tracker."""
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from fressnapftracker import FressnapfTrackerError
 
@@ -52,6 +52,7 @@ class FressnapfTrackerLight(FressnapfTrackerEntity, LightEntity):
     _attr_supported_color_modes: set[ColorMode] = {ColorMode.BRIGHTNESS}
 
     @property
+    @override
     def brightness(self) -> int:
         """Return the brightness of this light between 0..255."""
         if TYPE_CHECKING:
@@ -59,6 +60,7 @@ class FressnapfTrackerLight(FressnapfTrackerEntity, LightEntity):
             assert self.coordinator.data.led_brightness_value is not None
         return round((self.coordinator.data.led_brightness_value / 100) * 255)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the device."""
         self.raise_if_not_activatable()
@@ -70,6 +72,7 @@ class FressnapfTrackerLight(FressnapfTrackerEntity, LightEntity):
             handle_fressnapf_tracker_exception(e)
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the device."""
         try:
@@ -97,6 +100,7 @@ class FressnapfTrackerLight(FressnapfTrackerEntity, LightEntity):
             )
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if device is on."""
         if self.coordinator.data.led_brightness_value is not None:

--- a/homeassistant/components/fressnapf_tracker/sensor.py
+++ b/homeassistant/components/fressnapf_tracker/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from fressnapftracker import Tracker
 
@@ -61,6 +62,7 @@ class FressnapfTrackerSensor(FressnapfTrackerEntity, SensorEntity):
     entity_description: FressnapfTrackerSensorDescription
 
     @property
+    @override
     def native_value(self) -> int:
         """Return the state of the resources if it has been received yet."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/fressnapf_tracker/switch.py
+++ b/homeassistant/components/fressnapf_tracker/switch.py
@@ -1,6 +1,6 @@
 """Switch platform for Fressnapf Tracker."""
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from fressnapftracker import FressnapfTrackerError
 
@@ -44,6 +44,7 @@ async def async_setup_entry(
 class FressnapfTrackerSwitch(FressnapfTrackerEntity, SwitchEntity):
     """Fressnapf Tracker switch."""
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the device."""
         try:
@@ -52,6 +53,7 @@ class FressnapfTrackerSwitch(FressnapfTrackerEntity, SwitchEntity):
             handle_fressnapf_tracker_exception(e)
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the device."""
         try:
@@ -61,6 +63,7 @@ class FressnapfTrackerSwitch(FressnapfTrackerEntity, SwitchEntity):
         await self.coordinator.async_request_refresh()
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if device is on."""
         if TYPE_CHECKING:

--- a/homeassistant/components/fritz/binary_sensor.py
+++ b/homeassistant/components/fritz/binary_sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 import logging
+from typing import override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -76,6 +77,7 @@ class FritzBoxBinarySensor(FritzBoxBaseCoordinatorEntity, BinarySensorEntity):
     entity_description: FritzBinarySensorEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         if isinstance(

--- a/homeassistant/components/fritz/button.py
+++ b/homeassistant/components/fritz/button.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 import logging
-from typing import Any, Final
+from typing import Any, Final, override
 
 from homeassistant.components.button import (
     ButtonDeviceClass,
@@ -184,6 +184,7 @@ class FritzButton(ButtonEntity):
             name=device_friendly_name,
         )
 
+    @override
     async def async_press(self) -> None:
         """Triggers Fritz!Box service."""
         if self.entity_description.key == "cleanup":
@@ -248,6 +249,7 @@ class FritzBoxWOLButton(FritzDeviceBase, ButtonEntity):
         self._attr_unique_id = f"{self._mac}_wake_on_lan"
         self._is_available = True
 
+    @override
     async def async_press(self) -> None:
         """Press the button."""
         if self.mac_address:

--- a/homeassistant/components/fritz/config_flow.py
+++ b/homeassistant/components/fritz/config_flow.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 import ipaddress
 import logging
 import socket
-from typing import Any, Self
+from typing import Any, Self, override
 from urllib.parse import ParseResult, urlparse
 
 from fritzconnection import FritzConnection
@@ -65,6 +65,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: FritzConfigEntry,
     ) -> FritzBoxToolsOptionsFlowHandler:
@@ -155,6 +156,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow, domain=DOMAIN):
             return int(port)
         return DEFAULT_HTTPS_PORT if user_input[CONF_SSL] else DEFAULT_HTTP_PORT
 
+    @override
     async def async_step_ssdp(
         self, discovery_info: SsdpServiceInfo
     ) -> ConfigFlowResult:
@@ -193,6 +195,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_confirm()
 
+    @override
     def is_matching(self, other_flow: Self) -> bool:
         """Return True if other_flow is matching this flow."""
         return other_flow._host == self._host
@@ -263,6 +266,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow, domain=DOMAIN):
             errors=errors or {},
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/fritz/coordinator.py
+++ b/homeassistant/components/fritz/coordinator.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from functools import partial
 import logging
 import re
-from typing import Any, TypedDict, cast
+from typing import Any, TypedDict, cast, override
 from xml.etree.ElementTree import ParseError
 
 from fritzconnection import FritzConnection
@@ -307,6 +307,7 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
                 )
         return entity_states
 
+    @override
     async def _async_update_data(self) -> UpdateCoordinatorDataType:
         """Update FritzboxTools data."""
         entity_data: UpdateCoordinatorDataType = {

--- a/homeassistant/components/fritz/device_tracker.py
+++ b/homeassistant/components/fritz/device_tracker.py
@@ -2,6 +2,7 @@
 
 import datetime
 import logging
+from typing import override
 
 from homeassistant.components.device_tracker import ScannerEntity
 from homeassistant.core import HomeAssistant, callback
@@ -73,21 +74,25 @@ class FritzBoxTracker(FritzDeviceBase, ScannerEntity):
         self._last_activity: datetime.datetime | None = device.last_activity
 
     @property
+    @override
     def is_connected(self) -> bool:
         """Return device status."""
         return self._avm_wrapper.devices[self._mac].is_connected
 
     @property
+    @override
     def unique_id(self) -> str:
         """Return device unique id."""
         return f"{self._mac}_tracker"
 
     @property
+    @override
     def mac_address(self) -> str:
         """Return mac_address."""
         return self._mac
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, str]:
         """Return the attributes."""
         attrs: dict[str, str] = {}

--- a/homeassistant/components/fritz/entity.py
+++ b/homeassistant/components/fritz/entity.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from fritzconnection.lib.fritzstatus import FritzStatus
 
@@ -95,6 +95,7 @@ class FritzBoxBaseCoordinatorEntity(CoordinatorEntity[AvmWrapper]):
         self._device_name = device_name
         self._attr_unique_id = f"{avm_wrapper.unique_id}-{description.key}"
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
@@ -106,6 +107,7 @@ class FritzBoxBaseCoordinatorEntity(CoordinatorEntity[AvmWrapper]):
             )
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return the device information."""
         return DeviceInfo(

--- a/homeassistant/components/fritz/image.py
+++ b/homeassistant/components/fritz/image.py
@@ -2,6 +2,7 @@
 
 from io import BytesIO
 import logging
+from typing import override
 
 from requests.exceptions import RequestException
 
@@ -102,6 +103,7 @@ class FritzGuestWifiQRImage(FritzBoxBaseEntity, ImageEntity):
 
         return qr_bytes
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Fetch and set initial data and state."""
         self._current_qr_bytes = await self.hass.async_add_executor_job(
@@ -126,6 +128,7 @@ class FritzGuestWifiQRImage(FritzBoxBaseEntity, ImageEntity):
             self._current_qr_bytes = qr_bytes
             self.async_write_ha_state()
 
+    @override
     async def async_image(self) -> bytes | None:
         """Return bytes of image."""
         return self._current_qr_bytes

--- a/homeassistant/components/fritz/sensor.py
+++ b/homeassistant/components/fritz/sensor.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
+from typing import override
 
 from fritzconnection.core.exceptions import FritzConnectionException
 from fritzconnection.lib.fritzstatus import FritzStatus
@@ -348,6 +349,7 @@ class FritzBoxSensor(FritzBoxBaseCoordinatorEntity, SensorEntity):
     )
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the value reported by the sensor."""
         return self.coordinator.data["entity_states"].get(self.entity_description.key)

--- a/homeassistant/components/fritz/switch.py
+++ b/homeassistant/components/fritz/switch.py
@@ -1,7 +1,7 @@
 """Switches for AVM Fritz!Box functions."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.network import async_get_source_ip
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
@@ -333,6 +333,7 @@ class FritzBoxBaseCoordinatorSwitch(CoordinatorEntity[AvmWrapper], SwitchEntity)
         self._attr_unique_id = f"{avm_wrapper.unique_id}-{description.key}"
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return the device information."""
         return DeviceInfo(
@@ -351,6 +352,7 @@ class FritzBoxBaseCoordinatorSwitch(CoordinatorEntity[AvmWrapper], SwitchEntity)
         raise NotImplementedError
 
     @property
+    @override
     def available(self) -> bool:
         """Return availability based on data availability."""
         return super().available and bool(self.data)
@@ -359,10 +361,12 @@ class FritzBoxBaseCoordinatorSwitch(CoordinatorEntity[AvmWrapper], SwitchEntity)
         """Handle switch state change request."""
         raise NotImplementedError
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on switch."""
         await self._async_handle_turn_on_off(turn_on=True)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off switch."""
         await self._async_handle_turn_on_off(turn_on=False)
@@ -398,10 +402,12 @@ class FritzBoxBaseSwitch(FritzBoxBaseEntity, SwitchEntity):
         _LOGGER.debug("Updating '%s' (%s) switch state", self.name, self._type)
         await self._update()
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on switch."""
         await self._async_handle_turn_on_off(turn_on=True)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off switch."""
         await self._async_handle_turn_on_off(turn_on=False)
@@ -497,11 +503,13 @@ class FritzBoxDeflectionSwitch(FritzBoxBaseCoordinatorSwitch):
         super().__init__(avm_wrapper, device_friendly_name, description)
 
     @property
+    @override
     def data(self) -> dict[str, Any]:
         """Return call deflection data."""
         return self.coordinator.data["call_deflections"].get(self.deflection_id, {})
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, str]:
         """Return device attributes."""
         return {
@@ -514,10 +522,12 @@ class FritzBoxDeflectionSwitch(FritzBoxBaseCoordinatorSwitch):
         }
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Switch status."""
         return self.data.get("Enable") == "1"
 
+    @override
     async def _async_handle_turn_on_off(self, turn_on: bool) -> None:
         """Handle deflection switch."""
         await self.coordinator.async_set_deflection_enable(self.deflection_id, turn_on)
@@ -542,6 +552,7 @@ class FritzBoxProfileSwitch(FritzBoxBaseCoordinatorSwitch):
         self._attr_unique_id = f"{self._mac}_internet_access"
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return the device information."""
         return DeviceInfo(
@@ -554,6 +565,7 @@ class FritzBoxProfileSwitch(FritzBoxBaseCoordinatorSwitch):
         return self.coordinator.devices[self._mac]
 
     @property
+    @override
     def available(self) -> bool:
         """Return availability of the switch."""
         if self._device.wan_access is None:
@@ -561,10 +573,12 @@ class FritzBoxProfileSwitch(FritzBoxBaseCoordinatorSwitch):
         return self.coordinator.last_update_success
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Switch status."""
         return self._device.wan_access
 
+    @override
     async def _async_handle_turn_on_off(self, turn_on: bool) -> None:
         """Handle switch state change request."""
         await self.coordinator.async_set_allow_wan_access(

--- a/homeassistant/components/fritz/update.py
+++ b/homeassistant/components/fritz/update.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.update import (
     UpdateEntity,
@@ -61,11 +61,13 @@ class FritzBoxUpdateEntity(FritzBoxBaseCoordinatorEntity, UpdateEntity):
         super().__init__(avm_wrapper, device_friendly_name, description)
 
     @property
+    @override
     def installed_version(self) -> str | None:
         """Version currently in use."""
         return self.coordinator.current_firmware
 
     @property
+    @override
     def latest_version(self) -> str | None:
         """Latest version available for install."""
         if self.coordinator.update_available:
@@ -73,10 +75,12 @@ class FritzBoxUpdateEntity(FritzBoxBaseCoordinatorEntity, UpdateEntity):
         return self.coordinator.current_firmware
 
     @property
+    @override
     def release_url(self) -> str | None:
         """URL to the full release notes of the latest version available."""
         return self.coordinator.release_url
 
+    @override
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:

--- a/homeassistant/components/fritzbox/binary_sensor.py
+++ b/homeassistant/components/fritzbox/binary_sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Final
+from typing import Final, override
 
 from pyfritzhome.fritzhomedevice import FritzhomeDevice
 
@@ -118,6 +118,7 @@ class FritzboxBinarySensor(FritzBoxDeviceEntity, BinarySensorEntity):
     entity_description: FritzBinarySensorEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if sensor is on."""
         return self.entity_description.is_on(self.data)

--- a/homeassistant/components/fritzbox/button.py
+++ b/homeassistant/components/fritzbox/button.py
@@ -1,5 +1,7 @@
 """Support for AVM FRITZ!SmartHome templates."""
 
+from typing import override
+
 from pyfritzhome.devicetypes import FritzhomeTemplate
 
 from homeassistant.components.button import ButtonEntity
@@ -41,11 +43,13 @@ class FritzBoxTemplate(FritzBoxEntity, ButtonEntity):
     """Interface between FritzhomeTemplate and hass."""
 
     @property
+    @override
     def data(self) -> FritzhomeTemplate:
         """Return the template data entity."""
         return self.coordinator.data.templates[self.ain]
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return device specific attributes."""
         return DeviceInfo(
@@ -56,6 +60,7 @@ class FritzBoxTemplate(FritzBoxEntity, ButtonEntity):
             model="SmartHome Template",
         )
 
+    @override
     async def async_press(self) -> None:
         """Apply template and refresh."""
         await self.hass.async_add_executor_job(self.apply_template)

--- a/homeassistant/components/fritzbox/climate.py
+++ b/homeassistant/components/fritzbox/climate.py
@@ -1,6 +1,6 @@
 """Support for AVM FRITZ!SmartHome thermostat devices."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.climate import (
     ATTR_HVAC_MODE,
@@ -95,6 +95,7 @@ class FritzboxThermostat(FritzBoxDeviceEntity, ClimateEntity):
         super().__init__(coordinator, ain)
 
     @callback
+    @override
     def _async_write_ha_state(self) -> None:
         """Write the state to the HASS state machine."""
         if self.data.holiday_active:
@@ -110,6 +111,7 @@ class FritzboxThermostat(FritzBoxDeviceEntity, ClimateEntity):
         return super()._async_write_ha_state()
 
     @property
+    @override
     def current_temperature(self) -> float:
         """Return the current temperature."""
         if self.data.has_temperature_sensor and self.data.temperature is not None:
@@ -117,6 +119,7 @@ class FritzboxThermostat(FritzBoxDeviceEntity, ClimateEntity):
         return self.data.actual_temperature  # type: ignore [no-any-return]
 
     @property
+    @override
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
         if self.data.target_temperature in [ON_API_TEMPERATURE, OFF_API_TEMPERATURE]:
@@ -128,6 +131,7 @@ class FritzboxThermostat(FritzBoxDeviceEntity, ClimateEntity):
         await self.hass.async_add_executor_job(self.data.set_hkr_state, hkr_state, True)
         await self.coordinator.async_refresh()
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         self.check_active_or_lock_mode()
@@ -142,6 +146,7 @@ class FritzboxThermostat(FritzBoxDeviceEntity, ClimateEntity):
             return
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return the current operation mode."""
         if self.data.holiday_active:
@@ -153,6 +158,7 @@ class FritzboxThermostat(FritzBoxDeviceEntity, ClimateEntity):
 
         return HVACMode.HEAT
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new operation mode."""
         self.check_active_or_lock_mode()
@@ -171,6 +177,7 @@ class FritzboxThermostat(FritzBoxDeviceEntity, ClimateEntity):
             await self.async_set_temperature(temperature=target_temp)
 
     @property
+    @override
     def preset_mode(self) -> str | None:
         """Return current preset mode."""
         if self.data.holiday_active:
@@ -187,6 +194,7 @@ class FritzboxThermostat(FritzBoxDeviceEntity, ClimateEntity):
             return PRESET_ECO
         return None
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set preset mode."""
         self.check_active_or_lock_mode()

--- a/homeassistant/components/fritzbox/config_flow.py
+++ b/homeassistant/components/fritzbox/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import ipaddress
-from typing import Any, Self
+from typing import Any, Self, override
 from urllib.parse import urlparse
 
 from pyfritzhome import Fritzhome, LoginError
@@ -84,6 +84,7 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
             return RESULT_NO_DEVICES_FOUND
         return RESULT_SUCCESS
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -110,6 +111,7 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=DATA_SCHEMA_USER, errors=errors
         )
 
+    @override
     async def async_step_ssdp(
         self, discovery_info: SsdpServiceInfo
     ) -> ConfigFlowResult:
@@ -144,6 +146,7 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
         self.context["title_placeholders"] = {"name": self._name}
         return await self.async_step_confirm()
 
+    @override
     def is_matching(self, other_flow: Self) -> bool:
         """Return True if other_flow is matching this flow."""
         return other_flow._host == self._host

--- a/homeassistant/components/fritzbox/coordinator.py
+++ b/homeassistant/components/fritzbox/coordinator.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from datetime import timedelta
+from typing import override
 
 from pyfritzhome import Fritzhome, FritzhomeDevice, LoginError
 from pyfritzhome.devicetypes import FritzhomeTemplate, FritzhomeTrigger
@@ -181,6 +182,7 @@ class FritzboxDataUpdateCoordinator(DataUpdateCoordinator[FritzboxCoordinatorDat
             supported_color_properties=supported_color_properties,
         )
 
+    @override
     async def _async_update_data(self) -> FritzboxCoordinatorData:
         """Fetch all device data."""
         try:

--- a/homeassistant/components/fritzbox/cover.py
+++ b/homeassistant/components/fritzbox/cover.py
@@ -1,6 +1,6 @@
 """Support for AVM FRITZ!SmartHome cover devices."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.cover import (
     ATTR_POSITION,
@@ -56,6 +56,7 @@ class FritzboxCover(FritzBoxDeviceEntity, CoverEntity):
     )
 
     @property
+    @override
     def current_cover_position(self) -> int | None:
         """Return the current position."""
         position = None
@@ -64,28 +65,33 @@ class FritzboxCover(FritzBoxDeviceEntity, CoverEntity):
         return position
 
     @property
+    @override
     def is_closed(self) -> bool | None:
         """Return if the cover is closed."""
         if self.data.levelpercentage is None:
             return None
         return self.data.levelpercentage == 100  # type: ignore [no-any-return]
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         await self.hass.async_add_executor_job(self.data.set_blind_open, True)
         await self.coordinator.async_refresh()
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
         await self.hass.async_add_executor_job(self.data.set_blind_close, True)
         await self.coordinator.async_refresh()
 
+    @override
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
         await self.hass.async_add_executor_job(
             self.data.set_level_percentage, 100 - kwargs[ATTR_POSITION], True
         )
 
+    @override
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         await self.hass.async_add_executor_job(self.data.set_blind_stop, True)

--- a/homeassistant/components/fritzbox/entity.py
+++ b/homeassistant/components/fritzbox/entity.py
@@ -1,6 +1,7 @@
 """Support for AVM FRITZ!SmartHome devices."""
 
 from abc import ABC, abstractmethod
+from typing import override
 
 from pyfritzhome import FritzhomeDevice
 from pyfritzhome.devicetypes.fritzhomeentitybase import FritzhomeEntityBase
@@ -44,16 +45,19 @@ class FritzBoxDeviceEntity(FritzBoxEntity):
     """Reflect FritzhomeDevice and construct FritzBoxDeviceEntity."""
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return super().available and self.data.present
 
     @property
+    @override
     def data(self) -> FritzhomeDevice:
         """Return device data object from coordinator."""
         return self.coordinator.data.devices[self.ain]
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return device specific attributes."""
         return DeviceInfo(identifiers={(DOMAIN, self.data.device_and_unit_id[0])})

--- a/homeassistant/components/fritzbox/light.py
+++ b/homeassistant/components/fritzbox/light.py
@@ -1,6 +1,6 @@
 """Support for AVM FRITZ!SmartHome lightbulbs."""
 
-from typing import Any, cast
+from typing import Any, cast, override
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -84,16 +84,19 @@ class FritzboxLight(FritzBoxDeviceEntity, LightEntity):
             self._attr_min_color_temp_kelvin = int(min(supported_color_temps))
 
     @property
+    @override
     def is_on(self) -> bool:
         """If the light is currently on or off."""
         return self.data.state  # type: ignore [no-any-return]
 
     @property
+    @override
     def brightness(self) -> int:
         """Return the current Brightness."""
         return self.data.level  # type: ignore [no-any-return]
 
     @property
+    @override
     def hs_color(self) -> tuple[float, float]:
         """Return the hs color value."""
         hue = self.data.hue
@@ -102,11 +105,13 @@ class FritzboxLight(FritzBoxDeviceEntity, LightEntity):
         return (hue, float(saturation) * 100.0 / 255.0)
 
     @property
+    @override
     def color_temp_kelvin(self) -> int:
         """Return the CT color value."""
         return self.data.color_temp  # type: ignore [no-any-return]
 
     @property
+    @override
     def color_mode(self) -> ColorMode:
         """Return the color mode of the light."""
         if self.data.has_color:
@@ -117,6 +122,7 @@ class FritzboxLight(FritzBoxDeviceEntity, LightEntity):
             return ColorMode.BRIGHTNESS
         return ColorMode.ONOFF
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
         if kwargs.get(ATTR_BRIGHTNESS) is not None:
@@ -161,6 +167,7 @@ class FritzboxLight(FritzBoxDeviceEntity, LightEntity):
         await self.hass.async_add_executor_job(self.data.set_state_on, True)
         await self.coordinator.async_refresh()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         await self.hass.async_add_executor_job(self.data.set_state_off, True)

--- a/homeassistant/components/fritzbox/sensor.py
+++ b/homeassistant/components/fritzbox/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Final
+from typing import Final, override
 
 from pyfritzhome.fritzhomedevice import FritzhomeDevice
 
@@ -255,11 +255,13 @@ class FritzBoxSensor(FritzBoxDeviceEntity, SensorEntity):
     entity_description: FritzSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> StateType | datetime:
         """Return the state of the sensor."""
         return self.entity_description.native_value(self.data)
 
     @property
+    @override
     def entity_category(self) -> EntityCategory | None:
         """Return the category of the entity, if any."""
         if self.entity_description.entity_category_fn is not None:

--- a/homeassistant/components/fritzbox/switch.py
+++ b/homeassistant/components/fritzbox/switch.py
@@ -1,6 +1,6 @@
 """Support for AVM FRITZ!SmartHome switch devices."""
 
-from typing import Any
+from typing import Any, override
 
 from pyfritzhome.devicetypes import FritzhomeTrigger
 
@@ -54,16 +54,19 @@ class FritzboxSwitch(FritzBoxDeviceEntity, SwitchEntity):
     """The switch class for FRITZ!SmartHome switches."""
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the switch is on."""
         return self.data.switch_state  # type: ignore [no-any-return]
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         self.check_lock_state()
         await self.hass.async_add_executor_job(self.data.set_switch_state_on, True)
         await self.coordinator.async_refresh()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         self.check_lock_state()
@@ -83,11 +86,13 @@ class FritzboxTrigger(FritzBoxEntity, SwitchEntity):
     """The switch class for FRITZ!SmartHome triggers."""
 
     @property
+    @override
     def data(self) -> FritzhomeTrigger:
         """Return the trigger data entity."""
         return self.coordinator.data.triggers[self.ain]
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return device specific attributes."""
         return DeviceInfo(
@@ -99,10 +104,12 @@ class FritzboxTrigger(FritzBoxEntity, SwitchEntity):
         )
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the trigger is active."""
         return self.data.active  # type: ignore [no-any-return]
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Activate the trigger."""
         await self.hass.async_add_executor_job(
@@ -110,6 +117,7 @@ class FritzboxTrigger(FritzBoxEntity, SwitchEntity):
         )
         await self.coordinator.async_refresh()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Deactivate the trigger."""
         await self.hass.async_add_executor_job(

--- a/homeassistant/components/fritzbox_callmonitor/config_flow.py
+++ b/homeassistant/components/fritzbox_callmonitor/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 from enum import StrEnum
-from typing import Any, cast
+from typing import Any, cast, override
 
 from fritzconnection import FritzConnection
 from fritzconnection.core.exceptions import FritzConnectionException, FritzSecurityError
@@ -128,12 +128,14 @@ class FritzBoxCallMonitorConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> FritzBoxCallMonitorOptionsFlowHandler:
         """Get the options flow for this handler."""
         return FritzBoxCallMonitorOptionsFlowHandler()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/fritzbox_callmonitor/sensor.py
+++ b/homeassistant/components/fritzbox_callmonitor/sensor.py
@@ -7,7 +7,7 @@ import logging
 import queue
 from threading import Event as ThreadingEvent, Thread
 from time import sleep
-from typing import Any, cast
+from typing import Any, cast, override
 
 from fritzconnection.core.fritzmonitor import FritzMonitor
 
@@ -108,6 +108,7 @@ class FritzBoxCallSensor(SensorEntity):
             sw_version=self._fritzbox_phonebook.fph.fc.system_version,
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Connect to FRITZ!Box to monitor its call state."""
         await super().async_added_to_hass()
@@ -118,6 +119,7 @@ class FritzBoxCallSensor(SensorEntity):
             )
         )
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Disconnect from FRITZ!Box by stopping monitor."""
         await super().async_will_remove_from_hass()
@@ -155,6 +157,7 @@ class FritzBoxCallSensor(SensorEntity):
         self._attributes = {**attributes}
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, str | list[str] | bool]:
         """Return the state attributes."""
         if self._prefixes:

--- a/homeassistant/components/fronius/config_flow.py
+++ b/homeassistant/components/fronius/config_flow.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import Any, Final
+from typing import Any, Final, override
 
 from pyfronius import Fronius, FroniusError
 import voluptuous as vol
@@ -69,6 +69,7 @@ class FroniusConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize flow."""
         self.info: FroniusConfigEntryData
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -95,6 +96,7 @@ class FroniusConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from pyfronius import BadStatusError, FroniusError
 
@@ -57,6 +57,7 @@ class FroniusCoordinatorBase(
     async def _update_method(self) -> dict[SolarNetId, Any]:
         """Return data per solar net id from pyfronius."""
 
+    @override
     async def _async_update_data(self) -> dict[SolarNetId, Any]:
         """Fetch the latest data from the source."""
         async with self.solar_net.coordinator_lock:
@@ -143,6 +144,7 @@ class FroniusInverterUpdateCoordinator(FroniusCoordinatorBase):
         super().__init__(*args, **kwargs)
         self.inverter_info = inverter_info
 
+    @override
     async def _update_method(self) -> dict[SolarNetId, Any]:
         """Return data per solar net id from pyfronius."""
         # almost 1% of `current_inverter_data` requests on Symo devices result in
@@ -170,6 +172,7 @@ class FroniusLoggerUpdateCoordinator(FroniusCoordinatorBase):
     error_interval = timedelta(hours=1)
     valid_descriptions = LOGGER_ENTITY_DESCRIPTIONS
 
+    @override
     async def _update_method(self) -> dict[SolarNetId, Any]:
         """Return data per solar net id from pyfronius."""
         data = await self.solar_net.fronius.current_logger_info()
@@ -183,6 +186,7 @@ class FroniusMeterUpdateCoordinator(FroniusCoordinatorBase):
     error_interval = timedelta(minutes=10)
     valid_descriptions = METER_ENTITY_DESCRIPTIONS
 
+    @override
     async def _update_method(self) -> dict[SolarNetId, Any]:
         """Return data per solar net id from pyfronius."""
         data = await self.solar_net.fronius.current_system_meter_data()
@@ -196,6 +200,7 @@ class FroniusOhmpilotUpdateCoordinator(FroniusCoordinatorBase):
     error_interval = timedelta(minutes=10)
     valid_descriptions = OHMPILOT_ENTITY_DESCRIPTIONS
 
+    @override
     async def _update_method(self) -> dict[SolarNetId, Any]:
         """Return data per solar net id from pyfronius."""
         data = await self.solar_net.fronius.current_system_ohmpilot_data()
@@ -209,6 +214,7 @@ class FroniusPowerFlowUpdateCoordinator(FroniusCoordinatorBase):
     error_interval = timedelta(minutes=3)
     valid_descriptions = POWER_FLOW_ENTITY_DESCRIPTIONS
 
+    @override
     async def _update_method(self) -> dict[SolarNetId, Any]:
         """Return data per solar net id from pyfronius."""
         data = await self.solar_net.fronius.current_power_flow()
@@ -222,6 +228,7 @@ class FroniusStorageUpdateCoordinator(FroniusCoordinatorBase):
     error_interval = timedelta(minutes=10)
     valid_descriptions = STORAGE_ENTITY_DESCRIPTIONS
 
+    @override
     async def _update_method(self) -> dict[SolarNetId, Any]:
         """Return data per solar net id from pyfronius."""
         data = await self.solar_net.fronius.current_system_storage_data()

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -788,6 +788,7 @@ class _FroniusSensorEntity(CoordinatorEntity["FroniusCoordinatorBase"], SensorEn
         return new_value
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         try:

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -6,7 +6,7 @@ import logging
 import os
 import pathlib
 import shutil
-from typing import Any, TypedDict
+from typing import Any, TypedDict, override
 
 from aiohttp import hdrs, web, web_urldispatcher
 import jinja2
@@ -785,6 +785,7 @@ class IndexView(web_urldispatcher.AbstractResource):
         self._template_cache: jinja2.Template | None = None
 
     @cached_property
+    @override
     def canonical(self) -> str:
         """Return resource's canonical path."""
         return "/"
@@ -794,10 +795,12 @@ class IndexView(web_urldispatcher.AbstractResource):
         """Return the index route."""
         return web_urldispatcher.ResourceRoute("GET", self.get, self)
 
+    @override
     def url_for(self, **kwargs: str) -> URL:
         """Construct url for resource with additional params."""
         return URL("/")
 
+    @override
     async def resolve(
         self, request: web.Request
     ) -> tuple[web_urldispatcher.UrlMappingMatchInfo | None, set[str]]:
@@ -818,17 +821,20 @@ class IndexView(web_urldispatcher.AbstractResource):
 
         return web_urldispatcher.UrlMappingMatchInfo({}, self._route), {"GET"}
 
+    @override
     def add_prefix(self, prefix: str) -> None:
         """Add a prefix to processed URLs.
 
         Required for subapplications support.
         """
 
+    @override
     def get_info(self) -> dict[str, list[str]]:  # type: ignore[override]
         """Return a dict with additional info useful for introspection."""
         panels = self.hass.data[DATA_PANELS]
         return {"panels": list(panels)}
 
+    @override
     def raw_match(self, path: str) -> bool:
         """Perform a raw match against path."""
         return False
@@ -879,10 +885,12 @@ class IndexView(web_urldispatcher.AbstractResource):
         response.enable_compression()
         return response
 
+    @override
     def __len__(self) -> int:
         """Return length of resource."""
         return 1
 
+    @override
     def __iter__(self) -> Iterator[web_urldispatcher.ResourceRoute]:
         """Iterate over routes."""
         return iter([self._route])

--- a/homeassistant/components/frontier_silicon/config_flow.py
+++ b/homeassistant/components/frontier_silicon/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 from urllib.parse import urlparse
 
 from afsapi import AFSAPI, FSConnectionError, FSNotImplementedError, InvalidPinError
@@ -52,6 +52,7 @@ class FrontierSiliconConfigFlow(ConfigFlow, domain=DOMAIN):
     _name: str
     _webfsapi_url: str
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -79,6 +80,7 @@ class FrontierSiliconConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=data_schema, errors=errors
         )
 
+    @override
     async def async_step_ssdp(
         self, discovery_info: SsdpServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -3,7 +3,7 @@
 from collections.abc import Awaitable, Callable, Coroutine
 from functools import wraps
 import logging
-from typing import Any, Concatenate
+from typing import Any, Concatenate, override
 
 from afsapi import (
     AFSAPI,
@@ -131,6 +131,7 @@ class AFSAPIDevice(MediaPlayerEntity):
     )
 
     @property
+    @override
     def supported_features(self) -> MediaPlayerEntityFeature:
         """Return the currently supported features for this device."""
         features = self._BASE_SUPPORTED_FEATURES
@@ -308,16 +309,19 @@ class AFSAPIDevice(MediaPlayerEntity):
     # Management actions
     # power control
     @fs_command_exception_wrap
+    @override
     async def async_turn_on(self) -> None:
         """Turn on the device."""
         await self.fs_device.set_power(True)
 
     @fs_command_exception_wrap
+    @override
     async def async_turn_off(self) -> None:
         """Turn off the device."""
         await self.fs_device.set_power(False)
 
     @fs_command_exception_wrap
+    @override
     async def async_media_play(self) -> None:
         """Send play command."""
         if (await self.fs_device.get_play_status()) == PlayState.STOPPED:
@@ -328,32 +332,38 @@ class AFSAPIDevice(MediaPlayerEntity):
             await self.fs_device.play()
 
     @fs_command_exception_wrap
+    @override
     async def async_media_pause(self) -> None:
         """Send pause command."""
         await self.fs_device.pause()
 
     @fs_command_exception_wrap
+    @override
     async def async_media_stop(self) -> None:
         """Send stop command."""
         await self.fs_device.stop()
 
     @fs_command_exception_wrap
+    @override
     async def async_media_previous_track(self) -> None:
         """Send previous track command (results in rewind)."""
         await self.fs_device.rewind()
 
     @fs_command_exception_wrap
+    @override
     async def async_media_next_track(self) -> None:
         """Send next track command (results in fast-forward)."""
         await self.fs_device.forward()
 
     @fs_command_exception_wrap
+    @override
     async def async_mute_volume(self, mute: bool) -> None:
         """Send mute command."""
         await self.fs_device.set_mute(mute)
 
     # volume
     @fs_command_exception_wrap
+    @override
     async def async_volume_up(self) -> None:
         """Send volume up command."""
         volume = await self.fs_device.get_volume()
@@ -361,6 +371,7 @@ class AFSAPIDevice(MediaPlayerEntity):
         await self.fs_device.set_volume(min(volume, self._max_volume or 1))
 
     @fs_command_exception_wrap
+    @override
     async def async_volume_down(self) -> None:
         """Send volume down command."""
         volume = await self.fs_device.get_volume()
@@ -368,6 +379,7 @@ class AFSAPIDevice(MediaPlayerEntity):
         await self.fs_device.set_volume(max(volume, 0))
 
     @fs_command_exception_wrap
+    @override
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume command."""
         if self._max_volume:  # Can't do anything sensible if not set
@@ -375,6 +387,7 @@ class AFSAPIDevice(MediaPlayerEntity):
             await self.fs_device.set_volume(volume)
 
     @fs_command_exception_wrap
+    @override
     async def async_select_source(self, source: str) -> None:
         """Select input source."""
         await self.fs_device.set_power(True)
@@ -385,6 +398,7 @@ class AFSAPIDevice(MediaPlayerEntity):
             await self.fs_device.set_mode(mode)
 
     @fs_command_exception_wrap
+    @override
     async def async_select_sound_mode(self, sound_mode: str) -> None:
         """Select EQ Preset."""
         if (
@@ -394,6 +408,7 @@ class AFSAPIDevice(MediaPlayerEntity):
             await self.fs_device.set_eq_preset(mode)
 
     @fs_command_exception_wrap
+    @override
     async def async_set_repeat(self, repeat: RepeatMode) -> None:
         """Set repeat mode."""
         await self.fs_device.play_repeat(
@@ -405,15 +420,18 @@ class AFSAPIDevice(MediaPlayerEntity):
         )
 
     @fs_command_exception_wrap
+    @override
     async def async_set_shuffle(self, shuffle: bool) -> None:
         """Set shuffle mode."""
         await self.fs_device.set_play_shuffle(shuffle)
 
     @fs_command_exception_wrap
+    @override
     async def async_media_seek(self, position: float) -> None:
         """Seek to a position in seconds."""
         await self.fs_device.set_play_position(int(position * 1000))
 
+    @override
     async def async_browse_media(
         self,
         media_content_type: MediaType | str | None = None,
@@ -426,6 +444,7 @@ class AFSAPIDevice(MediaPlayerEntity):
         return await browse_node(self.fs_device, media_content_type, media_content_id)
 
     @fs_command_exception_wrap
+    @override
     async def async_play_media(
         self, media_type: MediaType | str, media_id: str, **kwargs: Any
     ) -> None:

--- a/homeassistant/components/fujitsu_fglair/climate.py
+++ b/homeassistant/components/fujitsu_fglair/climate.py
@@ -1,6 +1,6 @@
 """Support for Fujitsu HVAC devices that use the Ayla Iot platform."""
 
-from typing import Any
+from typing import Any, override
 
 from ayla_iot_unofficial.fujitsu_hvac import (
     Capability,
@@ -100,25 +100,30 @@ class FGLairDevice(FGLairEntity, ClimateEntity):
         self._set_attr()
 
     @property
+    @override
     def available(self) -> bool:
         """Return if the device is available."""
         return super().available and self.coordinator_context in self.coordinator.data
 
+    @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set Fan mode."""
         await self.device.async_set_fan_speed(HA_TO_FUJI_FAN[fan_mode])
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set HVAC mode."""
         await self.device.async_set_op_mode(HA_TO_FUJI_HVAC[hvac_mode])
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_set_swing_mode(self, swing_mode: str) -> None:
         """Set swing mode."""
         await self.device.async_set_swing_mode(HA_TO_FUJI_SWING[swing_mode])
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set target temperature."""
         if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
@@ -151,6 +156,7 @@ class FGLairDevice(FGLairEntity, ClimateEntity):
             self._attr_current_temperature = self.device.sensed_temp
             self._attr_target_temperature = self.device.set_temp
 
+    @override
     def _handle_coordinator_update(self) -> None:
         self._set_attr()
         super()._handle_coordinator_update()

--- a/homeassistant/components/fujitsu_fglair/config_flow.py
+++ b/homeassistant/components/fujitsu_fglair/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from ayla_iot_unofficial import AylaAuthError, new_ayla_api
 from ayla_iot_unofficial.fujitsu_consts import FGLAIR_APP_CREDENTIALS
@@ -68,6 +68,7 @@ class FGLairConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return errors
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/fujitsu_fglair/coordinator.py
+++ b/homeassistant/components/fujitsu_fglair/coordinator.py
@@ -1,6 +1,7 @@
 """Coordinator for Fujitsu HVAC integration."""
 
 import logging
+from typing import override
 
 from ayla_iot_unofficial import AylaApi, AylaAuthError
 from ayla_iot_unofficial.fujitsu_hvac import FujitsuHVAC
@@ -35,12 +36,14 @@ class FGLairCoordinator(DataUpdateCoordinator[dict[str, FujitsuHVAC]]):
         )
         self.api = api
 
+    @override
     async def _async_setup(self) -> None:
         try:
             await self.api.async_sign_in()
         except AylaAuthError as e:
             raise ConfigEntryAuthFailed("Credentials expired for Ayla IoT API") from e
 
+    @override
     async def _async_update_data(self) -> dict[str, FujitsuHVAC]:
         """Fetch data from api endpoint."""
         listening_entities = set(self.async_contexts())

--- a/homeassistant/components/fujitsu_fglair/entity.py
+++ b/homeassistant/components/fujitsu_fglair/entity.py
@@ -1,5 +1,7 @@
 """Fujitsu FGlair base entity."""
 
+from typing import override
+
 from ayla_iot_unofficial.fujitsu_hvac import FujitsuHVAC
 
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -28,6 +30,7 @@ class FGLairEntity(CoordinatorEntity[FGLairCoordinator]):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return super().available and self.coordinator_context in self.coordinator.data

--- a/homeassistant/components/fujitsu_fglair/sensor.py
+++ b/homeassistant/components/fujitsu_fglair/sensor.py
@@ -1,5 +1,7 @@
 """Outside temperature sensor for Fujitsu FGlair HVAC systems."""
 
+from typing import override
+
 from ayla_iot_unofficial.fujitsu_hvac import FujitsuHVAC
 
 from homeassistant.components.sensor import (
@@ -45,6 +47,7 @@ class FGLairOutsideTemperature(FGLairEntity, SensorEntity):
         self._attr_unique_id = f"{device.device_serial_number}_outside_temperature"
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the sensed outdoor temperature un celsius."""
         return self.device.outdoor_temperature  # type: ignore[no-any-return]

--- a/homeassistant/components/fully_kiosk/binary_sensor.py
+++ b/homeassistant/components/fully_kiosk/binary_sensor.py
@@ -1,5 +1,7 @@
 """Fully Kiosk Browser sensor."""
 
+from typing import override
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -62,6 +64,7 @@ class FullyBinarySensor(FullyKioskEntity, BinarySensorEntity):
         self._attr_unique_id = f"{coordinator.data['deviceID']}-{description.key}"
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return if the binary sensor is on."""
         if (value := self.coordinator.data.get(self.entity_description.key)) is None:

--- a/homeassistant/components/fully_kiosk/button.py
+++ b/homeassistant/components/fully_kiosk/button.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from fullykiosk import FullyKiosk
 
@@ -105,6 +105,7 @@ class FullyButtonEntity(FullyKioskEntity, ButtonEntity):
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.data['deviceID']}-{description.key}"
 
+    @override
     async def async_press(self) -> None:
         """Set the value of the entity."""
         await self.entity_description.press_action(self.coordinator.fully)

--- a/homeassistant/components/fully_kiosk/camera.py
+++ b/homeassistant/components/fully_kiosk/camera.py
@@ -1,5 +1,7 @@
 """Support for Fully Kiosk Browser camera."""
 
+from typing import override
+
 from fullykiosk import FullyKioskError
 
 from homeassistant.components.camera import Camera, CameraEntityFeature
@@ -34,6 +36,7 @@ class FullyCameraEntity(FullyKioskEntity, Camera):
         Camera.__init__(self)
         self._attr_unique_id = f"{coordinator.data['deviceID']}-camera"
 
+    @override
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
@@ -45,17 +48,20 @@ class FullyCameraEntity(FullyKioskEntity, Camera):
         else:
             return image_bytes
 
+    @override
     async def async_turn_on(self) -> None:
         """Turn on camera."""
         await self.coordinator.fully.enableMotionDetection()
         await self.coordinator.async_refresh()
 
+    @override
     async def async_turn_off(self) -> None:
         """Turn off camera."""
         await self.coordinator.fully.disableMotionDetection()
         await self.coordinator.async_refresh()
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._attr_is_on = self.coordinator.data["settings"].get("motionDetection")

--- a/homeassistant/components/fully_kiosk/config_flow.py
+++ b/homeassistant/components/fully_kiosk/config_flow.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import json
-from typing import Any
+from typing import Any, override
 
 from aiohttp.client_exceptions import ClientConnectorError
 from fullykiosk import FullyKiosk
@@ -100,6 +100,7 @@ class FullyKioskConfigFlow(ConfigFlow, domain=DOMAIN):
                 },
             )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -123,6 +124,7 @@ class FullyKioskConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:
@@ -170,6 +172,7 @@ class FullyKioskConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_mqtt(
         self, discovery_info: MqttServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/fully_kiosk/coordinator.py
+++ b/homeassistant/components/fully_kiosk/coordinator.py
@@ -1,7 +1,7 @@
 """Provides the Fully Kiosk Browser DataUpdateCoordinator."""
 
 import asyncio
-from typing import Any, cast
+from typing import Any, cast, override
 
 from fullykiosk import FullyKiosk
 from fullykiosk.exceptions import FullyKioskError
@@ -41,6 +41,7 @@ class FullyKioskDataUpdateCoordinator(DataUpdateCoordinator):
             update_interval=UPDATE_INTERVAL,
         )
 
+    @override
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via library."""
         try:

--- a/homeassistant/components/fully_kiosk/image.py
+++ b/homeassistant/components/fully_kiosk/image.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from fullykiosk import FullyKiosk, FullyKioskError
 
@@ -62,6 +62,7 @@ class FullyImageEntity(FullyKioskEntity, ImageEntity):
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.data['deviceID']}-{description.key}"
 
+    @override
     async def async_image(self) -> bytes | None:
         """Return bytes of image."""
         try:

--- a/homeassistant/components/fully_kiosk/media_player.py
+++ b/homeassistant/components/fully_kiosk/media_player.py
@@ -1,6 +1,6 @@
 """Fully Kiosk Browser media player."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components import media_source
 from homeassistant.components.media_player import (
@@ -43,6 +43,7 @@ class FullyMediaPlayer(FullyKioskEntity, MediaPlayerEntity):
         self._attr_unique_id = f"{coordinator.data['deviceID']}-mediaplayer"
         self._attr_state = MediaPlayerState.IDLE
 
+    @override
     async def async_play_media(
         self, media_type: MediaType | str, media_id: str, **kwargs: Any
     ) -> None:
@@ -74,6 +75,7 @@ class FullyMediaPlayer(FullyKioskEntity, MediaPlayerEntity):
         self._attr_state = MediaPlayerState.PLAYING
         self.async_write_ha_state()
 
+    @override
     async def async_media_stop(self) -> None:
         """Stop playing media."""
         if self._attr_media_content_type == MediaType.VIDEO:
@@ -83,6 +85,7 @@ class FullyMediaPlayer(FullyKioskEntity, MediaPlayerEntity):
         self._attr_state = MediaPlayerState.IDLE
         self.async_write_ha_state()
 
+    @override
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         await self.coordinator.fully.setAudioVolume(
@@ -91,6 +94,7 @@ class FullyMediaPlayer(FullyKioskEntity, MediaPlayerEntity):
         self._attr_volume_level = volume
         self.async_write_ha_state()
 
+    @override
     async def async_browse_media(
         self,
         media_content_type: MediaType | str | None = None,
@@ -107,6 +111,7 @@ class FullyMediaPlayer(FullyKioskEntity, MediaPlayerEntity):
         )
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._attr_state = (

--- a/homeassistant/components/fully_kiosk/notify.py
+++ b/homeassistant/components/fully_kiosk/notify.py
@@ -1,6 +1,7 @@
 """Support for Fully Kiosk Browser notifications."""
 
 from dataclasses import dataclass
+from typing import override
 
 from fullykiosk import FullyKioskError
 
@@ -63,6 +64,7 @@ class FullyNotifyEntity(FullyKioskEntity, NotifyEntity):
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.data['deviceID']}-{description.key}"
 
+    @override
     async def async_send_message(self, message: str, title: str | None = None) -> None:
         """Send a message."""
         try:

--- a/homeassistant/components/fully_kiosk/number.py
+++ b/homeassistant/components/fully_kiosk/number.py
@@ -1,6 +1,7 @@
 """Fully Kiosk Browser number entity."""
 
 from contextlib import suppress
+from typing import override
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.const import EntityCategory, UnitOfTime
@@ -78,6 +79,7 @@ class FullyNumberEntity(FullyKioskEntity, NumberEntity):
         self._attr_unique_id = f"{coordinator.data['deviceID']}-{description.key}"
 
     @property
+    @override
     def native_value(self) -> int | None:
         """Return the state of the number entity."""
         if (
@@ -90,6 +92,7 @@ class FullyNumberEntity(FullyKioskEntity, NumberEntity):
 
         return None
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set the value of the entity."""
         await self.coordinator.fully.setConfigurationString(

--- a/homeassistant/components/fully_kiosk/sensor.py
+++ b/homeassistant/components/fully_kiosk/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -154,6 +154,7 @@ class FullySensor(FullyKioskEntity, SensorEntity):
         super().__init__(coordinator)
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         extra_state_attributes: dict[str, Any] = {}
         value = self.coordinator.data.get(self.entity_description.key)

--- a/homeassistant/components/fully_kiosk/switch.py
+++ b/homeassistant/components/fully_kiosk/switch.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from fullykiosk import FullyKiosk
 
@@ -109,6 +109,7 @@ class FullySwitchEntity(FullyKioskEntity, SwitchEntity):
         self._turned_on_subscription: CALLBACK_TYPE | None = None
         self._turned_off_subscription: CALLBACK_TYPE | None = None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
@@ -120,6 +121,7 @@ class FullySwitchEntity(FullyKioskEntity, SwitchEntity):
             description.mqtt_on_event, self._turn_on
         )
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Close MQTT subscriptions when removed."""
         await super().async_will_remove_from_hass()
@@ -128,11 +130,13 @@ class FullySwitchEntity(FullyKioskEntity, SwitchEntity):
         if self._turned_on_subscription is not None:
             self._turned_on_subscription()
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         await self.entity_description.on_action(self.coordinator.fully)
         await self.coordinator.async_refresh()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         await self.entity_description.off_action(self.coordinator.fully)
@@ -149,6 +153,7 @@ class FullySwitchEntity(FullyKioskEntity, SwitchEntity):
         self.async_write_ha_state()
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._attr_is_on = bool(self.entity_description.is_on_fn(self.coordinator.data))

--- a/homeassistant/components/fumis/binary_sensor.py
+++ b/homeassistant/components/fumis/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from fumis import FumisInfo
 
@@ -69,6 +70,7 @@ class FumisBinarySensorEntity(FumisEntity, BinarySensorEntity):
         self._attr_unique_id = f"{coordinator.config_entry.unique_id}_{description.key}"
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return the state of the binary sensor."""
         return self.entity_description.is_on_fn(self.coordinator.data)

--- a/homeassistant/components/fumis/button.py
+++ b/homeassistant/components/fumis/button.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from fumis import Fumis
 
@@ -64,6 +64,7 @@ class FumisButtonEntity(FumisEntity, ButtonEntity):
         self._attr_unique_id = f"{coordinator.config_entry.unique_id}_{description.key}"
 
     @fumis_exception_handler
+    @override
     async def async_press(self) -> None:
         """Handle the button press."""
         await self.entity_description.press_fn(self.coordinator.client)

--- a/homeassistant/components/fumis/climate.py
+++ b/homeassistant/components/fumis/climate.py
@@ -1,6 +1,6 @@
 """Support for Fumis climate entities."""
 
-from typing import Any
+from typing import Any, override
 
 from fumis import StoveStatus
 
@@ -69,6 +69,7 @@ class FumisClimateEntity(FumisEntity, ClimateEntity):
         self._attr_unique_id = coordinator.config_entry.unique_id
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return the current HVAC mode."""
         if self.coordinator.data.controller.on:
@@ -76,6 +77,7 @@ class FumisClimateEntity(FumisEntity, ClimateEntity):
         return HVACMode.OFF
 
     @property
+    @override
     def hvac_action(self) -> HVACAction | None:
         """Return the current HVAC action."""
         return STOVE_STATUS_TO_HVAC_ACTION[
@@ -83,6 +85,7 @@ class FumisClimateEntity(FumisEntity, ClimateEntity):
         ]
 
     @property
+    @override
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         if (temp := self.coordinator.data.controller.main_temperature) is None:
@@ -90,6 +93,7 @@ class FumisClimateEntity(FumisEntity, ClimateEntity):
         return temp.actual
 
     @property
+    @override
     def target_temperature(self) -> float | None:
         """Return the target temperature."""
         if (temp := self.coordinator.data.controller.main_temperature) is None:
@@ -97,6 +101,7 @@ class FumisClimateEntity(FumisEntity, ClimateEntity):
         return temp.setpoint
 
     @fumis_exception_handler
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the HVAC mode."""
         if hvac_mode == HVACMode.HEAT:
@@ -106,6 +111,7 @@ class FumisClimateEntity(FumisEntity, ClimateEntity):
         await self.coordinator.async_request_refresh()
 
     @fumis_exception_handler
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set the target temperature."""
         if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
@@ -114,12 +120,14 @@ class FumisClimateEntity(FumisEntity, ClimateEntity):
         await self.coordinator.async_request_refresh()
 
     @fumis_exception_handler
+    @override
     async def async_turn_on(self) -> None:
         """Turn on the stove."""
         await self.coordinator.client.turn_on()
         await self.coordinator.async_request_refresh()
 
     @fumis_exception_handler
+    @override
     async def async_turn_off(self) -> None:
         """Turn off the stove."""
         await self.coordinator.client.turn_off()

--- a/homeassistant/components/fumis/config_flow.py
+++ b/homeassistant/components/fumis/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow to configure the Fumis integration."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 from fumis import (
     Fumis,
@@ -31,6 +31,7 @@ class FumisFlowHandler(ConfigFlow, domain=DOMAIN):
 
     _discovered_mac: str
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:
@@ -74,6 +75,7 @@ class FumisFlowHandler(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/fumis/coordinator.py
+++ b/homeassistant/components/fumis/coordinator.py
@@ -1,5 +1,7 @@
 """DataUpdateCoordinator for Fumis."""
 
+from typing import override
+
 from fumis import (
     Fumis,
     FumisAuthenticationError,
@@ -41,6 +43,7 @@ class FumisDataUpdateCoordinator(DataUpdateCoordinator[FumisInfo]):
             update_interval=SCAN_INTERVAL,
         )
 
+    @override
     async def _async_update_data(self) -> FumisInfo:
         """Fetch data from the Fumis API."""
         try:

--- a/homeassistant/components/fumis/number.py
+++ b/homeassistant/components/fumis/number.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from fumis import Fumis, FumisInfo
 
@@ -84,11 +84,13 @@ class FumisNumberEntity(FumisEntity, NumberEntity):
         self._attr_unique_id = f"{coordinator.config_entry.unique_id}_{description.key}"
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the current value."""
         return self.entity_description.value_fn(self.coordinator.data)
 
     @fumis_exception_handler
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set a new value."""
         await self.entity_description.set_fn(self.coordinator.client, value)

--- a/homeassistant/components/fumis/sensor.py
+++ b/homeassistant/components/fumis/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Any, override
 
 from fumis import FumisInfo, StoveAlert, StoveError, StoveState, StoveStatus
 
@@ -320,6 +320,7 @@ class FumisSensorEntity(FumisEntity, SensorEntity):
         self._attr_unique_id = f"{coordinator.config_entry.unique_id}_{description.key}"
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return additional state attributes."""
         if self.entity_description.attr_fn is None:
@@ -327,6 +328,7 @@ class FumisSensorEntity(FumisEntity, SensorEntity):
         return self.entity_description.attr_fn(self.coordinator.data)
 
     @property
+    @override
     def native_value(self) -> datetime | float | int | str | None:
         """Return the sensor value."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/fumis/switch.py
+++ b/homeassistant/components/fumis/switch.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from fumis import Fumis, FumisInfo
 
@@ -81,17 +81,20 @@ class FumisSwitchEntity(FumisEntity, SwitchEntity):
         self._attr_unique_id = f"{coordinator.config_entry.unique_id}_{description.key}"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the state of the switch."""
         return self.entity_description.is_on_fn(self.coordinator.data)
 
     @fumis_exception_handler
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
         await self.entity_description.turn_on_fn(self.coordinator.client)
         await self.coordinator.async_request_refresh()
 
     @fumis_exception_handler
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
         await self.entity_description.turn_off_fn(self.coordinator.client)

--- a/homeassistant/components/futurenow/light.py
+++ b/homeassistant/components/futurenow/light.py
@@ -1,6 +1,6 @@
 """Support for FutureNow Ethernet unit outputs as Lights."""
 
-from typing import Any
+from typing import Any, override
 
 import pyfnip
 import voluptuous as vol
@@ -90,6 +90,7 @@ class FutureNowLight(LightEntity):
             )
 
     @property
+    @override
     def color_mode(self) -> ColorMode:
         """Return the color mode of the light."""
         if self._dimmable:
@@ -97,10 +98,12 @@ class FutureNowLight(LightEntity):
         return ColorMode.ONOFF
 
     @property
+    @override
     def supported_color_modes(self) -> set[ColorMode]:
         """Flag supported color modes."""
         return {self.color_mode}
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
         if self._dimmable:
@@ -109,6 +112,7 @@ class FutureNowLight(LightEntity):
             level = 255
         self._light.turn_on(to_futurenow_level(level))
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         self._light.turn_off()

--- a/homeassistant/components/fyta/binary_sensor.py
+++ b/homeassistant/components/fyta/binary_sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Final
+from typing import Final, override
 
 from fyta_cli.fyta_models import Plant
 
@@ -111,6 +111,7 @@ class FytaPlantBinarySensor(FytaPlantEntity, BinarySensorEntity):
     entity_description: FytaBinarySensorEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return value of the binary sensor."""
 

--- a/homeassistant/components/fyta/config_flow.py
+++ b/homeassistant/components/fyta/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from fyta_cli.fyta_connector import FytaConnector
 from fyta_cli.fyta_exceptions import (
@@ -71,6 +71,7 @@ class FytaConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return {}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/fyta/coordinator.py
+++ b/homeassistant/components/fyta/coordinator.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from datetime import datetime, timedelta
 import logging
+from typing import override
 
 from fyta_cli.fyta_connector import FytaConnector
 from fyta_cli.fyta_exceptions import (
@@ -47,6 +48,7 @@ class FytaCoordinator(DataUpdateCoordinator[dict[int, Plant]]):
         self._plants_last_update: set[int] = set()
         self.new_device_callbacks: list[Callable[[int], None]] = []
 
+    @override
     async def _async_update_data(
         self,
     ) -> dict[int, Plant]:

--- a/homeassistant/components/fyta/entity.py
+++ b/homeassistant/components/fyta/entity.py
@@ -1,5 +1,7 @@
 """Entities for FYTA integration."""
 
+from typing import override
+
 from fyta_cli.fyta_models import Plant
 
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -42,6 +44,7 @@ class FytaPlantEntity(CoordinatorEntity[FytaCoordinator]):
         return self.coordinator.data[self.plant_id]
 
     @property
+    @override
     def available(self) -> bool:
         """Test if entity is available."""
         return super().available and self.plant_id in self.coordinator.data

--- a/homeassistant/components/fyta/image.py
+++ b/homeassistant/components/fyta/image.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 import logging
-from typing import Final
+from typing import Final, override
 
 from fyta_cli.fyta_models import Plant
 
@@ -86,6 +86,7 @@ class FytaPlantImageEntity(FytaPlantEntity, ImageEntity):
         super().__init__(coordinator, entry, description, plant_id)
         ImageEntity.__init__(self, coordinator.hass)
 
+    @override
     async def async_image(self) -> bytes | None:
         """Return bytes of image."""
         if self.entity_description.key == "plant_image_user":
@@ -111,6 +112,7 @@ class FytaPlantImageEntity(FytaPlantEntity, ImageEntity):
         return await ImageEntity.async_image(self)
 
     @property
+    @override
     def image_url(self) -> str:
         """Return the image_url for this plant."""
         url = self.entity_description.url_fn(self.plant)

--- a/homeassistant/components/fyta/sensor.py
+++ b/homeassistant/components/fyta/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Final
+from typing import Final, override
 
 from fyta_cli.fyta_models import Plant
 
@@ -238,6 +238,7 @@ class FytaPlantSensor(FytaPlantEntity, SensorEntity):
     entity_description: FytaSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> StateType | datetime:
         """Return the state for this sensor."""
 
@@ -250,6 +251,7 @@ class FytaPlantMeasurementSensor(FytaPlantSensor):
     entity_description: FytaMeasurementSensorEntityDescription
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, float | None]:
         """Return the device state attributes."""
 

--- a/homeassistant/components/garadget/cover.py
+++ b/homeassistant/components/garadget/cover.py
@@ -1,7 +1,7 @@
 """Platform for the Garadget cover component."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 import requests
 import voluptuous as vol
@@ -137,16 +137,19 @@ class GaradgetCover(CoverEntity):
             self.remove_token()
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the cover."""
         return self._name
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return self._available
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device state attributes."""
         data = {}
@@ -166,6 +169,7 @@ class GaradgetCover(CoverEntity):
         return data
 
     @property
+    @override
     def is_closed(self) -> bool | None:
         """Return if the cover is closed."""
         if self._state is None:
@@ -205,18 +209,21 @@ class GaradgetCover(CoverEntity):
         """Check the state of the service during an operation."""
         self.schedule_update_ha_state(True)
 
+    @override
     def close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
         if self._state not in ["close", "closing"]:
             self._put_command("setState", "close")
             self._start_watcher("close")
 
+    @override
     def open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         if self._state not in ["open", "opening"]:
             self._put_command("setState", "open")
             self._start_watcher("open")
 
+    @override
     def stop_cover(self, **kwargs: Any) -> None:
         """Stop the door where it is."""
         if self._state != "stopped":

--- a/homeassistant/components/garages_amsterdam/binary_sensor.py
+++ b/homeassistant/components/garages_amsterdam/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from odp_amsterdam import Garage
 
@@ -73,6 +74,7 @@ class GaragesAmsterdamBinarySensor(GaragesAmsterdamEntity, BinarySensorEntity):
         self._attr_unique_id = f"{garage_name}-{description.key}"
 
     @property
+    @override
     def is_on(self) -> bool:
         """If the binary sensor is currently on or off."""
         return self.entity_description.is_on(self.coordinator.data[self._garage_name])

--- a/homeassistant/components/garages_amsterdam/config_flow.py
+++ b/homeassistant/components/garages_amsterdam/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Garages Amsterdam integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiohttp import ClientResponseError
 from odp_amsterdam import ODPAmsterdam, VehicleType
@@ -21,6 +21,7 @@ class GaragesAmsterdamConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
     _options: list[str] | None = None
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/garages_amsterdam/coordinator.py
+++ b/homeassistant/components/garages_amsterdam/coordinator.py
@@ -1,5 +1,7 @@
 """Coordinator for the Garages Amsterdam integration."""
 
+from typing import override
+
 from odp_amsterdam import Garage, ODPAmsterdam, VehicleType
 
 from homeassistant.config_entries import ConfigEntry
@@ -32,6 +34,7 @@ class GaragesAmsterdamDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Gara
         )
         self.client = client
 
+    @override
     async def _async_update_data(self) -> dict[str, Garage]:
         return {
             garage.garage_name: garage

--- a/homeassistant/components/garages_amsterdam/sensor.py
+++ b/homeassistant/components/garages_amsterdam/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from odp_amsterdam import Garage
 
@@ -91,6 +92,7 @@ class GaragesAmsterdamSensor(GaragesAmsterdamEntity, SensorEntity):
         self._attr_unique_id = f"{garage_name}-{description.key}"
 
     @property
+    @override
     def available(self) -> bool:
         """Return if sensor is available."""
         return self.coordinator.last_update_success and (
@@ -98,6 +100,7 @@ class GaragesAmsterdamSensor(GaragesAmsterdamEntity, SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(

--- a/homeassistant/components/gardena_bluetooth/binary_sensor.py
+++ b/homeassistant/components/gardena_bluetooth/binary_sensor.py
@@ -1,6 +1,7 @@
 """Support for binary_sensor entities."""
 
 from dataclasses import dataclass, field
+from typing import override
 
 from gardena_bluetooth.const import AquaContour, Sensor, Valve
 from gardena_bluetooth.parse import CharacteristicBool
@@ -77,6 +78,7 @@ class GardenaBluetoothBinarySensor(
 
     entity_description: GardenaBluetoothBinarySensorEntityDescription
 
+    @override
     def _handle_coordinator_update(self) -> None:
         char = self.entity_description.char
         self._attr_is_on = self.coordinator.get_cached(char)

--- a/homeassistant/components/gardena_bluetooth/button.py
+++ b/homeassistant/components/gardena_bluetooth/button.py
@@ -1,6 +1,7 @@
 """Support for button entities."""
 
 from dataclasses import dataclass, field
+from typing import override
 
 from gardena_bluetooth.const import Reset
 from gardena_bluetooth.parse import CharacteristicBool
@@ -57,6 +58,7 @@ class GardenaBluetoothButton(GardenaBluetoothDescriptorEntity, ButtonEntity):
 
     entity_description: GardenaBluetoothButtonEntityDescription
 
+    @override
     async def async_press(self) -> None:
         """Trigger button action."""
         await self.coordinator.write(self.entity_description.char, True)

--- a/homeassistant/components/gardena_bluetooth/config_flow.py
+++ b/homeassistant/components/gardena_bluetooth/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Gardena Bluetooth integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from gardena_bluetooth.client import Client
 from gardena_bluetooth.const import PRODUCT_NAMES, DeviceInformation
@@ -60,6 +60,7 @@ class GardenaBluetoothConfigFlow(ConfigFlow, domain=DOMAIN):
             CONF_PRODUCT_TYPE: self.devices[self.address].product_type.name,
         }
 
+    @override
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfo
     ) -> ConfigFlowResult:
@@ -98,6 +99,7 @@ class GardenaBluetoothConfigFlow(ConfigFlow, domain=DOMAIN):
             description_placeholders=self.context["title_placeholders"],
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/gardena_bluetooth/coordinator.py
+++ b/homeassistant/components/gardena_bluetooth/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from gardena_bluetooth.client import Client
 from gardena_bluetooth.const import AquaContour, DeviceConfiguration, DeviceInformation
@@ -68,11 +69,13 @@ class GardenaBluetoothCoordinator(DataUpdateCoordinator[dict[str, bytes]]):
             name=config_entry.title,
         )
 
+    @override
     async def async_shutdown(self) -> None:
         """Shutdown coordinator and any connection."""
         await super().async_shutdown()
         await self.client.disconnect()
 
+    @override
     async def _async_setup(self) -> None:
         """Set up the coordinator and read initial device metadata."""
         try:
@@ -118,6 +121,7 @@ class GardenaBluetoothCoordinator(DataUpdateCoordinator[dict[str, bytes]]):
         except CharacteristicNoAccess:
             LOGGER.debug("No access to update internal time")
 
+    @override
     async def _async_update_data(self) -> dict[str, bytes]:
         """Poll the device."""
         uuids: set[str] = {

--- a/homeassistant/components/gardena_bluetooth/entity.py
+++ b/homeassistant/components/gardena_bluetooth/entity.py
@@ -1,6 +1,6 @@
 """Provides the DataUpdateCoordinator."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -21,6 +21,7 @@ class GardenaBluetoothEntity(CoordinatorEntity[GardenaBluetoothCoordinator]):
         self._attr_device_info = coordinator.device_info
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return self.coordinator.last_update_success and self._attr_available

--- a/homeassistant/components/gardena_bluetooth/number.py
+++ b/homeassistant/components/gardena_bluetooth/number.py
@@ -1,6 +1,7 @@
 """Support for number entities."""
 
 from dataclasses import dataclass, field
+from typing import override
 
 from gardena_bluetooth.const import (
     AquaContourWatering,
@@ -169,6 +170,7 @@ class GardenaBluetoothNumber(GardenaBluetoothDescriptorEntity, NumberEntity):
 
     entity_description: GardenaBluetoothNumberEntityDescription
 
+    @override
     def _handle_coordinator_update(self) -> None:
         data = self.coordinator.get_cached(self.entity_description.char)
         if data is None:
@@ -183,6 +185,7 @@ class GardenaBluetoothNumber(GardenaBluetoothDescriptorEntity, NumberEntity):
 
         super()._handle_coordinator_update()
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
         await self.coordinator.write(
@@ -210,6 +213,7 @@ class GardenaBluetoothRemainingOpenSetNumber(GardenaBluetoothEntity, NumberEntit
         super().__init__(coordinator, {Valve.remaining_open_time.uuid})
         self._attr_unique_id = f"{coordinator.address}-remaining_open_set"
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
         await self.coordinator.write(Valve.remaining_open_time, int(value * 60))

--- a/homeassistant/components/gardena_bluetooth/select.py
+++ b/homeassistant/components/gardena_bluetooth/select.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass, field
 from enum import IntEnum
+from typing import override
 
 from gardena_bluetooth.const import (
     AquaContour,
@@ -97,6 +98,7 @@ class GardenaBluetoothSelectEntity(GardenaBluetoothDescriptorEntity, SelectEntit
     entity_description: GardenaBluetoothSelectEntityDescription
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
         char = self.entity_description.char
@@ -105,6 +107,7 @@ class GardenaBluetoothSelectEntity(GardenaBluetoothDescriptorEntity, SelectEntit
             return None
         return self.entity_description.number_to_option.get(value)
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         char = self.entity_description.char

--- a/homeassistant/components/gardena_bluetooth/sensor.py
+++ b/homeassistant/components/gardena_bluetooth/sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
+from typing import override
 
 from gardena_bluetooth.const import (
     AquaContourBattery,
@@ -241,6 +242,7 @@ class GardenaBluetoothSensor(GardenaBluetoothDescriptorEntity, SensorEntity):
 
     entity_description: GardenaBluetoothSensorEntityDescription
 
+    @override
     def _handle_coordinator_update(self) -> None:
         value = self.coordinator.get_cached(self.entity_description.char)
         value = self.entity_description.get(value)
@@ -272,6 +274,7 @@ class GardenaBluetoothRemainSensor(GardenaBluetoothEntity, SensorEntity):
         self._attr_translation_key = key
         self._char = char
 
+    @override
     def _handle_coordinator_update(self) -> None:
         value = self.coordinator.get_cached(self._char)
         if not value:
@@ -291,6 +294,7 @@ class GardenaBluetoothRemainSensor(GardenaBluetoothEntity, SensorEntity):
         super()._handle_coordinator_update()
 
     @property
+    @override
     def available(self) -> bool:
         """Sensor only available when open."""
         return super().available and self._attr_native_value is not None

--- a/homeassistant/components/gardena_bluetooth/switch.py
+++ b/homeassistant/components/gardena_bluetooth/switch.py
@@ -1,6 +1,6 @@
 """Support for switch entities."""
 
-from typing import Any
+from typing import Any, override
 
 from gardena_bluetooth.const import Valve
 
@@ -51,10 +51,12 @@ class GardenaBluetoothValveSwitch(GardenaBluetoothEntity, SwitchEntity):
         self._attr_is_on = None
         self._attr_entity_registry_enabled_default = False
 
+    @override
     def _handle_coordinator_update(self) -> None:
         self._attr_is_on = self.coordinator.get_cached(Valve.state)
         super()._handle_coordinator_update()
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         if not (data := self.coordinator.data.get(Valve.manual_watering_time.uuid)):
@@ -65,6 +67,7 @@ class GardenaBluetoothValveSwitch(GardenaBluetoothEntity, SwitchEntity):
         self._attr_is_on = True
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         await self.coordinator.write(Valve.remaining_open_time, 0)

--- a/homeassistant/components/gardena_bluetooth/text.py
+++ b/homeassistant/components/gardena_bluetooth/text.py
@@ -1,6 +1,7 @@
 """Support for text entities."""
 
 from dataclasses import dataclass
+from typing import override
 
 from gardena_bluetooth.const import AquaContourContours, AquaContourPosition
 from gardena_bluetooth.parse import CharacteristicNullString
@@ -75,11 +76,13 @@ class GardenaBluetoothTextEntity(GardenaBluetoothDescriptorEntity, TextEntity):
     entity_description: GardenaBluetoothTextEntityDescription
 
     @property
+    @override
     def native_value(self) -> str | None:
         """Return the value reported by the text."""
         char = self.entity_description.char
         return self.coordinator.get_cached(char)
 
+    @override
     async def async_set_value(self, value: str) -> None:
         """Change the text."""
         char = self.entity_description.char

--- a/homeassistant/components/gardena_bluetooth/valve.py
+++ b/homeassistant/components/gardena_bluetooth/valve.py
@@ -1,6 +1,6 @@
 """Support for switch entities."""
 
-from typing import Any
+from typing import Any, override
 
 from gardena_bluetooth.const import Valve
 
@@ -57,10 +57,12 @@ class GardenaBluetoothValve(GardenaBluetoothEntity, ValveEntity):
         )
         self._attr_unique_id = f"{coordinator.address}-{Valve.state.unique_id}"
 
+    @override
     def _handle_coordinator_update(self) -> None:
         self._attr_is_closed = not self.coordinator.get_cached(Valve.state)
         super()._handle_coordinator_update()
 
+    @override
     async def async_open_valve(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         value = (
@@ -71,6 +73,7 @@ class GardenaBluetoothValve(GardenaBluetoothEntity, ValveEntity):
         self._attr_is_closed = False
         self.async_write_ha_state()
 
+    @override
     async def async_close_valve(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         await self.coordinator.write(Valve.remaining_open_time, 0)

--- a/homeassistant/components/gc100/binary_sensor.py
+++ b/homeassistant/components/gc100/binary_sensor.py
@@ -1,5 +1,7 @@
 """Support for binary sensor using GC100."""
 
+from typing import override
+
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import (
@@ -52,11 +54,13 @@ class GC100BinarySensor(BinarySensorEntity):
         self._gc100.subscribe(self._port_addr, self.set_state)
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the sensor."""
         return self._name
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return the state of the entity."""
         return self._state

--- a/homeassistant/components/gc100/switch.py
+++ b/homeassistant/components/gc100/switch.py
@@ -1,6 +1,6 @@
 """Support for switches using GC100."""
 
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -49,19 +49,23 @@ class GC100Switch(SwitchEntity):
         self._state: bool | None = None
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the switch."""
         return self._name
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return the state of the entity."""
         return self._state
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         self._gc100.write_switch(self._port_addr, 1, self.set_state)
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         self._gc100.write_switch(self._port_addr, 0, self.set_state)

--- a/homeassistant/components/gdacs/config_flow.py
+++ b/homeassistant/components/gdacs/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow to configure the GDACS integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -34,6 +34,7 @@ class GdacsFlowHandler(ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=DATA_SCHEMA, errors=errors or {}
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/gdacs/geo_location.py
+++ b/homeassistant/components/gdacs/geo_location.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from datetime import datetime
 import logging
-from typing import Any
+from typing import Any, override
 
 from aio_georss_gdacs.feed_entry import GdacsFeedEntry
 
@@ -108,6 +108,7 @@ class GdacsEvent(GeolocationEvent):
         self._remove_signal_delete: Callable[[], None]
         self._remove_signal_update: Callable[[], None]
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity is added to hass."""
         if self.hass.config.units is US_CUSTOMARY_SYSTEM:
@@ -119,6 +120,7 @@ class GdacsEvent(GeolocationEvent):
             self.hass, f"gdacs_update_{self._external_id}", self._update_callback
         )
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Call when entity will be removed from hass."""
         self._remove_signal_delete()
@@ -178,6 +180,7 @@ class GdacsEvent(GeolocationEvent):
         self._version = feed_entry.version
 
     @property
+    @override
     def icon(self) -> str:
         """Return the icon to use in the frontend, if any."""
         if self._event_type_short and self._event_type_short in ICONS:
@@ -185,6 +188,7 @@ class GdacsEvent(GeolocationEvent):
         return DEFAULT_ICON
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device state attributes."""
         return {

--- a/homeassistant/components/gdacs/sensor.py
+++ b/homeassistant/components/gdacs/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from datetime import datetime
 import logging
-from typing import Any
+from typing import Any, override
 
 from aio_georss_client.status_update import StatusUpdate
 
@@ -75,6 +75,7 @@ class GdacsSensor(SensorEntity):
             manufacturer="GDACS",
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity is added to hass."""
         self._remove_signal_status = async_dispatcher_connect(
@@ -86,6 +87,7 @@ class GdacsSensor(SensorEntity):
         # First update is manual because of how the feed entity manager is updated.
         await self.async_update()
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Call when entity will be removed from hass."""
         if self._remove_signal_status:
@@ -124,11 +126,13 @@ class GdacsSensor(SensorEntity):
         self._removed = status_info.removed
 
     @property
+    @override
     def native_value(self) -> int | None:
         """Return the state of the sensor."""
         return self._total
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device state attributes."""
         return {

--- a/homeassistant/components/generic/camera.py
+++ b/homeassistant/components/generic/camera.py
@@ -4,7 +4,7 @@ import asyncio
 from collections.abc import Mapping
 from datetime import datetime, timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 import httpx
 import voluptuous as vol
@@ -123,10 +123,12 @@ class GenericCamera(Camera):
         )
 
     @property
+    @override
     def use_stream_for_stills(self) -> bool:
         """Whether or not to use stream to generate stills."""
         return not self._still_image_url
 
+    @override
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
@@ -184,10 +186,12 @@ class GenericCamera(Camera):
             return self._last_image
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of this device."""
         return self._name
 
+    @override
     async def stream_source(self) -> str | None:
         """Return the source of the stream."""
         if self._stream_source is None:

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from errno import EHOSTUNREACH, EIO
 import io
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from aiohttp import web
 from httpx import HTTPStatusError, RequestError, TimeoutException
@@ -332,12 +332,14 @@ class GenericIPCamConfigFlow(ConfigFlow, domain=DOMAIN):
         self.title = ""
 
     @staticmethod
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> GenericOptionsFlowHandler:
         """Get the options flow for this handler."""
         return GenericOptionsFlowHandler()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -408,6 +410,7 @@ class GenericIPCamConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
     @staticmethod
+    @override
     async def async_setup_preview(hass: HomeAssistant) -> None:
         """Set up preview WS API."""
         websocket_api.async_register_command(hass, ws_start_preview)
@@ -502,6 +505,7 @@ class GenericOptionsFlowHandler(OptionsFlow):
         )
 
     @staticmethod
+    @override
     async def async_setup_preview(hass: HomeAssistant) -> None:
         """Set up preview WS API."""
         websocket_api.async_register_command(hass, ws_start_preview)

--- a/homeassistant/components/generic_hygrostat/config_flow.py
+++ b/homeassistant/components/generic_hygrostat/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Generic hygrostat."""
 
 from collections.abc import Mapping
-from typing import Any, cast
+from typing import Any, cast, override
 
 import voluptuous as vol
 
@@ -95,6 +95,7 @@ class ConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
     options_flow = OPTIONS_FLOW
     options_flow_reloads = True
 
+    @override
     def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
         """Return config entry title."""
         return cast(str, options["name"])

--- a/homeassistant/components/generic_hygrostat/humidifier.py
+++ b/homeassistant/components/generic_hygrostat/humidifier.py
@@ -4,7 +4,7 @@ import asyncio
 from collections.abc import Callable, Mapping
 from datetime import datetime, timedelta
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, cast, override
 
 from homeassistant.components.humidifier import (
     ATTR_HUMIDITY,
@@ -221,6 +221,7 @@ class GenericHygrostat(HumidifierEntity, RestoreEntity):
         self._attr_action = HumidifierAction.IDLE
         self._attr_unique_id = unique_id
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added."""
         await super().async_added_to_hass()
@@ -290,6 +291,7 @@ class GenericHygrostat(HumidifierEntity, RestoreEntity):
 
         await _async_startup(None)  # init the sensor
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from hass."""
         if self._remove_stale_tracking:
@@ -297,11 +299,13 @@ class GenericHygrostat(HumidifierEntity, RestoreEntity):
         return await super().async_will_remove_from_hass()
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return self._active
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the optional state attributes."""
         if self._saved_target_humidity:
@@ -309,26 +313,31 @@ class GenericHygrostat(HumidifierEntity, RestoreEntity):
         return None
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the hygrostat."""
         return self._name
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the hygrostat is on."""
         return self._state
 
     @property
+    @override
     def current_humidity(self) -> float | None:
         """Return the measured humidity."""
         return self._cur_humidity
 
     @property
+    @override
     def target_humidity(self) -> float | None:
         """Return the humidity we try to reach."""
         return self._target_humidity
 
     @property
+    @override
     def mode(self) -> str | None:
         """Return the current mode."""
         if self._away_humidity is None:
@@ -338,6 +347,7 @@ class GenericHygrostat(HumidifierEntity, RestoreEntity):
         return MODE_NORMAL
 
     @property
+    @override
     def available_modes(self) -> list[str] | None:
         """Return a list of available modes."""
         if self._away_humidity:
@@ -345,10 +355,12 @@ class GenericHygrostat(HumidifierEntity, RestoreEntity):
         return None
 
     @property
+    @override
     def device_class(self) -> HumidifierDeviceClass:
         """Return the device class of the humidifier."""
         return self._device_class
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn hygrostat on."""
         if not self._active:
@@ -357,6 +369,7 @@ class GenericHygrostat(HumidifierEntity, RestoreEntity):
         await self._async_operate(force=True)
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn hygrostat off."""
         if not self._active:
@@ -366,6 +379,7 @@ class GenericHygrostat(HumidifierEntity, RestoreEntity):
             await self._async_device_turn_off()
         self.async_write_ha_state()
 
+    @override
     async def async_set_humidity(self, humidity: int) -> None:
         """Set new target humidity."""
         if humidity is None:
@@ -381,6 +395,7 @@ class GenericHygrostat(HumidifierEntity, RestoreEntity):
         self.async_write_ha_state()
 
     @property
+    @override
     def min_humidity(self) -> float:
         """Return the minimum humidity."""
         if self._min_humidity:
@@ -390,6 +405,7 @@ class GenericHygrostat(HumidifierEntity, RestoreEntity):
         return super().min_humidity
 
     @property
+    @override
     def max_humidity(self) -> float:
         """Return the maximum humidity."""
         if self._max_humidity:
@@ -563,6 +579,7 @@ class GenericHygrostat(HumidifierEntity, RestoreEntity):
             HOMEASSISTANT_DOMAIN, SERVICE_TURN_OFF, data
         )
 
+    @override
     async def async_set_mode(self, mode: str) -> None:
         """Set new mode.
 

--- a/homeassistant/components/generic_thermostat/climate.py
+++ b/homeassistant/components/generic_thermostat/climate.py
@@ -7,7 +7,7 @@ from functools import partial
 import logging
 import math
 import time
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -297,6 +297,7 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
         self._presets = presets
         self._presets_inv = {v: k for k, v in presets.items()}
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added."""
         await super().async_added_to_hass()
@@ -385,6 +386,7 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
             self._hvac_mode = HVACMode.OFF
 
     @property
+    @override
     def precision(self) -> float:
         """Return the precision of the system."""
         if self._temp_precision is not None:
@@ -392,6 +394,7 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
         return super().precision
 
     @property
+    @override
     def target_temperature_step(self) -> float:
         """Return the supported step of target temperature."""
         if self._temp_target_temperature_step is not None:
@@ -400,16 +403,19 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
         return self.precision
 
     @property
+    @override
     def current_temperature(self) -> float | None:
         """Return the sensor temperature."""
         return self._cur_temp
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode | None:
         """Return current operation."""
         return self._hvac_mode
 
     @property
+    @override
     def hvac_action(self) -> HVACAction:
         """Return the current running hvac operation if supported.
 
@@ -424,10 +430,12 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
         return HVACAction.HEATING
 
     @property
+    @override
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
         return self._target_temp
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set hvac mode."""
         if hvac_mode == HVACMode.HEAT:
@@ -446,6 +454,7 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
         # Ensure we update the current operation after changing the mode
         self.async_write_ha_state()
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
@@ -459,6 +468,7 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
         self.async_write_ha_state()
 
     @property
+    @override
     def min_temp(self) -> float:
         """Return the minimum temperature."""
         if self._min_temp is not None:
@@ -468,6 +478,7 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
         return super().min_temp
 
     @property
+    @override
     def max_temp(self) -> float:
         """Return the maximum temperature."""
         if self._max_temp is not None:
@@ -688,6 +699,7 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
             self._last_toggled_time = dt_util.utcnow()
             self._cancel_timers()
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         if preset_mode not in (self.preset_modes or []):

--- a/homeassistant/components/generic_thermostat/config_flow.py
+++ b/homeassistant/components/generic_thermostat/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 from datetime import timedelta
-from typing import Any, cast
+from typing import Any, cast, override
 
 import voluptuous as vol
 
@@ -141,6 +141,7 @@ class ConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
     options_flow = OPTIONS_FLOW
     options_flow_reloads = True
 
+    @override
     def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
         """Return config entry title."""
         return cast(str, options["name"])

--- a/homeassistant/components/geniushub/binary_sensor.py
+++ b/homeassistant/components/geniushub/binary_sensor.py
@@ -1,5 +1,7 @@
 """Support for Genius Hub binary_sensor devices."""
 
+from typing import override
+
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -42,6 +44,7 @@ class GeniusBinarySensor(GeniusDevice, BinarySensorEntity):
             self._attr_name = f"{device.type} {device.id}"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the status of the sensor."""
         return self._device.data["state"][self._state_attr]

--- a/homeassistant/components/geniushub/climate.py
+++ b/homeassistant/components/geniushub/climate.py
@@ -1,5 +1,7 @@
 """Support for Genius Hub climate devices."""
 
+from typing import override
+
 from homeassistant.components.climate import (
     PRESET_ACTIVITY,
     PRESET_BOOST,
@@ -58,21 +60,25 @@ class GeniusClimateZone(GeniusHeatingZone, ClimateEntity):
         self._min_temp = 4.0
 
     @property
+    @override
     def icon(self) -> str:
         """Return the icon to use in the frontend UI."""
         return "mdi:radiator"
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode."""
         return GH_HVAC_TO_HA.get(self._zone.data["mode"], HVACMode.HEAT)
 
     @property
+    @override
     def hvac_modes(self) -> list[HVACMode]:
         """Return the list of available hvac operation modes."""
         return list(HA_HVAC_TO_GH)
 
     @property
+    @override
     def hvac_action(self) -> HVACAction | None:
         """Return the current running hvac operation if supported."""
         if "_state" in self._zone.data:  # only for v3 API
@@ -84,21 +90,25 @@ class GeniusClimateZone(GeniusHeatingZone, ClimateEntity):
         return None
 
     @property
+    @override
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., home, away, temp."""
         return GH_PRESET_TO_HA.get(self._zone.data["mode"])
 
     @property
+    @override
     def preset_modes(self) -> list[str] | None:
         """Return a list of available preset modes."""
         if "occupied" in self._zone.data:  # if has a movement sensor
             return [PRESET_ACTIVITY, PRESET_BOOST]
         return [PRESET_BOOST]
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set a new hvac mode."""
         await self._zone.set_mode(HA_HVAC_TO_GH.get(hvac_mode))
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set a new preset mode."""
         await self._zone.set_mode(HA_PRESET_TO_GH.get(preset_mode, "timer"))

--- a/homeassistant/components/geniushub/config_flow.py
+++ b/homeassistant/components/geniushub/config_flow.py
@@ -3,7 +3,7 @@
 from http import HTTPStatus
 import logging
 import socket
-from typing import Any
+from typing import Any, override
 
 import aiohttp
 from geniushubclient import GeniusService
@@ -38,6 +38,7 @@ class GeniusHubConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/geniushub/entity.py
+++ b/homeassistant/components/geniushub/entity.py
@@ -1,7 +1,7 @@
 """Base entity for Geniushub."""
 
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Any, override
 
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -31,6 +31,7 @@ class GeniusEntity(Entity):
         """Initialize the entity."""
         self._unique_id: str | None = None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Set up a listener when this entity is added to HA."""
         self.async_on_remove(async_dispatcher_connect(self.hass, DOMAIN, self._refresh))
@@ -40,6 +41,7 @@ class GeniusEntity(Entity):
         self.async_schedule_update_ha_state(force_refresh=True)
 
     @property
+    @override
     def unique_id(self) -> str | None:
         """Return a unique ID."""
         return self._unique_id
@@ -58,6 +60,7 @@ class GeniusDevice(GeniusEntity):
         self._state_attr = None
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device state attributes."""
         attrs = {}
@@ -93,6 +96,7 @@ class GeniusZone(GeniusEntity):
         self._zone = zone
         self._unique_id = f"{broker.hub_uid}_zone_{zone.id}"
 
+    @override
     async def _refresh(self, payload: dict | None = None) -> None:
         """Process any signals."""
         if payload is None:
@@ -119,11 +123,13 @@ class GeniusZone(GeniusEntity):
         await self._zone.set_mode(mode)
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the climate device."""
         return self._zone.name
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device state attributes."""
         status = {k: v for k, v in self._zone.data.items() if k in GH_ZONE_ATTRS}

--- a/homeassistant/components/geniushub/sensor.py
+++ b/homeassistant/components/geniushub/sensor.py
@@ -1,7 +1,7 @@
 """Support for Genius Hub sensor devices."""
 
 from datetime import timedelta
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.const import PERCENTAGE
@@ -55,6 +55,7 @@ class GeniusBattery(GeniusDevice, SensorEntity):
         self._attr_name = f"{device.type} {device.id}"
 
     @property
+    @override
     def icon(self) -> str:
         """Return the icon of the sensor."""
         if "_state" in self._device.data:  # only for v3 API
@@ -80,6 +81,7 @@ class GeniusBattery(GeniusDevice, SensorEntity):
         return icon
 
     @property
+    @override
     def native_value(self) -> int:
         """Return the state of the sensor."""
         level = self._device.data["state"][self._state_attr]
@@ -101,11 +103,13 @@ class GeniusIssue(GeniusEntity, SensorEntity):
         self._issues: list = []
 
     @property
+    @override
     def native_value(self) -> int:
         """Return the number of issues."""
         return len(self._issues)
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device state attributes."""
         return {f"{self._level}_list": self._issues}

--- a/homeassistant/components/geniushub/switch.py
+++ b/homeassistant/components/geniushub/switch.py
@@ -1,7 +1,7 @@
 """Support for Genius Hub switch/outlet devices."""
 
 from datetime import timedelta
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -55,11 +55,13 @@ class GeniusSwitch(GeniusZone, SwitchEntity):
     """Representation of a Genius Hub switch."""
 
     @property
+    @override
     def device_class(self) -> SwitchDeviceClass:
         """Return the class of this device, from component DEVICE_CLASSES."""
         return SwitchDeviceClass.OUTLET
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the current state of the on/off zone.
 
@@ -70,6 +72,7 @@ class GeniusSwitch(GeniusZone, SwitchEntity):
             and self._zone.data["setpoint"]
         )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Send the zone to Timer mode.
 
@@ -77,6 +80,7 @@ class GeniusSwitch(GeniusZone, SwitchEntity):
         """
         await self._zone.set_mode("timer")
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Set the zone to override/on ({'setpoint': true}) for x seconds."""
         await self._zone.set_override(1, kwargs.get(ATTR_DURATION, 3600))

--- a/homeassistant/components/geniushub/water_heater.py
+++ b/homeassistant/components/geniushub/water_heater.py
@@ -1,5 +1,7 @@
 """Support for Genius Hub water_heater devices."""
 
+from typing import override
+
 from homeassistant.components.water_heater import (
     WaterHeaterEntity,
     WaterHeaterEntityFeature,
@@ -63,15 +65,18 @@ class GeniusWaterHeater(GeniusHeatingZone, WaterHeaterEntity):
         self._min_temp = 30.0
 
     @property
+    @override
     def operation_list(self) -> list[str]:
         """Return the list of available operation modes."""
         return list(HA_OPMODE_TO_GH)
 
     @property
+    @override
     def current_operation(self) -> str | None:
         """Return the current operation mode."""
         return GH_STATE_TO_HA[self._zone.data["mode"]]
 
+    @override
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         """Set a new operation mode for this boiler."""
         await self._zone.set_mode(HA_OPMODE_TO_GH[operation_mode])

--- a/homeassistant/components/gentex_homelink/config_flow.py
+++ b/homeassistant/components/gentex_homelink/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 import botocore.exceptions
 from homelink.auth.srp_auth import SRPAuth
@@ -30,10 +30,12 @@ class SRPFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
         self.flow_impl = SRPAuthImplementation(self.hass, DOMAIN)
 
     @property
+    @override
     def logger(self):
         """Get the logger."""
         return _LOGGER
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -93,6 +95,7 @@ class SRPFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
             )
         return await self.async_step_user(user_input)
 
+    @override
     async def async_oauth_create_entry(self, data: dict) -> ConfigFlowResult:
         """Create an oauth config entry or update existing entry for reauth."""
         await self.async_set_unique_id(self.external_data[CONF_UNIQUE_ID])

--- a/homeassistant/components/gentex_homelink/event.py
+++ b/homeassistant/components/gentex_homelink/event.py
@@ -1,5 +1,7 @@
 """Platform for Event integration."""
 
+from typing import override
+
 from homeassistant.components.event import EventDeviceClass, EventEntity
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -55,6 +57,7 @@ class HomeLinkEventEntity(EventEntity):
         self.coordinator = coordinator
         self.last_request_id: str | None = None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()

--- a/homeassistant/components/gentex_homelink/oauth2.py
+++ b/homeassistant/components/gentex_homelink/oauth2.py
@@ -3,7 +3,7 @@
 from json import JSONDecodeError
 import logging
 import time
-from typing import cast
+from typing import cast, override
 
 from aiohttp import ClientError, ClientSession
 from homelink.auth.abstract_auth import AbstractAuth
@@ -29,19 +29,23 @@ class SRPAuthImplementation(config_entry_oauth2_flow.AbstractOAuth2Implementatio
         self.client_id = COGNITO_CLIENT_ID
 
     @property
+    @override
     def name(self) -> str:
         """Name of the implementation."""
         return "SRPAuth"
 
     @property
+    @override
     def domain(self) -> str:
         """Domain that is providing the implementation."""
         return self._domain
 
+    @override
     async def async_generate_authorize_url(self, flow_id: str) -> str:
         """Left intentionally blank because the auth is handled by SRP."""
         return ""
 
+    @override
     async def async_resolve_external_data(self, external_data) -> dict:
         """Format the token from the source appropriately for HomeAssistant."""
         tokens = external_data["tokens"]
@@ -79,6 +83,7 @@ class SRPAuthImplementation(config_entry_oauth2_flow.AbstractOAuth2Implementatio
         resp.raise_for_status()
         return cast(dict, await resp.json())
 
+    @override
     async def _async_refresh_token(self, token: dict) -> dict:
         """Refresh tokens."""
         new_token = await self._token_request(

--- a/homeassistant/components/geo_json_events/config_flow.py
+++ b/homeassistant/components/geo_json_events/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow to configure the GeoJSON events integration."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -32,6 +32,7 @@ DATA_SCHEMA = vol.Schema(
 class GeoJsonEventsFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a GeoJSON events config flow."""
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/geo_json_events/geo_location.py
+++ b/homeassistant/components/geo_json_events/geo_location.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 import logging
-from typing import Any
+from typing import Any, override
 
 from aio_geojson_generic_client.feed_entry import GenericFeedEntry
 
@@ -64,6 +64,7 @@ class GeoJsonLocationEvent(GeolocationEvent):
         self._remove_signal_delete: Callable[[], None]
         self._remove_signal_update: Callable[[], None]
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity is added to hass."""
         self._remove_signal_delete = async_dispatcher_connect(
@@ -108,6 +109,7 @@ class GeoJsonLocationEvent(GeolocationEvent):
         self._attr_longitude = feed_entry.coordinates[1]
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device state attributes."""
         if not self._external_id:

--- a/homeassistant/components/geo_location/__init__.py
+++ b/homeassistant/components/geo_location/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import Any, final
+from typing import Any, final, override
 
 from propcache.api import cached_property
 
@@ -69,6 +69,7 @@ class GeolocationEvent(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
 
     @final
     @property
+    @override
     def state(self) -> float | None:
         """Return the state of the sensor."""
         if self.distance is not None:
@@ -97,6 +98,7 @@ class GeolocationEvent(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
 
     @final
     @property
+    @override
     def state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of this external event."""
         data: dict[str, Any] = {ATTR_SOURCE: self.source}

--- a/homeassistant/components/geocaching/config_flow.py
+++ b/homeassistant/components/geocaching/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from geocachingapi.geocachingapi import GeocachingApi
 
@@ -20,6 +20,7 @@ class GeocachingFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
     VERSION = 1
 
     @property
+    @override
     def logger(self) -> logging.Logger:
         """Return logger."""
         return logging.getLogger(__name__)
@@ -38,6 +39,7 @@ class GeocachingFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
             return self.async_show_form(step_id="reauth_confirm")
         return await self.async_step_user()
 
+    @override
     async def async_oauth_create_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
         """Create an oauth config entry or update existing entry for reauth."""
         api = GeocachingApi(

--- a/homeassistant/components/geocaching/coordinator.py
+++ b/homeassistant/components/geocaching/coordinator.py
@@ -1,5 +1,7 @@
 """Provides the Geocaching DataUpdateCoordinator."""
 
+from typing import override
+
 from geocachingapi.exceptions import GeocachingApiError, GeocachingInvalidSettingsError
 from geocachingapi.geocachingapi import GeocachingApi
 from geocachingapi.models import GeocachingStatus
@@ -53,6 +55,7 @@ class GeocachingDataUpdateCoordinator(DataUpdateCoordinator[GeocachingStatus]):
             update_interval=UPDATE_INTERVAL,
         )
 
+    @override
     async def _async_update_data(self) -> GeocachingStatus:
         """Fetch the latest Geocaching status."""
         try:

--- a/homeassistant/components/geocaching/oauth.py
+++ b/homeassistant/components/geocaching/oauth.py
@@ -1,6 +1,6 @@
 """oAuth2 functions and classes for Geocaching API integration."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.application_credentials import (
     AuthImplementation,
@@ -33,10 +33,12 @@ class GeocachingOAuth2Implementation(AuthImplementation):
         )
 
     @property
+    @override
     def extra_authorize_data(self) -> dict:
         """Extra data that needs to be appended to the authorize url."""
         return {"scope": "*", "response_type": "code"}
 
+    @override
     async def async_resolve_external_data(self, external_data: Any) -> dict:
         """Initialize local Geocaching API auth implementation."""
         redirect_uri = external_data["state"]["redirect_uri"]
@@ -51,6 +53,7 @@ class GeocachingOAuth2Implementation(AuthImplementation):
         token["redirect_uri"] = redirect_uri
         return token
 
+    @override
     async def _async_refresh_token(self, token: dict) -> dict:
         """Refresh tokens."""
         data = {

--- a/homeassistant/components/geocaching/sensor.py
+++ b/homeassistant/components/geocaching/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 import datetime
-from typing import cast
+from typing import cast, override
 
 from geocachingapi.models import GeocachingCache, GeocachingStatus
 
@@ -153,6 +153,7 @@ class GeoEntityCacheSensorEntity(GeoEntityBaseCache, SensorEntity):
         self.entity_description = description
 
     @property
+    @override
     def native_value(self) -> StateType | datetime.date:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.cache)
@@ -184,6 +185,7 @@ class GeocachingProfileSensor(GeocachingBaseEntity, SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> str | int | None:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/geofency/device_tracker.py
+++ b/homeassistant/components/geofency/device_tracker.py
@@ -1,5 +1,7 @@
 """Support for the Geofency device tracker platform."""
 
+from typing import override
+
 from homeassistant.components.device_tracker import TrackerEntity
 from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
 from homeassistant.core import HomeAssistant, callback
@@ -73,6 +75,7 @@ class GeofencyEntity(TrackerEntity, RestoreEntity):
             name=device,
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register state update callback."""
         await super().async_added_to_hass()
@@ -92,6 +95,7 @@ class GeofencyEntity(TrackerEntity, RestoreEntity):
         self._attr_latitude = attr.get(ATTR_LATITUDE)
         self._attr_longitude = attr.get(ATTR_LONGITUDE)
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Clean up after entity before removal."""
         await super().async_will_remove_from_hass()

--- a/homeassistant/components/geonetnz_quakes/config_flow.py
+++ b/homeassistant/components/geonetnz_quakes/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow to configure the GeoNet NZ Quakes integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -49,6 +49,7 @@ class GeonetnzQuakesFlowHandler(ConfigFlow, domain=DOMAIN):
         """Import a config entry from configuration.yaml."""
         return await self.async_step_user(import_data)
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/geonetnz_quakes/geo_location.py
+++ b/homeassistant/components/geonetnz_quakes/geo_location.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 import logging
-from typing import Any
+from typing import Any, override
 
 from aio_geojson_geonetnz_quakes.feed_entry import GeonetnzQuakesFeedEntry
 
@@ -90,6 +90,7 @@ class GeonetnzQuakesEvent(GeolocationEvent):
         self._remove_signal_delete: Callable[[], None]
         self._remove_signal_update: Callable[[], None]
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity is added to hass."""
         if self.hass.config.units is US_CUSTOMARY_SYSTEM:
@@ -105,6 +106,7 @@ class GeonetnzQuakesEvent(GeolocationEvent):
             self._update_callback,
         )
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Call when entity will be removed from hass."""
         self._remove_signal_delete()
@@ -152,6 +154,7 @@ class GeonetnzQuakesEvent(GeolocationEvent):
         self._time = feed_entry.time
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device state attributes."""
         return {

--- a/homeassistant/components/geonetnz_quakes/sensor.py
+++ b/homeassistant/components/geonetnz_quakes/sensor.py
@@ -1,7 +1,7 @@
 """Feed Entity Manager Sensor support for GeoNet NZ Quakes Feeds."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.core import HomeAssistant, callback
@@ -60,6 +60,7 @@ class GeonetnzQuakesSensor(SensorEntity):
         self._removed = None
         self._remove_signal_status = None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity is added to hass."""
         self._remove_signal_status = async_dispatcher_connect(
@@ -71,6 +72,7 @@ class GeonetnzQuakesSensor(SensorEntity):
         # First update is manual because of how the feed entity manager is updated.
         await self.async_update()
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Call when entity will be removed from hass."""
         if self._remove_signal_status:
@@ -109,6 +111,7 @@ class GeonetnzQuakesSensor(SensorEntity):
         self._removed = status_info.removed
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device state attributes."""
         return {

--- a/homeassistant/components/geonetnz_volcano/config_flow.py
+++ b/homeassistant/components/geonetnz_volcano/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow to configure the GeoNet NZ Volcano integration."""
 
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -51,6 +51,7 @@ class GeonetnzVolcanoFlowHandler(ConfigFlow, domain=DOMAIN):
         """Import a config entry from configuration.yaml."""
         return await self.async_step_user(import_data)
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/geonetnz_volcano/sensor.py
+++ b/homeassistant/components/geonetnz_volcano/sensor.py
@@ -1,7 +1,7 @@
 """Feed Entity Manager Sensor support for GeoNet NZ Volcano Feeds."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, UnitOfLength
@@ -76,6 +76,7 @@ class GeonetnzVolcanoSensor(SensorEntity):
         self._feed_last_update_successful = None
         self._remove_signal_update = None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity is added to hass."""
         self._remove_signal_update = async_dispatcher_connect(
@@ -84,6 +85,7 @@ class GeonetnzVolcanoSensor(SensorEntity):
             self._update_callback,
         )
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Call when entity will be removed from hass."""
         if self._remove_signal_update:
@@ -130,11 +132,13 @@ class GeonetnzVolcanoSensor(SensorEntity):
         )
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the entity."""
         return f"Volcano {self._title}"
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device state attributes."""
         return {

--- a/homeassistant/components/ghost/config_flow.py
+++ b/homeassistant/components/ghost/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from aioghost import GhostAdminAPI
 from aioghost.exceptions import GhostAuthError, GhostError
@@ -82,6 +82,7 @@ class GhostConfigFlow(ConfigFlow, domain=DOMAIN):
             },
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/ghost/coordinator.py
+++ b/homeassistant/components/ghost/coordinator.py
@@ -4,7 +4,7 @@ import asyncio
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from aioghost import GhostAdminAPI
 from aioghost.exceptions import GhostAuthError, GhostError
@@ -59,6 +59,7 @@ class GhostDataUpdateCoordinator(DataUpdateCoordinator[GhostData]):
             config_entry=config_entry,
         )
 
+    @override
     async def _async_update_data(self) -> GhostData:
         """Fetch data from Ghost API."""
         try:

--- a/homeassistant/components/ghost/sensor.py
+++ b/homeassistant/components/ghost/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -305,6 +305,7 @@ class GhostSensorEntity(CoordinatorEntity[GhostDataUpdateCoordinator], SensorEnt
         )
 
     @property
+    @override
     def native_value(self) -> str | int | None:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)
@@ -345,6 +346,7 @@ class GhostNewsletterSensorEntity(
         return self.coordinator.data.newsletters.get(self._newsletter_id)
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if the entity is available."""
         return (
@@ -353,6 +355,7 @@ class GhostNewsletterSensorEntity(
         )
 
     @property
+    @override
     def native_value(self) -> int | None:
         """Return the subscriber count for this newsletter."""
         if newsletter := self._get_newsletter_by_id():

--- a/homeassistant/components/gios/config_flow.py
+++ b/homeassistant/components/gios/config_flow.py
@@ -1,7 +1,7 @@
 """Adds config flow for GIOS."""
 
 import asyncio
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from aiohttp.client_exceptions import ClientConnectorError
 from gios import ApiError, Gios, InvalidSensorsDataError, NoStationError
@@ -25,6 +25,7 @@ class GiosFlowHandler(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/gios/coordinator.py
+++ b/homeassistant/components/gios/coordinator.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from aiohttp.client_exceptions import ClientConnectorError
 from gios import Gios
@@ -60,6 +60,7 @@ class GiosDataUpdateCoordinator(DataUpdateCoordinator[GiosSensors]):
             configuration_url=URL.format(station_id=station_id),
         )
 
+    @override
     async def _async_update_data(self) -> GiosSensors:
         """Update data via library."""
         try:

--- a/homeassistant/components/gios/sensor.py
+++ b/homeassistant/components/gios/sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 import logging
+from typing import override
 
 from gios.model import GiosSensors
 
@@ -231,11 +232,13 @@ class GiosSensor(CoordinatorEntity[GiosDataUpdateCoordinator], SensorEntity):
         self.entity_description = description
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state."""
         return self.entity_description.value(self.coordinator.data)
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         sensor_data = getattr(self.coordinator.data, self.entity_description.key)

--- a/homeassistant/components/github/config_flow.py
+++ b/homeassistant/components/github/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for GitHub integration."""
 
 import asyncio
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from aiogithubapi import (
     GitHubAPI,
@@ -119,12 +119,14 @@ class GitHubConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @classmethod
     @callback
+    @override
     def async_get_supported_subentry_types(
         cls, config_entry: ConfigEntry
     ) -> dict[str, type[ConfigSubentryFlow]]:
         """Return subentries supported by this handler."""
         return {SUBENTRY_TYPE_REPOSITORY: RepositoryFlowHandler}
 
+    @override
     async def async_step_user(
         self,
         user_input: dict[str, Any] | None = None,

--- a/homeassistant/components/github/coordinator.py
+++ b/homeassistant/components/github/coordinator.py
@@ -1,7 +1,7 @@
 """Custom data update coordinator for the GitHub integration."""
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from aiogithubapi import (
     GitHubAPI,
@@ -140,6 +140,7 @@ class GitHubUserDataUpdateCoordinator(
             update_interval=FALLBACK_UPDATE_INTERVAL,
         )
 
+    @override
     async def _async_update_data(self) -> GitHubAuthenticatedUserModel:
         """Update data."""
         try:
@@ -180,6 +181,7 @@ class GitHubDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             update_interval=FALLBACK_UPDATE_INTERVAL,
         )
 
+    @override
     async def _async_update_data(self) -> GitHubResponseModel[dict[str, Any]]:
         """Update data."""
         owner, repository = self.repository.split("/")

--- a/homeassistant/components/github/sensor.py
+++ b/homeassistant/components/github/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from aiogithubapi import GitHubAuthenticatedUserModel
 
@@ -236,6 +236,7 @@ class GitHubSensorEntity(CoordinatorEntity[GitHubDataUpdateCoordinator], SensorE
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return (
@@ -245,11 +246,13 @@ class GitHubSensorEntity(CoordinatorEntity[GitHubDataUpdateCoordinator], SensorE
         )
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)
 
     @property
+    @override
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """Return the extra state attributes."""
         return self.entity_description.attr_fn(self.coordinator.data)
@@ -284,6 +287,7 @@ class GitHubUserSensorEntity(
         )
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/gitlab_ci/sensor.py
+++ b/homeassistant/components/gitlab_ci/sensor.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from gitlab import Gitlab, GitlabAuthenticationError, GitlabGetError
 import voluptuous as vol
@@ -83,6 +84,7 @@ class GitLabSensor(SensorEntity):
         self._attr_name = name
 
     @property
+    @override
     def icon(self) -> str:
         """Return the icon to use in the frontend."""
         if self.native_value == "success":

--- a/homeassistant/components/gitter/sensor.py
+++ b/homeassistant/components/gitter/sensor.py
@@ -1,7 +1,7 @@
 """Support for displaying details about a Gitter.im chat room."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from gitterpy.client import GitterClient
 from gitterpy.errors import GitterRoomError, GitterTokenError
@@ -74,21 +74,25 @@ class GitterSensor(SensorEntity):
         self._unit_of_measurement = "Msg"
 
     @property
+    @override
     def name(self):
         """Return the name of the sensor."""
         return self._name
 
     @property
+    @override
     def native_value(self):
         """Return the state of the sensor."""
         return self._state
 
     @property
+    @override
     def native_unit_of_measurement(self):
         """Return the unit the value is expressed in."""
         return self._unit_of_measurement
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         return {

--- a/homeassistant/components/glances/config_flow.py
+++ b/homeassistant/components/glances/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Glances."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 from glances_api.exceptions import (
     GlancesApiAuthorizationError,
@@ -78,6 +78,7 @@ class GlancesFlowHandler(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/glances/coordinator.py
+++ b/homeassistant/components/glances/coordinator.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from glances_api import Glances, exceptions
 
@@ -39,6 +39,7 @@ class GlancesDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             update_interval=DEFAULT_SCAN_INTERVAL,
         )
 
+    @override
     async def _async_update_data(self) -> dict[str, Any]:
         """Get the latest data from the Glances REST API."""
         try:

--- a/homeassistant/components/glances/sensor.py
+++ b/homeassistant/components/glances/sensor.py
@@ -1,6 +1,7 @@
 """Support gathering system information of hosts which are running Glances."""
 
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -356,11 +357,13 @@ class GlancesSensor(CoordinatorEntity[GlancesDataUpdateCoordinator], SensorEntit
         self._update_native_value()
 
     @property
+    @override
     def available(self) -> bool:
         """Set sensor unavailable when native value is invalid."""
         return super().available and self._data_valid
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._update_native_value()

--- a/homeassistant/components/go2rtc/__init__.py
+++ b/homeassistant/components/go2rtc/__init__.py
@@ -5,6 +5,7 @@ import logging
 from secrets import token_hex
 import shutil
 from tempfile import mkdtemp
+from typing import override
 
 from aiohttp import BasicAuth, ClientSession, UnixConnector
 from aiohttp.client_exceptions import ClientConnectionError, ServerConnectionError
@@ -279,6 +280,7 @@ class WebRTCProvider(CameraWebRTCProvider):
         self._supported_schemes: set[str] = set()
 
     @property
+    @override
     def domain(self) -> str:
         """Return the integration domain of the provider."""
         return DOMAIN
@@ -288,10 +290,12 @@ class WebRTCProvider(CameraWebRTCProvider):
         self._supported_schemes = await self._rest_client.schemes.list()
 
     @callback
+    @override
     def async_is_supported(self, stream_source: str) -> bool:
         """Return if this provider is supports the Camera as source."""
         return stream_source.partition(":")[0] in self._supported_schemes
 
+    @override
     async def async_handle_async_webrtc_offer(
         self,
         camera: Camera,
@@ -328,6 +332,7 @@ class WebRTCProvider(CameraWebRTCProvider):
         config = camera.async_get_webrtc_client_configuration()
         await ws_client.send(WebRTCOffer(offer_sdp, config.configuration.ice_servers))
 
+    @override
     async def async_on_webrtc_candidate(
         self, session_id: str, candidate: RTCIceCandidateInit
     ) -> None:
@@ -339,11 +344,13 @@ class WebRTCProvider(CameraWebRTCProvider):
             _LOGGER.debug("Unknown session %s. Ignoring candidate", session_id)
 
     @callback
+    @override
     def async_close_session(self, session_id: str) -> None:
         """Close the session."""
         ws_client = self._sessions.pop(session_id)
         self._hass.async_create_task(ws_client.close())
 
+    @override
     async def async_get_image(
         self,
         camera: Camera,

--- a/homeassistant/components/goalzero/binary_sensor.py
+++ b/homeassistant/components/goalzero/binary_sensor.py
@@ -1,6 +1,6 @@
 """Support for Goal Zero Yeti Sensors."""
 
-from typing import cast
+from typing import cast, override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -55,6 +55,7 @@ class GoalZeroBinarySensor(GoalZeroEntity, BinarySensorEntity):
     """Representation of a Goal Zero Yeti sensor."""
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return True if the service is on."""
         return cast(bool, self._api.data[self.entity_description.key] == 1)

--- a/homeassistant/components/goalzero/config_flow.py
+++ b/homeassistant/components/goalzero/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Goal Zero Yeti integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from goalzero import Yeti, exceptions
 import voluptuous as vol
@@ -24,6 +24,7 @@ class GoalZeroFlowHandler(ConfigFlow, domain=DOMAIN):
 
     _discovered_ip: str
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:
@@ -61,6 +62,7 @@ class GoalZeroFlowHandler(ConfigFlow, domain=DOMAIN):
             },
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/goalzero/coordinator.py
+++ b/homeassistant/components/goalzero/coordinator.py
@@ -1,6 +1,7 @@
 """Data update coordinator for the Goal zero integration."""
 
 from datetime import timedelta
+from typing import override
 
 from goalzero import Yeti, exceptions
 
@@ -31,6 +32,7 @@ class GoalZeroDataUpdateCoordinator(DataUpdateCoordinator[None]):
         )
         self.api = api
 
+    @override
     async def _async_update_data(self) -> None:
         """Fetch data from API endpoint."""
         try:

--- a/homeassistant/components/goalzero/entity.py
+++ b/homeassistant/components/goalzero/entity.py
@@ -1,5 +1,7 @@
 """Entity representing a Goal Zero Yeti device."""
 
+from typing import override
+
 from goalzero import Yeti
 
 from homeassistant.const import ATTR_MODEL, CONF_NAME
@@ -29,6 +31,7 @@ class GoalZeroEntity(CoordinatorEntity[GoalZeroDataUpdateCoordinator]):
         self._attr_unique_id = f"{coordinator.config_entry.entry_id}/{description.key}"
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return the device information of the entity."""
         return DeviceInfo(

--- a/homeassistant/components/goalzero/sensor.py
+++ b/homeassistant/components/goalzero/sensor.py
@@ -1,6 +1,6 @@
 """Support for Goal Zero Yeti Sensors."""
 
-from typing import cast
+from typing import cast, override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -142,6 +142,7 @@ class GoalZeroSensor(GoalZeroEntity, SensorEntity):
     """Representation of a Goal Zero Yeti sensor."""
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state."""
         return cast(StateType, self._api.data[self.entity_description.key])

--- a/homeassistant/components/goalzero/switch.py
+++ b/homeassistant/components/goalzero/switch.py
@@ -1,6 +1,6 @@
 """Support for Goal Zero Yeti Switches."""
 
-from typing import Any, cast
+from typing import Any, cast, override
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.core import HomeAssistant
@@ -40,16 +40,19 @@ class GoalZeroSwitch(GoalZeroEntity, SwitchEntity):
     """Representation of a Goal Zero Yeti switch."""
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return state of the switch."""
         return cast(bool, self._api.data[self.entity_description.key] == 1)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
         payload = {self.entity_description.key: 0}
         await self._api.post_state(payload=payload)
         self.coordinator.async_set_updated_data(None)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
         payload = {self.entity_description.key: 1}

--- a/homeassistant/components/gogogate2/config_flow.py
+++ b/homeassistant/components/gogogate2/config_flow.py
@@ -3,7 +3,7 @@
 import dataclasses
 import logging
 import re
-from typing import Any, Self
+from typing import Any, Self, override
 
 from ismartgate.common import AbstractInfoResponse, ApiError
 from ismartgate.const import GogoGate2ApiErrorCode, ISmartGateApiErrorCode
@@ -44,6 +44,7 @@ class Gogogate2FlowHandler(ConfigFlow, domain=DOMAIN):
         self._ip_address: str | None = None
         self._device_type: str | None = None
 
+    @override
     async def async_step_homekit(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
@@ -51,6 +52,7 @@ class Gogogate2FlowHandler(ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(discovery_info.properties[ATTR_PROPERTIES_ID])
         return await self._async_discovery_handler(discovery_info.host)
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:
@@ -71,10 +73,12 @@ class Gogogate2FlowHandler(ConfigFlow, domain=DOMAIN):
         self._device_type = DEVICE_TYPE_ISMARTGATE
         return await self.async_step_user()
 
+    @override
     def is_matching(self, other_flow: Self) -> bool:
         """Return True if other_flow is matching this flow."""
         return other_flow._ip_address == self._ip_address
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/gogogate2/cover.py
+++ b/homeassistant/components/gogogate2/cover.py
@@ -1,6 +1,6 @@
 """Support for Gogogate2 garage Doors."""
 
-from typing import Any
+from typing import Any, override
 
 from ismartgate.common import (
     AbstractDoor,
@@ -57,11 +57,13 @@ class DeviceCover(GoGoGate2Entity, CoverEntity):
         )
 
     @property
+    @override
     def name(self) -> str | None:
         """Return the name of the door."""
         return self.door.name
 
     @property
+    @override
     def is_closed(self) -> bool | None:
         """Return true if cover is closed, else False."""
         door_status = self.door_status
@@ -72,20 +74,24 @@ class DeviceCover(GoGoGate2Entity, CoverEntity):
         return None
 
     @property
+    @override
     def is_closing(self) -> bool:
         """Return if the cover is closing or not."""
         return self.door_status == TransitionDoorStatus.CLOSING
 
     @property
+    @override
     def is_opening(self) -> bool:
         """Return if the cover is opening or not."""
         return self.door_status == TransitionDoorStatus.OPENING
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the door."""
         await self._api.async_open_door(self._door_id)
         await self.coordinator.async_refresh()
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the door."""
         await self._api.async_close_door(self._door_id)

--- a/homeassistant/components/gogogate2/entity.py
+++ b/homeassistant/components/gogogate2/entity.py
@@ -1,6 +1,6 @@
 """Common code for GogoGate2 component."""
 
-from typing import Any
+from typing import Any, override
 
 from ismartgate.common import AbstractDoor, get_door_by_id
 
@@ -45,6 +45,7 @@ class GoGoGate2Entity(CoordinatorEntity[DeviceDataUpdateCoordinator]):
         return door_with_statuses[self._door_id]
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Device info for the controller."""
         data = self.coordinator.data
@@ -62,6 +63,7 @@ class GoGoGate2Entity(CoordinatorEntity[DeviceDataUpdateCoordinator]):
         )
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         return {"door_id": self._door_id}

--- a/homeassistant/components/gogogate2/sensor.py
+++ b/homeassistant/components/gogogate2/sensor.py
@@ -1,7 +1,7 @@
 """Support for Gogogate2 garage Doors."""
 
 from itertools import chain
-from typing import Any
+from typing import Any, override
 
 from ismartgate.common import AbstractDoor, get_configured_doors
 
@@ -48,6 +48,7 @@ class DoorSensorEntity(GoGoGate2Entity, SensorEntity):
     """Base class for door sensor entities."""
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         attrs = super().extra_state_attributes
@@ -76,11 +77,13 @@ class DoorSensorBattery(DoorSensorEntity):
         super().__init__(config_entry, data_update_coordinator, door, unique_id)
 
     @property
+    @override
     def name(self):
         """Return the name of the door."""
         return f"{self.door.name} battery"
 
     @property
+    @override
     def native_value(self):
         """Return the state of the entity."""
         return self.door.voltage  # This is a percentage, not an absolute voltage
@@ -104,11 +107,13 @@ class DoorSensorTemperature(DoorSensorEntity):
         super().__init__(config_entry, data_update_coordinator, door, unique_id)
 
     @property
+    @override
     def name(self):
         """Return the name of the door."""
         return f"{self.door.name} temperature"
 
     @property
+    @override
     def native_value(self):
         """Return the state of the entity."""
         return self.door.temperature

--- a/homeassistant/components/goodwe/button.py
+++ b/homeassistant/components/goodwe/button.py
@@ -4,6 +4,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import datetime
 import logging
+from typing import override
 
 from goodwe import Inverter, InverterError
 
@@ -73,6 +74,7 @@ class GoodweButtonEntity(ButtonEntity):
         self._attr_device_info = device_info
         self._inverter: Inverter = inverter
 
+    @override
     async def async_press(self) -> None:
         """Triggers the button press service."""
         await self.entity_description.action(self._inverter)

--- a/homeassistant/components/goodwe/config_flow.py
+++ b/homeassistant/components/goodwe/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow to configure Goodwe inverters using their local API."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from goodwe import Inverter, InverterError, connect
 from goodwe.const import GOODWE_TCP_PORT, GOODWE_UDP_PORT
@@ -45,6 +45,7 @@ class GoodweFlowHandler(ConfigFlow, domain=DOMAIN):
             },
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/goodwe/coordinator.py
+++ b/homeassistant/components/goodwe/coordinator.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 import logging
-from typing import Any
+from typing import Any, override
 
 from goodwe import Inverter, InverterError, RequestFailedException
 
@@ -49,6 +49,7 @@ class GoodweUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.inverter: Inverter = inverter
         self._last_data: dict[str, Any] = {}
 
+    @override
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from the inverter."""
         try:

--- a/homeassistant/components/goodwe/number.py
+++ b/homeassistant/components/goodwe/number.py
@@ -3,6 +3,7 @@
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 import logging
+from typing import override
 
 from goodwe import Inverter, InverterError
 
@@ -134,6 +135,7 @@ class InverterNumberEntity(NumberEntity):
         value = await self.entity_description.getter(self._inverter)
         self._attr_native_value = float(value)
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
         await self.entity_description.setter(self._inverter, int(value))

--- a/homeassistant/components/goodwe/select.py
+++ b/homeassistant/components/goodwe/select.py
@@ -1,6 +1,7 @@
 """GoodWe PV inverter selection settings entities."""
 
 import logging
+from typing import override
 
 from goodwe import Inverter, InverterError, OperationMode
 
@@ -102,6 +103,7 @@ class InverterOperationModeEntity(SelectEntity):
         value = await self._inverter.get_operation_mode()
         self._attr_current_option = _MODE_TO_OPTION[value]
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self._inverter.set_operation_mode(_OPTION_TO_MODE[option])

--- a/homeassistant/components/goodwe/sensor.py
+++ b/homeassistant/components/goodwe/sensor.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from decimal import Decimal
 import logging
-from typing import Any
+from typing import Any, override
 
 from goodwe import Inverter, Sensor, SensorKind
 
@@ -227,11 +227,13 @@ class InverterSensor(CoordinatorEntity[GoodweUpdateCoordinator], SensorEntity):
         self._stop_reset: Callable[[], None] | None = None
 
     @property
+    @override
     def native_value(self) -> StateType | date | datetime | Decimal:
         """Return the value reported by the sensor."""
         return self.entity_description.value(self.coordinator, self._sensor.id_)
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available.
 
@@ -262,6 +264,7 @@ class InverterSensor(CoordinatorEntity[GoodweUpdateCoordinator], SensorEntity):
             self.hass, self.async_reset, next_midnight
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Schedule reset task at midnight."""
         if self._sensor.id_ in DAILY_RESET:
@@ -273,6 +276,7 @@ class InverterSensor(CoordinatorEntity[GoodweUpdateCoordinator], SensorEntity):
             )
         await super().async_added_to_hass()
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Remove reset task at midnight."""
         if self._sensor.id_ in DAILY_RESET and self._stop_reset is not None:

--- a/homeassistant/components/google/api.py
+++ b/homeassistant/components/google/api.py
@@ -2,7 +2,7 @@
 
 import datetime
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 import aiohttp
 from gcal_sync.auth import AbstractAuth
@@ -44,6 +44,7 @@ class InvalidCredential(OAuthError):
 class GoogleHybridAuth(AuthImplementation):
     """OAuth implementation that supports both Web Auth (base class) and Device Auth."""
 
+    @override
     async def async_resolve_external_data(self, external_data: Any) -> dict:
         """Resolve a Google API Credentials object to Home Assistant token."""
         if DEVICE_AUTH_CREDS not in external_data:
@@ -195,6 +196,7 @@ class ApiAuthImpl(AbstractAuth):
         super().__init__(websession)
         self._session = session
 
+    @override
     async def async_get_access_token(self) -> str:
         """Return a valid access token."""
         await self._session.async_ensure_token_valid()
@@ -218,6 +220,7 @@ class AccessTokenAuthImpl(AbstractAuth):
         super().__init__(websession)
         self._access_token = access_token
 
+    @override
     async def async_get_access_token(self) -> str:
         """Return the access token."""
         return self._access_token

--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 import dataclasses
 from datetime import datetime, timedelta
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from gcal_sync.api import Range, SyncEventsRequest
 from gcal_sync.exceptions import ApiException
@@ -364,6 +364,7 @@ class GoogleCalendarEntity(
             )
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, bool]:
         """Return the device state attributes."""
         return {"offset_reached": self.offset_reached}
@@ -377,6 +378,7 @@ class GoogleCalendarEntity(
         return False
 
     @property
+    @override
     def event(self) -> CalendarEvent | None:
         """Return the next upcoming event."""
         (event, _) = self._event_with_offset()
@@ -406,6 +408,7 @@ class GoogleCalendarEntity(
             return True
         return event.transparency == OPAQUE
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
@@ -419,6 +422,7 @@ class GoogleCalendarEntity(
             "google.calendar-refresh",
         )
 
+    @override
     async def async_get_events(
         self, hass: HomeAssistant, start_date: datetime, end_date: datetime
     ) -> list[CalendarEvent]:
@@ -448,6 +452,7 @@ class GoogleCalendarEntity(
             return event, offset_value
         return None, None
 
+    @override
     async def async_create_event(self, **kwargs: Any) -> None:
         """Add a new event to calendar."""
         dtstart = kwargs[EVENT_START]
@@ -487,6 +492,7 @@ class GoogleCalendarEntity(
             raise HomeAssistantError(f"Error while creating event: {err!s}") from err
         await self.coordinator.async_refresh()
 
+    @override
     async def async_delete_event(
         self,
         uid: str,

--- a/homeassistant/components/google/config_flow.py
+++ b/homeassistant/components/google/config_flow.py
@@ -3,7 +3,7 @@
 import asyncio
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from gcal_sync.api import GoogleCalendarService
 from gcal_sync.exceptions import ApiException, ApiForbiddenException
@@ -81,11 +81,13 @@ class OAuth2FlowHandler(
         self._web_auth = False
 
     @property
+    @override
     def logger(self) -> logging.Logger:
         """Return logger."""
         return logging.getLogger(__name__)
 
     @property
+    @override
     def extra_authorize_data(self) -> dict[str, Any]:
         """Extra data that needs to be appended to the authorize url."""
         return {
@@ -95,6 +97,7 @@ class OAuth2FlowHandler(
             "prompt": "consent",
         }
 
+    @override
     async def async_step_auth(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -166,6 +169,7 @@ class OAuth2FlowHandler(
             progress_task=self._exchange_finished_task,
         )
 
+    @override
     async def async_step_creation(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -174,6 +178,7 @@ class OAuth2FlowHandler(
             return self.async_abort(reason="code_expired")
         return await super().async_step_creation(user_input)
 
+    @override
     async def async_oauth_create_entry(self, data: dict) -> ConfigFlowResult:
         """Create an entry for the flow, or update existing entry."""
         data[CONF_CREDENTIAL_TYPE] = (
@@ -238,6 +243,7 @@ class OAuth2FlowHandler(
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: GoogleConfigEntry,
     ) -> OptionsFlowHandler:

--- a/homeassistant/components/google/coordinator.py
+++ b/homeassistant/components/google/coordinator.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable
 from datetime import datetime, timedelta
 import itertools
 import logging
+from typing import override
 
 from gcal_sync.api import GoogleCalendarService, ListEventsRequest
 from gcal_sync.exceptions import ApiException
@@ -66,6 +67,7 @@ class CalendarSyncUpdateCoordinator(DataUpdateCoordinator[Timeline]):
         self.sync = sync
         self._upcoming_timeline: Timeline | None = None
 
+    @override
     async def _async_update_data(self) -> Timeline:
         """Fetch data from API endpoint."""
         try:
@@ -150,6 +152,7 @@ class CalendarQueryUpdateCoordinator(DataUpdateCoordinator[list[Event]]):
             raise HomeAssistantError(str(err)) from err
         return result_items
 
+    @override
     async def _async_update_data(self) -> list[Event]:
         """Fetch data from API endpoint."""
         request = ListEventsRequest(calendar_id=self.calendar_id, search=self._search)

--- a/homeassistant/components/google/store.py
+++ b/homeassistant/components/google/store.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 import logging
-from typing import Any
+from typing import Any, override
 
 from gcal_sync.api import GoogleCalendarService
 from gcal_sync.store import CalendarStore
@@ -44,12 +44,14 @@ class LocalCalendarStore(CalendarStore):
         )
         self._data: dict[str, Any] | None = None
 
+    @override
     async def async_load(self) -> dict[str, Any] | None:
         """Load data."""
         if self._data is None:
             self._data = await self._store.async_load() or {}
         return self._data
 
+    @override
     async def async_save(self, data: dict[str, Any]) -> None:
         """Save data."""
         self._data = data

--- a/homeassistant/components/google_air_quality/config_flow.py
+++ b/homeassistant/components/google_air_quality/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for the Google Air Quality integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from google_air_quality_api.api import GoogleAirQualityApi
 from google_air_quality_api.auth import Auth
@@ -178,6 +178,7 @@ class GoogleAirQualityConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -232,6 +233,7 @@ class GoogleAirQualityConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @classmethod
     @callback
+    @override
     def async_get_supported_subentry_types(
         cls, config_entry: ConfigEntry
     ) -> dict[str, type[ConfigSubentryFlow]]:

--- a/homeassistant/components/google_air_quality/coordinator.py
+++ b/homeassistant/components/google_air_quality/coordinator.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import Final
+from typing import Final, override
 
 from google_air_quality_api.api import GoogleAirQualityApi
 from google_air_quality_api.exceptions import GoogleAirQualityApiError
@@ -66,6 +66,7 @@ class GoogleAirQualityUpdateCoordinator(
                 self.custom_local_aqi = custom_laqi
                 self.region_code = region_code
 
+    @override
     async def _async_update_data(self) -> AirQualityCurrentConditionsData:
         """Fetch air quality data for this coordinate."""
         try:

--- a/homeassistant/components/google_air_quality/sensor.py
+++ b/homeassistant/components/google_air_quality/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from google_air_quality_api.model import AirQualityCurrentConditionsData, Index
 
@@ -251,16 +251,19 @@ class AirQualitySensorEntity(
             )
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)
 
     @property
+    @override
     def options(self) -> list[str] | None:
         """Return the option of the sensor."""
         return self.entity_description.options_fn(self.coordinator.data)
 
     @property
+    @override
     def native_unit_of_measurement(self) -> str | None:
         """Return the native unit of measurement of the sensor."""
         return self.entity_description.native_unit_of_measurement_fn(

--- a/homeassistant/components/google_assistant/button.py
+++ b/homeassistant/components/google_assistant/button.py
@@ -1,5 +1,7 @@
 """Support for buttons."""
 
+from typing import override
+
 from homeassistant.components.button import ButtonEntity
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
@@ -49,6 +51,7 @@ class SyncButton(ButtonEntity):
             name="Google Assistant",
         )
 
+    @override
     async def async_press(self) -> None:
         """Press the button."""
         assert self._context

--- a/homeassistant/components/google_assistant/error.py
+++ b/homeassistant/components/google_assistant/error.py
@@ -1,5 +1,7 @@
 """Errors for Google Assistant."""
 
+from typing import override
+
 from .const import ERR_CHALLENGE_NEEDED
 
 
@@ -30,6 +32,7 @@ class ChallengeNeeded(SmartHomeError):
         super().__init__(ERR_CHALLENGE_NEEDED, f"Challenge needed: {challenge_type}")
         self.challenge_type = challenge_type
 
+    @override
     def to_response(self):
         """Convert to a response format."""
         return {

--- a/homeassistant/components/google_assistant/helpers.py
+++ b/homeassistant/components/google_assistant/helpers.py
@@ -8,7 +8,7 @@ from functools import lru_cache
 from http import HTTPStatus
 import logging
 import pprint
-from typing import Any
+from typing import Any, override
 
 from aiohttp.web import json_response
 from awesomeversion import AwesomeVersion
@@ -530,6 +530,7 @@ class GoogleEntity:
         self.entity_id = state.entity_id
         self._traits: list[trait._Trait] | None = None
 
+    @override
     def __repr__(self) -> str:
         """Return the representation."""
         return f"<GoogleEntity {self.entity_id}: {self.state.name}>"

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -3,7 +3,7 @@
 from datetime import timedelta
 from http import HTTPStatus
 import logging
-from typing import Any
+from typing import Any, override
 from uuid import uuid4
 
 from aiohttp import ClientError, ClientResponseError
@@ -88,6 +88,7 @@ class GoogleConfig(AbstractConfig):
         self._access_token = None
         self._access_token_renew = None
 
+    @override
     async def async_initialize(self):
         """Perform async initialization of config."""
         # We need to initialize the store before calling super
@@ -99,25 +100,30 @@ class GoogleConfig(AbstractConfig):
         self.async_enable_local_sdk()
 
     @property
+    @override
     def enabled(self):
         """Return if Google is enabled."""
         return True
 
     @property
+    @override
     def entity_config(self):
         """Return entity config."""
         return self._config.get(CONF_ENTITY_CONFIG) or {}
 
     @property
+    @override
     def secure_devices_pin(self):
         """Return entity config."""
         return self._config.get(CONF_SECURE_DEVICES_PIN)
 
     @property
+    @override
     def should_report_state(self):
         """Return if states should be proactively reported."""
         return self._config.get(CONF_REPORT_STATE)
 
+    @override
     def get_local_user_id(self, webhook_id):
         """Map webhook ID to a Home Assistant user ID.
 
@@ -136,16 +142,19 @@ class GoogleConfig(AbstractConfig):
 
         return found_agent_user_id
 
+    @override
     def get_local_webhook_id(self, agent_user_id):
         """Return the webhook ID for a given agent user id via the local SDK."""
         if data := self._store.agent_user_ids.get(agent_user_id):
             return data[STORE_GOOGLE_LOCAL_WEBHOOK_ID]
         return None
 
+    @override
     def get_agent_user_id_from_context(self, context):
         """Get agent user ID making request."""
         return context.user_id
 
+    @override
     def get_agent_user_id_from_webhook(self, webhook_id):
         """Map webhook ID to a Google agent user ID.
 
@@ -157,6 +166,7 @@ class GoogleConfig(AbstractConfig):
 
         return None
 
+    @override
     def should_expose(self, entity_id: str) -> bool:
         """Return if entity should be exposed."""
         expose_by_default = self._config.get(CONF_EXPOSE_BY_DEFAULT)
@@ -189,10 +199,12 @@ class GoogleConfig(AbstractConfig):
 
         return is_default_exposed or explicit_expose
 
+    @override
     def should_2fa(self, state):
         """If an entity should have 2FA checked."""
         return True
 
+    @override
     async def _async_request_sync_devices(self, agent_user_id: str) -> HTTPStatus:
         if CONF_SERVICE_ACCOUNT in self._config:
             return await self.async_call_homegraph_api(
@@ -202,6 +214,7 @@ class GoogleConfig(AbstractConfig):
         _LOGGER.error("No configuration for request_sync available")
         return HTTPStatus.INTERNAL_SERVER_ERROR
 
+    @override
     async def async_connect_agent_user(self, agent_user_id: str):
         """Add a synced and known agent_user_id.
 
@@ -209,6 +222,7 @@ class GoogleConfig(AbstractConfig):
         """
         self._store.add_agent_user_id(agent_user_id)
 
+    @override
     async def async_disconnect_agent_user(self, agent_user_id: str):
         """Turn off report state and disable further state reporting.
 
@@ -220,6 +234,7 @@ class GoogleConfig(AbstractConfig):
         self._store.pop_agent_user_id(agent_user_id)
 
     @callback
+    @override
     def async_get_agent_users(self):
         """Return known agent users."""
         return self._store.agent_user_ids
@@ -277,6 +292,7 @@ class GoogleConfig(AbstractConfig):
             _LOGGER.error("Could not contact %s", url)
             return HTTPStatus.INTERNAL_SERVER_ERROR
 
+    @override
     async def async_report_state(
         self, message: dict[str, Any], agent_user_id: str, event_id: str | None = None
     ) -> HTTPStatus:

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -3,7 +3,7 @@
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components import (
     alarm_control_panel,
@@ -325,6 +325,7 @@ class BrightnessTrait(_Trait):
     commands = [COMMAND_BRIGHTNESS_ABSOLUTE]
 
     @staticmethod
+    @override
     def supported(domain, features, device_class, attributes):
         """Test if state is supported."""
         if domain == light.DOMAIN:
@@ -333,10 +334,12 @@ class BrightnessTrait(_Trait):
 
         return False
 
+    @override
     def sync_attributes(self) -> dict[str, Any]:
         """Return brightness attributes for a sync request."""
         return {}
 
+    @override
     def query_attributes(self) -> dict[str, Any]:
         """Return brightness query attributes."""
         domain = self.state.domain
@@ -349,6 +352,7 @@ class BrightnessTrait(_Trait):
 
         return response
 
+    @override
     async def execute(self, command, data, params, challenge):
         """Execute a brightness command."""
         if self.state.domain == light.DOMAIN:
@@ -377,6 +381,7 @@ class CameraStreamTrait(_Trait):
     stream_info: dict[str, str] | None = None
 
     @staticmethod
+    @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
         if domain == camera.DOMAIN:
@@ -384,6 +389,7 @@ class CameraStreamTrait(_Trait):
 
         return False
 
+    @override
     def sync_attributes(self) -> dict[str, Any]:
         """Return stream attributes for a sync request."""
         return {
@@ -392,10 +398,12 @@ class CameraStreamTrait(_Trait):
             "cameraStreamNeedDrmEncryption": False,
         }
 
+    @override
     def query_attributes(self) -> dict[str, Any]:
         """Return camera stream attributes."""
         return self.stream_info or {}
 
+    @override
     async def execute(self, command, data, params, challenge):
         """Execute a get camera stream command."""
         url = await camera.async_request_stream(self.hass, self.state.entity_id, "hls")
@@ -416,24 +424,29 @@ class ObjectDetection(_Trait):
     commands = []
 
     @staticmethod
+    @override
     def supported(domain, features, device_class, _) -> bool:
         """Test if state is supported."""
         return (
             domain == event.DOMAIN and device_class == event.EventDeviceClass.DOORBELL
         )
 
+    @override
     def sync_attributes(self) -> dict[str, Any]:
         """Return ObjectDetection attributes for a sync request."""
         return {}
 
+    @override
     def sync_options(self) -> dict[str, Any]:
         """Add options for the sync request."""
         return {"notificationSupportedByAgent": True}
 
+    @override
     def query_attributes(self) -> dict[str, Any]:
         """Return ObjectDetection query attributes."""
         return {}
 
+    @override
     def query_notifications(self) -> dict[str, Any] | None:
         """Return notifications payload."""
 
@@ -459,6 +472,7 @@ class ObjectDetection(_Trait):
             },
         }
 
+    @override
     async def execute(self, command, data, params, challenge):
         """Execute an ObjectDetection command."""
 
@@ -474,6 +488,7 @@ class OnOffTrait(_Trait):
     commands = [COMMAND_ON_OFF]
 
     @staticmethod
+    @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
         if domain == water_heater.DOMAIN and features & WaterHeaterEntityFeature.ON_OFF:
@@ -494,16 +509,19 @@ class OnOffTrait(_Trait):
             humidifier.DOMAIN,
         )
 
+    @override
     def sync_attributes(self) -> dict[str, Any]:
         """Return OnOff attributes for a sync request."""
         if self.state.attributes.get(ATTR_ASSUMED_STATE, False):
             return {"commandOnlyOnOff": True}
         return {}
 
+    @override
     def query_attributes(self) -> dict[str, Any]:
         """Return OnOff query attributes."""
         return {"on": self.state.state not in (STATE_OFF, STATE_UNKNOWN)}
 
+    @override
     async def execute(self, command, data, params, challenge):
         """Execute an OnOff command."""
         if (domain := self.state.domain) == group.DOMAIN:
@@ -534,6 +552,7 @@ class ColorSettingTrait(_Trait):
     commands = [COMMAND_COLOR_ABSOLUTE]
 
     @staticmethod
+    @override
     def supported(domain, features, device_class, attributes):
         """Test if state is supported."""
         if domain != light.DOMAIN:
@@ -544,6 +563,7 @@ class ColorSettingTrait(_Trait):
             color_modes
         )
 
+    @override
     def sync_attributes(self) -> dict[str, Any]:
         """Return color temperature attributes for a sync request."""
         attrs = self.state.attributes
@@ -561,6 +581,7 @@ class ColorSettingTrait(_Trait):
 
         return response
 
+    @override
     def query_attributes(self) -> dict[str, Any]:
         """Return color temperature query attributes."""
         color_mode = self.state.attributes.get(light.ATTR_COLOR_MODE)
@@ -596,6 +617,7 @@ class ColorSettingTrait(_Trait):
 
         return response
 
+    @override
     async def execute(self, command, data, params, challenge):
         """Execute a color temperature command."""
         if "temperature" in params["color"]:
@@ -664,6 +686,7 @@ class SceneTrait(_Trait):
     commands = [COMMAND_ACTIVATE_SCENE]
 
     @staticmethod
+    @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
         return domain in (
@@ -673,15 +696,18 @@ class SceneTrait(_Trait):
             script.DOMAIN,
         )
 
+    @override
     def sync_attributes(self) -> dict[str, Any]:
         """Return scene attributes for a sync request."""
         # None of the supported domains can support sceneReversible
         return {}
 
+    @override
     def query_attributes(self) -> dict[str, Any]:
         """Return scene query attributes."""
         return {}
 
+    @override
     async def execute(self, command, data, params, challenge):
         """Execute a scene command."""
         service = SERVICE_TURN_ON
@@ -713,14 +739,17 @@ class DockTrait(_Trait):
     commands = [COMMAND_DOCK]
 
     @staticmethod
+    @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
         return domain in (vacuum.DOMAIN, lawn_mower.DOMAIN)
 
+    @override
     def sync_attributes(self) -> dict[str, Any]:
         """Return dock attributes for a sync request."""
         return {}
 
+    @override
     def query_attributes(self) -> dict[str, Any]:
         """Return dock query attributes."""
         domain = self.state.domain
@@ -731,6 +760,7 @@ class DockTrait(_Trait):
             return {"isDocked": state == lawn_mower.LawnMowerActivity.DOCKED}
         raise NotImplementedError(f"Unsupported domain {domain}")
 
+    @override
     async def execute(self, command, data, params, challenge):
         """Execute a dock command."""
         domain = self.state.domain
@@ -762,18 +792,22 @@ class LocatorTrait(_Trait):
     commands = [COMMAND_LOCATE]
 
     @staticmethod
+    @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
         return domain == vacuum.DOMAIN and features & VacuumEntityFeature.LOCATE
 
+    @override
     def sync_attributes(self) -> dict[str, Any]:
         """Return locator attributes for a sync request."""
         return {}
 
+    @override
     def query_attributes(self) -> dict[str, Any]:
         """Return locator query attributes."""
         return {}
 
+    @override
     async def execute(self, command, data, params, challenge):
         """Execute a locate command."""
         if params.get("silence", False):
@@ -802,10 +836,12 @@ class EnergyStorageTrait(_Trait):
     commands = [COMMAND_CHARGE]
 
     @staticmethod
+    @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
         return domain == vacuum.DOMAIN and features & VacuumEntityFeature.BATTERY
 
+    @override
     def sync_attributes(self) -> dict[str, Any]:
         """Return EnergyStorage attributes for a sync request."""
         return {
@@ -813,6 +849,7 @@ class EnergyStorageTrait(_Trait):
             "queryOnlyEnergyStorage": True,
         }
 
+    @override
     def query_attributes(self) -> dict[str, Any]:
         """Return EnergyStorage query attributes."""
         battery_level = self.state.attributes.get(ATTR_BATTERY_LEVEL)
@@ -838,6 +875,7 @@ class EnergyStorageTrait(_Trait):
             "isPluggedIn": self.state.state == vacuum.VacuumActivity.DOCKED,
         }
 
+    @override
     async def execute(self, command, data, params, challenge):
         """Execute a dock command."""
         raise SmartHomeError(
@@ -857,6 +895,7 @@ class StartStopTrait(_Trait):
     commands = [COMMAND_START_STOP, COMMAND_PAUSE_UNPAUSE]
 
     @staticmethod
+    @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
         if domain in (vacuum.DOMAIN, lawn_mower.DOMAIN):
@@ -870,6 +909,7 @@ class StartStopTrait(_Trait):
 
         return False
 
+    @override
     def sync_attributes(self) -> dict[str, Any]:
         """Return StartStop attributes for a sync request."""
         domain = self.state.domain
@@ -908,6 +948,7 @@ class StartStopTrait(_Trait):
 
         raise NotImplementedError(f"Unsupported domain {domain}")
 
+    @override
     def query_attributes(self) -> dict[str, Any]:
         """Return StartStop query attributes."""
         domain = self.state.domain
@@ -944,6 +985,7 @@ class StartStopTrait(_Trait):
 
         raise NotImplementedError(f"Unsupported domain {domain}")
 
+    @override
     async def execute(self, command, data, params, challenge):
         """Execute a StartStop command."""
         domain = self.state.domain
@@ -1103,6 +1145,7 @@ class TemperatureControlTrait(_Trait):
     ]
 
     @staticmethod
+    @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
         return (
@@ -1113,6 +1156,7 @@ class TemperatureControlTrait(_Trait):
             and device_class == sensor.SensorDeviceClass.TEMPERATURE
         )
 
+    @override
     def sync_attributes(self) -> dict[str, Any]:
         """Return temperature attributes for a sync request."""
         response = {}
@@ -1151,6 +1195,7 @@ class TemperatureControlTrait(_Trait):
 
         return response
 
+    @override
     def query_attributes(self) -> dict[str, Any]:
         """Return temperature states."""
         response = {}
@@ -1193,6 +1238,7 @@ class TemperatureControlTrait(_Trait):
 
         return response
 
+    @override
     async def execute(self, command, data, params, challenge):
         """Execute a temperature point or mode command."""
         # All sent in temperatures are always in Celsius
@@ -1266,6 +1312,7 @@ class TemperatureSettingTrait(_Trait):
     }
 
     @staticmethod
+    @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
         return domain == climate.DOMAIN
@@ -1288,6 +1335,7 @@ class TemperatureSettingTrait(_Trait):
 
         return modes
 
+    @override
     def sync_attributes(self) -> dict[str, Any]:
         """Return temperature point and modes attributes for a sync request."""
         response = {}
@@ -1333,6 +1381,7 @@ class TemperatureSettingTrait(_Trait):
 
         return response
 
+    @override
     def query_attributes(self) -> dict[str, Any]:
         """Return temperature point and modes query attributes."""
         response: dict[str, Any] = {}
@@ -1403,6 +1452,7 @@ class TemperatureSettingTrait(_Trait):
 
         return response
 
+    @override
     async def execute(self, command, data, params, challenge):
         """Execute a temperature point or mode command."""
         # All sent in temperatures are always in Celsius
@@ -1543,6 +1593,7 @@ class HumiditySettingTrait(_Trait):
     commands = [COMMAND_SET_HUMIDITY]
 
     @staticmethod
+    @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
         if domain == humidifier.DOMAIN:
@@ -1553,6 +1604,7 @@ class HumiditySettingTrait(_Trait):
             and device_class == sensor.SensorDeviceClass.HUMIDITY
         )
 
+    @override
     def sync_attributes(self) -> dict[str, Any]:
         """Return humidity attributes for a sync request."""
         response: dict[str, Any] = {}
@@ -1576,6 +1628,7 @@ class HumiditySettingTrait(_Trait):
 
         return response
 
+    @override
     def query_attributes(self) -> dict[str, Any]:
         """Return humidity query attributes."""
         response = {}
@@ -1599,6 +1652,7 @@ class HumiditySettingTrait(_Trait):
 
         return response
 
+    @override
     async def execute(self, command, data, params, challenge):
         """Execute a humidity command."""
         if self.state.domain == sensor.DOMAIN:
@@ -1630,19 +1684,23 @@ class LockUnlockTrait(_Trait):
     commands = [COMMAND_LOCK_UNLOCK]
 
     @staticmethod
+    @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
         return domain == lock.DOMAIN
 
     @staticmethod
+    @override
     def might_2fa(domain, features, device_class):
         """Return if the trait might ask for 2FA."""
         return True
 
+    @override
     def sync_attributes(self) -> dict[str, Any]:
         """Return LockUnlock attributes for a sync request."""
         return {}
 
+    @override
     def query_attributes(self) -> dict[str, Any]:
         """Return LockUnlock query attributes."""
         if self.state.state == LockState.JAMMED:
@@ -1651,6 +1709,7 @@ class LockUnlockTrait(_Trait):
         # If its unlocking its not yet unlocked so we consider is locked
         return {"isLocked": self.state.state in (LockState.UNLOCKING, LockState.LOCKED)}
 
+    @override
     async def execute(self, command, data, params, challenge):
         """Execute an LockUnlock command."""
         if params["lock"]:
@@ -1698,11 +1757,13 @@ class ArmDisArmTrait(_Trait):
     """The list of states to support in increasing security state."""
 
     @staticmethod
+    @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
         return domain == alarm_control_panel.DOMAIN
 
     @staticmethod
+    @override
     def might_2fa(domain, features, device_class):
         """Return if the trait might ask for 2FA."""
         return True
@@ -1727,6 +1788,7 @@ class ArmDisArmTrait(_Trait):
 
         return states[0]
 
+    @override
     def sync_attributes(self) -> dict[str, Any]:
         """Return ArmDisarm attributes for a sync request."""
         response = {}
@@ -1747,6 +1809,7 @@ class ArmDisArmTrait(_Trait):
         response["availableArmLevels"] = {"levels": levels, "ordered": True}
         return response
 
+    @override
     def query_attributes(self) -> dict[str, Any]:
         """Return ArmDisarm query attributes."""
         armed_state = self.state.attributes.get("next_state", self.state.state)
@@ -1758,6 +1821,7 @@ class ArmDisArmTrait(_Trait):
             "currentArmLevel": self._default_arm_state(),
         }
 
+    @override
     async def execute(self, command, data, params, challenge):
         """Execute an ArmDisarm command."""
         if params["arm"] and not params.get("cancel"):
@@ -1836,6 +1900,7 @@ class FanSpeedTrait(_Trait):
                 self._ordered_speed = []
 
     @staticmethod
+    @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
         if domain == fan.DOMAIN:
@@ -1844,6 +1909,7 @@ class FanSpeedTrait(_Trait):
             return features & ClimateEntityFeature.FAN_MODE
         return False
 
+    @override
     def sync_attributes(self) -> dict[str, Any]:
         """Return speed point and modes attributes for a sync request."""
         domain = self.state.domain
@@ -1897,6 +1963,7 @@ class FanSpeedTrait(_Trait):
 
         return result
 
+    @override
     def query_attributes(self) -> dict[str, Any]:
         """Return speed point and modes query attributes."""
 
@@ -1968,6 +2035,7 @@ class FanSpeedTrait(_Trait):
                 context=data.context,
             )
 
+    @override
     async def execute(self, command, data, params, challenge):
         """Execute a smart home command."""
         if command == COMMAND_SET_FAN_SPEED:
@@ -1993,6 +2061,7 @@ class ModesTrait(_Trait):
     }
 
     @staticmethod
+    @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
         if domain == fan.DOMAIN and features & FanEntityFeature.PRESET_MODE:
@@ -2045,6 +2114,7 @@ class ModesTrait(_Trait):
             )
         return mode
 
+    @override
     def sync_attributes(self) -> dict[str, Any]:
         """Return mode attributes for a sync request."""
         modes = []
@@ -2069,6 +2139,7 @@ class ModesTrait(_Trait):
 
         return {"availableModes": modes}
 
+    @override
     def query_attributes(self) -> dict[str, Any]:
         """Return current modes."""
         attrs = self.state.attributes
@@ -2102,6 +2173,7 @@ class ModesTrait(_Trait):
 
         return response
 
+    @override
     async def execute(self, command, data, params, challenge):
         """Execute a SetModes command."""
         settings = params.get("updateModeSettings")
@@ -2224,6 +2296,7 @@ class InputSelectorTrait(_Trait):
     SYNONYMS: dict[str, list[str]] = {}
 
     @staticmethod
+    @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
         if domain == media_player.DOMAIN and (
@@ -2233,6 +2306,7 @@ class InputSelectorTrait(_Trait):
 
         return False
 
+    @override
     def sync_attributes(self) -> dict[str, Any]:
         """Return mode attributes for a sync request."""
         attrs = self.state.attributes
@@ -2244,11 +2318,13 @@ class InputSelectorTrait(_Trait):
 
         return {"availableInputs": inputs, "orderedInputs": True}
 
+    @override
     def query_attributes(self) -> dict[str, Any]:
         """Return current modes."""
         attrs = self.state.attributes
         return {"currentInput": attrs.get(media_player.ATTR_INPUT_SOURCE, "")}
 
+    @override
     async def execute(self, command, data, params, challenge):
         """Execute an SetInputSource command."""
         sources = self.state.attributes.get(media_player.ATTR_INPUT_SOURCE_LIST) or []
@@ -2296,6 +2372,7 @@ class OpenCloseTrait(_Trait):
     commands = [COMMAND_OPEN_CLOSE, COMMAND_OPEN_CLOSE_RELATIVE]
 
     @staticmethod
+    @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
         if domain in COVER_VALVE_DOMAINS:
@@ -2310,10 +2387,12 @@ class OpenCloseTrait(_Trait):
         )
 
     @staticmethod
+    @override
     def might_2fa(domain, features, device_class):
         """Return if the trait might ask for 2FA."""
         return domain == cover.DOMAIN and device_class in OpenCloseTrait.COVER_2FA
 
+    @override
     def sync_attributes(self) -> dict[str, Any]:
         """Return opening direction."""
         response = {}
@@ -2350,6 +2429,7 @@ class OpenCloseTrait(_Trait):
 
         return response
 
+    @override
     def query_attributes(self) -> dict[str, Any]:
         """Return state query attributes."""
         domain = self.state.domain
@@ -2385,6 +2465,7 @@ class OpenCloseTrait(_Trait):
 
         return response
 
+    @override
     async def execute(self, command, data, params, challenge):
         """Execute an Open, close, Set position command."""
         domain = self.state.domain
@@ -2449,6 +2530,7 @@ class VolumeTrait(_Trait):
     commands = [COMMAND_SET_VOLUME, COMMAND_VOLUME_RELATIVE, COMMAND_MUTE]
 
     @staticmethod
+    @override
     def supported(domain, features, device_class, _):
         """Test if trait is supported."""
         if domain == media_player.DOMAIN:
@@ -2459,6 +2541,7 @@ class VolumeTrait(_Trait):
 
         return False
 
+    @override
     def sync_attributes(self) -> dict[str, Any]:
         """Return volume attributes for a sync request."""
         features = self.state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
@@ -2476,6 +2559,7 @@ class VolumeTrait(_Trait):
             "levelStepSize": 10,
         }
 
+    @override
     def query_attributes(self) -> dict[str, Any]:
         """Return volume query attributes."""
         response = {}
@@ -2561,6 +2645,7 @@ class VolumeTrait(_Trait):
             context=data.context,
         )
 
+    @override
     async def execute(self, command, data, params, challenge):
         """Execute a volume command."""
         if command == COMMAND_SET_VOLUME:
@@ -2630,6 +2715,7 @@ class TransportControlTrait(_Trait):
     ]
 
     @staticmethod
+    @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
         if domain == media_player.DOMAIN:
@@ -2639,6 +2725,7 @@ class TransportControlTrait(_Trait):
 
         return False
 
+    @override
     def sync_attributes(self) -> dict[str, Any]:
         """Return opening direction."""
         response = {}
@@ -2654,10 +2741,12 @@ class TransportControlTrait(_Trait):
 
         return response
 
+    @override
     def query_attributes(self) -> dict[str, Any]:
         """Return the attributes of this trait for this entity."""
         return {}
 
+    @override
     async def execute(self, command, data, params, challenge):
         """Execute a media command."""
         service_attrs = {ATTR_ENTITY_ID: self.state.entity_id}
@@ -2749,14 +2838,17 @@ class MediaStateTrait(_Trait):
     }
 
     @staticmethod
+    @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
         return domain == media_player.DOMAIN
 
+    @override
     def sync_attributes(self) -> dict[str, Any]:
         """Return attributes for a sync request."""
         return {"supportActivityState": True, "supportPlaybackState": True}
 
+    @override
     def query_attributes(self) -> dict[str, Any]:
         """Return the attributes of this trait for this entity."""
         return {
@@ -2776,6 +2868,7 @@ class ChannelTrait(_Trait):
     commands = [COMMAND_SELECT_CHANNEL]
 
     @staticmethod
+    @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
         if (
@@ -2791,14 +2884,17 @@ class ChannelTrait(_Trait):
 
         return False
 
+    @override
     def sync_attributes(self) -> dict[str, Any]:
         """Return attributes for a sync request."""
         return {"availableChannels": [], "commandOnlyChannels": True}
 
+    @override
     def query_attributes(self) -> dict[str, Any]:
         """Return channel query attributes."""
         return {}
 
+    @override
     async def execute(self, command, data, params, challenge):
         """Execute an setChannel command."""
         if command == COMMAND_SELECT_CHANNEL:
@@ -2879,12 +2975,14 @@ class SensorStateTrait(_Trait):
         return "hazardous"
 
     @classmethod
+    @override
     def supported(cls, domain, features, device_class, _):
         """Test if state is supported."""
         return (domain == sensor.DOMAIN and device_class in cls.sensor_types) or (
             domain == binary_sensor.DOMAIN and device_class in cls.binary_sensor_types
         )
 
+    @override
     def sync_attributes(self) -> dict[str, Any]:
         """Return attributes for a sync request."""
         device_class = self.state.attributes.get(ATTR_DEVICE_CLASS)
@@ -2928,6 +3026,7 @@ class SensorStateTrait(_Trait):
             binary_sensor_data[0], available_states=binary_sensor_data[1]
         )
 
+    @override
     def query_attributes(self) -> dict[str, Any]:
         """Return the attributes of this trait for this entity."""
         device_class = self.state.attributes.get(ATTR_DEVICE_CLASS)

--- a/homeassistant/components/google_assistant_sdk/__init__.py
+++ b/homeassistant/components/google_assistant_sdk/__init__.py
@@ -1,5 +1,7 @@
 """Support for Google Assistant SDK."""
 
+from typing import override
+
 from aiohttp import ClientError
 from gassist_text import TextAssistant
 from google.oauth2.credentials import Credentials
@@ -103,10 +105,12 @@ class GoogleAssistantConversationAgent(conversation.AbstractConversationAgent):
         self.language: str | None = None
 
     @property
+    @override
     def supported_languages(self) -> list[str]:
         """Return a list of supported languages."""
         return SUPPORTED_LANGUAGE_CODES
 
+    @override
     async def async_process(
         self, user_input: conversation.ConversationInput
     ) -> conversation.ConversationResult:

--- a/homeassistant/components/google_assistant_sdk/config_flow.py
+++ b/homeassistant/components/google_assistant_sdk/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -29,11 +29,13 @@ class OAuth2FlowHandler(
     DOMAIN = DOMAIN
 
     @property
+    @override
     def logger(self) -> logging.Logger:
         """Return logger."""
         return logging.getLogger(__name__)
 
     @property
+    @override
     def extra_authorize_data(self) -> dict[str, Any]:
         """Extra data that needs to be appended to the authorize url."""
         return {
@@ -63,6 +65,7 @@ class OAuth2FlowHandler(
             return self.async_show_form(step_id="reauth_confirm")
         return await self.async_step_user()
 
+    @override
     async def async_oauth_create_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
         """Create an entry for the flow, or update existing entry."""
         if self.source == SOURCE_REAUTH:
@@ -84,6 +87,7 @@ class OAuth2FlowHandler(
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: GoogleAssistantSDKConfigEntry,
     ) -> OptionsFlow:

--- a/homeassistant/components/google_assistant_sdk/notify.py
+++ b/homeassistant/components/google_assistant_sdk/notify.py
@@ -1,6 +1,6 @@
 """Support for Google Assistant SDK broadcast notifications."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.notify import ATTR_TARGET, BaseNotificationService
 from homeassistant.core import HomeAssistant
@@ -54,6 +54,7 @@ class BroadcastNotificationService(BaseNotificationService):
         """Initialize the service."""
         self.hass = hass
 
+    @override
     async def async_send_message(self, message: str = "", **kwargs: Any) -> None:
         """Send a message."""
         if not message:

--- a/homeassistant/components/google_cloud/config_flow.py
+++ b/homeassistant/components/google_cloud/config_flow.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, cast, override
 
 from google.cloud import texttospeech
 import voluptuous as vol
@@ -69,6 +69,7 @@ class GoogleCloudConfigFlow(ConfigFlow, domain=DOMAIN):
             contents = file_path.read_text()
         return cast(dict[str, Any], json.loads(contents))
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -129,6 +130,7 @@ class GoogleCloudConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> GoogleCloudOptionsFlowHandler:

--- a/homeassistant/components/google_cloud/stt.py
+++ b/homeassistant/components/google_cloud/stt.py
@@ -2,6 +2,7 @@
 
 from collections.abc import AsyncGenerator, AsyncIterable
 import logging
+from typing import override
 
 from google.api_core.exceptions import GoogleAPIError, Unauthenticated
 from google.api_core.retry import AsyncRetry
@@ -69,6 +70,7 @@ class GoogleCloudSpeechToTextEntity(SpeechToTextEntity):
         self._model = entry.options.get(CONF_STT_MODEL, DEFAULT_STT_MODEL)
 
     @cached_property
+    @override
     def supported_languages(self) -> list[str]:
         """Return a list of supported languages."""
         # Combine the native Google languages and the standard HA languages.
@@ -78,30 +80,36 @@ class GoogleCloudSpeechToTextEntity(SpeechToTextEntity):
         return sorted(supported)
 
     @property
+    @override
     def supported_formats(self) -> list[AudioFormats]:
         """Return a list of supported formats."""
         return [AudioFormats.WAV, AudioFormats.OGG]
 
     @property
+    @override
     def supported_codecs(self) -> list[AudioCodecs]:
         """Return a list of supported codecs."""
         return [AudioCodecs.PCM, AudioCodecs.OPUS]
 
     @property
+    @override
     def supported_bit_rates(self) -> list[AudioBitRates]:
         """Return a list of supported bitrates."""
         return [AudioBitRates.BITRATE_16]
 
     @property
+    @override
     def supported_sample_rates(self) -> list[AudioSampleRates]:
         """Return a list of supported samplerates."""
         return [AudioSampleRates.SAMPLERATE_16000]
 
     @property
+    @override
     def supported_channels(self) -> list[AudioChannels]:
         """Return a list of supported channels."""
         return [AudioChannels.CHANNEL_MONO]
 
+    @override
     async def async_process_audio_stream(
         self, metadata: SpeechMetadata, stream: AsyncIterable[bytes]
     ) -> SpeechResult:

--- a/homeassistant/components/google_cloud/tts.py
+++ b/homeassistant/components/google_cloud/tts.py
@@ -2,7 +2,7 @@
 
 import logging
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, cast, override
 
 from google.api_core.exceptions import GoogleAPIError, Unauthenticated
 from google.api_core.retry import AsyncRetry
@@ -254,6 +254,7 @@ class GoogleCloudTTSEntity(BaseGoogleCloudProvider, TextToSpeechEntity):
         )
         self._entry = entry
 
+    @override
     async def async_get_tts_audio(
         self, message: str, language: str, options: dict[str, Any]
     ) -> TtsAudioType:
@@ -281,6 +282,7 @@ class GoogleCloudTTSProvider(BaseGoogleCloudProvider, Provider):
         super().__init__(client, voices, language, options_schema)
         self.name = "Google Cloud TTS"
 
+    @override
     async def async_get_tts_audio(
         self, message: str, language: str, options: dict[str, Any]
     ) -> TtsAudioType:

--- a/homeassistant/components/google_drive/api.py
+++ b/homeassistant/components/google_drive/api.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator, Callable, Coroutine
 from dataclasses import dataclass
 import json
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiohttp import ClientSession, ClientTimeout, StreamReader
 from aiohttp.client_exceptions import ClientError, ClientResponseError
@@ -50,6 +50,7 @@ class AsyncConfigEntryAuth(AbstractAuth):
         super().__init__(websession)
         self._oauth_session = oauth_session
 
+    @override
     async def async_get_access_token(self) -> str:
         """Return a valid access token."""
         try:
@@ -91,6 +92,7 @@ class AsyncConfigFlowAuth(AbstractAuth):
         super().__init__(websession)
         self._token = token
 
+    @override
     async def async_get_access_token(self) -> str:
         """Return a valid access token."""
         return self._token

--- a/homeassistant/components/google_drive/backup.py
+++ b/homeassistant/components/google_drive/backup.py
@@ -3,7 +3,7 @@
 from collections.abc import AsyncIterator, Callable, Coroutine
 from functools import wraps
 import logging
-from typing import Any
+from typing import Any, override
 
 from google_drive_api.exceptions import GoogleDriveApiError
 
@@ -70,6 +70,7 @@ class GoogleDriveBackupAgent(BackupAgent):
         self.unique_id = slugify(config_entry.unique_id)
         self._client = config_entry.runtime_data.client
 
+    @override
     async def async_upload_backup(
         self,
         *,
@@ -103,6 +104,7 @@ class GoogleDriveBackupAgent(BackupAgent):
             # pylint: disable-next=home-assistant-exception-not-translated
             raise BackupAgentError(f"Failed to upload backup: {err}") from err
 
+    @override
     async def async_list_backups(self, **kwargs: Any) -> list[AgentBackup]:
         """List backups."""
         try:
@@ -111,6 +113,7 @@ class GoogleDriveBackupAgent(BackupAgent):
             # pylint: disable-next=home-assistant-exception-not-translated
             raise BackupAgentError(f"Failed to list backups: {err}") from err
 
+    @override
     async def async_get_backup(
         self,
         backup_id: str,
@@ -124,6 +127,7 @@ class GoogleDriveBackupAgent(BackupAgent):
         # pylint: disable-next=home-assistant-exception-not-translated
         raise BackupNotFound(f"Backup {backup_id} not found")
 
+    @override
     async def async_download_backup(
         self,
         backup_id: str,
@@ -147,6 +151,7 @@ class GoogleDriveBackupAgent(BackupAgent):
         # pylint: disable-next=home-assistant-exception-not-translated
         raise BackupNotFound(f"Backup {backup_id} not found")
 
+    @override
     async def async_delete_backup(
         self,
         backup_id: str,

--- a/homeassistant/components/google_drive/config_flow.py
+++ b/homeassistant/components/google_drive/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from google_drive_api.exceptions import GoogleDriveApiError
 
@@ -32,11 +32,13 @@ class OAuth2FlowHandler(
     DOMAIN = DOMAIN
 
     @property
+    @override
     def logger(self) -> logging.Logger:
         """Return logger."""
         return logging.getLogger(__name__)
 
     @property
+    @override
     def extra_authorize_data(self) -> dict[str, Any]:
         """Extra data that needs to be appended to the authorize url."""
         return {
@@ -66,6 +68,7 @@ class OAuth2FlowHandler(
             return self.async_show_form(step_id="reauth_confirm")
         return await self.async_step_user()
 
+    @override
     async def async_oauth_create_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
         """Create an entry for the flow, or update existing entry."""
         client = DriveClient(

--- a/homeassistant/components/google_drive/coordinator.py
+++ b/homeassistant/components/google_drive/coordinator.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 import logging
+from typing import override
 
 from google_drive_api.exceptions import GoogleDriveApiError
 
@@ -53,10 +54,12 @@ class GoogleDriveDataUpdateCoordinator(DataUpdateCoordinator[SensorData]):
             update_interval=SCAN_INTERVAL,
         )
 
+    @override
     async def _async_setup(self) -> None:
         """Do initialization logic."""
         self.email_address = await self.client.async_get_email_address()
 
+    @override
     async def _async_update_data(self) -> SensorData:
         """Fetch data from Google Drive."""
         try:

--- a/homeassistant/components/google_drive/entity.py
+++ b/homeassistant/components/google_drive/entity.py
@@ -1,5 +1,7 @@
 """Define the Google Drive entity."""
 
+from typing import override
+
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -13,6 +15,7 @@ class GoogleDriveEntity(CoordinatorEntity[GoogleDriveDataUpdateCoordinator]):
     _attr_has_entity_name = True
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return device information about this Google Drive device."""
         return DeviceInfo(

--- a/homeassistant/components/google_drive/sensor.py
+++ b/homeassistant/components/google_drive/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -120,6 +121,7 @@ class GoogleDriveSensorEntity(GoogleDriveEntity, SensorEntity):
         self._attr_unique_id = f"{coordinator.config_entry.unique_id}_{description.key}"
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/google_generative_ai_conversation/ai_task.py
+++ b/homeassistant/components/google_generative_ai_conversation/ai_task.py
@@ -1,7 +1,7 @@
 """AI Task integration for Google Generative AI Conversation."""
 
 from json import JSONDecodeError
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from google.genai.errors import APIError
 from google.genai.types import GenerateContentConfig, Part, PartUnionDict
@@ -71,6 +71,7 @@ class GoogleGenerativeAITaskEntity(
         ):
             self._attr_supported_features |= ai_task.AITaskEntityFeature.GENERATE_IMAGE
 
+    @override
     async def _async_generate_data(
         self,
         task: ai_task.GenDataTask,
@@ -115,6 +116,7 @@ class GoogleGenerativeAITaskEntity(
             data=data,
         )
 
+    @override
     async def _async_generate_image(
         self,
         task: ai_task.GenImageTask,

--- a/homeassistant/components/google_generative_ai_conversation/config_flow.py
+++ b/homeassistant/components/google_generative_ai_conversation/config_flow.py
@@ -3,7 +3,7 @@
 from collections.abc import Mapping
 from functools import partial
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from google import genai
 from google.genai.errors import APIError, ClientError
@@ -162,6 +162,7 @@ class GoogleGenerativeAIConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -192,6 +193,7 @@ class GoogleGenerativeAIConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @classmethod
     @callback
+    @override
     def async_get_supported_subentry_types(
         cls, config_entry: ConfigEntry
     ) -> dict[str, type[ConfigSubentryFlow]]:

--- a/homeassistant/components/google_generative_ai_conversation/conversation.py
+++ b/homeassistant/components/google_generative_ai_conversation/conversation.py
@@ -1,6 +1,6 @@
 """Conversation support for the Google Generative AI Conversation integration."""
 
-from typing import Literal
+from typing import Literal, override
 
 from homeassistant.components import conversation
 from homeassistant.config_entries import ConfigEntry, ConfigSubentry
@@ -46,20 +46,24 @@ class GoogleGenerativeAIConversationEntity(
             )
 
     @property
+    @override
     def supported_languages(self) -> list[str] | Literal["*"]:
         """Return a list of supported languages."""
         return MATCH_ALL
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to Home Assistant."""
         await super().async_added_to_hass()
         conversation.async_set_agent(self.hass, self.entry, self)
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """When entity will be removed from Home Assistant."""
         conversation.async_unset_agent(self.hass, self.entry)
         await super().async_will_remove_from_hass()
 
+    @override
     async def _async_handle_message(
         self,
         user_input: conversation.ConversationInput,

--- a/homeassistant/components/google_generative_ai_conversation/stt.py
+++ b/homeassistant/components/google_generative_ai_conversation/stt.py
@@ -1,6 +1,7 @@
 """Speech to text support for Google Generative AI."""
 
 from collections.abc import AsyncIterable
+from typing import override
 
 from google.genai.errors import APIError, ClientError
 from google.genai.types import Part
@@ -42,6 +43,7 @@ class GoogleGenerativeAISttEntity(
         super().__init__(config_entry, subentry, RECOMMENDED_STT_MODEL)
 
     @property
+    @override
     def supported_languages(self) -> list[str]:
         """Return a list of supported languages."""
         return [
@@ -188,27 +190,32 @@ class GoogleGenerativeAISttEntity(
         ]
 
     @property
+    @override
     def supported_formats(self) -> list[stt.AudioFormats]:
         """Return a list of supported formats."""
         # https://ai.google.dev/gemini-api/docs/audio#supported-formats
         return [stt.AudioFormats.WAV, stt.AudioFormats.OGG]
 
     @property
+    @override
     def supported_codecs(self) -> list[stt.AudioCodecs]:
         """Return a list of supported codecs."""
         return [stt.AudioCodecs.PCM, stt.AudioCodecs.OPUS]
 
     @property
+    @override
     def supported_bit_rates(self) -> list[stt.AudioBitRates]:
         """Return a list of supported bit rates."""
         return [stt.AudioBitRates.BITRATE_16]
 
     @property
+    @override
     def supported_sample_rates(self) -> list[stt.AudioSampleRates]:
         """Return a list of supported sample rates."""
         return [stt.AudioSampleRates.SAMPLERATE_16000]
 
     @property
+    @override
     def supported_channels(self) -> list[stt.AudioChannels]:
         """Return a list of supported channels."""
         # Per
@@ -217,6 +224,7 @@ class GoogleGenerativeAISttEntity(
         # Gemini combines those channels into a single channel.
         return [stt.AudioChannels.CHANNEL_MONO]
 
+    @override
     async def async_process_audio_stream(
         self, metadata: stt.SpeechMetadata, stream: AsyncIterable[bytes]
     ) -> stt.SpeechResult:

--- a/homeassistant/components/google_generative_ai_conversation/tts.py
+++ b/homeassistant/components/google_generative_ai_conversation/tts.py
@@ -1,7 +1,7 @@
 """Text to speech support for Google Generative AI."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 from google.genai import types
 from google.genai.errors import APIError, ClientError
@@ -182,17 +182,20 @@ class GoogleGenerativeAITextToSpeechEntity(
         super().__init__(config_entry, subentry, RECOMMENDED_TTS_MODEL)
 
     @callback
+    @override
     def async_get_supported_voices(self, language: str) -> list[Voice]:
         """Return a list of supported voices for a language."""
         return self._supported_voices
 
     @cached_property
+    @override
     def default_options(self) -> Mapping[str, Any]:
         """Return a mapping with the default options."""
         return {
             ATTR_VOICE: self._supported_voices[0].voice_id,
         }
 
+    @override
     async def async_get_tts_audio(
         self, message: str, language: str, options: dict[str, Any]
     ) -> TtsAudioType:

--- a/homeassistant/components/google_mail/config_flow.py
+++ b/homeassistant/components/google_mail/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
@@ -22,11 +22,13 @@ class OAuth2FlowHandler(
     DOMAIN = DOMAIN
 
     @property
+    @override
     def logger(self) -> logging.Logger:
         """Return logger."""
         return logging.getLogger(__name__)
 
     @property
+    @override
     def extra_authorize_data(self) -> dict[str, Any]:
         """Extra data that needs to be appended to the authorize url."""
         return {
@@ -50,6 +52,7 @@ class OAuth2FlowHandler(
             return self.async_show_form(step_id="reauth_confirm")
         return await self.async_step_user()
 
+    @override
     async def async_oauth_create_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
         """Create an entry for the flow, or update existing entry."""
 

--- a/homeassistant/components/google_mail/notify.py
+++ b/homeassistant/components/google_mail/notify.py
@@ -3,7 +3,7 @@
 import base64
 from email.mime.text import MIMEText
 from email.utils import formataddr
-from typing import Any
+from typing import Any, override
 
 from googleapiclient.http import HttpRequest
 
@@ -48,6 +48,7 @@ class GMailNotificationService(BaseNotificationService):
         """Initialize the service."""
         self.auth: AsyncConfigEntryAuth = config[DATA_AUTH]
 
+    @override
     async def async_send_message(self, message: str, **kwargs: Any) -> None:
         """Send a message."""
         data: dict[str, Any] = kwargs.get(ATTR_DATA) or {}

--- a/homeassistant/components/google_photos/api.py
+++ b/homeassistant/components/google_photos/api.py
@@ -1,6 +1,6 @@
 """API for Google Photos bound to Home Assistant OAuth."""
 
-from typing import cast
+from typing import cast, override
 
 import aiohttp
 from google_photos_library_api import api
@@ -21,6 +21,7 @@ class AsyncConfigEntryAuth(api.AbstractAuth):
         super().__init__(websession)
         self._session = oauth_session
 
+    @override
     async def async_get_access_token(self) -> str:
         """Return a valid access token."""
         await self._session.async_ensure_token_valid()
@@ -39,6 +40,7 @@ class AsyncConfigFlowAuth(api.AbstractAuth):
         super().__init__(websession)
         self._token = token
 
+    @override
     async def async_get_access_token(self) -> str:
         """Return a valid access token."""
         return self._token

--- a/homeassistant/components/google_photos/config_flow.py
+++ b/homeassistant/components/google_photos/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from google_photos_library_api.api import GooglePhotosLibraryApi
 from google_photos_library_api.exceptions import GooglePhotosApiError
@@ -23,11 +23,13 @@ class OAuth2FlowHandler(
     DOMAIN = DOMAIN
 
     @property
+    @override
     def logger(self) -> logging.Logger:
         """Return logger."""
         return logging.getLogger(__name__)
 
     @property
+    @override
     def extra_authorize_data(self) -> dict[str, Any]:
         """Extra data that needs to be appended to the authorize url."""
         return {
@@ -37,6 +39,7 @@ class OAuth2FlowHandler(
             "prompt": "consent",
         }
 
+    @override
     async def async_oauth_create_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
         """Create an entry for the flow."""
         session = aiohttp_client.async_get_clientsession(self.hass)

--- a/homeassistant/components/google_photos/coordinator.py
+++ b/homeassistant/components/google_photos/coordinator.py
@@ -9,7 +9,7 @@ are short lived.
 import asyncio
 import datetime
 import logging
-from typing import Final
+from typing import Final, override
 
 from google_photos_library_api.api import GooglePhotosLibraryApi
 from google_photos_library_api.exceptions import GooglePhotosApiError
@@ -51,6 +51,7 @@ class GooglePhotosUpdateCoordinator(DataUpdateCoordinator[dict[str, str]]):
         )
         self.client = client
 
+    @override
     async def _async_update_data(self) -> dict[str, str]:
         """Fetch albums from API endpoint."""
         albums: dict[str, str] = {}

--- a/homeassistant/components/google_photos/media_source.py
+++ b/homeassistant/components/google_photos/media_source.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from enum import StrEnum
 import logging
-from typing import Self, cast
+from typing import Self, cast, override
 
 from google_photos_library_api.exceptions import GooglePhotosApiError
 from google_photos_library_api.model import Album, MediaItem
@@ -108,6 +108,7 @@ class GooglePhotosMediaSource(MediaSource):
         super().__init__(DOMAIN)
         self.hass = hass
 
+    @override
     async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:
         """Resolve media identifier to a url.
 
@@ -139,6 +140,7 @@ class GooglePhotosMediaSource(MediaSource):
             mime_type=media_item.mime_type,
         )
 
+    @override
     async def async_browse_media(self, item: MediaSourceItem) -> BrowseMediaSource:
         """Return details about the media source.
 

--- a/homeassistant/components/google_pubsub/__init__.py
+++ b/homeassistant/components/google_pubsub/__init__.py
@@ -4,6 +4,7 @@ import datetime
 import json
 import logging
 import os
+from typing import override
 
 from google.cloud.pubsub_v1 import PublisherClient
 import voluptuous as vol
@@ -83,6 +84,7 @@ class DateTimeJSONEncoder(json.JSONEncoder):
     Additionally add encoding for datetime objects as isoformat.
     """
 
+    @override
     def default(self, o):
         """Implement encoding logic."""
         if isinstance(o, datetime.datetime):

--- a/homeassistant/components/google_sheets/config_flow.py
+++ b/homeassistant/components/google_sheets/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from google.oauth2.credentials import Credentials
 from gspread import Client, GSpreadException
@@ -24,11 +24,13 @@ class OAuth2FlowHandler(
     DOMAIN = DOMAIN
 
     @property
+    @override
     def logger(self) -> logging.Logger:
         """Return logger."""
         return logging.getLogger(__name__)
 
     @property
+    @override
     def extra_authorize_data(self) -> dict[str, Any]:
         """Extra data that needs to be appended to the authorize url."""
         return {
@@ -52,6 +54,7 @@ class OAuth2FlowHandler(
             return self.async_show_form(step_id="reauth_confirm")
         return await self.async_step_user()
 
+    @override
     async def async_oauth_create_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
         """Create an entry for the flow, or update existing entry."""
         service = Client(

--- a/homeassistant/components/google_tasks/config_flow.py
+++ b/homeassistant/components/google_tasks/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
@@ -24,11 +24,13 @@ class OAuth2FlowHandler(
     DOMAIN = DOMAIN
 
     @property
+    @override
     def logger(self) -> logging.Logger:
         """Return logger."""
         return logging.getLogger(__name__)
 
     @property
+    @override
     def extra_authorize_data(self) -> dict[str, Any]:
         """Extra data that needs to be appended to the authorize url."""
         return {
@@ -38,6 +40,7 @@ class OAuth2FlowHandler(
             "prompt": "consent",
         }
 
+    @override
     async def async_oauth_create_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
         """Create an entry for the flow."""
         credentials = Credentials(token=data[CONF_TOKEN][CONF_ACCESS_TOKEN])

--- a/homeassistant/components/google_tasks/coordinator.py
+++ b/homeassistant/components/google_tasks/coordinator.py
@@ -3,7 +3,7 @@
 import asyncio
 import datetime
 import logging
-from typing import Any, Final
+from typing import Any, Final, override
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -44,6 +44,7 @@ class TaskUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         self.task_list_id = task_list_id
         self.task_list_title = task_list_title
 
+    @override
     async def _async_update_data(self) -> list[dict[str, Any]]:
         """Fetch tasks from API endpoint."""
         async with asyncio.timeout(TIMEOUT):

--- a/homeassistant/components/google_tasks/todo.py
+++ b/homeassistant/components/google_tasks/todo.py
@@ -1,7 +1,7 @@
 """Google Tasks todo platform."""
 
 from datetime import UTC, date, datetime
-from typing import Any, cast
+from typing import Any, cast, override
 
 from homeassistant.components.todo import (
     TodoItem,
@@ -115,10 +115,12 @@ class GoogleTaskTodoListEntity(
         self._task_list_id = task_list_id
 
     @property
+    @override
     def todo_items(self) -> list[TodoItem] | None:
         """Get the current set of To-do items."""
         return [_convert_api_item(item) for item in _order_tasks(self.coordinator.data)]
 
+    @override
     async def async_create_todo_item(self, item: TodoItem) -> None:
         """Add an item to the To-do list."""
         await self.coordinator.api.insert(
@@ -127,6 +129,7 @@ class GoogleTaskTodoListEntity(
         )
         await self.coordinator.async_refresh()
 
+    @override
     async def async_update_todo_item(self, item: TodoItem) -> None:
         """Update a To-do item."""
         uid: str = cast(str, item.uid)
@@ -137,11 +140,13 @@ class GoogleTaskTodoListEntity(
         )
         await self.coordinator.async_refresh()
 
+    @override
     async def async_delete_todo_items(self, uids: list[str]) -> None:
         """Delete To-do items."""
         await self.coordinator.api.delete(self._task_list_id, uids)
         await self.coordinator.async_refresh()
 
+    @override
     async def async_move_todo_item(
         self, uid: str, previous_uid: str | None = None
     ) -> None:

--- a/homeassistant/components/google_translate/config_flow.py
+++ b/homeassistant/components/google_translate/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for Google Translate text-to-speech integration."""
 
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -29,6 +29,7 @@ class GoogleTranslateConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/google_translate/tts.py
+++ b/homeassistant/components/google_translate/tts.py
@@ -2,7 +2,7 @@
 
 from io import BytesIO
 import logging
-from typing import Any
+from typing import Any, override
 
 from gtts import gTTS, gTTSError
 import voluptuous as vol
@@ -90,6 +90,7 @@ class GoogleTTSEntity(TextToSpeechEntity):
         )
         self._attr_default_language = self._lang
 
+    @override
     def get_tts_audio(
         self, message: str, language: str, options: dict[str, Any] | None = None
     ) -> TtsAudioType:
@@ -131,20 +132,24 @@ class GoogleProvider(Provider):
         self.name = "Google Translate"
 
     @property
+    @override
     def default_language(self) -> str:
         """Return the default language."""
         return self._lang
 
     @property
+    @override
     def supported_languages(self) -> list[str]:
         """Return list of supported languages."""
         return SUPPORT_LANGUAGES
 
     @property
+    @override
     def supported_options(self) -> list[str]:
         """Return a list of supported options."""
         return SUPPORT_OPTIONS
 
+    @override
     def get_tts_audio(
         self, message: str, language: str, options: dict[str, Any]
     ) -> TtsAudioType:

--- a/homeassistant/components/google_travel_time/config_flow.py
+++ b/homeassistant/components/google_travel_time/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for Google Maps Travel Time integration."""
 
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -168,12 +168,14 @@ class GoogleTravelTimeConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> GoogleOptionsFlow:
         """Get the options flow for this handler."""
         return GoogleOptionsFlow()
 
+    @override
     async def async_step_user(self, user_input=None) -> ConfigFlowResult:
         """Handle the initial step."""
         errors: dict[str, str] | None = None

--- a/homeassistant/components/google_travel_time/sensor.py
+++ b/homeassistant/components/google_travel_time/sensor.py
@@ -2,7 +2,7 @@
 
 import datetime
 import logging
-from typing import Any
+from typing import Any, override
 
 from google.api_core.client_options import ClientOptions
 from google.api_core.exceptions import GoogleAPIError, PermissionDenied
@@ -122,6 +122,7 @@ class GoogleTravelTimeSensor(SensorEntity):
         self._resolved_origin: str | None = None
         self._resolved_destination: str | None = None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Handle when entity is added."""
         if self.hass.state is not CoreState.running:
@@ -132,6 +133,7 @@ class GoogleTravelTimeSensor(SensorEntity):
             await self.first_update()
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the state of the sensor."""
         if self._route is None:
@@ -140,6 +142,7 @@ class GoogleTravelTimeSensor(SensorEntity):
         return self._route.duration.seconds
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the state attributes."""
         if self._route is None:

--- a/homeassistant/components/google_weather/config_flow.py
+++ b/homeassistant/components/google_weather/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from google_weather_api import GoogleWeatherApi, GoogleWeatherApiError
 import voluptuous as vol
@@ -113,6 +113,7 @@ class GoogleWeatherConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -217,6 +218,7 @@ class GoogleWeatherConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @classmethod
     @callback
+    @override
     def async_get_supported_subentry_types(
         cls, config_entry: ConfigEntry
     ) -> dict[str, type[ConfigSubentryFlow]]:

--- a/homeassistant/components/google_weather/coordinator.py
+++ b/homeassistant/components/google_weather/coordinator.py
@@ -4,7 +4,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import TypeVar
+from typing import TypeVar, override
 
 from google_weather_api import (
     CurrentConditionsResponse,
@@ -85,6 +85,7 @@ class GoogleWeatherBaseCoordinator(TimestampDataUpdateCoordinator[T]):
         self._data_type_name = data_type_name
         self._api_method = api_method
 
+    @override
     async def _async_update_data(self) -> T:
         """Fetch data from API and handle errors."""
         try:

--- a/homeassistant/components/google_weather/sensor.py
+++ b/homeassistant/components/google_weather/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from google_weather_api import CurrentConditionsResponse
 
@@ -226,6 +227,7 @@ class GoogleWeatherSensor(
         self.entity_description = description
 
     @property
+    @override
     def native_value(self) -> str | int | float | None:
         """Return the state."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/google_weather/weather.py
+++ b/homeassistant/components/google_weather/weather.py
@@ -1,5 +1,7 @@
 """Weather entity."""
 
+from typing import override
+
 from google_weather_api import (
     DailyForecastResponse,
     HourlyForecastResponse,
@@ -174,6 +176,7 @@ class GoogleWeatherEntity(
         GoogleWeatherBaseEntity.__init__(self, entry, subentry)
 
     @property
+    @override
     def condition(self) -> str | None:
         """Return the current condition."""
         return _get_condition(
@@ -182,61 +185,73 @@ class GoogleWeatherEntity(
         )
 
     @property
+    @override
     def native_temperature(self) -> float:
         """Return the temperature."""
         return self.coordinator.data.temperature.degrees
 
     @property
+    @override
     def native_apparent_temperature(self) -> float:
         """Return the apparent temperature."""
         return self.coordinator.data.feels_like_temperature.degrees
 
     @property
+    @override
     def native_dew_point(self) -> float:
         """Return the dew point."""
         return self.coordinator.data.dew_point.degrees
 
     @property
+    @override
     def humidity(self) -> int:
         """Return the humidity."""
         return self.coordinator.data.relative_humidity
 
     @property
+    @override
     def uv_index(self) -> float:
         """Return the UV index."""
         return float(self.coordinator.data.uv_index)
 
     @property
+    @override
     def native_pressure(self) -> float:
         """Return the pressure."""
         return self.coordinator.data.air_pressure.mean_sea_level_millibars
 
     @property
+    @override
     def native_wind_gust_speed(self) -> float:
         """Return the wind gust speed."""
         return self.coordinator.data.wind.gust.value
 
     @property
+    @override
     def native_wind_speed(self) -> float:
         """Return the wind speed."""
         return self.coordinator.data.wind.speed.value
 
     @property
+    @override
     def wind_bearing(self) -> int:
         """Return the wind bearing."""
         return self.coordinator.data.wind.direction.degrees
 
     @property
+    @override
     def native_visibility(self) -> float:
         """Return the visibility."""
         return self.coordinator.data.visibility.distance
 
     @property
+    @override
     def cloud_coverage(self) -> float:
         """Return the Cloud coverage in %."""
         return float(self.coordinator.data.cloud_cover)
 
     @callback
+    @override
     def _async_forecast_daily(self) -> list[Forecast] | None:
         """Return the daily forecast in native units."""
         coordinator = self.forecast_coordinators["daily"]
@@ -281,6 +296,7 @@ class GoogleWeatherEntity(
         ]
 
     @callback
+    @override
     def _async_forecast_hourly(self) -> list[Forecast] | None:
         """Return the hourly forecast in native units."""
         coordinator = self.forecast_coordinators["hourly"]
@@ -315,6 +331,7 @@ class GoogleWeatherEntity(
         ]
 
     @callback
+    @override
     def _async_forecast_twice_daily(self) -> list[Forecast] | None:
         """Return the twice daily forecast in native units."""
         coordinator = self.forecast_coordinators["twice_daily"]

--- a/homeassistant/components/google_wifi/sensor.py
+++ b/homeassistant/components/google_wifi/sensor.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
+from typing import override
 
 import requests
 import voluptuous as vol
@@ -139,6 +140,7 @@ class GoogleWifiSensor(SensorEntity):
         self._attr_name = f"{name}_{description.key}"
 
     @property
+    @override
     def available(self) -> bool:
         """Return availability of Google Wifi API."""
         return self._api.available

--- a/homeassistant/components/govee_ble/binary_sensor.py
+++ b/homeassistant/components/govee_ble/binary_sensor.py
@@ -1,5 +1,7 @@
 """Support for govee-ble binary sensors."""
 
+from typing import override
+
 from govee_ble import (
     BinarySensorDeviceClass as GoveeBLEBinarySensorDeviceClass,
     SensorUpdate,
@@ -102,6 +104,7 @@ class GoveeBluetoothBinarySensorEntity(
     processor: GoveeBLEPassiveBluetoothDataProcessor[bool | None]
 
     @property
+    @override
     def available(self) -> bool:
         """Return False if sensor is in error."""
         coordinator = self.processor.coordinator
@@ -111,6 +114,7 @@ class GoveeBluetoothBinarySensorEntity(
         )
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return the native value."""
         return self.processor.entity_data.get(self.entity_key)

--- a/homeassistant/components/govee_ble/config_flow.py
+++ b/homeassistant/components/govee_ble/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for govee ble integration."""
 
-from typing import Any
+from typing import Any, override
 
 from govee_ble import GoveeBluetoothDeviceData as DeviceData
 import voluptuous as vol
@@ -29,6 +29,7 @@ class GoveeConfigFlow(ConfigFlow, domain=DOMAIN):
             str, tuple[DeviceData, BluetoothServiceInfoBleak]
         ] = {}
 
+    @override
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfoBleak
     ) -> ConfigFlowResult:
@@ -63,6 +64,7 @@ class GoveeConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="bluetooth_confirm", description_placeholders=placeholders
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/govee_ble/event.py
+++ b/homeassistant/components/govee_ble/event.py
@@ -1,5 +1,7 @@
 """Support for govee_ble event entities."""
 
+from typing import override
+
 from govee_ble import ModelInfo, SensorType
 
 from homeassistant.components.bluetooth import (
@@ -68,6 +70,7 @@ class GoveeBluetoothEventEntity(EventEntity):
             self._address, self.entity_description.key
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Entity added to hass."""
         await super().async_added_to_hass()

--- a/homeassistant/components/govee_ble/sensor.py
+++ b/homeassistant/components/govee_ble/sensor.py
@@ -2,6 +2,7 @@
 
 from datetime import date, datetime
 from decimal import Decimal
+from typing import override
 
 from govee_ble import DeviceClass, SensorUpdate, Units
 from govee_ble.parser import ERROR
@@ -136,6 +137,7 @@ class GoveeBluetoothSensorEntity(
     processor: GoveeBLEPassiveBluetoothDataProcessor[_SensorValueType]
 
     @property
+    @override
     def available(self) -> bool:
         """Return False if sensor is in error."""
         coordinator = self.processor.coordinator
@@ -145,6 +147,7 @@ class GoveeBluetoothSensorEntity(
         )
 
     @property
+    @override
     def native_value(self) -> _SensorValueType:  # pylint: disable=home-assistant-return-type
         """Return the native value."""
         return self.processor.entity_data.get(self.entity_key)

--- a/homeassistant/components/govee_light_local/coordinator.py
+++ b/homeassistant/components/govee_light_local/coordinator.py
@@ -3,6 +3,7 @@
 import asyncio
 from collections.abc import Callable
 import logging
+from typing import override
 
 from govee_local_api import GoveeController, GoveeDevice
 
@@ -111,6 +112,7 @@ class GoveeLocalApiCoordinator(DataUpdateCoordinator[list[GoveeDevice]]):
             devices = devices + controller.devices
         return devices
 
+    @override
     async def _async_update_data(self) -> list[GoveeDevice]:
         for controller in self._controllers:
             controller.send_update_message()

--- a/homeassistant/components/govee_light_local/light.py
+++ b/homeassistant/components/govee_light_local/light.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 import logging
-from typing import Any
+from typing import Any, override
 
 from govee_local_api import GoveeDevice, GoveeLightFeatures
 
@@ -118,6 +118,7 @@ class GoveeLight(CoordinatorEntity[GoveeLocalApiCoordinator], LightEntity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return if the device is reachable.
 
@@ -131,26 +132,31 @@ class GoveeLight(CoordinatorEntity[GoveeLocalApiCoordinator], LightEntity):
         return datetime.now() - self._device.lastseen < DEVICE_TIMEOUT  # pylint: disable=home-assistant-enforce-naive-now
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if device is on (brightness above 0)."""
         return self._device.on
 
     @property
+    @override
     def brightness(self) -> int:
         """Return the brightness of this light between 0..255."""
         return int((self._device.brightness / 100.0) * 255.0)
 
     @property
+    @override
     def color_temp_kelvin(self) -> int | None:
         """Return the color temperature in Kelvin."""
         return self._device.temperature_color
 
     @property
+    @override
     def rgb_color(self) -> tuple[int, int, int] | None:
         """Return the rgb color."""
         return self._device.rgb_color
 
     @property
+    @override
     def color_mode(self) -> ColorMode:
         """Return the color mode."""
         if self._fixed_color_mode:
@@ -166,6 +172,7 @@ class GoveeLight(CoordinatorEntity[GoveeLocalApiCoordinator], LightEntity):
             return ColorMode.COLOR_TEMP
         return ColorMode.RGB
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         if ATTR_BRIGHTNESS in kwargs:
@@ -200,16 +207,19 @@ class GoveeLight(CoordinatorEntity[GoveeLocalApiCoordinator], LightEntity):
 
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         await self.coordinator.turn_off(self._device)
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register update callback when entity is added."""
         await super().async_added_to_hass()
         self._device.set_update_callback(self._update_callback)
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Unregister update callback when entity is removed."""
         self._device.set_update_callback(None)

--- a/homeassistant/components/gpsd/config_flow.py
+++ b/homeassistant/components/gpsd/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for GPSD integration."""
 
 import socket
-from typing import Any
+from typing import Any, override
 
 from gps3.agps3threaded import GPSD_PORT as DEFAULT_PORT, HOST as DEFAULT_HOST
 import voluptuous as vol
@@ -37,6 +37,7 @@ class GPSDConfigFlow(ConfigFlow, domain=DOMAIN):
         else:
             return True
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/gpsd/sensor.py
+++ b/homeassistant/components/gpsd/sensor.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 import logging
+from typing import override
 
 from gps3.agps3threaded import AGPS3mechanism
 
@@ -193,6 +194,7 @@ class GpsdSensor(SensorEntity):
         self.agps_thread = agps_thread
 
     @property
+    @override
     def native_value(self) -> StateType | datetime:
         """Return the state of GPSD."""
         value = self.entity_description.value_fn(self.agps_thread)

--- a/homeassistant/components/gpslogger/device_tracker.py
+++ b/homeassistant/components/gpslogger/device_tracker.py
@@ -1,5 +1,7 @@
 """Support for the GPSLogger device tracking."""
 
+from typing import override
+
 from homeassistant.components.device_tracker import TrackerEntity
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL,
@@ -86,10 +88,12 @@ class GPSLoggerEntity(TrackerEntity, RestoreEntity):
         )
 
     @property
+    @override
     def battery_level(self) -> int | None:
         """Return battery value of the device."""
         return self._battery
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register state update callback."""
         await super().async_added_to_hass()
@@ -128,6 +132,7 @@ class GPSLoggerEntity(TrackerEntity, RestoreEntity):
         }
         self._battery = attr.get(ATTR_BATTERY_LEVEL)
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Clean up after entity before removal."""
         await super().async_will_remove_from_hass()

--- a/homeassistant/components/graphite/__init__.py
+++ b/homeassistant/components/graphite/__init__.py
@@ -6,6 +6,7 @@ import queue
 import socket
 import threading
 import time
+from typing import override
 
 import voluptuous as vol
 
@@ -151,6 +152,7 @@ class GraphiteFeeder(threading.Thread):
         except OSError:
             _LOGGER.exception("Failed to send data to graphite")
 
+    @override
     def run(self):
         """Run the process to export the data."""
         while True:

--- a/homeassistant/components/gree/climate.py
+++ b/homeassistant/components/gree/climate.py
@@ -1,7 +1,7 @@
 """Support for interface with a Gree climate systems."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from greeclimate.device import (
     TEMP_MAX,
@@ -128,15 +128,18 @@ class GreeClimateEntity(GreeEntity, ClimateEntity):
         self._attr_unique_id = coordinator.device.device_info.mac
 
     @property
+    @override
     def current_temperature(self) -> float:
         """Return the reported current temperature for the device."""
         return self.coordinator.device.current_temperature
 
     @property
+    @override
     def target_temperature(self) -> float:
         """Return the target temperature for the device."""
         return self.coordinator.device.target_temperature
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         if ATTR_TEMPERATURE not in kwargs:
@@ -157,6 +160,7 @@ class GreeClimateEntity(GreeEntity, ClimateEntity):
         self.async_write_ha_state()
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode | None:
         """Return the current HVAC mode for the device."""
         if not self.coordinator.device.power:
@@ -164,6 +168,7 @@ class GreeClimateEntity(GreeEntity, ClimateEntity):
 
         return HVAC_MODES.get(self.coordinator.device.mode)
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         if hvac_mode not in self.hvac_modes:
@@ -188,6 +193,7 @@ class GreeClimateEntity(GreeEntity, ClimateEntity):
         await self.coordinator.push_state_update()
         self.async_write_ha_state()
 
+    @override
     async def async_turn_on(self) -> None:
         """Turn on the device."""
         _LOGGER.debug("Turning on HVAC for device %s", self._attr_name)
@@ -196,6 +202,7 @@ class GreeClimateEntity(GreeEntity, ClimateEntity):
         await self.coordinator.push_state_update()
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self) -> None:
         """Turn off the device."""
         _LOGGER.debug("Turning off HVAC for device %s", self._attr_name)
@@ -205,6 +212,7 @@ class GreeClimateEntity(GreeEntity, ClimateEntity):
         self.async_write_ha_state()
 
     @property
+    @override
     def preset_mode(self) -> str:
         """Return the current preset mode for the device."""
         if self.coordinator.device.steady_heat:
@@ -217,6 +225,7 @@ class GreeClimateEntity(GreeEntity, ClimateEntity):
             return PRESET_BOOST
         return PRESET_NONE
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         if preset_mode not in PRESET_MODES:
@@ -246,11 +255,13 @@ class GreeClimateEntity(GreeEntity, ClimateEntity):
         self.async_write_ha_state()
 
     @property
+    @override
     def fan_mode(self) -> str | None:
         """Return the current fan mode for the device."""
         speed = self.coordinator.device.fan_speed
         return FAN_MODES.get(speed)
 
+    @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
         if fan_mode not in FAN_MODES_REVERSE:
@@ -261,6 +272,7 @@ class GreeClimateEntity(GreeEntity, ClimateEntity):
         self.async_write_ha_state()
 
     @property
+    @override
     def swing_mode(self) -> str:
         """Return the current swing mode for the device."""
         h_swing = self.coordinator.device.horizontal_swing == HorizontalSwing.FullSwing
@@ -274,6 +286,7 @@ class GreeClimateEntity(GreeEntity, ClimateEntity):
             return SWING_VERTICAL
         return SWING_OFF
 
+    @override
     async def async_set_swing_mode(self, swing_mode: str) -> None:
         """Set new target swing operation."""
         if swing_mode not in SWING_MODES:
@@ -295,6 +308,7 @@ class GreeClimateEntity(GreeEntity, ClimateEntity):
         await self.coordinator.push_state_update()
         self.async_write_ha_state()
 
+    @override
     def _handle_coordinator_update(self) -> None:
         """Update the state of the entity."""
         units = self.coordinator.device.temperature_units

--- a/homeassistant/components/gree/coordinator.py
+++ b/homeassistant/components/gree/coordinator.py
@@ -4,7 +4,7 @@ import copy
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from greeclimate.device import Device, DeviceInfo
 from greeclimate.discovery import Discovery, Listener
@@ -71,6 +71,7 @@ class DeviceDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._last_response_time = utcnow()
         self.async_set_updated_data(self.device.raw_properties)
 
+    @override
     async def _async_update_data(self) -> dict[str, Any]:
         """Update the state of the device."""
         _LOGGER.debug(

--- a/homeassistant/components/gree/switch.py
+++ b/homeassistant/components/gree/switch.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from greeclimate.device import Device
 
@@ -125,16 +125,19 @@ class GreeSwitch(GreeEntity, SwitchEntity):
         super().__init__(coordinator, description.key)
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return if the state is turned on."""
         return self.entity_description.get_value_fn(self.coordinator.device)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         self.entity_description.set_value_fn(self.coordinator.device, True)
         await self.coordinator.push_state_update()
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         self.entity_description.set_value_fn(self.coordinator.device, False)

--- a/homeassistant/components/green_planet_energy/config_flow.py
+++ b/homeassistant/components/green_planet_energy/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Green Planet Energy integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from greenplanet_energy_api import (
     GreenPlanetEnergyAPI,
@@ -23,6 +23,7 @@ class GreenPlanetEnergyConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
     MINOR_VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/green_planet_energy/coordinator.py
+++ b/homeassistant/components/green_planet_energy/coordinator.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from greenplanet_energy_api import (
     GreenPlanetEnergyAPI,
@@ -39,6 +39,7 @@ class GreenPlanetEnergyUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
         self.api = GreenPlanetEnergyAPI(session=async_get_clientsession(hass))
 
+    @override
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via library."""
         try:

--- a/homeassistant/components/green_planet_energy/sensor.py
+++ b/homeassistant/components/green_planet_energy/sensor.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from greenplanet_energy_api import GreenPlanetEnergyAPI
 
@@ -182,6 +182,7 @@ class GreenPlanetEnergySensor(
         )
 
     @property
+    @override
     def native_value(self) -> float | datetime | None:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(

--- a/homeassistant/components/greencell/config_flow.py
+++ b/homeassistant/components/greencell/config_flow.py
@@ -4,7 +4,7 @@ import asyncio
 from collections.abc import Callable
 import json
 import logging
-from typing import Any
+from typing import Any, override
 
 from greencell_client.utils import GreencellUtils
 import voluptuous as vol
@@ -64,6 +64,7 @@ class EVSEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if self._discovery_event:
                 self._discovery_event.set()
 
+    @override
     async def async_step_mqtt(
         self, discovery_info: MqttServiceInfo
     ) -> config_entries.ConfigFlowResult:
@@ -103,6 +104,7 @@ class EVSEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             description_placeholders={"serial": serial},
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> config_entries.ConfigFlowResult:

--- a/homeassistant/components/greencell/sensor.py
+++ b/homeassistant/components/greencell/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 import logging
-from typing import Any
+from typing import Any, override
 
 from greencell_client.access import GreencellAccess
 from greencell_client.elec_data import ElecData3Phase, ElecDataSinglePhase
@@ -276,10 +276,12 @@ class HabuSensor(SensorEntity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if the entity is available."""
         return not self._access.is_disabled()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register the entity with Home Assistant."""
         unsub = self._access.register_listener(self._schedule_update)
@@ -309,6 +311,7 @@ class Habu3PhaseSensor(HabuSensor):
         self._phase = phase
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         raw_value = self._sensor_data.get_value(self._phase)
@@ -333,6 +336,7 @@ class HabuSingleSensor(HabuSensor):
         self._value = sensor_data
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         raw_value = self._value.data

--- a/homeassistant/components/greeneye_monitor/sensor.py
+++ b/homeassistant/components/greeneye_monitor/sensor.py
@@ -1,6 +1,6 @@
 """Support for the sensors in a GreenEye Monitor."""
 
-from typing import Any
+from typing import Any, override
 
 import greeneye
 
@@ -146,10 +146,12 @@ class GEMSensor(SensorEntity):
             f"{self._monitor_serial_number}-{self._sensor_type}-{self._number}"
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Wait for and connect to the sensor."""
         self._sensor.add_listener(self.async_write_ha_state)
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Remove listener from the sensor."""
         if self._sensor:
@@ -175,11 +177,13 @@ class CurrentSensor(GEMSensor):
         self._net_metering = net_metering
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the current number of watts being used by the channel."""
         return self._sensor.watts
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return total wattseconds in the state dictionary."""
         if self._net_metering:
@@ -214,6 +218,7 @@ class PulseCounter(GEMSensor):
         self._attr_native_unit_of_measurement = f"{counted_quantity}/{self._time_unit}"
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the current rate of change for the given pulse counter."""
         if self._sensor.pulses_per_second is None:
@@ -242,6 +247,7 @@ class PulseCounter(GEMSensor):
         )
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return total pulses in the data dictionary."""
         return {DATA_PULSES: self._sensor.pulses}
@@ -263,6 +269,7 @@ class TemperatureSensor(GEMSensor):
         self._attr_native_unit_of_measurement = unit
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the current temperature being reported by this sensor."""
         return self._sensor.temperature
@@ -282,6 +289,7 @@ class VoltageSensor(GEMSensor):
         self._sensor: greeneye.monitor.VoltageSensor = self._sensor
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the current voltage being reported by this sensor."""
         return self._sensor.voltage

--- a/homeassistant/components/greenwave/light.py
+++ b/homeassistant/components/greenwave/light.py
@@ -3,7 +3,7 @@
 from datetime import timedelta
 import logging
 import os
-from typing import Any
+from typing import Any, override
 
 import greenwavereality as greenwave
 import voluptuous as vol
@@ -79,12 +79,14 @@ class GreenwaveLight(LightEntity):
         self._token = token
         self._gatewaydata = gatewaydata
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Instruct the light to turn on."""
         temp_brightness = int((kwargs.get(ATTR_BRIGHTNESS, 255) / 255) * 100)
         greenwave.set_brightness(self._host, self._did, temp_brightness, self._token)
         greenwave.turn_on(self._host, self._did, self._token)
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Instruct the light to turn off."""
         greenwave.turn_off(self._host, self._did, self._token)

--- a/homeassistant/components/group/binary_sensor.py
+++ b/homeassistant/components/group/binary_sensor.py
@@ -1,6 +1,6 @@
 """Platform allowing several binary sensor to be grouped into one binary sensor."""
 
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -128,6 +128,7 @@ class BinarySensorGroup(GroupEntity, BinarySensorEntity):
             self.mode = all
 
     @callback
+    @override
     def async_update_group_state(self) -> None:
         """Query all members and determine the binary sensor group state."""
         states = [
@@ -150,6 +151,7 @@ class BinarySensorGroup(GroupEntity, BinarySensorEntity):
             self._attr_is_on = self.mode(state == STATE_ON for state in states)
 
     @property
+    @override
     def device_class(self) -> BinarySensorDeviceClass | None:
         """Return the sensor class of the binary sensor."""
         return self._device_class

--- a/homeassistant/components/group/button.py
+++ b/homeassistant/components/group/button.py
@@ -1,6 +1,6 @@
 """Platform allowing several button entities to be grouped into one single button."""
 
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -111,6 +111,7 @@ class ButtonGroup(GroupEntity, ButtonEntity):
         self._attr_extra_state_attributes = {ATTR_ENTITY_ID: entity_ids}
         self._attr_unique_id = unique_id
 
+    @override
     async def async_press(self) -> None:
         """Forward the press to all buttons in the group."""
         await self.hass.services.async_call(
@@ -122,6 +123,7 @@ class ButtonGroup(GroupEntity, ButtonEntity):
         )
 
     @callback
+    @override
     def async_update_group_state(self) -> None:
         """Query all members and determine the button group state."""
         # Set group as unavailable if all members are unavailable or missing

--- a/homeassistant/components/group/config_flow.py
+++ b/homeassistant/components/group/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Coroutine, Mapping
 from functools import partial
-from typing import Any, cast
+from typing import Any, cast, override
 
 import voluptuous as vol
 
@@ -343,6 +343,7 @@ class GroupConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
     options_flow_reloads = True
 
     @callback
+    @override
     def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
         """Return config entry title.
 
@@ -352,6 +353,7 @@ class GroupConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
         return cast(str, options["name"]) if "name" in options else ""
 
     @callback
+    @override
     def async_config_flow_finished(self, options: Mapping[str, Any]) -> None:
         """Hide the group members if requested."""
         if options[CONF_HIDE_MEMBERS]:
@@ -361,6 +363,7 @@ class GroupConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
 
     @callback
     @staticmethod
+    @override
     def async_options_flow_finished(
         hass: HomeAssistant, options: Mapping[str, Any]
     ) -> None:
@@ -371,6 +374,7 @@ class GroupConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
         _async_hide_members(hass, options[CONF_ENTITIES], hidden_by)
 
     @staticmethod
+    @override
     async def async_setup_preview(hass: HomeAssistant) -> None:
         """Set up preview WS API."""
         for group_type, form_step in OPTIONS_FLOW.items():

--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -1,6 +1,6 @@
 """Platform allowing several cover to be grouped into one cover."""
 
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -134,6 +134,7 @@ class CoverGroup(GroupEntity, CoverEntity):
         self._attr_unique_id = unique_id
 
     @callback
+    @override
     def async_update_supported_features(
         self,
         entity_id: str,
@@ -175,6 +176,7 @@ class CoverGroup(GroupEntity, CoverEntity):
         else:
             self._tilts[KEY_POSITION].discard(entity_id)
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Move the covers up."""
         data = {ATTR_ENTITY_ID: self._covers[KEY_OPEN_CLOSE]}
@@ -182,6 +184,7 @@ class CoverGroup(GroupEntity, CoverEntity):
             COVER_DOMAIN, SERVICE_OPEN_COVER, data, blocking=True, context=self._context
         )
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Move the covers down."""
         data = {ATTR_ENTITY_ID: self._covers[KEY_OPEN_CLOSE]}
@@ -193,6 +196,7 @@ class CoverGroup(GroupEntity, CoverEntity):
             context=self._context,
         )
 
+    @override
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Fire the stop action."""
         data = {ATTR_ENTITY_ID: self._covers[KEY_STOP]}
@@ -200,6 +204,7 @@ class CoverGroup(GroupEntity, CoverEntity):
             COVER_DOMAIN, SERVICE_STOP_COVER, data, blocking=True, context=self._context
         )
 
+    @override
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Set covers position."""
         data = {
@@ -214,6 +219,7 @@ class CoverGroup(GroupEntity, CoverEntity):
             context=self._context,
         )
 
+    @override
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Tilt covers open."""
         data = {ATTR_ENTITY_ID: self._tilts[KEY_OPEN_CLOSE]}
@@ -225,6 +231,7 @@ class CoverGroup(GroupEntity, CoverEntity):
             context=self._context,
         )
 
+    @override
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Tilt covers closed."""
         data = {ATTR_ENTITY_ID: self._tilts[KEY_OPEN_CLOSE]}
@@ -236,6 +243,7 @@ class CoverGroup(GroupEntity, CoverEntity):
             context=self._context,
         )
 
+    @override
     async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
         """Stop cover tilt."""
         data = {ATTR_ENTITY_ID: self._tilts[KEY_STOP]}
@@ -247,6 +255,7 @@ class CoverGroup(GroupEntity, CoverEntity):
             context=self._context,
         )
 
+    @override
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Set tilt position."""
         data = {
@@ -262,6 +271,7 @@ class CoverGroup(GroupEntity, CoverEntity):
         )
 
     @callback
+    @override
     def async_update_group_state(self) -> None:
         """Update state and attributes."""
         states = [

--- a/homeassistant/components/group/entity.py
+++ b/homeassistant/components/group/entity.py
@@ -3,7 +3,7 @@
 from abc import abstractmethod
 from collections.abc import Callable, Collection, Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.const import (
     ATTR_ASSUMED_STATE,
@@ -74,6 +74,7 @@ class GroupEntity(Entity):
             self.hass, self._entity_ids, async_state_changed_listener
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register listeners."""
         for entity_id in self._entity_ids:
@@ -255,6 +256,7 @@ class Group(Entity):
         self._attr_name = value
 
     @property
+    @override
     def state(self) -> str | None:
         """Return the state of the group."""
         return self._state
@@ -264,6 +266,7 @@ class Group(Entity):
         self._attr_icon = value
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes for the group."""
         data = {ATTR_ENTITY_ID: self.tracking, ATTR_ORDER: self._order}
@@ -273,6 +276,7 @@ class Group(Entity):
         return data
 
     @property
+    @override
     def assumed_state(self) -> bool:
         """Test if any member has an assumed state."""
         return self._assumed_state
@@ -377,6 +381,7 @@ class Group(Entity):
         self._state = None
         self._async_update_group_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Handle addition to Home Assistant."""
         self._registry = self.hass.data[REG_KEY]
@@ -384,6 +389,7 @@ class Group(Entity):
         self.async_on_remove(start.async_at_start(self.hass, self._async_start))
         self.async_on_remove(self._async_deregister)
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Handle removal from Home Assistant."""
         self._async_stop()

--- a/homeassistant/components/group/event.py
+++ b/homeassistant/components/group/event.py
@@ -1,7 +1,7 @@
 """Platform allowing several event entities to be grouped into one event."""
 
 import itertools
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -118,6 +118,7 @@ class EventGroup(GroupEntity, EventEntity):
         self._attr_unique_id = unique_id
         self._attr_event_types = []
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
 
@@ -166,6 +167,7 @@ class EventGroup(GroupEntity, EventEntity):
         await super().async_added_to_hass()
 
     @callback
+    @override
     def async_update_group_state(self) -> None:
         """Query all members and determine the event group properties."""
         states = [

--- a/homeassistant/components/group/fan.py
+++ b/homeassistant/components/group/fan.py
@@ -3,7 +3,7 @@
 from functools import reduce
 import logging
 from operator import ior
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -125,31 +125,37 @@ class FanGroup(GroupEntity, FanEntity):
         self._attr_unique_id = unique_id
 
     @property
+    @override
     def speed_count(self) -> int:
         """Return the number of speeds the fan supports."""
         return self._speed_count
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the entity is on."""
         return self._is_on
 
     @property
+    @override
     def percentage(self) -> int | None:
         """Return the current speed as a percentage."""
         return self._percentage
 
     @property
+    @override
     def current_direction(self) -> str | None:
         """Return the current direction of the fan."""
         return self._direction
 
     @property
+    @override
     def oscillating(self) -> bool | None:
         """Return whether or not the fan is currently oscillating."""
         return self._oscillating
 
     @callback
+    @override
     def async_update_supported_features(
         self,
         entity_id: str,
@@ -167,6 +173,7 @@ class FanGroup(GroupEntity, FanEntity):
                 else:
                     self._fans[feature].discard(entity_id)
 
+    @override
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed of the fan, as a percentage."""
         if percentage == 0:
@@ -177,6 +184,7 @@ class FanGroup(GroupEntity, FanEntity):
             {ATTR_PERCENTAGE: percentage},
         )
 
+    @override
     async def async_oscillate(self, oscillating: bool) -> None:
         """Oscillate the fan."""
         await self._async_call_supported_entities(
@@ -185,6 +193,7 @@ class FanGroup(GroupEntity, FanEntity):
             {ATTR_OSCILLATING: oscillating},
         )
 
+    @override
     async def async_set_direction(self, direction: str) -> None:
         """Set the direction of the fan."""
         await self._async_call_supported_entities(
@@ -193,6 +202,7 @@ class FanGroup(GroupEntity, FanEntity):
             {ATTR_DIRECTION: direction},
         )
 
+    @override
     async def async_turn_on(
         self,
         percentage: int | None = None,
@@ -207,6 +217,7 @@ class FanGroup(GroupEntity, FanEntity):
             SERVICE_TURN_ON, FanEntityFeature.TURN_ON, {}
         )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the fans off."""
         await self._async_call_supported_entities(
@@ -248,6 +259,7 @@ class FanGroup(GroupEntity, FanEntity):
         setattr(self, attr, most_frequent_attribute(states, entity_attr))
 
     @callback
+    @override
     def async_update_group_state(self) -> None:
         """Update state and attributes."""
         self._update_assumed_state_from_members()

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -3,7 +3,7 @@
 from collections import Counter
 import itertools
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 import voluptuous as vol
 
@@ -168,6 +168,7 @@ class LightGroup(GroupEntity, LightEntity):
         self._attr_color_mode = ColorMode.UNKNOWN
         self._attr_supported_color_modes = {ColorMode.ONOFF}
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Forward the turn_on command to all lights in the light group."""
         data = {
@@ -185,6 +186,7 @@ class LightGroup(GroupEntity, LightEntity):
             context=self._context,
         )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Forward the turn_off command to all lights in the light group."""
         data = {ATTR_ENTITY_ID: self._entity_ids}
@@ -201,6 +203,7 @@ class LightGroup(GroupEntity, LightEntity):
         )
 
     @callback
+    @override
     def async_update_group_state(self) -> None:
         """Query all members and determine the light group state."""
         self._update_assumed_state_from_members()

--- a/homeassistant/components/group/lock.py
+++ b/homeassistant/components/group/lock.py
@@ -1,7 +1,7 @@
 """Platform allowing several locks to be grouped into one lock."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -121,6 +121,7 @@ class LockGroup(GroupEntity, LockEntity):
         self._attr_unique_id = unique_id
 
     @callback
+    @override
     def async_update_group_state(self) -> None:
         """Query all members and determine the lock group state."""
         states = [

--- a/homeassistant/components/group/media_player.py
+++ b/homeassistant/components/group/media_player.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Mapping
 from contextlib import suppress
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -250,6 +250,7 @@ class MediaPlayerGroup(MediaPlayerEntity):
             self.hass, self._entities, async_state_changed_listener
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register listeners."""
         for entity_id in self._entities:
@@ -262,15 +263,18 @@ class MediaPlayerGroup(MediaPlayerEntity):
         self.async_write_ha_state()
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the entity."""
         return self._name
 
     @property
+    @override
     def extra_state_attributes(self) -> Mapping[str, Any]:
         """Return the state attributes for the media group."""
         return {ATTR_ENTITY_ID: self._entities}
 
+    @override
     async def async_clear_playlist(self) -> None:
         """Clear players playlist."""
         data = {ATTR_ENTITY_ID: self._features[KEY_CLEAR_PLAYLIST]}
@@ -281,6 +285,7 @@ class MediaPlayerGroup(MediaPlayerEntity):
             context=self._context,
         )
 
+    @override
     async def async_media_next_track(self) -> None:
         """Send next track command."""
         data = {ATTR_ENTITY_ID: self._features[KEY_TRACKS]}
@@ -291,6 +296,7 @@ class MediaPlayerGroup(MediaPlayerEntity):
             context=self._context,
         )
 
+    @override
     async def async_media_pause(self) -> None:
         """Send pause command."""
         data = {ATTR_ENTITY_ID: self._features[KEY_PAUSE_PLAY_STOP]}
@@ -301,6 +307,7 @@ class MediaPlayerGroup(MediaPlayerEntity):
             context=self._context,
         )
 
+    @override
     async def async_media_play(self) -> None:
         """Send play command."""
         data = {ATTR_ENTITY_ID: self._features[KEY_PAUSE_PLAY_STOP]}
@@ -311,6 +318,7 @@ class MediaPlayerGroup(MediaPlayerEntity):
             context=self._context,
         )
 
+    @override
     async def async_media_previous_track(self) -> None:
         """Send previous track command."""
         data = {ATTR_ENTITY_ID: self._features[KEY_TRACKS]}
@@ -321,6 +329,7 @@ class MediaPlayerGroup(MediaPlayerEntity):
             context=self._context,
         )
 
+    @override
     async def async_media_seek(self, position: float) -> None:
         """Send seek command."""
         data = {
@@ -334,6 +343,7 @@ class MediaPlayerGroup(MediaPlayerEntity):
             context=self._context,
         )
 
+    @override
     async def async_media_stop(self) -> None:
         """Send stop command."""
         data = {ATTR_ENTITY_ID: self._features[KEY_PAUSE_PLAY_STOP]}
@@ -344,6 +354,7 @@ class MediaPlayerGroup(MediaPlayerEntity):
             context=self._context,
         )
 
+    @override
     async def async_mute_volume(self, mute: bool) -> None:
         """Mute the volume."""
         data = {
@@ -357,6 +368,7 @@ class MediaPlayerGroup(MediaPlayerEntity):
             context=self._context,
         )
 
+    @override
     async def async_play_media(
         self, media_type: MediaType | str, media_id: str, **kwargs: Any
     ) -> None:
@@ -375,6 +387,7 @@ class MediaPlayerGroup(MediaPlayerEntity):
             context=self._context,
         )
 
+    @override
     async def async_set_shuffle(self, shuffle: bool) -> None:
         """Enable/disable shuffle mode."""
         data = {
@@ -388,6 +401,7 @@ class MediaPlayerGroup(MediaPlayerEntity):
             context=self._context,
         )
 
+    @override
     async def async_turn_on(self) -> None:
         """Forward the turn_on command to all media in the media group."""
         data = {ATTR_ENTITY_ID: self._features[KEY_ON_OFF]}
@@ -398,6 +412,7 @@ class MediaPlayerGroup(MediaPlayerEntity):
             context=self._context,
         )
 
+    @override
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level(s)."""
         data = {
@@ -411,6 +426,7 @@ class MediaPlayerGroup(MediaPlayerEntity):
             context=self._context,
         )
 
+    @override
     async def async_turn_off(self) -> None:
         """Forward the turn_off command to all media in the media group."""
         data = {ATTR_ENTITY_ID: self._features[KEY_ON_OFF]}
@@ -421,6 +437,7 @@ class MediaPlayerGroup(MediaPlayerEntity):
             context=self._context,
         )
 
+    @override
     async def async_volume_up(self) -> None:
         """Turn volume up for media player(s)."""
         for entity in self._features[KEY_VOLUME]:
@@ -428,6 +445,7 @@ class MediaPlayerGroup(MediaPlayerEntity):
             if volume_level < 1:
                 await self.async_set_volume_level(min(1, volume_level + 0.1))
 
+    @override
     async def async_volume_down(self) -> None:
         """Turn volume down for media player(s)."""
         for entity in self._features[KEY_VOLUME]:

--- a/homeassistant/components/group/notify.py
+++ b/homeassistant/components/group/notify.py
@@ -3,7 +3,7 @@
 import asyncio
 from collections.abc import Mapping
 from copy import deepcopy
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -101,6 +101,7 @@ class GroupNotifyPlatform(BaseNotificationService):
         self.hass = hass
         self.entities = entities
 
+    @override
     async def async_send_message(self, message: str = "", **kwargs: Any) -> None:
         """Send message to all entities in the group."""
         payload: dict[str, Any] = {ATTR_MESSAGE: message}
@@ -171,6 +172,7 @@ class NotifyGroup(GroupEntity, NotifyEntity):
         self._attr_extra_state_attributes = {ATTR_ENTITY_ID: entity_ids}
         self._attr_unique_id = unique_id
 
+    @override
     async def async_send_message(self, message: str, title: str | None = None) -> None:
         """Send a message to all members of the group."""
 
@@ -195,6 +197,7 @@ class NotifyGroup(GroupEntity, NotifyEntity):
         )
 
     @callback
+    @override
     def async_update_group_state(self) -> None:
         """Query all members and determine the notify group state."""
         # Set group as unavailable if all members are unavailable or missing

--- a/homeassistant/components/group/sensor.py
+++ b/homeassistant/components/group/sensor.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from datetime import datetime
 import logging
 import statistics
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 import voluptuous as vol
 
@@ -388,6 +388,7 @@ class SensorGroup(GroupEntity, SensorEntity):
         self._valid_units = self._get_valid_units()
 
     @callback
+    @override
     def async_update_group_state(self) -> None:
         """Query all members and determine the sensor group state."""
         self.calculate_state_attributes(self._get_valid_entities())
@@ -480,11 +481,13 @@ class SensorGroup(GroupEntity, SensorEntity):
         )
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the sensor."""
         return {ATTR_ENTITY_ID: self._entity_ids, **self._extra_state_attribute}
 
     @property
+    @override
     def icon(self) -> str | None:
         """Return the icon.
 

--- a/homeassistant/components/group/switch.py
+++ b/homeassistant/components/group/switch.py
@@ -1,7 +1,7 @@
 """Platform allowing several switches to be grouped into one switch."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -127,6 +127,7 @@ class SwitchGroup(GroupEntity, SwitchEntity):
         if mode:
             self.mode = all
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Forward the turn_on command to all switches in the group."""
         data = {ATTR_ENTITY_ID: self._entity_ids}
@@ -140,6 +141,7 @@ class SwitchGroup(GroupEntity, SwitchEntity):
             context=self._context,
         )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Forward the turn_off command to all switches in the group."""
         data = {ATTR_ENTITY_ID: self._entity_ids}
@@ -152,6 +154,7 @@ class SwitchGroup(GroupEntity, SwitchEntity):
         )
 
     @callback
+    @override
     def async_update_group_state(self) -> None:
         """Query all members and determine the switch group state."""
         self._update_assumed_state_from_members()

--- a/homeassistant/components/group/valve.py
+++ b/homeassistant/components/group/valve.py
@@ -1,6 +1,6 @@
 """Platform allowing several valves to be grouped into one valve."""
 
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -124,6 +124,7 @@ class ValveGroup(GroupEntity, ValveEntity):
         self._attr_unique_id = unique_id
 
     @callback
+    @override
     def async_update_supported_features(
         self,
         entity_id: str,
@@ -150,6 +151,7 @@ class ValveGroup(GroupEntity, ValveEntity):
         else:
             self._valves[KEY_SET_POSITION].discard(entity_id)
 
+    @override
     async def async_open_valve(self) -> None:
         """Open the valves."""
         data = {ATTR_ENTITY_ID: self._valves[KEY_OPEN_CLOSE]}
@@ -157,7 +159,8 @@ class ValveGroup(GroupEntity, ValveEntity):
             VALVE_DOMAIN, SERVICE_OPEN_VALVE, data, blocking=True, context=self._context
         )
 
-    async def async_handle_open_valve(self) -> None:  # type: ignore[misc]
+    @override  # type: ignore[misc]
+    async def async_handle_open_valve(self) -> None:
         """Open the valves.
 
         Override the base class to avoid calling the set position service
@@ -166,6 +169,7 @@ class ValveGroup(GroupEntity, ValveEntity):
         """
         await self.async_open_valve()
 
+    @override
     async def async_close_valve(self) -> None:
         """Close valves."""
         data = {ATTR_ENTITY_ID: self._valves[KEY_OPEN_CLOSE]}
@@ -177,7 +181,8 @@ class ValveGroup(GroupEntity, ValveEntity):
             context=self._context,
         )
 
-    async def async_handle_close_valve(self) -> None:  # type: ignore[misc]
+    @override  # type: ignore[misc]
+    async def async_handle_close_valve(self) -> None:
         """Close the valves.
 
         Override the base class to avoid calling the set position service
@@ -186,6 +191,7 @@ class ValveGroup(GroupEntity, ValveEntity):
         """
         await self.async_close_valve()
 
+    @override
     async def async_set_valve_position(self, position: int) -> None:
         """Move the valves to a specific position."""
         data = {
@@ -200,6 +206,7 @@ class ValveGroup(GroupEntity, ValveEntity):
             context=self._context,
         )
 
+    @override
     async def async_stop_valve(self) -> None:
         """Stop the valves."""
         data = {ATTR_ENTITY_ID: self._valves[KEY_STOP]}
@@ -208,6 +215,7 @@ class ValveGroup(GroupEntity, ValveEntity):
         )
 
     @callback
+    @override
     def async_update_group_state(self) -> None:
         """Update state and attributes."""
         states = [

--- a/homeassistant/components/growatt_server/config_flow.py
+++ b/homeassistant/components/growatt_server/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 import growattServer
 from growattServer import GrowattV1ApiErrorCode
@@ -55,6 +55,7 @@ class GrowattServerConfigFlow(ConfigFlow, domain=DOMAIN):
         self.auth_type: str | None = None
         self.plants: list[dict[str, Any]] = []
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/growatt_server/coordinator.py
+++ b/homeassistant/components/growatt_server/coordinator.py
@@ -3,7 +3,7 @@
 import datetime
 import json
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 import growattServer
 from growattServer import GrowattV1ApiErrorCode
@@ -331,6 +331,7 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         return self.data
 
+    @override
     async def _async_update_data(self) -> dict[str, Any]:
         """Asynchronously update data via library."""
         try:

--- a/homeassistant/components/growatt_server/number.py
+++ b/homeassistant/components/growatt_server/number.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 import logging
+from typing import override
 
 from growattServer import GrowattV1ApiError
 
@@ -158,6 +159,7 @@ class GrowattNumber(CoordinatorEntity[GrowattCoordinator], NumberEntity):
         )
 
     @property
+    @override
     def native_value(self) -> int | None:
         """Return the current value of the number."""
         value = self.coordinator.data.get(self.entity_description.api_key)
@@ -165,6 +167,7 @@ class GrowattNumber(CoordinatorEntity[GrowattCoordinator], NumberEntity):
             return None
         return int(value)
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set the value of the number."""
         # Use write_key if specified, otherwise fall back to api_key

--- a/homeassistant/components/growatt_server/sensor/__init__.py
+++ b/homeassistant/components/growatt_server/sensor/__init__.py
@@ -3,6 +3,7 @@
 
 from datetime import date, datetime
 import logging
+from typing import override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.core import HomeAssistant, callback
@@ -132,11 +133,13 @@ class GrowattSensor(CoordinatorEntity[GrowattCoordinator], SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> StateType | date | datetime:
         """Return the state of the sensor."""
         return self.coordinator.get_data(self.entity_description)
 
     @property
+    @override
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit of measurement of the sensor, if any."""
         if self.entity_description.currency:

--- a/homeassistant/components/growatt_server/switch.py
+++ b/homeassistant/components/growatt_server/switch.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 import logging
-from typing import Any
+from typing import Any, override
 
 from growattServer import GrowattV1ApiError
 
@@ -115,6 +115,7 @@ class GrowattSwitch(CoordinatorEntity[GrowattCoordinator], SwitchEntity):
         )
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the switch is on."""
         value = self.coordinator.data.get(self.entity_description.api_key)
@@ -124,10 +125,12 @@ class GrowattSwitch(CoordinatorEntity[GrowattCoordinator], SwitchEntity):
         # API returns integer 1 for enabled, 0 for disabled
         return bool(value)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self._async_set_state(True)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self._async_set_state(False)

--- a/homeassistant/components/gtfs/sensor.py
+++ b/homeassistant/components/gtfs/sensor.py
@@ -4,7 +4,7 @@ import datetime
 import logging
 import os
 import threading
-from typing import Any
+from typing import Any, override
 
 import pygtfs
 from sqlalchemy.sql import text
@@ -550,26 +550,31 @@ class GTFSDepartureSensor(SensorEntity):
         self.update()
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the sensor."""
         return self._name
 
     @property
+    @override
     def native_value(self) -> datetime.datetime | None:
         """Return the state of the sensor."""
         return self._state
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return self._available
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         return self._attributes
 
     @property
+    @override
     def icon(self) -> str:
         """Icon to use in the frontend, if any."""
         return self._icon

--- a/homeassistant/components/guardian/binary_sensor.py
+++ b/homeassistant/components/guardian/binary_sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.binary_sensor import (
     DOMAIN as BINARY_SENSOR_DOMAIN,
@@ -157,6 +157,7 @@ class PairedSensorBinarySensor(PairedSensorEntity, BinarySensorEntity):
         self._attr_is_on = True
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
         return self.entity_description.is_on_fn(self.coordinator.data)
@@ -179,6 +180,7 @@ class ValveControllerBinarySensor(ValveControllerEntity, BinarySensorEntity):
         self._attr_is_on = True
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
         return self.entity_description.is_on_fn(self.coordinator.data)

--- a/homeassistant/components/guardian/button.py
+++ b/homeassistant/components/guardian/button.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import override
 
 from aioguardian import Client
 
@@ -97,6 +98,7 @@ class GuardianButton(ValveControllerEntity, ButtonEntity):
         self._client = data.client
 
     @convert_exceptions_to_homeassistant_error
+    @override
     async def async_press(self) -> None:
         """Send out a restart command."""
         async with self._client:

--- a/homeassistant/components/guardian/config_flow.py
+++ b/homeassistant/components/guardian/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for Elexa Guardian integration."""
 
-from typing import Any
+from typing import Any, override
 
 from aioguardian import Client
 from aioguardian.errors import GuardianError
@@ -73,6 +73,7 @@ class GuardianConfigFlow(ConfigFlow, domain=DOMAIN):
         else:
             self._abort_if_unique_id_configured()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -99,6 +100,7 @@ class GuardianConfigFlow(ConfigFlow, domain=DOMAIN):
             title=info[CONF_UID], data={CONF_UID: info["uid"], **user_input}
         )
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:
@@ -112,6 +114,7 @@ class GuardianConfigFlow(ConfigFlow, domain=DOMAIN):
         )
         return await self.async_step_discovery_confirm()
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/guardian/coordinator.py
+++ b/homeassistant/components/guardian/coordinator.py
@@ -3,7 +3,7 @@
 import asyncio
 from collections.abc import Callable, Coroutine
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, cast, override
 
 from aioguardian import Client
 from aioguardian.errors import GuardianError
@@ -55,6 +55,7 @@ class GuardianDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self.config_entry.entry_id
         )
 
+    @override
     async def _async_update_data(self) -> dict[str, Any]:
         """Execute a "locked" API request against the valve controller."""
         async with self._api_lock, self._client:

--- a/homeassistant/components/guardian/sensor.py
+++ b/homeassistant/components/guardian/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -183,6 +183,7 @@ class PairedSensorSensor(PairedSensorEntity, SensorEntity):
     entity_description: PairedSensorDescription
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the value reported by the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)
@@ -194,6 +195,7 @@ class ValveControllerSensor(ValveControllerEntity, SensorEntity):
     entity_description: ValveControllerSensorDescription
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the value reported by the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/guardian/switch.py
+++ b/homeassistant/components/guardian/switch.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from aioguardian import Client
 
@@ -137,22 +137,26 @@ class ValveControllerSwitch(ValveControllerEntity, SwitchEntity):
         self._client = data.client
 
     @property
+    @override
     def extra_state_attributes(self) -> Mapping[str, Any]:
         """Return entity specific state attributes."""
         return self.entity_description.extra_state_attributes_fn(self.coordinator.data)
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return True if entity is on."""
         return self.entity_description.is_on_fn(self.coordinator.data)
 
     @convert_exceptions_to_homeassistant_error
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self.entity_description.off_fn(self._client)
         await self.coordinator.async_request_refresh()
 
     @convert_exceptions_to_homeassistant_error
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self.entity_description.on_fn(self._client)

--- a/homeassistant/components/guardian/valve.py
+++ b/homeassistant/components/guardian/valve.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any
+from typing import Any, override
 
 from aioguardian import Client
 
@@ -139,33 +139,39 @@ class ValveControllerValve(ValveControllerEntity, ValveEntity):
         self._client = data.client
 
     @property
+    @override
     def is_closing(self) -> bool:
         """Return if the valve is closing or not."""
         return self.entity_description.is_closing_fn(self.coordinator.data)
 
     @property
+    @override
     def is_closed(self) -> bool:
         """Return if the valve is closed or not."""
         return self.entity_description.is_closed_fn(self.coordinator.data)
 
     @property
+    @override
     def is_opening(self) -> bool:
         """Return if the valve is opening or not."""
         return self.entity_description.is_opening_fn(self.coordinator.data)
 
     @convert_exceptions_to_homeassistant_error
+    @override
     async def async_close_valve(self) -> None:
         """Close the valve."""
         await self.entity_description.close_coro_fn(self._client)
         await self.coordinator.async_request_refresh()
 
     @convert_exceptions_to_homeassistant_error
+    @override
     async def async_open_valve(self) -> None:
         """Open the valve."""
         await self.entity_description.open_coro_fn(self._client)
         await self.coordinator.async_request_refresh()
 
     @convert_exceptions_to_homeassistant_error
+    @override
     async def async_stop_valve(self) -> None:
         """Stop the valve."""
         await self.entity_description.halt_coro_fn(self._client)

--- a/homeassistant/components/guntamatic/config_flow.py
+++ b/homeassistant/components/guntamatic/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for the guntamatic integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from guntamatic.heater import Heater, NoSerialException
 import requests
@@ -27,6 +27,7 @@ class GuntamaticConfigFlow(ConfigFlow, domain=DOMAIN):
 
     _discovered_ip: str
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:
@@ -58,6 +59,7 @@ class GuntamaticConfigFlow(ConfigFlow, domain=DOMAIN):
         self._set_confirm_only()
         return self.async_show_form(step_id="discovery_confirm")
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/guntamatic/coordinator.py
+++ b/homeassistant/components/guntamatic/coordinator.py
@@ -1,6 +1,7 @@
 """Coordinator for Guntamatic integration."""
 
 import logging
+from typing import override
 
 from guntamatic.heater import Heater
 import requests
@@ -31,6 +32,7 @@ class GuntamaticCoordinator(DataUpdateCoordinator[dict[str, list[str]]]):
         )
         self.heater = Heater(entry.data[CONF_HOST])
 
+    @override
     async def _async_update_data(self) -> dict[str, list[str]]:
         """Fetch data from heater."""
         try:

--- a/homeassistant/components/guntamatic/sensor.py
+++ b/homeassistant/components/guntamatic/sensor.py
@@ -1,5 +1,7 @@
 """Support for Guntamatic sensors in Home Assistant."""
 
+from typing import override
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -146,6 +148,7 @@ class GuntamaticSensor(CoordinatorEntity[GuntamaticCoordinator], SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the current value of the sensor."""
         return self.coordinator.data[self.entity_description.key][0]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In preparation to enable the mypy check for `@override` in https://github.com/home-assistant/core/pull/171853

To make it easier to review, you can get a simplified diff with only changed lines (no context), and check that only imports changed and `@override` lines added: `git show override_componets_f_g --unified=0 | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)'`

Or get a diff with only the non-decorator changes:

`git show override_componets_f_g --unified=0 | grep -E '^[+-]' | grep -vE '^(\+\+\+|---) ' | grep -vE '^[+-][[:space:]]*@override$' | grep -vE '^[+-]from typing import '`

To reproduce and double check this change, run the following:

```bash
# generate errors list:
python extract_override_errors.py homeassistant/components

# filter component range
grep -E 'components/[f-g]' explicit_override_errors.txt | sort -o explicit_override_errors.txt

# add override decorator and ruff it
python add_override_decorators.py explicit_override_errors.txt
```

The two scripts can be found in https://github.com/home-assistant/core/pull/171853

### Extra manual changes:
- mypy `# type: ignore` comment moved in group


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


