### PR TITLE
Fix Tado config flow crash on device activation polling

### DIFF
--- a/homeassistant/components/tado/config_flow.py
+++ b/homeassistant/components/tado/config_flow.py
@@ -40,6 +40,8 @@ class TadoConfigFlow(ConfigFlow, domain=DOMAIN):
     login_task: asyncio.Task | None = None
     refresh_token: str | None = None
     tado: Tado | None = None
+    tado_device_url: str = ""
+    user_code: str = ""
 
     async def async_step_reauth(
         self, entry_data: Mapping[str, Any]
@@ -69,8 +71,8 @@ class TadoConfigFlow(ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Error while initiating Tado")
                 return self.async_abort(reason="cannot_connect")
             assert self.tado is not None
-            tado_device_url = self.tado.device_verification_url()
-            user_code = URL(tado_device_url).query["user_code"]
+            self.tado_device_url = self.tado.device_verification_url()
+            self.user_code = URL(self.tado_device_url).query["user_code"]
 
         async def _wait_for_login() -> None:
             """Wait for the user to login."""
@@ -119,8 +121,8 @@ class TadoConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user",
             progress_action="wait_for_device",
             description_placeholders={
-                "url": tado_device_url,
-                "code": user_code,
+                "url": self.tado_device_url,
+                "code": self.user_code,
             },
             progress_task=self.login_task,
         )

--- a/tests/components/tado/test_config_flow.py
+++ b/tests/components/tado/test_config_flow.py
@@ -231,6 +231,43 @@ async def test_options_flow(
     assert result["data"] == {CONF_FALLBACK: CONST_OVERLAY_TADO_DEFAULT}
 
 
+async def test_show_progress_polling(
+    hass: HomeAssistant,
+    mock_tado_api: MagicMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test progress step re-entry while login task is still running."""
+
+    event = threading.Event()
+
+    def mock_tado_api_device_activation() -> None:
+        event.wait(timeout=5)
+
+    mock_tado_api.device_activation = mock_tado_api_device_activation
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
+    assert result["step_id"] == "user"
+    assert result["description_placeholders"]["url"] is not None
+    assert result["description_placeholders"]["code"] == "TEST"
+
+    # Poll again while task is still running — this re-enters async_step_user
+    # with self.tado already set
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
+    assert result["description_placeholders"]["url"] is not None
+    assert result["description_placeholders"]["code"] == "TEST"
+
+    # Now complete the login
+    event.set()
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
 async def test_homekit(hass: HomeAssistant, mock_tado_api: MagicMock) -> None:
     """Test that we abort from homekit if tado is already setup."""
 


### PR DESCRIPTION
## Breaking change


## Proposed change

The Tado device activation config flow crashes with `UnboundLocalError` when the progress step polls while the login task is still running. On the first call to `async_step_user`, `tado_device_url` and `user_code` are set as local variables inside the `if self.tado is None:` block. On subsequent polling re-entries, that block is skipped but the variables are still referenced in `async_show_progress`, causing the crash.

Promote the two variables to instance attributes so they persist across polling calls.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #165355
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr