### PR TITLE
Fix Volvo lock crash when API field is missing from coordinator data

### DIFF
--- a/homeassistant/components/volvo/lock.py
+++ b/homeassistant/components/volvo/lock.py
@@ -75,6 +75,10 @@ class VolvoLock(VolvoEntity, LockEntity):
 
     def _update_state(self, api_field: VolvoCarsApiBaseModel | None) -> None:
         """Update the state of the entity."""
+        if api_field is None:
+            self._attr_is_locked = None
+            return
+
         assert isinstance(api_field, VolvoCarsValue)
         self._attr_is_locked = api_field.value == "LOCKED"
 

--- a/tests/components/volvo/test_lock.py
+++ b/tests/components/volvo/test_lock.py
@@ -1,8 +1,10 @@
 """Test Volvo locks."""
 
 from collections.abc import Awaitable, Callable
+from datetime import timedelta
 from unittest.mock import patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 from volvocarsapi.api import VolvoCarsApi
@@ -14,7 +16,8 @@ from homeassistant.components.lock import (
     SERVICE_UNLOCK,
     LockState,
 )
-from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.components.volvo.coordinator import FAST_INTERVAL
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
@@ -22,7 +25,7 @@ from homeassistant.helpers import entity_registry as er
 from . import configure_mock
 from .const import DEFAULT_VIN
 
-from tests.common import MockConfigEntry, snapshot_platform
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
 
 @pytest.mark.usefixtures("mock_api", "full_model")
@@ -134,3 +137,28 @@ async def test_unlock_failure(
         )
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == LockState.LOCKED
+
+
+@pytest.mark.freeze_time("2025-05-31T10:00:00+00:00")
+@pytest.mark.usefixtures("full_model")
+async def test_lock_unavailable_when_api_field_missing(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    setup_integration: Callable[[], Awaitable[bool]],
+    mock_api: VolvoCarsApi,
+) -> None:
+    """Test lock becomes unavailable when centralLock is missing from API response."""
+
+    with patch("homeassistant.components.volvo.PLATFORMS", [Platform.LOCK]):
+        assert await setup_integration()
+
+    entity_id = "lock.volvo_xc40_lock"
+    assert hass.states.get(entity_id).state == LockState.LOCKED
+
+    # Simulate API returning doors data without centralLock
+    configure_mock(mock_api.async_get_doors_status, return_value={})
+    freezer.tick(timedelta(minutes=FAST_INTERVAL))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE


### PR DESCRIPTION
## Proposed change

When the Volvo API returns door status data without the `centralLock` field (e.g. during a partial data refresh), the lock entity's `_update_state` method receives `None` and crashes with an `AssertionError`.

Add a `None` guard before the assert, matching the existing pattern in `binary_sensor.py`. When the field is missing, the entity reports as unavailable instead of crashing.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr