### PR TITLE
Migrate landisgyr_heat_meter to ultraheat-api 0.6.0 (serialx)

### DIFF
--- a/homeassistant/components/landisgyr_heat_meter/config_flow.py
+++ b/homeassistant/components/landisgyr_heat_meter/config_flow.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from typing import Any
 
-import serial
+import serialx
 import ultraheat_api
 import voluptuous as vol
 
@@ -103,7 +103,7 @@ class LandisgyrConfigFlow(ConfigFlow, domain=DOMAIN):
                 # validate and retrieve the model and device number for a unique id
                 data = await self.hass.async_add_executor_job(heat_meter.read)
 
-        except (TimeoutError, serial.SerialException) as err:
+        except (OSError, TimeoutError, serialx.SerialException) as err:
             _LOGGER.warning("Failed read data from: %s. %s", port, err)
             raise CannotConnect(f"Error communicating with device: {err}") from err
 

--- a/homeassistant/components/landisgyr_heat_meter/coordinator.py
+++ b/homeassistant/components/landisgyr_heat_meter/coordinator.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 
-import serial
+import serialx
 from ultraheat_api.response import HeatMeterResponse
 from ultraheat_api.service import HeatMeterService
 
@@ -44,5 +44,5 @@ class UltraheatCoordinator(DataUpdateCoordinator[HeatMeterResponse]):
         try:
             async with asyncio.timeout(ULTRAHEAT_TIMEOUT):
                 return await self.hass.async_add_executor_job(self.api.read)
-        except (FileNotFoundError, serial.SerialException) as err:
+        except (OSError, TimeoutError, serialx.SerialException) as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err

--- a/homeassistant/components/landisgyr_heat_meter/manifest.json
+++ b/homeassistant/components/landisgyr_heat_meter/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/landisgyr_heat_meter",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "requirements": ["ultraheat-api==0.5.7"]
+  "requirements": ["ultraheat-api==0.6.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3227,7 +3227,7 @@ uhooapi==1.2.8
 uiprotect==10.5.0
 
 # homeassistant.components.landisgyr_heat_meter
-ultraheat-api==0.5.7
+ultraheat-api==0.6.0
 
 # homeassistant.components.unifi_discovery
 unifi-discovery==1.4.0

--- a/tests/components/landisgyr_heat_meter/test_config_flow.py
+++ b/tests/components/landisgyr_heat_meter/test_config_flow.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from unittest.mock import patch
 
 import pytest
-import serial
+import serialx
 
 from homeassistant import config_entries
 from homeassistant.components.landisgyr_heat_meter import DOMAIN
@@ -110,7 +110,7 @@ async def test_list_entry(mock_port, mock_heat_meter, hass: HomeAssistant) -> No
 async def test_manual_entry_fail(mock_heat_meter, hass: HomeAssistant) -> None:
     """Test manual entry fails."""
 
-    mock_heat_meter().read.side_effect = serial.SerialException
+    mock_heat_meter().read.side_effect = OSError("device unavailable")
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -144,7 +144,7 @@ async def test_manual_entry_fail(mock_heat_meter, hass: HomeAssistant) -> None:
 async def test_list_entry_fail(mock_port, mock_heat_meter, hass: HomeAssistant) -> None:
     """Test select from list entry fails."""
 
-    mock_heat_meter().read.side_effect = serial.SerialException
+    mock_heat_meter().read.side_effect = serialx.SerialException("connection failed")
     port = mock_serial_port()
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/landisgyr_heat_meter/test_init.py
+++ b/tests/components/landisgyr_heat_meter/test_init.py
@@ -69,6 +69,14 @@ async def test_migrate_entry(
         suggested_object_id="heat_meter_measuring_range",
         config_entry=mock_entry,
     )
+    # Entity already using the new unique ID format (no migration needed)
+    entity_registry.async_get_or_create(
+        SENSOR_DOMAIN,
+        DOMAIN,
+        "12345_heat_usage_gj",
+        suggested_object_id="heat_meter_heat_usage_gj",
+        config_entry=mock_entry,
+    )
 
     assert await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/landisgyr_heat_meter/test_sensor.py
+++ b/tests/components/landisgyr_heat_meter/test_sensor.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
-import serial
 from syrupy.assertion import SnapshotAssertion
 from ultraheat_api.response import HeatMeterResponse
 
@@ -151,7 +150,7 @@ async def test_exception_on_polling(
     assert state.state == "123.0"
 
     # Now 'disable' the connection and wait for polling and see if it fails
-    mock_heat_meter().read.side_effect = serial.SerialException
+    mock_heat_meter().read.side_effect = TimeoutError
     freezer.tick(POLLING_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replace pyserial with serialx as underlying serial library via ultraheat-api 0.6.0. Update exception handling to cover OSError, TimeoutError and serialx.SerialException, and replace serial.tools.list_ports with serialx.tools.list_ports.
See: https://github.com/vpathuis/ultraheat/releases/tag/v0.6.0 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
