### PR TITLE
Fix blocking time_zone validation in config/core/update websocket command

### DIFF
--- a/homeassistant/components/config/core.py
+++ b/homeassistant/components/config/core.py
@@ -60,7 +60,9 @@ class CheckConfigView(HomeAssistantView):
         vol.Optional("location_name"): str,
         vol.Optional("longitude"): cv.longitude,
         vol.Optional("radius"): cv.positive_int,
-        vol.Optional("time_zone"): cv.time_zone,
+        # Validated by async_set_time_zone in the executor to avoid
+        # blocking I/O loading zoneinfo data on the event loop.
+        vol.Optional("time_zone"): str,
         vol.Optional("update_units"): bool,
         vol.Optional("unit_system"): unit_system.validate_unit_system,
     }

--- a/tests/components/config/test_core.py
+++ b/tests/components/config/test_core.py
@@ -220,6 +220,27 @@ async def test_websocket_bad_core_update(hass: HomeAssistant, client) -> None:
     assert msg["error"]["code"] == "invalid_format"
 
 
+async def test_websocket_core_update_invalid_time_zone(
+    hass: HomeAssistant, client
+) -> None:
+    """Test core config update rejects an invalid time zone."""
+    await client.send_json(
+        {
+            "id": 8,
+            "type": "config/core/update",
+            "time_zone": "not/a/zone",
+        }
+    )
+
+    msg = await client.receive_json()
+
+    assert msg["id"] == 8
+    assert msg["type"] == TYPE_RESULT
+    assert not msg["success"]
+    assert msg["error"]["code"] == "invalid_info"
+    assert hass.config.time_zone != "not/a/zone"
+
+
 async def test_detect_config(hass: HomeAssistant, client) -> None:
     """Test detect config."""
     with patch(

--- a/tests/components/config/test_core.py
+++ b/tests/components/config/test_core.py
@@ -221,7 +221,7 @@ async def test_websocket_bad_core_update(hass: HomeAssistant, client) -> None:
 
 
 async def test_websocket_core_update_invalid_time_zone(
-    hass: HomeAssistant, client
+    hass: HomeAssistant, client: MockHAClientWebSocket
 ) -> None:
     """Test core config update rejects an invalid time zone."""
     await client.send_json(


### PR DESCRIPTION
## Proposed change

The `config/core/update` websocket schema validates `time_zone` with `cv.time_zone`, which calls `zoneinfo.ZoneInfo` synchronously inside the websocket schema validation step (run on the event loop). On first use this imports `tzdata.zoneinfo` and reads the zoneinfo file from disk, producing blocking-call warnings during onboarding.

This drops the synchronous validator from the schema, relying on `Config.async_set_time_zone` which already validates via `dt_util.async_get_time_zone` in the executor; invalid time zones still raise `ValueError` and are returned to the client as `invalid_info`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #171774
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr