### PR TITLE
Rename trigger behavior options

### DIFF
--- a/homeassistant/components/air_quality/triggers.yaml
+++ b/homeassistant/components/air_quality/triggers.yaml
@@ -1,7 +1,7 @@
 .trigger_common_fields:
   behavior: &trigger_behavior
     required: true
-    default: any
+    default: each
     selector:
       automation_behavior:
         mode: trigger

--- a/homeassistant/components/alarm_control_panel/triggers.yaml
+++ b/homeassistant/components/alarm_control_panel/triggers.yaml
@@ -5,7 +5,7 @@
   fields: &trigger_common_fields
     behavior:
       required: true
-      default: any
+      default: each
       selector:
         automation_behavior:
           mode: trigger

--- a/homeassistant/components/assist_satellite/triggers.yaml
+++ b/homeassistant/components/assist_satellite/triggers.yaml
@@ -5,7 +5,7 @@
   fields:
     behavior:
       required: true
-      default: any
+      default: each
       selector:
         automation_behavior:
           mode: trigger

--- a/homeassistant/components/battery/triggers.yaml
+++ b/homeassistant/components/battery/triggers.yaml
@@ -1,7 +1,7 @@
 .trigger_common_fields:
   behavior: &trigger_behavior
     required: true
-    default: any
+    default: each
     selector:
       automation_behavior:
         mode: trigger

--- a/homeassistant/components/climate/trigger.py
+++ b/homeassistant/components/climate/trigger.py
@@ -7,7 +7,7 @@ from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.automation import DomainSpec
 from homeassistant.helpers.trigger import (
-    ENTITY_STATE_TRIGGER_SCHEMA_FIRST_LAST,
+    ENTITY_STATE_TRIGGER_SCHEMA_WITH_BEHAVIOR,
     EntityNumericalStateChangedTriggerBase,
     EntityNumericalStateChangedTriggerWithUnitBase,
     EntityNumericalStateCrossedThresholdTriggerBase,
@@ -26,7 +26,7 @@ from .const import ATTR_HUMIDITY, ATTR_HVAC_ACTION, DOMAIN, HVACAction, HVACMode
 
 CONF_HVAC_MODE = "hvac_mode"
 
-HVAC_MODE_CHANGED_TRIGGER_SCHEMA = ENTITY_STATE_TRIGGER_SCHEMA_FIRST_LAST.extend(
+HVAC_MODE_CHANGED_TRIGGER_SCHEMA = ENTITY_STATE_TRIGGER_SCHEMA_WITH_BEHAVIOR.extend(
     {
         vol.Required(CONF_OPTIONS): {
             vol.Required(CONF_HVAC_MODE): vol.All(

--- a/homeassistant/components/climate/triggers.yaml
+++ b/homeassistant/components/climate/triggers.yaml
@@ -5,7 +5,7 @@
   fields:
     behavior: &trigger_behavior
       required: true
-      default: any
+      default: each
       selector:
         automation_behavior:
           mode: trigger

--- a/homeassistant/components/counter/triggers.yaml
+++ b/homeassistant/components/counter/triggers.yaml
@@ -5,7 +5,7 @@
   fields:
     behavior:
       required: true
-      default: any
+      default: each
       selector:
         automation_behavior:
           mode: trigger

--- a/homeassistant/components/cover/triggers.yaml
+++ b/homeassistant/components/cover/triggers.yaml
@@ -1,7 +1,7 @@
 .trigger_common_fields: &trigger_common_fields
   behavior:
     required: true
-    default: any
+    default: each
     selector:
       automation_behavior:
         mode: trigger

--- a/homeassistant/components/door/triggers.yaml
+++ b/homeassistant/components/door/triggers.yaml
@@ -1,7 +1,7 @@
 .trigger_common_fields: &trigger_common_fields
   behavior:
     required: true
-    default: any
+    default: each
     selector:
       automation_behavior:
         mode: trigger

--- a/homeassistant/components/fan/triggers.yaml
+++ b/homeassistant/components/fan/triggers.yaml
@@ -5,7 +5,7 @@
   fields:
     behavior:
       required: true
-      default: any
+      default: each
       selector:
         automation_behavior:
           mode: trigger

--- a/homeassistant/components/garage_door/triggers.yaml
+++ b/homeassistant/components/garage_door/triggers.yaml
@@ -1,7 +1,7 @@
 .trigger_common_fields: &trigger_common_fields
   behavior:
     required: true
-    default: any
+    default: each
     selector:
       automation_behavior:
         mode: trigger

--- a/homeassistant/components/gate/triggers.yaml
+++ b/homeassistant/components/gate/triggers.yaml
@@ -1,7 +1,7 @@
 .trigger_common_fields: &trigger_common_fields
   behavior:
     required: true
-    default: any
+    default: each
     selector:
       automation_behavior:
         mode: trigger

--- a/homeassistant/components/humidifier/trigger.py
+++ b/homeassistant/components/humidifier/trigger.py
@@ -9,7 +9,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.automation import DomainSpec
 from homeassistant.helpers.entity import get_supported_features
 from homeassistant.helpers.trigger import (
-    ENTITY_STATE_TRIGGER_SCHEMA_FIRST_LAST,
+    ENTITY_STATE_TRIGGER_SCHEMA_WITH_BEHAVIOR,
     EntityTargetStateTriggerBase,
     Trigger,
     TriggerConfig,
@@ -18,7 +18,7 @@ from homeassistant.helpers.trigger import (
 
 from .const import ATTR_ACTION, DOMAIN, HumidifierAction, HumidifierEntityFeature
 
-MODE_CHANGED_TRIGGER_SCHEMA = ENTITY_STATE_TRIGGER_SCHEMA_FIRST_LAST.extend(
+MODE_CHANGED_TRIGGER_SCHEMA = ENTITY_STATE_TRIGGER_SCHEMA_WITH_BEHAVIOR.extend(
     {
         vol.Required(CONF_OPTIONS): {
             vol.Required(CONF_MODE): vol.All(cv.ensure_list, vol.Length(min=1), [str]),

--- a/homeassistant/components/humidifier/triggers.yaml
+++ b/homeassistant/components/humidifier/triggers.yaml
@@ -5,7 +5,7 @@
   fields:
     behavior: &trigger_behavior
       required: true
-      default: any
+      default: each
       selector:
         automation_behavior:
           mode: trigger

--- a/homeassistant/components/humidity/triggers.yaml
+++ b/homeassistant/components/humidity/triggers.yaml
@@ -1,7 +1,7 @@
 .trigger_common_fields:
   behavior: &trigger_behavior
     required: true
-    default: any
+    default: each
     selector:
       automation_behavior:
         mode: trigger

--- a/homeassistant/components/illuminance/triggers.yaml
+++ b/homeassistant/components/illuminance/triggers.yaml
@@ -1,7 +1,7 @@
 .trigger_common_fields: &trigger_common_fields
   behavior: &trigger_behavior
     required: true
-    default: any
+    default: each
     selector:
       automation_behavior:
         mode: trigger

--- a/homeassistant/components/lawn_mower/triggers.yaml
+++ b/homeassistant/components/lawn_mower/triggers.yaml
@@ -5,7 +5,7 @@
   fields:
     behavior:
       required: true
-      default: any
+      default: each
       selector:
         automation_behavior:
           mode: trigger

--- a/homeassistant/components/light/triggers.yaml
+++ b/homeassistant/components/light/triggers.yaml
@@ -5,7 +5,7 @@
   fields:
     behavior: &trigger_behavior
       required: true
-      default: any
+      default: each
       selector:
         automation_behavior:
           mode: trigger

--- a/homeassistant/components/lock/triggers.yaml
+++ b/homeassistant/components/lock/triggers.yaml
@@ -5,7 +5,7 @@
   fields:
     behavior:
       required: true
-      default: any
+      default: each
       selector:
         automation_behavior:
           mode: trigger

--- a/homeassistant/components/media_player/triggers.yaml
+++ b/homeassistant/components/media_player/triggers.yaml
@@ -5,7 +5,7 @@
   fields:
     behavior: &trigger_behavior
       required: true
-      default: any
+      default: each
       selector:
         automation_behavior:
           mode: trigger

--- a/homeassistant/components/moisture/triggers.yaml
+++ b/homeassistant/components/moisture/triggers.yaml
@@ -1,7 +1,7 @@
 .trigger_common_fields: &trigger_common_fields
   behavior: &trigger_behavior
     required: true
-    default: any
+    default: each
     selector:
       automation_behavior:
         mode: trigger

--- a/homeassistant/components/motion/triggers.yaml
+++ b/homeassistant/components/motion/triggers.yaml
@@ -1,7 +1,7 @@
 .trigger_common_fields: &trigger_common_fields
   behavior:
     required: true
-    default: any
+    default: each
     selector:
       automation_behavior:
         mode: trigger

--- a/homeassistant/components/occupancy/triggers.yaml
+++ b/homeassistant/components/occupancy/triggers.yaml
@@ -1,7 +1,7 @@
 .trigger_common_fields: &trigger_common_fields
   behavior:
     required: true
-    default: any
+    default: each
     selector:
       automation_behavior:
         mode: trigger

--- a/homeassistant/components/power/triggers.yaml
+++ b/homeassistant/components/power/triggers.yaml
@@ -1,7 +1,7 @@
 .trigger_common_fields:
   behavior: &trigger_behavior
     required: true
-    default: any
+    default: each
     selector:
       automation_behavior:
         mode: trigger

--- a/homeassistant/components/remote/triggers.yaml
+++ b/homeassistant/components/remote/triggers.yaml
@@ -5,7 +5,7 @@
   fields:
     behavior:
       required: true
-      default: any
+      default: each
       selector:
         automation_behavior:
           mode: trigger

--- a/homeassistant/components/schedule/triggers.yaml
+++ b/homeassistant/components/schedule/triggers.yaml
@@ -5,7 +5,7 @@
   fields:
     behavior:
       required: true
-      default: any
+      default: each
       selector:
         automation_behavior:
           mode: trigger

--- a/homeassistant/components/siren/triggers.yaml
+++ b/homeassistant/components/siren/triggers.yaml
@@ -5,7 +5,7 @@
   fields:
     behavior:
       required: true
-      default: any
+      default: each
       selector:
         automation_behavior:
           mode: trigger

--- a/homeassistant/components/switch/triggers.yaml
+++ b/homeassistant/components/switch/triggers.yaml
@@ -6,7 +6,7 @@
   fields:
     behavior:
       required: true
-      default: any
+      default: each
       selector:
         automation_behavior:
           mode: trigger

--- a/homeassistant/components/temperature/triggers.yaml
+++ b/homeassistant/components/temperature/triggers.yaml
@@ -1,7 +1,7 @@
 .trigger_common_fields:
   behavior: &trigger_behavior
     required: true
-    default: any
+    default: each
     selector:
       automation_behavior:
         mode: trigger

--- a/homeassistant/components/timer/triggers.yaml
+++ b/homeassistant/components/timer/triggers.yaml
@@ -5,7 +5,7 @@
   fields:
     behavior:
       required: true
-      default: any
+      default: each
       selector:
         automation_behavior:
           mode: trigger

--- a/homeassistant/components/update/triggers.yaml
+++ b/homeassistant/components/update/triggers.yaml
@@ -5,7 +5,7 @@
   fields:
     behavior:
       required: true
-      default: any
+      default: each
       selector:
         automation_behavior:
           mode: trigger

--- a/homeassistant/components/vacuum/triggers.yaml
+++ b/homeassistant/components/vacuum/triggers.yaml
@@ -5,7 +5,7 @@
   fields:
     behavior:
       required: true
-      default: any
+      default: each
       selector:
         automation_behavior:
           mode: trigger

--- a/homeassistant/components/valve/triggers.yaml
+++ b/homeassistant/components/valve/triggers.yaml
@@ -5,7 +5,7 @@
   fields:
     behavior:
       required: true
-      default: any
+      default: each
       selector:
         automation_behavior:
           mode: trigger

--- a/homeassistant/components/water_heater/trigger.py
+++ b/homeassistant/components/water_heater/trigger.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.automation import DomainSpec
 from homeassistant.helpers.trigger import (
-    ENTITY_STATE_TRIGGER_SCHEMA_FIRST_LAST,
+    ENTITY_STATE_TRIGGER_SCHEMA_WITH_BEHAVIOR,
     EntityNumericalStateChangedTriggerWithUnitBase,
     EntityNumericalStateCrossedThresholdTriggerWithUnitBase,
     EntityNumericalStateTriggerWithUnitBase,
@@ -28,14 +28,16 @@ from .const import DOMAIN
 
 CONF_OPERATION_MODE = "operation_mode"
 
-_OPERATION_MODE_CHANGED_TRIGGER_SCHEMA = ENTITY_STATE_TRIGGER_SCHEMA_FIRST_LAST.extend(
-    {
-        vol.Required(CONF_OPTIONS): {
-            vol.Required(CONF_OPERATION_MODE): vol.All(
-                cv.ensure_list, vol.Length(min=1), [str]
-            ),
-        },
-    }
+_OPERATION_MODE_CHANGED_TRIGGER_SCHEMA = (
+    ENTITY_STATE_TRIGGER_SCHEMA_WITH_BEHAVIOR.extend(
+        {
+            vol.Required(CONF_OPTIONS): {
+                vol.Required(CONF_OPERATION_MODE): vol.All(
+                    cv.ensure_list, vol.Length(min=1), [str]
+                ),
+            },
+        }
+    )
 )
 
 

--- a/homeassistant/components/water_heater/triggers.yaml
+++ b/homeassistant/components/water_heater/triggers.yaml
@@ -5,7 +5,7 @@
   fields:
     behavior: &trigger_behavior
       required: true
-      default: any
+      default: each
       selector:
         automation_behavior:
           mode: trigger

--- a/homeassistant/components/window/triggers.yaml
+++ b/homeassistant/components/window/triggers.yaml
@@ -1,7 +1,7 @@
 .trigger_common_fields: &trigger_common_fields
   behavior:
     required: true
-    default: any
+    default: each
     selector:
       automation_behavior:
         mode: trigger

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -432,7 +432,7 @@ class AutomationBehavior(StrEnum):
 
     ALL = "all"
     FIRST = "first"
-    LAST = "last"
+    EACH = "each"
     ANY = "any"
 
 
@@ -446,8 +446,8 @@ class AutomationBehaviorSelectorMode(StrEnum):
 _AUTOMATION_BEHAVIOR_MODES: dict[AutomationBehaviorSelectorMode, list[str]] = {
     AutomationBehaviorSelectorMode.TRIGGER: [
         AutomationBehavior.FIRST,
-        AutomationBehavior.LAST,
-        AutomationBehavior.ANY,
+        AutomationBehavior.ALL,
+        AutomationBehavior.EACH,
     ],
     AutomationBehaviorSelectorMode.CONDITION: [
         AutomationBehavior.ALL,

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -337,7 +337,7 @@ ENTITY_STATE_TRIGGER_SCHEMA = vol.Schema(
     }
 )
 
-ENTITY_STATE_TRIGGER_SCHEMA_FIRST_LAST = ENTITY_STATE_TRIGGER_SCHEMA.extend(
+ENTITY_STATE_TRIGGER_SCHEMA_WITH_BEHAVIOR = ENTITY_STATE_TRIGGER_SCHEMA.extend(
     {
         vol.Required(CONF_OPTIONS, default={}): {
             vol.Required(ATTR_BEHAVIOR, default=BEHAVIOR_EACH): vol.In(
@@ -361,7 +361,7 @@ class EntityTriggerBase(Trigger):
     # `_excluded_states`. Subclasses can override to relax the origin
     # check.
     _excluded_from_states: ClassVar[frozenset[str]] = _excluded_states
-    _schema: vol.Schema = ENTITY_STATE_TRIGGER_SCHEMA_FIRST_LAST
+    _schema: vol.Schema = ENTITY_STATE_TRIGGER_SCHEMA_WITH_BEHAVIOR
     # When True, indirect target expansion (via device/area/floor) skips
     # entities with an entity_category.
     _primary_entities_only: ClassVar[bool] = True
@@ -871,7 +871,7 @@ class EntityNumericalStateChangedTriggerWithUnitBase(
 
 
 NUMERICAL_ATTRIBUTE_CROSSED_THRESHOLD_SCHEMA = (
-    ENTITY_STATE_TRIGGER_SCHEMA_FIRST_LAST.extend(
+    ENTITY_STATE_TRIGGER_SCHEMA_WITH_BEHAVIOR.extend(
         {
             vol.Required(CONF_OPTIONS): {
                 vol.Required("threshold"): NumericThresholdSelector(
@@ -905,7 +905,7 @@ def _make_numerical_state_crossed_threshold_with_unit_schema(
     This trigger only fires when the observed attribute
     changes from not within to within the defined threshold.
     """
-    return ENTITY_STATE_TRIGGER_SCHEMA_FIRST_LAST.extend(
+    return ENTITY_STATE_TRIGGER_SCHEMA_WITH_BEHAVIOR.extend(
         {
             vol.Required(CONF_OPTIONS, default={}): {
                 vol.Required("threshold"): NumericThresholdSelector(

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -327,8 +327,8 @@ class Trigger(abc.ABC):
 
 ATTR_BEHAVIOR: Final = "behavior"
 BEHAVIOR_FIRST: Final = "first"
-BEHAVIOR_LAST: Final = "last"
-BEHAVIOR_ANY: Final = "any"
+BEHAVIOR_ALL: Final = "all"
+BEHAVIOR_EACH: Final = "each"
 
 ENTITY_STATE_TRIGGER_SCHEMA = vol.Schema(
     {
@@ -340,8 +340,8 @@ ENTITY_STATE_TRIGGER_SCHEMA = vol.Schema(
 ENTITY_STATE_TRIGGER_SCHEMA_FIRST_LAST = ENTITY_STATE_TRIGGER_SCHEMA.extend(
     {
         vol.Required(CONF_OPTIONS, default={}): {
-            vol.Required(ATTR_BEHAVIOR, default=BEHAVIOR_ANY): vol.In(
-                [BEHAVIOR_FIRST, BEHAVIOR_LAST, BEHAVIOR_ANY]
+            vol.Required(ATTR_BEHAVIOR, default=BEHAVIOR_EACH): vol.In(
+                [BEHAVIOR_FIRST, BEHAVIOR_ALL, BEHAVIOR_EACH]
             ),
             vol.Optional(CONF_FOR): cv.positive_time_period,
         },
@@ -454,7 +454,7 @@ class EntityTriggerBase(Trigger):
     ) -> CALLBACK_TYPE:
         """Attach the trigger to an action runner."""
 
-        behavior: str = self._options.get(ATTR_BEHAVIOR, BEHAVIOR_ANY)
+        behavior: str = self._options.get(ATTR_BEHAVIOR, BEHAVIOR_EACH)
         unsub_track_same: dict[str, Callable[[], None]] = {}
 
         @callback
@@ -474,10 +474,10 @@ class EntityTriggerBase(Trigger):
 
                 Called by async_track_same_state on each state change to
                 determine whether to cancel the timer.
-                For behavior any, checks the individual entity's state.
-                For behavior first/last, checks the combined state.
+                For behavior each, checks the individual entity's state.
+                For behavior first/all, checks the combined state.
                 """
-                if behavior == BEHAVIOR_LAST:
+                if behavior == BEHAVIOR_ALL:
                     matches, included = self.count_matches(
                         target_state_change_data.targeted_entity_ids
                     )
@@ -492,7 +492,7 @@ class EntityTriggerBase(Trigger):
                         target_state_change_data.targeted_entity_ids
                     )
                     return matches >= 1
-                # Behavior any: check the individual entity's state
+                # Behavior each: check the individual entity's state
                 if not to_state or to_state.state in self._excluded_states:
                     return False
                 return self.is_valid_state(to_state)
@@ -515,7 +515,7 @@ class EntityTriggerBase(Trigger):
             ):
                 return
 
-            if behavior == BEHAVIOR_LAST:
+            if behavior == BEHAVIOR_ALL:
                 matches, included = self.count_matches(
                     target_state_change_data.targeted_entity_ids
                 )
@@ -553,7 +553,7 @@ class EntityTriggerBase(Trigger):
                 call_action()
                 return
 
-            subscription_key = entity_id if behavior == BEHAVIOR_ANY else behavior
+            subscription_key = entity_id if behavior == BEHAVIOR_EACH else behavior
             if subscription_key in unsub_track_same:
                 unsub_track_same.pop(subscription_key)()
             unsub_track_same[subscription_key] = async_track_same_state(
@@ -563,7 +563,7 @@ class EntityTriggerBase(Trigger):
                 state_still_valid,
                 entity_ids=(
                     entity_id
-                    if behavior == BEHAVIOR_ANY
+                    if behavior == BEHAVIOR_EACH
                     else target_state_change_data.targeted_entity_ids
                 ),
             )

--- a/tests/components/air_quality/test_trigger.py
+++ b/tests/components/air_quality/test_trigger.py
@@ -21,9 +21,9 @@ from homeassistant.core import HomeAssistant
 from tests.components.common import (
     TriggerStateDescription,
     arm_trigger,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     parametrize_numerical_state_value_changed_trigger_states,
@@ -229,7 +229,7 @@ async def test_air_quality_trigger_options_validation(
         ),
     ],
 )
-async def test_air_quality_trigger_binary_sensor_behavior_any(
+async def test_air_quality_trigger_binary_sensor_behavior_each(
     hass: HomeAssistant,
     target_binary_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -243,7 +243,7 @@ async def test_air_quality_trigger_binary_sensor_behavior_any(
 
     Covers gas, CO, and smoke device classes.
     """
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_binary_sensors,
         trigger_target_config=trigger_target_config,
@@ -390,7 +390,7 @@ async def test_air_quality_trigger_binary_sensor_behavior_first(
         ),
     ],
 )
-async def test_air_quality_trigger_binary_sensor_behavior_last(
+async def test_air_quality_trigger_binary_sensor_behavior_all(
     hass: HomeAssistant,
     target_binary_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -401,7 +401,7 @@ async def test_air_quality_trigger_binary_sensor_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test air quality trigger fires when the last binary_sensor changes state."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_binary_sensors,
         trigger_target_config=trigger_target_config,
@@ -570,7 +570,7 @@ async def test_air_quality_trigger_binary_sensor_behavior_last(
         ),
     ],
 )
-async def test_air_quality_trigger_sensor_behavior_any(
+async def test_air_quality_trigger_sensor_behavior_each(
     hass: HomeAssistant,
     target_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -581,7 +581,7 @@ async def test_air_quality_trigger_sensor_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test air quality trigger fires for sensor entities."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_sensors,
         trigger_target_config=trigger_target_config,
@@ -789,7 +789,7 @@ async def test_air_quality_trigger_sensor_crossed_threshold_behavior_first(
         ),
     ],
 )
-async def test_air_quality_trigger_sensor_crossed_threshold_behavior_last(
+async def test_air_quality_trigger_sensor_crossed_threshold_behavior_all(
     hass: HomeAssistant,
     target_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -803,7 +803,7 @@ async def test_air_quality_trigger_sensor_crossed_threshold_behavior_last(
 
     Fires when the last sensor changes state.
     """
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_sensors,
         trigger_target_config=trigger_target_config,

--- a/tests/components/air_quality/test_trigger.py
+++ b/tests/components/air_quality/test_trigger.py
@@ -400,7 +400,7 @@ async def test_air_quality_trigger_binary_sensor_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test air quality trigger fires when the last binary_sensor changes state."""
+    """Test air quality trigger fires when all binary_sensors have changed state."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_binary_sensors,

--- a/tests/components/alarm_control_panel/test_trigger.py
+++ b/tests/components/alarm_control_panel/test_trigger.py
@@ -13,9 +13,9 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     other_states,
@@ -153,7 +153,7 @@ async def test_alarm_control_panel_trigger_options_validation(
         ),
     ],
 )
-async def test_alarm_control_panel_state_trigger_behavior_any(
+async def test_alarm_control_panel_state_trigger_behavior_each(
     hass: HomeAssistant,
     target_alarm_control_panels: dict[str, list[str]],
     trigger_target_config: dict,
@@ -168,7 +168,7 @@ async def test_alarm_control_panel_state_trigger_behavior_any(
     Fires when any alarm control panel state changes to a
     specific state.
     """
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_alarm_control_panels,
         trigger_target_config=trigger_target_config,
@@ -353,7 +353,7 @@ async def test_alarm_control_panel_state_trigger_behavior_first(
         ),
     ],
 )
-async def test_alarm_control_panel_state_trigger_behavior_last(
+async def test_alarm_control_panel_state_trigger_behavior_all(
     hass: HomeAssistant,
     target_alarm_control_panels: dict[str, list[str]],
     trigger_target_config: dict,
@@ -368,7 +368,7 @@ async def test_alarm_control_panel_state_trigger_behavior_last(
     Fires when the last alarm_control_panel changes to a
     specific state.
     """
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_alarm_control_panels,
         trigger_target_config=trigger_target_config,

--- a/tests/components/assist_satellite/test_trigger.py
+++ b/tests/components/assist_satellite/test_trigger.py
@@ -9,9 +9,9 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     other_states,
@@ -100,7 +100,7 @@ async def test_assist_satellite_trigger_options_validation(
         ),
     ],
 )
-async def test_assist_satellite_state_trigger_behavior_any(
+async def test_assist_satellite_state_trigger_behavior_each(
     hass: HomeAssistant,
     target_assist_satellites: dict[str, list[str]],
     trigger_target_config: dict,
@@ -111,7 +111,7 @@ async def test_assist_satellite_state_trigger_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test assist satellite trigger fires when any satellite changes state."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_assist_satellites,
         trigger_target_config=trigger_target_config,
@@ -206,7 +206,7 @@ async def test_assist_satellite_state_trigger_behavior_first(
         ),
     ],
 )
-async def test_assist_satellite_state_trigger_behavior_last(
+async def test_assist_satellite_state_trigger_behavior_all(
     hass: HomeAssistant,
     target_assist_satellites: dict[str, list[str]],
     trigger_target_config: dict,
@@ -217,7 +217,7 @@ async def test_assist_satellite_state_trigger_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test assist satellite trigger fires when last satellite changes state."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_assist_satellites,
         trigger_target_config=trigger_target_config,

--- a/tests/components/battery/test_trigger.py
+++ b/tests/components/battery/test_trigger.py
@@ -16,9 +16,9 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     parametrize_numerical_state_value_changed_trigger_states,
@@ -134,7 +134,7 @@ async def test_battery_trigger_options_validation(
         ),
     ],
 )
-async def test_battery_binary_sensor_trigger_behavior_any(
+async def test_battery_binary_sensor_trigger_behavior_each(
     hass: HomeAssistant,
     target_binary_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -144,8 +144,8 @@ async def test_battery_binary_sensor_trigger_behavior_any(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test the battery binary sensor triggers with 'any' behavior."""
-    await assert_trigger_behavior_any(
+    """Test the battery binary sensor triggers with 'each' behavior."""
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_binary_sensors,
         trigger_target_config=trigger_target_config,
@@ -256,7 +256,7 @@ async def test_battery_binary_sensor_trigger_behavior_first(
         ),
     ],
 )
-async def test_battery_binary_sensor_trigger_behavior_last(
+async def test_battery_binary_sensor_trigger_behavior_all(
     hass: HomeAssistant,
     target_binary_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -266,8 +266,8 @@ async def test_battery_binary_sensor_trigger_behavior_last(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test the battery binary sensor triggers with 'last' behavior."""
-    await assert_trigger_behavior_last(
+    """Test the battery binary sensor triggers with 'all' behavior."""
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_binary_sensors,
         trigger_target_config=trigger_target_config,
@@ -299,7 +299,7 @@ async def test_battery_binary_sensor_trigger_behavior_last(
         ),
     ],
 )
-async def test_battery_sensor_trigger_behavior_any(
+async def test_battery_sensor_trigger_behavior_each(
     hass: HomeAssistant,
     target_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -309,8 +309,8 @@ async def test_battery_sensor_trigger_behavior_any(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test battery sensor triggers with 'any' behavior."""
-    await assert_trigger_behavior_any(
+    """Test battery sensor triggers with 'each' behavior."""
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_sensors,
         trigger_target_config=trigger_target_config,
@@ -375,7 +375,7 @@ async def test_battery_level_crossed_threshold_sensor_behavior_first(
         ),
     ],
 )
-async def test_battery_level_crossed_threshold_sensor_behavior_last(
+async def test_battery_level_crossed_threshold_sensor_behavior_all(
     hass: HomeAssistant,
     target_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -386,7 +386,7 @@ async def test_battery_level_crossed_threshold_sensor_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test trigger fires when the last sensor changes."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_sensors,
         trigger_target_config=trigger_target_config,

--- a/tests/components/battery/test_trigger.py
+++ b/tests/components/battery/test_trigger.py
@@ -385,7 +385,7 @@ async def test_battery_level_crossed_threshold_sensor_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test trigger fires when the last sensor changes."""
+    """Test trigger fires when all sensors have changed."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_sensors,

--- a/tests/components/climate/test_trigger.py
+++ b/tests/components/climate/test_trigger.py
@@ -472,7 +472,7 @@ async def test_climate_state_trigger_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test climate trigger fires on last state change."""
+    """Test climate trigger fires when all climate entities have changed state."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_climates,
@@ -533,7 +533,7 @@ async def test_climate_state_attribute_trigger_behavior_all(
     trigger_options: dict[str, Any],
     states: list[tuple[tuple[str, dict], int]],
 ) -> None:
-    """Test climate attribute trigger fires on last change."""
+    """Test climate attribute trigger fires when all climate entities have changed."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_climates,

--- a/tests/components/climate/test_trigger.py
+++ b/tests/components/climate/test_trigger.py
@@ -25,9 +25,9 @@ from homeassistant.helpers.trigger import async_validate_trigger_config
 
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     other_states,
@@ -211,7 +211,7 @@ async def test_climate_trigger_validation(
         ),
     ],
 )
-async def test_climate_state_trigger_behavior_any(
+async def test_climate_state_trigger_behavior_each(
     hass: HomeAssistant,
     target_climates: dict[str, list[str]],
     trigger_target_config: dict,
@@ -222,7 +222,7 @@ async def test_climate_state_trigger_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test climate trigger fires on any state change."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_climates,
         trigger_target_config=trigger_target_config,
@@ -285,7 +285,7 @@ async def test_climate_state_trigger_behavior_any(
         ),
     ],
 )
-async def test_climate_state_attribute_trigger_behavior_any(
+async def test_climate_state_attribute_trigger_behavior_each(
     hass: HomeAssistant,
     target_climates: dict[str, list[str]],
     trigger_target_config: dict,
@@ -296,7 +296,7 @@ async def test_climate_state_attribute_trigger_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test climate attribute trigger fires on any change."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_climates,
         trigger_target_config=trigger_target_config,
@@ -462,7 +462,7 @@ async def test_climate_state_attribute_trigger_behavior_first(
         ),
     ],
 )
-async def test_climate_state_trigger_behavior_last(
+async def test_climate_state_trigger_behavior_all(
     hass: HomeAssistant,
     target_climates: dict[str, list[str]],
     trigger_target_config: dict,
@@ -473,7 +473,7 @@ async def test_climate_state_trigger_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test climate trigger fires on last state change."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_climates,
         trigger_target_config=trigger_target_config,
@@ -523,7 +523,7 @@ async def test_climate_state_trigger_behavior_last(
         ),
     ],
 )
-async def test_climate_state_attribute_trigger_behavior_last(
+async def test_climate_state_attribute_trigger_behavior_all(
     hass: HomeAssistant,
     target_climates: dict[str, list[str]],
     trigger_target_config: dict,
@@ -534,7 +534,7 @@ async def test_climate_state_attribute_trigger_behavior_last(
     states: list[tuple[tuple[str, dict], int]],
 ) -> None:
     """Test climate attribute trigger fires on last change."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_climates,
         trigger_target_config=trigger_target_config,

--- a/tests/components/common.py
+++ b/tests/components/common.py
@@ -1632,7 +1632,7 @@ async def assert_trigger_options_supported(
         return {**(base_options or {}), **extra}
 
     # Behavior
-    for behavior in ("any", "first", "last"):
+    for behavior in ("each", "first", "all"):
         await _validate_trigger_options(
             hass, trigger, _merge({"behavior": behavior}), valid=supports_behavior
         )
@@ -1750,7 +1750,7 @@ async def assert_condition_behavior_all(
         assert cond.async_check() == state["condition_true"]
 
 
-async def assert_trigger_behavior_any(
+async def assert_trigger_behavior_each(
     hass: HomeAssistant,
     *,
     target_entities: dict[str, list[str]],
@@ -1761,7 +1761,7 @@ async def assert_trigger_behavior_any(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test trigger fires in mode any."""
+    """Test trigger fires in mode each."""
     calls: list[str] = []
     other_entity_ids = set(target_entities["included_entities"]) - {entity_id}
     excluded_entity_ids = set(target_entities["excluded_entities"]) - {entity_id}
@@ -1855,7 +1855,7 @@ async def assert_trigger_behavior_first(
         assert len(calls) == 0
 
 
-async def assert_trigger_behavior_last(
+async def assert_trigger_behavior_all(
     hass: HomeAssistant,
     *,
     target_entities: dict[str, list[str]],
@@ -1866,7 +1866,7 @@ async def assert_trigger_behavior_last(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test trigger fires in mode last."""
+    """Test trigger fires in mode all."""
     calls: list[str] = []
     other_entity_ids = set(target_entities["included_entities"]) - {entity_id}
     excluded_entity_ids = set(target_entities["excluded_entities"]) - {entity_id}
@@ -1881,7 +1881,7 @@ async def assert_trigger_behavior_last(
     await arm_trigger(
         hass,
         trigger,
-        {"behavior": "last"} | trigger_options,
+        {"behavior": "all"} | trigger_options,
         trigger_target_config,
         calls,
     )

--- a/tests/components/counter/test_trigger.py
+++ b/tests/components/counter/test_trigger.py
@@ -263,7 +263,7 @@ async def test_counter_state_trigger_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test counter trigger fires on last state change."""
+    """Test counter trigger fires when all counters have changed state."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_counters,

--- a/tests/components/counter/test_trigger.py
+++ b/tests/components/counter/test_trigger.py
@@ -17,9 +17,9 @@ from tests.components.common import (
     BasicTriggerStateDescription,
     TriggerStateDescription,
     arm_trigger,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     parametrize_target_entities,
@@ -191,7 +191,7 @@ async def test_counter_state_trigger(
 @pytest.mark.parametrize(
     ("trigger", "trigger_options", "states"), BEHAVIOR_AWARE_TRIGGERS
 )
-async def test_counter_state_trigger_behavior_any(
+async def test_counter_state_trigger_behavior_each(
     hass: HomeAssistant,
     target_counters: dict[str, list[str]],
     trigger_target_config: dict,
@@ -202,7 +202,7 @@ async def test_counter_state_trigger_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test counter trigger fires on any state change."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_counters,
         trigger_target_config=trigger_target_config,
@@ -253,7 +253,7 @@ async def test_counter_state_trigger_behavior_first(
 @pytest.mark.parametrize(
     ("trigger", "trigger_options", "states"), BEHAVIOR_AWARE_TRIGGERS
 )
-async def test_counter_state_trigger_behavior_last(
+async def test_counter_state_trigger_behavior_all(
     hass: HomeAssistant,
     target_counters: dict[str, list[str]],
     trigger_target_config: dict,
@@ -264,7 +264,7 @@ async def test_counter_state_trigger_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test counter trigger fires on last state change."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_counters,
         trigger_target_config=trigger_target_config,

--- a/tests/components/cover/test_trigger.py
+++ b/tests/components/cover/test_trigger.py
@@ -10,9 +10,9 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     parametrize_target_entities,
@@ -139,7 +139,7 @@ async def test_cover_trigger_options_validation(
         )
     ],
 )
-async def test_cover_trigger_behavior_any(
+async def test_cover_trigger_behavior_each(
     hass: HomeAssistant,
     target_covers: dict[str, list[str]],
     trigger_target_config: dict,
@@ -150,7 +150,7 @@ async def test_cover_trigger_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test cover trigger fires for cover entities with matching device_class."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_covers,
         trigger_target_config=trigger_target_config,
@@ -283,7 +283,7 @@ async def test_cover_trigger_behavior_first(
         )
     ],
 )
-async def test_cover_trigger_behavior_last(
+async def test_cover_trigger_behavior_all(
     hass: HomeAssistant,
     target_covers: dict[str, list[str]],
     trigger_target_config: dict,
@@ -294,7 +294,7 @@ async def test_cover_trigger_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test cover trigger fires when the last cover changes state."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_covers,
         trigger_target_config=trigger_target_config,

--- a/tests/components/cover/test_trigger.py
+++ b/tests/components/cover/test_trigger.py
@@ -293,7 +293,7 @@ async def test_cover_trigger_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test cover trigger fires when the last cover changes state."""
+    """Test cover trigger fires when all covers have changed state."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_covers,

--- a/tests/components/door/test_trigger.py
+++ b/tests/components/door/test_trigger.py
@@ -11,9 +11,9 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     parametrize_target_entities,
@@ -101,7 +101,7 @@ async def test_door_trigger_options_validation(
         ),
     ],
 )
-async def test_door_trigger_binary_sensor_behavior_any(
+async def test_door_trigger_binary_sensor_behavior_each(
     hass: HomeAssistant,
     target_binary_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -112,7 +112,7 @@ async def test_door_trigger_binary_sensor_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test door trigger fires for binary_sensor entities with device_class door."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_binary_sensors,
         trigger_target_config=trigger_target_config,
@@ -169,7 +169,7 @@ async def test_door_trigger_binary_sensor_behavior_any(
         ),
     ],
 )
-async def test_door_trigger_cover_behavior_any(
+async def test_door_trigger_cover_behavior_each(
     hass: HomeAssistant,
     target_covers: dict[str, list[str]],
     trigger_target_config: dict,
@@ -180,7 +180,7 @@ async def test_door_trigger_cover_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test door trigger fires for cover entities with device_class door."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_covers,
         trigger_target_config=trigger_target_config,
@@ -271,7 +271,7 @@ async def test_door_trigger_binary_sensor_behavior_first(
         ),
     ],
 )
-async def test_door_trigger_binary_sensor_behavior_last(
+async def test_door_trigger_binary_sensor_behavior_all(
     hass: HomeAssistant,
     target_binary_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -282,7 +282,7 @@ async def test_door_trigger_binary_sensor_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test door trigger fires when the last binary_sensor changes state."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_binary_sensors,
         trigger_target_config=trigger_target_config,
@@ -407,7 +407,7 @@ async def test_door_trigger_cover_behavior_first(
         ),
     ],
 )
-async def test_door_trigger_cover_behavior_last(
+async def test_door_trigger_cover_behavior_all(
     hass: HomeAssistant,
     target_covers: dict[str, list[str]],
     trigger_target_config: dict,
@@ -418,7 +418,7 @@ async def test_door_trigger_cover_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test door trigger fires when the last cover changes state."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_covers,
         trigger_target_config=trigger_target_config,

--- a/tests/components/door/test_trigger.py
+++ b/tests/components/door/test_trigger.py
@@ -281,7 +281,7 @@ async def test_door_trigger_binary_sensor_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test door trigger fires when the last binary_sensor changes state."""
+    """Test door trigger fires when all binary_sensors have changed state."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_binary_sensors,
@@ -417,7 +417,7 @@ async def test_door_trigger_cover_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test door trigger fires when the last cover changes state."""
+    """Test door trigger fires when all covers have changed state."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_covers,

--- a/tests/components/fan/test_trigger.py
+++ b/tests/components/fan/test_trigger.py
@@ -9,9 +9,9 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     parametrize_target_entities,
@@ -85,7 +85,7 @@ async def test_fan_trigger_options_validation(
         ),
     ],
 )
-async def test_fan_state_trigger_behavior_any(
+async def test_fan_state_trigger_behavior_each(
     hass: HomeAssistant,
     target_fans: dict[str, list[str]],
     trigger_target_config: dict,
@@ -96,7 +96,7 @@ async def test_fan_state_trigger_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test the fan state trigger fires on any fan state change."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_fans,
         trigger_target_config=trigger_target_config,
@@ -171,7 +171,7 @@ async def test_fan_state_trigger_behavior_first(
         ),
     ],
 )
-async def test_fan_state_trigger_behavior_last(
+async def test_fan_state_trigger_behavior_all(
     hass: HomeAssistant,
     target_fans: dict[str, list[str]],
     trigger_target_config: dict,
@@ -182,7 +182,7 @@ async def test_fan_state_trigger_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test the fan trigger fires on the last fan state change."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_fans,
         trigger_target_config=trigger_target_config,

--- a/tests/components/garage_door/test_trigger.py
+++ b/tests/components/garage_door/test_trigger.py
@@ -284,7 +284,7 @@ async def test_garage_door_trigger_binary_sensor_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test garage door trigger fires when the last binary_sensor changes state."""
+    """Test garage door trigger fires when all binary_sensors have changed state."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_binary_sensors,
@@ -420,7 +420,7 @@ async def test_garage_door_trigger_cover_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test garage door trigger fires when the last cover changes state."""
+    """Test garage door trigger fires when all covers have changed state."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_covers,

--- a/tests/components/garage_door/test_trigger.py
+++ b/tests/components/garage_door/test_trigger.py
@@ -11,9 +11,9 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     parametrize_target_entities,
@@ -101,7 +101,7 @@ async def test_garage_door_trigger_options_validation(
         ),
     ],
 )
-async def test_garage_door_trigger_binary_sensor_behavior_any(
+async def test_garage_door_trigger_binary_sensor_behavior_each(
     hass: HomeAssistant,
     target_binary_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -115,7 +115,7 @@ async def test_garage_door_trigger_binary_sensor_behavior_any(
 
     Specifically for entities with device_class garage_door.
     """
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_binary_sensors,
         trigger_target_config=trigger_target_config,
@@ -172,7 +172,7 @@ async def test_garage_door_trigger_binary_sensor_behavior_any(
         ),
     ],
 )
-async def test_garage_door_trigger_cover_behavior_any(
+async def test_garage_door_trigger_cover_behavior_each(
     hass: HomeAssistant,
     target_covers: dict[str, list[str]],
     trigger_target_config: dict,
@@ -183,7 +183,7 @@ async def test_garage_door_trigger_cover_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test garage door trigger fires for cover entities with device_class garage."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_covers,
         trigger_target_config=trigger_target_config,
@@ -274,7 +274,7 @@ async def test_garage_door_trigger_binary_sensor_behavior_first(
         ),
     ],
 )
-async def test_garage_door_trigger_binary_sensor_behavior_last(
+async def test_garage_door_trigger_binary_sensor_behavior_all(
     hass: HomeAssistant,
     target_binary_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -285,7 +285,7 @@ async def test_garage_door_trigger_binary_sensor_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test garage door trigger fires when the last binary_sensor changes state."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_binary_sensors,
         trigger_target_config=trigger_target_config,
@@ -410,7 +410,7 @@ async def test_garage_door_trigger_cover_behavior_first(
         ),
     ],
 )
-async def test_garage_door_trigger_cover_behavior_last(
+async def test_garage_door_trigger_cover_behavior_all(
     hass: HomeAssistant,
     target_covers: dict[str, list[str]],
     trigger_target_config: dict,
@@ -421,7 +421,7 @@ async def test_garage_door_trigger_cover_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test garage door trigger fires when the last cover changes state."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_covers,
         trigger_target_config=trigger_target_config,

--- a/tests/components/gate/test_trigger.py
+++ b/tests/components/gate/test_trigger.py
@@ -257,7 +257,7 @@ async def test_gate_trigger_cover_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test gate trigger fires when the last cover changes state."""
+    """Test gate trigger fires when all covers have changed state."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_covers,

--- a/tests/components/gate/test_trigger.py
+++ b/tests/components/gate/test_trigger.py
@@ -10,9 +10,9 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     parametrize_target_entities,
@@ -111,7 +111,7 @@ async def test_gate_trigger_options_validation(
         ),
     ],
 )
-async def test_gate_trigger_cover_behavior_any(
+async def test_gate_trigger_cover_behavior_each(
     hass: HomeAssistant,
     target_covers: dict[str, list[str]],
     trigger_target_config: dict,
@@ -122,7 +122,7 @@ async def test_gate_trigger_cover_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test gate trigger fires for cover entities with device_class gate."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_covers,
         trigger_target_config=trigger_target_config,
@@ -247,7 +247,7 @@ async def test_gate_trigger_cover_behavior_first(
         ),
     ],
 )
-async def test_gate_trigger_cover_behavior_last(
+async def test_gate_trigger_cover_behavior_all(
     hass: HomeAssistant,
     target_covers: dict[str, list[str]],
     trigger_target_config: dict,
@@ -258,7 +258,7 @@ async def test_gate_trigger_cover_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test gate trigger fires when the last cover changes state."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_covers,
         trigger_target_config=trigger_target_config,

--- a/tests/components/humidifier/test_trigger.py
+++ b/tests/components/humidifier/test_trigger.py
@@ -320,7 +320,7 @@ async def test_humidifier_state_trigger_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test humidifier trigger fires on last entity state change."""
+    """Test humidifier trigger fires when all entities have changed state."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_humidifiers,
@@ -378,7 +378,7 @@ async def test_humidifier_state_attribute_trigger_behavior_all(
     trigger_options: dict[str, Any],
     states: list[tuple[tuple[str, dict], int]],
 ) -> None:
-    """Test humidifier attribute trigger fires on last state change."""
+    """Test humidifier attribute trigger fires when all entities have changed state."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_humidifiers,

--- a/tests/components/humidifier/test_trigger.py
+++ b/tests/components/humidifier/test_trigger.py
@@ -26,9 +26,9 @@ from homeassistant.helpers.trigger import async_validate_trigger_config
 
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     parametrize_target_entities,
@@ -108,7 +108,7 @@ async def test_humidifier_trigger_options_validation(
         ),
     ],
 )
-async def test_humidifier_state_trigger_behavior_any(
+async def test_humidifier_state_trigger_behavior_each(
     hass: HomeAssistant,
     target_humidifiers: dict[str, list[str]],
     trigger_target_config: dict,
@@ -119,7 +119,7 @@ async def test_humidifier_state_trigger_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test humidifier state trigger fires on any state change."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_humidifiers,
         trigger_target_config=trigger_target_config,
@@ -166,7 +166,7 @@ async def test_humidifier_state_trigger_behavior_any(
         ),
     ],
 )
-async def test_humidifier_state_attribute_trigger_behavior_any(
+async def test_humidifier_state_attribute_trigger_behavior_each(
     hass: HomeAssistant,
     target_humidifiers: dict[str, list[str]],
     trigger_target_config: dict,
@@ -177,7 +177,7 @@ async def test_humidifier_state_attribute_trigger_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test humidifier attribute trigger fires on any state change."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_humidifiers,
         trigger_target_config=trigger_target_config,
@@ -310,7 +310,7 @@ async def test_humidifier_state_attribute_trigger_behavior_first(
         ),
     ],
 )
-async def test_humidifier_state_trigger_behavior_last(
+async def test_humidifier_state_trigger_behavior_all(
     hass: HomeAssistant,
     target_humidifiers: dict[str, list[str]],
     trigger_target_config: dict,
@@ -321,7 +321,7 @@ async def test_humidifier_state_trigger_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test humidifier trigger fires on last entity state change."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_humidifiers,
         trigger_target_config=trigger_target_config,
@@ -368,7 +368,7 @@ async def test_humidifier_state_trigger_behavior_last(
         ),
     ],
 )
-async def test_humidifier_state_attribute_trigger_behavior_last(
+async def test_humidifier_state_attribute_trigger_behavior_all(
     hass: HomeAssistant,
     target_humidifiers: dict[str, list[str]],
     trigger_target_config: dict,
@@ -379,7 +379,7 @@ async def test_humidifier_state_attribute_trigger_behavior_last(
     states: list[tuple[tuple[str, dict], int]],
 ) -> None:
     """Test humidifier attribute trigger fires on last state change."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_humidifiers,
         trigger_target_config=trigger_target_config,

--- a/tests/components/humidity/test_trigger.py
+++ b/tests/components/humidity/test_trigger.py
@@ -18,9 +18,9 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_ignores_limit_entities_with_wrong_unit,
     assert_trigger_options_supported,
@@ -129,7 +129,7 @@ async def test_humidity_trigger_options_validation(
         ),
     ],
 )
-async def test_humidity_trigger_sensor_behavior_any(
+async def test_humidity_trigger_sensor_behavior_each(
     hass: HomeAssistant,
     target_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -140,7 +140,7 @@ async def test_humidity_trigger_sensor_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test humidity trigger fires for sensor entities with device_class humidity."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_sensors,
         trigger_target_config=trigger_target_config,
@@ -205,7 +205,7 @@ async def test_humidity_trigger_sensor_crossed_threshold_behavior_first(
         ),
     ],
 )
-async def test_humidity_trigger_sensor_crossed_threshold_behavior_last(
+async def test_humidity_trigger_sensor_crossed_threshold_behavior_all(
     hass: HomeAssistant,
     target_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -216,7 +216,7 @@ async def test_humidity_trigger_sensor_crossed_threshold_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test crossed_threshold trigger fires when last sensor changes."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_sensors,
         trigger_target_config=trigger_target_config,
@@ -253,7 +253,7 @@ async def test_humidity_trigger_sensor_crossed_threshold_behavior_last(
         ),
     ],
 )
-async def test_humidity_trigger_climate_behavior_any(
+async def test_humidity_trigger_climate_behavior_each(
     hass: HomeAssistant,
     target_climates: dict[str, list[str]],
     trigger_target_config: dict,
@@ -264,7 +264,7 @@ async def test_humidity_trigger_climate_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test humidity trigger fires for climate entities."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_climates,
         trigger_target_config=trigger_target_config,
@@ -331,7 +331,7 @@ async def test_humidity_trigger_climate_crossed_threshold_behavior_first(
         ),
     ],
 )
-async def test_humidity_trigger_climate_crossed_threshold_behavior_last(
+async def test_humidity_trigger_climate_crossed_threshold_behavior_all(
     hass: HomeAssistant,
     target_climates: dict[str, list[str]],
     trigger_target_config: dict,
@@ -342,7 +342,7 @@ async def test_humidity_trigger_climate_crossed_threshold_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test crossed_threshold trigger fires on last climate change."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_climates,
         trigger_target_config=trigger_target_config,
@@ -379,7 +379,7 @@ async def test_humidity_trigger_climate_crossed_threshold_behavior_last(
         ),
     ],
 )
-async def test_humidity_trigger_humidifier_behavior_any(
+async def test_humidity_trigger_humidifier_behavior_each(
     hass: HomeAssistant,
     target_humidifiers: dict[str, list[str]],
     trigger_target_config: dict,
@@ -390,7 +390,7 @@ async def test_humidity_trigger_humidifier_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test humidity trigger fires for humidifier entities."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_humidifiers,
         trigger_target_config=trigger_target_config,
@@ -457,7 +457,7 @@ async def test_humidity_trigger_humidifier_crossed_threshold_behavior_first(
         ),
     ],
 )
-async def test_humidity_trigger_humidifier_crossed_threshold_behavior_last(
+async def test_humidity_trigger_humidifier_crossed_threshold_behavior_all(
     hass: HomeAssistant,
     target_humidifiers: dict[str, list[str]],
     trigger_target_config: dict,
@@ -468,7 +468,7 @@ async def test_humidity_trigger_humidifier_crossed_threshold_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test crossed_threshold trigger fires on last humidifier change."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_humidifiers,
         trigger_target_config=trigger_target_config,
@@ -505,7 +505,7 @@ async def test_humidity_trigger_humidifier_crossed_threshold_behavior_last(
         ),
     ],
 )
-async def test_humidity_trigger_weather_behavior_any(
+async def test_humidity_trigger_weather_behavior_each(
     hass: HomeAssistant,
     target_weathers: dict[str, list[str]],
     trigger_target_config: dict,
@@ -516,7 +516,7 @@ async def test_humidity_trigger_weather_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test humidity trigger fires for weather entities."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_weathers,
         trigger_target_config=trigger_target_config,
@@ -583,7 +583,7 @@ async def test_humidity_trigger_weather_crossed_threshold_behavior_first(
         ),
     ],
 )
-async def test_humidity_trigger_weather_crossed_threshold_behavior_last(
+async def test_humidity_trigger_weather_crossed_threshold_behavior_all(
     hass: HomeAssistant,
     target_weathers: dict[str, list[str]],
     trigger_target_config: dict,
@@ -594,7 +594,7 @@ async def test_humidity_trigger_weather_crossed_threshold_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test crossed_threshold trigger fires on last weather change."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_weathers,
         trigger_target_config=trigger_target_config,

--- a/tests/components/humidity/test_trigger.py
+++ b/tests/components/humidity/test_trigger.py
@@ -341,7 +341,7 @@ async def test_humidity_trigger_climate_crossed_threshold_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test crossed_threshold trigger fires on last climate change."""
+    """Test crossed_threshold trigger fires when all climate entities have changed."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_climates,
@@ -467,7 +467,7 @@ async def test_humidity_trigger_humidifier_crossed_threshold_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test crossed_threshold trigger fires on last humidifier change."""
+    """Test crossed_threshold trigger fires when all humidifiers have changed."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_humidifiers,
@@ -593,7 +593,7 @@ async def test_humidity_trigger_weather_crossed_threshold_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test crossed_threshold trigger fires on last weather change."""
+    """Test crossed_threshold trigger fires when all weather entities have changed."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_weathers,

--- a/tests/components/illuminance/test_trigger.py
+++ b/tests/components/illuminance/test_trigger.py
@@ -232,7 +232,7 @@ async def test_illuminance_trigger_binary_sensor_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test illuminance trigger fires when the last binary_sensor changes state."""
+    """Test illuminance trigger fires when all binary_sensors have changed state."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_binary_sensors,
@@ -354,7 +354,7 @@ async def test_illuminance_trigger_sensor_crossed_threshold_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test crossed_threshold trigger fires on last sensor change."""
+    """Test crossed_threshold trigger fires when all sensors have changed."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_sensors,

--- a/tests/components/illuminance/test_trigger.py
+++ b/tests/components/illuminance/test_trigger.py
@@ -17,9 +17,9 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     parametrize_numerical_state_value_changed_trigger_states,
@@ -120,7 +120,7 @@ async def test_illuminance_trigger_options_validation(
         ),
     ],
 )
-async def test_illuminance_trigger_binary_sensor_behavior_any(
+async def test_illuminance_trigger_binary_sensor_behavior_each(
     hass: HomeAssistant,
     target_binary_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -131,7 +131,7 @@ async def test_illuminance_trigger_binary_sensor_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test trigger fires for binary_sensor with device_class light."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_binary_sensors,
         trigger_target_config=trigger_target_config,
@@ -222,7 +222,7 @@ async def test_illuminance_trigger_binary_sensor_behavior_first(
         ),
     ],
 )
-async def test_illuminance_trigger_binary_sensor_behavior_last(
+async def test_illuminance_trigger_binary_sensor_behavior_all(
     hass: HomeAssistant,
     target_binary_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -233,7 +233,7 @@ async def test_illuminance_trigger_binary_sensor_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test illuminance trigger fires when the last binary_sensor changes state."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_binary_sensors,
         trigger_target_config=trigger_target_config,
@@ -268,7 +268,7 @@ async def test_illuminance_trigger_binary_sensor_behavior_last(
         ),
     ],
 )
-async def test_illuminance_trigger_sensor_behavior_any(
+async def test_illuminance_trigger_sensor_behavior_each(
     hass: HomeAssistant,
     target_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -279,7 +279,7 @@ async def test_illuminance_trigger_sensor_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test trigger fires for sensor with device_class illuminance."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_sensors,
         trigger_target_config=trigger_target_config,
@@ -344,7 +344,7 @@ async def test_illuminance_trigger_sensor_crossed_threshold_behavior_first(
         ),
     ],
 )
-async def test_illuminance_trigger_sensor_crossed_threshold_behavior_last(
+async def test_illuminance_trigger_sensor_crossed_threshold_behavior_all(
     hass: HomeAssistant,
     target_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -355,7 +355,7 @@ async def test_illuminance_trigger_sensor_crossed_threshold_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test crossed_threshold trigger fires on last sensor change."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_sensors,
         trigger_target_config=trigger_target_config,

--- a/tests/components/lawn_mower/test_trigger.py
+++ b/tests/components/lawn_mower/test_trigger.py
@@ -9,9 +9,9 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     other_states,
@@ -107,7 +107,7 @@ async def test_lawn_mower_trigger_options_validation(
         ),
     ],
 )
-async def test_lawn_mower_state_trigger_behavior_any(
+async def test_lawn_mower_state_trigger_behavior_each(
     hass: HomeAssistant,
     target_lawn_mowers: dict[str, list[str]],
     trigger_target_config: dict,
@@ -118,7 +118,7 @@ async def test_lawn_mower_state_trigger_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test lawn mower trigger fires when any mower changes state."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_lawn_mowers,
         trigger_target_config=trigger_target_config,
@@ -223,7 +223,7 @@ async def test_lawn_mower_state_trigger_behavior_first(
         ),
     ],
 )
-async def test_lawn_mower_state_trigger_behavior_last(
+async def test_lawn_mower_state_trigger_behavior_all(
     hass: HomeAssistant,
     target_lawn_mowers: dict[str, list[str]],
     trigger_target_config: dict,
@@ -234,7 +234,7 @@ async def test_lawn_mower_state_trigger_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test lawn mower trigger fires when last mower changes state."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_lawn_mowers,
         trigger_target_config=trigger_target_config,

--- a/tests/components/light/test_trigger.py
+++ b/tests/components/light/test_trigger.py
@@ -10,9 +10,9 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_ignores_limit_entities_with_wrong_unit,
     assert_trigger_options_supported,
@@ -111,7 +111,7 @@ async def test_light_trigger_options_validation(
         ),
     ],
 )
-async def test_light_state_trigger_behavior_any(
+async def test_light_state_trigger_behavior_each(
     hass: HomeAssistant,
     target_lights: dict[str, list[str]],
     trigger_target_config: dict,
@@ -122,7 +122,7 @@ async def test_light_state_trigger_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test light trigger fires when any light changes state."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_lights,
         trigger_target_config=trigger_target_config,
@@ -156,7 +156,7 @@ async def test_light_state_trigger_behavior_any(
         ),
     ],
 )
-async def test_light_state_attribute_trigger_behavior_any(
+async def test_light_state_attribute_trigger_behavior_each(
     hass: HomeAssistant,
     target_lights: dict[str, list[str]],
     trigger_target_config: dict,
@@ -167,7 +167,7 @@ async def test_light_state_attribute_trigger_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test light trigger fires when any light changes state."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_lights,
         trigger_target_config=trigger_target_config,
@@ -281,7 +281,7 @@ async def test_light_state_attribute_trigger_behavior_first(
         ),
     ],
 )
-async def test_light_state_trigger_behavior_last(
+async def test_light_state_trigger_behavior_all(
     hass: HomeAssistant,
     target_lights: dict[str, list[str]],
     trigger_target_config: dict,
@@ -292,7 +292,7 @@ async def test_light_state_trigger_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test light trigger fires when last light changes state."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_lights,
         trigger_target_config=trigger_target_config,
@@ -320,7 +320,7 @@ async def test_light_state_trigger_behavior_last(
         ),
     ],
 )
-async def test_light_state_attribute_trigger_behavior_last(
+async def test_light_state_attribute_trigger_behavior_all(
     hass: HomeAssistant,
     target_lights: dict[str, list[str]],
     trigger_target_config: dict,
@@ -331,7 +331,7 @@ async def test_light_state_attribute_trigger_behavior_last(
     states: list[tuple[tuple[str, dict], int]],
 ) -> None:
     """Test light trigger fires on last light state change."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_lights,
         trigger_target_config=trigger_target_config,

--- a/tests/components/light/test_trigger.py
+++ b/tests/components/light/test_trigger.py
@@ -330,7 +330,7 @@ async def test_light_state_attribute_trigger_behavior_all(
     trigger_options: dict[str, Any],
     states: list[tuple[tuple[str, dict], int]],
 ) -> None:
-    """Test light trigger fires on last light state change."""
+    """Test light trigger fires when all lights have changed state."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_lights,

--- a/tests/components/lock/test_trigger.py
+++ b/tests/components/lock/test_trigger.py
@@ -9,9 +9,9 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     other_states,
@@ -100,7 +100,7 @@ async def test_lock_trigger_options_validation(
         ),
     ],
 )
-async def test_lock_state_trigger_behavior_any(
+async def test_lock_state_trigger_behavior_each(
     hass: HomeAssistant,
     target_locks: dict[str, list[str]],
     trigger_target_config: dict,
@@ -111,7 +111,7 @@ async def test_lock_state_trigger_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test lock trigger fires when any lock changes state."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_locks,
         trigger_target_config=trigger_target_config,
@@ -206,7 +206,7 @@ async def test_lock_state_trigger_behavior_first(
         ),
     ],
 )
-async def test_lock_state_trigger_behavior_last(
+async def test_lock_state_trigger_behavior_all(
     hass: HomeAssistant,
     target_locks: dict[str, list[str]],
     trigger_target_config: dict,
@@ -217,7 +217,7 @@ async def test_lock_state_trigger_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test lock trigger fires when last lock changes state."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_locks,
         trigger_target_config=trigger_target_config,

--- a/tests/components/media_player/test_trigger.py
+++ b/tests/components/media_player/test_trigger.py
@@ -332,7 +332,7 @@ async def test_media_player_state_trigger_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test media player state trigger fires on last entity change."""
+    """Test media player state trigger fires when all entities have changed."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_media_players,

--- a/tests/components/media_player/test_trigger.py
+++ b/tests/components/media_player/test_trigger.py
@@ -15,9 +15,9 @@ from homeassistant.core import HomeAssistant
 from tests.components.common import (
     TriggerStateDescription,
     arm_trigger,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_ignores_limit_entities_with_wrong_unit,
     assert_trigger_options_supported,
@@ -226,7 +226,7 @@ async def test_media_player_trigger_options_validation(
         ),
     ],
 )
-async def test_media_player_state_trigger_behavior_any(
+async def test_media_player_state_trigger_behavior_each(
     hass: HomeAssistant,
     target_media_players: dict[str, list[str]],
     trigger_target_config: dict,
@@ -237,7 +237,7 @@ async def test_media_player_state_trigger_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test media player state trigger fires for any state change."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_media_players,
         trigger_target_config=trigger_target_config,
@@ -322,7 +322,7 @@ async def test_media_player_state_trigger_behavior_first(
         ),
     ],
 )
-async def test_media_player_state_trigger_behavior_last(
+async def test_media_player_state_trigger_behavior_all(
     hass: HomeAssistant,
     target_media_players: dict[str, list[str]],
     trigger_target_config: dict,
@@ -333,7 +333,7 @@ async def test_media_player_state_trigger_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test media player state trigger fires on last entity change."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_media_players,
         trigger_target_config=trigger_target_config,
@@ -369,7 +369,7 @@ async def test_media_player_state_trigger_behavior_last(
         ),
     ],
 )
-async def test_media_player_volume_trigger_behavior_any(
+async def test_media_player_volume_trigger_behavior_each(
     hass: HomeAssistant,
     target_media_players: dict[str, list[str]],
     trigger_target_config: dict,
@@ -380,7 +380,7 @@ async def test_media_player_volume_trigger_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test the media_player volume triggers fire when any entity matches."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_media_players,
         trigger_target_config=trigger_target_config,
@@ -449,7 +449,7 @@ async def test_media_player_volume_trigger_behavior_first(
         ),
     ],
 )
-async def test_media_player_volume_trigger_behavior_last(
+async def test_media_player_volume_trigger_behavior_all(
     hass: HomeAssistant,
     target_media_players: dict[str, list[str]],
     trigger_target_config: dict,
@@ -460,7 +460,7 @@ async def test_media_player_volume_trigger_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test volume crossed threshold trigger fires for last entity."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_media_players,
         trigger_target_config=trigger_target_config,

--- a/tests/components/moisture/test_trigger.py
+++ b/tests/components/moisture/test_trigger.py
@@ -229,7 +229,7 @@ async def test_moisture_trigger_binary_sensor_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test moisture trigger fires when the last binary_sensor changes state."""
+    """Test moisture trigger fires when all binary_sensors have changed state."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_binary_sensors,
@@ -348,7 +348,7 @@ async def test_moisture_trigger_sensor_crossed_threshold_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test crossed_threshold trigger fires on last sensor change."""
+    """Test crossed_threshold trigger fires when all sensors have changed."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_sensors,

--- a/tests/components/moisture/test_trigger.py
+++ b/tests/components/moisture/test_trigger.py
@@ -16,9 +16,9 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_ignores_limit_entities_with_wrong_unit,
     assert_trigger_options_supported,
@@ -117,7 +117,7 @@ async def test_moisture_trigger_options_validation(
         ),
     ],
 )
-async def test_moisture_trigger_binary_sensor_behavior_any(
+async def test_moisture_trigger_binary_sensor_behavior_each(
     hass: HomeAssistant,
     target_binary_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -128,7 +128,7 @@ async def test_moisture_trigger_binary_sensor_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test moisture trigger fires for moisture binary_sensors."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_binary_sensors,
         trigger_target_config=trigger_target_config,
@@ -219,7 +219,7 @@ async def test_moisture_trigger_binary_sensor_behavior_first(
         ),
     ],
 )
-async def test_moisture_trigger_binary_sensor_behavior_last(
+async def test_moisture_trigger_binary_sensor_behavior_all(
     hass: HomeAssistant,
     target_binary_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -230,7 +230,7 @@ async def test_moisture_trigger_binary_sensor_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test moisture trigger fires when the last binary_sensor changes state."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_binary_sensors,
         trigger_target_config=trigger_target_config,
@@ -262,7 +262,7 @@ async def test_moisture_trigger_binary_sensor_behavior_last(
         ),
     ],
 )
-async def test_moisture_trigger_sensor_behavior_any(
+async def test_moisture_trigger_sensor_behavior_each(
     hass: HomeAssistant,
     target_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -273,7 +273,7 @@ async def test_moisture_trigger_sensor_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test moisture trigger fires for sensor entities with device_class moisture."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_sensors,
         trigger_target_config=trigger_target_config,
@@ -338,7 +338,7 @@ async def test_moisture_trigger_sensor_crossed_threshold_behavior_first(
         ),
     ],
 )
-async def test_moisture_trigger_sensor_crossed_threshold_behavior_last(
+async def test_moisture_trigger_sensor_crossed_threshold_behavior_all(
     hass: HomeAssistant,
     target_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -349,7 +349,7 @@ async def test_moisture_trigger_sensor_crossed_threshold_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test crossed_threshold trigger fires on last sensor change."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_sensors,
         trigger_target_config=trigger_target_config,

--- a/tests/components/motion/test_trigger.py
+++ b/tests/components/motion/test_trigger.py
@@ -206,7 +206,7 @@ async def test_motion_trigger_binary_sensor_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test motion trigger fires when the last binary_sensor changes state."""
+    """Test motion trigger fires when all binary_sensors have changed state."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_binary_sensors,

--- a/tests/components/motion/test_trigger.py
+++ b/tests/components/motion/test_trigger.py
@@ -10,9 +10,9 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     parametrize_target_entities,
@@ -94,7 +94,7 @@ async def test_motion_trigger_options_validation(
         ),
     ],
 )
-async def test_motion_trigger_binary_sensor_behavior_any(
+async def test_motion_trigger_binary_sensor_behavior_each(
     hass: HomeAssistant,
     target_binary_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -105,7 +105,7 @@ async def test_motion_trigger_binary_sensor_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test motion trigger fires for binary_sensor entities with device_class motion."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_binary_sensors,
         trigger_target_config=trigger_target_config,
@@ -196,7 +196,7 @@ async def test_motion_trigger_binary_sensor_behavior_first(
         ),
     ],
 )
-async def test_motion_trigger_binary_sensor_behavior_last(
+async def test_motion_trigger_binary_sensor_behavior_all(
     hass: HomeAssistant,
     target_binary_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -207,7 +207,7 @@ async def test_motion_trigger_binary_sensor_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test motion trigger fires when the last binary_sensor changes state."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_binary_sensors,
         trigger_target_config=trigger_target_config,

--- a/tests/components/occupancy/test_trigger.py
+++ b/tests/components/occupancy/test_trigger.py
@@ -206,7 +206,7 @@ async def test_occupancy_trigger_binary_sensor_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test occupancy trigger fires when the last binary_sensor changes state."""
+    """Test occupancy trigger fires when all binary_sensors have changed state."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_binary_sensors,

--- a/tests/components/occupancy/test_trigger.py
+++ b/tests/components/occupancy/test_trigger.py
@@ -10,9 +10,9 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     parametrize_target_entities,
@@ -94,7 +94,7 @@ async def test_occupancy_trigger_options_validation(
         ),
     ],
 )
-async def test_occupancy_trigger_binary_sensor_behavior_any(
+async def test_occupancy_trigger_binary_sensor_behavior_each(
     hass: HomeAssistant,
     target_binary_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -105,7 +105,7 @@ async def test_occupancy_trigger_binary_sensor_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test occupancy trigger fires for occupancy binary_sensors."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_binary_sensors,
         trigger_target_config=trigger_target_config,
@@ -196,7 +196,7 @@ async def test_occupancy_trigger_binary_sensor_behavior_first(
         ),
     ],
 )
-async def test_occupancy_trigger_binary_sensor_behavior_last(
+async def test_occupancy_trigger_binary_sensor_behavior_all(
     hass: HomeAssistant,
     target_binary_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -207,7 +207,7 @@ async def test_occupancy_trigger_binary_sensor_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test occupancy trigger fires when the last binary_sensor changes state."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_binary_sensors,
         trigger_target_config=trigger_target_config,

--- a/tests/components/power/test_trigger.py
+++ b/tests/components/power/test_trigger.py
@@ -189,7 +189,7 @@ async def test_power_trigger_sensor_crossed_threshold_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test power crossed_threshold trigger fires when the last sensor changes state."""
+    """Test power crossed_threshold trigger fires when all sensors have changed state."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_sensors,

--- a/tests/components/power/test_trigger.py
+++ b/tests/components/power/test_trigger.py
@@ -10,9 +10,9 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     parametrize_numerical_state_value_changed_trigger_states,
@@ -101,7 +101,7 @@ async def test_power_trigger_options_validation(
         ),
     ],
 )
-async def test_power_trigger_sensor_behavior_any(
+async def test_power_trigger_sensor_behavior_each(
     hass: HomeAssistant,
     target_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -112,7 +112,7 @@ async def test_power_trigger_sensor_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test power trigger fires for sensor entities with device_class power."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_sensors,
         trigger_target_config=trigger_target_config,
@@ -179,7 +179,7 @@ async def test_power_trigger_sensor_crossed_threshold_behavior_first(
         ),
     ],
 )
-async def test_power_trigger_sensor_crossed_threshold_behavior_last(
+async def test_power_trigger_sensor_crossed_threshold_behavior_all(
     hass: HomeAssistant,
     target_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -190,7 +190,7 @@ async def test_power_trigger_sensor_crossed_threshold_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test power crossed_threshold trigger fires when the last sensor changes state."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_sensors,
         trigger_target_config=trigger_target_config,

--- a/tests/components/remote/test_trigger.py
+++ b/tests/components/remote/test_trigger.py
@@ -10,9 +10,9 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     parametrize_target_entities,
@@ -83,7 +83,7 @@ async def test_remote_trigger_options_validation(
         ),
     ],
 )
-async def test_remote_state_trigger_behavior_any(
+async def test_remote_state_trigger_behavior_each(
     hass: HomeAssistant,
     target_remotes: dict[str, list[str]],
     trigger_target_config: dict,
@@ -94,7 +94,7 @@ async def test_remote_state_trigger_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test that the remote triggers when any remote changes to a specific state."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_remotes,
         trigger_target_config=trigger_target_config,
@@ -169,7 +169,7 @@ async def test_remote_state_trigger_behavior_first(
         ),
     ],
 )
-async def test_remote_state_trigger_behavior_last(
+async def test_remote_state_trigger_behavior_all(
     hass: HomeAssistant,
     target_remotes: dict[str, list[str]],
     trigger_target_config: dict,
@@ -180,7 +180,7 @@ async def test_remote_state_trigger_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test remote triggers when last remote changes state."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_remotes,
         trigger_target_config=trigger_target_config,

--- a/tests/components/schedule/test_trigger.py
+++ b/tests/components/schedule/test_trigger.py
@@ -20,9 +20,9 @@ from tests.common import async_fire_time_changed
 from tests.components.common import (
     TriggerStateDescription,
     arm_trigger,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     parametrize_target_entities,
@@ -96,7 +96,7 @@ async def test_schedule_trigger_options_validation(
         ),
     ],
 )
-async def test_schedule_state_trigger_behavior_any(
+async def test_schedule_state_trigger_behavior_each(
     hass: HomeAssistant,
     target_schedules: dict[str, list[str]],
     trigger_target_config: dict,
@@ -107,7 +107,7 @@ async def test_schedule_state_trigger_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test schedule state trigger fires on any state change."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_schedules,
         trigger_target_config=trigger_target_config,
@@ -182,7 +182,7 @@ async def test_schedule_state_trigger_behavior_first(
         ),
     ],
 )
-async def test_schedule_state_trigger_behavior_last(
+async def test_schedule_state_trigger_behavior_all(
     hass: HomeAssistant,
     target_schedules: dict[str, list[str]],
     trigger_target_config: dict,
@@ -193,7 +193,7 @@ async def test_schedule_state_trigger_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test schedule trigger fires on last schedule state change."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_schedules,
         trigger_target_config=trigger_target_config,

--- a/tests/components/schedule/test_trigger.py
+++ b/tests/components/schedule/test_trigger.py
@@ -192,7 +192,7 @@ async def test_schedule_state_trigger_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test schedule trigger fires on last schedule state change."""
+    """Test schedule trigger fires when all schedules have changed state."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_schedules,

--- a/tests/components/siren/test_trigger.py
+++ b/tests/components/siren/test_trigger.py
@@ -182,7 +182,7 @@ async def test_siren_state_trigger_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test siren trigger fires on last siren state change."""
+    """Test siren trigger fires when all sirens have changed state."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_sirens,

--- a/tests/components/siren/test_trigger.py
+++ b/tests/components/siren/test_trigger.py
@@ -10,9 +10,9 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     parametrize_target_entities,
@@ -86,7 +86,7 @@ async def test_siren_trigger_options_validation(
         ),
     ],
 )
-async def test_siren_state_trigger_behavior_any(
+async def test_siren_state_trigger_behavior_each(
     hass: HomeAssistant,
     target_sirens: dict[str, list[str]],
     trigger_target_config: dict,
@@ -97,7 +97,7 @@ async def test_siren_state_trigger_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test siren state trigger fires on any state change."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_sirens,
         trigger_target_config=trigger_target_config,
@@ -172,7 +172,7 @@ async def test_siren_state_trigger_behavior_first(
         ),
     ],
 )
-async def test_siren_state_trigger_behavior_last(
+async def test_siren_state_trigger_behavior_all(
     hass: HomeAssistant,
     target_sirens: dict[str, list[str]],
     trigger_target_config: dict,
@@ -183,7 +183,7 @@ async def test_siren_state_trigger_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test siren trigger fires on last siren state change."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_sirens,
         trigger_target_config=trigger_target_config,

--- a/tests/components/switch/test_trigger.py
+++ b/tests/components/switch/test_trigger.py
@@ -172,7 +172,7 @@ async def test_switch_state_trigger_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test switch trigger fires when the last switch changes state."""
+    """Test switch trigger fires when all switches have changed state."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_switches,
@@ -271,7 +271,7 @@ async def test_input_boolean_state_trigger_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test that the switch trigger fires when the last input_boolean changes."""
+    """Test that the switch trigger fires when all input_booleans have changed."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_input_booleans,

--- a/tests/components/switch/test_trigger.py
+++ b/tests/components/switch/test_trigger.py
@@ -11,9 +11,9 @@ from homeassistant.core import HomeAssistant
 from tests.components.common import (
     TriggerStateDescription,
     arm_trigger,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     parametrize_target_entities,
@@ -98,7 +98,7 @@ async def test_switch_trigger_options_validation(
     ("trigger", "trigger_options", "states"),
     TRIGGER_STATES,
 )
-async def test_switch_state_trigger_behavior_any(
+async def test_switch_state_trigger_behavior_each(
     hass: HomeAssistant,
     target_switches: dict[str, list[str]],
     trigger_target_config: dict,
@@ -109,7 +109,7 @@ async def test_switch_state_trigger_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test switch trigger fires when any switch changes to a state."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_switches,
         trigger_target_config=trigger_target_config,
@@ -162,7 +162,7 @@ async def test_switch_state_trigger_behavior_first(
     ("trigger", "trigger_options", "states"),
     TRIGGER_STATES,
 )
-async def test_switch_state_trigger_behavior_last(
+async def test_switch_state_trigger_behavior_all(
     hass: HomeAssistant,
     target_switches: dict[str, list[str]],
     trigger_target_config: dict,
@@ -173,7 +173,7 @@ async def test_switch_state_trigger_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test switch trigger fires when the last switch changes state."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_switches,
         trigger_target_config=trigger_target_config,
@@ -197,7 +197,7 @@ async def test_switch_state_trigger_behavior_last(
     ("trigger", "trigger_options", "states"),
     TRIGGER_STATES,
 )
-async def test_input_boolean_state_trigger_behavior_any(
+async def test_input_boolean_state_trigger_behavior_each(
     hass: HomeAssistant,
     target_input_booleans: dict[str, list[str]],
     trigger_target_config: dict,
@@ -208,7 +208,7 @@ async def test_input_boolean_state_trigger_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test that the switch trigger fires when any input_boolean state changes."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_input_booleans,
         trigger_target_config=trigger_target_config,
@@ -261,7 +261,7 @@ async def test_input_boolean_state_trigger_behavior_first(
     ("trigger", "trigger_options", "states"),
     TRIGGER_STATES,
 )
-async def test_input_boolean_state_trigger_behavior_last(
+async def test_input_boolean_state_trigger_behavior_all(
     hass: HomeAssistant,
     target_input_booleans: dict[str, list[str]],
     trigger_target_config: dict,
@@ -272,7 +272,7 @@ async def test_input_boolean_state_trigger_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test that the switch trigger fires when the last input_boolean changes."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_input_booleans,
         trigger_target_config=trigger_target_config,

--- a/tests/components/temperature/test_trigger.py
+++ b/tests/components/temperature/test_trigger.py
@@ -234,7 +234,7 @@ async def test_temperature_trigger_sensor_crossed_threshold_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test crossed_threshold trigger fires on last sensor state change."""
+    """Test crossed_threshold trigger fires when all sensors have changed state."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_sensors,
@@ -364,7 +364,7 @@ async def test_temperature_trigger_climate_crossed_threshold_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test crossed_threshold trigger fires on last climate state change."""
+    """Test crossed_threshold trigger fires when all climate entities have changed state."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_climates,
@@ -494,7 +494,7 @@ async def test_temperature_trigger_water_heater_crossed_threshold_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test crossed_threshold fires on last water_heater state change."""
+    """Test crossed_threshold fires when all water_heater entities have changed state."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_water_heaters,
@@ -628,7 +628,7 @@ async def test_temperature_trigger_weather_crossed_threshold_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test crossed_threshold fires on last weather state change."""
+    """Test crossed_threshold fires when all weather entities have changed state."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_weathers,

--- a/tests/components/temperature/test_trigger.py
+++ b/tests/components/temperature/test_trigger.py
@@ -27,9 +27,9 @@ from homeassistant.core import HomeAssistant
 from tests.components.common import (
     TriggerStateDescription,
     arm_trigger,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     parametrize_numerical_attribute_changed_trigger_states,
@@ -146,7 +146,7 @@ async def test_temperature_trigger_options_validation(
         ),
     ],
 )
-async def test_temperature_trigger_sensor_behavior_any(
+async def test_temperature_trigger_sensor_behavior_each(
     hass: HomeAssistant,
     target_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -157,7 +157,7 @@ async def test_temperature_trigger_sensor_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test trigger fires for sensor entities with device_class temperature."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_sensors,
         trigger_target_config=trigger_target_config,
@@ -224,7 +224,7 @@ async def test_temperature_trigger_sensor_crossed_threshold_behavior_first(
         ),
     ],
 )
-async def test_temperature_trigger_sensor_crossed_threshold_behavior_last(
+async def test_temperature_trigger_sensor_crossed_threshold_behavior_all(
     hass: HomeAssistant,
     target_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -235,7 +235,7 @@ async def test_temperature_trigger_sensor_crossed_threshold_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test crossed_threshold trigger fires on last sensor state change."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_sensors,
         trigger_target_config=trigger_target_config,
@@ -274,7 +274,7 @@ async def test_temperature_trigger_sensor_crossed_threshold_behavior_last(
         ),
     ],
 )
-async def test_temperature_trigger_climate_behavior_any(
+async def test_temperature_trigger_climate_behavior_each(
     hass: HomeAssistant,
     target_climates: dict[str, list[str]],
     trigger_target_config: dict,
@@ -285,7 +285,7 @@ async def test_temperature_trigger_climate_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test temperature trigger fires for climate entities."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_climates,
         trigger_target_config=trigger_target_config,
@@ -354,7 +354,7 @@ async def test_temperature_trigger_climate_crossed_threshold_behavior_first(
         ),
     ],
 )
-async def test_temperature_trigger_climate_crossed_threshold_behavior_last(
+async def test_temperature_trigger_climate_crossed_threshold_behavior_all(
     hass: HomeAssistant,
     target_climates: dict[str, list[str]],
     trigger_target_config: dict,
@@ -365,7 +365,7 @@ async def test_temperature_trigger_climate_crossed_threshold_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test crossed_threshold trigger fires on last climate state change."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_climates,
         trigger_target_config=trigger_target_config,
@@ -404,7 +404,7 @@ async def test_temperature_trigger_climate_crossed_threshold_behavior_last(
         ),
     ],
 )
-async def test_temperature_trigger_water_heater_behavior_any(
+async def test_temperature_trigger_water_heater_behavior_each(
     hass: HomeAssistant,
     target_water_heaters: dict[str, list[str]],
     trigger_target_config: dict,
@@ -415,7 +415,7 @@ async def test_temperature_trigger_water_heater_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test temperature trigger fires for water_heater entities."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_water_heaters,
         trigger_target_config=trigger_target_config,
@@ -484,7 +484,7 @@ async def test_temperature_trigger_water_heater_crossed_threshold_behavior_first
         ),
     ],
 )
-async def test_temperature_trigger_water_heater_crossed_threshold_behavior_last(
+async def test_temperature_trigger_water_heater_crossed_threshold_behavior_all(
     hass: HomeAssistant,
     target_water_heaters: dict[str, list[str]],
     trigger_target_config: dict,
@@ -495,7 +495,7 @@ async def test_temperature_trigger_water_heater_crossed_threshold_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test crossed_threshold fires on last water_heater state change."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_water_heaters,
         trigger_target_config=trigger_target_config,
@@ -536,7 +536,7 @@ async def test_temperature_trigger_water_heater_crossed_threshold_behavior_last(
         ),
     ],
 )
-async def test_temperature_trigger_weather_behavior_any(
+async def test_temperature_trigger_weather_behavior_each(
     hass: HomeAssistant,
     target_weathers: dict[str, list[str]],
     trigger_target_config: dict,
@@ -547,7 +547,7 @@ async def test_temperature_trigger_weather_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test temperature trigger fires for weather entities."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_weathers,
         trigger_target_config=trigger_target_config,
@@ -618,7 +618,7 @@ async def test_temperature_trigger_weather_crossed_threshold_behavior_first(
         ),
     ],
 )
-async def test_temperature_trigger_weather_crossed_threshold_behavior_last(
+async def test_temperature_trigger_weather_crossed_threshold_behavior_all(
     hass: HomeAssistant,
     target_weathers: dict[str, list[str]],
     trigger_target_config: dict,
@@ -629,7 +629,7 @@ async def test_temperature_trigger_weather_crossed_threshold_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test crossed_threshold fires on last weather state change."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_weathers,
         trigger_target_config=trigger_target_config,

--- a/tests/components/timer/test_trigger.py
+++ b/tests/components/timer/test_trigger.py
@@ -260,7 +260,7 @@ async def test_timer_trigger_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test timer trigger fires on last timer last_transition change."""
+    """Test timer trigger fires when all timers have transitioned."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_timers,

--- a/tests/components/timer/test_trigger.py
+++ b/tests/components/timer/test_trigger.py
@@ -35,9 +35,9 @@ from homeassistant.util import dt as dt_util
 from tests.common import async_fire_time_changed
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     parametrize_target_entities,
@@ -134,7 +134,7 @@ async def test_timer_trigger_options_validation(
         ),
     ],
 )
-async def test_timer_trigger_behavior_any(
+async def test_timer_trigger_behavior_each(
     hass: HomeAssistant,
     target_timers: dict[str, list[str]],
     trigger_target_config: dict[str, Any],
@@ -145,7 +145,7 @@ async def test_timer_trigger_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test timer trigger fires on any timer last_transition change."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_timers,
         trigger_target_config=trigger_target_config,
@@ -250,7 +250,7 @@ async def test_timer_trigger_behavior_first(
         ),
     ],
 )
-async def test_timer_trigger_behavior_last(
+async def test_timer_trigger_behavior_all(
     hass: HomeAssistant,
     target_timers: dict[str, list[str]],
     trigger_target_config: dict[str, Any],
@@ -261,7 +261,7 @@ async def test_timer_trigger_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test timer trigger fires on last timer last_transition change."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_timers,
         trigger_target_config=trigger_target_config,

--- a/tests/components/update/test_trigger.py
+++ b/tests/components/update/test_trigger.py
@@ -10,9 +10,9 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     parametrize_target_entities,
@@ -79,7 +79,7 @@ async def test_update_trigger_options_validation(
         ),
     ],
 )
-async def test_update_state_trigger_behavior_any(
+async def test_update_state_trigger_behavior_each(
     hass: HomeAssistant,
     target_updates: dict[str, list[str]],
     trigger_target_config: dict,
@@ -90,7 +90,7 @@ async def test_update_state_trigger_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test update state trigger fires when any update changes to a specific state."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_updates,
         trigger_target_config=trigger_target_config,
@@ -155,7 +155,7 @@ async def test_update_state_trigger_behavior_first(
         ),
     ],
 )
-async def test_update_state_trigger_behavior_last(
+async def test_update_state_trigger_behavior_all(
     hass: HomeAssistant,
     target_updates: dict[str, list[str]],
     trigger_target_config: dict,
@@ -166,7 +166,7 @@ async def test_update_state_trigger_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test update state trigger fires when last update changes to a specific state."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_updates,
         trigger_target_config=trigger_target_config,

--- a/tests/components/vacuum/test_trigger.py
+++ b/tests/components/vacuum/test_trigger.py
@@ -9,9 +9,9 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     other_states,
@@ -107,7 +107,7 @@ async def test_vacuum_trigger_options_validation(
         ),
     ],
 )
-async def test_vacuum_state_trigger_behavior_any(
+async def test_vacuum_state_trigger_behavior_each(
     hass: HomeAssistant,
     target_vacuums: dict[str, list[str]],
     trigger_target_config: dict,
@@ -118,7 +118,7 @@ async def test_vacuum_state_trigger_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test vacuum state trigger fires when any vacuum changes to a specific state."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_vacuums,
         trigger_target_config=trigger_target_config,
@@ -223,7 +223,7 @@ async def test_vacuum_state_trigger_behavior_first(
         ),
     ],
 )
-async def test_vacuum_state_trigger_behavior_last(
+async def test_vacuum_state_trigger_behavior_all(
     hass: HomeAssistant,
     target_vacuums: dict[str, list[str]],
     trigger_target_config: dict,
@@ -234,7 +234,7 @@ async def test_vacuum_state_trigger_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test vacuum state trigger fires when last vacuum changes to a specific state."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_vacuums,
         trigger_target_config=trigger_target_config,

--- a/tests/components/valve/test_trigger.py
+++ b/tests/components/valve/test_trigger.py
@@ -9,9 +9,9 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     parametrize_target_entities,
@@ -106,7 +106,7 @@ async def test_valve_trigger_options_validation(
     parametrize_target_entities(DOMAIN),
 )
 @pytest.mark.parametrize(("trigger", "trigger_options", "states"), TRIGGER_STATES)
-async def test_valve_state_trigger_behavior_any(
+async def test_valve_state_trigger_behavior_each(
     hass: HomeAssistant,
     target_valves: dict[str, list[str]],
     trigger_target_config: dict,
@@ -117,7 +117,7 @@ async def test_valve_state_trigger_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test valve state trigger fires when any valve changes to a specific state."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_valves,
         trigger_target_config=trigger_target_config,
@@ -164,7 +164,7 @@ async def test_valve_state_trigger_behavior_first(
     parametrize_target_entities(DOMAIN),
 )
 @pytest.mark.parametrize(("trigger", "trigger_options", "states"), TRIGGER_STATES)
-async def test_valve_state_trigger_behavior_last(
+async def test_valve_state_trigger_behavior_all(
     hass: HomeAssistant,
     target_valves: dict[str, list[str]],
     trigger_target_config: dict,
@@ -175,7 +175,7 @@ async def test_valve_state_trigger_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test valve state trigger fires when last valve changes to a specific state."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_valves,
         trigger_target_config=trigger_target_config,

--- a/tests/components/water_heater/test_trigger.py
+++ b/tests/components/water_heater/test_trigger.py
@@ -17,9 +17,9 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     parametrize_numerical_attribute_changed_trigger_states,
@@ -155,7 +155,7 @@ async def test_water_heater_trigger_options_validation(
         ),
     ],
 )
-async def test_water_heater_state_trigger_behavior_any(
+async def test_water_heater_state_trigger_behavior_each(
     hass: HomeAssistant,
     target_water_heaters: list[str],
     trigger_target_config: dict,
@@ -166,7 +166,7 @@ async def test_water_heater_state_trigger_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test water heater state trigger fires on any state change."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_water_heaters,
         trigger_target_config=trigger_target_config,
@@ -202,7 +202,7 @@ async def test_water_heater_state_trigger_behavior_any(
         ),
     ],
 )
-async def test_water_heater_state_attribute_trigger_behavior_any(
+async def test_water_heater_state_attribute_trigger_behavior_each(
     hass: HomeAssistant,
     target_water_heaters: list[str],
     trigger_target_config: dict,
@@ -213,7 +213,7 @@ async def test_water_heater_state_attribute_trigger_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test water heater target temp trigger fires on threshold cross."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_water_heaters,
         trigger_target_config=trigger_target_config,
@@ -364,7 +364,7 @@ async def test_water_heater_state_attribute_trigger_behavior_first(
         ),
     ],
 )
-async def test_water_heater_state_trigger_behavior_last(
+async def test_water_heater_state_trigger_behavior_all(
     hass: HomeAssistant,
     target_water_heaters: list[str],
     trigger_target_config: dict,
@@ -375,7 +375,7 @@ async def test_water_heater_state_trigger_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test water heater state trigger fires on last entity change."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_water_heaters,
         trigger_target_config=trigger_target_config,
@@ -404,7 +404,7 @@ async def test_water_heater_state_trigger_behavior_last(
         ),
     ],
 )
-async def test_water_heater_state_attribute_trigger_behavior_last(
+async def test_water_heater_state_attribute_trigger_behavior_all(
     hass: HomeAssistant,
     target_water_heaters: list[str],
     trigger_target_config: dict,
@@ -415,7 +415,7 @@ async def test_water_heater_state_attribute_trigger_behavior_last(
     states: list[tuple[tuple[str, dict], int]],
 ) -> None:
     """Test water heater temp trigger fires on last entity threshold."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_water_heaters,
         trigger_target_config=trigger_target_config,

--- a/tests/components/water_heater/test_trigger.py
+++ b/tests/components/water_heater/test_trigger.py
@@ -374,7 +374,7 @@ async def test_water_heater_state_trigger_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test water heater state trigger fires on last entity change."""
+    """Test water heater state trigger fires when all entities have changed."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_water_heaters,
@@ -414,7 +414,7 @@ async def test_water_heater_state_attribute_trigger_behavior_all(
     trigger_options: dict[str, Any],
     states: list[tuple[tuple[str, dict], int]],
 ) -> None:
-    """Test water heater temp trigger fires on last entity threshold."""
+    """Test water heater temp trigger fires when all entities have crossed threshold."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_water_heaters,

--- a/tests/components/window/test_trigger.py
+++ b/tests/components/window/test_trigger.py
@@ -281,7 +281,7 @@ async def test_window_trigger_binary_sensor_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test window trigger fires when the last binary_sensor changes state."""
+    """Test window trigger fires when all binary_sensors have changed state."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_binary_sensors,
@@ -417,7 +417,7 @@ async def test_window_trigger_cover_behavior_all(
     trigger_options: dict[str, Any],
     states: list[TriggerStateDescription],
 ) -> None:
-    """Test window trigger fires when the last cover changes state."""
+    """Test window trigger fires when all covers have changed state."""
     await assert_trigger_behavior_all(
         hass,
         target_entities=target_covers,

--- a/tests/components/window/test_trigger.py
+++ b/tests/components/window/test_trigger.py
@@ -11,9 +11,9 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_gated_by_labs_flag,
     assert_trigger_options_supported,
     parametrize_target_entities,
@@ -101,7 +101,7 @@ async def test_window_trigger_options_validation(
         ),
     ],
 )
-async def test_window_trigger_binary_sensor_behavior_any(
+async def test_window_trigger_binary_sensor_behavior_each(
     hass: HomeAssistant,
     target_binary_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -112,7 +112,7 @@ async def test_window_trigger_binary_sensor_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test window trigger fires for binary_sensor entities with device_class window."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_binary_sensors,
         trigger_target_config=trigger_target_config,
@@ -169,7 +169,7 @@ async def test_window_trigger_binary_sensor_behavior_any(
         ),
     ],
 )
-async def test_window_trigger_cover_behavior_any(
+async def test_window_trigger_cover_behavior_each(
     hass: HomeAssistant,
     target_covers: dict[str, list[str]],
     trigger_target_config: dict,
@@ -180,7 +180,7 @@ async def test_window_trigger_cover_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test window trigger fires for cover entities with device_class window."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_covers,
         trigger_target_config=trigger_target_config,
@@ -271,7 +271,7 @@ async def test_window_trigger_binary_sensor_behavior_first(
         ),
     ],
 )
-async def test_window_trigger_binary_sensor_behavior_last(
+async def test_window_trigger_binary_sensor_behavior_all(
     hass: HomeAssistant,
     target_binary_sensors: dict[str, list[str]],
     trigger_target_config: dict,
@@ -282,7 +282,7 @@ async def test_window_trigger_binary_sensor_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test window trigger fires when the last binary_sensor changes state."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_binary_sensors,
         trigger_target_config=trigger_target_config,
@@ -407,7 +407,7 @@ async def test_window_trigger_cover_behavior_first(
         ),
     ],
 )
-async def test_window_trigger_cover_behavior_last(
+async def test_window_trigger_cover_behavior_all(
     hass: HomeAssistant,
     target_covers: dict[str, list[str]],
     trigger_target_config: dict,
@@ -418,7 +418,7 @@ async def test_window_trigger_cover_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test window trigger fires when the last cover changes state."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_covers,
         trigger_target_config=trigger_target_config,

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -1228,18 +1228,18 @@ def test_action_selector_schema(schema, valid_selections, invalid_selections) ->
     [
         (
             {"mode": "trigger"},
-            ("first", "last", "any"),
-            ("all", "invalid", None),
+            ("first", "all", "each"),
+            ("last", "any", "invalid", None),
         ),
         (
             {"mode": "condition"},
             ("all", "any"),
-            ("first", "last", "invalid", None),
+            ("first", "each", "last", "invalid", None),
         ),
         (
             {"mode": "trigger", "translation_key": "trigger_behavior"},
-            ("first", "last", "any"),
-            ("all", "invalid", None),
+            ("first", "all", "each"),
+            ("last", "any", "invalid", None),
         ),
     ],
 )

--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -49,9 +49,9 @@ from homeassistant.helpers.automation import (
 from homeassistant.helpers.template import Template
 from homeassistant.helpers.trigger import (
     ATTR_BEHAVIOR,
-    BEHAVIOR_ANY,
+    BEHAVIOR_ALL,
+    BEHAVIOR_EACH,
     BEHAVIOR_FIRST,
-    BEHAVIOR_LAST,
     DATA_PLUGGABLE_ACTIONS,
     TRIGGERS,
     EntityNumericalStateChangedTriggerWithUnitBase,
@@ -3858,7 +3858,7 @@ def _set_or_remove_state(
         hass.states.async_set(entity_id, state)
 
 
-@pytest.mark.parametrize("behavior", [BEHAVIOR_ANY, BEHAVIOR_FIRST, BEHAVIOR_LAST])
+@pytest.mark.parametrize("behavior", [BEHAVIOR_EACH, BEHAVIOR_FIRST, BEHAVIOR_ALL])
 async def test_entity_trigger_fires_on_valid_transition(
     hass: HomeAssistant, behavior: str
 ) -> None:
@@ -3891,7 +3891,7 @@ async def test_entity_trigger_fires_on_valid_transition(
     unsub()
 
 
-@pytest.mark.parametrize("behavior", [BEHAVIOR_ANY, BEHAVIOR_FIRST, BEHAVIOR_LAST])
+@pytest.mark.parametrize("behavior", [BEHAVIOR_EACH, BEHAVIOR_FIRST, BEHAVIOR_ALL])
 @pytest.mark.parametrize(
     "initial_state",
     [STATE_UNAVAILABLE, STATE_UNKNOWN, None],
@@ -3927,10 +3927,10 @@ async def test_entity_trigger_from_invalid_initial_state(
     unsub()
 
 
-async def test_entity_trigger_last_requires_all(
+async def test_entity_trigger_all_requires_all(
     hass: HomeAssistant,
 ) -> None:
-    """Test behavior last: trigger fires only when ALL entities are on."""
+    """Test behavior all: trigger fires only when ALL entities are on."""
     entity_a = "test.entity_a"
     entity_b = "test.entity_b"
     hass.states.async_set(entity_a, STATE_OFF)
@@ -3939,7 +3939,7 @@ async def test_entity_trigger_last_requires_all(
 
     calls: list[dict[str, Any]] = []
     unsub = await _arm_off_to_on_trigger(
-        hass, [entity_a, entity_b], BEHAVIOR_LAST, calls, duration=None
+        hass, [entity_a, entity_b], BEHAVIOR_ALL, calls, duration=None
     )
 
     # Turn only A on — not all match, should not fire
@@ -3988,10 +3988,10 @@ async def test_entity_trigger_first_requires_exactly_one(
     [STATE_UNAVAILABLE, STATE_UNKNOWN],
     ids=["unavailable", "unknown"],
 )
-async def test_entity_trigger_last_ignores_unavailable_and_unknown_entity(
+async def test_entity_trigger_all_ignores_unavailable_and_unknown_entity(
     hass: HomeAssistant, invalid_state: str
 ) -> None:
-    """Test behavior last: unavailable/unknown excluded from all-match.
+    """Test behavior all: unavailable/unknown excluded from all-match.
 
     With three entities (A=off, B=unavailable, C=off), turning A on should
     not fire because C is still off, so the available entities do not all
@@ -4008,7 +4008,7 @@ async def test_entity_trigger_last_ignores_unavailable_and_unknown_entity(
 
     calls: list[dict[str, Any]] = []
     unsub = await _arm_off_to_on_trigger(
-        hass, [entity_a, entity_b, entity_c], BEHAVIOR_LAST, calls, duration=None
+        hass, [entity_a, entity_b, entity_c], BEHAVIOR_ALL, calls, duration=None
     )
 
     # Turn A on — B is unavailable and skipped, only A is on → all doesn't match
@@ -4077,7 +4077,7 @@ async def test_entity_trigger_first_ignores_unavailable_and_unknown_entity(
     unsub()
 
 
-@pytest.mark.parametrize("behavior", [BEHAVIOR_ANY, BEHAVIOR_FIRST, BEHAVIOR_LAST])
+@pytest.mark.parametrize("behavior", [BEHAVIOR_EACH, BEHAVIOR_FIRST, BEHAVIOR_ALL])
 async def test_entity_trigger_with_duration(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory, behavior: str
 ) -> None:
@@ -4109,7 +4109,7 @@ async def test_entity_trigger_with_duration(
     unsub()
 
 
-@pytest.mark.parametrize("behavior", [BEHAVIOR_ANY, BEHAVIOR_FIRST, BEHAVIOR_LAST])
+@pytest.mark.parametrize("behavior", [BEHAVIOR_EACH, BEHAVIOR_FIRST, BEHAVIOR_ALL])
 async def test_entity_trigger_duration_cancelled_on_state_change(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory, behavior: str
 ) -> None:
@@ -4143,10 +4143,10 @@ async def test_entity_trigger_duration_cancelled_on_state_change(
     unsub()
 
 
-async def test_entity_trigger_duration_any_independent(
+async def test_entity_trigger_duration_each_independent(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:
-    """Test behavior any tracks per-entity durations independently."""
+    """Test behavior each tracks per-entity durations independently."""
     entity_a = "test.entity_a"
     entity_b = "test.entity_b"
     hass.states.async_set(entity_a, STATE_OFF)
@@ -4155,7 +4155,7 @@ async def test_entity_trigger_duration_any_independent(
 
     calls: list[dict[str, Any]] = []
     unsub = await _arm_off_to_on_trigger(
-        hass, [entity_a, entity_b], BEHAVIOR_ANY, calls, duration={"seconds": 5}
+        hass, [entity_a, entity_b], BEHAVIOR_EACH, calls, duration={"seconds": 5}
     )
 
     # Turn A on
@@ -4187,10 +4187,10 @@ async def test_entity_trigger_duration_any_independent(
     unsub()
 
 
-async def test_entity_trigger_duration_any_entity_off_cancels_only_that_entity(
+async def test_entity_trigger_duration_each_entity_off_cancels_only_that_entity(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:
-    """Test behavior any: turning off one entity doesn't cancel the other's timer."""
+    """Test behavior each: turning off one entity doesn't cancel the other's timer."""
     entity_a = "test.entity_a"
     entity_b = "test.entity_b"
     hass.states.async_set(entity_a, STATE_OFF)
@@ -4199,7 +4199,7 @@ async def test_entity_trigger_duration_any_entity_off_cancels_only_that_entity(
 
     calls: list[dict[str, Any]] = []
     unsub = await _arm_off_to_on_trigger(
-        hass, [entity_a, entity_b], BEHAVIOR_ANY, calls, duration={"seconds": 5}
+        hass, [entity_a, entity_b], BEHAVIOR_EACH, calls, duration={"seconds": 5}
     )
 
     # Turn both on
@@ -4223,10 +4223,10 @@ async def test_entity_trigger_duration_any_entity_off_cancels_only_that_entity(
     unsub()
 
 
-async def test_entity_trigger_duration_last_requires_all(
+async def test_entity_trigger_duration_all_requires_all(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:
-    """Test behavior last: trigger fires only when ALL entities are on for duration."""
+    """Test behavior all: trigger fires only when ALL entities are on for duration."""
     entity_a = "test.entity_a"
     entity_b = "test.entity_b"
     hass.states.async_set(entity_a, STATE_OFF)
@@ -4235,7 +4235,7 @@ async def test_entity_trigger_duration_last_requires_all(
 
     calls: list[dict[str, Any]] = []
     unsub = await _arm_off_to_on_trigger(
-        hass, [entity_a, entity_b], BEHAVIOR_LAST, calls, duration={"seconds": 5}
+        hass, [entity_a, entity_b], BEHAVIOR_ALL, calls, duration={"seconds": 5}
     )
 
     # Turn only A on — should not start timer (not all match)
@@ -4259,12 +4259,12 @@ async def test_entity_trigger_duration_last_requires_all(
     unsub()
 
 
-async def test_entity_trigger_duration_last_cancelled_when_all_entities_filtered(
+async def test_entity_trigger_duration_all_cancelled_when_all_entities_filtered(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:
-    """Test behavior last with for: timer cancelled when all entities filtered.
+    """Test behavior all with for: timer cancelled when all entities filtered.
 
-    With behavior=last + `for:`, an "all match" check that becomes vacuously
+    With behavior=all + `for:`, an "all match" check that becomes vacuously
     True (every targeted entity filtered by `_should_include` — here all
     entities go unavailable) must not keep the timer alive; otherwise the
     action would fire after the duration even though no entity still
@@ -4278,7 +4278,7 @@ async def test_entity_trigger_duration_last_cancelled_when_all_entities_filtered
 
     calls: list[dict[str, Any]] = []
     unsub = await _arm_off_to_on_trigger(
-        hass, [entity_a, entity_b], BEHAVIOR_LAST, calls, duration={"seconds": 5}
+        hass, [entity_a, entity_b], BEHAVIOR_ALL, calls, duration={"seconds": 5}
     )
 
     # Turn both on — combined state "all on", timer starts
@@ -4304,10 +4304,10 @@ async def test_entity_trigger_duration_last_cancelled_when_all_entities_filtered
     unsub()
 
 
-async def test_entity_trigger_duration_last_cancelled_when_one_turns_off(
+async def test_entity_trigger_duration_all_cancelled_when_one_turns_off(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:
-    """Test behavior last: timer is cancelled when one entity turns off."""
+    """Test behavior all: timer is cancelled when one entity turns off."""
     entity_a = "test.entity_a"
     entity_b = "test.entity_b"
     hass.states.async_set(entity_a, STATE_OFF)
@@ -4316,7 +4316,7 @@ async def test_entity_trigger_duration_last_cancelled_when_one_turns_off(
 
     calls: list[dict[str, Any]] = []
     unsub = await _arm_off_to_on_trigger(
-        hass, [entity_a, entity_b], BEHAVIOR_LAST, calls, duration={"seconds": 5}
+        hass, [entity_a, entity_b], BEHAVIOR_ALL, calls, duration={"seconds": 5}
     )
 
     # Turn both on
@@ -4339,10 +4339,10 @@ async def test_entity_trigger_duration_last_cancelled_when_one_turns_off(
     unsub()
 
 
-async def test_entity_trigger_duration_last_timer_reset(
+async def test_entity_trigger_duration_all_timer_reset(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:
-    """Test behavior last: timer resets when combined state goes off and back on."""
+    """Test behavior all: timer resets when combined state goes off and back on."""
     entity_a = "test.entity_a"
     entity_b = "test.entity_b"
     hass.states.async_set(entity_a, STATE_OFF)
@@ -4351,7 +4351,7 @@ async def test_entity_trigger_duration_last_timer_reset(
 
     calls: list[dict[str, Any]] = []
     unsub = await _arm_off_to_on_trigger(
-        hass, [entity_a, entity_b], BEHAVIOR_LAST, calls, duration={"seconds": 5}
+        hass, [entity_a, entity_b], BEHAVIOR_ALL, calls, duration={"seconds": 5}
     )
 
     # Turn both on — combined state "all on", timer starts
@@ -4524,17 +4524,17 @@ async def test_entity_trigger_duration_first_cancelled_when_all_off(
     unsub()
 
 
-async def test_entity_trigger_duration_any_retrigger_resets_timer(
+async def test_entity_trigger_duration_each_retrigger_resets_timer(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:
-    """Test behavior any: turning an entity off and on resets its timer."""
+    """Test behavior each: turning an entity off and on resets its timer."""
     entity_id = "test.entity_1"
     hass.states.async_set(entity_id, STATE_OFF)
     await hass.async_block_till_done()
 
     calls: list[dict[str, Any]] = []
     unsub = await _arm_off_to_on_trigger(
-        hass, [entity_id], BEHAVIOR_ANY, calls, duration={"seconds": 5}
+        hass, [entity_id], BEHAVIOR_EACH, calls, duration={"seconds": 5}
     )
 
     # Turn on
@@ -4566,7 +4566,7 @@ async def test_entity_trigger_duration_any_retrigger_resets_timer(
 
 @pytest.mark.parametrize(
     ("behavior", "expected_calls"),
-    [(BEHAVIOR_ANY, 0), (BEHAVIOR_FIRST, 0), (BEHAVIOR_LAST, 1)],
+    [(BEHAVIOR_EACH, 0), (BEHAVIOR_FIRST, 0), (BEHAVIOR_ALL, 1)],
 )
 @pytest.mark.parametrize(
     "invalid_state",
@@ -4598,7 +4598,7 @@ async def test_entity_trigger_duration_cancelled_on_invalid_state(
     # Turn on the entities needed to start the timer
     _set_or_remove_state(hass, entity_a, STATE_ON)
     await hass.async_block_till_done()
-    if behavior == BEHAVIOR_LAST:
+    if behavior == BEHAVIOR_ALL:
         _set_or_remove_state(hass, entity_b, STATE_ON)
         await hass.async_block_till_done()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
The trigger behavior options for triggers in labs have been renamed. In your automations and scripts, replace `behavior: any` with `behavior: each` and `behavior: last` with `behavior: all`.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rename trigger behavior options as requested in https://github.com/home-assistant/core/issues/166950

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
