### PR TITLE
Refactor bsblan schedule service helpers

### DIFF
--- a/homeassistant/components/bsblan/services.py
+++ b/homeassistant/components/bsblan/services.py
@@ -29,6 +29,16 @@ ATTR_FRIDAY_SLOTS = "friday_slots"
 ATTR_SATURDAY_SLOTS = "saturday_slots"
 ATTR_SUNDAY_SLOTS = "sunday_slots"
 
+_DAY_ATTRS: tuple[tuple[str, str], ...] = (
+    ("monday", ATTR_MONDAY_SLOTS),
+    ("tuesday", ATTR_TUESDAY_SLOTS),
+    ("wednesday", ATTR_WEDNESDAY_SLOTS),
+    ("thursday", ATTR_THURSDAY_SLOTS),
+    ("friday", ATTR_FRIDAY_SLOTS),
+    ("saturday", ATTR_SATURDAY_SLOTS),
+    ("sunday", ATTR_SUNDAY_SLOTS),
+)
+
 
 # Schema for a single time slot
 _SLOT_SCHEMA = vol.Schema(
@@ -39,16 +49,21 @@ _SLOT_SCHEMA = vol.Schema(
 )
 
 
+_WEEKLY_SCHEDULE_FIELDS: dict[vol.Marker, object] = {
+    vol.Optional(ATTR_MONDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
+    vol.Optional(ATTR_TUESDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
+    vol.Optional(ATTR_WEDNESDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
+    vol.Optional(ATTR_THURSDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
+    vol.Optional(ATTR_FRIDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
+    vol.Optional(ATTR_SATURDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
+    vol.Optional(ATTR_SUNDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
+}
+
+
 SERVICE_SET_HOT_WATER_SCHEDULE_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_DEVICE_ID): cv.string,
-        vol.Optional(ATTR_MONDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
-        vol.Optional(ATTR_TUESDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
-        vol.Optional(ATTR_WEDNESDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
-        vol.Optional(ATTR_THURSDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
-        vol.Optional(ATTR_FRIDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
-        vol.Optional(ATTR_SATURDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
-        vol.Optional(ATTR_SUNDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
+        **_WEEKLY_SCHEDULE_FIELDS,
     }
 )
 
@@ -98,11 +113,22 @@ def _convert_time_slots_to_day_schedule(
     return DaySchedule(slots=time_slots)
 
 
-async def set_hot_water_schedule(service_call: ServiceCall) -> None:
-    """Set hot water heating schedule."""
-    device_id = service_call.data[ATTR_DEVICE_ID]
+def _build_weekly_schedule_days(
+    service_call: ServiceCall,
+) -> dict[str, DaySchedule | None]:
+    """Build a dict of day-name -> DaySchedule from the service call data."""
+    return {
+        day_name: _convert_time_slots_to_day_schedule(service_call.data.get(attr_name))
+        for day_name, attr_name in _DAY_ATTRS
+    }
 
-    # Get the device and config entry
+
+def _resolve_config_entry(
+    service_call: ServiceCall,
+) -> tuple[BSBLanConfigEntry, dr.DeviceEntry]:
+    """Resolve device_id from a service call into a loaded BSBLAN config entry."""
+    device_id: str = service_call.data[ATTR_DEVICE_ID]
+
     device_registry = dr.async_get(service_call.hass)
     device_entry = device_registry.async_get(device_id)
 
@@ -137,56 +163,20 @@ async def set_hot_water_schedule(service_call: ServiceCall) -> None:
             translation_placeholders={"device_name": device_entry.name or device_id},
         )
 
+    return entry, device_entry
+
+
+async def set_hot_water_schedule(service_call: ServiceCall) -> None:
+    """Set hot water heating schedule."""
+    entry, _ = _resolve_config_entry(service_call)
     client = entry.runtime_data.client
 
-    # Convert time slots to DaySchedule objects
-    monday = _convert_time_slots_to_day_schedule(
-        service_call.data.get(ATTR_MONDAY_SLOTS)
-    )
-    tuesday = _convert_time_slots_to_day_schedule(
-        service_call.data.get(ATTR_TUESDAY_SLOTS)
-    )
-    wednesday = _convert_time_slots_to_day_schedule(
-        service_call.data.get(ATTR_WEDNESDAY_SLOTS)
-    )
-    thursday = _convert_time_slots_to_day_schedule(
-        service_call.data.get(ATTR_THURSDAY_SLOTS)
-    )
-    friday = _convert_time_slots_to_day_schedule(
-        service_call.data.get(ATTR_FRIDAY_SLOTS)
-    )
-    saturday = _convert_time_slots_to_day_schedule(
-        service_call.data.get(ATTR_SATURDAY_SLOTS)
-    )
-    sunday = _convert_time_slots_to_day_schedule(
-        service_call.data.get(ATTR_SUNDAY_SLOTS)
-    )
+    days = _build_weekly_schedule_days(service_call)
+    dhw_schedule = DHWSchedule(**days)
 
-    # Create the DHWSchedule object
-    dhw_schedule = DHWSchedule(
-        monday=monday,
-        tuesday=tuesday,
-        wednesday=wednesday,
-        thursday=thursday,
-        friday=friday,
-        saturday=saturday,
-        sunday=sunday,
-    )
-
-    LOGGER.debug(
-        "Setting hot water schedule - Monday: %s, Tuesday: %s, Wednesday: %s, "
-        "Thursday: %s, Friday: %s, Saturday: %s, Sunday: %s",
-        monday,
-        tuesday,
-        wednesday,
-        thursday,
-        friday,
-        saturday,
-        sunday,
-    )
+    LOGGER.debug("Setting hot water schedule: %s", dhw_schedule)
 
     try:
-        # Call the BSB-LAN API to set the schedule
         await client.set_hot_water_schedule(dhw_schedule)
     except BSBLANError as err:
         raise HomeAssistantError(
@@ -201,45 +191,11 @@ async def set_hot_water_schedule(service_call: ServiceCall) -> None:
 
 async def async_sync_time(service_call: ServiceCall) -> None:
     """Synchronize BSB-LAN device time with Home Assistant."""
-    device_id: str = service_call.data[ATTR_DEVICE_ID]
-
-    # Get the device and config entry
-    device_registry = dr.async_get(service_call.hass)
-    device_entry = device_registry.async_get(device_id)
-
-    if device_entry is None:
-        raise ServiceValidationError(
-            translation_domain=DOMAIN,
-            translation_key="invalid_device_id",
-            translation_placeholders={"device_id": device_id},
-        )
-
-    # Find the config entry for this device
-    matching_entries: list[BSBLanConfigEntry] = [
-        entry
-        for entry in service_call.hass.config_entries.async_entries(DOMAIN)
-        if entry.entry_id in device_entry.config_entries
-    ]
-
-    if not matching_entries:
-        raise ServiceValidationError(
-            translation_domain=DOMAIN,
-            translation_key="no_config_entry_for_device",
-            translation_placeholders={"device_id": device_entry.name or device_id},
-        )
-
-    entry = matching_entries[0]
-
-    # Verify the config entry is loaded
-    if entry.state is not ConfigEntryState.LOADED:
-        raise ServiceValidationError(
-            translation_domain=DOMAIN,
-            translation_key="config_entry_not_loaded",
-            translation_placeholders={"device_name": device_entry.name or device_id},
-        )
-
+    entry, device_entry = _resolve_config_entry(service_call)
     client = entry.runtime_data.client
-    await async_sync_device_time(client, device_entry.name or device_id)
+    await async_sync_device_time(
+        client, device_entry.name or service_call.data[ATTR_DEVICE_ID]
+    )
 
 
 SYNC_TIME_SCHEMA = vol.Schema(

--- a/homeassistant/components/bsblan/services.py
+++ b/homeassistant/components/bsblan/services.py
@@ -2,7 +2,7 @@
 
 from datetime import time
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Final
 
 from bsblan import BSBLANError, DaySchedule, DHWSchedule, TimeSlot
 import voluptuous as vol
@@ -49,7 +49,7 @@ _SLOT_SCHEMA = vol.Schema(
 )
 
 
-_WEEKLY_SCHEDULE_FIELDS: dict[vol.Marker, object] = {
+_WEEKLY_SCHEDULE_FIELDS: Final[dict[vol.Marker, Any]] = {
     vol.Optional(slot_attr): vol.All(cv.ensure_list, [_SLOT_SCHEMA])
     for _, slot_attr in _DAY_NAME_SLOT_ATTR_PAIRS
 }
@@ -111,7 +111,11 @@ def _convert_time_slots_to_day_schedule(
 def _build_weekly_schedule_days(
     service_call: ServiceCall,
 ) -> dict[str, DaySchedule | None]:
-    """Build a dict of day-name -> DaySchedule from the service call data."""
+    """Build day-name -> schedule values from the service call data.
+
+    Days omitted from the service call map to None, which tells python-bsblan not to
+    modify that day.
+    """
     return {
         day_name: _convert_time_slots_to_day_schedule(service_call.data.get(attr_name))
         for day_name, attr_name in _DAY_NAME_SLOT_ATTR_PAIRS

--- a/homeassistant/components/bsblan/services.py
+++ b/homeassistant/components/bsblan/services.py
@@ -29,7 +29,7 @@ ATTR_FRIDAY_SLOTS = "friday_slots"
 ATTR_SATURDAY_SLOTS = "saturday_slots"
 ATTR_SUNDAY_SLOTS = "sunday_slots"
 
-_DAY_ATTRS: tuple[tuple[str, str], ...] = (
+_DAY_NAME_SLOT_ATTR_PAIRS: tuple[tuple[str, str], ...] = (
     ("monday", ATTR_MONDAY_SLOTS),
     ("tuesday", ATTR_TUESDAY_SLOTS),
     ("wednesday", ATTR_WEDNESDAY_SLOTS),
@@ -50,13 +50,8 @@ _SLOT_SCHEMA = vol.Schema(
 
 
 _WEEKLY_SCHEDULE_FIELDS: dict[vol.Marker, object] = {
-    vol.Optional(ATTR_MONDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
-    vol.Optional(ATTR_TUESDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
-    vol.Optional(ATTR_WEDNESDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
-    vol.Optional(ATTR_THURSDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
-    vol.Optional(ATTR_FRIDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
-    vol.Optional(ATTR_SATURDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
-    vol.Optional(ATTR_SUNDAY_SLOTS): vol.All(cv.ensure_list, [_SLOT_SCHEMA]),
+    vol.Optional(slot_attr): vol.All(cv.ensure_list, [_SLOT_SCHEMA])
+    for _, slot_attr in _DAY_NAME_SLOT_ATTR_PAIRS
 }
 
 
@@ -119,7 +114,7 @@ def _build_weekly_schedule_days(
     """Build a dict of day-name -> DaySchedule from the service call data."""
     return {
         day_name: _convert_time_slots_to_day_schedule(service_call.data.get(attr_name))
-        for day_name, attr_name in _DAY_ATTRS
+        for day_name, attr_name in _DAY_NAME_SLOT_ATTR_PAIRS
     }
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


refactor of schedule service so it can be reused for heating etc.

<details>
<summary>Details</summary>

This pull request refactors and simplifies the service logic for setting the hot water schedule and synchronizing time in the `bsblan` Home Assistant integration. The main improvements are the introduction of helper functions to avoid code duplication, more maintainable schema definitions, and cleaner handling of device/config entry resolution.

Refactoring and code simplification:

* Introduced the `_DAY_ATTRS` tuple and `_WEEKLY_SCHEDULE_FIELDS` dict to streamline the handling of weekly schedule attributes and schema definition, reducing repetitive code when defining service schemas. [[1]](diffhunk://#diff-b7f50870b6df37769c2cb03348ed62e13a4efc8488f78f92e71ede57a3cfb225R32-R41) [[2]](diffhunk://#diff-b7f50870b6df37769c2cb03348ed62e13a4efc8488f78f92e71ede57a3cfb225L42-R52) [[3]](diffhunk://#diff-b7f50870b6df37769c2cb03348ed62e13a4efc8488f78f92e71ede57a3cfb225R61-R67)
* Added `_build_weekly_schedule_days` to generate the weekly schedule dictionary dynamically, replacing repetitive per-day code with a loop.
* Refactored device/config entry resolution into `_resolve_config_entry`, removing duplicated logic from multiple service handlers and improving maintainability. [[1]](diffhunk://#diff-b7f50870b6df37769c2cb03348ed62e13a4efc8488f78f92e71ede57a3cfb225L101-L105) [[2]](diffhunk://#diff-b7f50870b6df37769c2cb03348ed62e13a4efc8488f78f92e71ede57a3cfb225L204-R198)

Service handler improvements:

* Updated `set_hot_water_schedule` to use the new helper functions, significantly reducing code duplication and improving readability.
* Simplified `async_sync_time` by using the new `_resolve_config_entry` helper, making the code more concise and robust.

</details>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
