### PR TITLE
Growatt server fix storage power flow

### DIFF
--- a/homeassistant/components/growatt_server/coordinator.py
+++ b/homeassistant/components/growatt_server/coordinator.py
@@ -235,6 +235,16 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 **storage_info_detail["storageDetailBean"],
                 **storage_energy_overview,
             }
+            _LOGGER.debug(
+                "storage_info_detail for device %s: %r",
+                self.device_id,
+                storage_info_detail,
+            )
+            _LOGGER.debug(
+                "storage_energy_overview for device %s: %r",
+                self.device_id,
+                storage_energy_overview,
+            )
         elif self.device_type == "sph":
             try:
                 sph_detail = self.api.sph_detail(self.device_id)
@@ -300,6 +310,11 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 **mix_detail,
                 **dashboard_values_for_mix,
             }
+            _LOGGER.debug(
+                "mix data for device %s: %r",
+                self.device_id,
+                self.data,
+            )
         _LOGGER.debug(
             "Finished updating data for %s (%s)",
             self.device_id,

--- a/homeassistant/components/growatt_server/sensor/storage.py
+++ b/homeassistant/components/growatt_server/sensor/storage.py
@@ -127,6 +127,22 @@ STORAGE_SENSOR_TYPES: tuple[GrowattSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
     ),
     GrowattSensorEntityDescription(
+        key="storage_power_charge",
+        translation_key="storage_power_charge",
+        api_key="pCharge",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    GrowattSensorEntityDescription(
+        key="storage_power_discharge",
+        translation_key="storage_power_discharge",
+        api_key="pDischarge",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    GrowattSensorEntityDescription(
         key="storage_power_flow",
         translation_key="storage_power_flow",
         api_key="pBat",

--- a/homeassistant/components/growatt_server/sensor/storage.py
+++ b/homeassistant/components/growatt_server/sensor/storage.py
@@ -129,7 +129,7 @@ STORAGE_SENSOR_TYPES: tuple[GrowattSensorEntityDescription, ...] = (
     GrowattSensorEntityDescription(
         key="storage_power_flow",
         translation_key="storage_power_flow",
-        api_key="pCharge",
+        api_key="pBat",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,

--- a/homeassistant/components/growatt_server/strings.json
+++ b/homeassistant/components/growatt_server/strings.json
@@ -353,6 +353,12 @@
       "storage_output_voltage": {
         "name": "Output voltage"
       },
+      "storage_power_charge": {
+        "name": "Storage charging"
+      },
+      "storage_power_discharge": {
+        "name": "Storage discharging"
+      },
       "storage_power_flow": {
         "name": "Storage charging/ discharging(-ve)"
       },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The Storage Power Flow was using the wrong API key (`pCharge` instead of `pBat`), which is why only the charging information was being considered, but not the discharging information. If you only need the charging information, Storage Power Charge is available as a new sensor.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Storage Power Flow should contain both charging and discharging information. Since the wrong API key was used, only charging information was available, but no discharging information.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #152516
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.
