### PR TITLE
Add SecureOn password support to Wake On Lan

### DIFF
--- a/homeassistant/components/wake_on_lan/__init__.py
+++ b/homeassistant/components/wake_on_lan/__init__.py
@@ -49,7 +49,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         _LOGGER.debug(
             "Send magic packet to mac %s (secureon: %s, broadcast: %s, port: %s)",
             mac_address,
-            secureon_password,
+            secureon_password is not None,
             broadcast_address,
             broadcast_port,
         )

--- a/homeassistant/components/wake_on_lan/__init__.py
+++ b/homeassistant/components/wake_on_lan/__init__.py
@@ -2,6 +2,7 @@
 
 from functools import partial
 import logging
+from typing import TYPE_CHECKING
 
 import voluptuous as vol
 import wakeonlan
@@ -12,7 +13,7 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DOMAIN, PLATFORMS
+from .const import CONF_SECUREON_PASSWORD, DOMAIN, PLATFORMS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,6 +22,7 @@ SERVICE_SEND_MAGIC_PACKET = "send_magic_packet"
 WAKE_ON_LAN_SEND_MAGIC_PACKET_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_MAC): cv.string,
+        vol.Optional(CONF_SECUREON_PASSWORD): cv.string,
         vol.Optional(CONF_BROADCAST_ADDRESS): cv.string,
         vol.Optional(CONF_BROADCAST_PORT): cv.port,
     }
@@ -35,6 +37,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     async def send_magic_packet(call: ServiceCall) -> None:
         """Send magic packet to wake up a device."""
         mac_address = call.data.get(CONF_MAC)
+        secureon_password = call.data.get(CONF_SECUREON_PASSWORD)
         broadcast_address = call.data.get(CONF_BROADCAST_ADDRESS)
         broadcast_port = call.data.get(CONF_BROADCAST_PORT)
 
@@ -45,14 +48,21 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             service_kwargs["port"] = broadcast_port
 
         _LOGGER.debug(
-            "Send magic packet to mac %s (broadcast: %s, port: %s)",
+            "Send magic packet to mac %s (secureon: %s, broadcast: %s, port: %s)",
             mac_address,
+            secureon_password,
             broadcast_address,
             broadcast_port,
         )
 
+        if TYPE_CHECKING:
+            assert isinstance(mac_address, str)
+
+        if secureon_password:
+            mac_address += f"/{secureon_password}"
+
         await hass.async_add_executor_job(
-            partial(wakeonlan.send_magic_packet, mac_address, **service_kwargs)  # type: ignore[arg-type]
+            partial(wakeonlan.send_magic_packet, mac_address, **service_kwargs)
         )
 
     hass.services.async_register(

--- a/homeassistant/components/wake_on_lan/__init__.py
+++ b/homeassistant/components/wake_on_lan/__init__.py
@@ -2,7 +2,6 @@
 
 from functools import partial
 import logging
-from typing import TYPE_CHECKING
 
 import voluptuous as vol
 import wakeonlan
@@ -36,7 +35,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     async def send_magic_packet(call: ServiceCall) -> None:
         """Send magic packet to wake up a device."""
-        mac_address = call.data.get(CONF_MAC)
+        mac_address: str = call.data[CONF_MAC]
         secureon_password = call.data.get(CONF_SECUREON_PASSWORD)
         broadcast_address = call.data.get(CONF_BROADCAST_ADDRESS)
         broadcast_port = call.data.get(CONF_BROADCAST_PORT)
@@ -54,9 +53,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             broadcast_address,
             broadcast_port,
         )
-
-        if TYPE_CHECKING:
-            assert isinstance(mac_address, str)
 
         if secureon_password:
             mac_address += f"/{secureon_password}"

--- a/homeassistant/components/wake_on_lan/button.py
+++ b/homeassistant/components/wake_on_lan/button.py
@@ -78,7 +78,7 @@ class WolButton(ButtonEntity):
         _LOGGER.debug(
             "Send magic packet to mac %s (secureon: %s, broadcast: %s, port: %s)",
             self._mac_address,
-            self._secureon_password,
+            self._secureon_password is not None,
             self._broadcast_address,
             self._broadcast_port,
         )

--- a/homeassistant/components/wake_on_lan/button.py
+++ b/homeassistant/components/wake_on_lan/button.py
@@ -13,6 +13,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .const import CONF_SECUREON_PASSWORD
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -25,6 +27,7 @@ async def async_setup_entry(
     broadcast_address: str | None = entry.options.get(CONF_BROADCAST_ADDRESS)
     broadcast_port: int | None = entry.options.get(CONF_BROADCAST_PORT)
     mac_address: str = entry.options[CONF_MAC]
+    secureon_password: str | None = entry.options.get(CONF_SECUREON_PASSWORD)
     name: str = entry.title
 
     async_add_entities(
@@ -32,6 +35,7 @@ async def async_setup_entry(
             WolButton(
                 name,
                 mac_address,
+                secureon_password,
                 broadcast_address,
                 broadcast_port,
             )
@@ -48,11 +52,13 @@ class WolButton(ButtonEntity):
         self,
         name: str,
         mac_address: str,
+        secureon_password: str | None,
         broadcast_address: str | None,
         broadcast_port: int | None,
     ) -> None:
         """Initialize the WOL button."""
         self._mac_address = mac_address
+        self._secureon_password = secureon_password
         self._broadcast_address = broadcast_address
         self._broadcast_port = broadcast_port
         self._attr_unique_id = dr.format_mac(mac_address)
@@ -70,12 +76,17 @@ class WolButton(ButtonEntity):
             service_kwargs["port"] = self._broadcast_port
 
         _LOGGER.debug(
-            "Send magic packet to mac %s (broadcast: %s, port: %s)",
+            "Send magic packet to mac %s (secureon: %s, broadcast: %s, port: %s)",
             self._mac_address,
+            self._secureon_password,
             self._broadcast_address,
             self._broadcast_port,
         )
 
+        mac = self._mac_address
+        if self._secureon_password:
+            mac += f"/{self._secureon_password}"
+
         await self.hass.async_add_executor_job(
-            partial(wakeonlan.send_magic_packet, self._mac_address, **service_kwargs)
+            partial(wakeonlan.send_magic_packet, mac, **service_kwargs)
         )

--- a/homeassistant/components/wake_on_lan/config_flow.py
+++ b/homeassistant/components/wake_on_lan/config_flow.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.selector import (
     TextSelector,
 )
 
-from .const import DEFAULT_NAME, DOMAIN
+from .const import CONF_SECUREON_PASSWORD, DEFAULT_NAME, DOMAIN
 
 
 async def validate(
@@ -48,6 +48,7 @@ async def validate_options(
 
 DATA_SCHEMA = {vol.Required(CONF_MAC): TextSelector()}
 OPTIONS_SCHEMA = {
+    vol.Optional(CONF_SECUREON_PASSWORD): TextSelector(),
     vol.Optional(CONF_BROADCAST_ADDRESS): TextSelector(),
     vol.Optional(CONF_BROADCAST_PORT): NumberSelector(
         NumberSelectorConfig(min=0, max=65535, step=1, mode=NumberSelectorMode.BOX)

--- a/homeassistant/components/wake_on_lan/const.py
+++ b/homeassistant/components/wake_on_lan/const.py
@@ -6,6 +6,7 @@ DOMAIN = "wake_on_lan"
 PLATFORMS = [Platform.BUTTON]
 
 CONF_OFF_ACTION = "turn_off"
+CONF_SECUREON_PASSWORD = "secureon_password"
 
 DEFAULT_NAME = "Wake on LAN"
 DEFAULT_PING_TIMEOUT = 1

--- a/homeassistant/components/wake_on_lan/services.yaml
+++ b/homeassistant/components/wake_on_lan/services.yaml
@@ -5,6 +5,10 @@ send_magic_packet:
       example: "aa:bb:cc:dd:ee:ff"
       selector:
         text:
+    secureon_password:
+      example: "11:22:33:44:55:66"
+      selector:
+        text:
     broadcast_address:
       example: 192.168.255.255
       selector:

--- a/homeassistant/components/wake_on_lan/services.yaml
+++ b/homeassistant/components/wake_on_lan/services.yaml
@@ -9,6 +9,7 @@ send_magic_packet:
       example: "11:22:33:44:55:66"
       selector:
         text:
+          type: password
     broadcast_address:
       example: 192.168.255.255
       selector:

--- a/homeassistant/components/wake_on_lan/strings.json
+++ b/homeassistant/components/wake_on_lan/strings.json
@@ -8,12 +8,14 @@
         "data": {
           "broadcast_address": "Broadcast address",
           "broadcast_port": "Broadcast port",
-          "mac": "MAC address"
+          "mac": "MAC address",
+          "secureon_password": "SecureOn password"
         },
         "data_description": {
           "broadcast_address": "The IP address of the host to send the magic packet to. Defaults to `255.255.255.255` and is normally not changed.",
           "broadcast_port": "The port to send the magic packet to. Defaults to `9` and is normally not changed.",
-          "mac": "MAC address of the device to wake up."
+          "mac": "MAC address of the device to wake up.",
+          "secureon_password": "The SecureOn password to append to the magic packet."
         }
       }
     }
@@ -26,11 +28,13 @@
       "init": {
         "data": {
           "broadcast_address": "[%key:component::wake_on_lan::config::step::user::data::broadcast_address%]",
-          "broadcast_port": "[%key:component::wake_on_lan::config::step::user::data::broadcast_port%]"
+          "broadcast_port": "[%key:component::wake_on_lan::config::step::user::data::broadcast_port%]",
+          "secureon_password": "[%key:component::wake_on_lan::config::step::user::data::secureon_password%]"
         },
         "data_description": {
           "broadcast_address": "[%key:component::wake_on_lan::config::step::user::data_description::broadcast_address%]",
-          "broadcast_port": "[%key:component::wake_on_lan::config::step::user::data_description::broadcast_port%]"
+          "broadcast_port": "[%key:component::wake_on_lan::config::step::user::data_description::broadcast_port%]",
+          "secureon_password": "[%key:component::wake_on_lan::config::step::user::data_description::secureon_password%]"
         }
       }
     }
@@ -50,6 +54,10 @@
         "mac": {
           "description": "[%key:component::wake_on_lan::config::step::user::data_description::mac%]",
           "name": "[%key:component::wake_on_lan::config::step::user::data::mac%]"
+        },
+        "secureon_password": {
+          "description": "[%key:component::wake_on_lan::config::step::user::data_description::secureon_password%]",
+          "name": "[%key:component::wake_on_lan::config::step::user::data::secureon_password%]"
         }
       },
       "name": "Send magic packet"

--- a/homeassistant/components/wake_on_lan/strings.json
+++ b/homeassistant/components/wake_on_lan/strings.json
@@ -15,7 +15,7 @@
           "broadcast_address": "The IP address of the host to send the magic packet to. Defaults to `255.255.255.255` and is normally not changed.",
           "broadcast_port": "The port to send the magic packet to. Defaults to `9` and is normally not changed.",
           "mac": "MAC address of the device to wake up.",
-          "secureon_password": "The SecureOn password to append to the magic packet."
+          "secureon_password": "The SecureOn password in 6 bytes hexadecimal format to append to the magic packet."
         }
       }
     }

--- a/tests/components/wake_on_lan/conftest.py
+++ b/tests/components/wake_on_lan/conftest.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from homeassistant.components.wake_on_lan.const import DOMAIN
+from homeassistant.components.wake_on_lan.const import CONF_SECUREON_PASSWORD, DOMAIN
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_BROADCAST_ADDRESS, CONF_BROADCAST_PORT, CONF_MAC
 from homeassistant.core import HomeAssistant
@@ -56,6 +56,7 @@ async def get_config_to_integration_load() -> dict[str, Any]:
     """
     return {
         CONF_MAC: DEFAULT_MAC,
+        CONF_SECUREON_PASSWORD: "00:aa:22:bb:33:cc",
         CONF_BROADCAST_ADDRESS: "255.255.255.255",
         CONF_BROADCAST_PORT: 9,
     }
@@ -65,7 +66,7 @@ async def get_config_to_integration_load() -> dict[str, Any]:
 async def load_integration(
     hass: HomeAssistant, get_config: dict[str, Any]
 ) -> MockConfigEntry:
-    """Set up the Statistics integration in Home Assistant."""
+    """Set up the Wake on LAN integration in Home Assistant."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         title=f"Wake on LAN {DEFAULT_MAC}",

--- a/tests/components/wake_on_lan/test_button.py
+++ b/tests/components/wake_on_lan/test_button.py
@@ -3,9 +3,17 @@
 from unittest.mock import AsyncMock
 
 from freezegun.api import FrozenDateTimeFactory
+import pytest
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
-from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
+from homeassistant.components.wake_on_lan.const import CONF_SECUREON_PASSWORD
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_BROADCAST_ADDRESS,
+    CONF_BROADCAST_PORT,
+    CONF_MAC,
+    STATE_UNKNOWN,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
@@ -29,8 +37,31 @@ async def test_state(
     assert entry.unique_id == "00:01:02:03:04:05"
 
 
+@pytest.mark.parametrize(
+    ("get_config", "expected_mac_called"),
+    [
+        (
+            {
+                CONF_MAC: "00:01:02:03:04:05",
+                CONF_BROADCAST_ADDRESS: "255.255.255.255",
+                CONF_BROADCAST_PORT: 9,
+            },
+            "00:01:02:03:04:05",
+        ),
+        (
+            {
+                CONF_MAC: "00:01:02:03:04:05",
+                CONF_SECUREON_PASSWORD: "00:aa:22:bb:33:cc",
+                CONF_BROADCAST_ADDRESS: "255.255.255.255",
+                CONF_BROADCAST_PORT: 9,
+            },
+            "00:01:02:03:04:05/00:aa:22:bb:33:cc",
+        ),
+    ],
+)
 async def test_service_calls(
     hass: HomeAssistant,
+    expected_mac_called: str,
     freezer: FrozenDateTimeFactory,
     loaded_entry: MockConfigEntry,
     mock_send_magic_packet: AsyncMock,
@@ -45,6 +76,12 @@ async def test_service_calls(
         SERVICE_PRESS,
         {ATTR_ENTITY_ID: "button.wake_on_lan_00_01_02_03_04_05"},
         blocking=True,
+    )
+
+    mock_send_magic_packet.assert_called_once_with(
+        expected_mac_called,
+        ip_address="255.255.255.255",
+        port=9,
     )
 
     assert (

--- a/tests/components/wake_on_lan/test_config_flow.py
+++ b/tests/components/wake_on_lan/test_config_flow.py
@@ -3,7 +3,7 @@
 from unittest.mock import AsyncMock
 
 from homeassistant import config_entries
-from homeassistant.components.wake_on_lan.const import DOMAIN
+from homeassistant.components.wake_on_lan.const import CONF_SECUREON_PASSWORD, DOMAIN
 from homeassistant.const import CONF_BROADCAST_ADDRESS, CONF_BROADCAST_PORT, CONF_MAC
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -26,6 +26,7 @@ async def test_form(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
         result["flow_id"],
         {
             CONF_MAC: DEFAULT_MAC,
+            CONF_SECUREON_PASSWORD: "00:aa:22:bb:33:cc",
             CONF_BROADCAST_ADDRESS: "255.255.255.255",
             CONF_BROADCAST_PORT: 9,
         },
@@ -36,6 +37,7 @@ async def test_form(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
     assert result["version"] == 1
     assert result["options"] == {
         CONF_MAC: DEFAULT_MAC,
+        CONF_SECUREON_PASSWORD: "00:aa:22:bb:33:cc",
         CONF_BROADCAST_ADDRESS: "255.255.255.255",
         CONF_BROADCAST_PORT: 9,
     }
@@ -54,6 +56,7 @@ async def test_options_flow(hass: HomeAssistant, loaded_entry: MockConfigEntry) 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
+            CONF_SECUREON_PASSWORD: "ff:ee:dd:cc:bb:aa",
             CONF_BROADCAST_ADDRESS: "192.168.255.255",
             CONF_BROADCAST_PORT: 10,
         },
@@ -63,6 +66,7 @@ async def test_options_flow(hass: HomeAssistant, loaded_entry: MockConfigEntry) 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         CONF_MAC: DEFAULT_MAC,
+        CONF_SECUREON_PASSWORD: "ff:ee:dd:cc:bb:aa",
         CONF_BROADCAST_ADDRESS: "192.168.255.255",
         CONF_BROADCAST_PORT: 10,
     }
@@ -71,6 +75,7 @@ async def test_options_flow(hass: HomeAssistant, loaded_entry: MockConfigEntry) 
 
     assert loaded_entry.options == {
         CONF_MAC: DEFAULT_MAC,
+        CONF_SECUREON_PASSWORD: "ff:ee:dd:cc:bb:aa",
         CONF_BROADCAST_ADDRESS: "192.168.255.255",
         CONF_BROADCAST_PORT: 10,
     }

--- a/tests/components/wake_on_lan/test_init.py
+++ b/tests/components/wake_on_lan/test_init.py
@@ -26,6 +26,7 @@ async def test_send_magic_packet(hass: HomeAssistant) -> None:
     """Test of send magic packet service call."""
     with patch("homeassistant.components.wake_on_lan.wakeonlan") as mocked_wakeonlan:
         mac = "aa:bb:cc:dd:ee:ff"
+        secureon_password = "00:aa:22:bb:33:cc"
         bc_ip = "192.168.255.255"
         bc_port = 999
 
@@ -38,32 +39,52 @@ async def test_send_magic_packet(hass: HomeAssistant) -> None:
             blocking=True,
         )
         assert len(mocked_wakeonlan.mock_calls) == 1
-        assert mocked_wakeonlan.mock_calls[-1][1][0] == mac
-        assert mocked_wakeonlan.mock_calls[-1][2]["ip_address"] == bc_ip
-        assert mocked_wakeonlan.mock_calls[-1][2]["port"] == bc_port
+        assert mocked_wakeonlan.mock_calls[0][1][0] == mac
+        assert mocked_wakeonlan.mock_calls[0][2]["ip_address"] == bc_ip
+        assert mocked_wakeonlan.mock_calls[0][2]["port"] == bc_port
 
+        mocked_wakeonlan.reset_mock()
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SEND_MAGIC_PACKET,
+            {
+                "mac": mac,
+                "secureon_password": secureon_password,
+                "broadcast_address": bc_ip,
+                "broadcast_port": bc_port,
+            },
+            blocking=True,
+        )
+        assert len(mocked_wakeonlan.mock_calls) == 1
+        assert mocked_wakeonlan.mock_calls[0][1][0] == f"{mac}/{secureon_password}"
+        assert mocked_wakeonlan.mock_calls[0][2]["ip_address"] == bc_ip
+        assert mocked_wakeonlan.mock_calls[0][2]["port"] == bc_port
+
+        mocked_wakeonlan.reset_mock()
         await hass.services.async_call(
             DOMAIN,
             SERVICE_SEND_MAGIC_PACKET,
             {"mac": mac, "broadcast_address": bc_ip},
             blocking=True,
         )
-        assert len(mocked_wakeonlan.mock_calls) == 2
-        assert mocked_wakeonlan.mock_calls[-1][1][0] == mac
-        assert mocked_wakeonlan.mock_calls[-1][2]["ip_address"] == bc_ip
-        assert "port" not in mocked_wakeonlan.mock_calls[-1][2]
+        assert len(mocked_wakeonlan.mock_calls) == 1
+        assert mocked_wakeonlan.mock_calls[0][1][0] == mac
+        assert mocked_wakeonlan.mock_calls[0][2]["ip_address"] == bc_ip
+        assert "port" not in mocked_wakeonlan.mock_calls[0][2]
 
+        mocked_wakeonlan.reset_mock()
         await hass.services.async_call(
             DOMAIN,
             SERVICE_SEND_MAGIC_PACKET,
             {"mac": mac, "broadcast_port": bc_port},
             blocking=True,
         )
-        assert len(mocked_wakeonlan.mock_calls) == 3
-        assert mocked_wakeonlan.mock_calls[-1][1][0] == mac
-        assert mocked_wakeonlan.mock_calls[-1][2]["port"] == bc_port
-        assert "ip_address" not in mocked_wakeonlan.mock_calls[-1][2]
+        assert len(mocked_wakeonlan.mock_calls) == 1
+        assert mocked_wakeonlan.mock_calls[0][1][0] == mac
+        assert mocked_wakeonlan.mock_calls[0][2]["port"] == bc_port
+        assert "ip_address" not in mocked_wakeonlan.mock_calls[0][2]
 
+        mocked_wakeonlan.reset_mock()
         with pytest.raises(vol.Invalid):
             await hass.services.async_call(
                 DOMAIN,
@@ -71,11 +92,12 @@ async def test_send_magic_packet(hass: HomeAssistant) -> None:
                 {"broadcast_address": bc_ip},
                 blocking=True,
             )
-        assert len(mocked_wakeonlan.mock_calls) == 3
+        assert len(mocked_wakeonlan.mock_calls) == 0
 
+        mocked_wakeonlan.reset_mock()
         await hass.services.async_call(
             DOMAIN, SERVICE_SEND_MAGIC_PACKET, {"mac": mac}, blocking=True
         )
-        assert len(mocked_wakeonlan.mock_calls) == 4
-        assert mocked_wakeonlan.mock_calls[-1][1][0] == mac
-        assert not mocked_wakeonlan.mock_calls[-1][2]
+        assert len(mocked_wakeonlan.mock_calls) == 1
+        assert mocked_wakeonlan.mock_calls[0][1][0] == mac
+        assert not mocked_wakeonlan.mock_calls[0][2]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds support for a SecureOn password to the wake on lan integration. The support is only added to the action call and the modern UI configured button entities - the old-style configured switch platform is not allowed to be extended (_because of [adr-10](https://github.com/home-assistant/architecture/blob/master/adr/0010-integration-configuration.md)_)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/orgs/home-assistant/discussions/3845
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45573
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
