### PR TITLE
Harden backup tar extraction with Python tar_filter

### DIFF
--- a/homeassistant/backup_restore.py
+++ b/homeassistant/backup_restore.py
@@ -92,8 +92,7 @@ def _extract_backup(
     ):
         ostf.tar.extractall(
             path=Path(tempdir, "extracted"),
-            members=securetar.secure_path(ostf.tar),
-            filter="fully_trusted",
+            filter="tar",
         )
         backup_meta_file = Path(tempdir, "extracted", "backup.json")
         backup_meta = json.loads(backup_meta_file.read_text(encoding="utf8"))
@@ -119,8 +118,7 @@ def _extract_backup(
         ) as istf:
             istf.extractall(
                 path=Path(tempdir, "homeassistant"),
-                members=securetar.secure_path(istf),
-                filter="fully_trusted",
+                filter="tar",
             )
             if restore_content.restore_homeassistant:
                 keep = list(KEEP_BACKUPS)

--- a/tests/test_backup_restore.py
+++ b/tests/test_backup_restore.py
@@ -1,5 +1,6 @@
 """Test methods in backup_restore."""
 
+from io import BytesIO
 import json
 from pathlib import Path
 import tarfile
@@ -386,8 +387,8 @@ def test_restore_backup(
     }
 
 
-def test_restore_backup_filter_files(tmp_path: Path) -> None:
-    """Test filtering dangerous files when restoring a backup."""
+def test_restore_backup_rejects_unsafe_files(tmp_path: Path) -> None:
+    """Test that a backup with unsafe paths is rejected."""
     backup_file_path = tmp_path / "backups" / "test.tar"
     backup_file_path.parent.mkdir()
     get_fixture_path(
@@ -410,7 +411,55 @@ def test_restore_backup_filter_files(tmp_path: Path) -> None:
             "data/home-assistant_v2.db-wal",
         }
 
-    real_extractone = tarfile.TarFile._extract_one
+    with (
+        mock.patch(
+            "homeassistant.backup_restore.restore_backup_file_content",
+            return_value=backup_restore.RestoreBackupFileContent(
+                backup_file_path=backup_file_path,
+                password=None,
+                remove_after_restore=False,
+                restore_database=True,
+                restore_homeassistant=True,
+            ),
+        ),
+        pytest.raises(tarfile.FilterError),
+    ):
+        backup_restore.restore_backup(tmp_path.as_posix())
+
+    result = restore_result_file_content(tmp_path)
+    assert result is not None
+    assert result["success"] is False
+    assert result["error_type"] in {"AbsolutePathError", "OutsideDestinationError"}
+
+
+def test_restore_backup_rejects_absolute_symlink(tmp_path: Path) -> None:
+    """Test rejection of a symlink whose linkname escapes the destination.
+
+    A SYMTYPE entry followed by a regular file whose name traverses the
+    symlink would otherwise land attacker-controlled bytes outside the
+    extraction directory. The tar filter resolves the path after the
+    symlink and rejects the entry.
+    """
+    backup_file_path = tmp_path / "backups" / "test.tar"
+    backup_file_path.parent.mkdir()
+
+    with tarfile.open(backup_file_path, "w") as tar:
+        backup_json = json.dumps(
+            {"homeassistant": {"version": "0.0.0"}, "compressed": False}
+        ).encode()
+        info = tarfile.TarInfo(name="./backup.json")
+        info.size = len(backup_json)
+        tar.addfile(info, BytesIO(backup_json))
+
+        symlink = tarfile.TarInfo(name="pwn")
+        symlink.type = tarfile.SYMTYPE
+        symlink.linkname = "/tmp"  # noqa: S108
+        tar.addfile(symlink)
+
+        payload = b"pwned"
+        evil = tarfile.TarInfo(name="pwn/ha_escape_target")
+        evil.size = len(payload)
+        tar.addfile(evil, BytesIO(payload))
 
     with (
         mock.patch(
@@ -423,27 +472,11 @@ def test_restore_backup_filter_files(tmp_path: Path) -> None:
                 restore_homeassistant=True,
             ),
         ),
-        mock.patch(
-            "tarfile.TarFile._extract_one", autospec=True, wraps=real_extractone
-        ) as extractone_mock,
+        pytest.raises(tarfile.FilterError),
     ):
-        assert backup_restore.restore_backup(tmp_path.as_posix()) is True
+        backup_restore.restore_backup(tmp_path.as_posix())
 
-    # Check the unsafe files are not extracted, and that the safe files are extracted
-    extracted_files = {call.args[1].name for call in extractone_mock.mock_calls}
-    assert extracted_files == {
-        "./backup.json",  # From the outer tar
-        "homeassistant.tar.gz",  # From the outer tar
-        ".",
-        "data",
-        "data/home-assistant_v2.db",
-        "data/home-assistant_v2.db-wal",
-    }
-    assert restore_result_file_content(tmp_path) == {
-        "error": None,
-        "error_type": None,
-        "success": True,
-    }
+    assert not Path("/tmp/ha_escape_target").exists()  # noqa: S108
 
 
 @pytest.mark.parametrize(("remove_after_restore"), [True, False])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Replace `filter="fully_trusted"` + `members=securetar.secure_path(...)` at both `extractall` sites in `homeassistant/backup_restore.py` with Python's built-in [`filter="tar"`](https://docs.python.org/3/library/tarfile.html#tarfile.tar_filter).

The previous combination did not protect against a symlink whose `linkname` points outside the destination directory: `securetar.secure_path` inspected only `member.name`, and `fully_trusted` is a no-op that was added solely to silence Python 3.12 deprecation warnings. A backup containing a `SYMTYPE` entry with a benign name and an absolute `linkname`, followed by a regular-file member whose name traverses the symlink, could write attacker-controlled bytes outside the extraction tempdir.

Python's `tar` filter resolves member paths after following symlinks and rejects entries that would escape the destination. Compared to `data_filter` it preserves uid/gid and file permissions, which is important for backups that contain files owned by non-root users.

Restore now aborts on the first rejected member (raising `tarfile.FilterError`) instead of silently dropping it. The specific subclass (`AbsolutePathError`, `OutsideDestinationError`, `LinkOutsideDestinationError`) is recorded in `.HA_RESTORE_RESULT` so users see why the restore failed.

Mirrors [home-assistant/supervisor#6559](https://github.com/home-assistant/supervisor/pull/6559).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr