### PR TITLE
Increase ConfigEntryNotReady retry backoff cap from 80s to 10 minutes

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -138,6 +138,8 @@ SAVE_DELAY = 1
 
 DISCOVERY_COOLDOWN = 1
 
+SETUP_RETRY_MAX_WAIT = 600  # 10 minutes
+
 ISSUE_UNIQUE_ID_COLLISION = "config_entry_unique_id_collision"
 UNIQUE_ID_COLLISION_TITLE_LIMIT = 5
 
@@ -836,7 +838,7 @@ class ConfigEntry[_DataT = Any]:
                 error_reason_translation_key,
                 error_reason_translation_placeholders,
             )
-            wait_time = 2 ** min(self._tries, 4) * 5 + (
+            wait_time = min(2**self._tries * 5, SETUP_RETRY_MAX_WAIT) + (
                 randint(RANDOM_MICROSECOND_MIN, RANDOM_MICROSECOND_MAX) / 1000000
             )
             self._tries += 1

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1702,40 +1702,46 @@ async def test_setup_raise_not_ready(
     assert entry.reason is None
 
 
-@pytest.mark.parametrize(
-    ("try_count", "expected_wait"),
-    [
-        pytest.param(0, 5, id="first_retry"),
-        pytest.param(4, 80, id="fifth_retry"),
-        pytest.param(7, 600, id="capped_at_10_min"),
-        pytest.param(20, 600, id="stays_capped"),
-    ],
-)
 async def test_setup_not_ready_exponential_backoff(
     hass: HomeAssistant,
     manager: config_entries.ConfigEntries,
-    try_count: int,
-    expected_wait: int,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test setup retry uses exponential backoff capped at 10 minutes."""
     entry = MockConfigEntry(domain="test")
     entry.add_to_hass(hass)
 
-    mock_setup_entry = AsyncMock(side_effect=ConfigEntryNotReady)
-    mock_integration(hass, MockModule("test", async_setup_entry=mock_setup_entry))
+    attempts = 0
+
+    async def _mock_setup_entry(
+        hass: HomeAssistant, entry: ConfigEntry
+    ) -> bool:
+        nonlocal attempts
+        attempts += 1
+        raise ConfigEntryNotReady
+
+    mock_integration(
+        hass, MockModule("test", async_setup_entry=_mock_setup_entry)
+    )
     mock_platform(hass, "test.config_flow", None)
 
-    # Simulate previous failed attempts
-    object.__setattr__(entry, "_tries", try_count)
+    await manager.async_setup(entry.entry_id)
+    assert attempts == 1
 
-    with patch("homeassistant.config_entries.async_call_later") as mock_call:
-        await manager.async_setup(entry.entry_id)
+    expected_waits = [5, 10, 20, 40, 80, 160, 320, 600, 600]
+    for i, wait in enumerate(expected_waits):
+        # Advance to just before the retry should fire
+        freezer.tick(wait - 1)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+        assert attempts == i + 1, f"Retry {i + 1} fired too early"
 
-    assert len(mock_call.mock_calls) == 1
-    _hass, wait_time, _setup = mock_call.mock_calls[0][1]
-    # The jitter adds 0.05–0.5 seconds
-    assert expected_wait <= wait_time <= expected_wait + 0.5
-    assert entry.state is config_entries.ConfigEntryState.SETUP_RETRY
+        # Advance past the retry point (+ 1s for jitter)
+        freezer.tick(2)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+        assert attempts == i + 2, f"Retry {i + 1} did not fire"
+        assert entry.state is config_entries.ConfigEntryState.SETUP_RETRY
 
 
 async def test_setup_raise_not_ready_from_exception(

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1702,6 +1702,42 @@ async def test_setup_raise_not_ready(
     assert entry.reason is None
 
 
+@pytest.mark.parametrize(
+    ("try_count", "expected_wait"),
+    [
+        pytest.param(0, 5, id="first_retry"),
+        pytest.param(4, 80, id="fifth_retry"),
+        pytest.param(7, 600, id="capped_at_10_min"),
+        pytest.param(20, 600, id="stays_capped"),
+    ],
+)
+async def test_setup_not_ready_exponential_backoff(
+    hass: HomeAssistant,
+    manager: config_entries.ConfigEntries,
+    try_count: int,
+    expected_wait: int,
+) -> None:
+    """Test setup retry uses exponential backoff capped at 10 minutes."""
+    entry = MockConfigEntry(domain="test")
+    entry.add_to_hass(hass)
+
+    mock_setup_entry = AsyncMock(side_effect=ConfigEntryNotReady)
+    mock_integration(hass, MockModule("test", async_setup_entry=mock_setup_entry))
+    mock_platform(hass, "test.config_flow", None)
+
+    # Simulate previous failed attempts
+    object.__setattr__(entry, "_tries", try_count)
+
+    with patch("homeassistant.config_entries.async_call_later") as mock_call:
+        await manager.async_setup(entry.entry_id)
+
+    assert len(mock_call.mock_calls) == 1
+    _hass, wait_time, _setup = mock_call.mock_calls[0][1]
+    # The jitter adds 0.05–0.5 seconds
+    assert expected_wait <= wait_time <= expected_wait + 0.5
+    assert entry.state is config_entries.ConfigEntryState.SETUP_RETRY
+
+
 async def test_setup_raise_not_ready_from_exception(
     hass: HomeAssistant,
     manager: config_entries.ConfigEntries,

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1713,16 +1713,12 @@ async def test_setup_not_ready_exponential_backoff(
 
     attempts = 0
 
-    async def _mock_setup_entry(
-        hass: HomeAssistant, entry: ConfigEntry
-    ) -> bool:
+    async def _mock_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         nonlocal attempts
         attempts += 1
         raise ConfigEntryNotReady
 
-    mock_integration(
-        hass, MockModule("test", async_setup_entry=_mock_setup_entry)
-    )
+    mock_integration(hass, MockModule("test", async_setup_entry=_mock_setup_entry))
     mock_platform(hass, "test.config_flow", None)
 
     await manager.async_setup(entry.entry_id)


### PR DESCRIPTION
## Proposed change

The `ConfigEntryNotReady` retry backoff currently uses `2^min(tries, 4) * 5`, which caps at **80 seconds**. Many cloud APIs enforce rate limit cooldowns of 5 to 30 minutes, and retrying every 80 seconds sustains the rate-limited state. Each retry counts against the limit, preventing recovery. This creates a vicious cycle where the mechanism designed to help recovery actually prevents it.

This has been a recurring pain point across many integrations:

- **Growatt** (#171202, #172472): 5-minute API cooldown; 80s retries would never clear it
- **Tractive** (#169057): had to slow down polling at the library level to work around aggressive retries
- **Home Connect** (#139379): implemented its own deferred loading to avoid retry-induced rate limits
- **ForecastSolar** (#106771): retries every ~90s filling logs with 429 errors, preventing cooldown
- **Airly** (#85490): 429 errors arriving like clockwork at ~80s intervals
- **Honeywell** (#88716): retry loop caused more rate limiting, requiring manual reload
- **Steam** (#95702, #139762): 80s retries too aggressive for Steam's rate limiting
- **Roborock** (#164486, #164540, #165627): sustained "maximum requests" errors
- **VeSync** (#166724): 319 rate limit errors in 3 hours with only 2 devices

This PR raises the cap to **600 seconds (10 minutes)** while keeping the same doubling progression for fast recovery from transient failures:

| Retry | Wait |
|-------|------|
| 1 | 5s |
| 2 | 10s |
| 3 | 20s |
| 4 | 40s |
| 5 | 80s |
| 6 | 160s |
| 7 | 320s |
| 8+ | 600s (capped) |

The first retries remain fast for transient issues (network blips, service restarts), while persistent failures naturally back off past common rate limit windows.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #171202
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr