### PR TITLE
Handle malformed response errors in Denon AVR error wrapper

### DIFF
--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -20,6 +20,8 @@ from denonavr.const import (
 from denonavr.exceptions import (
     AvrCommandError,
     AvrForbiddenError,
+    AvrIncompleteResponseError,
+    AvrInvalidResponseError,
     AvrNetworkError,
     AvrProcessingError,
     AvrTimoutError,
@@ -187,6 +189,17 @@ def async_log_errors[_DenonDeviceT: DenonDevice, **_P, _R](
                         "Denon AVR receiver at host %s responded with HTTP 403 error. "
                         "Device is unavailable. Please consider power cycling your "
                         "receiver"
+                    ),
+                    self._receiver.host,
+                )
+                self._attr_available = False
+        except AvrInvalidResponseError, AvrIncompleteResponseError:
+            available = False
+            if self.available:
+                _LOGGER.warning(
+                    (
+                        "Denon AVR receiver at host %s returned malformed response. "
+                        "Device is unavailable"
                     ),
                     self._receiver.host,
                 )

--- a/tests/components/denonavr/test_media_player.py
+++ b/tests/components/denonavr/test_media_player.py
@@ -1,7 +1,10 @@
 """The tests for the denonavr media player platform."""
 
+from datetime import timedelta
 from unittest.mock import patch
 
+from denonavr.exceptions import AvrIncompleteResponseError, AvrInvalidResponseError
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components import media_player
@@ -18,10 +21,10 @@ from homeassistant.components.denonavr.services import (
     SERVICE_SET_DYNAMIC_EQ,
     SERVICE_UPDATE_AUDYSSEY,
 )
-from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_MODEL
+from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_MODEL, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 TEST_HOST = "1.2.3.4"
 TEST_NAME = "Test_Receiver"
@@ -137,3 +140,40 @@ async def test_update_audyssey(hass: HomeAssistant, client) -> None:
     await hass.async_block_till_done()
 
     client.async_update_audyssey.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        pytest.param(
+            AvrInvalidResponseError("XML parse error", "GET"),
+            id="invalid_response",
+        ),
+        pytest.param(
+            AvrIncompleteResponseError("Incomplete", "GET"),
+            id="incomplete_response",
+        ),
+    ],
+)
+async def test_malformed_response_marks_unavailable(
+    hass: HomeAssistant,
+    client,
+    freezer: FrozenDateTimeFactory,
+    exception: Exception,
+) -> None:
+    """Test that malformed response errors mark the entity unavailable."""
+    await setup_denonavr(hass)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state.state != STATE_UNAVAILABLE
+
+    # Force polling by disabling telnet, then trigger the error
+    client.telnet_connected = False
+    client.telnet_healthy = False
+    client.async_update.side_effect = exception
+    freezer.tick(timedelta(seconds=11))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
## Proposed change

When a Denon AVR receiver returns malformed XML, the `denonavr` library raises `AvrInvalidResponseError` or `AvrIncompleteResponseError`. These were not explicitly caught in the `async_log_errors` wrapper, so they fell through to the generic `DenonAvrError` handler which logs a full ERROR traceback every poll cycle (~10s) without marking the device unavailable. Since the device stays "available", the error is never suppressed, flooding the logs indefinitely.

Add explicit handling for both exceptions matching the existing pattern for network/timeout errors: log a warning once and mark the device unavailable until it recovers.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #171326
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr