### PR TITLE
Handle FileNotFoundError in Immich upload_file action

### DIFF
--- a/homeassistant/components/immich/services.py
+++ b/homeassistant/components/immich/services.py
@@ -67,7 +67,7 @@ async def _async_upload_file(service_call: ServiceCall) -> None:
             await coordinator.api.albums.async_add_assets_to_album(
                 target_album, [upload_result.asset_id]
             )
-    except ImmichError as ex:
+    except (ImmichError, FileNotFoundError) as ex:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="upload_failed",

--- a/tests/components/immich/test_services.py
+++ b/tests/components/immich/test_services.py
@@ -1,5 +1,6 @@
 """Test the Immich services."""
 
+import re
 from unittest.mock import Mock, patch
 
 from aioimmich.exceptions import ImmichError, ImmichNotFoundError
@@ -210,8 +211,30 @@ async def test_upload_file_album_not_found(
         )
 
 
+@pytest.mark.parametrize(
+    ("side_effect", "expected_err_message"),
+    [
+        (
+            ImmichError(
+                {
+                    "message": "Boom! Upload failed",
+                    "error": "Bad Request",
+                    "statusCode": 400,
+                    "correlationId": "nyzxjkno",
+                }
+            ),
+            "Boom! Upload failed (error: 'Bad Request' code: '400' correlation_id: 'nyzxjkno')",
+        ),
+        (
+            FileNotFoundError(2, "No such file or directory", "/media/screenshot.jpg"),
+            "[Errno 2] No such file or directory: '/media/screenshot.jpg'",
+        ),
+    ],
+)
 async def test_upload_file_upload_failed(
     hass: HomeAssistant,
+    side_effect: Exception,
+    expected_err_message: str,
     mock_immich: Mock,
     mock_config_entry: MockConfigEntry,
     mock_media_source: Mock,
@@ -219,16 +242,12 @@ async def test_upload_file_upload_failed(
     """Test upload_file service raising upload_failed."""
     await setup_integration(hass, mock_config_entry)
 
-    mock_immich.assets.async_upload_asset.side_effect = ImmichError(
-        {
-            "message": "Boom! Upload failed",
-            "error": "Bad Request",
-            "statusCode": 400,
-            "correlationId": "nyzxjkno",
-        }
-    )
+    mock_immich.assets.async_upload_asset.side_effect = side_effect
     with pytest.raises(
-        ServiceValidationError, match="Upload of file `/media/screenshot.jpg` failed"
+        ServiceValidationError,
+        match=re.escape(
+            f"Upload of file `/media/screenshot.jpg` failed ({expected_err_message})"
+        ),
     ):
         await hass.services.async_call(
             DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This handles a FileNotFoundError in the `upload_file` action call, to raise a proper `ServiceValidationError`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #172192
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
