### PR TITLE
Environment Canada integration: add get_alerts action

### DIFF
--- a/homeassistant/components/environment_canada/__init__.py
+++ b/homeassistant/components/environment_canada/__init__.py
@@ -8,9 +8,12 @@ from env_canada import ECAirQuality, ECRadar, ECWeather
 from homeassistant.const import CONF_LANGUAGE, CONF_LATITUDE, CONF_LONGITUDE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.typing import ConfigType
 
-from .const import CONF_STATION
+from .const import CONF_STATION, DOMAIN
 from .coordinator import ECConfigEntry, ECDataUpdateCoordinator, ECRuntimeData
+from .services import async_setup_services
 
 DEFAULT_RADAR_UPDATE_INTERVAL = timedelta(minutes=5)
 DEFAULT_WEATHER_UPDATE_INTERVAL = timedelta(minutes=5)
@@ -18,6 +21,14 @@ DEFAULT_WEATHER_UPDATE_INTERVAL = timedelta(minutes=5)
 PLATFORMS = [Platform.CAMERA, Platform.SENSOR, Platform.WEATHER]
 
 _LOGGER = logging.getLogger(__name__)
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Environment Canada services."""
+    async_setup_services(hass)
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ECConfigEntry) -> bool:

--- a/homeassistant/components/environment_canada/icons.json
+++ b/homeassistant/components/environment_canada/icons.json
@@ -19,6 +19,9 @@
     }
   },
   "services": {
+    "get_alerts": {
+      "service": "mdi:bell-alert"
+    },
     "get_forecasts": {
       "service": "mdi:weather-cloudy-clock"
     },

--- a/homeassistant/components/environment_canada/services.py
+++ b/homeassistant/components/environment_canada/services.py
@@ -5,9 +5,10 @@ from typing import Any
 from env_canada import ECWeather
 import voluptuous as vol
 
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_CONFIG_ENTRY_ID
 from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse, callback
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import config_validation as cv, service
 
 from .const import DOMAIN
@@ -17,10 +18,17 @@ SERVICE_GET_ALERTS_SCHEMA = vol.Schema({vol.Required(ATTR_CONFIG_ENTRY_ID): cv.s
 
 
 async def _async_get_alerts(call: ServiceCall) -> dict[str, Any]:
-    """Clear text in the keyboard input field on an Apple TV."""
+    """Return the active alerts."""
     entry = service.async_get_config_entry(
         call.hass, DOMAIN, call.data[ATTR_CONFIG_ENTRY_ID]
     )
+
+    if entry is None or entry.state is not ConfigEntryState.LOADED:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="service_entry_ex",
+        )
+
     ec: ECWeather | None = entry.runtime_data.weather_coordinator.ec_data
     if ec is None:
         raise HomeAssistantError(
@@ -32,7 +40,7 @@ async def _async_get_alerts(call: ServiceCall) -> dict[str, Any]:
 
 @callback
 def async_setup_services(hass: HomeAssistant) -> None:
-    """Set up the services for the Apple TV integration."""
+    """Set up the services for the Environment Canada integration."""
     hass.services.async_register(
         DOMAIN,
         SERVICE_GET_ALERTS,

--- a/homeassistant/components/environment_canada/services.py
+++ b/homeassistant/components/environment_canada/services.py
@@ -5,10 +5,9 @@ from typing import Any
 from env_canada import ECWeather
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_CONFIG_ENTRY_ID
 from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse, callback
-from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, service
 
 from .const import DOMAIN
@@ -22,12 +21,6 @@ async def _async_get_alerts(call: ServiceCall) -> dict[str, Any]:
     entry = service.async_get_config_entry(
         call.hass, DOMAIN, call.data[ATTR_CONFIG_ENTRY_ID]
     )
-
-    if entry is None or entry.state is not ConfigEntryState.LOADED:
-        raise ServiceValidationError(
-            translation_domain=DOMAIN,
-            translation_key="service_entry_ex",
-        )
 
     ec: ECWeather | None = entry.runtime_data.weather_coordinator.ec_data
     if ec is None:

--- a/homeassistant/components/environment_canada/services.py
+++ b/homeassistant/components/environment_canada/services.py
@@ -1,6 +1,6 @@
 """Define services for the Environment Canada integration."""
 
-from typing import Any
+from typing import Any, cast
 
 from env_canada import ECWeather
 import voluptuous as vol
@@ -28,7 +28,24 @@ async def _async_get_alerts(call: ServiceCall) -> dict[str, Any]:
             translation_domain=DOMAIN,
             translation_key="not_connected",
         )
-    return ec.alerts
+
+    data = cast(dict[str, list[dict[str, Any]]], ec.alerts)
+    return {
+        k: [
+            {
+                (
+                    "alert_colour_level"
+                    if ik == "alertColourLevel"
+                    else "expiry_time"
+                    if ik == "expiryTime"
+                    else ik
+                ): iv
+                for ik, iv in item.items()
+            }
+            for item in v
+        ]
+        for k, v in data.items()
+    }
 
 
 @callback

--- a/homeassistant/components/environment_canada/services.py
+++ b/homeassistant/components/environment_canada/services.py
@@ -1,0 +1,42 @@
+"""Define services for the Environment Canada integration."""
+
+from typing import Any
+
+from env_canada import ECWeather
+import voluptuous as vol
+
+from homeassistant.const import ATTR_CONFIG_ENTRY_ID
+from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv, service
+
+from .const import DOMAIN
+
+SERVICE_GET_ALERTS = "get_alerts"
+SERVICE_GET_ALERTS_SCHEMA = vol.Schema({vol.Required(ATTR_CONFIG_ENTRY_ID): cv.string})
+
+
+async def _async_get_alerts(call: ServiceCall) -> dict[str, Any]:
+    """Clear text in the keyboard input field on an Apple TV."""
+    entry = service.async_get_config_entry(
+        call.hass, DOMAIN, call.data[ATTR_CONFIG_ENTRY_ID]
+    )
+    ec: ECWeather | None = entry.runtime_data.weather_coordinator.ec_data
+    if ec is None:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="not_connected",
+        )
+    return ec.alerts
+
+
+@callback
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Set up the services for the Apple TV integration."""
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_GET_ALERTS,
+        _async_get_alerts,
+        schema=SERVICE_GET_ALERTS_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
+    )

--- a/homeassistant/components/environment_canada/services.py
+++ b/homeassistant/components/environment_canada/services.py
@@ -1,6 +1,6 @@
 """Define services for the Environment Canada integration."""
 
-from typing import Any, cast
+from typing import Any
 
 from env_canada import ECWeather
 import voluptuous as vol
@@ -14,6 +14,11 @@ from .const import DOMAIN
 
 SERVICE_GET_ALERTS = "get_alerts"
 SERVICE_GET_ALERTS_SCHEMA = vol.Schema({vol.Required(ATTR_CONFIG_ENTRY_ID): cv.string})
+
+SNAKE_MAPPING = {
+    "alertColourLevel": "alert_colour_level",
+    "expiryTime": "expiry_time",
+}
 
 
 async def _async_get_alerts(call: ServiceCall) -> dict[str, Any]:
@@ -29,20 +34,11 @@ async def _async_get_alerts(call: ServiceCall) -> dict[str, Any]:
             translation_key="not_connected",
         )
 
-    data = cast(dict[str, list[dict[str, Any]]], ec.alerts)
+    data: dict[str, Any] = ec.alerts
     return {
         k: [
-            {
-                (
-                    "alert_colour_level"
-                    if ik == "alertColourLevel"
-                    else "expiry_time"
-                    if ik == "expiryTime"
-                    else ik
-                ): iv
-                for ik, iv in item.items()
-            }
-            for item in v
+            {SNAKE_MAPPING.get(ik, ik): iv for ik, iv in item.items()}
+            for item in v["value"]
         ]
         for k, v in data.items()
     }

--- a/homeassistant/components/environment_canada/services.yaml
+++ b/homeassistant/components/environment_canada/services.yaml
@@ -1,3 +1,11 @@
+get_alerts:
+  fields:
+    config_entry_id:
+      required: true
+      selector:
+        config_entry:
+          integration: environment_canada
+
 get_forecasts:
   target:
     entity:

--- a/homeassistant/components/environment_canada/strings.json
+++ b/homeassistant/components/environment_canada/strings.json
@@ -115,9 +115,6 @@
   "exceptions": {
     "not_connected": {
       "message": "Environment Canada is not connected"
-    },
-    "service_entry_ex": {
-      "message": "Environment Canada get_alerts error: config entry not found or not loaded"
     }
   },
   "services": {

--- a/homeassistant/components/environment_canada/strings.json
+++ b/homeassistant/components/environment_canada/strings.json
@@ -115,11 +115,14 @@
   "exceptions": {
     "not_connected": {
       "message": "Environment Canada is not connected"
+    },
+    "service_entry_ex": {
+      "message": "Environment Canada get_alerts error: config entry not found or not loaded"
     }
   },
   "services": {
     "get_alerts": {
-      "description": "Retrieves the alerts from selected weather service.",
+      "description": "Retrieves the alerts from the selected weather service.",
       "fields": {
         "config_entry_id": {
           "description": "The Environment Canada service to retrieve alerts from.",

--- a/homeassistant/components/environment_canada/strings.json
+++ b/homeassistant/components/environment_canada/strings.json
@@ -112,7 +112,22 @@
       }
     }
   },
+  "exceptions": {
+    "not_connected": {
+      "message": "Environment Canada is not connected"
+    }
+  },
   "services": {
+    "get_alerts": {
+      "description": "Retrieves the alerts from selected weather service.",
+      "fields": {
+        "config_entry_id": {
+          "description": "The Environment Canada service to retrieve alerts from.",
+          "name": "Environment Canada service"
+        }
+      },
+      "name": "Get alerts"
+    },
     "get_forecasts": {
       "description": "Retrieves the forecast from selected weather services.",
       "name": "Get forecasts"

--- a/tests/components/environment_canada/fixtures/current_conditions_data.json
+++ b/tests/components/environment_canada/fixtures/current_conditions_data.json
@@ -1,35 +1,50 @@
 {
   "alerts": {
-    "warnings": [
-      {
-        "title": "Air Quality Warning",
-        "date": "2026-06-04T10:35:16.386Z",
-        "alert_colour_level": "yellow",
-        "expiry_time": "2026-06-04T19:00:16.386Z",
-        "text": "Wildfire smoke is causing poor air quality. Conditions are expected to improve later this morning. Air quality and visibility due to wildfire smoke can fluctuate over short distances and can vary considerably from hour to hour. As smoke levels increase, health risks increase. Limit time outdoors. Consider reducing or rescheduling outdoor sports, activities and events.",
-        "area": "Yellowknife Region",
-        "status": "continued",
-        "confidence": "High",
-        "impact": "Moderate",
-        "alert_code": "AQW"
-      },
-      {
-        "title": "Wow, it is hot out there",
-        "date": "2026-06-04T10:35:16.386Z",
-        "alert_colour_level": "red",
-        "expiry_time": "2026-06-04T19:00:16.386Z",
-        "text": "It is so hot you can fry an egg on the pavement!",
-        "area": "Yellowknife Region",
-        "status": "continued",
-        "confidence": "High",
-        "impact": "Moderate",
-        "alert_code": "HOT"
-      }
-    ],
-    "watches": [],
-    "advisories": [],
-    "statements": [],
-    "endings": []
+    "warnings": {
+      "label": "Warnings",
+      "value": [
+        {
+          "title": "Air Quality Warning",
+          "date": "2026-06-04T10:35:16.386Z",
+          "alertColourLevel": "yellow",
+          "expiryTime": "2026-06-04T19:00:16.386Z",
+          "text": "Wildfire smoke is causing poor air quality. Conditions are expected to improve later this morning. Air quality and visibility due to wildfire smoke can fluctuate over short distances and can vary considerably from hour to hour. As smoke levels increase, health risks increase. Limit time outdoors. Consider reducing or rescheduling outdoor sports, activities and events.",
+          "area": "Yellowknife Region",
+          "status": "continued",
+          "confidence": "High",
+          "impact": "Moderate",
+          "alert_code": "AQW"
+        },
+        {
+          "title": "Wow, it is hot out there!",
+          "date": "2026-06-04T10:35:16.386Z",
+          "alertColourLevel": "red",
+          "expiry_time": "2026-06-04T19:00:16.386Z",
+          "text": "It is so hot you can fry an egg on the pavement!",
+          "area": "Yellowknife Region",
+          "status": "continued",
+          "confidence": "High",
+          "impact": "Moderate",
+          "alert_code": "HOT"
+        }
+      ]
+    },
+    "watches": {
+      "label": "Watches",
+      "value": []
+    },
+    "advisories": {
+      "label": "Advisories",
+      "value": []
+    },
+    "statements": {
+      "label": "Statements",
+      "value": []
+    },
+    "endings": {
+      "label": "Endings",
+      "value": []
+    }
   },
   "conditions": {
     "temperature": {

--- a/tests/components/environment_canada/fixtures/current_conditions_data.json
+++ b/tests/components/environment_canada/fixtures/current_conditions_data.json
@@ -19,7 +19,7 @@
           "title": "Wow, it is hot out there!",
           "date": "2026-06-04T10:35:16.386Z",
           "alertColourLevel": "red",
-          "expiry_time": "2026-06-04T19:00:16.386Z",
+          "expiryTime": "2026-06-04T19:00:16.386Z",
           "text": "It is so hot you can fry an egg on the pavement!",
           "area": "Yellowknife Region",
           "status": "continued",

--- a/tests/components/environment_canada/fixtures/current_conditions_data.json
+++ b/tests/components/environment_canada/fixtures/current_conditions_data.json
@@ -1,29 +1,37 @@
 {
   "alerts": {
     "warnings": {
-      "value": [],
-      "label": "Warnings"
+      "label": "Warnings",
+      "value": []
     },
     "watches": {
-      "value": [],
-      "label": "Watches"
-    },
-    "advisories": {
+      "label": "Watches",
       "value": [
         {
-          "title": "Frost Advisory",
-          "date": "Monday October 03, 2022 at 15:05 EDT"
+          "title": "Severe Thunderstorm Watch",
+          "date": "2026-06-04T01:11:57.362Z",
+          "alertColourLevel": "yellow",
+          "expiryTime": "2026-06-04T17:11:57.362Z",
+          "text": "Conditions are favourable for the development of severe thunderstorms that may be capable of producing strong wind gusts, large hail and heavy rain. Locations: Portions of southern Manitoba. Potential rainfall rates: locally 30 to 50 mm per hour in thunderstorms. Potential wind gusts: 90 km/h or higher in thunderstorms. Time span: Continuing through this evening. Remarks: Thunderstorms, some of which may be severe, continue to track across parts of southern Manitoba starting this evening.",
+          "area": "City of Winnipeg",
+          "status": "continued",
+          "confidence": "High",
+          "impact": "Moderate",
+          "alert_code": "STV"
         }
-      ],
-      "label": "Advisories"
+      ]
+    },
+    "advisories": {
+      "label": "Advisories",
+      "value": []
     },
     "statements": {
-      "value": [],
-      "label": "Statements"
+      "label": "Statements",
+      "value": []
     },
     "endings": {
-      "value": [],
-      "label": "Endings"
+      "label": "Endings",
+      "value": []
     }
   },
   "conditions": {

--- a/tests/components/environment_canada/fixtures/current_conditions_data.json
+++ b/tests/components/environment_canada/fixtures/current_conditions_data.json
@@ -1,38 +1,35 @@
 {
   "alerts": {
-    "warnings": {
-      "label": "Warnings",
-      "value": []
-    },
-    "watches": {
-      "label": "Watches",
-      "value": [
-        {
-          "title": "Severe Thunderstorm Watch",
-          "date": "2026-06-04T01:11:57.362Z",
-          "alertColourLevel": "yellow",
-          "expiryTime": "2026-06-04T17:11:57.362Z",
-          "text": "Conditions are favourable for the development of severe thunderstorms that may be capable of producing strong wind gusts, large hail and heavy rain. Locations: Portions of southern Manitoba. Potential rainfall rates: locally 30 to 50 mm per hour in thunderstorms. Potential wind gusts: 90 km/h or higher in thunderstorms. Time span: Continuing through this evening. Remarks: Thunderstorms, some of which may be severe, continue to track across parts of southern Manitoba starting this evening.",
-          "area": "City of Winnipeg",
-          "status": "continued",
-          "confidence": "High",
-          "impact": "Moderate",
-          "alert_code": "STV"
-        }
-      ]
-    },
-    "advisories": {
-      "label": "Advisories",
-      "value": []
-    },
-    "statements": {
-      "label": "Statements",
-      "value": []
-    },
-    "endings": {
-      "label": "Endings",
-      "value": []
-    }
+    "warnings": [
+      {
+        "title": "Air Quality Warning",
+        "date": "2026-06-04T10:35:16.386Z",
+        "alert_colour_level": "yellow",
+        "expiry_time": "2026-06-04T19:00:16.386Z",
+        "text": "Wildfire smoke is causing poor air quality. Conditions are expected to improve later this morning. Air quality and visibility due to wildfire smoke can fluctuate over short distances and can vary considerably from hour to hour. As smoke levels increase, health risks increase. Limit time outdoors. Consider reducing or rescheduling outdoor sports, activities and events.",
+        "area": "Yellowknife Region",
+        "status": "continued",
+        "confidence": "High",
+        "impact": "Moderate",
+        "alert_code": "AQW"
+      },
+      {
+        "title": "Wow, it is hot out there",
+        "date": "2026-06-04T10:35:16.386Z",
+        "alert_colour_level": "red",
+        "expiry_time": "2026-06-04T19:00:16.386Z",
+        "text": "It is so hot you can fry an egg on the pavement!",
+        "area": "Yellowknife Region",
+        "status": "continued",
+        "confidence": "High",
+        "impact": "Moderate",
+        "alert_code": "HOT"
+      }
+    ],
+    "watches": [],
+    "advisories": [],
+    "statements": [],
+    "endings": []
   },
   "conditions": {
     "temperature": {

--- a/tests/components/environment_canada/snapshots/test_services.ambr
+++ b/tests/components/environment_canada/snapshots/test_services.ambr
@@ -1,42 +1,39 @@
 # serializer version: 1
 # name: test_get_alerts
   dict({
-    'advisories': dict({
-      'label': 'Advisories',
-      'value': list([
-      ]),
-    }),
-    'endings': dict({
-      'label': 'Endings',
-      'value': list([
-      ]),
-    }),
-    'statements': dict({
-      'label': 'Statements',
-      'value': list([
-      ]),
-    }),
-    'warnings': dict({
-      'label': 'Warnings',
-      'value': list([
-      ]),
-    }),
-    'watches': dict({
-      'label': 'Watches',
-      'value': list([
-        dict({
-          'alertColourLevel': 'yellow',
-          'alert_code': 'STV',
-          'area': 'City of Winnipeg',
-          'confidence': 'High',
-          'date': '2026-06-04T01:11:57.362Z',
-          'expiryTime': '2026-06-04T17:11:57.362Z',
-          'impact': 'Moderate',
-          'status': 'continued',
-          'text': 'Conditions are favourable for the development of severe thunderstorms that may be capable of producing strong wind gusts, large hail and heavy rain. Locations: Portions of southern Manitoba. Potential rainfall rates: locally 30 to 50 mm per hour in thunderstorms. Potential wind gusts: 90 km/h or higher in thunderstorms. Time span: Continuing through this evening. Remarks: Thunderstorms, some of which may be severe, continue to track across parts of southern Manitoba starting this evening.',
-          'title': 'Severe Thunderstorm Watch',
-        }),
-      ]),
-    }),
+    'advisories': list([
+    ]),
+    'endings': list([
+    ]),
+    'statements': list([
+    ]),
+    'warnings': list([
+      dict({
+        'alert_code': 'AQW',
+        'alert_colour_level': 'yellow',
+        'area': 'Yellowknife Region',
+        'confidence': 'High',
+        'date': '2026-06-04T10:35:16.386Z',
+        'expiry_time': '2026-06-04T19:00:16.386Z',
+        'impact': 'Moderate',
+        'status': 'continued',
+        'text': 'Wildfire smoke is causing poor air quality. Conditions are expected to improve later this morning. Air quality and visibility due to wildfire smoke can fluctuate over short distances and can vary considerably from hour to hour. As smoke levels increase, health risks increase. Limit time outdoors. Consider reducing or rescheduling outdoor sports, activities and events.',
+        'title': 'Air Quality Warning',
+      }),
+      dict({
+        'alert_code': 'HOT',
+        'alert_colour_level': 'red',
+        'area': 'Yellowknife Region',
+        'confidence': 'High',
+        'date': '2026-06-04T10:35:16.386Z',
+        'expiry_time': '2026-06-04T19:00:16.386Z',
+        'impact': 'Moderate',
+        'status': 'continued',
+        'text': 'It is so hot you can fry an egg on the pavement!',
+        'title': 'Wow, it is hot out there',
+      }),
+    ]),
+    'watches': list([
+    ]),
   })
 # ---

--- a/tests/components/environment_canada/snapshots/test_services.ambr
+++ b/tests/components/environment_canada/snapshots/test_services.ambr
@@ -4,10 +4,6 @@
     'advisories': dict({
       'label': 'Advisories',
       'value': list([
-        dict({
-          'date': 'Monday October 03, 2022 at 15:05 EDT',
-          'title': 'Frost Advisory',
-        }),
       ]),
     }),
     'endings': dict({
@@ -28,6 +24,18 @@
     'watches': dict({
       'label': 'Watches',
       'value': list([
+        dict({
+          'alertColourLevel': 'yellow',
+          'alert_code': 'STV',
+          'area': 'City of Winnipeg',
+          'confidence': 'High',
+          'date': '2026-06-04T01:11:57.362Z',
+          'expiryTime': '2026-06-04T17:11:57.362Z',
+          'impact': 'Moderate',
+          'status': 'continued',
+          'text': 'Conditions are favourable for the development of severe thunderstorms that may be capable of producing strong wind gusts, large hail and heavy rain. Locations: Portions of southern Manitoba. Potential rainfall rates: locally 30 to 50 mm per hour in thunderstorms. Potential wind gusts: 90 km/h or higher in thunderstorms. Time span: Continuing through this evening. Remarks: Thunderstorms, some of which may be severe, continue to track across parts of southern Manitoba starting this evening.',
+          'title': 'Severe Thunderstorm Watch',
+        }),
       ]),
     }),
   })

--- a/tests/components/environment_canada/snapshots/test_services.ambr
+++ b/tests/components/environment_canada/snapshots/test_services.ambr
@@ -1,0 +1,34 @@
+# serializer version: 1
+# name: test_get_alerts
+  dict({
+    'advisories': dict({
+      'label': 'Advisories',
+      'value': list([
+        dict({
+          'date': 'Monday October 03, 2022 at 15:05 EDT',
+          'title': 'Frost Advisory',
+        }),
+      ]),
+    }),
+    'endings': dict({
+      'label': 'Endings',
+      'value': list([
+      ]),
+    }),
+    'statements': dict({
+      'label': 'Statements',
+      'value': list([
+      ]),
+    }),
+    'warnings': dict({
+      'label': 'Warnings',
+      'value': list([
+      ]),
+    }),
+    'watches': dict({
+      'label': 'Watches',
+      'value': list([
+      ]),
+    }),
+  })
+# ---

--- a/tests/components/environment_canada/snapshots/test_services.ambr
+++ b/tests/components/environment_canada/snapshots/test_services.ambr
@@ -30,7 +30,7 @@
         'impact': 'Moderate',
         'status': 'continued',
         'text': 'It is so hot you can fry an egg on the pavement!',
-        'title': 'Wow, it is hot out there',
+        'title': 'Wow, it is hot out there!',
       }),
     ]),
     'watches': list([

--- a/tests/components/environment_canada/test_services.py
+++ b/tests/components/environment_canada/test_services.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.environment_canada.const import DOMAIN
 from homeassistant.core import HomeAssistant
@@ -13,7 +14,9 @@ from . import init_integration
 SERVICE_GET_ALERTS = "get_alerts"
 
 
-async def test_get_alerts(hass: HomeAssistant, ec_data: dict[str, Any]) -> None:
+async def test_get_alerts(
+    hass: HomeAssistant, snapshot: SnapshotAssertion, ec_data: dict[str, Any]
+) -> None:
     """Test the get_alerts service returns active alerts."""
     config_entry = await init_integration(hass, ec_data)
 
@@ -24,7 +27,7 @@ async def test_get_alerts(hass: HomeAssistant, ec_data: dict[str, Any]) -> None:
         blocking=True,
         return_response=True,
     )
-    assert response == ec_data["alerts"]
+    assert response == snapshot
 
 
 async def test_get_alerts_not_connected(

--- a/tests/components/environment_canada/test_services.py
+++ b/tests/components/environment_canada/test_services.py
@@ -1,0 +1,44 @@
+"""Tests for the Environment Canada services."""
+
+from typing import Any
+
+import pytest
+
+from homeassistant.components.environment_canada.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from . import init_integration
+
+SERVICE_GET_ALERTS = "get_alerts"
+
+
+async def test_get_alerts(hass: HomeAssistant, ec_data: dict[str, Any]) -> None:
+    """Test the get_alerts service returns active alerts."""
+    config_entry = await init_integration(hass, ec_data)
+
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_GET_ALERTS,
+        {"config_entry_id": config_entry.entry_id},
+        blocking=True,
+        return_response=True,
+    )
+    assert response == ec_data["alerts"]
+
+
+async def test_get_alerts_not_connected(
+    hass: HomeAssistant, ec_data: dict[str, Any]
+) -> None:
+    """Test get_alerts raises when weather data is not connected."""
+    config_entry = await init_integration(hass, ec_data)
+    config_entry.runtime_data.weather_coordinator.ec_data = None
+
+    with pytest.raises(HomeAssistantError, match="not connected"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_GET_ALERTS,
+            {"config_entry_id": config_entry.entry_id},
+            blocking=True,
+            return_response=True,
+        )


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds the get_alerts action - there is a new Environment Canada API recently integration into the base library that retrieves much more data around weather alerts. This new service retrieves that data. The following is the structure of the data that is provided by the base lib:
```
class AlertDetail(TypedDict):
    """Fields in a weather alert."""

    title: str
    date: str
    alertColourLevel: str
    expiryTime: str
    text: str
    area: str
    status: str
    confidence: str
    impact: str
    alert_code: str


class AlertCategory(TypedDict):
    """A category of weather alerts."""

    label: str
    value: list[AlertDetail]


class WeatherAlertData(TypedDict):
    """The 5 types of weather alerts."""

    warnings: AlertCategory
    watches: AlertCategory
    advisories: AlertCategory
    statements: AlertCategory
    endings: AlertCategory
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45621
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
