### PR TITLE
Add support for video attachments in OpenRouter

### DIFF
--- a/homeassistant/components/ai_task/task.py
+++ b/homeassistant/components/ai_task/task.py
@@ -80,15 +80,12 @@ async def _resolve_attachments(
         else:
             # Handle regular media sources
             media = await media_source.async_resolve_media(hass, media_content_id, None)
-            if media.path is None:
-                raise HomeAssistantError(
-                    "Only local attachments are currently supported"
-                )
             resolved_attachments.append(
                 conversation.Attachment(
                     media_content_id=media_content_id,
                     mime_type=attachment.get("media_content_type") or media.mime_type,
                     path=media.path,
+                    url=media.url,
                 )
             )
 

--- a/homeassistant/components/anthropic/entity.py
+++ b/homeassistant/components/anthropic/entity.py
@@ -1093,7 +1093,10 @@ class AnthropicBaseLLMEntity(CoordinatorEntity[AnthropicCoordinator]):
                 await async_prepare_files_for_prompt(
                     self.hass,
                     self.model_info,
-                    [(a.path, a.mime_type) for a in last_content.attachments],
+                    [
+                        (a.require_local_path(), a.mime_type)
+                        for a in last_content.attachments
+                    ],
                 )
             )
 

--- a/homeassistant/components/cloud/ai_task.py
+++ b/homeassistant/components/cloud/ai_task.py
@@ -60,7 +60,7 @@ async def async_prepare_image_generation_attachments(
                 raise HomeAssistantError(
                     "Only image attachments are supported for image generation"
                 )
-            path = attachment.path
+            path = attachment.require_local_path()
             if not path.exists():
                 raise HomeAssistantError(f"`{path}` does not exist")
 

--- a/homeassistant/components/cloud/entity.py
+++ b/homeassistant/components/cloud/entity.py
@@ -521,7 +521,7 @@ class BaseCloudLLMEntity(Entity):
             content: list[dict[str, Any]] = []
             for attachment in attachments:
                 mime_type = attachment.mime_type
-                path = attachment.path
+                path = attachment.require_local_path()
                 if not path.exists():
                     raise HomeAssistantError(f"`{path}` does not exist")
 

--- a/homeassistant/components/conversation/chat_log.py
+++ b/homeassistant/components/conversation/chat_log.py
@@ -245,15 +245,27 @@ class Attachment:
     mime_type: str
     """MIME type of the attachment."""
 
-    path: Path
-    """Path to the attachment on disk."""
+    path: Path | None = None
+    """Path to the attachment on disk, if it is available locally."""
+
+    url: str | None = None
+    """URL to the attachment, if it is only available remotely."""
+
+    def require_local_path(self) -> Path:
+        """Return the local path, raising if the attachment is remote-only."""
+        if self.path is None:
+            raise HomeAssistantError(
+                f"Attachment {self.media_content_id} is not available locally"
+            )
+        return self.path
 
     def as_dict(self) -> dict[str, Any]:
         """Return a dictionary representation of the attachment."""
         return {
             "media_content_id": self.media_content_id,
             "mime_type": self.mime_type,
-            "path": str(self.path),
+            "path": str(self.path) if self.path is not None else None,
+            "url": self.url,
         }
 
 

--- a/homeassistant/components/google_generative_ai_conversation/ai_task.py
+++ b/homeassistant/components/google_generative_ai_conversation/ai_task.py
@@ -134,7 +134,10 @@ class GoogleGenerativeAITaskEntity(
                 await async_prepare_files_for_prompt(
                     self.hass,
                     self._genai_client,
-                    [(a.path, a.mime_type) for a in user_message.attachments],
+                    [
+                        (a.require_local_path(), a.mime_type)
+                        for a in user_message.attachments
+                    ],
                 )
             )
 

--- a/homeassistant/components/google_generative_ai_conversation/entity.py
+++ b/homeassistant/components/google_generative_ai_conversation/entity.py
@@ -618,7 +618,10 @@ class GoogleGenerativeAILLMBaseEntity(Entity):
                 await async_prepare_files_for_prompt(
                     self.hass,
                     self._genai_client,
-                    [(a.path, a.mime_type) for a in user_message.attachments],
+                    [
+                        (a.require_local_path(), a.mime_type)
+                        for a in user_message.attachments
+                    ],
                 )
             )
 

--- a/homeassistant/components/llama_cpp/entity.py
+++ b/homeassistant/components/llama_cpp/entity.py
@@ -335,7 +335,7 @@ class LlamaCppBaseLLMEntity(Entity):
         ):
             files = await async_prepare_files_for_prompt(
                 self.hass,
-                [a.path for a in last_content.attachments],
+                [a.require_local_path() for a in last_content.attachments],
             )
             for i in range(len(messages) - 1, -1, -1):
                 if messages[i]["role"] == "user":

--- a/homeassistant/components/ollama/entity.py
+++ b/homeassistant/components/ollama/entity.py
@@ -119,7 +119,7 @@ def _convert_content(
                     translation_domain=DOMAIN,
                     translation_key="unsupported_attachment_type",
                 )
-            images.append(ollama.Image(value=attachment.path))
+            images.append(ollama.Image(value=attachment.require_local_path()))
         return ollama.Message(
             role=MessageRole.USER.value,
             content=chat_content.content,

--- a/homeassistant/components/open_router/entity.py
+++ b/homeassistant/components/open_router/entity.py
@@ -6,8 +6,8 @@ from datetime import timedelta
 import json
 from mimetypes import guess_file_type
 from pathlib import Path
-from urllib.parse import urljoin
 from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
+from urllib.parse import urljoin
 
 import openai
 from openai.types.chat import (

--- a/homeassistant/components/open_router/entity.py
+++ b/homeassistant/components/open_router/entity.py
@@ -6,12 +6,14 @@ from datetime import timedelta
 import json
 from mimetypes import guess_file_type
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, TypedDict
+from urllib.parse import urljoin
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
 
 import openai
 from openai.types.chat import (
     ChatCompletionAssistantMessageParam,
     ChatCompletionContentPartImageParam,
+    ChatCompletionContentPartParam,
     ChatCompletionFunctionToolParam,
     ChatCompletionMessage,
     ChatCompletionMessageFunctionToolCallParam,
@@ -184,7 +186,7 @@ async def _transform_response(
 async def async_prepare_files_for_prompt(
     hass: HomeAssistant,
     attachments: list[conversation.Attachment],
-) -> list[ChatCompletionContentPartImageParam | VideoUrlParam]:
+) -> list[ChatCompletionContentPartParam]:
     """Prepare files for use in a prompt.
 
     Caller needs to ensure that the files are allowed.
@@ -200,6 +202,8 @@ async def async_prepare_files_for_prompt(
                 def encode_video(
                     path: Path = file_path, mime: str = mime_type
                 ) -> VideoUrlParam:
+                    if not path.exists():
+                        raise HomeAssistantError(f"`{path}` does not exist, file may have been deleted/moved during encoding")
                     base64_file = base64.b64encode(path.read_bytes()).decode("utf-8")
                     return VideoUrlParam(
                         type="video_url",
@@ -225,7 +229,7 @@ async def async_prepare_files_for_prompt(
                 content.append(
                     VideoUrlParam(
                         type="video_url",
-                        video_url={"url": f"{external_url}{signed_path}"},
+                        video_url={"url": urljoin(external_url, signed_path)},
                     )
                 )
         elif mime_type.startswith(("image/", "application/pdf")):
@@ -246,7 +250,7 @@ async def async_prepare_files_for_prompt(
                 f"`{file_path}` has unsupported type: {mime_type}"
             )
 
-    return content
+    return cast(list[ChatCompletionContentPartParam], content)
 
 
 class OpenRouterEntity(Entity):

--- a/homeassistant/components/open_router/entity.py
+++ b/homeassistant/components/open_router/entity.py
@@ -199,11 +199,14 @@ async def async_prepare_files_for_prompt(
 
         if mime_type.startswith("video/"):
             if file_path.exists():
+
                 def encode_video(
                     path: Path = file_path, mime: str = mime_type
                 ) -> VideoUrlParam:
                     if not path.exists():
-                        raise HomeAssistantError(f"`{path}` does not exist, file may have been deleted/moved during encoding")
+                        raise HomeAssistantError(
+                            f"`{path}` does not exist, file may have been deleted/moved during encoding"
+                        )
                     base64_file = base64.b64encode(path.read_bytes()).decode("utf-8")
                     return VideoUrlParam(
                         type="video_url",
@@ -233,6 +236,7 @@ async def async_prepare_files_for_prompt(
                     )
                 )
         elif mime_type.startswith(("image/", "application/pdf")):
+
             def encode_image(
                 path: Path = file_path, mime: str = mime_type
             ) -> ChatCompletionContentPartImageParam:
@@ -243,6 +247,7 @@ async def async_prepare_files_for_prompt(
                     type="image_url",
                     image_url={"url": f"data:{mime};base64,{encoded}"},
                 )
+
             content.append(await hass.async_add_executor_job(encode_image))
         else:
             raise HomeAssistantError(

--- a/homeassistant/components/open_router/entity.py
+++ b/homeassistant/components/open_router/entity.py
@@ -2,10 +2,11 @@
 
 import base64
 from collections.abc import AsyncGenerator, Callable
+from datetime import timedelta
 import json
 from mimetypes import guess_file_type
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 import openai
 from openai.types.chat import (
@@ -25,7 +26,8 @@ from openai.types.shared_params.response_format_json_schema import JSONSchema
 import voluptuous as vol
 from voluptuous_openapi import convert
 
-from homeassistant.components import conversation
+from homeassistant.components import conversation, media_source
+from homeassistant.components.http.auth import async_sign_path
 from homeassistant.config_entries import ConfigSubentry
 from homeassistant.const import CONF_MODEL
 from homeassistant.core import HomeAssistant
@@ -33,11 +35,19 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, llm
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.json import json_dumps
+from homeassistant.helpers.network import NoURLAvailableError, get_url
 
 from . import OpenRouterConfigEntry
 from .const import CONF_WEB_SEARCH, DOMAIN, LOGGER
 
 MAX_TOOL_ITERATIONS = 10
+
+
+class VideoUrlParam(TypedDict):
+    """Content part for a video URL input (OpenRouter extension)."""
+
+    type: Literal["video_url"]
+    video_url: dict[str, str]
 
 
 def _adjust_schema(schema: dict[str, Any]) -> None:
@@ -172,40 +182,71 @@ async def _transform_response(
 
 
 async def async_prepare_files_for_prompt(
-    hass: HomeAssistant, files: list[tuple[Path, str | None]]
-) -> list[ChatCompletionContentPartImageParam]:
-    """Append files to a prompt.
+    hass: HomeAssistant,
+    attachments: list[conversation.Attachment],
+) -> list[ChatCompletionContentPartImageParam | VideoUrlParam]:
+    """Prepare files for use in a prompt.
 
     Caller needs to ensure that the files are allowed.
     """
+    content: list[ChatCompletionContentPartImageParam | VideoUrlParam] = []
 
-    def append_files_to_content() -> list[ChatCompletionContentPartImageParam]:
-        content: list[ChatCompletionContentPartImageParam] = []
+    for attachment in attachments:
+        file_path = attachment.path
+        mime_type = attachment.mime_type or guess_file_type(file_path)[0] or ""
 
-        for file_path, mime_type in files:
-            if not file_path.exists():
-                raise HomeAssistantError(f"`{file_path}` does not exist")
+        if mime_type.startswith("video/"):
+            if file_path.exists():
+                def encode_video(
+                    path: Path = file_path, mime: str = mime_type
+                ) -> VideoUrlParam:
+                    base64_file = base64.b64encode(path.read_bytes()).decode("utf-8")
+                    return VideoUrlParam(
+                        type="video_url",
+                        video_url={"url": f"data:{mime};base64,{base64_file}"},
+                    )
 
-            if mime_type is None:
-                mime_type = guess_file_type(file_path)[0]
-
-            if not mime_type or not mime_type.startswith(("image/", "application/pdf")):
-                raise HomeAssistantError(
-                    "Only images and PDF are supported by the OpenRouter API, "
-                    f"`{file_path}` is not an image file or PDF"
+                content.append(await hass.async_add_executor_job(encode_video))
+            else:
+                try:
+                    external_url = get_url(
+                        hass, prefer_external=True, allow_internal=False
+                    )
+                except NoURLAvailableError as err:
+                    raise HomeAssistantError(
+                        "An external URL must be configured to serve non-local video files to OpenRouter"
+                    ) from err
+                media = await media_source.async_resolve_media(
+                    hass, attachment.media_content_id, None
                 )
-
-            base64_file = base64.b64encode(file_path.read_bytes()).decode("utf-8")
-            content.append(
-                {
-                    "type": "image_url",
-                    "image_url": {"url": f"data:{mime_type};base64,{base64_file}"},
-                }
+                signed_path = async_sign_path(
+                    hass, media.url, timedelta(hours=1), use_content_user=True
+                )
+                content.append(
+                    VideoUrlParam(
+                        type="video_url",
+                        video_url={"url": f"{external_url}{signed_path}"},
+                    )
+                )
+        elif mime_type.startswith(("image/", "application/pdf")):
+            def encode_image(
+                path: Path = file_path, mime: str = mime_type
+            ) -> ChatCompletionContentPartImageParam:
+                if not path.exists():
+                    raise HomeAssistantError(f"`{path}` does not exist")
+                encoded = base64.b64encode(path.read_bytes()).decode("utf-8")
+                return ChatCompletionContentPartImageParam(
+                    type="image_url",
+                    image_url={"url": f"data:{mime};base64,{encoded}"},
+                )
+            content.append(await hass.async_add_executor_job(encode_image))
+        else:
+            raise HomeAssistantError(
+                "Only images, PDF, and video are supported by the OpenRouter API, "
+                f"`{file_path}` has unsupported type: {mime_type}"
             )
 
-        return content
-
-    return await hass.async_add_executor_job(append_files_to_content)
+    return content
 
 
 class OpenRouterEntity(Entity):
@@ -276,7 +317,7 @@ class OpenRouterEntity(Entity):
             # Encode files with base64 and append them to the text prompt
             files = await async_prepare_files_for_prompt(
                 self.hass,
-                [(a.path, a.mime_type) for a in last_content.attachments],
+                list(last_content.attachments),
             )
             last_message["content"] = [
                 {"type": "text", "text": last_message["content"]},

--- a/homeassistant/components/open_router/entity.py
+++ b/homeassistant/components/open_router/entity.py
@@ -28,7 +28,7 @@ from openai.types.shared_params.response_format_json_schema import JSONSchema
 import voluptuous as vol
 from voluptuous_openapi import convert
 
-from homeassistant.components import conversation, media_source
+from homeassistant.components import conversation
 from homeassistant.components.http.auth import async_sign_path
 from homeassistant.config_entries import ConfigSubentry
 from homeassistant.const import CONF_MODEL
@@ -183,6 +183,32 @@ async def _transform_response(
     yield data
 
 
+def _encode_video(file_path: Path, mime_type: str) -> VideoUrlParam:
+    """Read and base64-encode a local video file for use in a prompt."""
+    if not file_path.exists():
+        raise HomeAssistantError(
+            f"`{file_path}` does not exist, file may have been deleted/moved during encoding"
+        )
+    base64_file = base64.b64encode(file_path.read_bytes()).decode("utf-8")
+    return VideoUrlParam(
+        type="video_url",
+        video_url={"url": f"data:{mime_type};base64,{base64_file}"},
+    )
+
+
+def _encode_image(
+    file_path: Path, mime_type: str
+) -> ChatCompletionContentPartImageParam:
+    """Read and base64-encode a local image or PDF file for use in a prompt."""
+    if not file_path.exists():
+        raise HomeAssistantError(f"`{file_path}` does not exist")
+    encoded = base64.b64encode(file_path.read_bytes()).decode("utf-8")
+    return ChatCompletionContentPartImageParam(
+        type="image_url",
+        image_url={"url": f"data:{mime_type};base64,{encoded}"},
+    )
+
+
 async def async_prepare_files_for_prompt(
     hass: HomeAssistant,
     attachments: list[conversation.Attachment],
@@ -195,26 +221,18 @@ async def async_prepare_files_for_prompt(
 
     for attachment in attachments:
         file_path = attachment.path
-        mime_type = attachment.mime_type or guess_file_type(file_path)[0] or ""
+        mime_type = attachment.mime_type or ""
+        if not mime_type and file_path is not None:
+            mime_type = guess_file_type(file_path)[0] or ""
 
         if mime_type.startswith("video/"):
-            if file_path.exists():
-
-                def encode_video(
-                    path: Path = file_path, mime: str = mime_type
-                ) -> VideoUrlParam:
-                    if not path.exists():
-                        raise HomeAssistantError(
-                            f"`{path}` does not exist, file may have been deleted/moved during encoding"
-                        )
-                    base64_file = base64.b64encode(path.read_bytes()).decode("utf-8")
-                    return VideoUrlParam(
-                        type="video_url",
-                        video_url={"url": f"data:{mime};base64,{base64_file}"},
+            if file_path is not None:
+                content.append(
+                    await hass.async_add_executor_job(
+                        _encode_video, file_path, mime_type
                     )
-
-                content.append(await hass.async_add_executor_job(encode_video))
-            else:
+                )
+            elif attachment.url is not None:
                 try:
                     external_url = get_url(
                         hass, prefer_external=True, allow_internal=False
@@ -223,11 +241,8 @@ async def async_prepare_files_for_prompt(
                     raise HomeAssistantError(
                         "An external URL must be configured to serve non-local video files to OpenRouter"
                     ) from err
-                media = await media_source.async_resolve_media(
-                    hass, attachment.media_content_id, None
-                )
                 signed_path = async_sign_path(
-                    hass, media.url, timedelta(hours=1), use_content_user=True
+                    hass, attachment.url, timedelta(hours=1), use_content_user=True
                 )
                 content.append(
                     VideoUrlParam(
@@ -235,24 +250,24 @@ async def async_prepare_files_for_prompt(
                         video_url={"url": urljoin(external_url, signed_path)},
                     )
                 )
-        elif mime_type.startswith(("image/", "application/pdf")):
-
-            def encode_image(
-                path: Path = file_path, mime: str = mime_type
-            ) -> ChatCompletionContentPartImageParam:
-                if not path.exists():
-                    raise HomeAssistantError(f"`{path}` does not exist")
-                encoded = base64.b64encode(path.read_bytes()).decode("utf-8")
-                return ChatCompletionContentPartImageParam(
-                    type="image_url",
-                    image_url={"url": f"data:{mime};base64,{encoded}"},
+            else:
+                raise HomeAssistantError(
+                    f"Video attachment `{attachment.media_content_id}` has "
+                    "neither a local path nor a URL"
                 )
-
-            content.append(await hass.async_add_executor_job(encode_image))
+        elif mime_type.startswith(("image/", "application/pdf")):
+            if file_path is None:
+                raise HomeAssistantError(
+                    "Only local images and PDFs are supported by the OpenRouter API, "
+                    f"`{attachment.media_content_id}` is not available locally"
+                )
+            content.append(
+                await hass.async_add_executor_job(_encode_image, file_path, mime_type)
+            )
         else:
             raise HomeAssistantError(
                 "Only images, PDF, and video are supported by the OpenRouter API, "
-                f"`{file_path}` has unsupported type: {mime_type}"
+                f"`{attachment.media_content_id}` has unsupported type: {mime_type}"
             )
 
     return cast(list[ChatCompletionContentPartParam], content)

--- a/homeassistant/components/openai_conversation/entity.py
+++ b/homeassistant/components/openai_conversation/entity.py
@@ -643,7 +643,10 @@ class OpenAIBaseLLMEntity(Entity):
         if last_content.role == "user" and last_content.attachments:
             files = await async_prepare_files_for_prompt(
                 self.hass,
-                [(a.path, a.mime_type) for a in last_content.attachments],
+                [
+                    (a.require_local_path(), a.mime_type)
+                    for a in last_content.attachments
+                ],
             )
             last_message = messages[-1]
             assert (

--- a/tests/components/ai_task/test_task.py
+++ b/tests/components/ai_task/test_task.py
@@ -325,6 +325,46 @@ async def test_generate_data_content_type(
     assert media_attachment.path == Path("/media/test.png")
 
 
+async def test_generate_data_url_attachment(
+    hass: HomeAssistant,
+    init_components: None,
+    mock_ai_task_entity: MockAITaskEntity,
+) -> None:
+    """Test that a media source returning only a URL (no local path) is resolved."""
+    with patch(
+        "homeassistant.components.media_source.async_resolve_media",
+        return_value=media_source.PlayMedia(
+            url="http://example.com/clip.mp4",
+            mime_type="video/mp4",
+            path=None,
+        ),
+    ) as mock_resolve_media:
+        await async_generate_data(
+            hass,
+            task_name="Test Task",
+            entity_id=TEST_ENTITY_ID,
+            instructions="Describe this video",
+            attachments=[
+                {"media_content_id": "media-source://unifiprotect/clip.mp4"},
+            ],
+        )
+
+    mock_resolve_media.assert_called_once_with(
+        hass, "media-source://unifiprotect/clip.mp4", None
+    )
+
+    assert len(mock_ai_task_entity.mock_generate_data_tasks) == 1
+    task = mock_ai_task_entity.mock_generate_data_tasks[0]
+    assert task.attachments is not None
+    assert len(task.attachments) == 1
+
+    media_attachment = task.attachments[0]
+    assert media_attachment.media_content_id == "media-source://unifiprotect/clip.mp4"
+    assert media_attachment.mime_type == "video/mp4"
+    assert media_attachment.path is None
+    assert media_attachment.url == "http://example.com/clip.mp4"
+
+
 @pytest.mark.freeze_time("2025-06-14 22:59:00")
 async def test_generate_image(
     hass: HomeAssistant,

--- a/tests/components/open_router/test_ai_task.py
+++ b/tests/components/open_router/test_ai_task.py
@@ -391,7 +391,9 @@ async def test_generate_data_with_video_attachment_local(
             task_name="Test Task",
             entity_id="ai_task.gemini_1_5_pro",
             instructions="Describe the video",
-            attachments=[{"media_content_id": "media-source://media_source/local/clip.mp4"}],
+            attachments=[
+                {"media_content_id": "media-source://media_source/local/clip.mp4"}
+            ],
         )
 
     assert result.data == "Video processed"
@@ -473,7 +475,9 @@ async def test_generate_data_with_video_attachment_remote(
             task_name="Test Task",
             entity_id="ai_task.gemini_1_5_pro",
             instructions="Describe the video",
-            attachments=[{"media_content_id": "media-source://media_source/local/clip.mp4"}],
+            attachments=[
+                {"media_content_id": "media-source://media_source/local/clip.mp4"}
+            ],
         )
 
     assert result.data == "Video processed via URL"
@@ -521,5 +525,7 @@ async def test_generate_data_with_video_attachment_remote_no_external_url(
             task_name="Test Task",
             entity_id="ai_task.gemini_1_5_pro",
             instructions="Describe the video",
-            attachments=[{"media_content_id": "media-source://media_source/local/clip.mp4"}],
+            attachments=[
+                {"media_content_id": "media-source://media_source/local/clip.mp4"}
+            ],
         )

--- a/tests/components/open_router/test_ai_task.py
+++ b/tests/components/open_router/test_ai_task.py
@@ -1,6 +1,7 @@
 """Test AI Task structured data generation."""
 
 from pathlib import Path
+import tempfile
 from unittest.mock import AsyncMock, patch
 
 from openai.types import CompletionUsage
@@ -294,6 +295,10 @@ async def test_generate_data_with_attachments(
             ],
         ),
         patch("pathlib.Path.exists", return_value=True),
+        patch(
+            "homeassistant.components.open_router.entity.guess_file_type",
+            return_value=("image/jpeg", None),
+        ),
         patch("pathlib.Path.read_bytes", return_value=b"fake_image_data"),
     ):
         result = await ai_task.async_generate_data(
@@ -375,7 +380,7 @@ async def test_generate_data_with_video_attachment_local(
             return_value=media_source.PlayMedia(
                 url="/local/clip.mp4",
                 mime_type="video/mp4",
-                path=Path("/tmp/clip.mp4"),
+                path=Path(tempfile.gettempdir()) / "clip.mp4",
             ),
         ),
         patch("pathlib.Path.exists", return_value=True),
@@ -443,13 +448,13 @@ async def test_generate_data_with_video_attachment_remote(
                 media_source.PlayMedia(
                     url="/local/clip.mp4",
                     mime_type="video/mp4",
-                    path=Path("/tmp/clip.mp4"),
+                    path=Path(tempfile.gettempdir()) / "clip.mp4",
                 ),
                 # Second call: from entity.py non-local video handler
                 media_source.PlayMedia(
                     url="/local/clip.mp4",
                     mime_type="video/mp4",
-                    path=Path("/tmp/clip.mp4"),
+                    path=Path(tempfile.gettempdir()) / "clip.mp4",
                 ),
             ],
         ),
@@ -498,7 +503,7 @@ async def test_generate_data_with_video_attachment_remote_no_external_url(
             return_value=media_source.PlayMedia(
                 url="/local/clip.mp4",
                 mime_type="video/mp4",
-                path=Path("/tmp/clip.mp4"),
+                path=Path(tempfile.gettempdir()) / "clip.mp4",
             ),
         ),
         patch("pathlib.Path.exists", return_value=False),

--- a/tests/components/open_router/test_ai_task.py
+++ b/tests/components/open_router/test_ai_task.py
@@ -15,6 +15,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er, selector
+from homeassistant.helpers.network import NoURLAvailableError
 
 from . import setup_integration
 
@@ -293,10 +294,6 @@ async def test_generate_data_with_attachments(
             ],
         ),
         patch("pathlib.Path.exists", return_value=True),
-        patch(
-            "homeassistant.components.open_router.entity.guess_file_type",
-            return_value=("image/jpeg", None),
-        ),
         patch("pathlib.Path.read_bytes", return_value=b"fake_image_data"),
     ):
         result = await ai_task.async_generate_data(
@@ -337,3 +334,187 @@ async def test_generate_data_with_attachments(
             "image_url": {"url": "data:application/pdf;base64,ZmFrZV9pbWFnZV9kYXRh"},
         },
     ]
+
+
+async def test_generate_data_with_video_attachment_local(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_openai_client: AsyncMock,
+) -> None:
+    """Test AI Task data generation with a local video attachment."""
+    await setup_integration(hass, mock_config_entry)
+
+    mock_openai_client.chat.completions.create = AsyncMock(
+        return_value=ChatCompletion(
+            id="chatcmpl-1234567890ABCDEFGHIJKLMNOPQRS",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    message=ChatCompletionMessage(
+                        content="Video processed",
+                        role="assistant",
+                        function_call=None,
+                        tool_calls=None,
+                    ),
+                )
+            ],
+            created=1700000000,
+            model="x-ai/grok-3",
+            object="chat.completion",
+            system_fingerprint=None,
+            usage=CompletionUsage(
+                completion_tokens=2, prompt_tokens=8, total_tokens=10
+            ),
+        )
+    )
+
+    with (
+        patch(
+            "homeassistant.components.media_source.async_resolve_media",
+            return_value=media_source.PlayMedia(
+                url="/local/clip.mp4",
+                mime_type="video/mp4",
+                path=Path("/tmp/clip.mp4"),
+            ),
+        ),
+        patch("pathlib.Path.exists", return_value=True),
+        patch("pathlib.Path.read_bytes", return_value=b"fake_video_data"),
+    ):
+        result = await ai_task.async_generate_data(
+            hass,
+            task_name="Test Task",
+            entity_id="ai_task.gemini_1_5_pro",
+            instructions="Describe the video",
+            attachments=[{"media_content_id": "media-source://media_source/local/clip.mp4"}],
+        )
+
+    assert result.data == "Video processed"
+
+    call_args = mock_openai_client.chat.completions.create.call_args
+    user_message = call_args[1]["messages"][-2]
+    assert user_message["content"] == [
+        {"type": "text", "text": "Describe the video"},
+        {
+            "type": "video_url",
+            "video_url": {"url": "data:video/mp4;base64,ZmFrZV92aWRlb19kYXRh"},
+        },
+    ]
+
+
+async def test_generate_data_with_video_attachment_remote(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_openai_client: AsyncMock,
+) -> None:
+    """Test AI Task data generation with a non-local video using a signed URL."""
+    await setup_integration(hass, mock_config_entry)
+
+    mock_openai_client.chat.completions.create = AsyncMock(
+        return_value=ChatCompletion(
+            id="chatcmpl-1234567890ABCDEFGHIJKLMNOPQRS",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    message=ChatCompletionMessage(
+                        content="Video processed via URL",
+                        role="assistant",
+                        function_call=None,
+                        tool_calls=None,
+                    ),
+                )
+            ],
+            created=1700000000,
+            model="x-ai/grok-3",
+            object="chat.completion",
+            system_fingerprint=None,
+            usage=CompletionUsage(
+                completion_tokens=3, prompt_tokens=8, total_tokens=11
+            ),
+        )
+    )
+
+    with (
+        patch(
+            "homeassistant.components.media_source.async_resolve_media",
+            side_effect=[
+                # First call: from ai_task._resolve_attachments
+                media_source.PlayMedia(
+                    url="/local/clip.mp4",
+                    mime_type="video/mp4",
+                    path=Path("/tmp/clip.mp4"),
+                ),
+                # Second call: from entity.py non-local video handler
+                media_source.PlayMedia(
+                    url="/local/clip.mp4",
+                    mime_type="video/mp4",
+                    path=Path("/tmp/clip.mp4"),
+                ),
+            ],
+        ),
+        patch("pathlib.Path.exists", return_value=False),
+        patch(
+            "homeassistant.components.open_router.entity.async_sign_path",
+            return_value="/local/clip.mp4?authSig=xxx",
+        ),
+        patch(
+            "homeassistant.components.open_router.entity.get_url",
+            return_value="http://ha.example.com",
+        ),
+    ):
+        result = await ai_task.async_generate_data(
+            hass,
+            task_name="Test Task",
+            entity_id="ai_task.gemini_1_5_pro",
+            instructions="Describe the video",
+            attachments=[{"media_content_id": "media-source://media_source/local/clip.mp4"}],
+        )
+
+    assert result.data == "Video processed via URL"
+
+    call_args = mock_openai_client.chat.completions.create.call_args
+    user_message = call_args[1]["messages"][-2]
+    assert user_message["content"] == [
+        {"type": "text", "text": "Describe the video"},
+        {
+            "type": "video_url",
+            "video_url": {"url": "http://ha.example.com/local/clip.mp4?authSig=xxx"},
+        },
+    ]
+
+
+async def test_generate_data_with_video_attachment_remote_no_external_url(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_openai_client: AsyncMock,
+) -> None:
+    """Test that a HomeAssistantError is raised when no external URL is configured."""
+    await setup_integration(hass, mock_config_entry)
+
+    with (
+        patch(
+            "homeassistant.components.media_source.async_resolve_media",
+            return_value=media_source.PlayMedia(
+                url="/local/clip.mp4",
+                mime_type="video/mp4",
+                path=Path("/tmp/clip.mp4"),
+            ),
+        ),
+        patch("pathlib.Path.exists", return_value=False),
+        patch(
+            "homeassistant.components.open_router.entity.get_url",
+            side_effect=NoURLAvailableError,
+        ),
+        pytest.raises(
+            HomeAssistantError,
+            match="An external URL must be configured to serve non-local video files to OpenRouter",
+        ),
+    ):
+        await ai_task.async_generate_data(
+            hass,
+            task_name="Test Task",
+            entity_id="ai_task.gemini_1_5_pro",
+            instructions="Describe the video",
+            attachments=[{"media_content_id": "media-source://media_source/local/clip.mp4"}],
+        )

--- a/tests/components/open_router/test_ai_task.py
+++ b/tests/components/open_router/test_ai_task.py
@@ -445,22 +445,14 @@ async def test_generate_data_with_video_attachment_remote(
     with (
         patch(
             "homeassistant.components.media_source.async_resolve_media",
-            side_effect=[
-                # First call: from ai_task._resolve_attachments
-                media_source.PlayMedia(
-                    url="/local/clip.mp4",
-                    mime_type="video/mp4",
-                    path=Path(tempfile.gettempdir()) / "clip.mp4",
-                ),
-                # Second call: from entity.py non-local video handler
-                media_source.PlayMedia(
-                    url="/local/clip.mp4",
-                    mime_type="video/mp4",
-                    path=Path(tempfile.gettempdir()) / "clip.mp4",
-                ),
-            ],
+            # A URL-backed media source (e.g. UniFi Protect, Reolink) resolves to
+            # a PlayMedia with no local path.
+            return_value=media_source.PlayMedia(
+                url="/local/clip.mp4",
+                mime_type="video/mp4",
+                path=None,
+            ),
         ),
-        patch("pathlib.Path.exists", return_value=False),
         patch(
             "homeassistant.components.open_router.entity.async_sign_path",
             return_value="/local/clip.mp4?authSig=xxx",
@@ -507,10 +499,9 @@ async def test_generate_data_with_video_attachment_remote_no_external_url(
             return_value=media_source.PlayMedia(
                 url="/local/clip.mp4",
                 mime_type="video/mp4",
-                path=Path(tempfile.gettempdir()) / "clip.mp4",
+                path=None,
             ),
         ),
-        patch("pathlib.Path.exists", return_value=False),
         patch(
             "homeassistant.components.open_router.entity.get_url",
             side_effect=NoURLAvailableError,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
OpenRouter supports video attachments using either base64 encoded video files or video URLs using the `video_url` conversation content type. This PR adds support for both:
1) attaching base64 encoded images when a local file is available
2) generating a signed public URL for proxied videos (e.g. Unifi Protect recordings)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: n/a
- This PR is related to issue: n/a
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45617
- Link to developer documentation pull request: n/a
- Link to frontend pull request: n/a

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository] (See https://github.com/home-assistant/home-assistant.io/pull/45617)

If the code communicates with devices, web services, or third-party tools:

- [n/a] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [n/a] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [n/a] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
