### PR TITLE
prusalink: guard non-string original in config_flow workaround

### DIFF
--- a/homeassistant/components/prusalink/config_flow.py
+++ b/homeassistant/components/prusalink/config_flow.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import Any, cast
+from typing import Any
 
 from awesomeversion import AwesomeVersion, AwesomeVersionException
 from httpx import HTTPError, InvalidURL
@@ -41,7 +41,8 @@ def ensure_printer_is_supported(version: VersionInfo) -> None:
 
         # Workaround to allow PrusaLink 0.7.2 on MK3 and MK2.5 that supports
         # the 2.0.0 API, but doesn't advertise it yet
-        original = cast(str, version.get("original", ""))
+        original_value = version.get("original")
+        original = original_value if isinstance(original_value, str) else ""
         if original.startswith(("PrusaLink I3MK3", "PrusaLink I3MK2")) and (
             AwesomeVersion("0.7.2") <= AwesomeVersion(version["server"])
         ):


### PR DESCRIPTION
## Proposed change

This PR addresses an unresolved type-safety issue identified during PR #170480 review. The `ensure_printer_is_supported()` function in `config_flow.py` uses `cast(str, version.get("original", ""))` to handle an undocumented version field. However, `cast()` is a type-checker-only construct and provides no runtime safety; if the API returns `None` or a non-string value for `original`, the subsequent `.startswith()` call will raise `AttributeError` during config flow initialization.

**Current behavior:** Runtime-unsafe cast without validation.

**New behavior:** Defensive type-guard checks the value at runtime and normalizes non-strings to empty string, allowing `.startswith()` to execute safely.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Followup from PR #170480 review (unresolved Copilot comment)
- Related to ensuring runtime safety of the MK3/MK2.5 firmware version workaround

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] The code has been formatted using Ruff.
