### PR TITLE
Fix SmartThings light checking wrong component for capabilities

### DIFF
--- a/homeassistant/components/smartthings/light.py
+++ b/homeassistant/components/smartthings/light.py
@@ -72,8 +72,10 @@ async def async_setup_entry(
         for device in entry_data.devices.values()
         for component in device.status
         if (
-            Capability.SWITCH in device.status[MAIN]
-            and any(capability in device.status[MAIN] for capability in CAPABILITIES)
+            Capability.SWITCH in device.status[component]
+            and any(
+                capability in device.status[component] for capability in CAPABILITIES
+            )
             and Capability.SAMSUNG_CE_LAMP not in device.status[component]
         )
     ]

--- a/tests/components/smartthings/__init__.py
+++ b/tests/components/smartthings/__init__.py
@@ -39,6 +39,7 @@ DEVICE_FIXTURES = [
     "copper_water_meter_v03",
     "base_electric_meter",
     "smart_plug",
+    "fibaro_dimmer_2",
     "vd_stv_2017_k",
     "c2c_arlo_pro_3_switch",
     "yale_push_button_deadbolt_lock",

--- a/tests/components/smartthings/fixtures/device_status/fibaro_dimmer_2.json
+++ b/tests/components/smartthings/fixtures/device_status/fibaro_dimmer_2.json
@@ -1,0 +1,70 @@
+{
+  "components": {
+    "button2": {
+      "button": {
+        "button": {
+          "value": null
+        },
+        "numberOfButtons": {
+          "value": null
+        },
+        "supportedButtonValues": {
+          "value": null
+        }
+      }
+    },
+    "main": {
+      "powerMeter": {
+        "power": {
+          "value": 0.0,
+          "unit": "W",
+          "timestamp": "2026-05-28T12:21:31.639Z"
+        }
+      },
+      "energyMeter": {
+        "energy": {
+          "value": 36.89,
+          "unit": "kWh",
+          "timestamp": "2026-05-28T12:32:57.766Z"
+        }
+      },
+      "switchLevel": {
+        "levelRange": {
+          "value": null
+        },
+        "level": {
+          "value": 0,
+          "unit": "%",
+          "timestamp": "2026-05-28T10:20:37.674Z"
+        }
+      },
+      "legendabsolute60149.forcedOnLevel": {
+        "forcedOnLevel": {
+          "value": 5,
+          "unit": "%",
+          "timestamp": "2026-05-21T15:10:35.371Z"
+        }
+      },
+      "refresh": {},
+      "switch": {
+        "switch": {
+          "value": "off",
+          "timestamp": "2026-05-28T10:20:37.616Z"
+        }
+      }
+    },
+    "button1": {
+      "button": {
+        "button": {
+          "value": null
+        },
+        "numberOfButtons": {
+          "value": null
+        },
+        "supportedButtonValues": {
+          "value": null
+        }
+      }
+    }
+  }
+}

--- a/tests/components/smartthings/fixtures/devices/fibaro_dimmer_2.json
+++ b/tests/components/smartthings/fixtures/devices/fibaro_dimmer_2.json
@@ -1,0 +1,110 @@
+{
+  "items": [
+    {
+      "deviceId": "df9f5405-f930-46aa-9693-14c570b35c83",
+      "name": "fibaro-dimmer-2",
+      "label": "Dimmer entr\u00e9 1 1",
+      "manufacturerName": "SmartThingsCommunity",
+      "presentationId": "b1b79065-1923-3e7a-b016-9abcc3d1d416",
+      "deviceManufacturerCode": "010F-0102-1001",
+      "locationId": "c85a9f8a-5d2e-4cdd-8bdb-bc49ba4a3544",
+      "ownerId": "7b68139b-d068-45d8-bf27-961320350024",
+      "roomId": "f4084bf6-2985-47cc-b3c9-3907d098ec0c",
+      "components": [
+        {
+          "id": "main",
+          "label": "main",
+          "capabilities": [
+            {
+              "id": "switch",
+              "version": 1
+            },
+            {
+              "id": "switchLevel",
+              "version": 1
+            },
+            {
+              "id": "powerMeter",
+              "version": 1
+            },
+            {
+              "id": "energyMeter",
+              "version": 1
+            },
+            {
+              "id": "legendabsolute60149.forcedOnLevel",
+              "version": 1
+            },
+            {
+              "id": "refresh",
+              "version": 1
+            }
+          ],
+          "categories": [
+            {
+              "name": "Switch",
+              "categoryType": "manufacturer"
+            }
+          ],
+          "optional": false
+        },
+        {
+          "id": "button1",
+          "label": "button1",
+          "capabilities": [
+            {
+              "id": "button",
+              "version": 1
+            }
+          ],
+          "categories": [
+            {
+              "name": "RemoteController",
+              "categoryType": "manufacturer"
+            }
+          ],
+          "optional": false
+        },
+        {
+          "id": "button2",
+          "label": "button2",
+          "capabilities": [
+            {
+              "id": "button",
+              "version": 1
+            }
+          ],
+          "categories": [
+            {
+              "name": "RemoteController",
+              "categoryType": "manufacturer"
+            }
+          ],
+          "optional": false
+        }
+      ],
+      "createTime": "2023-04-23T06:35:16.202Z",
+      "parentDeviceId": "4869d882-e898-40c3-a198-7611b72187a5",
+      "profile": {
+        "id": "c6edf569-c7bb-38e7-a442-fe397ebe0cae"
+      },
+      "zwave": {
+        "networkId": "0A",
+        "driverId": "17c05c19-f008-42e2-aa12-f12f1aae5612",
+        "executingLocally": true,
+        "hubId": "4869d882-e898-40c3-a198-7611b72187a5",
+        "networkSecurityLevel": "ZWAVE_S0_LEGACY",
+        "provisioningState": "NONFUNCTIONAL",
+        "manufacturerId": 271,
+        "productType": 258,
+        "productId": 4097
+      },
+      "type": "ZWAVE",
+      "restrictionTier": 0,
+      "allowed": null,
+      "executionContext": "LOCAL",
+      "relationships": []
+    }
+  ],
+  "_links": {}
+}

--- a/tests/components/smartthings/snapshots/test_event.ambr
+++ b/tests/components/smartthings/snapshots/test_event.ambr
@@ -1,4 +1,114 @@
 # serializer version: 1
+# name: test_all_entities[fibaro_dimmer_2][event.dimmer_entre_1_1_button1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'event_types': None,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'event',
+    'entity_category': None,
+    'entity_id': 'event.dimmer_entre_1_1_button1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'button1',
+    'options': dict({
+    }),
+    'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
+    'original_icon': None,
+    'original_name': 'button1',
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'button',
+    'unique_id': 'df9f5405-f930-46aa-9693-14c570b35c83_button1_button',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[fibaro_dimmer_2][event.dimmer_entre_1_1_button1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'button',
+      'event_type': None,
+      'event_types': None,
+      'friendly_name': 'Dimmer entré 1 1 button1',
+    }),
+    'context': <ANY>,
+    'entity_id': 'event.dimmer_entre_1_1_button1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_all_entities[fibaro_dimmer_2][event.dimmer_entre_1_1_button2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'event_types': None,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'event',
+    'entity_category': None,
+    'entity_id': 'event.dimmer_entre_1_1_button2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'button2',
+    'options': dict({
+    }),
+    'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
+    'original_icon': None,
+    'original_name': 'button2',
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'button',
+    'unique_id': 'df9f5405-f930-46aa-9693-14c570b35c83_button2_button',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[fibaro_dimmer_2][event.dimmer_entre_1_1_button2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'button',
+      'event_type': None,
+      'event_types': None,
+      'friendly_name': 'Dimmer entré 1 1 button2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'event.dimmer_entre_1_1_button2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_all_entities[heatit_zpushwall][event.livingroom_smart_switch_button1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/smartthings/snapshots/test_init.ambr
+++ b/tests/components/smartthings/snapshots/test_init.ambr
@@ -1828,6 +1828,37 @@
     'via_device_id': None,
   })
 # ---
+# name: test_devices[fibaro_dimmer_2]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': 'https://account.smartthings.com',
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'smartthings',
+        'df9f5405-f930-46aa-9693-14c570b35c83',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': None,
+    'model': None,
+    'model_id': None,
+    'name': 'Dimmer entré 1 1',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
 # name: test_devices[gas_detector]
   DeviceRegistryEntrySnapshot({
     'area_id': None,

--- a/tests/components/smartthings/snapshots/test_light.ambr
+++ b/tests/components/smartthings/snapshots/test_light.ambr
@@ -542,6 +542,66 @@
     'state': 'on',
   })
 # ---
+# name: test_all_entities[fibaro_dimmer_2][light.dimmer_entre_1_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'supported_color_modes': list([
+        <ColorMode.BRIGHTNESS: 'brightness'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.dimmer_entre_1_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <LightEntityFeature: 32>,
+    'translation_key': None,
+    'unique_id': 'df9f5405-f930-46aa-9693-14c570b35c83_main',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[fibaro_dimmer_2][light.dimmer_entre_1_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'brightness': None,
+      'color_mode': None,
+      'friendly_name': 'Dimmer entré 1 1',
+      'supported_color_modes': list([
+        <ColorMode.BRIGHTNESS: 'brightness'>,
+      ]),
+      'supported_features': <LightEntityFeature: 32>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.dimmer_entre_1_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_all_entities[ge_in_wall_smart_dimmer][light.theater_basement_exit_light-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/smartthings/snapshots/test_sensor.ambr
+++ b/tests/components/smartthings/snapshots/test_sensor.ambr
@@ -19725,6 +19725,122 @@
     'state': 'unknown',
   })
 # ---
+# name: test_all_entities[fibaro_dimmer_2][sensor.dimmer_entre_1_1_energy-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.dimmer_entre_1_1_energy',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Energy',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': None,
+    'original_name': 'Energy',
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'df9f5405-f930-46aa-9693-14c570b35c83_main_energyMeter_energy_energy',
+    'unit_of_measurement': 'kWh',
+  })
+# ---
+# name: test_all_entities[fibaro_dimmer_2][sensor.dimmer_entre_1_1_energy-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Dimmer entré 1 1 Energy',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': 'kWh',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.dimmer_entre_1_1_energy',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '36.89',
+  })
+# ---
+# name: test_all_entities[fibaro_dimmer_2][sensor.dimmer_entre_1_1_power-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.dimmer_entre_1_1_power',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Power',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Power',
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'df9f5405-f930-46aa-9693-14c570b35c83_main_powerMeter_power_power',
+    'unit_of_measurement': 'W',
+  })
+# ---
+# name: test_all_entities[fibaro_dimmer_2][sensor.dimmer_entre_1_1_power-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Dimmer entré 1 1 Power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'W',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.dimmer_entre_1_1_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
 # name: test_all_entities[gas_detector][sensor.gas_detector_link_quality-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([


### PR DESCRIPTION
## Proposed change

Fix SmartThings light entity creation to check the current component's capabilities instead of always checking the main component. Previously, the setup iterated over all device components but only checked `device.status[MAIN]` for `SWITCH` and lighting capabilities. This caused entities to be created for sub-components (e.g., `main-1`, `main-2` on Fibaro dimmers) that don't have the `SWITCH` capability, resulting in `KeyError` crashes when the entity tried to read its state.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #169726
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr