### PR TITLE
Raise errors instead of swallowing exceptions in Toon action handlers

### DIFF
--- a/homeassistant/components/toon/climate.py
+++ b/homeassistant/components/toon/climate.py
@@ -102,14 +102,12 @@ class ToonThermostatDevice(ToonDisplayDeviceEntity, ClimateEntity):
         """Return the current state of the burner."""
         return {"heating_type": self.coordinator.data.agreement.heating_type}
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @toon_exception_handler
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Change the setpoint of the thermostat."""
         temperature = kwargs.get(ATTR_TEMPERATURE)
         await self.coordinator.toon.set_current_setpoint(temperature)
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @toon_exception_handler
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""

--- a/homeassistant/components/toon/helpers.py
+++ b/homeassistant/components/toon/helpers.py
@@ -1,14 +1,14 @@
 """Helpers for Toon."""
 
 from collections.abc import Callable, Coroutine
-import logging
 from typing import Any, Concatenate
 
 from toonapi import ToonConnectionError, ToonError
 
-from .entity import ToonEntity
+from homeassistant.exceptions import HomeAssistantError
 
-_LOGGER = logging.getLogger(__name__)
+from .const import DOMAIN
+from .entity import ToonEntity
 
 
 def toon_exception_handler[_ToonEntityT: ToonEntity, **_P](
@@ -17,20 +17,24 @@ def toon_exception_handler[_ToonEntityT: ToonEntity, **_P](
     """Decorate Toon calls to handle Toon exceptions.
 
     A decorator that wraps the passed in function, catches Toon errors,
-    and handles the availability of the device in the data coordinator.
+    and raises a translated ``HomeAssistantError``.
     """
 
     async def handler(self: _ToonEntityT, *args: _P.args, **kwargs: _P.kwargs) -> None:
         try:
             await func(self, *args, **kwargs)
             self.coordinator.async_update_listeners()
-
         except ToonConnectionError as error:
-            _LOGGER.error("Error communicating with API: %s", error)
             self.coordinator.last_update_success = False
             self.coordinator.async_update_listeners()
-
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+            ) from error
         except ToonError as error:
-            _LOGGER.error("Invalid response from API: %s", error)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="unknown_error",
+            ) from error
 
     return handler

--- a/homeassistant/components/toon/helpers.py
+++ b/homeassistant/components/toon/helpers.py
@@ -34,7 +34,7 @@ def toon_exception_handler[_ToonEntityT: ToonEntity, **_P](
         except ToonError as error:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
-                translation_key="unknown_error",
+                translation_key="invalid_response",
             ) from error
 
     return handler

--- a/homeassistant/components/toon/strings.json
+++ b/homeassistant/components/toon/strings.json
@@ -37,11 +37,11 @@
     "communication_error": {
       "message": "An error occurred while communicating with the Toon device."
     },
+    "invalid_response": {
+      "message": "Received an invalid response from the Toon device."
+    },
     "oauth2_implementation_unavailable": {
       "message": "[%key:common::exceptions::oauth2_implementation_unavailable::message%]"
-    },
-    "unknown_error": {
-      "message": "An unknown error occurred while communicating with the Toon device."
     }
   }
 }

--- a/homeassistant/components/toon/strings.json
+++ b/homeassistant/components/toon/strings.json
@@ -34,8 +34,14 @@
     }
   },
   "exceptions": {
+    "communication_error": {
+      "message": "An error occurred while communicating with the Toon device."
+    },
     "oauth2_implementation_unavailable": {
       "message": "[%key:common::exceptions::oauth2_implementation_unavailable::message%]"
+    },
+    "unknown_error": {
+      "message": "An unknown error occurred while communicating with the Toon device."
     }
   }
 }

--- a/homeassistant/components/toon/switch.py
+++ b/homeassistant/components/toon/switch.py
@@ -60,7 +60,6 @@ class ToonSwitch(ToonEntity, SwitchEntity):
 class ToonProgramSwitch(ToonSwitch, ToonDisplayDeviceEntity):
     """Defines a Toon program switch."""
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @toon_exception_handler
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the Toon program switch."""
@@ -68,7 +67,6 @@ class ToonProgramSwitch(ToonSwitch, ToonDisplayDeviceEntity):
             ACTIVE_STATE_AWAY, PROGRAM_STATE_OFF
         )
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @toon_exception_handler
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the Toon program switch."""
@@ -80,7 +78,6 @@ class ToonProgramSwitch(ToonSwitch, ToonDisplayDeviceEntity):
 class ToonHolidayModeSwitch(ToonSwitch, ToonDisplayDeviceEntity):
     """Defines a Toon Holiday mode switch."""
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @toon_exception_handler
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the Toon holiday mode switch."""
@@ -88,7 +85,6 @@ class ToonHolidayModeSwitch(ToonSwitch, ToonDisplayDeviceEntity):
             ACTIVE_STATE_AWAY, PROGRAM_STATE_ON
         )
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @toon_exception_handler
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the Toon holiday mode switch."""


### PR DESCRIPTION

## Proposed change

The Toon `toon_exception_handler` decorator catches `ToonConnectionError` and `ToonError` but only logs them, swallowing the errors. This means the UI shows no feedback when actions like `set_temperature` or `set_preset_mode` fail, and automations continue as if they succeeded.

Raise `HomeAssistantError` with translation keys instead, following the same pattern as the Elgato integration. Remove the `pylint: disable-next=home-assistant-action-swallowed-exception` comments from all 6 affected action handlers in `climate.py` and `switch.py`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #170643
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr