### PR TITLE
Fix OctoPrint config flow crash when discovery plugin is disabled

### DIFF
--- a/homeassistant/components/octoprint/config_flow.py
+++ b/homeassistant/components/octoprint/config_flow.py
@@ -155,8 +155,11 @@ class OctoPrintConfigFlow(ConfigFlow, domain=DOMAIN):
         finally:
             await self._sessions.pop().close()
 
-        await self.async_set_unique_id(discovery.upnp_uuid, raise_on_progress=False)
-        self._abort_if_unique_id_configured()
+        if discovery and (unique_id := discovery.upnp_uuid):
+            await self.async_set_unique_id(unique_id, raise_on_progress=False)
+            self._abort_if_unique_id_configured()
+        else:
+            self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
 
         return self.async_create_entry(title=user_input[CONF_HOST], data=user_input)
 

--- a/tests/components/octoprint/test_config_flow.py
+++ b/tests/components/octoprint/test_config_flow.py
@@ -608,3 +608,50 @@ async def test_reauth_form(hass: HomeAssistant) -> None:
 
     assert result2["type"] is FlowResultType.ABORT
     assert result2["reason"] == "reauth_successful"
+
+
+async def test_form_discovery_plugin_disabled(hass: HomeAssistant) -> None:
+    """Test setup succeeds when discovery plugin is disabled."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "pyoctoprintapi.OctoprintClient.request_app_key", return_value="test-key"
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "username": "testuser",
+                "host": "1.1.1.1",
+                "name": "Printer",
+                "port": 81,
+                "ssl": True,
+                "path": "/",
+            },
+        )
+        await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
+
+    with (
+        patch(
+            "pyoctoprintapi.OctoprintClient.get_server_info",
+            return_value=True,
+        ),
+        patch(
+            "pyoctoprintapi.OctoprintClient.get_discovery_info",
+            return_value=None,
+        ),
+        patch("homeassistant.components.octoprint.async_setup", return_value=True),
+        patch(
+            "homeassistant.components.octoprint.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "1.1.1.1"


### PR DESCRIPTION
## Proposed change

When the OctoPrint discovery plugin is disabled, `get_discovery_info()` returns `None`. The config flow accesses `discovery.upnp_uuid` without a null check, crashing with `AttributeError: 'NoneType' object has no attribute 'upnp_uuid'`.

When discovery info is unavailable, skip setting a unique ID and use `_async_abort_entries_match` on the host to prevent duplicate entries instead.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #160512
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr