### PR TITLE
Bump qingping-ble to 1.1.4 and update CGPR1 test fixtures

### DIFF
--- a/homeassistant/components/qingping/manifest.json
+++ b/homeassistant/components/qingping/manifest.json
@@ -21,5 +21,5 @@
   "documentation": "https://www.home-assistant.io/integrations/qingping",
   "integration_type": "device",
   "iot_class": "local_push",
-  "requirements": ["qingping-ble==1.1.0"]
+  "requirements": ["qingping-ble==1.1.4"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2839,7 +2839,7 @@ qbittorrent-api==2026.5.1
 qbusmqttapi==1.5.0
 
 # homeassistant.components.qingping
-qingping-ble==1.1.0
+qingping-ble==1.1.4
 
 # homeassistant.components.qnap
 qnapstats==0.4.0

--- a/tests/components/qingping/__init__.py
+++ b/tests/components/qingping/__init__.py
@@ -26,6 +26,23 @@ LIGHT_AND_SIGNAL_SERVICE_INFO = BluetoothServiceInfo(
     source="local",
 )
 
+# Non-event variant (first byte 0x08 instead of 0x48 clears the event bit);
+# qingping-ble 1.1.3 drops illuminance from CGPR1 event packets because the
+# trailing bytes after motion are not a valid reading there.
+LIGHT_SERVICE_INFO = BluetoothServiceInfo(
+    name="Qingping Motion & Light",
+    manufacturer_data={},
+    service_uuids=[],
+    address="aa:bb:cc:dd:ee:ff",
+    rssi=-60,
+    service_data={
+        "0000fdcd-0000-1000-8000-00805f9b34fb": (
+            b"\x08\x12\xcd\xd5`4-X\x08\x04\x00\r\x00\x00\x0f\x01\xee"
+        )
+    },
+    source="local",
+)
+
 
 NO_DATA_SERVICE_INFO = BluetoothServiceInfo(
     name="Qingping Motion & Light",

--- a/tests/components/qingping/test_sensor.py
+++ b/tests/components/qingping/test_sensor.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
-from . import LIGHT_AND_SIGNAL_SERVICE_INFO, NO_DATA_SERVICE_INFO
+from . import LIGHT_SERVICE_INFO, NO_DATA_SERVICE_INFO
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.components.bluetooth import (
@@ -38,7 +38,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert len(hass.states.async_all("sensor")) == 0
-    inject_bluetooth_service_info(hass, LIGHT_AND_SIGNAL_SERVICE_INFO)
+    inject_bluetooth_service_info(hass, LIGHT_SERVICE_INFO)
     await hass.async_block_till_done()
     assert len(hass.states.async_all("sensor")) == 1
 
@@ -66,7 +66,7 @@ async def test_binary_sensor_restore_state(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert len(hass.states.async_all("sensor")) == 0
-    inject_bluetooth_service_info(hass, LIGHT_AND_SIGNAL_SERVICE_INFO)
+    inject_bluetooth_service_info(hass, LIGHT_SERVICE_INFO)
     await hass.async_block_till_done()
     assert len(hass.states.async_all("sensor")) == 1
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps qingping-ble from 1.1.0 to 1.1.4; fixes illuminance parsing to correctly combine the uint24 value, adds parsing of the CGP22C CO2 TLV id 0x18 from firmware 1.6.0, ignores illuminance from CGPR1 event packets (the trailing bytes after motion are not a valid reading there).

The existing CGPR1 test fixture is an event packet and no longer yields an illuminance sensor; a sibling non-event fixture is added and used in the sensor test so illuminance coverage is preserved while the motion-event test keeps using the event fixture.

Changelog: https://github.com/Bluetooth-Devices/qingping-ble/compare/v1.1.0...v1.1.4

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr