### PR TITLE
Handle invalid SSDP locations in UPnP integration

### DIFF
--- a/homeassistant/components/upnp/config_flow.py
+++ b/homeassistant/components/upnp/config_flow.py
@@ -194,7 +194,13 @@ class UpnpFlowHandler(ConfigFlow, domain=DOMAIN):
         # Ensure not already configuring/configured.
         unique_id = discovery_info.ssdp_usn
         await self.async_set_unique_id(unique_id)
-        mac_address = await _async_mac_address_from_discovery(self.hass, discovery_info)
+        try:
+            mac_address = await _async_mac_address_from_discovery(
+                self.hass, discovery_info
+            )
+        except ValueError as err:
+            LOGGER.debug("Invalid UPnP discovery location, ignoring: %s", err)
+            return self.async_abort(reason="invalid_discovery_info")
         host = discovery_info.ssdp_headers["_host"]
         self._abort_if_unique_id_configured(
             # Store mac address and other data for older entries.

--- a/homeassistant/components/upnp/config_flow.py
+++ b/homeassistant/components/upnp/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 from typing import Any, cast
-from urllib.parse import urlparse
+from urllib.parse import ParseResult, urlparse
 
 import voluptuous as vol
 
@@ -69,11 +69,13 @@ async def _async_discovered_igd_devices(
     ) + await ssdp.async_get_discovery_info_by_st(hass, ST_IGD_V2)
 
 
-def _redact_discovery_location(location: str) -> str:
+def _redact_discovery_location(parsed_location: ParseResult) -> str:
     """Redact credentials from a discovery location for logging."""
     try:
-        parsed_location = urlparse(location)
+        hostname = parsed_location.hostname
     except ValueError:
+        return "<invalid URL>"
+    if not parsed_location.netloc or hostname is None:
         return "<invalid URL>"
 
     netloc = parsed_location.netloc.rsplit("@", 1)[-1]
@@ -87,10 +89,13 @@ async def _async_mac_address_from_discovery(
 ) -> str | None:
     """Get the mac address from a discovery."""
     location = get_preferred_location(discovery.ssdp_all_locations)
-    redacted_location = _redact_discovery_location(location)
-    error_msg = f"Invalid UPnP discovery location: {redacted_location}"
     try:
         parsed_location = urlparse(location)
+    except ValueError as err:
+        raise ValueError("Invalid UPnP discovery location: <invalid URL>") from err
+    redacted_location = _redact_discovery_location(parsed_location)
+    error_msg = f"Invalid UPnP discovery location: {redacted_location}"
+    try:
         host = parsed_location.hostname
         _ = parsed_location.port  # Validate invalid port values.
     except ValueError as err:
@@ -98,9 +103,9 @@ async def _async_mac_address_from_discovery(
     if host is None:
         raise ValueError(error_msg)
     host_with_optional_port = parsed_location.netloc.rsplit("@", 1)[-1]
-    if host_with_optional_port.count(":") > 1 and not host_with_optional_port.startswith(
-        "["
-    ):
+    if host_with_optional_port.count(
+        ":"
+    ) > 1 and not host_with_optional_port.startswith("["):
         raise ValueError(error_msg)
     return await async_get_mac_address_from_host(hass, host)
 

--- a/homeassistant/components/upnp/config_flow.py
+++ b/homeassistant/components/upnp/config_flow.py
@@ -74,8 +74,14 @@ async def _async_mac_address_from_discovery(
 ) -> str | None:
     """Get the mac address from a discovery."""
     location = get_preferred_location(discovery.ssdp_all_locations)
-    host = urlparse(location).hostname
-    assert host is not None
+    try:
+        parsed_location = urlparse(location)
+        host = parsed_location.hostname
+        _ = parsed_location.port
+    except ValueError as err:
+        raise ValueError(f"Invalid UPnP discovery location: {location}") from err
+    if host is None:
+        raise ValueError(f"Invalid UPnP discovery location: {location}")
     return await async_get_mac_address_from_host(hass, host)
 
 

--- a/homeassistant/components/upnp/config_flow.py
+++ b/homeassistant/components/upnp/config_flow.py
@@ -77,7 +77,7 @@ async def _async_mac_address_from_discovery(
     try:
         parsed_location = urlparse(location)
         host = parsed_location.hostname
-        _ = parsed_location.port
+        _ = parsed_location.port  # Validate malformed netlocs, including IPv6.
     except ValueError as err:
         raise ValueError(f"Invalid UPnP discovery location: {location}") from err
     if host is None:

--- a/homeassistant/components/upnp/config_flow.py
+++ b/homeassistant/components/upnp/config_flow.py
@@ -69,19 +69,38 @@ async def _async_discovered_igd_devices(
     ) + await ssdp.async_get_discovery_info_by_st(hass, ST_IGD_V2)
 
 
+def _redact_discovery_location(location: str) -> str:
+    """Redact credentials from a discovery location for logging."""
+    try:
+        parsed_location = urlparse(location)
+    except ValueError:
+        return "<invalid URL>"
+
+    netloc = parsed_location.netloc.rsplit("@", 1)[-1]
+    return parsed_location._replace(
+        netloc=netloc, path="", params="", query="", fragment=""
+    ).geturl()
+
+
 async def _async_mac_address_from_discovery(
     hass: HomeAssistant, discovery: SsdpServiceInfo
 ) -> str | None:
     """Get the mac address from a discovery."""
     location = get_preferred_location(discovery.ssdp_all_locations)
-    error_msg = "Invalid UPnP discovery location"
+    redacted_location = _redact_discovery_location(location)
+    error_msg = f"Invalid UPnP discovery location: {redacted_location}"
     try:
         parsed_location = urlparse(location)
         host = parsed_location.hostname
-        _ = parsed_location.port  # Validate malformed netlocs, including IPv6.
+        _ = parsed_location.port  # Validate invalid port values.
     except ValueError as err:
         raise ValueError(error_msg) from err
     if host is None:
+        raise ValueError(error_msg)
+    host_with_optional_port = parsed_location.netloc.rsplit("@", 1)[-1]
+    if host_with_optional_port.count(":") > 1 and not host_with_optional_port.startswith(
+        "["
+    ):
         raise ValueError(error_msg)
     return await async_get_mac_address_from_host(hass, host)
 

--- a/homeassistant/components/upnp/config_flow.py
+++ b/homeassistant/components/upnp/config_flow.py
@@ -74,14 +74,15 @@ async def _async_mac_address_from_discovery(
 ) -> str | None:
     """Get the mac address from a discovery."""
     location = get_preferred_location(discovery.ssdp_all_locations)
+    error_msg = "Invalid UPnP discovery location"
     try:
         parsed_location = urlparse(location)
         host = parsed_location.hostname
         _ = parsed_location.port  # Validate malformed netlocs, including IPv6.
     except ValueError as err:
-        raise ValueError(f"Invalid UPnP discovery location: {location}") from err
+        raise ValueError(error_msg) from err
     if host is None:
-        raise ValueError(f"Invalid UPnP discovery location: {location}")
+        raise ValueError(error_msg)
     return await async_get_mac_address_from_host(hass, host)
 
 

--- a/homeassistant/components/upnp/strings.json
+++ b/homeassistant/components/upnp/strings.json
@@ -3,6 +3,7 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "incomplete_discovery": "Incomplete discovery",
+      "invalid_discovery_info": "Invalid discovery information",
       "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]"
     },
     "flow_title": "{name}",

--- a/tests/components/upnp/test_config_flow.py
+++ b/tests/components/upnp/test_config_flow.py
@@ -1,13 +1,13 @@
 """Test UPnP/IGD config flow."""
 
 import copy
+import logging
 from copy import deepcopy
 from unittest.mock import patch
 
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.upnp.config_flow import _redact_discovery_location
 from homeassistant.components.upnp.const import (
     CONFIG_ENTRY_FORCE_POLL,
     CONFIG_ENTRY_HOST,
@@ -39,14 +39,6 @@ from .conftest import (
 )
 
 from tests.common import MockConfigEntry
-
-
-def test_redact_discovery_location() -> None:
-    """Test discovery location redaction."""
-    assert (
-        _redact_discovery_location("http://user:pass@192.168.1.1/desc.xml?token=abc")
-        == "http://192.168.1.1"
-    )
 
 
 @pytest.mark.usefixtures(
@@ -182,6 +174,36 @@ async def test_flow_ssdp_invalid_discovery_location(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "invalid_discovery_info"
+
+
+async def test_flow_ssdp_invalid_discovery_location_redacts_credentials(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test config flow redacts credentials in invalid SSDP discovery logs."""
+    caplog.set_level(logging.DEBUG)
+    test_discovery = deepcopy(TEST_DISCOVERY)
+    bad_location = "http://user:pass@fe80::1/rootDesc.xml?token=abc"
+    test_discovery.ssdp_location = bad_location
+    test_discovery.ssdp_all_locations = {bad_location}
+    test_discovery.upnp["location"] = bad_location
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_SSDP},
+        data=test_discovery,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "invalid_discovery_info"
+    invalid_location_log = next(
+        record.getMessage()
+        for record in caplog.records
+        if "Invalid UPnP discovery location, ignoring" in record.getMessage()
+    )
+    assert "Invalid UPnP discovery location: http://fe80::1" in invalid_location_log
+    assert "user:pass" not in invalid_location_log
+    assert "rootDesc.xml" not in invalid_location_log
+    assert "token=abc" not in invalid_location_log
 
 
 @pytest.mark.usefixtures(

--- a/tests/components/upnp/test_config_flow.py
+++ b/tests/components/upnp/test_config_flow.py
@@ -149,10 +149,18 @@ async def test_flow_ssdp_non_igd_device(hass: HomeAssistant) -> None:
     assert result["reason"] == "non_igd_device"
 
 
-async def test_flow_ssdp_invalid_discovery_location(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    "bad_location",
+    [
+        pytest.param("http://fe80::1/rootDesc.xml", id="malformed_ipv6"),
+        pytest.param("http:///rootDesc.xml", id="missing_hostname"),
+    ],
+)
+async def test_flow_ssdp_invalid_discovery_location(
+    hass: HomeAssistant, bad_location: str
+) -> None:
     """Test config flow aborts invalid SSDP discovery location."""
     test_discovery = deepcopy(TEST_DISCOVERY)
-    bad_location = "http://fe80::1/rootDesc.xml"
     test_discovery.ssdp_location = bad_location
     test_discovery.ssdp_all_locations = {bad_location}
     test_discovery.upnp["location"] = bad_location

--- a/tests/components/upnp/test_config_flow.py
+++ b/tests/components/upnp/test_config_flow.py
@@ -149,6 +149,24 @@ async def test_flow_ssdp_non_igd_device(hass: HomeAssistant) -> None:
     assert result["reason"] == "non_igd_device"
 
 
+async def test_flow_ssdp_invalid_discovery_location(hass: HomeAssistant) -> None:
+    """Test config flow aborts invalid SSDP discovery location."""
+    test_discovery = deepcopy(TEST_DISCOVERY)
+    bad_location = "http://fe80::1/rootDesc.xml"
+    test_discovery.ssdp_location = bad_location
+    test_discovery.ssdp_all_locations = {bad_location}
+    test_discovery.upnp["location"] = bad_location
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_SSDP},
+        data=test_discovery,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "invalid_discovery_info"
+
+
 @pytest.mark.usefixtures(
     "ssdp_instant_discovery",
     "mock_setup_entry",

--- a/tests/components/upnp/test_config_flow.py
+++ b/tests/components/upnp/test_config_flow.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant import config_entries
+from homeassistant.components.upnp.config_flow import _redact_discovery_location
 from homeassistant.components.upnp.const import (
     CONFIG_ENTRY_FORCE_POLL,
     CONFIG_ENTRY_HOST,
@@ -38,6 +39,14 @@ from .conftest import (
 )
 
 from tests.common import MockConfigEntry
+
+
+def test_redact_discovery_location() -> None:
+    """Test discovery location redaction."""
+    assert (
+        _redact_discovery_location("http://user:pass@192.168.1.1/desc.xml?token=abc")
+        == "http://192.168.1.1"
+    )
 
 
 @pytest.mark.usefixtures(

--- a/tests/components/upnp/test_config_flow.py
+++ b/tests/components/upnp/test_config_flow.py
@@ -1,8 +1,8 @@
 """Test UPnP/IGD config flow."""
 
 import copy
-import logging
 from copy import deepcopy
+import logging
 from unittest.mock import patch
 
 import pytest


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Malformed UPnP SSDP discovery data can include an invalid LOCATION URL, such as an unbracketed IPv6 URL that parses the host as `fe80` or a URL without a host. These malformed locations can raise while resolving the MAC address.

This changes the SSDP config flow to abort invalid discovery data with `invalid_discovery_info` instead of raising an unhandled exception. A regression test covers malformed LOCATION cases.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #172202
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
