### PR TITLE
Tighten the Axis unique ID in config flow

### DIFF
--- a/homeassistant/components/axis/config_flow.py
+++ b/homeassistant/components/axis/config_flow.py
@@ -96,8 +96,11 @@ class AxisFlowHandler(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "cannot_connect"
 
             else:
-                if (serial := self._get_serial_number(api)) is None:
-                    return self.async_abort(reason="no_serial_number")
+                if not self.unique_id:
+                    if (serial := self._get_serial_number(api)) is None:
+                        return self.async_abort(reason="no_serial_number")
+                    await self.async_set_unique_id(format_mac(serial))
+
                 config = {
                     CONF_PROTOCOL: user_input[CONF_PROTOCOL],
                     CONF_HOST: user_input[CONF_HOST],
@@ -105,8 +108,6 @@ class AxisFlowHandler(ConfigFlow, domain=DOMAIN):
                     CONF_USERNAME: user_input[CONF_USERNAME],
                     CONF_PASSWORD: user_input[CONF_PASSWORD],
                 }
-
-                await self.async_set_unique_id(format_mac(serial))
 
                 if self.source == SOURCE_REAUTH:
                     self._abort_if_unique_id_mismatch()
@@ -122,7 +123,7 @@ class AxisFlowHandler(ConfigFlow, domain=DOMAIN):
 
                 self.config = config | {CONF_MODEL: api.vapix.product_number}
 
-                return await self._create_entry(serial)
+                return await self._create_entry()
 
         data = self.discovery_schema or {
             vol.Required(CONF_PROTOCOL): vol.In(PROTOCOL_CHOICES),
@@ -139,7 +140,7 @@ class AxisFlowHandler(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def _create_entry(self, serial: str) -> ConfigFlowResult:
+    async def _create_entry(self) -> ConfigFlowResult:
         """Create entry for device.
 
         Use the discovered device name when available.
@@ -147,7 +148,7 @@ class AxisFlowHandler(ConfigFlow, domain=DOMAIN):
         if (title_placeholders := self.context.get("title_placeholders")) is not None:
             name = title_placeholders[CONF_NAME]
         else:
-            name = f"{self.config[CONF_MODEL]} - {serial}"
+            name = f"{self.config[CONF_MODEL]} - {self.unique_id}"
         self.config[CONF_NAME] = name
 
         return self.async_create_entry(title=name, data=self.config)
@@ -193,7 +194,7 @@ class AxisFlowHandler(ConfigFlow, domain=DOMAIN):
         return await self._process_discovered_device(
             {
                 CONF_HOST: discovery_info.ip,
-                CONF_MAC: format_mac(discovery_info.macaddress),
+                CONF_MAC: discovery_info.macaddress,
                 CONF_NAME: discovery_info.hostname,
                 CONF_PORT: 80,
             }
@@ -207,7 +208,7 @@ class AxisFlowHandler(ConfigFlow, domain=DOMAIN):
         return await self._process_discovered_device(
             {
                 CONF_HOST: url.hostname,
-                CONF_MAC: format_mac(discovery_info.upnp[ATTR_UPNP_SERIAL]),
+                CONF_MAC: discovery_info.upnp[ATTR_UPNP_SERIAL],
                 CONF_NAME: f"{discovery_info.upnp[ATTR_UPNP_FRIENDLY_NAME]}",
                 CONF_PORT: url.port,
             }
@@ -220,7 +221,7 @@ class AxisFlowHandler(ConfigFlow, domain=DOMAIN):
         return await self._process_discovered_device(
             {
                 CONF_HOST: discovery_info.host,
-                CONF_MAC: format_mac(discovery_info.properties["macaddress"]),
+                CONF_MAC: discovery_info.properties["macaddress"],
                 CONF_NAME: discovery_info.name.split(".", 1)[0],
                 CONF_PORT: discovery_info.port,
             }
@@ -230,17 +231,17 @@ class AxisFlowHandler(ConfigFlow, domain=DOMAIN):
         self, discovery_info: dict[str, Any]
     ) -> ConfigFlowResult:
         """Prepare configuration for a discovered Axis device."""
-        if discovery_info[CONF_MAC][:8] not in AXIS_OUI:
+        serial = format_mac(discovery_info[CONF_MAC])
+        if serial[:8] not in AXIS_OUI:
             return self.async_abort(reason="not_axis_device")
 
         if is_link_local(ip_address(discovery_info[CONF_HOST])):
             return self.async_abort(reason="link_local_address")
 
-        await self.async_set_unique_id(discovery_info[CONF_MAC])
-
-        self._abort_if_unique_id_configured(
-            updates={CONF_HOST: discovery_info[CONF_HOST]}, reload_on_update=False
-        )
+        if await self.async_set_unique_id(serial):
+            self._abort_if_unique_id_configured(
+                updates={CONF_HOST: discovery_info[CONF_HOST]}, reload_on_update=False
+            )
 
         self.context.update(
             {

--- a/homeassistant/components/axis/config_flow.py
+++ b/homeassistant/components/axis/config_flow.py
@@ -97,9 +97,9 @@ class AxisFlowHandler(ConfigFlow, domain=DOMAIN):
 
             else:
                 if not self.unique_id:
-                    if (serial := self._get_serial_number(api)) is None:
+                    if (serial := self._get_formatted_serial(api)) is None:
                         return self.async_abort(reason="no_serial_number")
-                    await self.async_set_unique_id(format_mac(serial))
+                    await self.async_set_unique_id(serial)
 
                 config = {
                     CONF_PROTOCOL: user_input[CONF_PROTOCOL],
@@ -264,16 +264,16 @@ class AxisFlowHandler(ConfigFlow, domain=DOMAIN):
         return await self.async_step_user()
 
     @staticmethod
-    def _get_serial_number(api: axis.AxisDevice) -> str | None:
+    def _get_formatted_serial(api: axis.AxisDevice) -> str | None:
         """Retrieve the device serial number from the Axis API.
 
         Tries basic_device_info first, then property_handler. Returns None if not found.
         """
         vapix = api.vapix
         if vapix.basic_device_info.initialized:
-            return vapix.basic_device_info["0"].serial_number
+            return format_mac(vapix.basic_device_info["0"].serial_number)
         if vapix.params.property_handler.initialized:
-            return vapix.params.property_handler["0"].system_serial_number
+            return format_mac(vapix.params.property_handler["0"].system_serial_number)
         return None
 
 

--- a/homeassistant/components/axis/config_flow.py
+++ b/homeassistant/components/axis/config_flow.py
@@ -27,6 +27,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.selector import TextSelector, TextSelectorConfig
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from homeassistant.helpers.service_info.ssdp import (
     ATTR_UPNP_FRIENDLY_NAME,
@@ -255,7 +256,9 @@ class AxisFlowHandler(ConfigFlow, domain=DOMAIN):
 
         self.discovery_schema = {
             vol.Required(CONF_PROTOCOL): vol.In(PROTOCOL_CHOICES),
-            vol.Required(CONF_HOST, default=discovery_info[CONF_HOST]): str,
+            vol.Required(CONF_HOST, default=discovery_info[CONF_HOST]): TextSelector(
+                TextSelectorConfig(read_only=True)
+            ),
             vol.Required(CONF_USERNAME): str,
             vol.Required(CONF_PASSWORD): str,
             vol.Required(CONF_PORT, default=DEFAULT_PORT): int,

--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -65,7 +65,7 @@ async def test_flow_manual_configuration(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == f"M1065-LW - {MAC}"
+    assert result["title"] == f"M1065-LW - {dr.format_mac(MAC)}"
     assert result["data"] == {
         CONF_PROTOCOL: "http",
         CONF_HOST: "1.2.3.4",
@@ -73,7 +73,7 @@ async def test_flow_manual_configuration(hass: HomeAssistant) -> None:
         CONF_PASSWORD: "pass",
         CONF_PORT: 80,
         CONF_MODEL: "M1065-LW",
-        CONF_NAME: f"M1065-LW - {MAC}",
+        CONF_NAME: f"M1065-LW - {dr.format_mac(MAC)}",
     }
 
 
@@ -197,10 +197,10 @@ async def test_flow_succeeds_with_basic_device_info(
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == f"M1065-LW - {MAC}"
+    assert result["title"] == f"M1065-LW - {dr.format_mac(MAC)}"
     assert result["data"][CONF_HOST] == "1.2.3.4"
     assert result["data"][CONF_MODEL] == "M1065-LW"
-    assert result["data"][CONF_NAME] == f"M1065-LW - {MAC}"
+    assert result["data"][CONF_NAME] == f"M1065-LW - {dr.format_mac(MAC)}"
 
 
 @pytest.mark.usefixtures("mock_default_requests")
@@ -238,7 +238,7 @@ async def test_flow_create_entry_multiple_existing_entries_of_same_model(
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == f"M1065-LW - {MAC}"
+    assert result["title"] == f"M1065-LW - {dr.format_mac(MAC)}"
     assert result["data"] == {
         CONF_PROTOCOL: "http",
         CONF_HOST: "1.2.3.4",
@@ -246,10 +246,10 @@ async def test_flow_create_entry_multiple_existing_entries_of_same_model(
         CONF_PASSWORD: "pass",
         CONF_PORT: 80,
         CONF_MODEL: "M1065-LW",
-        CONF_NAME: f"M1065-LW - {MAC}",
+        CONF_NAME: f"M1065-LW - {dr.format_mac(MAC)}",
     }
 
-    assert result["data"][CONF_NAME] == f"M1065-LW - {MAC}"
+    assert result["data"][CONF_NAME] == f"M1065-LW - {dr.format_mac(MAC)}"
 
 
 async def test_reauth_flow_update_configuration(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Streamline the Axis unique ID management in config flow

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
