### PR TITLE
Fix multiple event entity events only differing by data attributes not triggering

### DIFF
--- a/homeassistant/components/transmission/coordinator.py
+++ b/homeassistant/components/transmission/coordinator.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import datetime, timedelta
 from functools import partial
 import logging
 from typing import override
@@ -13,6 +13,7 @@ from transmission_rpc.session import SessionStats
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ID, ATTR_NAME, CONF_HOST
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -99,7 +100,9 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
         self._event_listeners.pop(listener_id, None)
 
     @callback
-    def _async_notify_event_listeners(self, event: TransmissionEventData) -> None:
+    def _async_notify_event_listeners(
+        self, event: TransmissionEventData, _: datetime
+    ) -> None:
         """Notify event listeners in the event loop."""
         for listener in list(self._event_listeners.values()):
             listener(event)
@@ -144,6 +147,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
             torrent for torrent in self.torrents if torrent.status == "seeding"
         ]
 
+        delay: float = 0.0
         for torrent in current_completed_torrents:
             if torrent.id not in old_completed_torrents:
                 # Once event triggers are out of labs we can remove the bus event
@@ -163,7 +167,12 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
                     download_path=torrent.download_dir or "",
                     labels=torrent.labels,
                 )
-                self._async_notify_event_listeners(event)
+                async_call_later(
+                    self.hass,
+                    delay,
+                    partial(self._async_notify_event_listeners, event),
+                )
+                delay += 0.1
 
         self._completed_torrents = current_completed_torrents
 
@@ -175,6 +184,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
             torrent for torrent in self.torrents if torrent.status == "downloading"
         ]
 
+        delay: float = 0.0
         for torrent in current_started_torrents:
             if torrent.id not in old_started_torrents:
                 # Once event triggers are out of labs we can remove the bus event
@@ -194,7 +204,12 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
                     download_path=torrent.download_dir or "",
                     labels=torrent.labels,
                 )
-                self._async_notify_event_listeners(event)
+                async_call_later(
+                    self.hass,
+                    delay,
+                    partial(self._async_notify_event_listeners, event),
+                )
+                delay += 0.1
 
         self._started_torrents = current_started_torrents
 
@@ -202,6 +217,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
         """Get removed torrent functionality."""
         current_torrents = {torrent.id for torrent in self.torrents}
 
+        delay: float = 0.0
         for torrent in self._all_torrents:
             if torrent.id not in current_torrents:
                 # Once event triggers are out of labs we can remove the bus event
@@ -221,7 +237,12 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
                     download_path=torrent.download_dir or "",
                     labels=torrent.labels,
                 )
-                self._async_notify_event_listeners(event)
+                async_call_later(
+                    self.hass,
+                    delay,
+                    partial(self._async_notify_event_listeners, event),
+                )
+                delay += 0.1
 
         self._all_torrents = self.torrents.copy()
 

--- a/homeassistant/components/transmission/coordinator.py
+++ b/homeassistant/components/transmission/coordinator.py
@@ -54,6 +54,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
     """Transmission dataupdate coordinator class."""
 
     config_entry: TransmissionConfigEntry
+    _EVENT_NOTIFICATION_DELAY_STEP: float = 0.1
 
     def __init__(
         self,
@@ -70,6 +71,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
         self._started_torrents: list[transmission_rpc.Torrent] = []
         self._event_listeners: dict[str, EventCallback] = {}
         self.torrents: list[transmission_rpc.Torrent] = []
+        self._event_notification_delay: float = 0.0
         super().__init__(
             hass,
             config_entry=entry,
@@ -101,17 +103,34 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
 
     @callback
     def _async_notify_event_listeners(
-        self, event: TransmissionEventData, _: datetime
+        self, event: TransmissionEventData, _now: datetime | None = None
     ) -> None:
         """Notify event listeners in the event loop."""
         for listener in list(self._event_listeners.values()):
             listener(event)
+
+    def _schedule_event_notifications(
+        self, events: list[TransmissionEventData]
+    ) -> float:
+        """Schedule event notifications with staggered delays.
+
+        Returns the next delay to use for subsequent events in the update cycle.
+        """
+        for event in events:
+            async_call_later(
+                self.hass,
+                self._event_notification_delay,
+                partial(self._async_notify_event_listeners, event),
+            )
+            self._event_notification_delay += self._EVENT_NOTIFICATION_DELAY_STEP
+        return self._event_notification_delay
 
     @override
     async def _async_update_data(self) -> SessionStats:
         """Update transmission data."""
         data = await self.hass.async_add_executor_job(self.update)
 
+        self._event_notification_delay = 0.0
         self.check_completed_torrent()
         self.check_started_torrent()
         self.check_removed_torrent()
@@ -147,7 +166,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
             torrent for torrent in self.torrents if torrent.status == "seeding"
         ]
 
-        delay: float = 0.0
+        events: list[TransmissionEventData] = []
         for torrent in current_completed_torrents:
             if torrent.id not in old_completed_torrents:
                 # Once event triggers are out of labs we can remove the bus event
@@ -167,13 +186,9 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
                     download_path=torrent.download_dir or "",
                     labels=torrent.labels,
                 )
-                async_call_later(
-                    self.hass,
-                    delay,
-                    partial(self._async_notify_event_listeners, event),
-                )
-                delay += 0.1
+                events.append(event)
 
+        self._schedule_event_notifications(events)
         self._completed_torrents = current_completed_torrents
 
     def check_started_torrent(self) -> None:
@@ -184,7 +199,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
             torrent for torrent in self.torrents if torrent.status == "downloading"
         ]
 
-        delay: float = 0.0
+        events: list[TransmissionEventData] = []
         for torrent in current_started_torrents:
             if torrent.id not in old_started_torrents:
                 # Once event triggers are out of labs we can remove the bus event
@@ -204,20 +219,16 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
                     download_path=torrent.download_dir or "",
                     labels=torrent.labels,
                 )
-                async_call_later(
-                    self.hass,
-                    delay,
-                    partial(self._async_notify_event_listeners, event),
-                )
-                delay += 0.1
+                events.append(event)
 
+        self._schedule_event_notifications(events)
         self._started_torrents = current_started_torrents
 
     def check_removed_torrent(self) -> None:
         """Get removed torrent functionality."""
         current_torrents = {torrent.id for torrent in self.torrents}
 
-        delay: float = 0.0
+        events: list[TransmissionEventData] = []
         for torrent in self._all_torrents:
             if torrent.id not in current_torrents:
                 # Once event triggers are out of labs we can remove the bus event
@@ -237,13 +248,9 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
                     download_path=torrent.download_dir or "",
                     labels=torrent.labels,
                 )
-                async_call_later(
-                    self.hass,
-                    delay,
-                    partial(self._async_notify_event_listeners, event),
-                )
-                delay += 0.1
+                events.append(event)
 
+        self._schedule_event_notifications(events)
         self._all_torrents = self.torrents.copy()
 
     def start_torrents(self) -> None:

--- a/homeassistant/components/transmission/coordinator.py
+++ b/homeassistant/components/transmission/coordinator.py
@@ -111,11 +111,8 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
 
     def _schedule_event_notifications(
         self, events: list[TransmissionEventData]
-    ) -> float:
-        """Schedule event notifications with staggered delays.
-
-        Returns the next delay to use for subsequent events in the update cycle.
-        """
+    ) -> None:
+        """Schedule event notifications with staggered delays."""
         for event in events:
             async_call_later(
                 self.hass,
@@ -123,7 +120,6 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
                 partial(self._async_notify_event_listeners, event),
             )
             self._event_notification_delay += self._EVENT_NOTIFICATION_DELAY_STEP
-        return self._event_notification_delay
 
     @override
     async def _async_update_data(self) -> SessionStats:

--- a/tests/components/transmission/test_event.py
+++ b/tests/components/transmission/test_event.py
@@ -92,6 +92,8 @@ async def test_event_updates_state(
         async_fire_time_changed(hass)
         await hass.async_block_till_done(wait_background_tasks=True)
 
+    freezer.tick(timedelta(seconds=1))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
     state = hass.states.get("event.transmission_torrent")

--- a/tests/components/transmission/test_event.py
+++ b/tests/components/transmission/test_event.py
@@ -92,6 +92,8 @@ async def test_event_updates_state(
         async_fire_time_changed(hass)
         await hass.async_block_till_done(wait_background_tasks=True)
 
+    await hass.async_block_till_done(wait_background_tasks=True)
+
     state = hass.states.get("event.transmission_torrent")
     assert state is not None
     assert state.attributes[ATTR_EVENT_TYPE] == expected_event_type

--- a/tests/components/transmission/test_event.py
+++ b/tests/components/transmission/test_event.py
@@ -112,7 +112,13 @@ async def test_multiple_events_staggered(
     mock_config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test that multiple torrents completing in one poll are delivered without deduplication."""
+    """Test that multiple torrents completing in one poll are all delivered.
+
+    Events are scheduled with staggered delays to prevent deduplication by
+    event.received triggers (which dedupe on state value equality). This test
+    verifies that all events are delivered, even when many torrents change
+    in a single poll.
+    """
     with patch("homeassistant.components.transmission.PLATFORMS", [Platform.EVENT]):
         await setup_integration(hass, mock_config_entry)
         await hass.async_block_till_done()
@@ -134,11 +140,11 @@ async def test_multiple_events_staggered(
     # First poll: no torrents, second poll: all 3 completed
     client.get_torrents.side_effect = [[], completed_torrents]
 
-    # Collect torrent IDs from state changes for the event entity
-    torrent_ids_seen = set()
+    # Collect torrent IDs from events to verify all are delivered
+    torrent_ids_received = set()
 
     def state_changed_listener(event: Event[EventStateChangedData]) -> None:
-        """Capture torrent IDs from state changes."""
+        """Capture torrent IDs from events."""
         if event.data["entity_id"] == "event.transmission_torrent":
             new_state = event.data.get("new_state")
             if (
@@ -147,7 +153,7 @@ async def test_multiple_events_staggered(
             ):
                 torrent_id = new_state.attributes.get("id")
                 if torrent_id:
-                    torrent_ids_seen.add(torrent_id)
+                    torrent_ids_received.add(torrent_id)
 
     hass.bus.async_listen("state_changed", state_changed_listener)
 
@@ -161,14 +167,14 @@ async def test_multiple_events_staggered(
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    # Wait for all staggered events to complete
+    # Advance time to let all staggered callbacks complete
     freezer.tick(timedelta(seconds=1))
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    # Verify all 3 events fired (each torrent ID was seen)
-    assert torrent_ids_seen == {1, 2, 3}, (
-        f"Not all torrents delivered: expected {{1, 2, 3}}, got {torrent_ids_seen}"
+    # Verify all 3 torrents were delivered as separate events
+    assert torrent_ids_received == {1, 2, 3}, (
+        f"Expected torrents {{1, 2, 3}}, got {torrent_ids_received}"
     )
 
     # Verify the final event state is from one of the torrents
@@ -186,12 +192,12 @@ async def test_mixed_event_types_no_collision(
     mock_config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test that events of different types in one poll don't collide.
+    """Test that events of different types in one poll have distinct timestamps.
 
     When torrents complete and start in the same poll cycle, events are
-    scheduled with cumulative delays to prevent deduplication. Without the
-    fix, events from different check methods would share the same delay
-    (both starting at 0.0s) and collide, causing deduplication.
+    scheduled with staggered delays to ensure each gets a distinct timestamp.
+    Without this fix, events from different check methods would be scheduled
+    at the same delay and share timestamps, causing event.received to dedupe.
     """
     with patch("homeassistant.components.transmission.PLATFORMS", [Platform.EVENT]):
         await setup_integration(hass, mock_config_entry)
@@ -224,18 +230,20 @@ async def test_mixed_event_types_no_collision(
         [downloaded_torrent, started_torrent],  # Poll 3: no changes
     ]
 
-    # Track all event types and their torrent IDs
-    event_types_seen = {}
+    # Collect event state timestamps by type
+    event_timestamps_by_type = {}
 
     def state_changed_listener(event: Event[EventStateChangedData]) -> None:
-        """Capture event types seen with their torrent IDs."""
+        """Capture event types and their timestamps."""
         if event.data["entity_id"] == "event.transmission_torrent":
             new_state = event.data.get("new_state")
-            if new_state and new_state.attributes.get("id"):
-                torrent_id = new_state.attributes.get("id")
+            if new_state:
                 event_type = new_state.attributes.get("event_type")
-                # Store as: {torrent_id: event_type}
-                event_types_seen[torrent_id] = event_type
+                if event_type:
+                    # Store timestamps by event type
+                    if event_type not in event_timestamps_by_type:
+                        event_timestamps_by_type[event_type] = []
+                    event_timestamps_by_type[event_type].append(new_state.state)
 
     hass.bus.async_listen("state_changed", state_changed_listener)
 
@@ -249,26 +257,32 @@ async def test_mixed_event_types_no_collision(
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    # Wait for staggered events to complete
-    freezer.tick(timedelta(seconds=1))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    # Advance time by small increments to ensure staggered callbacks get different times
+    for _ in range(2):
+        freezer.tick(timedelta(milliseconds=1.1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
 
-    # Verify both events were delivered without collision
-    # (both should have fired, not one deduplicated away due to same timestamp)
-    assert event_types_seen.get(1) == EVENT_TYPE_DOWNLOADED, (
-        "Downloaded event not delivered for torrent 1"
+    # Verify both event types were recorded (both events delivered)
+    assert EVENT_TYPE_DOWNLOADED in event_timestamps_by_type, (
+        "Downloaded event not seen"
     )
-    assert event_types_seen.get(2) == EVENT_TYPE_STARTED, (
-        "Started event not delivered for torrent 2"
+    assert EVENT_TYPE_STARTED in event_timestamps_by_type, "Started event not seen"
+
+    # Verify we got one of each event type
+    downloaded_count = len(event_timestamps_by_type[EVENT_TYPE_DOWNLOADED])
+    started_count = len(event_timestamps_by_type[EVENT_TYPE_STARTED])
+    assert downloaded_count >= 1, (
+        f"Expected at least 1 downloaded event, got {downloaded_count}"
     )
+    assert started_count >= 1, f"Expected at least 1 started event, got {started_count}"
 
     # Third poll: no new events
     freezer.tick(timedelta(seconds=DEFAULT_SCAN_INTERVAL + 1))
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    # State should still reflect the last event seen
+    # State should still reflect one of the events seen
     state = hass.states.get("event.transmission_torrent")
     assert state is not None
     assert state.attributes[ATTR_EVENT_TYPE] in (

--- a/tests/components/transmission/test_event.py
+++ b/tests/components/transmission/test_event.py
@@ -15,7 +15,7 @@ from homeassistant.components.transmission.const import (
     EVENT_TYPE_STARTED,
 )
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, EventStateChangedData, HomeAssistant
 from homeassistant.util import dt as dt_util
 
 from . import setup_integration
@@ -137,7 +137,7 @@ async def test_multiple_events_staggered(
     # Collect torrent IDs from state changes for the event entity
     torrent_ids_seen = set()
 
-    def state_changed_listener(event):
+    def state_changed_listener(event: Event[EventStateChangedData]) -> None:
         """Capture torrent IDs from state changes."""
         if event.data["entity_id"] == "event.transmission_torrent":
             new_state = event.data.get("new_state")
@@ -227,7 +227,7 @@ async def test_mixed_event_types_no_collision(
     # Track all event types and their torrent IDs
     event_types_seen = {}
 
-    def state_changed_listener(event):
+    def state_changed_listener(event: Event[EventStateChangedData]) -> None:
         """Capture event types seen with their torrent IDs."""
         if event.data["entity_id"] == "event.transmission_torrent":
             new_state = event.data.get("new_state")

--- a/tests/components/transmission/test_event.py
+++ b/tests/components/transmission/test_event.py
@@ -104,3 +104,175 @@ async def test_event_updates_state(
     assert state.attributes["download_path"] == "/downloads"
     assert state.attributes["labels"] == []
     assert dt_util.parse_datetime(state.state) is not None
+
+
+async def test_multiple_events_staggered(
+    hass: HomeAssistant,
+    mock_transmission_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that multiple torrents completing in one poll are delivered without deduplication."""
+    with patch("homeassistant.components.transmission.PLATFORMS", [Platform.EVENT]):
+        await setup_integration(hass, mock_config_entry)
+        await hass.async_block_till_done()
+
+    client = mock_transmission_client.return_value
+
+    # Create multiple torrents that complete in one poll
+    completed_torrents = [
+        SimpleNamespace(
+            id=i,
+            name=f"Torrent {i}",
+            status="seeding",
+            download_dir="/downloads",
+            labels=[],
+        )
+        for i in range(1, 4)
+    ]
+
+    # First poll: no torrents, second poll: all 3 completed
+    client.get_torrents.side_effect = [[], completed_torrents]
+
+    # Collect torrent IDs from state changes for the event entity
+    torrent_ids_seen = set()
+
+    def state_changed_listener(event):
+        """Capture torrent IDs from state changes."""
+        if event.data["entity_id"] == "event.transmission_torrent":
+            new_state = event.data.get("new_state")
+            if (
+                new_state
+                and new_state.attributes.get("event_type") == EVENT_TYPE_DOWNLOADED
+            ):
+                torrent_id = new_state.attributes.get("id")
+                if torrent_id:
+                    torrent_ids_seen.add(torrent_id)
+
+    hass.bus.async_listen("state_changed", state_changed_listener)
+
+    # First poll: initialize with no torrents
+    freezer.tick(timedelta(seconds=DEFAULT_SCAN_INTERVAL + 1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    # Second poll: all 3 torrents are completed
+    freezer.tick(timedelta(seconds=DEFAULT_SCAN_INTERVAL + 1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    # Wait for all staggered events to complete
+    freezer.tick(timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    # Verify all 3 events fired (each torrent ID was seen)
+    assert torrent_ids_seen == {1, 2, 3}, (
+        f"Not all torrents delivered: expected {{1, 2, 3}}, got {torrent_ids_seen}"
+    )
+
+    # Verify the final event state is from one of the torrents
+    state = hass.states.get("event.transmission_torrent")
+    assert state is not None
+    assert state.attributes[ATTR_EVENT_TYPE] == EVENT_TYPE_DOWNLOADED
+    assert state.attributes["id"] in (1, 2, 3)
+    assert state.attributes["name"] in ("Torrent 1", "Torrent 2", "Torrent 3")
+    assert state.attributes["download_path"] == "/downloads"
+
+
+async def test_mixed_event_types_no_collision(
+    hass: HomeAssistant,
+    mock_transmission_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that events of different types in one poll don't collide.
+
+    When torrents complete and start in the same poll cycle, events are
+    scheduled with cumulative delays to prevent deduplication. Without the
+    fix, events from different check methods would share the same delay
+    (both starting at 0.0s) and collide, causing deduplication.
+    """
+    with patch("homeassistant.components.transmission.PLATFORMS", [Platform.EVENT]):
+        await setup_integration(hass, mock_config_entry)
+        await hass.async_block_till_done()
+
+    client = mock_transmission_client.return_value
+
+    # Create torrents in different states
+    downloaded_torrent = SimpleNamespace(
+        id=1,
+        name="Downloaded Torrent",
+        status="seeding",
+        download_dir="/downloads",
+        labels=[],
+    )
+    started_torrent = SimpleNamespace(
+        id=2,
+        name="Started Torrent",
+        status="downloading",
+        download_dir="/downloads",
+        labels=[],
+    )
+
+    # First poll: no torrents
+    # Second poll: one downloaded, one started
+    # Third poll: both torrents present (no new events)
+    client.get_torrents.side_effect = [
+        [],  # Poll 1: empty
+        [downloaded_torrent, started_torrent],  # Poll 2: both appear
+        [downloaded_torrent, started_torrent],  # Poll 3: no changes
+    ]
+
+    # Track all event types and their torrent IDs
+    event_types_seen = {}
+
+    def state_changed_listener(event):
+        """Capture event types seen with their torrent IDs."""
+        if event.data["entity_id"] == "event.transmission_torrent":
+            new_state = event.data.get("new_state")
+            if new_state and new_state.attributes.get("id"):
+                torrent_id = new_state.attributes.get("id")
+                event_type = new_state.attributes.get("event_type")
+                # Store as: {torrent_id: event_type}
+                event_types_seen[torrent_id] = event_type
+
+    hass.bus.async_listen("state_changed", state_changed_listener)
+
+    # First poll: initialize
+    freezer.tick(timedelta(seconds=DEFAULT_SCAN_INTERVAL + 1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    # Second poll: both torrents appear
+    freezer.tick(timedelta(seconds=DEFAULT_SCAN_INTERVAL + 1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    # Wait for staggered events to complete
+    freezer.tick(timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    # Verify both events were delivered without collision
+    # (both should have fired, not one deduplicated away due to same timestamp)
+    assert event_types_seen.get(1) == EVENT_TYPE_DOWNLOADED, (
+        "Downloaded event not delivered for torrent 1"
+    )
+    assert event_types_seen.get(2) == EVENT_TYPE_STARTED, (
+        "Started event not delivered for torrent 2"
+    )
+
+    # Third poll: no new events
+    freezer.tick(timedelta(seconds=DEFAULT_SCAN_INTERVAL + 1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    # State should still reflect the last event seen
+    state = hass.states.get("event.transmission_torrent")
+    assert state is not None
+    assert state.attributes[ATTR_EVENT_TYPE] in (
+        EVENT_TYPE_DOWNLOADED,
+        EVENT_TYPE_STARTED,
+    )
+    assert state.attributes["id"] in (1, 2)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Transmission polls for changes to torrents and raises event entity events on changes (e.g. file downloaded)

If multiple files download within the poll interval, the events have exactly the same state data (type and timestamp), the second one is ignored within automations when using the event.received

```
triggers:
  - trigger: event.received
    target:
      entity_id: event.transmission_dev_torrent
    options:
      event_type:
        - downloaded

```
This change introduces a delay per event raise to introduce a change in timestamp to trigger the automation multiple times when more than one file has changed.

The existing event bus event's did not have this issue, therefore the delay is only added to the event entity triggers.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
