### PR TITLE
Move Teslemetry destination name from device tracker to a sensor

### DIFF
--- a/homeassistant/components/teslemetry/device_tracker.py
+++ b/homeassistant/components/teslemetry/device_tracker.py
@@ -11,7 +11,6 @@ from homeassistant.components.device_tracker import (
     TrackerEntity,
     TrackerEntityDescription,
 )
-from homeassistant.const import STATE_HOME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -31,12 +30,6 @@ class TeslemetryDeviceTrackerEntityDescription(TrackerEntityDescription):
         [TeslemetryStreamVehicle, Callable[[TeslaLocation | None], None]],
         Callable[[], None],
     ]
-    name_listener: (
-        Callable[
-            [TeslemetryStreamVehicle, Callable[[str | None], None]], Callable[[], None]
-        ]
-        | None
-    ) = None
     streaming_firmware: str
     polling_prefix: str | None = None
 
@@ -52,9 +45,6 @@ DESCRIPTIONS: tuple[TeslemetryDeviceTrackerEntityDescription, ...] = (
         key="route",
         polling_prefix="drive_state_active_route",
         value_listener=lambda vehicle, callback: vehicle.listen_DestinationLocation(
-            callback
-        ),
-        name_listener=lambda vehicle, callback: vehicle.listen_DestinationName(
             callback
         ),
         streaming_firmware="2024.26",
@@ -126,11 +116,6 @@ class TeslemetryVehiclePollingDeviceTrackerEntity(
         self._attr_longitude = self.get(
             f"{self.entity_description.polling_prefix}_longitude"
         )
-        self._attr_location_name = self.get(
-            f"{self.entity_description.polling_prefix}_destination"
-        )
-        if self._attr_location_name == "Home":
-            self._attr_location_name = STATE_HOME
         self._attr_available = (
             self._attr_latitude is not None and self._attr_longitude is not None
         )
@@ -158,28 +143,14 @@ class TeslemetryStreamingDeviceTrackerEntity(
         if (state := await self.async_get_last_state()) is not None:
             self._attr_latitude = state.attributes.get("latitude")
             self._attr_longitude = state.attributes.get("longitude")
-            self._attr_location_name = state.attributes.get("location_name")
         self.async_on_remove(
             self.entity_description.value_listener(
                 self.vehicle.stream_vehicle, self._location_callback
             )
         )
-        if self.entity_description.name_listener:
-            self.async_on_remove(
-                self.entity_description.name_listener(
-                    self.vehicle.stream_vehicle, self._name_callback
-                )
-            )
 
     def _location_callback(self, location: TeslaLocation | None) -> None:
         """Update the value of the entity."""
         self._attr_latitude = None if location is None else location.latitude
         self._attr_longitude = None if location is None else location.longitude
-        self.async_write_ha_state()
-
-    def _name_callback(self, name: str | None) -> None:
-        """Update the value of the entity."""
-        self._attr_location_name = name
-        if self._attr_location_name == "Home":
-            self._attr_location_name = STATE_HOME
         self.async_write_ha_state()

--- a/homeassistant/components/teslemetry/sensor.py
+++ b/homeassistant/components/teslemetry/sensor.py
@@ -511,6 +511,14 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
         entity_registry_enabled_default=False,
     ),
     TeslemetryVehicleSensorEntityDescription(
+        key="drive_state_active_route_destination",
+        polling=True,
+        streaming_listener=lambda vehicle, callback: vehicle.listen_DestinationName(
+            callback
+        ),
+        entity_registry_enabled_default=False,
+    ),
+    TeslemetryVehicleSensorEntityDescription(
         key="drive_state_active_route_traffic_minutes_delay",
         polling=True,
         streaming_listener=lambda vehicle, callback: (

--- a/tests/components/teslemetry/snapshots/test_device_tracker.ambr
+++ b/tests/components/teslemetry/snapshots/test_device_tracker.ambr
@@ -108,7 +108,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'home',
+    'state': 'not_home',
   })
 # ---
 # name: test_device_tracker_alt[device_tracker.test_location-statealt]

--- a/tests/components/teslemetry/snapshots/test_sensor.ambr
+++ b/tests/components/teslemetry/snapshots/test_sensor.ambr
@@ -3228,6 +3228,69 @@
     'state': 'stopped',
   })
 # ---
+# name: test_sensors[sensor.test_destination-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_destination',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Destination',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Destination',
+    'platform': 'teslemetry',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'drive_state_active_route_destination',
+    'unique_id': 'LRW3F7EK4NC700000-drive_state_active_route_destination',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.test_destination-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Test Destination',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_destination',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Home',
+  })
+# ---
+# name: test_sensors[sensor.test_destination-statealt]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Test Destination',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_destination',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_sensors[sensor.test_distance_to_arrival-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/teslemetry/test_device_tracker.py
+++ b/tests/components/teslemetry/test_device_tracker.py
@@ -81,7 +81,6 @@ async def test_device_tracker_streaming(
                     "latitude": 3.0,
                     "longitude": 4.0,
                 },
-                Signal.DESTINATION_NAME: "Home",
                 Signal.ORIGIN_LOCATION: None,
             },
             "createdAt": "2024-10-04T10:45:17.537Z",
@@ -91,7 +90,7 @@ async def test_device_tracker_streaming(
 
     # Assert the entities have correct state values
     assert hass.states.get("device_tracker.test_location").state == "not_home"
-    assert hass.states.get("device_tracker.test_route").state == "home"
+    assert hass.states.get("device_tracker.test_route").state == "not_home"
     assert hass.states.get("device_tracker.test_origin").state == "unknown"
 
     # Reload the entry


### PR DESCRIPTION
## Breaking change

The Teslemetry `route` device tracker no longer reports the active route's destination as its state or via a `location_name` attribute. Per the Home Assistant architecture team's guidance (epic home-assistant/epics#81), integrations should not inject descriptive text into a `TrackerEntity` state. The tracker state is now derived purely from latitude/longitude (zone-aware, e.g. `home`/`not_home`). If you relied on the destination name, enable the new **Destination** sensor (`sensor.*_destination`, disabled by default), which reports the raw destination name as Tesla provides it.

## Proposed change

Removes the use of `_attr_location_name` on the Teslemetry device trackers, in line with the architecture team's effort to stop integrations from injecting extra context into a `TrackerEntity`'s state. The `route` tracker's destination is now exposed as its own `drive_state_active_route_destination` sensor (disabled by default, reusing the existing strings/icons), while the dead `location` destination lookup is simply removed. Device tracker state is now driven solely by lat/lon, so zone detection is handled by Home Assistant (`in_zones` is already exposed).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #172436
- This PR is related to issue: home-assistant/epics#81
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45637/
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
