### PR TITLE
fix(irm-kmi): Fix stale state after API error

### DIFF
--- a/homeassistant/components/irm_kmi/coordinator.py
+++ b/homeassistant/components/irm_kmi/coordinator.py
@@ -81,7 +81,7 @@ class IrmKmiCoordinator(TimestampDataUpdateCoordinator[ProcessedCoordinatorData]
                 )
             else:
                 _LOGGER.warning("Could not connect to the API yet")
-                raise UpdateFailed(
+            raise UpdateFailed(
                 f"Error communicating with API for general forecast: {err}. "
                 + (
                     f"Last success time is: {self._last_successful_api_update}"

--- a/homeassistant/components/irm_kmi/coordinator.py
+++ b/homeassistant/components/irm_kmi/coordinator.py
@@ -46,7 +46,7 @@ class IrmKmiCoordinator(TimestampDataUpdateCoordinator[ProcessedCoordinatorData]
         # because _async_update_data can return old data without raising an exception, which still counts as a
         # successful update for the coordinator.
         self._last_successful_api_update: datetime | None = None
-        self._warned_no_success_yet = False
+        self._api_reachable = True
 
     async def _async_update_data(self) -> ProcessedCoordinatorData:
         """Fetch data from API endpoint.
@@ -66,6 +66,8 @@ class IrmKmiCoordinator(TimestampDataUpdateCoordinator[ProcessedCoordinatorData]
             )
 
         except IrmKmiApiError as err:
+            self._api_reachable = False
+
             if (
                 self.data is not None
                 and self._last_successful_api_update is not None
@@ -75,32 +77,21 @@ class IrmKmiCoordinator(TimestampDataUpdateCoordinator[ProcessedCoordinatorData]
             ):
                 return self.data
 
-            if self._last_successful_api_update is not None:
-                _LOGGER.warning(
-                    "Could not connect to the API since %s",
-                    self._last_successful_api_update,
-                )
-                success_info = (
-                    f"Last success time is: {self._last_successful_api_update}"
-                )
-            else:
-                if not self._warned_no_success_yet:
-                    _LOGGER.warning("Could not connect to the API yet")
-                    self._warned_no_success_yet = True
-                else:
-                    _LOGGER.debug("Could not connect to the API yet")
-                success_info = "No successful API update yet."
-
+            success_info = (
+                f"Last success time is: {self._last_successful_api_update}"
+                if self._last_successful_api_update is not None
+                else "No successful API update yet."
+            )
             raise UpdateFailed(
                 f"Error communicating with API for general forecast: {err}. {success_info}"
             ) from err
 
         data = await self.process_api_data()
         self._last_successful_api_update = utcnow()
-        self._warned_no_success_yet = False
 
-        if not self.last_update_success:
+        if not self._api_reachable:
             _LOGGER.warning("Successfully reconnected to the API")
+            self._api_reachable = True
 
         return data
 

--- a/homeassistant/components/irm_kmi/coordinator.py
+++ b/homeassistant/components/irm_kmi/coordinator.py
@@ -1,6 +1,6 @@
 """DataUpdateCoordinator for the IRM KMI integration."""
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 import logging
 
 from irm_kmi_api import IrmKmiApiClientHa, IrmKmiApiError
@@ -42,6 +42,7 @@ class IrmKmiCoordinator(TimestampDataUpdateCoordinator[ProcessedCoordinatorData]
         )
         self._api = api_client
         self._location = entry.data[CONF_LOCATION]
+        self._last_successful_data_update: datetime | None = None
 
     async def _async_update_data(self) -> ProcessedCoordinatorData:
         """Fetch data from API endpoint.
@@ -62,25 +63,30 @@ class IrmKmiCoordinator(TimestampDataUpdateCoordinator[ProcessedCoordinatorData]
 
         except IrmKmiApiError as err:
             if (
-                self.last_update_success_time is not None
+                self.data is not None
+                and self._last_successful_data_update is not None
                 and self.update_interval is not None
-                and self.last_update_success_time - utcnow()
-                < timedelta(seconds=2.5 * self.update_interval.seconds)
+                and utcnow() - self._last_successful_data_update
+                < 2.5 * self.update_interval
             ):
                 return self.data
 
             _LOGGER.warning(
-                "Could not connect to the API since %s", self.last_update_success_time
+                "Could not connect to the API since %s",
+                self._last_successful_data_update,
             )
             raise UpdateFailed(
                 f"Error communicating with API for general forecast: {err}. "
-                f"Last success time is: {self.last_update_success_time}"
+                f"Last success time is: {self._last_successful_data_update}"
             ) from err
+
+        data = await self.process_api_data()
+        self._last_successful_data_update = utcnow()
 
         if not self.last_update_success:
             _LOGGER.warning("Successfully reconnected to the API")
 
-        return await self.process_api_data()
+        return data
 
     async def process_api_data(self) -> ProcessedCoordinatorData:
         """From the API data, create the object that will be used in the entities."""

--- a/homeassistant/components/irm_kmi/coordinator.py
+++ b/homeassistant/components/irm_kmi/coordinator.py
@@ -46,7 +46,7 @@ class IrmKmiCoordinator(TimestampDataUpdateCoordinator[ProcessedCoordinatorData]
         # because _async_update_data can return old data without raising an exception, which still counts as a
         # successful update for the coordinator.
         self._last_successful_api_update: datetime | None = None
-        self._api_reachable = True
+        self._api_reachable: bool | None = None
 
     async def _async_update_data(self) -> ProcessedCoordinatorData:
         """Fetch data from API endpoint.
@@ -78,7 +78,7 @@ class IrmKmiCoordinator(TimestampDataUpdateCoordinator[ProcessedCoordinatorData]
                 return self.data
 
             success_info = (
-                f"Last success time is: {self._last_successful_api_update}"
+                f"Last success time is: {self._last_successful_api_update.isoformat()}"
                 if self._last_successful_api_update is not None
                 else "No successful API update yet."
             )
@@ -89,9 +89,9 @@ class IrmKmiCoordinator(TimestampDataUpdateCoordinator[ProcessedCoordinatorData]
         data = await self.process_api_data()
         self._last_successful_api_update = utcnow()
 
-        if not self._api_reachable:
+        if self._api_reachable is False:
             _LOGGER.warning("Successfully reconnected to the API")
-            self._api_reachable = True
+        self._api_reachable = True
 
         return data
 

--- a/homeassistant/components/irm_kmi/coordinator.py
+++ b/homeassistant/components/irm_kmi/coordinator.py
@@ -1,7 +1,7 @@
 """DataUpdateCoordinator for the IRM KMI integration."""
 
-import logging
 from datetime import datetime, timedelta
+import logging
 
 from irm_kmi_api import IrmKmiApiClientHa, IrmKmiApiError
 
@@ -46,6 +46,7 @@ class IrmKmiCoordinator(TimestampDataUpdateCoordinator[ProcessedCoordinatorData]
         # because _async_update_data can return old data without raising an exception, which still counts as a
         # successful update for the coordinator.
         self._last_successful_api_update: datetime | None = None
+        self._warned_no_success_yet = False
 
     async def _async_update_data(self) -> ProcessedCoordinatorData:
         """Fetch data from API endpoint.
@@ -79,19 +80,24 @@ class IrmKmiCoordinator(TimestampDataUpdateCoordinator[ProcessedCoordinatorData]
                     "Could not connect to the API since %s",
                     self._last_successful_api_update,
                 )
-            else:
-                _LOGGER.warning("Could not connect to the API yet")
-            raise UpdateFailed(
-                f"Error communicating with API for general forecast: {err}. "
-                + (
+                success_info = (
                     f"Last success time is: {self._last_successful_api_update}"
-                    if self._last_successful_api_update is not None
-                    else "No successful API update yet."
                 )
+            else:
+                if not self._warned_no_success_yet:
+                    _LOGGER.warning("Could not connect to the API yet")
+                    self._warned_no_success_yet = True
+                else:
+                    _LOGGER.debug("Could not connect to the API yet")
+                success_info = "No successful API update yet."
+
+            raise UpdateFailed(
+                f"Error communicating with API for general forecast: {err}. {success_info}"
             ) from err
 
         data = await self.process_api_data()
         self._last_successful_api_update = utcnow()
+        self._warned_no_success_yet = False
 
         if not self.last_update_success:
             _LOGGER.warning("Successfully reconnected to the API")

--- a/homeassistant/components/irm_kmi/coordinator.py
+++ b/homeassistant/components/irm_kmi/coordinator.py
@@ -18,7 +18,7 @@ from homeassistant.util.dt import utcnow
 from .data import ProcessedCoordinatorData
 from .utils import preferred_language
 
-GRACE_FACTOR = 2.5
+API_FAILURE_GRACE_MULTIPLIER = 2.5
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -75,7 +75,7 @@ class IrmKmiCoordinator(TimestampDataUpdateCoordinator[ProcessedCoordinatorData]
                 and self._last_successful_api_update is not None
                 and self.update_interval is not None
                 and utcnow() - self._last_successful_api_update
-                < GRACE_FACTOR * self.update_interval
+                < API_FAILURE_GRACE_MULTIPLIER * self.update_interval
             ):
                 return self.data
 
@@ -89,10 +89,16 @@ class IrmKmiCoordinator(TimestampDataUpdateCoordinator[ProcessedCoordinatorData]
             ) from err
 
         data = await self.process_api_data()
+        was_previously_successful = self._last_successful_api_update is not None
         self._last_successful_api_update = utcnow()
 
         if self._api_reachable is False:
-            _LOGGER.warning("Successfully reconnected to the API")
+            message = (
+                "Successfully reconnected to the API"
+                if was_previously_successful
+                else "Successfully connected to the API"
+            )
+            _LOGGER.info(message)
         self._api_reachable = True
 
         return data

--- a/homeassistant/components/irm_kmi/coordinator.py
+++ b/homeassistant/components/irm_kmi/coordinator.py
@@ -18,6 +18,8 @@ from homeassistant.util.dt import utcnow
 from .data import ProcessedCoordinatorData
 from .utils import preferred_language
 
+GRACE_FACTOR = 2.5
+
 _LOGGER = logging.getLogger(__name__)
 
 type IrmKmiConfigEntry = ConfigEntry[IrmKmiCoordinator]
@@ -73,7 +75,7 @@ class IrmKmiCoordinator(TimestampDataUpdateCoordinator[ProcessedCoordinatorData]
                 and self._last_successful_api_update is not None
                 and self.update_interval is not None
                 and utcnow() - self._last_successful_api_update
-                < 2.5 * self.update_interval
+                < GRACE_FACTOR * self.update_interval
             ):
                 return self.data
 

--- a/homeassistant/components/irm_kmi/coordinator.py
+++ b/homeassistant/components/irm_kmi/coordinator.py
@@ -42,7 +42,10 @@ class IrmKmiCoordinator(TimestampDataUpdateCoordinator[ProcessedCoordinatorData]
         )
         self._api = api_client
         self._location = entry.data[CONF_LOCATION]
-        self._last_successful_data_update: datetime | None = None
+        # We have to track the last successful update separately from the coordinator's built-in last_update_success,
+        # because _async_update_data can return old data without raising an exception, which still counts as a
+        # successful update for the coordinator.
+        self._last_successful_api_update: datetime | None = None
 
     async def _async_update_data(self) -> ProcessedCoordinatorData:
         """Fetch data from API endpoint.
@@ -64,24 +67,29 @@ class IrmKmiCoordinator(TimestampDataUpdateCoordinator[ProcessedCoordinatorData]
         except IrmKmiApiError as err:
             if (
                 self.data is not None
-                and self._last_successful_data_update is not None
+                and self._last_successful_api_update is not None
                 and self.update_interval is not None
-                and utcnow() - self._last_successful_data_update
+                and utcnow() - self._last_successful_api_update
                 < 2.5 * self.update_interval
             ):
                 return self.data
 
-            _LOGGER.warning(
-                "Could not connect to the API since %s",
-                self._last_successful_data_update,
-            )
+            if self._last_successful_api_update is not None:
+                _LOGGER.warning(
+                    "Could not connect to the API since %s",
+                    self._last_successful_api_update,
+                )
+            else:
+                _LOGGER.warning("Could not connect to the API yet")
             raise UpdateFailed(
                 f"Error communicating with API for general forecast: {err}. "
-                f"Last success time is: {self._last_successful_data_update}"
+                f"Last success time is: {self._last_successful_api_update}"
+                if self._last_successful_api_update is not None
+                else "No successful API update yet."
             ) from err
 
         data = await self.process_api_data()
-        self._last_successful_data_update = utcnow()
+        self._last_successful_api_update = utcnow()
 
         if not self.last_update_success:
             _LOGGER.warning("Successfully reconnected to the API")

--- a/homeassistant/components/irm_kmi/coordinator.py
+++ b/homeassistant/components/irm_kmi/coordinator.py
@@ -1,7 +1,7 @@
 """DataUpdateCoordinator for the IRM KMI integration."""
 
-from datetime import datetime, timedelta
 import logging
+from datetime import datetime, timedelta
 
 from irm_kmi_api import IrmKmiApiClientHa, IrmKmiApiError
 
@@ -81,11 +81,13 @@ class IrmKmiCoordinator(TimestampDataUpdateCoordinator[ProcessedCoordinatorData]
                 )
             else:
                 _LOGGER.warning("Could not connect to the API yet")
-            raise UpdateFailed(
+                raise UpdateFailed(
                 f"Error communicating with API for general forecast: {err}. "
-                f"Last success time is: {self._last_successful_api_update}"
-                if self._last_successful_api_update is not None
-                else "No successful API update yet."
+                + (
+                    f"Last success time is: {self._last_successful_api_update}"
+                    if self._last_successful_api_update is not None
+                    else "No successful API update yet."
+                )
             ) from err
 
         data = await self.process_api_data()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
This PR fixes a bug in the IRM-KMI integration, where the coordinator would never emit a failure state to Home Assistant.

The API failure "tolerance" delay check could keep passing forever after one successful update.
The code relied on `TimestampDataUpdateCoordinator`'s success timestamp, which is updated every time it received data. Thus, by returning cached data, it was updated, and it would never go under the "2.5 * update_interval" threshold.
Furthermore, the time delta computation was inverted.

The proposed fixed it just to manually store the last update success time in the coordinator instead.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
