### PR TITLE
Update recommended chat model to gemini-3.1-flash-lite

### DIFF
--- a/homeassistant/components/google_generative_ai_conversation/const.py
+++ b/homeassistant/components/google_generative_ai_conversation/const.py
@@ -19,7 +19,7 @@ DEFAULT_STT_PROMPT = "Transcribe the attached audio"
 
 CONF_RECOMMENDED = "recommended"
 CONF_CHAT_MODEL = "chat_model"
-RECOMMENDED_CHAT_MODEL = "models/gemini-2.5-flash"
+RECOMMENDED_CHAT_MODEL = "models/gemini-3.1-flash-lite"
 RECOMMENDED_STT_MODEL = RECOMMENDED_CHAT_MODEL
 RECOMMENDED_TTS_MODEL = "models/gemini-2.5-flash-preview-tts"
 RECOMMENDED_IMAGE_MODEL = "models/gemini-2.5-flash-image"

--- a/tests/components/google_generative_ai_conversation/snapshots/test_diagnostics.ambr
+++ b/tests/components/google_generative_ai_conversation/snapshots/test_diagnostics.ambr
@@ -18,7 +18,7 @@
       }),
       'ulid-conversation': dict({
         'data': dict({
-          'chat_model': 'models/gemini-2.5-flash',
+          'chat_model': 'models/gemini-3.1-flash-lite',
           'dangerous_block_threshold': 'BLOCK_MEDIUM_AND_ABOVE',
           'harassment_block_threshold': 'BLOCK_MEDIUM_AND_ABOVE',
           'hate_block_threshold': 'BLOCK_MEDIUM_AND_ABOVE',

--- a/tests/components/google_generative_ai_conversation/snapshots/test_init.ambr
+++ b/tests/components/google_generative_ai_conversation/snapshots/test_init.ambr
@@ -21,7 +21,7 @@
       'labels': set({
       }),
       'manufacturer': 'Google',
-      'model': 'gemini-2.5-flash',
+      'model': 'gemini-3.1-flash-lite',
       'model_id': None,
       'name': 'Google AI Conversation',
       'name_by_user': None,
@@ -50,7 +50,7 @@
       'labels': set({
       }),
       'manufacturer': 'Google',
-      'model': 'gemini-2.5-flash',
+      'model': 'gemini-3.1-flash-lite',
       'model_id': None,
       'name': 'Google AI STT',
       'name_by_user': None,
@@ -108,7 +108,7 @@
       'labels': set({
       }),
       'manufacturer': 'Google',
-      'model': 'gemini-2.5-flash',
+      'model': 'gemini-3.1-flash-lite',
       'model_id': None,
       'name': 'Google AI Task',
       'name_by_user': None,

--- a/tests/components/google_generative_ai_conversation/test_config_flow.py
+++ b/tests/components/google_generative_ai_conversation/test_config_flow.py
@@ -51,7 +51,7 @@ def get_models_pager():
     model_25_flash = Mock(
         supported_actions=["generateContent"],
     )
-    model_25_flash.name = "models/gemini-2.5-flash"
+    model_25_flash.name = "models/gemini-3.1-flash-lite"
 
     model_20_flash = Mock(
         supported_actions=["generateContent"],

--- a/tests/components/google_generative_ai_conversation/test_stt.py
+++ b/tests/components/google_generative_ai_conversation/test_stt.py
@@ -21,7 +21,7 @@ from . import API_ERROR_500, CLIENT_ERROR_BAD_REQUEST
 
 from tests.common import MockConfigEntry
 
-TEST_CHAT_MODEL = "models/gemini-2.5-flash"
+TEST_CHAT_MODEL = "models/gemini-3.1-flash-lite"
 TEST_PROMPT = "Please transcribe the audio."
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update recommended chat model to gemini-3.1-flash-lite
According to https://github.com/allenporter/home-assistant-datasets/tree/main/reports it ranks a bit higher than the current default gemini-2.5-flash
It's one year newer, budget-conscious model focused on speed and latency.
According to https://ai.google.dev/gemini-api/docs/pricing it's cheaper than 2.5 flash.

In the free tier it has more generous quota:
- 15 requests/min (instead of 5),
- 500 requests/day (instead of 20).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
