### PR TITLE
Add valve platform to Ouman EH-800

### DIFF
--- a/homeassistant/components/ouman_eh_800/__init__.py
+++ b/homeassistant/components/ouman_eh_800/__init__.py
@@ -7,6 +7,7 @@ from .coordinator import OumanEh800ConfigEntry, OumanEh800Coordinator
 
 _PLATFORMS: list[Platform] = [
     Platform.SENSOR,
+    Platform.VALVE,
 ]
 
 

--- a/homeassistant/components/ouman_eh_800/coordinator.py
+++ b/homeassistant/components/ouman_eh_800/coordinator.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 import logging
 
 from ouman_eh_800_api import (
+    ControllableEndpoint,
     L1BaseEndpoints,
     L2BaseEndpoints,
     OumanClientAuthenticationError,
@@ -17,7 +18,11 @@ from ouman_eh_800_api import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
+from homeassistant.exceptions import (
+    ConfigEntryError,
+    ConfigEntryNotReady,
+    HomeAssistantError,
+)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -96,6 +101,21 @@ class OumanEh800Coordinator(DataUpdateCoordinator[dict[OumanEndpoint, OumanValue
             return await self.client.get_values(self._registry_set)
         except OumanClientCommunicationError as err:
             raise UpdateFailed("Error communicating with API") from err
+
+    async def async_set_endpoint_value(
+        self, endpoint: ControllableEndpoint, value: OumanValues | int
+    ) -> None:
+        """Set a value on the device and refresh."""
+        try:
+            result = await self.client.set_endpoint_value(endpoint, value)
+        except OumanClientAuthenticationError as err:
+            raise HomeAssistantError("Authentication failed") from err
+        except OumanClientCommunicationError as err:
+            raise HomeAssistantError("Error communicating with API") from err
+
+        self.async_set_updated_data({**self.data, endpoint: result})
+        # Separate refresh on all endpoints to catch cascading changes.
+        await self.async_request_refresh()
 
     def sync_circuit_device_names(self) -> None:
         """Set the device-reported circuit names for the L1/L2 sub-device names.

--- a/homeassistant/components/ouman_eh_800/strings.json
+++ b/homeassistant/components/ouman_eh_800/strings.json
@@ -49,6 +49,9 @@
         "name": "Supply water temperature setpoint"
       },
       "valve_position": { "name": "Valve position" }
+    },
+    "valve": {
+      "valve_position_setpoint": { "name": "Valve position setpoint" }
     }
   }
 }

--- a/homeassistant/components/ouman_eh_800/valve.py
+++ b/homeassistant/components/ouman_eh_800/valve.py
@@ -1,0 +1,92 @@
+"""Valve platform for the Ouman EH-800 integration."""
+
+from dataclasses import dataclass
+
+from ouman_eh_800_api import IntControlOumanEndpoint, L1BaseEndpoints, L2BaseEndpoints
+
+from homeassistant.components.valve import (
+    ValveDeviceClass,
+    ValveEntity,
+    ValveEntityDescription,
+    ValveEntityFeature,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import OumanDevice
+from .coordinator import OumanEh800ConfigEntry, OumanEh800Coordinator
+from .entity import OumanEh800Entity, OumanEh800EntityDescription
+
+PARALLEL_UPDATES = 1
+
+
+@dataclass(frozen=True, kw_only=True)
+class OumanEh800ValveEntityDescription(
+    OumanEh800EntityDescription, ValveEntityDescription
+):
+    """Valve description with main/L1/L2 device assignment."""
+
+
+VALVE_DESCRIPTIONS: dict[IntControlOumanEndpoint, OumanEh800ValveEntityDescription] = {
+    L1BaseEndpoints.VALVE_POSITION_SETPOINT: OumanEh800ValveEntityDescription(
+        device=OumanDevice.L1,
+        key="valve_position_setpoint",
+        translation_key="valve_position_setpoint",
+        device_class=ValveDeviceClass.WATER,
+    ),
+    L2BaseEndpoints.VALVE_POSITION_SETPOINT: OumanEh800ValveEntityDescription(
+        device=OumanDevice.L2,
+        key="valve_position_setpoint",
+        translation_key="valve_position_setpoint",
+        device_class=ValveDeviceClass.WATER,
+    ),
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: OumanEh800ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Ouman EH-800 valve entities based on a config entry."""
+    coordinator = entry.runtime_data
+    async_add_entities(
+        OumanEh800ValveEntity(coordinator, endpoint, description)
+        for endpoint in coordinator.data
+        if isinstance(endpoint, IntControlOumanEndpoint)
+        and (description := VALVE_DESCRIPTIONS.get(endpoint)) is not None
+    )
+
+
+class OumanEh800ValveEntity(OumanEh800Entity, ValveEntity):
+    """Ouman EH-800 valve entity."""
+
+    entity_description: OumanEh800ValveEntityDescription
+    _endpoint: IntControlOumanEndpoint
+
+    _attr_reports_position = True
+    _attr_supported_features = (
+        ValveEntityFeature.SET_POSITION
+        | ValveEntityFeature.OPEN
+        | ValveEntityFeature.CLOSE
+    )
+
+    def __init__(
+        self,
+        coordinator: OumanEh800Coordinator,
+        endpoint: IntControlOumanEndpoint,
+        description: OumanEh800ValveEntityDescription,
+    ) -> None:
+        """Initialize the valve entity."""
+        super().__init__(coordinator, endpoint, description)
+
+    @property
+    def current_valve_position(self) -> int:
+        """Return the current valve position 0-100."""
+        value = self.coordinator.data[self._endpoint]
+        assert isinstance(value, float)
+        return int(value)
+
+    async def async_set_valve_position(self, position: int) -> None:
+        """Move the valve to the given position."""
+        await self.coordinator.async_set_endpoint_value(self._endpoint, position)

--- a/homeassistant/components/ouman_eh_800/valve.py
+++ b/homeassistant/components/ouman_eh_800/valve.py
@@ -14,7 +14,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import OumanDevice
-from .coordinator import OumanEh800ConfigEntry, OumanEh800Coordinator
+from .coordinator import OumanEh800ConfigEntry
 from .entity import OumanEh800Entity, OumanEh800EntityDescription
 
 PARALLEL_UPDATES = 1
@@ -70,15 +70,6 @@ class OumanEh800ValveEntity(OumanEh800Entity, ValveEntity):
         | ValveEntityFeature.OPEN
         | ValveEntityFeature.CLOSE
     )
-
-    def __init__(
-        self,
-        coordinator: OumanEh800Coordinator,
-        endpoint: IntControlOumanEndpoint,
-        description: OumanEh800ValveEntityDescription,
-    ) -> None:
-        """Initialize the valve entity."""
-        super().__init__(coordinator, endpoint, description)
 
     @property
     def current_valve_position(self) -> int:

--- a/tests/components/ouman_eh_800/conftest.py
+++ b/tests/components/ouman_eh_800/conftest.py
@@ -236,6 +236,21 @@ def mock_ouman_client(registry_set: OumanRegistrySet) -> Generator[AsyncMock]:
         client = mock_client.return_value
         client.get_active_registries.return_value = registry_set
         client.get_values.return_value = values
+
+        # Simulate the device: a successful write changes what subsequent
+        # reads return, so the coordinator's post-write refresh keeps the
+        # new value instead of reverting. The API library parses numeric
+        # responses as floats via ``NumberOumanEndpoint.parse_value``, so
+        # we mirror that here so int writes round-trip as floats. Tests can
+        # override by replacing ``set_endpoint_value.side_effect``.
+        def _set_endpoint_value(
+            endpoint: OumanEndpoint, value: OumanValues
+        ) -> OumanValues:
+            stored: OumanValues = float(value) if isinstance(value, int) else value
+            values[endpoint] = stored
+            return stored
+
+        client.set_endpoint_value.side_effect = _set_endpoint_value
         yield client
 
 

--- a/tests/components/ouman_eh_800/snapshots/test_valve.ambr
+++ b/tests/components/ouman_eh_800/snapshots/test_valve.ambr
@@ -1,0 +1,109 @@
+# serializer version: 1
+# name: test_entities[valve-room_sensors][valve.heating_circuit_1_patterilammitys_valve_position_setpoint-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'valve',
+    'entity_category': None,
+    'entity_id': 'valve.heating_circuit_1_patterilammitys_valve_position_setpoint',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Valve position setpoint',
+    'options': dict({
+    }),
+    'original_device_class': <ValveDeviceClass.WATER: 'water'>,
+    'original_icon': None,
+    'original_name': 'Valve position setpoint',
+    'platform': 'ouman_eh_800',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ValveEntityFeature: 7>,
+    'translation_key': 'valve_position_setpoint',
+    'unique_id': '01JABCDEFGHIJKLMNOPQRSTUVW_l1_valve_position_setpoint',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[valve-room_sensors][valve.heating_circuit_1_patterilammitys_valve_position_setpoint-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_position': 0,
+      'device_class': 'water',
+      'friendly_name': 'Heating circuit 1 Patterilämmitys Valve position setpoint',
+      'is_closed': True,
+      'supported_features': <ValveEntityFeature: 7>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'valve.heating_circuit_1_patterilammitys_valve_position_setpoint',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'closed',
+  })
+# ---
+# name: test_entities[valve-room_sensors][valve.heating_circuit_2_lattialammitys_valve_position_setpoint-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'valve',
+    'entity_category': None,
+    'entity_id': 'valve.heating_circuit_2_lattialammitys_valve_position_setpoint',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Valve position setpoint',
+    'options': dict({
+    }),
+    'original_device_class': <ValveDeviceClass.WATER: 'water'>,
+    'original_icon': None,
+    'original_name': 'Valve position setpoint',
+    'platform': 'ouman_eh_800',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ValveEntityFeature: 7>,
+    'translation_key': 'valve_position_setpoint',
+    'unique_id': '01JABCDEFGHIJKLMNOPQRSTUVW_l2_valve_position_setpoint',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[valve-room_sensors][valve.heating_circuit_2_lattialammitys_valve_position_setpoint-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_position': 0,
+      'device_class': 'water',
+      'friendly_name': 'Heating circuit 2 Lattialämmitys Valve position setpoint',
+      'is_closed': True,
+      'supported_features': <ValveEntityFeature: 7>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'valve.heating_circuit_2_lattialammitys_valve_position_setpoint',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'closed',
+  })
+# ---

--- a/tests/components/ouman_eh_800/test_valve.py
+++ b/tests/components/ouman_eh_800/test_valve.py
@@ -1,0 +1,123 @@
+"""Tests for the Ouman EH-800 valve platform."""
+
+from unittest.mock import AsyncMock
+
+from ouman_eh_800_api import (
+    L1BaseEndpoints,
+    OumanClientAuthenticationError,
+    OumanClientCommunicationError,
+)
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.valve import (
+    ATTR_POSITION,
+    DOMAIN as VALVE_DOMAIN,
+    SERVICE_CLOSE_VALVE,
+    SERVICE_OPEN_VALVE,
+    SERVICE_SET_VALVE_POSITION,
+)
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+# Only L1 and L2 base endpoints produce valve entities. A single scenario
+# that exposes both is enough to cover the snapshot; the relay-only and
+# single-circuit scenarios would either be empty or duplicate this output.
+@pytest.mark.parametrize("scenario", ["room_sensors"], indirect=True)
+@pytest.mark.parametrize("init_integration", [Platform.VALVE], indirect=True)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
+async def test_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the valve entities for each registry-set scenario."""
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize("init_integration", [Platform.VALVE], indirect=True)
+@pytest.mark.usefixtures("init_integration")
+@pytest.mark.parametrize(
+    ("service", "service_data", "expected_position"),
+    [
+        pytest.param(
+            SERVICE_SET_VALVE_POSITION,
+            {ATTR_POSITION: 42},
+            42,
+            id="set_position",
+        ),
+        pytest.param(SERVICE_OPEN_VALVE, {}, 100, id="open"),
+        pytest.param(SERVICE_CLOSE_VALVE, {}, 0, id="close"),
+    ],
+)
+async def test_async_set_valve_position(
+    hass: HomeAssistant,
+    mock_ouman_client: AsyncMock,
+    service: str,
+    service_data: dict[str, int],
+    expected_position: int,
+) -> None:
+    """Test that valve services write to the device and update state."""
+    entity_id = "valve.heating_circuit_1_patterilammitys_valve_position_setpoint"
+
+    await hass.services.async_call(
+        VALVE_DOMAIN,
+        service,
+        {ATTR_ENTITY_ID: entity_id, **service_data},
+        blocking=True,
+    )
+
+    mock_ouman_client.set_endpoint_value.assert_called_once_with(
+        L1BaseEndpoints.VALVE_POSITION_SETPOINT, expected_position
+    )
+    assert (
+        hass.states.get(entity_id).attributes["current_position"] == expected_position
+    )
+
+
+@pytest.mark.parametrize("init_integration", [Platform.VALVE], indirect=True)
+@pytest.mark.usefixtures("init_integration")
+@pytest.mark.parametrize(
+    ("client_error", "expected_message"),
+    [
+        pytest.param(
+            OumanClientAuthenticationError("Wrong username or password"),
+            "Authentication failed",
+            id="auth_failure",
+        ),
+        pytest.param(
+            OumanClientCommunicationError("Network error: Connection refused"),
+            "Error communicating with API",
+            id="communication_failure",
+        ),
+    ],
+)
+async def test_async_set_valve_position_errors(
+    hass: HomeAssistant,
+    mock_ouman_client: AsyncMock,
+    client_error: Exception,
+    expected_message: str,
+) -> None:
+    """Test that client errors are mapped to HomeAssistantError."""
+    mock_ouman_client.set_endpoint_value.side_effect = client_error
+
+    with pytest.raises(HomeAssistantError, match=expected_message):
+        await hass.services.async_call(
+            VALVE_DOMAIN,
+            SERVICE_SET_VALVE_POSITION,
+            {
+                ATTR_ENTITY_ID: "valve.heating_circuit_1_patterilammitys_valve_position_setpoint",
+                ATTR_POSITION: 50,
+            },
+            blocking=True,
+        )
+
+    mock_ouman_client.set_endpoint_value.assert_called_once_with(
+        L1BaseEndpoints.VALVE_POSITION_SETPOINT, 50
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds the valve platform to the Ouman EH-800 integration so users can manually control the mixing valve position on each heating circuit. One `valve` entity per active heating circuit (H1/H2) is exposed, reporting the current position and supporting `open_valve`, `close_valve`, and `set_valve_position` services.

The first commit moves the shared write path (`coordinator.async_set_endpoint_value`) and the test mock that simulates the device's read-after-write behavior onto this branch. It is identical to the version on the open select and number platform PRs; whichever lands first absorbs it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45568
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
