### PR TITLE
Handle DAVError in CalDAV get_supported_components

### DIFF
--- a/homeassistant/components/caldav/api.py
+++ b/homeassistant/components/caldav/api.py
@@ -3,6 +3,7 @@
 import logging
 
 import caldav
+from caldav.lib.error import DAVError
 
 from homeassistant.core import HomeAssistant
 
@@ -26,7 +27,7 @@ async def async_get_calendars(
         for calendar in client.principal().calendars():
             try:
                 supported_components = calendar.get_supported_components()
-            except KeyError:
+            except KeyError, DAVError:
                 needs_warning.append((str(calendar.url), calendar.name, component))
 
                 if component in ASSUMED_COMPONENTS:

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -8,6 +8,7 @@ from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 import zoneinfo
 
+from caldav.lib.error import NotFoundError
 from caldav.objects import Event
 from freezegun.api import FrozenDateTimeFactory
 import pytest
@@ -1328,15 +1329,23 @@ async def test_add_vevent(
     assert calendars[0].add_event.call_args[1] == expected_ics_fields
 
 
+@pytest.mark.parametrize(
+    "exception",
+    [
+        pytest.param(KeyError(), id="key_error"),
+        pytest.param(NotFoundError(), id="not_found_error"),
+    ],
+)
 async def test_missing_supported_components(
     hass: HomeAssistant,
     calendars: list[Mock],
     setup_platform_cb: Callable[[], Awaitable[None]],
     caplog: pytest.LogCaptureFixture,
+    exception: Exception,
 ) -> None:
-    """Test setup works when calendar raises KeyError on get_supported_components."""
+    """Test setup works when calendar raises on get_supported_components."""
     caplog.set_level(logging.WARNING, logger="homeassistant.components.caldav.api")
-    calendars[0].get_supported_components.side_effect = KeyError()
+    calendars[0].get_supported_components.side_effect = exception
     await setup_platform_cb()
 
     assert hass.states.get(TEST_ENTITY)
@@ -1367,14 +1376,22 @@ async def test_missing_supported_components(
     assert vjournal_warning in caplog.text
 
 
+@pytest.mark.parametrize(
+    "exception",
+    [
+        pytest.param(KeyError(), id="key_error"),
+        pytest.param(NotFoundError(), id="not_found_error"),
+    ],
+)
 async def test_missing_supported_components_not_assumed(
     hass: HomeAssistant,
     calendars: list[Mock],
     caplog: pytest.LogCaptureFixture,
+    exception: Exception,
 ) -> None:
-    """Test get_calendars excludes calendars on KeyError."""
+    """Test get_calendars excludes calendars when components unavailable."""
     caplog.set_level(logging.WARNING, logger="homeassistant.components.caldav.api")
-    calendars[0].get_supported_components.side_effect = KeyError()
+    calendars[0].get_supported_components.side_effect = exception
     client = MagicMock()
     client.principal().calendars.return_value = calendars
 


### PR DESCRIPTION
## Breaking change


## Proposed change

When a CalDAV server returns a 404 for a calendar (e.g. a deleted Google Calendar import), `get_supported_components()` raises a `NotFoundError` (a `DAVError` subclass). Only `KeyError` was caught, so the `NotFoundError` propagated and crashed the entire platform setup — no calendars were set up at all, even valid ones.

Catch `DAVError` alongside `KeyError` so the inaccessible calendar is skipped gracefully while the rest continue to work.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #172363
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr