### PR TITLE
Fix Duco regression where entities become unavailable when LAN info fetch fails

### DIFF
--- a/homeassistant/components/duco/coordinator.py
+++ b/homeassistant/components/duco/coordinator.py
@@ -100,13 +100,11 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
             ) from err
 
         # LAN info only backs the diagnostic RSSI sensor, so failures on this
-        # supplemental endpoint should not make the primary node entities
-        # unavailable.
+        # supplemental endpoint, including connection failures, should not make
+        # the primary node entities unavailable.
         rssi_wifi = self.data.rssi_wifi if self.data else None
         try:
             lan_info = await self.client.async_get_lan_info()
-        except DucoConnectionError as err:
-            _LOGGER.debug("Could not fetch Duco LAN info", exc_info=err)
         except DucoError as err:
             _LOGGER.debug("Could not fetch Duco LAN info", exc_info=err)
         else:

--- a/homeassistant/components/duco/coordinator.py
+++ b/homeassistant/components/duco/coordinator.py
@@ -86,7 +86,6 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
         """Fetch node data from the Duco box."""
         try:
             nodes = await self.client.async_get_nodes()
-            lan_info = await self.client.async_get_lan_info()
         except DucoConnectionError as err:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
@@ -100,7 +99,18 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
                 translation_placeholders={"error": repr(err)},
             ) from err
 
+        # LAN info only backs the diagnostic RSSI sensor, so failures on this
+        # supplemental endpoint should not make the primary node entities
+        # unavailable.
+        rssi_wifi = self.data.rssi_wifi if self.data else None
+        try:
+            lan_info = await self.client.async_get_lan_info()
+        except DucoError as err:
+            _LOGGER.debug("Could not fetch Duco LAN info", exc_info=err)
+        else:
+            rssi_wifi = lan_info.rssi_wifi
+
         return DucoData(
             nodes={node.node_id: node for node in nodes},
-            rssi_wifi=lan_info.rssi_wifi,
+            rssi_wifi=rssi_wifi,
         )

--- a/homeassistant/components/duco/coordinator.py
+++ b/homeassistant/components/duco/coordinator.py
@@ -105,6 +105,8 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
         rssi_wifi = self.data.rssi_wifi if self.data else None
         try:
             lan_info = await self.client.async_get_lan_info()
+        except DucoConnectionError as err:
+            _LOGGER.debug("Could not fetch Duco LAN info", exc_info=err)
         except DucoError as err:
             _LOGGER.debug("Could not fetch Duco LAN info", exc_info=err)
         else:

--- a/tests/components/duco/test_init.py
+++ b/tests/components/duco/test_init.py
@@ -98,6 +98,21 @@ async def test_setup_entry_success(
     assert init_integration.state is ConfigEntryState.LOADED
 
 
+async def test_setup_entry_ignores_lan_info_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_duco_client: AsyncMock,
+) -> None:
+    """Test setup succeeds when the supplemental LAN info endpoint fails."""
+    mock_duco_client.async_get_lan_info.side_effect = DucoError("lan info error")
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+
 @pytest.mark.parametrize("unsupported_board_info", UNSUPPORTED_BOARD_INFOS)
 async def test_setup_entry_unsupported_board_info(
     hass: HomeAssistant,

--- a/tests/components/duco/test_init.py
+++ b/tests/components/duco/test_init.py
@@ -98,13 +98,21 @@ async def test_setup_entry_success(
     assert init_integration.state is ConfigEntryState.LOADED
 
 
-async def test_setup_entry_ignores_lan_info_error(
+@pytest.mark.parametrize(
+    "exception",
+    [
+        pytest.param(DucoError("lan info error"), id="duco_error"),
+        pytest.param(DucoConnectionError("lan info offline"), id="connection_error"),
+    ],
+)
+async def test_setup_entry_ignores_lan_info_failures(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_duco_client: AsyncMock,
+    exception: Exception,
 ) -> None:
     """Test setup succeeds when the supplemental LAN info endpoint fails."""
-    mock_duco_client.async_get_lan_info.side_effect = DucoError("lan info error")
+    mock_duco_client.async_get_lan_info.side_effect = exception
     mock_config_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -123,12 +123,12 @@ async def test_coordinator_update_duco_error_marks_unavailable(
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
-async def test_lan_info_duco_error_marks_unavailable(
+async def test_lan_info_duco_error_keeps_node_entities_available(
     hass: HomeAssistant,
     mock_duco_client: AsyncMock,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test entities become unavailable when async_get_lan_info raises DucoError."""
+    """Test node entities stay available when async_get_lan_info raises DucoError."""
     mock_duco_client.async_get_lan_info = AsyncMock(
         side_effect=DucoError("lan info error")
     )
@@ -137,9 +137,13 @@ async def test_lan_info_duco_error_marks_unavailable(
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
+    state = hass.states.get("sensor.office_co2_carbon_dioxide")
+    assert state is not None
+    assert state.state == "405"
+
     state = hass.states.get("sensor.living_signal_strength")
     assert state is not None
-    assert state.state == STATE_UNAVAILABLE
+    assert state.state == "-60"
 
 
 @pytest.mark.parametrize(

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -122,16 +122,22 @@ async def test_coordinator_update_duco_error_marks_unavailable(
     assert state.state == STATE_UNAVAILABLE
 
 
+@pytest.mark.parametrize(
+    "exception",
+    [
+        pytest.param(DucoError("lan info error"), id="duco_error"),
+        pytest.param(DucoConnectionError("lan info offline"), id="connection_error"),
+    ],
+)
 @pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
-async def test_lan_info_duco_error_keeps_node_entities_available(
+async def test_lan_info_failures_keep_node_entities_available(
     hass: HomeAssistant,
     mock_duco_client: AsyncMock,
     freezer: FrozenDateTimeFactory,
+    exception: Exception,
 ) -> None:
-    """Test node entities stay available when async_get_lan_info raises DucoError."""
-    mock_duco_client.async_get_lan_info = AsyncMock(
-        side_effect=DucoError("lan info error")
-    )
+    """Test node entities stay available when LAN info retrieval fails."""
+    mock_duco_client.async_get_lan_info = AsyncMock(side_effect=exception)
 
     freezer.tick(SCAN_INTERVAL)
     async_fire_time_changed(hass)


### PR DESCRIPTION
## Proposed change
Adjust the Duco coordinator so failures from `async_get_lan_info()` no longer fail the whole update cycle.

LAN info only backs the diagnostic RSSI sensor, so node polling remains the authoritative path and the primary Duco fan and sensor entities stay available when that supplemental endpoint fails.

> [!IMPORTANT]
> This issue surfaced during the current beta test cycle. If possible, please include this fix in the upcoming release.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: n/a
- This PR is related to issue: n/a
- Link to documentation pull request: n/a
- Link to developer documentation pull request: n/a
- Link to frontend pull request: n/a

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr