### PR TITLE
Add tilt-only mode support for BleBox cover entities

### DIFF
--- a/homeassistant/components/blebox/cover.py
+++ b/homeassistant/components/blebox/cover.py
@@ -76,6 +76,14 @@ class BleBoxCoverEntity(BleBoxEntity[blebox_uniapi.cover.Cover], CoverEntity):
                 | CoverEntityFeature.CLOSE_TILT
             )
 
+        if feature.tilt_only:
+            self._attr_supported_features &= ~(
+                CoverEntityFeature.OPEN
+                | CoverEntityFeature.CLOSE
+                | CoverEntityFeature.SET_POSITION
+                | CoverEntityFeature.STOP
+            )
+
     @property
     def current_cover_position(self) -> int | None:
         """Return the current cover position."""

--- a/tests/components/blebox/test_cover.py
+++ b/tests/components/blebox/test_cover.py
@@ -52,6 +52,7 @@ def shutterbox_fixture():
         has_tilt=True,
         is_slider=True,
         is_position_inverted=True,
+        tilt_only=False,
     )
     product = feature.product
     type(product).name = PropertyMock(return_value="My shutter")
@@ -73,6 +74,7 @@ def gatebox_fixture():
         has_stop=False,
         is_slider=False,
         is_position_inverted=False,
+        tilt_only=False,
     )
     product = feature.product
     type(product).name = PropertyMock(return_value="My gatebox")
@@ -94,6 +96,7 @@ def gate_fixture():
         has_stop=True,
         is_slider=True,
         is_position_inverted=True,
+        tilt_only=False,
     )
     product = feature.product
     type(product).name = PropertyMock(return_value="My gate controller")
@@ -394,6 +397,43 @@ async def test_with_no_stop(gatebox, hass: HomeAssistant) -> None:
     state = hass.states.get(entity_id)
     supported_features = state.attributes[ATTR_SUPPORTED_FEATURES]
     assert not supported_features & CoverEntityFeature.STOP
+
+
+async def test_tilt_only_supported_features(shutterbox, hass: HomeAssistant) -> None:
+    """Test that tilt_only removes position/open/close/stop features."""
+
+    feature_mock, entity_id = shutterbox
+    feature_mock.tilt_only = True
+
+    await async_setup_entity(hass, entity_id)
+
+    supported_features = hass.states.get(entity_id).attributes[ATTR_SUPPORTED_FEATURES]
+    assert not supported_features & CoverEntityFeature.OPEN
+    assert not supported_features & CoverEntityFeature.CLOSE
+    assert not supported_features & CoverEntityFeature.SET_POSITION
+    assert not supported_features & CoverEntityFeature.STOP
+    assert supported_features & CoverEntityFeature.OPEN_TILT
+    assert supported_features & CoverEntityFeature.CLOSE_TILT
+    assert supported_features & CoverEntityFeature.SET_TILT_POSITION
+
+
+async def test_tilt_with_position_supported_features(
+    shutterbox, hass: HomeAssistant
+) -> None:
+    """Test that has_tilt without tilt_only keeps both position and tilt features."""
+
+    await async_setup_entity(hass, shutterbox[1])
+
+    supported_features = hass.states.get(shutterbox[1]).attributes[
+        ATTR_SUPPORTED_FEATURES
+    ]
+    assert supported_features & CoverEntityFeature.OPEN
+    assert supported_features & CoverEntityFeature.CLOSE
+    assert supported_features & CoverEntityFeature.SET_POSITION
+    assert supported_features & CoverEntityFeature.STOP
+    assert supported_features & CoverEntityFeature.OPEN_TILT
+    assert supported_features & CoverEntityFeature.CLOSE_TILT
+    assert supported_features & CoverEntityFeature.SET_TILT_POSITION
 
 
 @pytest.mark.parametrize("feature", ALL_COVER_FIXTURES, indirect=["feature"])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for BleBox shutters operating in tilt-only mode. These devices can control only the slat angle without moving the cover up or down. When the tilt_only property is set on the underlying feature, the OPEN, CLOSE, SET_POSITION, and STOP capabilities are removed from the entity’s supported features, leaving only tilt controls exposed to Home Assistant.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
