### PR TITLE
Correct fan speed mapping for Jasco 55258 ZW4002 fw 5.50 for zwavejs

### DIFF
--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -205,7 +205,7 @@ DISCOVERY_SCHEMAS = [
             FanValueMapping(speeds=[(1, 33), (34, 67), (68, 99)]),
         ),
     ),
-    # GE/Jasco - In-Wall Smart Fan Controls - 14314 / ZW4002
+    # GE/Jasco - In-Wall Smart Fan Controls - 14287 / 14314 / ZW4002
     ZWaveDiscoverySchema(
         platform=Platform.FAN,
         hint="has_fan_value_mapping",
@@ -220,16 +220,30 @@ DISCOVERY_SCHEMAS = [
             FanValueMapping(speeds=[(1, 32), (33, 66), (67, 99)]),
         ),
     ),
-    # GE/Jasco - In-Wall Smart Fan Controls - 14287 / 55258 / ZW4002
+    # GE/Jasco - In-Wall Smart Fan Controls - 55258 / ZW4002 (firmware >= 5.51)
     ZWaveDiscoverySchema(
         platform=Platform.FAN,
         hint="has_fan_value_mapping",
         manufacturer_id={0x0063},
         product_id={0x3337},
         product_type={0x4944},
+        firmware_version_range=FirmwareVersionRange(min="5.51"),
         primary_value=SWITCH_MULTILEVEL_CURRENT_VALUE_SCHEMA,
         data_template=FixedFanValueMappingDataTemplate(
             FanValueMapping(speeds=[(1, 33), (34, 66), (67, 99)]),
+        ),
+    ),
+    # GE/Jasco - In-Wall Smart Fan Controls - 55258 / ZW4002 (firmware <= 5.50)
+    ZWaveDiscoverySchema(
+        platform=Platform.FAN,
+        hint="has_fan_value_mapping",
+        manufacturer_id={0x0063},
+        product_id={0x3337},
+        product_type={0x4944},
+        firmware_version_range=FirmwareVersionRange(max="5.50"),
+        primary_value=SWITCH_MULTILEVEL_CURRENT_VALUE_SCHEMA,
+        data_template=FixedFanValueMappingDataTemplate(
+            FanValueMapping(speeds=[(1, 32), (33, 66), (67, 99)]),
         ),
     ),
     # GE/Jasco - In-Wall Smart Fan Controls - 58446 / ZWA4013

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -1214,7 +1214,7 @@ def enbrighten_55258_zw4002_firmware_5_50_fixture(
     enbrighten_55258_zw4002_state_firmware_5_50: dict[str, Any],
 ) -> Node:
     """Mock an Enbrighten_55258/ZW4002 fan controller node with firmware 5.50."""
-    node = Node(client, copy.deepcopy(enbrighten_55258_zw4002_state_firmware_5_50))
+    node = Node(client, enbrighten_55258_zw4002_state_firmware_5_50)
     client.driver.controller.nodes[node.node_id] = node
     return node
 

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -354,10 +354,10 @@ def enbrighten_55258_zw4002_state_fixture() -> dict[str, Any]:
 
 @pytest.fixture(name="enbrighten_55258_zw4002_state_firmware_5_50")
 def enbrighten_55258_zw4002_state_firmware_5_50_fixture(
-    enbrighten_55258_zw4002_state,
+    enbrighten_55258_zw4002_state: dict[str, Any],
 ) -> dict[str, Any]:
     """Load Enbrighten/GE 55258/ZW4002 node state fixture data for firmware 5.50."""
-    state = copy.deepcopy(enbrighten_55258_zw4002_state)
+    state = enbrighten_55258_zw4002_state.copy()
     state["firmwareVersion"] = "5.50"
     return state
 
@@ -1210,7 +1210,8 @@ def enbrighten_55258_zw4002_fixture(client, enbrighten_55258_zw4002_state) -> No
 
 @pytest.fixture(name="enbrighten_55258_zw4002_firmware_5_50")
 def enbrighten_55258_zw4002_firmware_5_50_fixture(
-    client, enbrighten_55258_zw4002_state_firmware_5_50
+    client: MagicMock,
+    enbrighten_55258_zw4002_state_firmware_5_50: dict[str, Any],
 ) -> Node:
     """Mock an Enbrighten_55258/ZW4002 fan controller node with firmware 5.50."""
     node = Node(client, copy.deepcopy(enbrighten_55258_zw4002_state_firmware_5_50))

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -352,6 +352,16 @@ def enbrighten_55258_zw4002_state_fixture() -> dict[str, Any]:
     return load_json_object_fixture("enbrighten_55258_zw4002_state.json", DOMAIN)
 
 
+@pytest.fixture(name="enbrighten_55258_zw4002_state_firmware_5_50")
+def enbrighten_55258_zw4002_state_firmware_5_50_fixture(
+    enbrighten_55258_zw4002_state,
+) -> dict[str, Any]:
+    """Load Enbrighten/GE 55258/ZW4002 node state fixture data for firmware 5.50."""
+    state = copy.deepcopy(enbrighten_55258_zw4002_state)
+    state["firmwareVersion"] = "5.50"
+    return state
+
+
 @pytest.fixture(name="enbrighten_58446_zwa4013_state", scope="package")
 def enbrighten_58446_zwa4013_state_fixture() -> dict[str, Any]:
     """Load the Enbrighten/GE 58446/zwa401 node state fixture data."""
@@ -1194,6 +1204,16 @@ def jasco_14314_fixture(client, jasco_14314_state) -> Node:
 def enbrighten_55258_zw4002_fixture(client, enbrighten_55258_zw4002_state) -> Node:
     """Mock a Enbrighten_55258/ZW4002 fan controller node."""
     node = Node(client, copy.deepcopy(enbrighten_55258_zw4002_state))
+    client.driver.controller.nodes[node.node_id] = node
+    return node
+
+
+@pytest.fixture(name="enbrighten_55258_zw4002_firmware_5_50")
+def enbrighten_55258_zw4002_firmware_5_50_fixture(
+    client, enbrighten_55258_zw4002_state_firmware_5_50
+) -> Node:
+    """Mock an Enbrighten_55258/ZW4002 fan controller node with firmware 5.50."""
+    node = Node(client, copy.deepcopy(enbrighten_55258_zw4002_state_firmware_5_50))
     client.driver.controller.nodes[node.node_id] = node
     return node
 

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -357,7 +357,7 @@ def enbrighten_55258_zw4002_state_firmware_5_50_fixture(
     enbrighten_55258_zw4002_state: dict[str, Any],
 ) -> dict[str, Any]:
     """Load Enbrighten/GE 55258/ZW4002 node state fixture data for firmware 5.50."""
-    state = enbrighten_55258_zw4002_state.copy()
+    state = copy.deepcopy(enbrighten_55258_zw4002_state)
     state["firmwareVersion"] = "5.50"
     return state
 

--- a/tests/components/zwave_js/test_fan.py
+++ b/tests/components/zwave_js/test_fan.py
@@ -722,7 +722,7 @@ async def test_leviton_zw4sf_fan(
 async def test_enbrighten_55258_zw4002_fan(
     hass: HomeAssistant, client, enbrighten_55258_zw4002, integration
 ) -> None:
-    """Test a GE/Jasco Enbrighten 55258/ZW4002 fan with 3 fixed speeds."""
+    """Test a GE/Jasco Enbrighten 55258/ZW4002 fan on firmware 5.51+."""
     node = enbrighten_55258_zw4002
     node_id = 57
     entity_id = "fan.zwa4002_fan"
@@ -773,6 +773,76 @@ async def test_enbrighten_55258_zw4002_fan(
         [[0], [0]],
         [range(1, 34), range(1, 34)],
         [range(34, 67), range(34, 67)],
+        [range(67, 101), range(67, 100)],
+    ]
+
+    for percentages, zwave_speeds in percentages_to_zwave_speeds:
+        for percentage in percentages:
+            actual_zwave_speed = await get_zwave_speed_from_percentage(percentage)
+            assert actual_zwave_speed in zwave_speeds
+        for zwave_speed in zwave_speeds:
+            actual_percentage = await get_percentage_from_zwave_speed(zwave_speed)
+            assert actual_percentage in percentages
+
+    state = hass.states.get(entity_id)
+    assert state.attributes[ATTR_PERCENTAGE_STEP] == pytest.approx(33.3333, rel=1e-3)
+    assert state.attributes[ATTR_PRESET_MODES] == []
+
+
+async def test_enbrighten_55258_zw4002_fan_firmware_5_50(
+    hass: HomeAssistant, client, enbrighten_55258_zw4002_firmware_5_50, integration
+) -> None:
+    """Test a GE/Jasco Enbrighten 55258/ZW4002 fan on firmware 5.50 and lower."""
+    node = enbrighten_55258_zw4002_firmware_5_50
+    node_id = 57
+    entity_id = "fan.zwa4002_fan"
+
+    async def get_zwave_speed_from_percentage(percentage):
+        """Set the fan to a particular percentage and get the resulting Zwave speed."""
+        client.async_send_command.reset_mock()
+
+        await hass.services.async_call(
+            "fan",
+            "turn_on",
+            {"entity_id": entity_id, "percentage": percentage},
+            blocking=True,
+        )
+
+        assert len(client.async_send_command.call_args_list) == 1
+        args = client.async_send_command.call_args[0][0]
+        assert args["command"] == "node.set_value"
+        assert args["nodeId"] == node_id
+        return args["value"]
+
+    async def get_percentage_from_zwave_speed(zwave_speed):
+        """Set the underlying device speed and get the resulting percentage."""
+        event = Event(
+            type="value updated",
+            data={
+                "source": "node",
+                "event": "value updated",
+                "nodeId": node_id,
+                "args": {
+                    "commandClassName": "Multilevel Switch",
+                    "commandClass": 38,
+                    "endpoint": 0,
+                    "property": "currentValue",
+                    "newValue": zwave_speed,
+                    "prevValue": 0,
+                    "propertyName": "currentValue",
+                },
+            },
+        )
+        node.receive_event(event)
+        state = hass.states.get(entity_id)
+        return state.attributes[ATTR_PERCENTAGE]
+
+    # This device has the following speeds in Z-Wave JS:
+    # 1 = 1-32, 2 = 33-66, 3 = 67-99
+    percentages_to_zwave_speeds = [
+        [[0], [0]],
+        [range(1, 34), range(1, 33)],
+        [range(34, 67), range(33, 67)],
         [range(67, 101), range(67, 100)],
     ]
 

--- a/tests/components/zwave_js/test_fan.py
+++ b/tests/components/zwave_js/test_fan.py
@@ -1,6 +1,7 @@
 """Test the Z-Wave JS fan platform."""
 
 import copy
+from unittest.mock import MagicMock
 
 import pytest
 from voluptuous.error import MultipleInvalid
@@ -34,6 +35,8 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture
@@ -790,7 +793,10 @@ async def test_enbrighten_55258_zw4002_fan(
 
 
 async def test_enbrighten_55258_zw4002_fan_firmware_5_50(
-    hass: HomeAssistant, client, enbrighten_55258_zw4002_firmware_5_50, integration
+    hass: HomeAssistant,
+    client: MagicMock,
+    enbrighten_55258_zw4002_firmware_5_50: Node,
+    integration: MockConfigEntry,
 ) -> None:
     """Test a GE/Jasco Enbrighten 55258/ZW4002 fan on firmware 5.50 and lower."""
     node = enbrighten_55258_zw4002_firmware_5_50
@@ -798,7 +804,7 @@ async def test_enbrighten_55258_zw4002_fan_firmware_5_50(
     entity_id = "fan.zwa4002_fan"
 
     async def get_zwave_speed_from_percentage(percentage):
-        """Set the fan to a particular percentage and get the resulting Zwave speed."""
+        """Set the fan to a particular percentage and get the resulting Z-Wave speed."""
         client.async_send_command.reset_mock()
 
         await hass.services.async_call(


### PR DESCRIPTION
## Proposed change

The Enbrighten/Jasco 55258 ZW4002 3-speed fan controller on firmware 5.50 maps the low speed range to 1-32. Home Assistant currently treats the low range as 1-33, which causes Low to be interpreted as Medium on this firmware.

This change adds firmware-aware mapping for 55258:

Firmware 5.51 and newer uses the existing 1-33 / 34-66 / 67-99 mapping.
Firmware 5.50 and older uses 1-32 / 33-66 / 67-99.
Tests were updated to cover both firmware paths.

I have two of these fan controls both on 5.50 and have verified this behavior and the fix.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #166780
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
