### PR TITLE
Update route_b_smart_meter to reopen session and force-close serial ports on failure

### DIFF
--- a/homeassistant/components/route_b_smart_meter/coordinator.py
+++ b/homeassistant/components/route_b_smart_meter/coordinator.py
@@ -131,6 +131,6 @@ class BRouteUpdateCoordinator(DataUpdateCoordinator[BRouteData]):
                 _LOGGER.warning(
                     "Serial port closed cleanly; ready for the next polling cycle"
                 )
-            except Exception:  # noqa: BLE001
+            except Exception:
                 _LOGGER.exception("Could not close serial port")
             raise UpdateFailed(error) from error

--- a/homeassistant/components/route_b_smart_meter/coordinator.py
+++ b/homeassistant/components/route_b_smart_meter/coordinator.py
@@ -131,6 +131,6 @@ class BRouteUpdateCoordinator(DataUpdateCoordinator[BRouteData]):
                 _LOGGER.warning(
                     "Serial port closed cleanly; ready for the next polling cycle"
                 )
-            except Exception as close_error:  # noqa: BLE001
-                _LOGGER.error("Could not close serial port: %s", close_error)
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Could not close serial port")
             raise UpdateFailed(error) from error

--- a/homeassistant/components/route_b_smart_meter/coordinator.py
+++ b/homeassistant/components/route_b_smart_meter/coordinator.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 import logging
 import time
 
-from momonga import Momonga, MomongaError
+from momonga import Momonga, MomongaError, MomongaNeedToReopen
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICE, CONF_ID, CONF_PASSWORD
@@ -109,15 +109,13 @@ class BRouteUpdateCoordinator(DataUpdateCoordinator[BRouteData]):
         def fetch_with_reopen() -> BRouteData:
             try:
                 return self._get_data()
-            except RuntimeError as err:
-                if "not open" in str(err):
-                    _LOGGER.info(
-                        "Route-B API is closed (likely from a previous recovery). "
-                        "Reopening session"
-                    )
-                    self.api.open()
-                    return self._get_data()
-                raise
+            except MomongaNeedToReopen:
+                _LOGGER.info(
+                    "Route-B API is closed (likely from a previous recovery). "
+                    "Reopening session"
+                )
+                self.api.open()
+                return self._get_data()
 
         try:
             return await self.hass.async_add_executor_job(fetch_with_reopen)
@@ -128,7 +126,7 @@ class BRouteUpdateCoordinator(DataUpdateCoordinator[BRouteData]):
             )
             try:
                 await self.hass.async_add_executor_job(self.api.close)
-                _LOGGER.warning(
+                _LOGGER.info(
                     "Serial port closed cleanly; ready for the next polling cycle"
                 )
             except Exception:

--- a/homeassistant/components/route_b_smart_meter/coordinator.py
+++ b/homeassistant/components/route_b_smart_meter/coordinator.py
@@ -105,7 +105,32 @@ class BRouteUpdateCoordinator(DataUpdateCoordinator[BRouteData]):
 
     async def _async_update_data(self) -> BRouteData:
         """Update data."""
+
+        def fetch_with_reopen() -> BRouteData:
+            try:
+                return self._get_data()
+            except RuntimeError as err:
+                if "not open" in str(err):
+                    _LOGGER.info(
+                        "Route-B API is closed (likely from a previous recovery). "
+                        "Reopening session"
+                    )
+                    self.api.open()
+                    return self._get_data()
+                raise
+
         try:
-            return await self.hass.async_add_executor_job(self._get_data)
-        except MomongaError as error:
+            return await self.hass.async_add_executor_job(fetch_with_reopen)
+        except (MomongaError, RuntimeError) as error:
+            _LOGGER.warning(
+                "Route-B poll failed. Attempting to force-close the serial port to "
+                "prevent lockup"
+            )
+            try:
+                await self.hass.async_add_executor_job(self.api.close)
+                _LOGGER.warning(
+                    "Serial port closed cleanly; ready for the next polling cycle"
+                )
+            except Exception as close_error:  # noqa: BLE001
+                _LOGGER.error("Could not close serial port: %s", close_error)
             raise UpdateFailed(error) from error

--- a/homeassistant/components/route_b_smart_meter/coordinator.py
+++ b/homeassistant/components/route_b_smart_meter/coordinator.py
@@ -42,6 +42,7 @@ class BRouteUpdateCoordinator(DataUpdateCoordinator[BRouteData]):
     """The B Route update coordinator."""
 
     device_info_data: BRouteDeviceInfo
+    _port_locked: bool = False
 
     def __init__(
         self,
@@ -108,6 +109,10 @@ class BRouteUpdateCoordinator(DataUpdateCoordinator[BRouteData]):
 
         def fetch_with_reopen() -> BRouteData:
             try:
+                if self._port_locked:
+                    _LOGGER.info("Serial port was previously locked. Reopening session")
+                    self.api.open()
+                    self._port_locked = False
                 return self._get_data()
             except MomongaNeedToReopen:
                 _LOGGER.info(
@@ -119,7 +124,10 @@ class BRouteUpdateCoordinator(DataUpdateCoordinator[BRouteData]):
 
         try:
             return await self.hass.async_add_executor_job(fetch_with_reopen)
-        except (MomongaError, RuntimeError) as error:
+        except (
+            MomongaError,
+            RuntimeError,  # The momonga library raises RuntimeError for session/comm failures
+        ) as error:
             _LOGGER.warning(
                 "Route-B poll failed. Attempting to force-close the serial port to "
                 "prevent lockup"
@@ -129,6 +137,9 @@ class BRouteUpdateCoordinator(DataUpdateCoordinator[BRouteData]):
                 _LOGGER.info(
                     "Serial port closed cleanly; ready for the next polling cycle"
                 )
+                self._port_locked = False
             except Exception:
+                # If close fails, mark the port as locked so the next cycle attempts a fresh open
+                self._port_locked = True
                 _LOGGER.exception("Could not close serial port")
             raise UpdateFailed(error) from error

--- a/tests/components/route_b_smart_meter/test_sensor.py
+++ b/tests/components/route_b_smart_meter/test_sensor.py
@@ -57,3 +57,64 @@ async def test_route_b_smart_meter_sensor_no_update(
 
     entity = hass.states.get(entity_id)
     assert entity.state is STATE_UNAVAILABLE
+
+
+async def test_recovery_reopen_session(
+    hass: HomeAssistant,
+    mock_momonga: Mock,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test recovery when session is closed."""
+    entity_id = (
+        "sensor.route_b_smart_meter_"
+        "01234567890123456789012345f789_"
+        "instantaneous_current_r_phase"
+    )
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Initial state
+    assert hass.states.get(entity_id).state == "1"
+
+    # Simulate session closed error on next update
+    client = mock_momonga.return_value
+    client.get_instantaneous_current.side_effect = [
+        RuntimeError("session not open"),
+        {"r phase current": 10, "t phase current": 20},
+    ]
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    # Verify api.open() was called and data was updated
+    assert client.open.call_count == 2  # Once in setup, once in recovery
+    assert hass.states.get(entity_id).state == "10"
+
+
+async def test_recovery_force_close_on_failure(
+    hass: HomeAssistant,
+    mock_momonga: Mock,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test serial port is closed on failure."""
+    entity_id = (
+        "sensor.route_b_smart_meter_"
+        "01234567890123456789012345f789_"
+        "instantaneous_current_r_phase"
+    )
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    client = mock_momonga.return_value
+    client.get_instantaneous_current.side_effect = MomongaError("Poll failed")
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    # Verify state is unavailable and api.close() was called
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+    client.close.assert_called_once()

--- a/tests/components/route_b_smart_meter/test_sensor.py
+++ b/tests/components/route_b_smart_meter/test_sensor.py
@@ -3,7 +3,7 @@
 from unittest.mock import Mock
 
 from freezegun.api import FrozenDateTimeFactory
-from momonga import MomongaError
+from momonga import MomongaError, MomongaNeedToReopen
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.route_b_smart_meter.const import DEFAULT_SCAN_INTERVAL
@@ -79,8 +79,9 @@ async def test_recovery_reopen_session(
 
     # Simulate session closed error on next update
     client = mock_momonga.return_value
+    initial_open_count = client.open.call_count
     client.get_instantaneous_current.side_effect = [
-        RuntimeError("session not open"),
+        MomongaNeedToReopen("session not open"),
         {"r phase current": 10, "t phase current": 20},
     ]
 
@@ -89,7 +90,7 @@ async def test_recovery_reopen_session(
     await hass.async_block_till_done(wait_background_tasks=True)
 
     # Verify api.open() was called and data was updated
-    assert client.open.call_count == 2  # Once in setup, once in recovery
+    assert client.open.call_count == initial_open_count + 1
     assert hass.states.get(entity_id).state == "10"
 
 
@@ -126,7 +127,7 @@ async def test_recovery_unhandled_runtime_error(
     freezer: FrozenDateTimeFactory,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test that a generic RuntimeError is not swallowed."""
+    """Test that a generic RuntimeError is wrapped in UpdateFailed and sets state to unavailable."""
     entity_id = (
         "sensor.route_b_smart_meter_"
         "01234567890123456789012345f789_"

--- a/tests/components/route_b_smart_meter/test_sensor.py
+++ b/tests/components/route_b_smart_meter/test_sensor.py
@@ -118,3 +118,56 @@ async def test_recovery_force_close_on_failure(
     # Verify state is unavailable and api.close() was called
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
     client.close.assert_called_once()
+
+
+async def test_recovery_unhandled_runtime_error(
+    hass: HomeAssistant,
+    mock_momonga: Mock,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that a generic RuntimeError is not swallowed."""
+    entity_id = (
+        "sensor.route_b_smart_meter_"
+        "01234567890123456789012345f789_"
+        "instantaneous_current_r_phase"
+    )
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    client = mock_momonga.return_value
+    client.get_instantaneous_current.side_effect = RuntimeError("Unknown error")
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+
+
+async def test_recovery_close_fails(
+    hass: HomeAssistant,
+    mock_momonga: Mock,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test recovery when api.close() also fails."""
+    entity_id = (
+        "sensor.route_b_smart_meter_"
+        "01234567890123456789012345f789_"
+        "instantaneous_current_r_phase"
+    )
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    client = mock_momonga.return_value
+    client.get_instantaneous_current.side_effect = MomongaError("Primary failure")
+    client.close.side_effect = Exception("Emergency close failed")
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    # Verify state is still unavailable even if cleanup fails
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+    client.close.assert_called_once()


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR should address an issue with the route_b_smart_meter integration that causes the integration to continuously fail after a signal is dropped. Previously, the DataUpdateCoordinator would catch an error and marks the sensors as unavailable. When this happens, the serial port would remain home and the Wi-SUN dongle stayed in a stale session state. Subsequent polling attempts via the _async_update_data method resulted in calls to an already open port which resulted in failures. The current way to recover from this was to fully restart home assistant.

This fix does the following:
   1. Session Re-opening: In _async_update_data, we now catch RuntimeError: session not open and attempt to re-open the API session if it was previously closed by a recovery attempt.
   2. Forced Cleanup: When a poll fails (MomongaError or RuntimeError), the coordinator now explicitly attempts to force-close the serial port using self.api.close(). This clears the stale state and ensures the next polling cycle can start with a clean initialization sequence.
   3. Stability: This prevents the need for a full system restart or external USB watchdogs to recover from transient network drops.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
