### PR TITLE
Upgrade HomeLink package, set integration type

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -623,8 +623,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/generic_hygrostat/ @Shulyaka
 /homeassistant/components/geniushub/ @manzanotti
 /tests/components/geniushub/ @manzanotti
-/homeassistant/components/gentex_homelink/ @rjones-gentex
-/tests/components/gentex_homelink/ @rjones-gentex
+/homeassistant/components/gentex_homelink/ @Gentex-Corporation/Homelink @rjones-gentex
+/tests/components/gentex_homelink/ @Gentex-Corporation/Homelink @rjones-gentex
 /homeassistant/components/geo_json_events/ @exxamalte
 /tests/components/geo_json_events/ @exxamalte
 /homeassistant/components/geo_location/ @home-assistant/core

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -623,8 +623,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/generic_hygrostat/ @Shulyaka
 /homeassistant/components/geniushub/ @manzanotti
 /tests/components/geniushub/ @manzanotti
-/homeassistant/components/gentex_homelink/ @niaexa @ryanjones-gentex
-/tests/components/gentex_homelink/ @niaexa @ryanjones-gentex
+/homeassistant/components/gentex_homelink/ @rjones-gentex
+/tests/components/gentex_homelink/ @rjones-gentex
 /homeassistant/components/geo_json_events/ @exxamalte
 /tests/components/geo_json_events/ @exxamalte
 /homeassistant/components/geo_location/ @home-assistant/core

--- a/homeassistant/components/gentex_homelink/manifest.json
+++ b/homeassistant/components/gentex_homelink/manifest.json
@@ -5,6 +5,7 @@
   "config_flow": true,
   "dependencies": ["application_credentials"],
   "documentation": "https://www.home-assistant.io/integrations/gentex_homelink",
+  "integration_type": "hub",
   "iot_class": "cloud_push",
   "quality_scale": "bronze",
   "requirements": ["homelink-integration-api==0.0.4"]

--- a/homeassistant/components/gentex_homelink/manifest.json
+++ b/homeassistant/components/gentex_homelink/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/gentex_homelink",
   "iot_class": "cloud_push",
   "quality_scale": "bronze",
-  "requirements": ["homelink-integration-api==0.0.1"]
+  "requirements": ["homelink-integration-api==0.0.4"]
 }

--- a/homeassistant/components/gentex_homelink/manifest.json
+++ b/homeassistant/components/gentex_homelink/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "quality_scale": "bronze",
-  "requirements": ["homelink-integration-api==0.0.4"]
+  "requirements": ["homelink-integration-api==0.0.5"]
 }

--- a/homeassistant/components/gentex_homelink/manifest.json
+++ b/homeassistant/components/gentex_homelink/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "gentex_homelink",
   "name": "HomeLink",
-  "codeowners": ["@niaexa", "@ryanjones-gentex"],
+  "codeowners": ["@rjones-gentex"],
   "config_flow": true,
   "dependencies": ["application_credentials"],
   "documentation": "https://www.home-assistant.io/integrations/gentex_homelink",

--- a/homeassistant/components/gentex_homelink/manifest.json
+++ b/homeassistant/components/gentex_homelink/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "gentex_homelink",
   "name": "HomeLink",
-  "codeowners": ["@rjones-gentex"],
+  "codeowners": ["@Gentex-Corporation/Homelink", "@rjones-gentex"],
   "config_flow": true,
   "dependencies": ["application_credentials"],
   "documentation": "https://www.home-assistant.io/integrations/gentex_homelink",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1275,7 +1275,7 @@ home-assistant-intents==2026.5.5
 homekit-audio-proxy==1.2.1
 
 # homeassistant.components.gentex_homelink
-homelink-integration-api==0.0.4
+homelink-integration-api==0.0.5
 
 # homeassistant.components.homematicip_cloud
 homematicip==2.12.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1275,7 +1275,7 @@ home-assistant-intents==2026.5.5
 homekit-audio-proxy==1.2.1
 
 # homeassistant.components.gentex_homelink
-homelink-integration-api==0.0.1
+homelink-integration-api==0.0.4
 
 # homeassistant.components.homematicip_cloud
 homematicip==2.12.0

--- a/script/hassfest/integration_type.py
+++ b/script/hassfest/integration_type.py
@@ -27,7 +27,6 @@ MISSING_INTEGRATION_TYPE = {
     "folder_watcher",
     "forked_daapd",
     "geniushub",
-    "gentex_homelink",
     "geofency",
     "govee_light_local",
     "gpsd",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR upgrades the [`homelink-integration-api`](https://github.com/Gentex-Corporation/homelink-integration-api) package version to [`0.0.5`](https://pypi.org/project/homelink-integration-api/0.0.5/). This is necessary because we discovered a bug in our MQTT client creation which did not create a unique Client ID per instance of the integration, instead containing the string, `"TODO"`. This was an oversight in our development process, and did allow the integration to work, but only for one user at a time. Any other connections would try and reuse the same Client ID and result in a failure of the service. This package upgrade has been tested and is working with the new package version across multiple HA instances.

Here is a diff of the changes made in the library (Note specifically the changes made to [`mqtt_provider.py`](https://github.com/Gentex-Corporation/homelink-integration-api/compare/v0.0.1...v0.0.5#diff-e2c4f776e31bc1ce9a8d520538fb972b0d8e6ca6d5afee51c77d0cf6efee9388) for the bugfix code): https://github.com/Gentex-Corporation/homelink-integration-api/compare/v0.0.1...v0.0.5

This PR also sets the `integration_type` for `gentex_homelink` to `"hub"` to line up with the [documentation](https://developers.home-assistant.io/docs/creating_integration_manifest/#integration-type).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #168539
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
