### PR TITLE
Catch network errors during Roborock config entry setup

### DIFF
--- a/homeassistant/components/roborock/__init__.py
+++ b/homeassistant/components/roborock/__init__.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 import logging
 from typing import Any
 
+import aiohttp
 from roborock import (
     RoborockException,
     RoborockInvalidCredentials,
@@ -119,6 +120,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: RoborockConfigEntry) -> 
         raise ConfigEntryNotReady(
             translation_domain=DOMAIN,
             translation_key="home_data_fail",
+        ) from err
+    except (aiohttp.ClientError, TimeoutError) as err:
+        _LOGGER.debug("Network error setting up Roborock: %s", err)
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="network_error",
         ) from err
 
     async def shutdown_roborock(_: Event | None = None) -> None:

--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -677,6 +677,9 @@
     "mqtt_unauthorized": {
       "message": "Roborock MQTT servers rejected the connection due to rate limiting or invalid credentials. You may either attempt to reauthenticate or wait and reload the integration."
     },
+    "network_error": {
+      "message": "Network error connecting to Roborock servers. Check your internet connection and the Roborock service status."
+    },
     "no_coordinators": {
       "message": "No devices were able to successfully setup"
     },

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -5,6 +5,7 @@ import pathlib
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
+import aiohttp
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from roborock import (
@@ -254,6 +255,26 @@ async def test_no_user_agreement(
         await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
         assert mock_roborock_entry.state is ConfigEntryState.SETUP_RETRY
         assert mock_roborock_entry.error_reason_translation_key == "no_user_agreement"
+
+
+@pytest.mark.parametrize(
+    "side_effect",
+    [aiohttp.ClientError(), TimeoutError()],
+    ids=["client_error", "timeout"],
+)
+async def test_network_error_during_setup(
+    hass: HomeAssistant,
+    mock_roborock_entry: MockConfigEntry,
+    side_effect: Exception,
+) -> None:
+    """Test that network errors during setup trigger retry, not terminal failure."""
+    with patch(
+        "homeassistant.components.roborock.create_device_manager",
+        side_effect=side_effect,
+    ):
+        await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+        assert mock_roborock_entry.state is ConfigEntryState.SETUP_RETRY
+        assert mock_roborock_entry.error_reason_translation_key == "network_error"
 
 
 @pytest.mark.parametrize("platforms", [[Platform.SENSOR]])


### PR DESCRIPTION
## Proposed change

When `create_device_manager()` raises a raw `aiohttp.ClientError` or `TimeoutError` (e.g. DNS resolution failure during boot, transient connectivity loss), the exception is not a subclass of `RoborockException` and bypasses the existing handler. It surfaces as a generic `ConfigEntryError`, marking the entry as terminally failed and requiring a manual reload or HA restart once connectivity is restored.

This is most commonly observed after a power outage, where Home Assistant boots faster than the upstream network (modem, ISP, DNS) becomes available. Example log from a real outage on a Home Assistant OS install:

```
ERROR (MainThread) [homeassistant.config_entries] Error setting up entry <account> for roborock
```

In the same boot, well-behaved integrations on the same install (`nws`, `mqtt`, `metno`, `google` calendars) all recovered automatically via the `ConfigEntryNotReady` retry path. Roborock did not, because the underlying library leaks raw `aiohttp` exceptions past the integration's `except RoborockException` handler.

This PR adds a defensive catch for `aiohttp.ClientError` and `TimeoutError` in `async_setup_entry`, raising `ConfigEntryNotReady` so the existing retry/backoff machinery recovers automatically once the network returns.

The underlying library should also be fixed: network exceptions raised inside `UserWebApiClient.get_home_data()` and the MQTT session setup should be wrapped in `RoborockException`. I'll open a separate issue against [Python roborock/python-roborock] for that. This PR is defensive-in-depth in HA core and protects users regardless of library
version.

The existing `ConfigEntryAuthFailed` paths (`RoborockInvalidCredentials`, `MqttSessionUnauthorized`) are unchanged — auth failures remain terminal and continue to trigger reauth as expected.

[Python-roborock/python-roborock]: https://github.com/Python-roborock/python-roborock

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

No existing issue matched this specific bypass path. Closest related open
issues are different code paths:
- #164540 — same \`home_data_fail\` translation key, but the underlying
  cause (rate-limit hit) raises \`RoborockException\` correctly and goes
  through the retry path; the open complaint there is UI-message clarity.
- #172206 — multi-device partial-setup failures, different code path.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (\`ruff format homeassistant tests\`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.