### PR TITLE
Add zone entered left triggers

### DIFF
--- a/homeassistant/components/device_tracker/device_trigger.py
+++ b/homeassistant/components/device_tracker/device_trigger.py
@@ -12,13 +12,18 @@ from homeassistant.const import (
     CONF_DOMAIN,
     CONF_ENTITY_ID,
     CONF_EVENT,
+    CONF_OPTIONS,
     CONF_PLATFORM,
     CONF_TYPE,
     CONF_ZONE,
 )
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_registry as er
-from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
+from homeassistant.helpers.trigger import (
+    TriggerActionType,
+    TriggerInfo,
+    _async_attach_trigger_cls,
+)
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
@@ -79,16 +84,18 @@ async def async_attach_trigger(
         event = zone.EVENT_ENTER
     else:
         event = zone.EVENT_LEAVE
-
-    zone_config = {
-        CONF_PLATFORM: ZONE_DOMAIN,
-        CONF_ENTITY_ID: config[CONF_ENTITY_ID],
-        CONF_ZONE: config[CONF_ZONE],
-        CONF_EVENT: event,
-    }
-    zone_config = await zone.async_validate_trigger_config(hass, zone_config)
-    return await zone.async_attach_trigger(
-        hass, zone_config, action, trigger_info, platform_type="device"
+    zone_config = await zone.LegacyZoneTrigger.async_validate_config(
+        hass,
+        {
+            CONF_OPTIONS: {
+                CONF_ENTITY_ID: [config[CONF_ENTITY_ID]],
+                CONF_ZONE: config[CONF_ZONE],
+                CONF_EVENT: event,
+            }
+        },
+    )
+    return await _async_attach_trigger_cls(
+        hass, zone.LegacyZoneTrigger, "device", zone_config, action, trigger_info
     )
 
 

--- a/homeassistant/components/device_tracker/device_trigger.py
+++ b/homeassistant/components/device_tracker/device_trigger.py
@@ -22,6 +22,7 @@ from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.trigger import (
     TriggerActionType,
     TriggerInfo,
+    #  protected, but only used for legacy triggers
     _async_attach_trigger_cls,
 )
 from homeassistant.helpers.typing import ConfigType

--- a/homeassistant/components/zone/icons.json
+++ b/homeassistant/components/zone/icons.json
@@ -3,5 +3,13 @@
     "reload": {
       "service": "mdi:reload"
     }
+  },
+  "triggers": {
+    "entered": {
+      "trigger": "mdi:map-marker-plus"
+    },
+    "left": {
+      "trigger": "mdi:map-marker-minus"
+    }
   }
 }

--- a/homeassistant/components/zone/strings.json
+++ b/homeassistant/components/zone/strings.json
@@ -1,7 +1,9 @@
 {
   "common": {
     "trigger_behavior_name": "Trigger when",
-    "trigger_for_name": "For at least"
+    "trigger_for_name": "For at least",
+    "trigger_zone_description": "The zone to trigger on.",
+    "trigger_zone_name": "Zone"
   },
   "services": {
     "reload": {
@@ -20,8 +22,8 @@
           "name": "[%key:component::zone::common::trigger_for_name%]"
         },
         "zone": {
-          "description": "The zone to trigger on.",
-          "name": "Zone"
+          "description": "[%key:component::zone::common::trigger_zone_description%]",
+          "name": "[%key:component::zone::common::trigger_zone_name%]"
         }
       },
       "name": "Entered zone"
@@ -36,8 +38,8 @@
           "name": "[%key:component::zone::common::trigger_for_name%]"
         },
         "zone": {
-          "description": "The zone to trigger on.",
-          "name": "Zone"
+          "description": "[%key:component::zone::common::trigger_zone_description%]",
+          "name": "[%key:component::zone::common::trigger_zone_name%]"
         }
       },
       "name": "Left zone"

--- a/homeassistant/components/zone/strings.json
+++ b/homeassistant/components/zone/strings.json
@@ -20,8 +20,8 @@
           "name": "[%key:component::zone::common::trigger_for_name%]"
         },
         "zone": {
-          "description": "The zones to trigger on.",
-          "name": "Zones"
+          "description": "The zone to trigger on.",
+          "name": "Zone"
         }
       },
       "name": "Entered zone"
@@ -36,8 +36,8 @@
           "name": "[%key:component::zone::common::trigger_for_name%]"
         },
         "zone": {
-          "description": "The zones to trigger on.",
-          "name": "Zones"
+          "description": "The zone to trigger on.",
+          "name": "Zone"
         }
       },
       "name": "Left zone"

--- a/homeassistant/components/zone/strings.json
+++ b/homeassistant/components/zone/strings.json
@@ -1,8 +1,46 @@
 {
+  "common": {
+    "trigger_behavior_name": "Trigger when",
+    "trigger_for_name": "For at least"
+  },
   "services": {
     "reload": {
       "description": "Reloads zones from the YAML-configuration.",
       "name": "Reload zones"
+    }
+  },
+  "triggers": {
+    "entered": {
+      "description": "Triggers when one or more persons or device trackers enter a zone.",
+      "fields": {
+        "behavior": {
+          "name": "[%key:component::zone::common::trigger_behavior_name%]"
+        },
+        "for": {
+          "name": "[%key:component::zone::common::trigger_for_name%]"
+        },
+        "zone": {
+          "description": "The zones to trigger on.",
+          "name": "Zones"
+        }
+      },
+      "name": "Entered zone"
+    },
+    "left": {
+      "description": "Triggers when one or more persons or device trackers leave a zone.",
+      "fields": {
+        "behavior": {
+          "name": "[%key:component::zone::common::trigger_behavior_name%]"
+        },
+        "for": {
+          "name": "[%key:component::zone::common::trigger_for_name%]"
+        },
+        "zone": {
+          "description": "The zones to trigger on.",
+          "name": "Zones"
+        }
+      },
+      "name": "Left zone"
     }
   }
 }

--- a/homeassistant/components/zone/trigger.py
+++ b/homeassistant/components/zone/trigger.py
@@ -1,22 +1,24 @@
 """Offer zone automation rules."""
 
 import logging
+from typing import TYPE_CHECKING, Any, cast
 
 import voluptuous as vol
 
+from homeassistant.components.device_tracker import ATTR_IN_ZONES
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
     CONF_ENTITY_ID,
     CONF_EVENT,
-    CONF_PLATFORM,
+    CONF_OPTIONS,
     CONF_ZONE,
 )
 from homeassistant.core import (
     CALLBACK_TYPE,
     Event,
     EventStateChangedData,
-    HassJob,
     HomeAssistant,
+    State,
     callback,
 )
 from homeassistant.helpers import (
@@ -24,8 +26,18 @@ from homeassistant.helpers import (
     entity_registry as er,
     location,
 )
+from homeassistant.helpers.automation import (
+    DomainSpec,
+    move_top_level_schema_fields_to_options,
+)
 from homeassistant.helpers.event import async_track_state_change_event
-from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
+from homeassistant.helpers.trigger import (
+    ENTITY_STATE_TRIGGER_SCHEMA_FIRST_LAST,
+    EntityTriggerBase,
+    Trigger,
+    TriggerActionRunner,
+    TriggerConfig,
+)
 from homeassistant.helpers.typing import ConfigType
 
 from . import condition
@@ -38,93 +50,168 @@ _LOGGER = logging.getLogger(__name__)
 
 _EVENT_DESCRIPTION = {EVENT_ENTER: "entering", EVENT_LEAVE: "leaving"}
 
-_TRIGGER_SCHEMA = cv.TRIGGER_BASE_SCHEMA.extend(
+_LEGACY_OPTIONS_SCHEMA: dict[vol.Marker, Any] = {
+    vol.Required(CONF_ENTITY_ID): cv.entity_ids_or_uuids,
+    vol.Required(CONF_ZONE): cv.entity_id,
+    vol.Required(CONF_EVENT, default=DEFAULT_EVENT): vol.Any(EVENT_ENTER, EVENT_LEAVE),
+}
+
+_LEGACY_TRIGGER_OPTIONS_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_PLATFORM): "zone",
-        vol.Required(CONF_ENTITY_ID): cv.entity_ids_or_uuids,
-        vol.Required(CONF_ZONE): cv.entity_id,
-        vol.Required(CONF_EVENT, default=DEFAULT_EVENT): vol.Any(
-            EVENT_ENTER, EVENT_LEAVE
-        ),
+        vol.Required(CONF_OPTIONS): _LEGACY_OPTIONS_SCHEMA,
+    },
+)
+
+# New-style zone trigger schema
+_ZONE_TRIGGER_SCHEMA = ENTITY_STATE_TRIGGER_SCHEMA_FIRST_LAST.extend(
+    {
+        vol.Required(CONF_OPTIONS): {
+            vol.Required(CONF_ZONE): vol.All(
+                cv.ensure_list, [cv.entity_id], vol.Length(min=1)
+            ),
+        },
     }
 )
 
-
-async def async_validate_trigger_config(
-    hass: HomeAssistant, config: ConfigType
-) -> ConfigType:
-    """Validate trigger config."""
-    config = _TRIGGER_SCHEMA(config)
-    registry = er.async_get(hass)
-    config[CONF_ENTITY_ID] = er.async_validate_entity_ids(
-        registry, config[CONF_ENTITY_ID]
-    )
-    return config
+_DOMAIN_SPECS: dict[str, DomainSpec] = {
+    "person": DomainSpec(),
+    "device_tracker": DomainSpec(),
+}
 
 
-async def async_attach_trigger(
-    hass: HomeAssistant,
-    config: ConfigType,
-    action: TriggerActionType,
-    trigger_info: TriggerInfo,
-    *,
-    platform_type: str = "zone",
-) -> CALLBACK_TYPE:
-    """Listen for state changes based on configuration."""
-    trigger_data = trigger_info["trigger_data"]
-    entity_id: list[str] = config[CONF_ENTITY_ID]
-    zone_entity_id: str = config[CONF_ZONE]
-    event: str = config[CONF_EVENT]
-    job = HassJob(action)
+class LegacyZoneTrigger(Trigger):
+    """Legacy zone trigger (platform: zone)."""
 
-    @callback
-    def zone_automation_listener(zone_event: Event[EventStateChangedData]) -> None:
-        """Listen for state changes and calls action."""
-        entity = zone_event.data["entity_id"]
-        from_s = zone_event.data["old_state"]
-        to_s = zone_event.data["new_state"]
+    @classmethod
+    async def async_validate_complete_config(
+        cls, hass: HomeAssistant, complete_config: ConfigType
+    ) -> ConfigType:
+        """Validate complete config, migrating legacy format to options."""
+        complete_config = move_top_level_schema_fields_to_options(
+            complete_config, _LEGACY_OPTIONS_SCHEMA
+        )
+        return await super().async_validate_complete_config(hass, complete_config)
 
-        if (from_s and not location.has_location(from_s)) or (
-            to_s and not location.has_location(to_s)
-        ):
-            return
+    @classmethod
+    async def async_validate_config(
+        cls, hass: HomeAssistant, config: ConfigType
+    ) -> ConfigType:
+        """Validate config."""
+        config = cast(ConfigType, _LEGACY_TRIGGER_OPTIONS_SCHEMA(config))
+        registry = er.async_get(hass)
+        config[CONF_OPTIONS][CONF_ENTITY_ID] = er.async_validate_entity_ids(
+            registry, config[CONF_OPTIONS][CONF_ENTITY_ID]
+        )
+        return config
 
-        if not (zone_state := hass.states.get(zone_entity_id)):
-            _LOGGER.warning(
-                (
-                    "Automation '%s' is referencing non-existing zone '%s' in a zone"
-                    " trigger"
-                ),
-                trigger_info["name"],
-                zone_entity_id,
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Initialize trigger."""
+        super().__init__(hass, config)
+        if TYPE_CHECKING:
+            assert config.options is not None
+        self._options = config.options
+
+    async def async_attach_runner(
+        self, run_action: TriggerActionRunner
+    ) -> CALLBACK_TYPE:
+        """Listen for state changes based on configuration."""
+        entity_id: list[str] = self._options[CONF_ENTITY_ID]
+        zone_entity_id: str = self._options[CONF_ZONE]
+        event: str = self._options[CONF_EVENT]
+
+        @callback
+        def zone_automation_listener(zone_event: Event[EventStateChangedData]) -> None:
+            """Listen for state changes and calls action."""
+            entity = zone_event.data["entity_id"]
+            from_s = zone_event.data["old_state"]
+            to_s = zone_event.data["new_state"]
+
+            if (from_s and not location.has_location(from_s)) or (
+                to_s and not location.has_location(to_s)
+            ):
+                return
+
+            if not (zone_state := self._hass.states.get(zone_entity_id)):
+                _LOGGER.warning(
+                    "Non-existing zone '%s' in a zone trigger",
+                    zone_entity_id,
+                )
+                return
+
+            from_match = (
+                condition.zone(self._hass, zone_state, from_s) if from_s else False
             )
-            return
+            to_match = condition.zone(self._hass, zone_state, to_s) if to_s else False
 
-        from_match = condition.zone(hass, zone_state, from_s) if from_s else False
-        to_match = condition.zone(hass, zone_state, to_s) if to_s else False
-
-        if (event == EVENT_ENTER and not from_match and to_match) or (
-            event == EVENT_LEAVE and from_match and not to_match
-        ):
-            description = (
-                f"{entity} {_EVENT_DESCRIPTION[event]}"
-                f" {zone_state.attributes[ATTR_FRIENDLY_NAME]}"
-            )
-            hass.async_run_hass_job(
-                job,
-                {
-                    "trigger": {
-                        **trigger_data,
-                        "platform": platform_type,
+            if (event == EVENT_ENTER and not from_match and to_match) or (
+                event == EVENT_LEAVE and from_match and not to_match
+            ):
+                description = f"{entity} {_EVENT_DESCRIPTION[event]} {zone_state.attributes[ATTR_FRIENDLY_NAME]}"
+                run_action(
+                    {
                         "entity_id": entity,
                         "from_state": from_s,
                         "to_state": to_s,
                         "zone": zone_state,
                         "event": event,
-                        "description": description,
-                    }
-                },
-                to_s.context if to_s else None,
-            )
+                    },
+                    description,
+                    to_s.context if to_s else None,
+                )
 
-    return async_track_state_change_event(hass, entity_id, zone_automation_listener)
+        return async_track_state_change_event(
+            self._hass, entity_id, zone_automation_listener
+        )
+
+
+class ZoneTriggerBase(EntityTriggerBase):
+    """Base for zone-based triggers targeting person and device_tracker entities."""
+
+    _domain_specs = _DOMAIN_SPECS
+    _schema = _ZONE_TRIGGER_SCHEMA
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Initialize the trigger."""
+        super().__init__(hass, config)
+        self._zones: set[str] = set(self._options[CONF_ZONE])
+
+    def _in_target_zones(self, state: State) -> bool:
+        """Check if the entity is in any of the selected zones."""
+        in_zones = set(state.attributes.get(ATTR_IN_ZONES) or [])
+        return bool(in_zones.intersection(self._zones))
+
+
+class EnteredZoneTrigger(ZoneTriggerBase):
+    """Trigger when an entity enters one of the selected zones."""
+
+    def is_valid_transition(self, from_state: State, to_state: State) -> bool:
+        """Check that the entity was not already in any of the selected zones."""
+        return not self._in_target_zones(from_state)
+
+    def is_valid_state(self, state: State) -> bool:
+        """Check that the entity is now in at least one of the selected zones."""
+        return self._in_target_zones(state)
+
+
+class LeftZoneTrigger(ZoneTriggerBase):
+    """Trigger when an entity leaves all of the selected zones."""
+
+    def is_valid_transition(self, from_state: State, to_state: State) -> bool:
+        """Check that the entity was previously in at least one of the selected zones."""
+        return self._in_target_zones(from_state)
+
+    def is_valid_state(self, state: State) -> bool:
+        """Check that the entity is no longer in any of the selected zones."""
+        return not self._in_target_zones(state)
+
+
+TRIGGERS: dict[str, type[Trigger]] = {
+    "_": LegacyZoneTrigger,
+    "entered": EnteredZoneTrigger,
+    "left": LeftZoneTrigger,
+}
+
+
+async def async_get_triggers(hass: HomeAssistant) -> dict[str, type[Trigger]]:
+    """Return the triggers for zones."""
+    return TRIGGERS

--- a/homeassistant/components/zone/trigger.py
+++ b/homeassistant/components/zone/trigger.py
@@ -32,7 +32,7 @@ from homeassistant.helpers.automation import (
 )
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.trigger import (
-    ENTITY_STATE_TRIGGER_SCHEMA_FIRST_LAST,
+    ENTITY_STATE_TRIGGER_SCHEMA_WITH_BEHAVIOR,
     EntityTriggerBase,
     Trigger,
     TriggerActionRunner,
@@ -63,7 +63,7 @@ _LEGACY_TRIGGER_OPTIONS_SCHEMA = vol.Schema(
 )
 
 # New-style zone trigger schema
-_ZONE_TRIGGER_SCHEMA = ENTITY_STATE_TRIGGER_SCHEMA_FIRST_LAST.extend(
+_ZONE_TRIGGER_SCHEMA = ENTITY_STATE_TRIGGER_SCHEMA_WITH_BEHAVIOR.extend(
     {
         vol.Required(CONF_OPTIONS): {
             vol.Required(CONF_ZONE): cv.entity_domain("zone"),

--- a/homeassistant/components/zone/trigger.py
+++ b/homeassistant/components/zone/trigger.py
@@ -66,9 +66,7 @@ _LEGACY_TRIGGER_OPTIONS_SCHEMA = vol.Schema(
 _ZONE_TRIGGER_SCHEMA = ENTITY_STATE_TRIGGER_SCHEMA_FIRST_LAST.extend(
     {
         vol.Required(CONF_OPTIONS): {
-            vol.Required(CONF_ZONE): vol.All(
-                cv.ensure_list, [cv.entity_domain("zone")], vol.Length(min=1)
-            ),
+            vol.Required(CONF_ZONE): cv.entity_domain("zone"),
         },
     }
 )
@@ -173,36 +171,36 @@ class ZoneTriggerBase(EntityTriggerBase):
     def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
         """Initialize the trigger."""
         super().__init__(hass, config)
-        self._zones: set[str] = set(self._options[CONF_ZONE])
+        self._zone: str = self._options[CONF_ZONE]
 
-    def _in_target_zones(self, state: State) -> bool:
-        """Check if the entity is in any of the selected zones."""
-        in_zones = set(state.attributes.get(ATTR_IN_ZONES) or [])
-        return bool(in_zones.intersection(self._zones))
+    def _in_target_zone(self, state: State) -> bool:
+        """Check if the entity is in the selected zone."""
+        in_zones = state.attributes.get(ATTR_IN_ZONES) or ()
+        return self._zone in in_zones
 
 
 class EnteredZoneTrigger(ZoneTriggerBase):
-    """Trigger when an entity enters one of the selected zones."""
+    """Trigger when an entity enters the selected zone."""
 
     def is_valid_transition(self, from_state: State, to_state: State) -> bool:
-        """Check that the entity was not already in any of the selected zones."""
-        return not self._in_target_zones(from_state)
+        """Check that the entity was not already in the selected zone."""
+        return not self._in_target_zone(from_state)
 
     def is_valid_state(self, state: State) -> bool:
-        """Check that the entity is now in at least one of the selected zones."""
-        return self._in_target_zones(state)
+        """Check that the entity is now in the selected zone."""
+        return self._in_target_zone(state)
 
 
 class LeftZoneTrigger(ZoneTriggerBase):
-    """Trigger when an entity leaves all of the selected zones."""
+    """Trigger when an entity leaves the selected zone."""
 
     def is_valid_transition(self, from_state: State, to_state: State) -> bool:
-        """Check that the entity was previously in at least one of the selected zones."""
-        return self._in_target_zones(from_state)
+        """Check that the entity was previously in the selected zone."""
+        return self._in_target_zone(from_state)
 
     def is_valid_state(self, state: State) -> bool:
-        """Check that the entity is no longer in any of the selected zones."""
-        return not self._in_target_zones(state)
+        """Check that the entity is no longer in the selected zone."""
+        return not self._in_target_zone(state)
 
 
 TRIGGERS: dict[str, type[Trigger]] = {

--- a/homeassistant/components/zone/trigger.py
+++ b/homeassistant/components/zone/trigger.py
@@ -67,7 +67,7 @@ _ZONE_TRIGGER_SCHEMA = ENTITY_STATE_TRIGGER_SCHEMA_FIRST_LAST.extend(
     {
         vol.Required(CONF_OPTIONS): {
             vol.Required(CONF_ZONE): vol.All(
-                cv.ensure_list, [cv.entity_id], vol.Length(min=1)
+                cv.ensure_list, [cv.entity_domain("zone")], vol.Length(min=1)
             ),
         },
     }

--- a/homeassistant/components/zone/triggers.yaml
+++ b/homeassistant/components/zone/triggers.yaml
@@ -7,7 +7,7 @@
   fields:
     behavior:
       required: true
-      default: any
+      default: each
       selector:
         automation_behavior:
           mode: trigger

--- a/homeassistant/components/zone/triggers.yaml
+++ b/homeassistant/components/zone/triggers.yaml
@@ -21,7 +21,6 @@
       selector:
         entity:
           domain: zone
-          multiple: true
 
 entered: *trigger_zone
 left: *trigger_zone

--- a/homeassistant/components/zone/triggers.yaml
+++ b/homeassistant/components/zone/triggers.yaml
@@ -1,0 +1,27 @@
+.trigger_zone: &trigger_zone
+  target:
+    entity:
+      domain:
+        - person
+        - device_tracker
+  fields:
+    behavior:
+      required: true
+      default: any
+      selector:
+        automation_behavior:
+          mode: trigger
+    for:
+      required: true
+      default: 00:00:00
+      selector:
+        duration:
+    zone:
+      required: true
+      selector:
+        entity:
+          domain: zone
+          multiple: true
+
+entered: *trigger_zone
+left: *trigger_zone

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -1714,7 +1714,14 @@ def async_extract_entities(trigger_conf: dict) -> list[str]:
         return [trigger_conf[CONF_OPTIONS][CONF_ENTITY_ID]]
 
     if trigger_conf[CONF_PLATFORM] == "zone":
-        return trigger_conf[CONF_ENTITY_ID] + [trigger_conf[CONF_ZONE]]  # type: ignore[no-any-return]
+        options = trigger_conf[CONF_OPTIONS]
+        return [*options[CONF_ENTITY_ID], options[CONF_ZONE]]
+
+    if trigger_conf[CONF_PLATFORM] in ("zone.entered", "zone.left"):
+        return [
+            *async_extract_targets(trigger_conf, CONF_ENTITY_ID),
+            *trigger_conf[CONF_OPTIONS][CONF_ZONE],
+        ]
 
     if trigger_conf[CONF_PLATFORM] == "geo_location":
         return [trigger_conf[CONF_ZONE]]

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -1720,7 +1720,7 @@ def async_extract_entities(trigger_conf: dict) -> list[str]:
     if trigger_conf[CONF_PLATFORM] in ("zone.entered", "zone.left"):
         return [
             *async_extract_targets(trigger_conf, CONF_ENTITY_ID),
-            *trigger_conf[CONF_OPTIONS][CONF_ZONE],
+            trigger_conf[CONF_OPTIONS][CONF_ZONE],
         ]
 
     if trigger_conf[CONF_PLATFORM] == "geo_location":

--- a/tests/components/zone/test_trigger.py
+++ b/tests/components/zone/test_trigger.py
@@ -1,5 +1,7 @@
 """The tests for the location automation."""
 
+from typing import Any
+
 import pytest
 
 from homeassistant.components import automation, zone
@@ -9,6 +11,16 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_component
+from tests.components.common import (
+    TriggerStateDescription,
+    assert_trigger_behavior_any,
+    assert_trigger_behavior_first,
+    assert_trigger_behavior_last,
+    assert_trigger_options_supported,
+    parametrize_target_entities,
+    parametrize_trigger_states,
+    target_entities,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -343,10 +355,7 @@ async def test_unknown_zone(
         },
     )
 
-    assert (
-        "Automation 'My Automation' is referencing non-existing zone"
-        " 'zone.no_such_zone' in a zone trigger" not in caplog.text
-    )
+    assert "Non-existing zone 'zone.no_such_zone' in a zone trigger" not in caplog.text
 
     hass.states.async_set(
         "test.entity",
@@ -356,7 +365,206 @@ async def test_unknown_zone(
     )
     await hass.async_block_till_done()
 
-    assert (
-        "Automation 'My Automation' is referencing non-existing zone"
-        " 'zone.no_such_zone' in a zone trigger" in caplog.text
+    assert "Non-existing zone 'zone.no_such_zone' in a zone trigger" in caplog.text
+
+
+# --- New-style zone trigger tests ---
+
+ZONE_HOME = "zone.home"
+ZONE_WORK = "zone.work"
+IN_ZONES_HOME = {"in_zones": [ZONE_HOME]}
+IN_ZONES_WORK = {"in_zones": [ZONE_WORK]}
+IN_ZONES_NONE: dict[str, list[str]] = {"in_zones": []}
+TRIGGER_ZONES = [ZONE_HOME, ZONE_WORK]
+
+
+@pytest.mark.parametrize(
+    ("trigger_key", "base_options", "supports_behavior", "supports_duration"),
+    [
+        ("zone.entered", {"zone": TRIGGER_ZONES}, True, True),
+        ("zone.left", {"zone": TRIGGER_ZONES}, True, True),
+    ],
+)
+async def test_zone_trigger_options_validation(
+    hass: HomeAssistant,
+    trigger_key: str,
+    base_options: dict[str, Any] | None,
+    supports_behavior: bool,
+    supports_duration: bool,
+) -> None:
+    """Test that zone triggers support the expected options."""
+    await assert_trigger_options_supported(
+        hass,
+        trigger_key,
+        base_options,
+        supports_behavior=supports_behavior,
+        supports_duration=supports_duration,
+    )
+
+
+@pytest.fixture
+async def target_persons(hass: HomeAssistant) -> dict[str, list[str]]:
+    """Create multiple person entities associated with different targets."""
+    return await target_entities(hass, "person", domain_excluded="sensor")
+
+
+@pytest.mark.parametrize(
+    ("trigger_target_config", "entity_id", "entities_in_target"),
+    parametrize_target_entities("person"),
+)
+@pytest.mark.parametrize(
+    ("trigger", "trigger_options", "states"),
+    [
+        *parametrize_trigger_states(
+            trigger="zone.entered",
+            trigger_options={"zone": TRIGGER_ZONES},
+            target_states=[
+                ("home", IN_ZONES_HOME),
+                ("Work", IN_ZONES_WORK),
+            ],
+            other_states=[
+                ("not_home", IN_ZONES_NONE),
+            ],
+        ),
+        *parametrize_trigger_states(
+            trigger="zone.left",
+            trigger_options={"zone": TRIGGER_ZONES},
+            target_states=[
+                ("not_home", IN_ZONES_NONE),
+            ],
+            other_states=[
+                ("home", IN_ZONES_HOME),
+                ("Work", IN_ZONES_WORK),
+            ],
+        ),
+    ],
+)
+async def test_zone_trigger_behavior_any(
+    hass: HomeAssistant,
+    target_persons: dict[str, list[str]],
+    trigger_target_config: dict[str, Any],
+    entity_id: str,
+    entities_in_target: int,
+    trigger: str,
+    trigger_options: dict[str, Any],
+    states: list[TriggerStateDescription],
+) -> None:
+    """Test zone triggers fire when any targeted entity changes."""
+    await assert_trigger_behavior_any(
+        hass,
+        target_entities=target_persons,
+        trigger_target_config=trigger_target_config,
+        entity_id=entity_id,
+        entities_in_target=entities_in_target,
+        trigger=trigger,
+        trigger_options=trigger_options,
+        states=states,
+    )
+
+
+@pytest.mark.parametrize(
+    ("trigger_target_config", "entity_id", "entities_in_target"),
+    parametrize_target_entities("person"),
+)
+@pytest.mark.parametrize(
+    ("trigger", "trigger_options", "states"),
+    [
+        *parametrize_trigger_states(
+            trigger="zone.entered",
+            trigger_options={"zone": TRIGGER_ZONES},
+            target_states=[
+                ("home", IN_ZONES_HOME),
+                ("Work", IN_ZONES_WORK),
+            ],
+            other_states=[
+                ("not_home", IN_ZONES_NONE),
+            ],
+        ),
+        *parametrize_trigger_states(
+            trigger="zone.left",
+            trigger_options={"zone": TRIGGER_ZONES},
+            target_states=[
+                ("not_home", IN_ZONES_NONE),
+            ],
+            other_states=[
+                ("home", IN_ZONES_HOME),
+                ("Work", IN_ZONES_WORK),
+            ],
+        ),
+    ],
+)
+async def test_zone_trigger_behavior_first(
+    hass: HomeAssistant,
+    target_persons: dict[str, list[str]],
+    trigger_target_config: dict[str, Any],
+    entity_id: str,
+    entities_in_target: int,
+    trigger: str,
+    trigger_options: dict[str, Any],
+    states: list[TriggerStateDescription],
+) -> None:
+    """Test zone triggers fire when first targeted entity changes."""
+    await assert_trigger_behavior_first(
+        hass,
+        target_entities=target_persons,
+        trigger_target_config=trigger_target_config,
+        entity_id=entity_id,
+        entities_in_target=entities_in_target,
+        trigger=trigger,
+        trigger_options=trigger_options,
+        states=states,
+    )
+
+
+@pytest.mark.parametrize(
+    ("trigger_target_config", "entity_id", "entities_in_target"),
+    parametrize_target_entities("person"),
+)
+@pytest.mark.parametrize(
+    ("trigger", "trigger_options", "states"),
+    [
+        *parametrize_trigger_states(
+            trigger="zone.entered",
+            trigger_options={"zone": TRIGGER_ZONES},
+            target_states=[
+                ("home", IN_ZONES_HOME),
+                ("Work", IN_ZONES_WORK),
+            ],
+            other_states=[
+                ("not_home", IN_ZONES_NONE),
+            ],
+        ),
+        *parametrize_trigger_states(
+            trigger="zone.left",
+            trigger_options={"zone": TRIGGER_ZONES},
+            target_states=[
+                ("not_home", IN_ZONES_NONE),
+            ],
+            other_states=[
+                ("home", IN_ZONES_HOME),
+                ("Work", IN_ZONES_WORK),
+            ],
+        ),
+    ],
+)
+async def test_zone_trigger_behavior_last(
+    hass: HomeAssistant,
+    target_persons: dict[str, list[str]],
+    trigger_target_config: dict[str, Any],
+    entity_id: str,
+    entities_in_target: int,
+    trigger: str,
+    trigger_options: dict[str, Any],
+    states: list[TriggerStateDescription],
+) -> None:
+    """Test zone triggers fire when last targeted entity changes."""
+    await assert_trigger_behavior_last(
+        hass,
+        target_entities=target_persons,
+        trigger_target_config=trigger_target_config,
+        entity_id=entity_id,
+        entities_in_target=entities_in_target,
+        trigger=trigger,
+        trigger_options=trigger_options,
+        states=states,
     )

--- a/tests/components/zone/test_trigger.py
+++ b/tests/components/zone/test_trigger.py
@@ -15,9 +15,9 @@ from homeassistant.setup import async_setup_component
 from tests.common import mock_component
 from tests.components.common import (
     TriggerStateDescription,
-    assert_trigger_behavior_any,
+    assert_trigger_behavior_all,
+    assert_trigger_behavior_each,
     assert_trigger_behavior_first,
-    assert_trigger_behavior_last,
     assert_trigger_options_supported,
     parametrize_target_entities,
     parametrize_trigger_states,
@@ -473,7 +473,7 @@ def _parametrize_zone_target_entities() -> list[tuple[dict[str, Any], str, int, 
     ("trigger", "trigger_options", "states"),
     _ZONE_TRIGGER_STATES,
 )
-async def test_zone_trigger_behavior_any(
+async def test_zone_trigger_behavior_each(
     hass: HomeAssistant,
     target_zone_entities: dict[str, list[str]],
     trigger_target_config: dict[str, Any],
@@ -484,7 +484,7 @@ async def test_zone_trigger_behavior_any(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test zone triggers fire when any targeted entity changes."""
-    await assert_trigger_behavior_any(
+    await assert_trigger_behavior_each(
         hass,
         target_entities=target_zone_entities,
         trigger_target_config=trigger_target_config,
@@ -535,7 +535,7 @@ async def test_zone_trigger_behavior_first(
     ("trigger", "trigger_options", "states"),
     _ZONE_TRIGGER_STATES,
 )
-async def test_zone_trigger_behavior_last(
+async def test_zone_trigger_behavior_all(
     hass: HomeAssistant,
     target_zone_entities: dict[str, list[str]],
     trigger_target_config: dict[str, Any],
@@ -546,7 +546,7 @@ async def test_zone_trigger_behavior_last(
     states: list[TriggerStateDescription],
 ) -> None:
     """Test zone triggers fire when last targeted entity changes."""
-    await assert_trigger_behavior_last(
+    await assert_trigger_behavior_all(
         hass,
         target_entities=target_zone_entities,
         trigger_target_config=trigger_target_config,

--- a/tests/components/zone/test_trigger.py
+++ b/tests/components/zone/test_trigger.py
@@ -3,11 +3,13 @@
 from typing import Any
 
 import pytest
+import voluptuous as vol
 
 from homeassistant.components import automation, zone
 from homeassistant.const import ATTR_ENTITY_ID, ENTITY_MATCH_ALL, SERVICE_TURN_OFF
 from homeassistant.core import Context, HomeAssistant, ServiceCall
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.trigger import async_validate_trigger_config
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_component
@@ -402,46 +404,78 @@ async def test_zone_trigger_options_validation(
     )
 
 
+@pytest.mark.parametrize("trigger_key", ["zone.entered", "zone.left"])
+async def test_zone_trigger_rejects_non_zone_entity_id(
+    hass: HomeAssistant, trigger_key: str
+) -> None:
+    """Test that the zone option must reference entities in the zone domain."""
+    with pytest.raises(vol.Invalid):
+        await async_validate_trigger_config(
+            hass,
+            [
+                {
+                    "platform": trigger_key,
+                    "target": {"entity_id": "person.alice"},
+                    "options": {"zone": "person.alice"},
+                }
+            ],
+        )
+
+
 @pytest.fixture
-async def target_persons(hass: HomeAssistant) -> dict[str, list[str]]:
-    """Create multiple person entities associated with different targets."""
-    return await target_entities(hass, "person", domain_excluded="sensor")
+async def target_zone_entities(
+    hass: HomeAssistant, domain: str
+) -> dict[str, list[str]]:
+    """Create multiple zone-trackable entities associated with different targets."""
+    return await target_entities(hass, domain, domain_excluded="sensor")
+
+
+_ZONE_TRIGGER_STATES = [
+    *parametrize_trigger_states(
+        trigger="zone.entered",
+        trigger_options={"zone": TRIGGER_ZONES},
+        target_states=[
+            ("home", IN_ZONES_HOME),
+            ("Work", IN_ZONES_WORK),
+        ],
+        other_states=[
+            ("not_home", IN_ZONES_NONE),
+        ],
+    ),
+    *parametrize_trigger_states(
+        trigger="zone.left",
+        trigger_options={"zone": TRIGGER_ZONES},
+        target_states=[
+            ("not_home", IN_ZONES_NONE),
+        ],
+        other_states=[
+            ("home", IN_ZONES_HOME),
+            ("Work", IN_ZONES_WORK),
+        ],
+    ),
+]
+
+
+def _parametrize_zone_target_entities() -> list[tuple[dict[str, Any], str, int, str]]:
+    """Parametrize target entities for all supported zone trigger domains."""
+    return [
+        (*params, domain)
+        for domain in ("person", "device_tracker")
+        for params in parametrize_target_entities(domain)
+    ]
 
 
 @pytest.mark.parametrize(
-    ("trigger_target_config", "entity_id", "entities_in_target"),
-    parametrize_target_entities("person"),
+    ("trigger_target_config", "entity_id", "entities_in_target", "domain"),
+    _parametrize_zone_target_entities(),
 )
 @pytest.mark.parametrize(
     ("trigger", "trigger_options", "states"),
-    [
-        *parametrize_trigger_states(
-            trigger="zone.entered",
-            trigger_options={"zone": TRIGGER_ZONES},
-            target_states=[
-                ("home", IN_ZONES_HOME),
-                ("Work", IN_ZONES_WORK),
-            ],
-            other_states=[
-                ("not_home", IN_ZONES_NONE),
-            ],
-        ),
-        *parametrize_trigger_states(
-            trigger="zone.left",
-            trigger_options={"zone": TRIGGER_ZONES},
-            target_states=[
-                ("not_home", IN_ZONES_NONE),
-            ],
-            other_states=[
-                ("home", IN_ZONES_HOME),
-                ("Work", IN_ZONES_WORK),
-            ],
-        ),
-    ],
+    _ZONE_TRIGGER_STATES,
 )
 async def test_zone_trigger_behavior_any(
     hass: HomeAssistant,
-    target_persons: dict[str, list[str]],
+    target_zone_entities: dict[str, list[str]],
     trigger_target_config: dict[str, Any],
     entity_id: str,
     entities_in_target: int,
@@ -452,7 +486,7 @@ async def test_zone_trigger_behavior_any(
     """Test zone triggers fire when any targeted entity changes."""
     await assert_trigger_behavior_any(
         hass,
-        target_entities=target_persons,
+        target_entities=target_zone_entities,
         trigger_target_config=trigger_target_config,
         entity_id=entity_id,
         entities_in_target=entities_in_target,
@@ -463,39 +497,16 @@ async def test_zone_trigger_behavior_any(
 
 
 @pytest.mark.parametrize(
-    ("trigger_target_config", "entity_id", "entities_in_target"),
-    parametrize_target_entities("person"),
+    ("trigger_target_config", "entity_id", "entities_in_target", "domain"),
+    _parametrize_zone_target_entities(),
 )
 @pytest.mark.parametrize(
     ("trigger", "trigger_options", "states"),
-    [
-        *parametrize_trigger_states(
-            trigger="zone.entered",
-            trigger_options={"zone": TRIGGER_ZONES},
-            target_states=[
-                ("home", IN_ZONES_HOME),
-                ("Work", IN_ZONES_WORK),
-            ],
-            other_states=[
-                ("not_home", IN_ZONES_NONE),
-            ],
-        ),
-        *parametrize_trigger_states(
-            trigger="zone.left",
-            trigger_options={"zone": TRIGGER_ZONES},
-            target_states=[
-                ("not_home", IN_ZONES_NONE),
-            ],
-            other_states=[
-                ("home", IN_ZONES_HOME),
-                ("Work", IN_ZONES_WORK),
-            ],
-        ),
-    ],
+    _ZONE_TRIGGER_STATES,
 )
 async def test_zone_trigger_behavior_first(
     hass: HomeAssistant,
-    target_persons: dict[str, list[str]],
+    target_zone_entities: dict[str, list[str]],
     trigger_target_config: dict[str, Any],
     entity_id: str,
     entities_in_target: int,
@@ -506,7 +517,7 @@ async def test_zone_trigger_behavior_first(
     """Test zone triggers fire when first targeted entity changes."""
     await assert_trigger_behavior_first(
         hass,
-        target_entities=target_persons,
+        target_entities=target_zone_entities,
         trigger_target_config=trigger_target_config,
         entity_id=entity_id,
         entities_in_target=entities_in_target,
@@ -517,39 +528,16 @@ async def test_zone_trigger_behavior_first(
 
 
 @pytest.mark.parametrize(
-    ("trigger_target_config", "entity_id", "entities_in_target"),
-    parametrize_target_entities("person"),
+    ("trigger_target_config", "entity_id", "entities_in_target", "domain"),
+    _parametrize_zone_target_entities(),
 )
 @pytest.mark.parametrize(
     ("trigger", "trigger_options", "states"),
-    [
-        *parametrize_trigger_states(
-            trigger="zone.entered",
-            trigger_options={"zone": TRIGGER_ZONES},
-            target_states=[
-                ("home", IN_ZONES_HOME),
-                ("Work", IN_ZONES_WORK),
-            ],
-            other_states=[
-                ("not_home", IN_ZONES_NONE),
-            ],
-        ),
-        *parametrize_trigger_states(
-            trigger="zone.left",
-            trigger_options={"zone": TRIGGER_ZONES},
-            target_states=[
-                ("not_home", IN_ZONES_NONE),
-            ],
-            other_states=[
-                ("home", IN_ZONES_HOME),
-                ("Work", IN_ZONES_WORK),
-            ],
-        ),
-    ],
+    _ZONE_TRIGGER_STATES,
 )
 async def test_zone_trigger_behavior_last(
     hass: HomeAssistant,
-    target_persons: dict[str, list[str]],
+    target_zone_entities: dict[str, list[str]],
     trigger_target_config: dict[str, Any],
     entity_id: str,
     entities_in_target: int,
@@ -560,7 +548,7 @@ async def test_zone_trigger_behavior_last(
     """Test zone triggers fire when last targeted entity changes."""
     await assert_trigger_behavior_last(
         hass,
-        target_entities=target_persons,
+        target_entities=target_zone_entities,
         trigger_target_config=trigger_target_config,
         entity_id=entity_id,
         entities_in_target=entities_in_target,

--- a/tests/components/zone/test_trigger.py
+++ b/tests/components/zone/test_trigger.py
@@ -377,14 +377,14 @@ ZONE_WORK = "zone.work"
 IN_ZONES_HOME = {"in_zones": [ZONE_HOME]}
 IN_ZONES_WORK = {"in_zones": [ZONE_WORK]}
 IN_ZONES_NONE: dict[str, list[str]] = {"in_zones": []}
-TRIGGER_ZONES = [ZONE_HOME, ZONE_WORK]
+TRIGGER_ZONE = ZONE_HOME
 
 
 @pytest.mark.parametrize(
     ("trigger_key", "base_options", "supports_behavior", "supports_duration"),
     [
-        ("zone.entered", {"zone": TRIGGER_ZONES}, True, True),
-        ("zone.left", {"zone": TRIGGER_ZONES}, True, True),
+        ("zone.entered", {"zone": TRIGGER_ZONE}, True, True),
+        ("zone.left", {"zone": TRIGGER_ZONE}, True, True),
     ],
 )
 async def test_zone_trigger_options_validation(
@@ -433,24 +433,24 @@ async def target_zone_entities(
 _ZONE_TRIGGER_STATES = [
     *parametrize_trigger_states(
         trigger="zone.entered",
-        trigger_options={"zone": TRIGGER_ZONES},
+        trigger_options={"zone": TRIGGER_ZONE},
         target_states=[
             ("home", IN_ZONES_HOME),
-            ("Work", IN_ZONES_WORK),
         ],
         other_states=[
             ("not_home", IN_ZONES_NONE),
+            ("Work", IN_ZONES_WORK),
         ],
     ),
     *parametrize_trigger_states(
         trigger="zone.left",
-        trigger_options={"zone": TRIGGER_ZONES},
+        trigger_options={"zone": TRIGGER_ZONE},
         target_states=[
             ("not_home", IN_ZONES_NONE),
+            ("Work", IN_ZONES_WORK),
         ],
         other_states=[
             ("home", IN_ZONES_HOME),
-            ("Work", IN_ZONES_WORK),
         ],
     ),
 ]

--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -4652,16 +4652,16 @@ async def test_entity_trigger_duration_cancelled_on_invalid_state(
             {
                 "platform": "zone.entered",
                 "target": {"entity_id": ["person.a", "device_tracker.b"]},
-                "options": {"zone": ["zone.home", "zone.work"]},
+                "options": {"zone": "zone.home"},
             },
-            ["person.a", "device_tracker.b", "zone.home", "zone.work"],
+            ["person.a", "device_tracker.b", "zone.home"],
             id="zone-entered-modern",
         ),
         pytest.param(
             {
                 "platform": "zone.left",
                 "target": {"entity_id": "person.a"},
-                "options": {"zone": ["zone.home"]},
+                "options": {"zone": "zone.home"},
             },
             ["person.a", "zone.home"],
             id="zone-left-modern",

--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -4639,12 +4639,32 @@ async def test_entity_trigger_duration_cancelled_on_invalid_state(
         pytest.param(
             {
                 "platform": "zone",
-                "entity_id": ["person.a"],
-                "zone": "zone.home",
-                "event": "enter",
+                "options": {
+                    "entity_id": ["person.a"],
+                    "zone": "zone.home",
+                    "event": "enter",
+                },
             },
             ["person.a", "zone.home"],
             id="zone-legacy",
+        ),
+        pytest.param(
+            {
+                "platform": "zone.entered",
+                "target": {"entity_id": ["person.a", "device_tracker.b"]},
+                "options": {"zone": ["zone.home", "zone.work"]},
+            },
+            ["person.a", "device_tracker.b", "zone.home", "zone.work"],
+            id="zone-entered-modern",
+        ),
+        pytest.param(
+            {
+                "platform": "zone.left",
+                "target": {"entity_id": "person.a"},
+                "options": {"zone": ["zone.home"]},
+            },
+            ["person.a", "zone.home"],
+            id="zone-left-modern",
         ),
         pytest.param(
             {"platform": "geo_location", "zone": "zone.home"},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add zone triggers entered/left zone

Same as reverted PR https://github.com/home-assistant/core/pull/171751, but with a commit from the future which adds zone occupied / zone unoccupied triggers removed

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
  - fixes https://github.com/home-assistant/core/issues/168373
  - fixes https://github.com/home-assistant/core/issues/168374
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
