### PR TITLE
Simplify Duco sensor tests

### DIFF
--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -94,7 +94,7 @@ async def test_coordinator_update_failure_marks_unavailable(
     hass: HomeAssistant,
     mock_duco_client: AsyncMock,
     freezer: FrozenDateTimeFactory,
-    exception_type: type[Exception],
+    exception_type: type[DucoError],
     exception_message: str,
 ) -> None:
     """Test sensor entities become unavailable when the coordinator update fails."""

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -84,20 +84,23 @@ async def test_diagnostic_sensor_entities_disabled_by_default(
 
 @pytest.mark.usefixtures("init_integration")
 @pytest.mark.parametrize(
-    "exception",
+    ("exception_type", "exception_message"),
     [
-        pytest.param(DucoConnectionError("offline"), id="connection_error"),
-        pytest.param(DucoError("api error"), id="duco_error"),
+        pytest.param(DucoConnectionError, "offline", id="connection_error"),
+        pytest.param(DucoError, "api error", id="duco_error"),
     ],
 )
 async def test_coordinator_update_failure_marks_unavailable(
     hass: HomeAssistant,
     mock_duco_client: AsyncMock,
     freezer: FrozenDateTimeFactory,
-    exception: Exception,
+    exception_type: type[Exception],
+    exception_message: str,
 ) -> None:
     """Test sensor entities become unavailable when the coordinator update fails."""
-    mock_duco_client.async_get_nodes = AsyncMock(side_effect=exception)
+    mock_duco_client.async_get_nodes = AsyncMock(
+        side_effect=exception_type(exception_message)
+    )
 
     freezer.tick(SCAN_INTERVAL)
     async_fire_time_changed(hass)

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -83,33 +83,21 @@ async def test_diagnostic_sensor_entities_disabled_by_default(
 
 
 @pytest.mark.usefixtures("init_integration")
-async def test_coordinator_update_marks_unavailable(
+@pytest.mark.parametrize(
+    "exception",
+    [
+        pytest.param(DucoConnectionError("offline"), id="connection_error"),
+        pytest.param(DucoError("api error"), id="duco_error"),
+    ],
+)
+async def test_coordinator_update_failure_marks_unavailable(
     hass: HomeAssistant,
     mock_duco_client: AsyncMock,
     freezer: FrozenDateTimeFactory,
+    exception: Exception,
 ) -> None:
-    """Test that sensor entities become unavailable when the coordinator fails."""
-    mock_duco_client.async_get_nodes = AsyncMock(
-        side_effect=DucoConnectionError("offline")
-    )
-
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
-
-    state = hass.states.get("sensor.office_co2_carbon_dioxide")
-    assert state is not None
-    assert state.state == STATE_UNAVAILABLE
-
-
-@pytest.mark.usefixtures("init_integration")
-async def test_coordinator_update_duco_error_marks_unavailable(
-    hass: HomeAssistant,
-    mock_duco_client: AsyncMock,
-    freezer: FrozenDateTimeFactory,
-) -> None:
-    """Test sensor entities become unavailable when async_get_nodes raises DucoError."""
-    mock_duco_client.async_get_nodes = AsyncMock(side_effect=DucoError("api error"))
+    """Test sensor entities become unavailable when the coordinator update fails."""
+    mock_duco_client.async_get_nodes = AsyncMock(side_effect=exception)
 
     freezer.tick(SCAN_INTERVAL)
     async_fire_time_changed(hass)
@@ -198,10 +186,9 @@ async def test_deregistered_node_removes_device(
     mock_sensor_nodes: list[Node],
     mock_config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
+    device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test a node disappearing from the API removes its device from the registry."""
-    device_registry = dr.async_get(hass)
-
     # Verify node 2 (UCCO2 RF sensor) device exists before deregistration.
     device = device_registry.async_get_device(
         identifiers={(DOMAIN, f"{mock_config_entry.unique_id}_2")}

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -98,9 +98,7 @@ async def test_coordinator_update_failure_marks_unavailable(
     exception_message: str,
 ) -> None:
     """Test sensor entities become unavailable when the coordinator update fails."""
-    mock_duco_client.async_get_nodes = AsyncMock(
-        side_effect=exception_type(exception_message)
-    )
+    mock_duco_client.async_get_nodes.side_effect = exception_type(exception_message)
 
     freezer.tick(SCAN_INTERVAL)
     async_fire_time_changed(hass)


### PR DESCRIPTION
## Proposed change

This PR keeps the Duco sensor test coverage the same while reducing repetition in the sensor platform tests.

- Merge the two coordinator failure tests into one parametrized test that verifies the shared unavailable behavior for both `DucoConnectionError` and `DucoError`
- Use the `device_registry` fixture instead of calling `dr.async_get(hass)` inline in the deregistration test

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr