### PR TITLE
Guard Shelly repairs checks for uninitialized RPC devices

### DIFF
--- a/homeassistant/components/shelly/repairs.py
+++ b/homeassistant/components/shelly/repairs.py
@@ -132,6 +132,9 @@ def async_manage_outbound_websocket_incorrectly_enabled_issue(
 
     device = entry.runtime_data.rpc.device
 
+    if not device.initialized:
+        return
+
     if (
         (ws_config := device.config.get("ws"))
         and ws_config["enable"]
@@ -168,6 +171,9 @@ def async_manage_open_wifi_ap_issue(
         assert entry.runtime_data.rpc is not None
 
     device = entry.runtime_data.rpc.device
+
+    if not device.initialized:
+        return
 
     # Check if WiFi AP is enabled and is open (no password)
     if (

--- a/tests/components/shelly/test_repairs.py
+++ b/tests/components/shelly/test_repairs.py
@@ -179,6 +179,19 @@ async def test_outbound_websocket_incorrectly_enabled_issue(
     assert len(issue_registry.issues) == 0
 
 
+async def test_repairs_skipped_when_device_not_initialized(
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test repair checks are skipped when the RPC device is not initialized."""
+    mock_rpc_device.initialized = False
+
+    await init_integration(hass, 2)
+
+    assert len(issue_registry.issues) == 0
+
+
 @pytest.mark.parametrize(
     "exception", [DeviceConnectionError, RpcCallError(999, "Unknown error")]
 )

--- a/tests/components/shelly/test_repairs.py
+++ b/tests/components/shelly/test_repairs.py
@@ -4,7 +4,7 @@ from typing import Any
 from unittest.mock import Mock, patch
 
 from aioshelly.const import MODEL_PLUG, MODEL_WALL_DISPLAY
-from aioshelly.exceptions import DeviceConnectionError, RpcCallError
+from aioshelly.exceptions import DeviceConnectionError, NotInitialized, RpcCallError
 import pytest
 
 from homeassistant.components.shelly.const import (
@@ -186,6 +186,9 @@ async def test_repairs_skipped_when_device_not_initialized(
 ) -> None:
     """Test repair checks are skipped when the RPC device is not initialized."""
     mock_rpc_device.initialized = False
+    type(mock_rpc_device).config = property(
+        lambda self: (_ for _ in ()).throw(NotInitialized)
+    )
 
     await init_integration(hass, 2)
 


### PR DESCRIPTION


## Proposed change

During setup, `async_manage_outbound_websocket_incorrectly_enabled_issue()` and `async_manage_open_wifi_ap_issue()` in `repairs.py` access `device.config` without checking `device.initialized`. On a race at startup where the RPC device hasn't finished initializing, this raises `aioshelly.exceptions.NotInitialized`, which is unhandled and permanently fails the config entry with no auto-retry.

Add `if not device.initialized: return` guards to both functions, skipping the repair checks when the device isn't ready yet. The checks will run on the next coordinator update once the device is initialized.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #172507
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr