### PR TITLE
Bump bthome-ble to 3.23.2 and add support for light level, settings revision, and command events

### DIFF
--- a/homeassistant/components/bthome/const.py
+++ b/homeassistant/components/bthome/const.py
@@ -17,6 +17,7 @@ BTHOME_BLE_EVENT: Final = "bthome_ble_event"
 
 EVENT_CLASS_BUTTON: Final = "button"
 EVENT_CLASS_DIMMER: Final = "dimmer"
+EVENT_CLASS_COMMAND: Final = "command"
 
 CONF_EVENT_CLASS: Final = "event_class"
 CONF_EVENT_PROPERTIES: Final = "event_properties"

--- a/homeassistant/components/bthome/device_trigger.py
+++ b/homeassistant/components/bthome/device_trigger.py
@@ -28,6 +28,7 @@ from .const import (
     DOMAIN,
     EVENT_CLASS,
     EVENT_CLASS_BUTTON,
+    EVENT_CLASS_COMMAND,
     EVENT_CLASS_DIMMER,
     EVENT_TYPE,
 )
@@ -43,6 +44,7 @@ EVENT_TYPES_BY_EVENT_CLASS = {
         "hold_press",
     },
     EVENT_CLASS_DIMMER: {"rotate_left", "rotate_right"},
+    EVENT_CLASS_COMMAND: {"off", "on", "toggle", "step_up", "step_down"},
 }
 
 TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(

--- a/homeassistant/components/bthome/event.py
+++ b/homeassistant/components/bthome/event.py
@@ -16,6 +16,7 @@ from . import format_discovered_event_class, format_event_dispatcher_name
 from .const import (
     DOMAIN,
     EVENT_CLASS_BUTTON,
+    EVENT_CLASS_COMMAND,
     EVENT_CLASS_DIMMER,
     EVENT_PROPERTIES,
     EVENT_TYPE,
@@ -42,6 +43,11 @@ DESCRIPTIONS_BY_EVENT_CLASS = {
         key=EVENT_CLASS_DIMMER,
         translation_key="dimmer",
         event_types=["rotate_left", "rotate_right"],
+    ),
+    EVENT_CLASS_COMMAND: EventEntityDescription(
+        key=EVENT_CLASS_COMMAND,
+        translation_key="command",
+        event_types=["off", "on", "toggle", "step_up", "step_down"],
     ),
 }
 

--- a/homeassistant/components/bthome/manifest.json
+++ b/homeassistant/components/bthome/manifest.json
@@ -20,5 +20,5 @@
   "dependencies": ["bluetooth_adapters"],
   "documentation": "https://www.home-assistant.io/integrations/bthome",
   "iot_class": "local_push",
-  "requirements": ["bthome-ble==3.17.0"]
+  "requirements": ["bthome-ble==3.23.2"]
 }

--- a/homeassistant/components/bthome/sensor.py
+++ b/homeassistant/components/bthome/sensor.py
@@ -192,6 +192,12 @@ SENSOR_DESCRIPTIONS = {
         native_unit_of_measurement=LIGHT_LUX,
         state_class=SensorStateClass.MEASUREMENT,
     ),
+    # Light level (-)
+    (BTHomeExtendedSensorDeviceClass.LIGHT_LEVEL, None): SensorEntityDescription(
+        key=str(BTHomeExtendedSensorDeviceClass.LIGHT_LEVEL),
+        state_class=SensorStateClass.MEASUREMENT,
+        translation_key="light_level",
+    ),
     # Mass sensor (kg)
     (BTHomeSensorDeviceClass.MASS, Units.MASS_KILOGRAMS): SensorEntityDescription(
         key=f"{BTHomeSensorDeviceClass.MASS}_{Units.MASS_KILOGRAMS}",
@@ -286,6 +292,12 @@ SENSOR_DESCRIPTIONS = {
         native_unit_of_measurement=REVOLUTIONS_PER_MINUTE,
         state_class=SensorStateClass.MEASUREMENT,
         translation_key="rotational_speed",
+    ),
+    # Settings revision (-)
+    (BTHomeExtendedSensorDeviceClass.SETTINGS_REVISION, None): SensorEntityDescription(
+        key=str(BTHomeExtendedSensorDeviceClass.SETTINGS_REVISION),
+        entity_category=EntityCategory.DIAGNOSTIC,
+        translation_key="settings_revision",
     ),
     # Signal Strength (RSSI) (dB)
     (

--- a/homeassistant/components/bthome/strings.json
+++ b/homeassistant/components/bthome/strings.json
@@ -36,13 +36,19 @@
       "long_double_press": "Long Double Press",
       "long_press": "Long Press",
       "long_triple_press": "Long Triple Press",
+      "off": "Off",
+      "on": "On",
       "press": "Press",
       "rotate_left": "Rotate Left",
       "rotate_right": "Rotate Right",
+      "step_down": "Step Down",
+      "step_up": "Step Up",
+      "toggle": "Toggle",
       "triple_press": "Triple Press"
     },
     "trigger_type": {
       "button": "Button \"{subtype}\"",
+      "command": "Command \"{subtype}\"",
       "dimmer": "Dimmer \"{subtype}\""
     }
   },
@@ -64,6 +70,19 @@
               "long_triple_press": "Long triple press",
               "press": "Press",
               "triple_press": "Triple press"
+            }
+          }
+        }
+      },
+      "command": {
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "off": "Off",
+              "on": "On",
+              "step_down": "Step down",
+              "step_up": "Step up",
+              "toggle": "Toggle"
             }
           }
         }
@@ -98,6 +117,9 @@
       "gyroscope": {
         "name": "Gyroscope"
       },
+      "light_level": {
+        "name": "Light level"
+      },
       "packet_id": {
         "name": "Packet ID"
       },
@@ -109,6 +131,9 @@
       },
       "rotational_speed": {
         "name": "Rotational speed"
+      },
+      "settings_revision": {
+        "name": "Settings revision"
       },
       "text": {
         "name": "Text"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -718,7 +718,7 @@ brottsplatskartan==1.0.5
 brunt==1.2.0
 
 # homeassistant.components.bthome
-bthome-ble==3.17.0
+bthome-ble==3.23.2
 
 # homeassistant.components.bt_home_hub_5
 bthomehub5-devicelist==0.1.1

--- a/tests/components/bthome/test_event.py
+++ b/tests/components/bthome/test_event.py
@@ -54,6 +54,26 @@ from tests.components.bluetooth import (
                 }
             ],
         ),
+        (
+            "A4:C1:38:8D:18:B2",
+            make_bthome_v2_adv(
+                "A4:C1:38:8D:18:B2",
+                b"\x40\x3b\x00\x01\x3b\x00\x02",
+            ),
+            None,
+            [
+                {
+                    "entity": "event.test_device_18b2_command_1",
+                    ATTR_FRIENDLY_NAME: "Test Device 18B2 Command 1",
+                    ATTR_EVENT_TYPE: "on",
+                },
+                {
+                    "entity": "event.test_device_18b2_command_2",
+                    ATTR_FRIENDLY_NAME: "Test Device 18B2 Command 2",
+                    ATTR_EVENT_TYPE: "toggle",
+                },
+            ],
+        ),
     ],
 )
 async def test_v2_events(

--- a/tests/components/bthome/test_sensor.py
+++ b/tests/components/bthome/test_sensor.py
@@ -1090,6 +1090,37 @@ async def test_v1_sensors(
                 },
             ],
         ),
+        (
+            "A4:C1:38:8D:18:B2",
+            make_bthome_v2_adv(
+                "A4:C1:38:8D:18:B2",
+                b"\x40\x64\x42",
+            ),
+            None,
+            [
+                {
+                    "sensor_entity": "sensor.test_device_18b2_light_level",
+                    "friendly_name": "Test Device 18B2 Light level",
+                    "state_class": "measurement",
+                    "expected_state": "66",
+                },
+            ],
+        ),
+        (
+            "A4:C1:38:8D:18:B2",
+            make_bthome_v2_adv(
+                "A4:C1:38:8D:18:B2",
+                b"\x40\x65\x07",
+            ),
+            None,
+            [
+                {
+                    "sensor_entity": "sensor.test_device_18b2_settings_revision",
+                    "friendly_name": "Test Device 18B2 Settings revision",
+                    "expected_state": "7",
+                },
+            ],
+        ),
     ],
 )
 async def test_v2_sensors(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps bthome-ble from 3.17.0 to 3.23.2 and adds support for the new types it exposes: light level sensor (0x64), settings revision sensor (0x65), and command event (0x3B).

The bump and the integration changes must land together; `sensor.py` and `event.py` look up descriptions with direct dict access, so a device broadcasting any of the new types would raise `KeyError` if the bump shipped alone, and the integration code cannot import without the bump since the new enum values do not exist in 3.17.0.

Changelog: https://github.com/Bluetooth-Devices/bthome-ble/compare/v3.17.0...v3.23.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr