### PR TITLE
Fix iZone integration broken by python-izone 1.2.10 API change

### DIFF
--- a/homeassistant/components/izone/climate.py
+++ b/homeassistant/components/izone/climate.py
@@ -94,7 +94,7 @@ async def async_setup_entry(
         async_add_entities(device.zones.values())
 
     # create any components not yet created
-    for controller in disco.pi_disco.controllers.values():
+    for controller in (await disco.pi_disco.fetch_controllers()).values():
         init_controller(controller)
 
     # connect to register any further components

--- a/homeassistant/components/izone/config_flow.py
+++ b/homeassistant/components/izone/config_flow.py
@@ -29,12 +29,13 @@ async def _async_has_devices(hass: HomeAssistant) -> bool:
         async with asyncio.timeout(TIMEOUT_DISCOVERY):
             await controller_ready.wait()
 
-    if not disco.pi_disco.controllers:
+    controllers = await disco.pi_disco.fetch_controllers()
+    if not controllers:
         await async_stop_discovery_service(hass)
         _LOGGER.debug("No controllers found")
         return False
 
-    _LOGGER.debug("Controllers %s", disco.pi_disco.controllers)
+    _LOGGER.debug("Controllers %s", controllers)
     return True
 
 

--- a/tests/components/izone/conftest.py
+++ b/tests/components/izone/conftest.py
@@ -26,7 +26,7 @@ def mock_config_entry() -> MockConfigEntry:
 def mock_pizone_discovery_service() -> Mock:
     """Create a mock pizone discovery service."""
     disco = Mock()
-    disco.controllers = {}
+    disco.fetch_controllers = AsyncMock(return_value={})
     disco.start_discovery = AsyncMock()
     disco.close = AsyncMock()
     return disco
@@ -96,9 +96,9 @@ async def mock_discovery(
         "homeassistant.components.izone.discovery.pizone.discovery", autospec=True
     ) as mock_disco:
         mock_disco.return_value.start_discovery = AsyncMock()
-        mock_disco.return_value.controllers = {
-            mock_controller.device_uid: mock_controller
-        }
+        mock_disco.return_value.fetch_controllers = AsyncMock(
+            return_value={mock_controller.device_uid: mock_controller}
+        )
         mock_disco.return_value.close = AsyncMock()
         yield mock_disco
 

--- a/tests/components/izone/test_config_flow.py
+++ b/tests/components/izone/test_config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -18,7 +18,7 @@ def mock_disco() -> Mock:
     """Mock discovery service."""
     disco = Mock()
     disco.pi_disco = Mock()
-    disco.pi_disco.controllers = {}
+    disco.pi_disco.fetch_controllers = AsyncMock(return_value={})
     return disco
 
 
@@ -60,7 +60,7 @@ async def test_not_found(hass: HomeAssistant, mock_disco: Mock) -> None:
 
 async def test_found(hass: HomeAssistant, mock_disco: Mock) -> None:
     """Test not finding iZone controller."""
-    mock_disco.pi_disco.controllers["blah"] = object()
+    mock_disco.pi_disco.fetch_controllers = AsyncMock(return_value={"blah": object()})
 
     with (
         patch(


### PR DESCRIPTION
## Proposed change

Update iZone integration to use the new `fetch_controllers()` async method instead of the removed `controllers` attribute. The `python-izone` library v1.2.10 (bumped in #172021) replaced the synchronous `controllers` property with an async `fetch_controllers()` method, breaking the integration on 2026.6.0b0.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #172406
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr