### PR TITLE
Fix Matter BLE proxy blocking startup

### DIFF
--- a/homeassistant/components/matter/ble_proxy.py
+++ b/homeassistant/components/matter/ble_proxy.py
@@ -104,7 +104,6 @@ def _to_advertisement_data(
 
 def create_matter_ble_proxy(hass: HomeAssistant, ws_url: str) -> MatterBleProxy:
     """Return a `MatterBleProxy` wired into Home Assistant's bluetooth component."""
-
     return MatterBleProxy(
         ws_url=ws_url,
         scan_source=HaBluetoothScanSource(hass),

--- a/homeassistant/components/matter/ble_proxy.py
+++ b/homeassistant/components/matter/ble_proxy.py
@@ -10,8 +10,10 @@ See `docs/ble-proxy-protocol.md` in the matter-server repository for the
 protocol specification.
 """
 
-from collections.abc import Callable
+import asyncio
+from collections.abc import Callable, Coroutine
 import logging
+from typing import Any
 
 from bleak.backends.device import BLEDevice
 from home_assistant_bluetooth import BluetoothServiceInfoBleak
@@ -104,9 +106,18 @@ def _to_advertisement_data(
 
 def create_matter_ble_proxy(hass: HomeAssistant, ws_url: str) -> MatterBleProxy:
     """Return a `MatterBleProxy` wired into Home Assistant's bluetooth component."""
+
+    def _background_task_factory(
+        coro: Coroutine[Any, Any, Any],
+    ) -> asyncio.Task[Any]:
+        # Background task: the library's `_message_loop` runs for the lifetime
+        # of the connection, so `async_create_task` would block bootstrap until
+        # the startup timeout fires.
+        return hass.async_create_background_task(coro, name="matter_ble_proxy")
+
     return MatterBleProxy(
         ws_url=ws_url,
         scan_source=HaBluetoothScanSource(hass),
         device_resolver=HaBluetoothDeviceResolver(hass),
-        task_factory=hass.async_create_task,
+        task_factory=_background_task_factory,
     )

--- a/homeassistant/components/matter/ble_proxy.py
+++ b/homeassistant/components/matter/ble_proxy.py
@@ -10,10 +10,8 @@ See `docs/ble-proxy-protocol.md` in the matter-server repository for the
 protocol specification.
 """
 
-import asyncio
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable
 import logging
-from typing import Any
 
 from bleak.backends.device import BLEDevice
 from home_assistant_bluetooth import BluetoothServiceInfoBleak
@@ -107,17 +105,11 @@ def _to_advertisement_data(
 def create_matter_ble_proxy(hass: HomeAssistant, ws_url: str) -> MatterBleProxy:
     """Return a `MatterBleProxy` wired into Home Assistant's bluetooth component."""
 
-    def _background_task_factory(
-        coro: Coroutine[Any, Any, Any],
-    ) -> asyncio.Task[Any]:
-        # Background task: the library's `_message_loop` runs for the lifetime
-        # of the connection, so `async_create_task` would block bootstrap until
-        # the startup timeout fires.
-        return hass.async_create_background_task(coro, name="matter_ble_proxy")
-
     return MatterBleProxy(
         ws_url=ws_url,
         scan_source=HaBluetoothScanSource(hass),
         device_resolver=HaBluetoothDeviceResolver(hass),
-        task_factory=_background_task_factory,
+        task_factory=lambda coro: hass.async_create_background_task(
+            coro, name="matter_ble_proxy"
+        ),
     )

--- a/tests/components/matter/test_ble_proxy.py
+++ b/tests/components/matter/test_ble_proxy.py
@@ -73,9 +73,12 @@ def test_create_matter_ble_proxy_wires_ha_backends(hass: HomeAssistant) -> None:
 
     # The library's long-running `_message_loop` must run as a background task,
     # otherwise HA bootstrap waits on it and times out (#172380).
+    coro = MagicMock()
     with patch.object(hass, "async_create_background_task") as bg_task:
-        kwargs["task_factory"](MagicMock())
-    bg_task.assert_called_once()
+        task = kwargs["task_factory"](coro)
+
+    bg_task.assert_called_once_with(coro, name="matter_ble_proxy")
+    assert task is bg_task.return_value
 
 
 async def test_scan_source_start_registers_passive_callback(

--- a/tests/components/matter/test_ble_proxy.py
+++ b/tests/components/matter/test_ble_proxy.py
@@ -59,7 +59,7 @@ def test_to_advertisement_data_translates_fields() -> None:
     assert ad.service_uuids == list(info.service_uuids)
 
 
-def test_create_matter_ble_proxy_wires_ha_backends(hass: HomeAssistant) -> None:
+async def test_create_matter_ble_proxy_wires_ha_backends(hass: HomeAssistant) -> None:
     """Factory builds MatterBleProxy with HA-backed scan_source and resolver."""
     with patch("homeassistant.components.matter.ble_proxy.MatterBleProxy") as proxy_cls:
         result = create_matter_ble_proxy(hass, "ws://localhost:5580/ble")
@@ -69,8 +69,21 @@ def test_create_matter_ble_proxy_wires_ha_backends(hass: HomeAssistant) -> None:
     assert kwargs["ws_url"] == "ws://localhost:5580/ble"
     assert isinstance(kwargs["scan_source"], HaBluetoothScanSource)
     assert isinstance(kwargs["device_resolver"], HaBluetoothDeviceResolver)
-    assert kwargs["task_factory"] == hass.async_create_task
     assert result is proxy_cls.return_value
+
+    # The library's long-running `_message_loop` would block Home Assistant's
+    # startup if scheduled via `async_create_task`; it must use a background task.
+    async def _noop() -> None:
+        return
+
+    with patch.object(
+        hass, "async_create_background_task", wraps=hass.async_create_background_task
+    ) as create_background:
+        task = kwargs["task_factory"](_noop())
+
+    create_background.assert_called_once()
+    assert create_background.call_args.kwargs.get("name") == "matter_ble_proxy"
+    await task
 
 
 async def test_scan_source_start_registers_passive_callback(

--- a/tests/components/matter/test_ble_proxy.py
+++ b/tests/components/matter/test_ble_proxy.py
@@ -71,8 +71,6 @@ def test_create_matter_ble_proxy_wires_ha_backends(hass: HomeAssistant) -> None:
     assert isinstance(kwargs["device_resolver"], HaBluetoothDeviceResolver)
     assert result is proxy_cls.return_value
 
-    # The library's long-running `_message_loop` must run as a background task,
-    # otherwise HA bootstrap waits on it and times out (#172380).
     coro = MagicMock()
     with patch.object(hass, "async_create_background_task") as bg_task:
         task = kwargs["task_factory"](coro)

--- a/tests/components/matter/test_ble_proxy.py
+++ b/tests/components/matter/test_ble_proxy.py
@@ -59,7 +59,7 @@ def test_to_advertisement_data_translates_fields() -> None:
     assert ad.service_uuids == list(info.service_uuids)
 
 
-async def test_create_matter_ble_proxy_wires_ha_backends(hass: HomeAssistant) -> None:
+def test_create_matter_ble_proxy_wires_ha_backends(hass: HomeAssistant) -> None:
     """Factory builds MatterBleProxy with HA-backed scan_source and resolver."""
     with patch("homeassistant.components.matter.ble_proxy.MatterBleProxy") as proxy_cls:
         result = create_matter_ble_proxy(hass, "ws://localhost:5580/ble")
@@ -71,19 +71,11 @@ async def test_create_matter_ble_proxy_wires_ha_backends(hass: HomeAssistant) ->
     assert isinstance(kwargs["device_resolver"], HaBluetoothDeviceResolver)
     assert result is proxy_cls.return_value
 
-    # The library's long-running `_message_loop` would block Home Assistant's
-    # startup if scheduled via `async_create_task`; it must use a background task.
-    async def _noop() -> None:
-        return
-
-    with patch.object(
-        hass, "async_create_background_task", wraps=hass.async_create_background_task
-    ) as create_background:
-        task = kwargs["task_factory"](_noop())
-
-    create_background.assert_called_once()
-    assert create_background.call_args.kwargs.get("name") == "matter_ble_proxy"
-    await task
+    # The library's long-running `_message_loop` must run as a background task,
+    # otherwise HA bootstrap waits on it and times out (#172380).
+    with patch.object(hass, "async_create_background_task") as bg_task:
+        kwargs["task_factory"](MagicMock())
+    bg_task.assert_called_once()
 
 
 async def test_scan_source_start_registers_passive_callback(


### PR DESCRIPTION
## Proposed change

This fixes an issue where enabling the experimental "BLE Proxy" option for the Matter.js server, and then restarting Home Assistant, locked up HA startup. HA eventually times out and logs "Something is blocking Home Assistant from wrapping up the start up phase". See the linked issue for more details.

### Cause & Change

The `matter_ble_proxy` library's `_message_loop` runs for the lifetime of the WebSocket connection, so the task never finishes (during startup). `async_create_task` should not have been passed, as the library uses the passed `task_factory` to create the never-ending task / message loop. The [library docstrings](https://github.com/matter-js/matterjs-server/blob/1f59aff7434c3a06c03c2f457278a9515fc4f626/python_ble_proxy/matter_ble_proxy/client.py#L155-L158) also should also be updated.

To fix the issue, the `task_factory` for `create_matter_ble_proxy` is now passed `async_create_background_task`. This is correct, as tasks created with it don't block HA startup. HA would also auto-cancel this on shutdown, which is fine, but we properly call `ble_proxy.disconnect()` on unload and shutdown already, so the library cleanly cancels the message loop task then.

The test is updated to verify the coroutine is forwarded with the `matter_ble_proxy` task name and the created task is returned.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #172380
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
The `matter_ble_proxy` library's `_message_loop` runs for the lifetime
of the WebSocket connection. Spawning it via `hass.async_create_task`
registered it as a tracked task that bootstrap waits for, causing the
documented "Setup timed out for bootstrap waiting on
MatterBleProxy._message_loop" warning at startup.

Route the library's `task_factory` through
`hass.async_create_background_task` so the long-running loop (and the
fire-and-forget event/binary sends that share this factory) do not
block the startup phase.