### PR TITLE
Fix Hue light ZeroDivisionError when mirek value is zero

### DIFF
--- a/homeassistant/components/hue/v2/light.py
+++ b/homeassistant/components/hue/v2/light.py
@@ -178,17 +178,21 @@ class HueLight(HueBaseEntity, LightEntity):
     @property
     def max_color_temp_mireds(self) -> int:
         """Return the warmest color_temp in mireds that this light supports."""
-        if color_temp := self.resource.color_temperature:
-            return color_temp.mirek_schema.mirek_maximum
-        # return a fallback value if the light doesn't provide limits
+        if (color_temp := self.resource.color_temperature) and (
+            mirek_max := color_temp.mirek_schema.mirek_maximum
+        ):
+            return mirek_max
+        # return a fallback value if the light doesn't provide valid limits
         return FALLBACK_MAX_MIREDS
 
     @property
     def min_color_temp_mireds(self) -> int:
         """Return the coldest color_temp in mireds that this light supports."""
-        if color_temp := self.resource.color_temperature:
-            return color_temp.mirek_schema.mirek_minimum
-        # return a fallback value if the light doesn't provide limits
+        if (color_temp := self.resource.color_temperature) and (
+            mirek_min := color_temp.mirek_schema.mirek_minimum
+        ):
+            return mirek_min
+        # return a fallback value if the light doesn't provide valid limits
         return FALLBACK_MIN_MIREDS
 
     @property

--- a/tests/components/hue/test_light_v2.py
+++ b/tests/components/hue/test_light_v2.py
@@ -1046,3 +1046,29 @@ async def test_light_turn_on_service_deprecation(
         blocking=True,
     )
     assert mock_bridge_v2.mock_requests[0]["json"]["effects"]["effect"] == "no_effect"
+
+
+async def test_light_with_zero_mirek(
+    hass: HomeAssistant, mock_bridge_v2: Mock, v2_resources_test_data: JsonArrayType
+) -> None:
+    """Test light doesn't crash when bridge reports zero mirek values.
+
+    Regression test for https://github.com/home-assistant/core/issues/116258
+    """
+    # Patch the fixture data to have zero mirek values before loading
+    for resource in v2_resources_test_data:
+        if resource.get("type") == "light" and "color_temperature" in resource:
+            resource["color_temperature"]["mirek_schema"]["mirek_minimum"] = 0
+            resource["color_temperature"]["mirek_schema"]["mirek_maximum"] = 0
+            break
+
+    await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
+
+    # Should not raise ZeroDivisionError during setup
+    await setup_platform(hass, mock_bridge_v2, Platform.LIGHT)
+
+    test_light = hass.states.get("light.hue_light_with_color_and_color_temperature_1")
+    assert test_light is not None
+    # Should fall back to defaults instead of crashing
+    assert test_light.attributes["max_color_temp_kelvin"] == 6535
+    assert test_light.attributes["min_color_temp_kelvin"] == 2000


### PR DESCRIPTION
## Proposed change

Guard against zero mirek values in the Hue v2 light entity's color temperature properties. Some Hue lights (e.g., brightness-only innr PL 110) report `mirek_minimum` or `mirek_maximum` as 0 from the bridge, which causes a `ZeroDivisionError` in `color_temperature_mired_to_kelvin()`. Now falls back to the default mireds values when the bridge reports zero.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #116258
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr