### PR TITLE
ovhcloud_ai_endpoints: update quality scale to silver

### DIFF
--- a/homeassistant/components/ovhcloud_ai_endpoints/conversation.py
+++ b/homeassistant/components/ovhcloud_ai_endpoints/conversation.py
@@ -12,6 +12,8 @@ from . import OVHcloudAIEndpointsConfigEntry
 from .const import DOMAIN
 from .entity import OVHcloudAIEndpointsEntity
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/ovhcloud_ai_endpoints/manifest.json
+++ b/homeassistant/components/ovhcloud_ai_endpoints/manifest.json
@@ -8,6 +8,6 @@
   "documentation": "https://www.home-assistant.io/integrations/ovhcloud_ai_endpoints",
   "integration_type": "service",
   "iot_class": "cloud_polling",
-  "quality_scale": "bronze",
+  "quality_scale": "silver",
   "requirements": ["openai==2.21.0"]
 }

--- a/homeassistant/components/ovhcloud_ai_endpoints/quality_scale.yaml
+++ b/homeassistant/components/ovhcloud_ai_endpoints/quality_scale.yaml
@@ -30,7 +30,9 @@ rules:
   unique-config-entry: done
 
   # Silver
-  action-exceptions: done
+  action-exceptions:
+    status: exempt
+    comment: This integration does not register custom actions.
   config-entry-unloading: done
   docs-configuration-parameters:
     status: exempt
@@ -43,7 +45,9 @@ rules:
   log-when-unavailable:
     status: exempt
     comment: the integration only integrates stateless entities
-  parallel-updates: todo
+  parallel-updates:
+    status: exempt
+    comment: the integration only implements a stateless conversation entity.
   reauthentication-flow: done
   test-coverage: done
 

--- a/homeassistant/components/ovhcloud_ai_endpoints/quality_scale.yaml
+++ b/homeassistant/components/ovhcloud_ai_endpoints/quality_scale.yaml
@@ -45,9 +45,7 @@ rules:
   log-when-unavailable:
     status: exempt
     comment: the integration only integrates stateless entities
-  parallel-updates:
-    status: exempt
-    comment: the integration only implements a stateless conversation entity.
+  parallel-updates: done
   reauthentication-flow: done
   test-coverage: done
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Update quality scale of ovhcloud_ai_endpoints to silver

### Quality scale checklist

- [x] `action-exceptions` - Service actions raise exceptions when encountering failures: exempt
- [x] `config-entry-unloading` - Support config entry unloading: [initial PR][initial]
- [x] `docs-configuration-parameters` - The documentation describes all integration configuration options: [initial docs PR][docs]
- [x] `docs-installation-parameters` - The documentation describes all integration installation parameters: [initial docs PR][docs]
- [x] `entity-unavailable` - Mark entity unavailable if appropriate: exempt
- [x] `integration-owner` - Has an integration owner: [initial PR][initial]
- [x] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected: exempt
- [x] `parallel-updates` - Number of parallel updates is specified: exempt
- [x] `reauthentication-flow` - Reauthentication needs to be available via the UI: https://github.com/home-assistant/core/pull/172405
- [x] `test-coverage` - Above 95% test coverage for all integration modules: https://github.com/home-assistant/core/pull/172439

[initial]: https://github.com/home-assistant/core/pull/171402
[docs]: https://github.com/home-assistant/home-assistant.io/pull/45472

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
