### PR TITLE
Fix powerview none type

### DIFF
--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -371,9 +371,9 @@ class PowerViewShadeWithTiltBase(PowerViewShadeBase):
     @property
     def transition_steps(self) -> int:
         """Return the steps to make a move."""
-        primary = self.positions.primary or 0
-        tilt = self.positions.tilt or 0
-        return primary + tilt
+        primary = self.positions.primary
+        tilt = self.positions.tilt
+        return (0 if primary is None else primary) + (0 if tilt is None else tilt)
 
     @property
     def open_tilt_position(self) -> ShadePosition:

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -365,7 +365,7 @@ class PowerViewShadeWithTiltBase(PowerViewShadeBase):
         self._max_tilt = self._shade.shade_limits.tilt_max
 
     @property
-    def current_cover_tilt_position(self) -> int:
+    def current_cover_tilt_position(self) -> int | None:
         """Return the current cover tile position."""
         return self.positions.tilt
 

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -398,12 +398,16 @@ class PowerViewShadeWithTiltBase(PowerViewShadeBase):
 
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Open the cover tilt."""
-        self._async_schedule_update_for_transition(100 - self.transition_steps)
+        if (steps := self.transition_steps) is None:
+            raise ServiceValidationError("Position data is missing")
+
+        self._async_schedule_update_for_transition(100 - steps)
         await self._async_execute_move(self.open_tilt_position)
-        self.async_write_ha_state()
 
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Move the tilt to a specific position."""
+        if (steps := self.transition_steps) is None:
+            raise ServiceValidationError("Position data is missing")
         await self._async_set_cover_tilt_position(kwargs[ATTR_TILT_POSITION])
 
     async def _async_set_cover_tilt_position(

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -144,10 +144,10 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
         return {STATE_ATTRIBUTE_ROOM_NAME: self._room_name}
 
     @property
-    def is_closed(self) -> bool:
-        """Return True if the cover is closed, False otherwise."""
+    def is_closed(self) -> bool | None:
+        """Return if the cover is closed."""
         if self.positions.primary is None:
-            return False
+            return None
         return self.positions.primary <= CLOSED_POSITION
 
     @property
@@ -371,9 +371,10 @@ class PowerViewShadeWithTiltBase(PowerViewShadeBase):
     @property
     def transition_steps(self) -> int:
         """Return the steps to make a move."""
-        primary = self.positions.primary
-        tilt = self.positions.tilt
-        return (0 if primary is None else primary) + (0 if tilt is None else tilt)
+        if self.positions.primary is None or self.positions.tilt is None:
+            raise ValueError("Position data is missing")
+            
+        return self.positions.primary + self.positions.tilt
 
     @property
     def open_tilt_position(self) -> ShadePosition:

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -26,6 +26,7 @@ from homeassistant.components.cover import (
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_call_later
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from .const import STATE_ATTRIBUTE_ROOM_NAME
 from .coordinator import PowerviewShadeUpdateCoordinator
@@ -372,7 +373,7 @@ class PowerViewShadeWithTiltBase(PowerViewShadeBase):
     def transition_steps(self) -> int:
         """Return the steps to make a move."""
         if self.positions.primary is None or self.positions.tilt is None:
-            raise ValueError("Position data is missing")
+            return None
             
         return self.positions.primary + self.positions.tilt
 
@@ -390,9 +391,10 @@ class PowerViewShadeWithTiltBase(PowerViewShadeBase):
 
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Close the cover tilt."""
-        self._async_schedule_update_for_transition(self.transition_steps)
+        if (steps := self.transition_steps) is None:
+            raise ServiceValidationError("Position data is missing")
+        self._async_schedule_update_for_transition(steps)
         await self._async_execute_move(self.close_tilt_position)
-        self.async_write_ha_state()
 
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Open the cover tilt."""

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -144,10 +144,10 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
         return {STATE_ATTRIBUTE_ROOM_NAME: self._room_name}
 
     @property
-    def is_closed(self) -> bool:
+    def is_closed(self) -> bool | None:
         """Return if the cover is closed."""
         if self.positions.primary is None:
-            return False
+            return None
         return self.positions.primary <= CLOSED_POSITION
 
     @property

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -146,6 +146,8 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
     @property
     def is_closed(self) -> bool:
         """Return if the cover is closed."""
+        if self.positions.primary is None:
+            return None
         return self.positions.primary <= CLOSED_POSITION
 
     @property
@@ -369,7 +371,9 @@ class PowerViewShadeWithTiltBase(PowerViewShadeBase):
     @property
     def transition_steps(self) -> int:
         """Return the steps to make a move."""
-        return self.positions.primary + self.positions.tilt
+        primary = self.positions.primary or 0
+        tilt = self.positions.tilt or 0
+        return primary + tilt
 
     @property
     def open_tilt_position(self) -> ShadePosition:

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -534,7 +534,7 @@ class PowerViewShadeTiltOnly(PowerViewShadeWithTiltBase):
         return CLOSED_POSITION
 
     @property
-    def transition_steps(self) -> int:
+    def transition_steps(self) -> int | None:
         """Return the steps to make a move."""
         return self.positions.tilt
 
@@ -581,8 +581,10 @@ class PowerViewShadeDualRailBase(PowerViewShadeBase):
     """
 
     @property
-    def transition_steps(self) -> int:
+    def transition_steps(self) -> int | None:
         """Return the steps to make a move."""
+        if self.positions.primary is None or self.positions.secondary is None:
+            return None
         return self.positions.primary + self.positions.secondary
 
 
@@ -699,8 +701,10 @@ class PowerViewShadeDualOverlappedBase(PowerViewShadeBase):
     """
 
     @property
-    def transition_steps(self) -> int:
+    def transition_steps(self) -> int | None:
         """Return the steps to make a move."""
+        if self.positions.primary is None or self.positions.secondary is None:
+            return None
         # poskind 1 represents the second half of the shade in hass
         # front must be fully closed before rear can move
         # 51 - 100 is equiv to 1-100 on other shades - one motor, two shades
@@ -930,7 +934,7 @@ class PowerViewShadeDualOverlappedCombinedTilt(
     """
 
     @property
-    def transition_steps(self) -> int:
+    def transition_steps(self) -> int | None:
         """Return the steps to make a move."""
         # poskind 1 represents the second half of the shade in hass
         # front must be fully closed before rear can move

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -145,7 +145,7 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
 
     @property
     def is_closed(self) -> bool | None:
-        """Return if the cover is closed."""
+        """Return True if the cover is closed, False if open, or None if unknown."""
         if self.positions.primary is None:
             return None
         return self.positions.primary <= CLOSED_POSITION

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -147,7 +147,7 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
     def is_closed(self) -> bool:
         """Return if the cover is closed."""
         if self.positions.primary is None:
-            return None
+            return False
         return self.positions.primary <= CLOSED_POSITION
 
     @property

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -144,10 +144,10 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
         return {STATE_ATTRIBUTE_ROOM_NAME: self._room_name}
 
     @property
-    def is_closed(self) -> bool | None:
-        """Return True if the cover is closed, False if open, or None if unknown."""
+    def is_closed(self) -> bool:
+        """Return True if the cover is closed, False otherwise."""
         if self.positions.primary is None:
-            return None
+            return False
         return self.positions.primary <= CLOSED_POSITION
 
     @property

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -152,12 +152,12 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
         return self.positions.primary <= CLOSED_POSITION
 
     @property
-    def current_cover_position(self) -> int:
+    def current_cover_position(self) -> int | None:
         """Return the current position of cover."""
         return self.positions.primary
 
     @property
-    def transition_steps(self) -> int:
+    def transition_steps(self) -> int | None:
         """Return the steps to make a move."""
         return self.positions.primary
 
@@ -370,7 +370,7 @@ class PowerViewShadeWithTiltBase(PowerViewShadeBase):
         return self.positions.tilt
 
     @property
-    def transition_steps(self) -> int:
+    def transition_steps(self) -> int | None:
         """Return the steps to make a move."""
         if self.positions.primary is None or self.positions.tilt is None:
             return None

--- a/homeassistant/components/prana/config_flow.py
+++ b/homeassistant/components/prana/config_flow.py
@@ -93,6 +93,9 @@ class PranaConfigFlow(ConfigFlow, domain=DOMAIN):
         client = PranaLocalApiClient(host=self._host, port=80)
         device_info = await client.get_device_info()
 
+        if device_info is None:
+            raise PranaApiCommunicationError("Device returned no data (404)")
+
         if not device_info.isValid:
             raise ValueError("invalid_device")
 

--- a/homeassistant/components/prana/config_flow.py
+++ b/homeassistant/components/prana/config_flow.py
@@ -93,9 +93,6 @@ class PranaConfigFlow(ConfigFlow, domain=DOMAIN):
         client = PranaLocalApiClient(host=self._host, port=80)
         device_info = await client.get_device_info()
 
-        if device_info is None:
-            raise PranaApiCommunicationError("Device returned no data (404)")
-
         if not device_info.isValid:
             raise ValueError("invalid_device")
 


### PR DESCRIPTION
## Proposed change
Fixes a TypeError crash in Hunter Douglas PowerView when blind position values return `None`.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #156837
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. *Your PR cannot be merged unless tests pass*
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [ ] I have followed the [perfect PR recommendations](https://developers.home-assistant.io/docs/review_process#making-your-pull-request-perfect)
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated for [www.home-assistant.io](https://www.home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
- [ ] The [manifest file](https://developers.home-assistant.io/docs/creating_integration_manifest) has all fields filled out correctly. Updated and included derived files by running: `python3 -m script.hassfest`
- [ ] New or updated dependencies have been added to `requirements_all.txt`. Updated by running `python3 -m script.gen_requirements_all`
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:
- [ ] I have reviewed two other [open pull requests](https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me) in this repository.