### PR TITLE
Fix Jellyfin media source crash when entry is not loaded

### DIFF
--- a/homeassistant/components/jellyfin/media_source.py
+++ b/homeassistant/components/jellyfin/media_source.py
@@ -52,13 +52,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_get_media_source(hass: HomeAssistant) -> MediaSource:
     """Set up Jellyfin media source."""
-    # Currently only a single Jellyfin server is supported
-    if not (entries := hass.config_entries.async_loaded_entries(DOMAIN)):
-        raise BrowseError("Jellyfin integration not loaded")
-    entry: JellyfinConfigEntry = entries[0]
-    coordinator = entry.runtime_data
-
-    return JellyfinSource(hass, coordinator.api_client, entry)
+    return JellyfinSource(hass)
 
 
 class JellyfinSource(MediaSource):
@@ -66,21 +60,28 @@ class JellyfinSource(MediaSource):
 
     name: str = "Jellyfin"
 
-    def __init__(
-        self, hass: HomeAssistant, client: JellyfinClient, entry: JellyfinConfigEntry
-    ) -> None:
+    def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the Jellyfin media source."""
         super().__init__(DOMAIN)
-
         self.hass = hass
-        self.entry = entry
+        self.entry: JellyfinConfigEntry
+        self.client: JellyfinClient
+        self.api: Any
+        self.url: str
 
-        self.client = client
-        self.api = client.jellyfin
-        self.url = jellyfin_url(client, "")
+    def _ensure_loaded(self) -> None:
+        """Ensure the Jellyfin integration is loaded and set up instance state."""
+        if not (entries := self.hass.config_entries.async_loaded_entries(DOMAIN)):
+            raise BrowseError("Jellyfin integration not loaded")
+        entry: JellyfinConfigEntry = entries[0]
+        self.entry = entry
+        self.client = entry.runtime_data.api_client
+        self.api = self.client.jellyfin
+        self.url = jellyfin_url(self.client, "")
 
     async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:
         """Return a streamable URL and associated mime type."""
+        self._ensure_loaded()
         media_item = await self.hass.async_add_executor_job(
             self.api.get_item, item.identifier
         )
@@ -96,6 +97,7 @@ class JellyfinSource(MediaSource):
 
     async def async_browse_media(self, item: MediaSourceItem) -> BrowseMediaSource:
         """Return a browsable Jellyfin media source."""
+        self._ensure_loaded()
         if not item.identifier:
             return await self._build_libraries()
 

--- a/homeassistant/components/jellyfin/media_source.py
+++ b/homeassistant/components/jellyfin/media_source.py
@@ -53,7 +53,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_get_media_source(hass: HomeAssistant) -> MediaSource:
     """Set up Jellyfin media source."""
     # Currently only a single Jellyfin server is supported
-    entry: JellyfinConfigEntry = hass.config_entries.async_entries(DOMAIN)[0]
+    entry: JellyfinConfigEntry = hass.config_entries.async_loaded_entries(DOMAIN)[0]
     coordinator = entry.runtime_data
 
     return JellyfinSource(hass, coordinator.api_client, entry)

--- a/homeassistant/components/jellyfin/media_source.py
+++ b/homeassistant/components/jellyfin/media_source.py
@@ -53,7 +53,10 @@ _LOGGER = logging.getLogger(__name__)
 async def async_get_media_source(hass: HomeAssistant) -> MediaSource:
     """Set up Jellyfin media source."""
     # Currently only a single Jellyfin server is supported
-    entry: JellyfinConfigEntry = hass.config_entries.async_loaded_entries(DOMAIN)[0]
+    entries = hass.config_entries.async_loaded_entries(DOMAIN)
+    if not entries:
+        raise BrowseError("Jellyfin integration not loaded")
+    entry: JellyfinConfigEntry = entries[0]
     coordinator = entry.runtime_data
 
     return JellyfinSource(hass, coordinator.api_client, entry)

--- a/homeassistant/components/jellyfin/media_source.py
+++ b/homeassistant/components/jellyfin/media_source.py
@@ -53,8 +53,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_get_media_source(hass: HomeAssistant) -> MediaSource:
     """Set up Jellyfin media source."""
     # Currently only a single Jellyfin server is supported
-    entries = hass.config_entries.async_loaded_entries(DOMAIN)
-    if not entries:
+    if not (entries := hass.config_entries.async_loaded_entries(DOMAIN)):
         raise BrowseError("Jellyfin integration not loaded")
     entry: JellyfinConfigEntry = entries[0]
     coordinator = entry.runtime_data


### PR DESCRIPTION
## Proposed change

Use `async_loaded_entries()` instead of `async_entries()` when getting the Jellyfin config entry in the media source. `async_entries()` returns all entries including ones that failed to set up, which don't have `runtime_data` and crash with `AttributeError`. This can happen when the Jellyfin server is temporarily unreachable during HA startup.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #169716
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr