### PR TITLE
Adjust PrusaLink job entity state semantics

### DIFF
--- a/homeassistant/components/prusalink/camera.py
+++ b/homeassistant/components/prusalink/camera.py
@@ -36,7 +36,8 @@ class PrusaLinkJobPreviewEntity(PrusaLinkEntity, Camera):
         key="job_preview",
         translation_key="job_preview",
         available_fn=lambda data: bool(
-            data.get("state") != PrinterState.IDLE.value
+            data is not None
+            and data.get("state") != PrinterState.IDLE.value
             and (file := data.get("file"))
             and file.get("refs", {}).get("thumbnail")
         ),

--- a/homeassistant/components/prusalink/entity.py
+++ b/homeassistant/components/prusalink/entity.py
@@ -29,15 +29,13 @@ class PrusaLinkEntity(CoordinatorEntity[PrusaLinkUpdateCoordinator]):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        # `coordinator.data` can be None when the underlying endpoint
-        # returns no payload — e.g. the job coordinator yields None when
-        # no job is running on pyprusalink >= 3.0.0. Short-circuit to
-        # avoid passing None into `available_fn` lambdas that assume a
-        # dict (.get(), index, etc.).
-        return (
-            super().available
-            and self.coordinator.data is not None
-            and self.entity_description.available_fn(self.coordinator.data)
+        # Availability should only reflect coordinator connectivity or
+        # entity-specific data absence. Entities that stay available when their
+        # current value is not known, such as idle/no-job sensors, return True
+        # here and expose `native_value = None` so Home Assistant shows
+        # `unknown` instead of `unavailable`.
+        return super().available and self.entity_description.available_fn(
+            self.coordinator.data
         )
 
     @property

--- a/homeassistant/components/prusalink/sensor.py
+++ b/homeassistant/components/prusalink/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import cast
+from typing import Any, cast
 
 from pyprusalink.types import JobInfo, PrinterInfo, PrinterState, PrinterStatus
 from pyprusalink.types_legacy import LegacyPrinterStatus, LegacyPrinterTelemetry
@@ -300,7 +300,7 @@ class PrusaLinkSensorEntity(PrusaLinkEntity, SensorEntity):
     """Defines a PrusaLink sensor."""
 
     entity_description: PrusaLinkSensorEntityDescription
-    _value_fn: Callable[[object], datetime | StateType]
+    _value_fn: Callable[[Any], datetime | StateType]
 
     def __init__(
         self,
@@ -312,9 +312,12 @@ class PrusaLinkSensorEntity(PrusaLinkEntity, SensorEntity):
         self.entity_description = description
         if description.value_fn_factory is not None:
             self._value_fn = description.value_fn_factory()
-        else:
-            assert description.value_fn is not None
+        elif description.value_fn is not None:
             self._value_fn = description.value_fn
+        else:
+            raise ValueError(
+                f"Sensor description {description.key} must define value_fn or value_fn_factory"
+            )
         self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{description.key}"
 
     @property

--- a/homeassistant/components/prusalink/sensor.py
+++ b/homeassistant/components/prusalink/sensor.py
@@ -5,13 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import cast
 
-from pyprusalink.types import (
-    JobFilePrint,
-    JobInfo,
-    PrinterInfo,
-    PrinterState,
-    PrinterStatus,
-)
+from pyprusalink.types import JobInfo, PrinterInfo, PrinterState, PrinterStatus
 from pyprusalink.types_legacy import LegacyPrinterStatus, LegacyPrinterTelemetry
 
 from homeassistant.components.sensor import (
@@ -36,16 +30,85 @@ from .coordinator import PrusaLinkConfigEntry, PrusaLinkUpdateCoordinator
 from .entity import PrusaLinkEntity, PrusaLinkEntityDescription
 
 
+def _has_active_job(data: JobInfo | None) -> JobInfo | None:
+    """Return the job payload when an active job exists, otherwise None."""
+    if data is None or data.get("state") == PrinterState.IDLE.value:
+        return None
+    return data
+
+
+def _job_progress(data: JobInfo | None) -> float | None:
+    """Return job progress when an active job exists, otherwise None."""
+    if (active_job := _has_active_job(data)) is None:
+        return None
+    return active_job["progress"]
+
+
+def _job_filename(data: JobInfo | None) -> str | None:
+    """Return the job filename when an active job file exists, otherwise None."""
+    if (active_job := _has_active_job(data)) is None:
+        return None
+    file_data = active_job["file"]
+    if file_data is None:
+        return None
+    return file_data["display_name"]
+
+
+def _make_stable_job_start() -> Callable[[JobInfo | None], datetime | None]:
+    """Create a per-entity stable job-start value function."""
+    # `ignore_variance` keeps internal state, so timestamp sensors need a
+    # fresh callable per entity instead of sharing one description-level
+    # function across config entries.
+    stable_job_start = ignore_variance(
+        lambda printing_seconds: utcnow() - timedelta(seconds=printing_seconds),
+        timedelta(minutes=2),
+    )
+
+    def _value_fn(data: JobInfo | None) -> datetime | None:
+        if (active_job := _has_active_job(data)) is None:
+            return None
+        return stable_job_start(active_job["time_printing"])
+
+    return _value_fn
+
+
+def _make_stable_job_finish() -> Callable[[JobInfo | None], datetime | None]:
+    """Create a per-entity stable job-finish value function."""
+    # `ignore_variance` keeps internal state, so timestamp sensors need a
+    # fresh callable per entity instead of sharing one description-level
+    # function across config entries.
+    stable_job_finish = ignore_variance(
+        lambda remaining_seconds: utcnow() + timedelta(seconds=remaining_seconds),
+        timedelta(minutes=2),
+    )
+
+    def _value_fn(data: JobInfo | None) -> datetime | None:
+        if (active_job := _has_active_job(data)) is None:
+            return None
+        time_remaining = active_job["time_remaining"]
+        if time_remaining is None:
+            return None
+        return stable_job_finish(time_remaining)
+
+    return _value_fn
+
+
+def _always_available(_: object) -> bool:
+    """Keep the entity available while the coordinator remains available."""
+    return True
+
+
 @dataclass(frozen=True, kw_only=True)
 class PrusaLinkSensorEntityDescription[
-    T: (PrinterStatus, LegacyPrinterStatus, JobInfo, PrinterInfo)
+    T: PrinterStatus | LegacyPrinterStatus | JobInfo | None | PrinterInfo
 ](
     SensorEntityDescription,
     PrusaLinkEntityDescription,
 ):
     """Describes PrusaLink sensor entity."""
 
-    value_fn: Callable[[T], datetime | StateType]
+    value_fn: Callable[[T], datetime | StateType] | None = None
+    value_fn_factory: Callable[[], Callable[[T], datetime | StateType]] | None = None
 
 
 SENSORS: dict[str, tuple[PrusaLinkSensorEntityDescription, ...]] = {
@@ -162,58 +225,32 @@ SENSORS: dict[str, tuple[PrusaLinkSensorEntityDescription, ...]] = {
         ),
     ),
     "job": (
-        PrusaLinkSensorEntityDescription[JobInfo](
+        PrusaLinkSensorEntityDescription[JobInfo | None](
             key="job.progress",
             translation_key="progress",
             native_unit_of_measurement=PERCENTAGE,
-            value_fn=lambda data: cast(float, data["progress"]),
-            available_fn=lambda data: (
-                data.get("progress") is not None
-                and data.get("state") != PrinterState.IDLE.value
-            ),
+            value_fn=_job_progress,
+            available_fn=_always_available,
         ),
-        PrusaLinkSensorEntityDescription[JobInfo](
+        PrusaLinkSensorEntityDescription[JobInfo | None](
             key="job.filename",
             translation_key="filename",
-            # `available_fn` guarantees `file` is not None at this point;
-            # the inner cast narrows the Optional for the index.
-            value_fn=lambda data: cast(
-                str, cast(JobFilePrint, data["file"])["display_name"]
-            ),
-            available_fn=lambda data: (
-                data.get("file") is not None
-                and data.get("state") != PrinterState.IDLE.value
-            ),
+            value_fn=_job_filename,
+            available_fn=_always_available,
         ),
-        PrusaLinkSensorEntityDescription[JobInfo](
+        PrusaLinkSensorEntityDescription[JobInfo | None](
             key="job.start",
             translation_key="print_start",
             device_class=SensorDeviceClass.TIMESTAMP,
-            value_fn=ignore_variance(
-                lambda data: utcnow() - timedelta(seconds=data["time_printing"]),
-                timedelta(minutes=2),
-            ),
-            available_fn=lambda data: (
-                data.get("time_printing") is not None
-                and data.get("state") != PrinterState.IDLE.value
-            ),
+            value_fn_factory=_make_stable_job_start,
+            available_fn=_always_available,
         ),
-        PrusaLinkSensorEntityDescription[JobInfo](
+        PrusaLinkSensorEntityDescription[JobInfo | None](
             key="job.finish",
             translation_key="print_finish",
             device_class=SensorDeviceClass.TIMESTAMP,
-            # `available_fn` guarantees `time_remaining` is not None at this
-            # point; the cast narrows the Optional for `timedelta`.
-            value_fn=ignore_variance(
-                lambda data: (
-                    utcnow() + timedelta(seconds=cast(int, data["time_remaining"]))
-                ),
-                timedelta(minutes=2),
-            ),
-            available_fn=lambda data: (
-                data.get("time_remaining") is not None
-                and data.get("state") != PrinterState.IDLE.value
-            ),
+            value_fn_factory=_make_stable_job_finish,
+            available_fn=_always_available,
         ),
     ),
     "info": (
@@ -263,6 +300,7 @@ class PrusaLinkSensorEntity(PrusaLinkEntity, SensorEntity):
     """Defines a PrusaLink sensor."""
 
     entity_description: PrusaLinkSensorEntityDescription
+    _value_fn: Callable[[object], datetime | StateType]
 
     def __init__(
         self,
@@ -272,9 +310,14 @@ class PrusaLinkSensorEntity(PrusaLinkEntity, SensorEntity):
         """Initialize a PrusaLink sensor entity."""
         super().__init__(coordinator=coordinator)
         self.entity_description = description
+        if description.value_fn_factory is not None:
+            self._value_fn = description.value_fn_factory()
+        else:
+            assert description.value_fn is not None
+            self._value_fn = description.value_fn
         self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{description.key}"
 
     @property
     def native_value(self) -> datetime | StateType:
         """Return the state of the sensor."""
-        return self.entity_description.value_fn(self.coordinator.data)
+        return self._value_fn(self.coordinator.data)

--- a/tests/components/prusalink/test_sensor.py
+++ b/tests/components/prusalink/test_sensor.py
@@ -110,21 +110,21 @@ async def test_sensors_no_job(hass: HomeAssistant, mock_config_entry, mock_api) 
 
     state = hass.states.get("sensor.workshop_mock_title_progress")
     assert state is not None
-    assert state.state == "unavailable"
+    assert state.state == "unknown"
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == "%"
 
     state = hass.states.get("sensor.workshop_mock_title_filename")
     assert state is not None
-    assert state.state == "unavailable"
+    assert state.state == "unknown"
 
     state = hass.states.get("sensor.workshop_mock_title_print_start")
     assert state is not None
-    assert state.state == "unavailable"
+    assert state.state == "unknown"
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.TIMESTAMP
 
     state = hass.states.get("sensor.workshop_mock_title_print_finish")
     assert state is not None
-    assert state.state == "unavailable"
+    assert state.state == "unknown"
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.TIMESTAMP
 
     state = hass.states.get("sensor.workshop_mock_title_hotend_fan")
@@ -219,21 +219,21 @@ async def test_sensors_idle_job_mk3(
 
     state = hass.states.get("sensor.workshop_mock_title_progress")
     assert state is not None
-    assert state.state == "unavailable"
+    assert state.state == "unknown"
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == "%"
 
     state = hass.states.get("sensor.workshop_mock_title_filename")
     assert state is not None
-    assert state.state == "unavailable"
+    assert state.state == "unknown"
 
     state = hass.states.get("sensor.workshop_mock_title_print_start")
     assert state is not None
-    assert state.state == "unavailable"
+    assert state.state == "unknown"
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.TIMESTAMP
 
     state = hass.states.get("sensor.workshop_mock_title_print_finish")
     assert state is not None
-    assert state.state == "unavailable"
+    assert state.state == "unknown"
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.TIMESTAMP
 
     state = hass.states.get("sensor.workshop_mock_title_hotend_fan")
@@ -294,6 +294,46 @@ async def test_sensors_active_job(
     assert state is not None
     assert state.state == "2500"
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == REVOLUTIONS_PER_MINUTE
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_sensors_active_job_with_nullable_fields(
+    hass: HomeAssistant,
+    mock_config_entry,
+    mock_api,
+    mock_get_status_printing,
+    mock_job_api_printing: dict[str, Any],
+) -> None:
+    """Nullable active-job fields should surface as unknown, not unavailable."""
+    mock_job_api_printing["progress"] = 45.0
+    mock_job_api_printing["file"] = None
+    mock_job_api_printing["time_remaining"] = None
+
+    with patch(
+        "homeassistant.components.prusalink.sensor.utcnow",
+        return_value=datetime(2022, 8, 27, 14, 0, 0, tzinfo=UTC),
+    ):
+        assert await async_setup_component(hass, "prusalink", {})
+
+    state = hass.states.get("sensor.workshop_mock_title")
+    assert state is not None
+    assert state.state == "printing"
+
+    state = hass.states.get("sensor.workshop_mock_title_progress")
+    assert state is not None
+    assert state.state == "45.0"
+
+    state = hass.states.get("sensor.workshop_mock_title_filename")
+    assert state is not None
+    assert state.state == "unknown"
+
+    state = hass.states.get("sensor.workshop_mock_title_print_start")
+    assert state is not None
+    assert state.state == "2022-08-27T01:46:53+00:00"
+
+    state = hass.states.get("sensor.workshop_mock_title_print_finish")
+    assert state is not None
+    assert state.state == "unknown"
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")


### PR DESCRIPTION
## Breaking change

PrusaLink job sensors now report `unknown` instead of `unavailable` when no job
is active, or when an active job is missing nullable job fields returned by
pyprusalink 3.0.0.

If you have automations, templates, or dashboards that explicitly match on
`unavailable` for these PrusaLink job sensors, update them to handle `unknown`
instead.

## Proposed change

This follow-up from #170480 updates the PrusaLink integration for the job
endpoint behavior introduced by pyprusalink 3.0.0.

With pyprusalink 3.0.0, the job endpoint can legitimately return no payload when
no job is active. This change keeps the job sensors available when the
coordinator is still healthy, and returns `None` for job values that are not
known. That lets Home Assistant represent idle/no-job states as `unknown`
instead of `unavailable`.

It also makes the job preview camera's availability check `None`-safe, since it
reads from the same job coordinator and the job endpoint can return `None`.

Tests were updated to cover:
- no active job
- idle MK3 job payloads
- active jobs with nullable job fields

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: #170480
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.