### PR TITLE
Reject backup uploads with unsafe inner name

### DIFF
--- a/homeassistant/components/backup/backup.py
+++ b/homeassistant/components/backup/backup.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.hassio import is_hassio
 
 from .agent import BackupAgent, LocalBackupAgent, OnProgressCallback
 from .const import DOMAIN, LOGGER
-from .models import AgentBackup, BackupNotFound
+from .models import AgentBackup, BackupNotFound, InvalidBackupFilename
 from .util import read_backup, suggested_filename
 
 
@@ -54,7 +54,13 @@ class CoreLocalBackupAgent(LocalBackupAgent):
             try:
                 backup = read_backup(backup_path)
                 backups[backup.backup_id] = (backup, backup_path)
-            except (OSError, TarError, json.JSONDecodeError, KeyError) as err:
+            except (
+                OSError,
+                TarError,
+                json.JSONDecodeError,
+                KeyError,
+                InvalidBackupFilename,
+            ) as err:
                 LOGGER.warning("Unable to read backup %s: %s", backup_path, err)
         return backups
 
@@ -122,7 +128,14 @@ class CoreLocalBackupAgent(LocalBackupAgent):
 
     def get_new_backup_path(self, backup: AgentBackup) -> Path:
         """Return the local path to a new backup."""
-        return self._backup_dir / suggested_filename(backup)
+        candidate = self._backup_dir / suggested_filename(backup)
+        # suggested_filename does not strip separators; refuse paths that would
+        # land outside the backup directory.
+        if candidate.parent != self._backup_dir:
+            raise InvalidBackupFilename(
+                f"Refusing to write outside {self._backup_dir}: {candidate}"
+            )
+        return candidate
 
     async def async_delete_backup(self, backup_id: str, **kwargs: Any) -> None:
         """Delete a backup file."""

--- a/homeassistant/components/backup/manager.py
+++ b/homeassistant/components/backup/manager.py
@@ -1978,7 +1978,13 @@ class CoreBackupReaderWriter(BackupReaderWriter):
 
         try:
             backup = await async_add_executor_job(read_backup, temp_file)
-        except (OSError, tarfile.TarError, json.JSONDecodeError, KeyError) as err:
+        except (
+            OSError,
+            tarfile.TarError,
+            json.JSONDecodeError,
+            KeyError,
+            InvalidBackupFilename,
+        ) as err:
             LOGGER.warning("Unable to parse backup %s: %s", temp_file, err)
             raise
 

--- a/homeassistant/components/backup/util.py
+++ b/homeassistant/components/backup/util.py
@@ -6,7 +6,7 @@ import copy
 from dataclasses import dataclass, replace
 from io import BytesIO
 import json
-from pathlib import Path, PurePath
+from pathlib import Path, PurePath, PureWindowsPath
 from queue import SimpleQueue
 import tarfile
 import threading
@@ -34,7 +34,7 @@ from homeassistant.util.async_iterator import (
 from homeassistant.util.json import JsonObjectType, json_loads_object
 
 from .const import BUF_SIZE, LOGGER, SECURETAR_CREATE_VERSION
-from .models import AddonInfo, AgentBackup, Folder
+from .models import AddonInfo, AgentBackup, Folder, InvalidBackupFilename
 
 
 class DecryptError(HomeAssistantError):
@@ -109,6 +109,13 @@ def read_backup(backup_path: Path) -> AgentBackup:
         extra_metadata = cast(dict[str, bool | str], data.get("extra", {}))
         date = extra_metadata.get("supervisor.backup_request_date", data["date"])
 
+        name = cast(str, data["name"])
+        # The name is used to derive the on-disk filename via suggested_filename;
+        # reject anything that could escape the backup directory.
+        safe_name = PureWindowsPath(name).name
+        if safe_name != name or name in ("", ".", ".."):
+            raise InvalidBackupFilename(f"Invalid backup name: {name!r}")
+
         return AgentBackup(
             addons=addons,
             backup_id=cast(str, data["slug"]),
@@ -118,7 +125,7 @@ def read_backup(backup_path: Path) -> AgentBackup:
             folders=folders,
             homeassistant_included=homeassistant_included,
             homeassistant_version=homeassistant_version,
-            name=cast(str, data["name"]),
+            name=name,
             protected=cast(bool, data.get("protected", False)),
             size=backup_path.stat().st_size,
         )

--- a/tests/components/backup/test_manager.py
+++ b/tests/components/backup/test_manager.py
@@ -2088,6 +2088,36 @@ async def test_receive_backup_path_traversal(
     assert resp.status == 400
 
 
+@pytest.mark.parametrize(
+    "name",
+    [
+        "/absolute/path",
+        "../parent",
+        "with/slash",
+    ],
+)
+async def test_receive_backup_rejects_unsafe_inner_name(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    name: str,
+) -> None:
+    """Test receive backup rejects an inner name that would escape the backup dir."""
+    await setup_backup_integration(hass)
+    client = await hass_client()
+
+    backup = replace(TEST_BACKUP_ABC123, name=name)
+    with patch(
+        "homeassistant.components.backup.manager.read_backup",
+        return_value=backup,
+    ):
+        resp = await client.post(
+            "/api/backup/upload?agent_id=backup.local",
+            data={"file": StringIO("test")},
+        )
+
+    assert resp.status == 400
+
+
 async def test_receive_backup_busy_manager(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,

--- a/tests/components/backup/test_util.py
+++ b/tests/components/backup/test_util.py
@@ -14,6 +14,7 @@ import pytest
 import securetar
 
 from homeassistant.components.backup import DOMAIN, AddonInfo, AgentBackup, Folder
+from homeassistant.components.backup.models import InvalidBackupFilename
 from homeassistant.components.backup.util import (
     DecryptedBackupStreamer,
     EncryptedBackupStreamer,
@@ -156,6 +157,37 @@ def test_read_backup(backup_json_content: bytes, expected_backup: AgentBackup) -
         tar_ctx.extractfile.return_value.read.return_value = backup_json_content
         backup = read_backup(mock_path)
         assert backup == expected_backup
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "/absolute/path",
+        "../parent",
+        "with/slash",
+        "with\\backslash",
+        "C:\\drive\\path",
+        "",
+        ".",
+        "..",
+    ],
+)
+def test_read_backup_rejects_unsafe_name(name: str) -> None:
+    """Test that read_backup rejects names that could escape the backup directory."""
+    backup_json_content = (
+        b'{"compressed":true,"date":"2024-12-02T07:23:58.261875-05:00","homeassistant":'
+        b'{"exclude_database":true,"version":"2024.12.0.dev0"},"name":"'
+        + name.encode().replace(b"\\", b"\\\\")
+        + b'","protected":true,"slug":"455645fe","type":"partial","version":2}'
+    )
+    mock_path = Mock()
+    mock_path.stat.return_value.st_size = 1234
+
+    with patch("homeassistant.components.backup.util.tarfile.open") as mock_open_tar:
+        tar_ctx = mock_open_tar.return_value.__enter__.return_value
+        tar_ctx.extractfile.return_value.read.return_value = backup_json_content
+        with pytest.raises(InvalidBackupFilename):
+            read_backup(mock_path)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Breaking change

## Proposed change

Validate the `name` field read from the inner `backup.json` so an attacker-controlled value containing path separators or an absolute path can't escape the backup directory when it flows through `suggested_filename` into `get_new_backup_path`. Adds a second-layer containment check in `CoreLocalBackupAgent.get_new_backup_path` as defense in depth, covering both the receive sink and the generate sink.

#167211 previously closed the same class of bug for the multipart upload filename, but only validated `Content-Disposition` — the inner `backup.json` `name` is a separate attacker-controlled input on the same code path and was not covered.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: follow-up to #167211
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (\`ruff format homeassistant tests\`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: \`python3 -m script.hassfest\`.
- [ ] New or updated dependencies have been added to \`requirements_all.txt\`.
      Updated by running \`python3 -m script.gen_requirements_all\`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr