### PR TITLE
[Songpal] Add media_player entity per zone

### DIFF
--- a/homeassistant/components/songpal/media_player.py
+++ b/homeassistant/components/songpal/media_player.py
@@ -6,6 +6,7 @@ import asyncio
 from collections import OrderedDict
 import logging
 import re
+from typing import Any
 
 from songpal import (
     ConnectChange,
@@ -16,7 +17,7 @@ from songpal import (
     SongpalException,
     VolumeChange,
 )
-from songpal.containers import Setting
+from songpal.containers import Setting, Sysinfo
 
 from homeassistant.components.media_player import (
     MediaPlayerDeviceClass,
@@ -95,8 +96,7 @@ async def _async_migrate_legacy_entity_to_first_zone(
         return
 
     entity_registry.async_update_entity(
-        old_entity_id,
-        new_unique_id=first_zone_unique_id
+        old_entity_id, new_unique_id=first_zone_unique_id
     )
 
 
@@ -157,7 +157,7 @@ class SongpalEntity(MediaPlayerEntity):
 
     _attr_should_poll = False
     _attr_device_class = MediaPlayerDeviceClass.RECEIVER
-    _attr_supported_features: MediaPlayerEntityFeature | None = (
+    _attr_supported_features: MediaPlayerEntityFeature = (
         MediaPlayerEntityFeature.VOLUME_SET
         | MediaPlayerEntityFeature.VOLUME_STEP
         | MediaPlayerEntityFeature.VOLUME_MUTE
@@ -167,30 +167,30 @@ class SongpalEntity(MediaPlayerEntity):
         | MediaPlayerEntityFeature.TURN_OFF
     )
     _attr_has_entity_name = True
-    _attr_name = None
+    _attr_name: str | None = None
 
     def __init__(self, name, device) -> None:
         """Init."""
         self._name = name
         self._dev = device
-        self._sysinfo = None
-        self._model = None
+        self._sysinfo: Sysinfo | None = None
+        self._model: str | None = None
 
         self._state = False
         self._attr_available = False
         self._initialized = False
-        self._device_unique_id = None
+        self._device_unique_id: str | None = None
 
-        self._volume_control = None
+        self._volume_control: Any = None
         self._volume_min = 0
         self._volume_max = 1
         self._volume = 0
         self._attr_is_volume_muted = False
 
-        self._active_source = None
-        self._sources = {}
-        self._active_sound_mode = None
-        self._sound_modes = {}
+        self._active_source: Any = None
+        self._sources: OrderedDict[str, Any] = OrderedDict()
+        self._active_sound_mode: str | None = None
+        self._sound_modes: dict[str, Any] = {}
         self._manage_notifications = True
 
     async def async_added_to_hass(self) -> None:
@@ -312,13 +312,16 @@ class SongpalEntity(MediaPlayerEntity):
         self.hass.loop.create_task(self._dev.listen_notifications())
 
     @property
-    def unique_id(self):
+    def unique_id(self) -> str | None:
         """Return a unique ID."""
         return self._device_unique_id
 
     @property
     def device_info(self) -> DeviceInfo:
         """Return the device info."""
+        assert self._sysinfo is not None
+        assert self._device_unique_id is not None
+
         connections = set()
         if self._sysinfo.macAddr:
             connections.add((dr.CONNECTION_NETWORK_MAC, self._sysinfo.macAddr))
@@ -405,7 +408,7 @@ class SongpalEntity(MediaPlayerEntity):
         _LOGGER.error("Unable to find output: %s", source)
 
     @property
-    def source_list(self):
+    def source_list(self) -> list[str] | None:
         """Return list of available sources."""
         return [src.title for src in self._sources.values()]
 
@@ -438,7 +441,7 @@ class SongpalEntity(MediaPlayerEntity):
         return MediaPlayerState.OFF
 
     @property
-    def source(self):
+    def source(self) -> str | None:
         """Return currently active source."""
         # Avoid a KeyError when _active_source is not (yet) populated
         return getattr(self._active_source, "title", None)
@@ -446,26 +449,33 @@ class SongpalEntity(MediaPlayerEntity):
     @property
     def sound_mode(self) -> str | None:
         """Return currently active sound_mode."""
+        if self._active_sound_mode is None:
+            return None
         active_sound_mode = self._sound_modes.get(self._active_sound_mode)
         return active_sound_mode.title if active_sound_mode else None
 
     @property
-    def volume_level(self):
+    def volume_level(self) -> float | None:
         """Return volume level."""
+        if self._volume_max == 0:
+            return None
         return self._volume / self._volume_max
 
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level."""
+        assert self._volume_control is not None
         volume = int(volume * self._volume_max)
         _LOGGER.debug("Setting volume to %s", volume)
         return await self._volume_control.set_volume(volume)
 
     async def async_volume_up(self) -> None:
         """Set volume up."""
+        assert self._volume_control is not None
         return await self._volume_control.set_volume(self._volume + 1)
 
     async def async_volume_down(self) -> None:
         """Set volume down."""
+        assert self._volume_control is not None
         return await self._volume_control.set_volume(self._volume - 1)
 
     async def async_turn_on(self) -> None:
@@ -494,6 +504,7 @@ class SongpalEntity(MediaPlayerEntity):
 
     async def async_mute_volume(self, mute: bool) -> None:
         """Mute or unmute the device."""
+        assert self._volume_control is not None
         _LOGGER.debug("Set mute: %s", mute)
         return await self._volume_control.set_mute(mute)
 
@@ -503,7 +514,7 @@ class SongpalZoneEntity(SongpalEntity):
 
     _attr_should_poll = True
     _attr_name: str | None = None
-    _attr_supported_features: MediaPlayerEntityFeature | None = (
+    _attr_supported_features: MediaPlayerEntityFeature = (
         MediaPlayerEntityFeature.SELECT_SOURCE
         | MediaPlayerEntityFeature.TURN_ON
         | MediaPlayerEntityFeature.TURN_OFF
@@ -514,12 +525,12 @@ class SongpalZoneEntity(SongpalEntity):
         super().__init__(name, device)
         self._zone_uri = zone_uri
         self._zone_title = zone_title
-        self._zone = None
+        self._zone: Any = None
         self._attr_name = zone_title
         self._manage_notifications = False
 
     @property
-    def unique_id(self):
+    def unique_id(self) -> str | None:
         """Return a unique ID for this zone entity."""
         if self._device_unique_id is None:
             return None

--- a/homeassistant/components/songpal/media_player.py
+++ b/homeassistant/components/songpal/media_player.py
@@ -25,10 +25,10 @@ from homeassistant.components.media_player import (
     MediaPlayerState,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME, EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import CONF_NAME, EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import (
     AddConfigEntryEntitiesCallback,
@@ -45,6 +45,59 @@ PARAM_VALUE = "value"
 
 INITIAL_RETRY_DELAY = 10
 ZONE_UNIQUE_ID_SEPARATOR = "_zone_"
+
+
+def _zone_unique_id(device_unique_id: str, zone_uri: str) -> str:
+    """Return zone unique ID derived from the device unique ID and zone URI."""
+    zone_id = re.sub(r"[^A-Za-z0-9]", "_", zone_uri)
+    return f"{device_unique_id}{ZONE_UNIQUE_ID_SEPARATOR}{zone_id}"
+
+
+async def _async_migrate_legacy_entity_to_first_zone(
+    hass: HomeAssistant,
+    device: Device,
+    zones: list,
+) -> None:
+    """Migrate old single-entity Songpal unique ID to first discovered zone."""
+    if not zones:
+        return
+
+    try:
+        sysinfo = await device.get_system_info()
+    except SongpalException as ex:
+        _LOGGER.debug("Unable to fetch system info for migration: %s", ex)
+        return
+
+    device_unique_id = sysinfo.macAddr or sysinfo.wirelessMacAddr
+    if device_unique_id is None:
+        return
+
+    entity_registry = er.async_get(hass)
+    old_entity_id = entity_registry.async_get_entity_id(
+        Platform.MEDIA_PLAYER,
+        DOMAIN,
+        device_unique_id,
+    )
+    if old_entity_id is None:
+        return
+
+    first_zone_unique_id = _zone_unique_id(device_unique_id, zones[0].uri)
+    existing_zone_entity_id = entity_registry.async_get_entity_id(
+        Platform.MEDIA_PLAYER,
+        DOMAIN,
+        first_zone_unique_id,
+    )
+    if existing_zone_entity_id and existing_zone_entity_id != old_entity_id:
+        _LOGGER.debug(
+            "Skipping Songpal entity migration due to unique ID conflict: %s",
+            first_zone_unique_id,
+        )
+        return
+
+    entity_registry.async_update_entity(
+        old_entity_id,
+        new_unique_id=first_zone_unique_id
+    )
 
 
 async def async_setup_platform(
@@ -89,6 +142,7 @@ async def async_setup_entry(
         return
 
     if zones:
+        await _async_migrate_legacy_entity_to_first_zone(hass, device, zones)
         async_add_entities(
             [SongpalZoneEntity(name, device, zone.uri, zone.title) for zone in zones],
             True,
@@ -103,7 +157,7 @@ class SongpalEntity(MediaPlayerEntity):
 
     _attr_should_poll = False
     _attr_device_class = MediaPlayerDeviceClass.RECEIVER
-    _attr_supported_features = (
+    _attr_supported_features: MediaPlayerEntityFeature | None = (
         MediaPlayerEntityFeature.VOLUME_SET
         | MediaPlayerEntityFeature.VOLUME_STEP
         | MediaPlayerEntityFeature.VOLUME_MUTE
@@ -115,7 +169,7 @@ class SongpalEntity(MediaPlayerEntity):
     _attr_has_entity_name = True
     _attr_name = None
 
-    def __init__(self, name, device):
+    def __init__(self, name, device) -> None:
         """Init."""
         self._name = name
         self._dev = device
@@ -137,14 +191,19 @@ class SongpalEntity(MediaPlayerEntity):
         self._sources = {}
         self._active_sound_mode = None
         self._sound_modes = {}
+        self._manage_notifications = True
 
     async def async_added_to_hass(self) -> None:
         """Run when entity is added to hass."""
-        await self.async_activate_websocket()
+        if self._manage_notifications:
+            await self.async_activate_websocket()
+        await super().async_added_to_hass()
 
     async def async_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from hass."""
-        await self._dev.stop_listen_notifications()
+        if self._manage_notifications:
+            await self._dev.stop_listen_notifications()
+        await super().async_will_remove_from_hass()
 
     async def _get_sound_modes_info(self):
         """Get available sound modes and the active one."""
@@ -443,33 +502,28 @@ class SongpalZoneEntity(SongpalEntity):
     """Class representing a Songpal zone as a media player entity."""
 
     _attr_should_poll = True
-    _attr_supported_features = (
+    _attr_name: str | None = None
+    _attr_supported_features: MediaPlayerEntityFeature | None = (
         MediaPlayerEntityFeature.SELECT_SOURCE
         | MediaPlayerEntityFeature.TURN_ON
         | MediaPlayerEntityFeature.TURN_OFF
     )
 
-    def __init__(self, name, device, zone_uri: str, zone_title: str):
+    def __init__(self, name, device, zone_uri: str, zone_title: str) -> None:
         """Initialize zone entity."""
         super().__init__(name, device)
         self._zone_uri = zone_uri
         self._zone_title = zone_title
         self._zone = None
         self._attr_name = zone_title
-
-    async def async_added_to_hass(self) -> None:
-        """Run when entity is added to hass."""
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Run when entity will be removed from hass."""
+        self._manage_notifications = False
 
     @property
     def unique_id(self):
         """Return a unique ID for this zone entity."""
         if self._device_unique_id is None:
             return None
-        zone_id = re.sub(r"[^A-Za-z0-9]", "_", self._zone_uri)
-        return f"{self._device_unique_id}{ZONE_UNIQUE_ID_SEPARATOR}{zone_id}"
+        return _zone_unique_id(self._device_unique_id, self._zone_uri)
 
     @property
     def supported_features(self) -> MediaPlayerEntityFeature:
@@ -553,7 +607,16 @@ class SongpalZoneEntity(SongpalEntity):
 
             self._attr_available = True
         except SongpalException as ex:
-            _LOGGER.error("Unable to update zone %s: %s", self._zone_title, ex)
+            if (
+                "Cannot connect to host" in str(ex) or "Request timeout" in str(ex)
+            ) and not self._attr_available:
+                _LOGGER.debug(
+                    "Got expected exception when updating zone %s: %s",
+                    self._zone_title,
+                    ex,
+                )
+            else:
+                _LOGGER.error("Unable to update zone %s: %s", self._zone_title, ex)
             self._attr_available = False
 
     async def async_select_source(self, source: str) -> None:

--- a/homeassistant/components/songpal/media_player.py
+++ b/homeassistant/components/songpal/media_player.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections import OrderedDict
 import logging
+import re
 
 from songpal import (
     ConnectChange,
@@ -43,6 +44,7 @@ PARAM_NAME = "name"
 PARAM_VALUE = "value"
 
 INITIAL_RETRY_DELAY = 10
+ZONE_UNIQUE_ID_SEPARATOR = "_zone_"
 
 
 async def async_setup_platform(
@@ -78,8 +80,25 @@ async def async_setup_entry(
         _LOGGER.debug("Unable to get methods from songpal: %s", ex)
         raise PlatformNotReady from ex
 
-    songpal_entity = SongpalEntity(name, device)
-    async_add_entities([songpal_entity], True)
+    try:
+        zones = await device.get_zones()
+    except SongpalException as ex:
+        if "Device has no zones" not in str(ex):
+            _LOGGER.debug("Unable to get zones, falling back to root entity: %s", ex)
+        async_add_entities([SongpalEntity(name, device)], True)
+        return
+
+    if zones:
+        async_add_entities(
+            [
+                SongpalZoneEntity(name, device, zone.uri, zone.title)
+                for zone in zones
+            ],
+            True,
+        )
+        return
+
+    async_add_entities([SongpalEntity(name, device)], True)
 
 
 class SongpalEntity(MediaPlayerEntity):
@@ -109,6 +128,7 @@ class SongpalEntity(MediaPlayerEntity):
         self._state = False
         self._attr_available = False
         self._initialized = False
+        self._device_unique_id = None
 
         self._volume_control = None
         self._volume_min = 0
@@ -238,7 +258,7 @@ class SongpalEntity(MediaPlayerEntity):
     @property
     def unique_id(self):
         """Return a unique ID."""
-        return self._sysinfo.macAddr or self._sysinfo.wirelessMacAddr
+        return self._device_unique_id
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -250,7 +270,7 @@ class SongpalEntity(MediaPlayerEntity):
             connections.add((dr.CONNECTION_NETWORK_MAC, self._sysinfo.wirelessMacAddr))
         return DeviceInfo(
             connections=connections,
-            identifiers={(DOMAIN, self.unique_id)},
+            identifiers={(DOMAIN, self._device_unique_id)},
             manufacturer="Sony Corporation",
             model=self._model,
             name=self._name,
@@ -267,6 +287,9 @@ class SongpalEntity(MediaPlayerEntity):
         try:
             if self._sysinfo is None:
                 self._sysinfo = await self._dev.get_system_info()
+                self._device_unique_id = (
+                    self._sysinfo.macAddr or self._sysinfo.wirelessMacAddr
+                )
 
             if self._model is None:
                 interface_info = await self._dev.get_interface_information()
@@ -417,3 +440,155 @@ class SongpalEntity(MediaPlayerEntity):
         """Mute or unmute the device."""
         _LOGGER.debug("Set mute: %s", mute)
         return await self._volume_control.set_mute(mute)
+
+
+class SongpalZoneEntity(SongpalEntity):
+    """Class representing a Songpal zone as a media player entity."""
+
+    _attr_should_poll = True
+    _attr_supported_features = (
+        MediaPlayerEntityFeature.SELECT_SOURCE
+        | MediaPlayerEntityFeature.TURN_ON
+        | MediaPlayerEntityFeature.TURN_OFF
+    )
+
+    def __init__(self, name, device, zone_uri: str, zone_title: str):
+        """Initialize zone entity."""
+        super().__init__(name, device)
+        self._zone_uri = zone_uri
+        self._zone_title = zone_title
+        self._zone = None
+        self._attr_name = zone_title
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity is added to hass."""
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+
+    @property
+    def unique_id(self):
+        """Return a unique ID for this zone entity."""
+        if self._device_unique_id is None:
+            return None
+        zone_id = re.sub(r"[^A-Za-z0-9]", "_", self._zone_uri)
+        return f"{self._device_unique_id}{ZONE_UNIQUE_ID_SEPARATOR}{zone_id}"
+
+    @property
+    def supported_features(self) -> MediaPlayerEntityFeature:
+        """Return supported features for this zone."""
+        features = self._attr_supported_features
+        if self._volume_control is not None:
+            features |= (
+                MediaPlayerEntityFeature.VOLUME_SET
+                | MediaPlayerEntityFeature.VOLUME_STEP
+                | MediaPlayerEntityFeature.VOLUME_MUTE
+            )
+        return features
+
+    @property
+    def sound_mode_list(self) -> list[str] | None:
+        """Return list of available sound modes."""
+        return None
+
+    @property
+    def sound_mode(self) -> str | None:
+        """Return currently active sound mode."""
+        return None
+
+    async def async_select_sound_mode(self, sound_mode: str) -> None:
+        """Ignore sound mode selection for zone entities."""
+        return
+
+    async def async_update(self) -> None:
+        """Fetch updates for the zone from the device."""
+        try:
+            if self._sysinfo is None:
+                self._sysinfo = await self._dev.get_system_info()
+                self._device_unique_id = (
+                    self._sysinfo.macAddr or self._sysinfo.wirelessMacAddr
+                )
+
+            if self._model is None:
+                interface_info = await self._dev.get_interface_information()
+                self._model = interface_info.modelName
+
+            zone = next(
+                (
+                    zone
+                    for zone in await self._dev.get_zones()
+                    if zone.uri == self._zone_uri
+                ),
+                None,
+            )
+            if zone is None:
+                self._attr_available = False
+                return
+            self._zone = zone
+            self._state = zone.active
+
+            self._volume_control = next(
+                (
+                    volume
+                    for volume in await self._dev.get_volume_information()
+                    if volume.output == self._zone_uri
+                ),
+                None,
+            )
+            if self._volume_control is not None:
+                self._volume_max = self._volume_control.maxVolume
+                self._volume_min = self._volume_control.minVolume
+                self._volume = self._volume_control.volume
+                self._attr_is_volume_muted = self._volume_control.is_muted
+            else:
+                self._volume = 0
+                self._attr_is_volume_muted = False
+
+            inputs = await self._dev.get_inputs()
+            self._sources = OrderedDict()
+            self._active_source = None
+            for input_ in inputs:
+                if self._zone_uri not in input_.outputs:
+                    continue
+                self._sources[input_.uri] = input_
+                if input_.active:
+                    self._active_source = input_
+
+            self._attr_available = True
+        except SongpalException as ex:
+            _LOGGER.error("Unable to update zone %s: %s", self._zone_title, ex)
+            self._attr_available = False
+
+    async def async_select_source(self, source: str) -> None:
+        """Select source for the zone."""
+        if self._zone is None:
+            _LOGGER.error(
+                "Unable to select source for zone %s: zone unavailable",
+                self._zone_title,
+            )
+            return
+
+        for input_ in self._sources.values():
+            if input_.title == source:
+                await input_.activate(self._zone)
+                return
+
+        _LOGGER.error(
+            "Unable to find source %s for zone %s",
+            source,
+            self._zone_title,
+        )
+
+    async def async_turn_on(self) -> None:
+        """Activate zone."""
+        if self._zone is None:
+            await self.async_update()
+        if self._zone is not None:
+            await self._zone.activate(True)
+
+    async def async_turn_off(self) -> None:
+        """Deactivate zone."""
+        if self._zone is None:
+            await self.async_update()
+        if self._zone is not None:
+            await self._zone.activate(False)

--- a/homeassistant/components/songpal/media_player.py
+++ b/homeassistant/components/songpal/media_player.py
@@ -90,10 +90,7 @@ async def async_setup_entry(
 
     if zones:
         async_add_entities(
-            [
-                SongpalZoneEntity(name, device, zone.uri, zone.title)
-                for zone in zones
-            ],
+            [SongpalZoneEntity(name, device, zone.uri, zone.title) for zone in zones],
             True,
         )
         return

--- a/tests/components/songpal/__init__.py
+++ b/tests/components/songpal/__init__.py
@@ -24,9 +24,38 @@ CONF_DATA = {
 
 
 def _create_mocked_device(
-    throw_exception=False, wired_mac=MAC, wireless_mac=None, no_soundfield=False
+    throw_exception=False,
+    wired_mac=MAC,
+    wireless_mac=None,
+    no_soundfield=False,
+    with_zones=False,
 ):
     mocked_device = MagicMock()
+
+    zones = []
+    if with_zones:
+        zone1 = MagicMock()
+        zone1.title = "Main Zone"
+        zone1.uri = "extOutput:zone?zone=1"
+        zone1.active = True
+        zone1.activate = AsyncMock()
+        mocked_device.zone1 = zone1
+
+        zone2 = MagicMock()
+        zone2.title = "Zone 2"
+        zone2.uri = "extOutput:zone?zone=2"
+        zone2.active = True
+        zone2.activate = AsyncMock()
+        mocked_device.zone2 = zone2
+
+        zone3 = MagicMock()
+        zone3.title = "Zone 3"
+        zone3.uri = "extOutput:zone?zone=3"
+        zone3.active = False
+        zone3.activate = AsyncMock()
+        mocked_device.zone3 = zone3
+
+        zones = [zone1, zone2, zone3]
 
     type(mocked_device).get_supported_methods = AsyncMock(
         side_effect=SongpalException("Unable to do POST request: ")
@@ -59,6 +88,7 @@ def _create_mocked_device(
     volume1.minVolume = 0
     volume1.volume = 50
     volume1.is_muted = False
+    volume1.output = "extOutput:zone?zone=1" if with_zones else ""
     volume1.set_volume = AsyncMock()
     volume1.set_mute = AsyncMock()
     volume2 = MagicMock()
@@ -66,7 +96,9 @@ def _create_mocked_device(
     volume2.minVolume = 0
     volume2.volume = 20
     volume2.is_muted = True
+    volume2.output = "extOutput:zone?zone=2" if with_zones else ""
     mocked_device.volume1 = volume1
+    mocked_device.volume2 = volume2
     type(mocked_device).get_volume_information = AsyncMock(
         return_value=[volume1, volume2]
     )
@@ -79,13 +111,32 @@ def _create_mocked_device(
     input1.title = "title1"
     input1.uri = "uri1"
     input1.active = False
+    input1.outputs = [zone.uri for zone in zones] if with_zones else []
     input1.activate = AsyncMock()
     mocked_device.input1 = input1
     input2 = MagicMock()
     input2.title = "title2"
     input2.uri = "uri2"
     input2.active = True
+    input2.outputs = [zones[0].uri] if with_zones else []
+    input2.activate = AsyncMock()
+    mocked_device.input2 = input2
     type(mocked_device).get_inputs = AsyncMock(return_value=[input1, input2])
+
+    if with_zones:
+        type(mocked_device).get_zones = AsyncMock(return_value=zones)
+    else:
+        type(mocked_device).get_zones = AsyncMock(
+            side_effect=SongpalException("Device has no zones")
+        )
+
+    async def _get_zone(name: str):
+        for zone in zones:
+            if zone.title == name:
+                return zone
+        raise SongpalException(f"Unable to find zone {name}")
+
+    type(mocked_device).get_zone = AsyncMock(side_effect=_get_zone)
 
     sound_mode1 = MagicMock()
     sound_mode1.title = "Sound Mode 1"

--- a/tests/components/songpal/test_media_player.py
+++ b/tests/components/songpal/test_media_player.py
@@ -409,6 +409,41 @@ async def test_zone_entities(
     mocked_device.input1.activate.assert_called_once_with(mocked_device.zone2)
 
 
+async def test_migrate_legacy_entity_to_first_zone(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test legacy Songpal entity unique ID migrates to first discovered zone."""
+    mocked_device = _create_mocked_device(with_zones=True)
+    entry = MockConfigEntry(domain=songpal.DOMAIN, data=CONF_DATA)
+    entry.add_to_hass(hass)
+
+    old_entity_entry = entity_registry.async_get_or_create(
+        media_player.DOMAIN,
+        songpal.DOMAIN,
+        MAC,
+        config_entry=entry,
+    )
+    original_entity_id = old_entity_entry.entity_id
+
+    with _patch_media_player_device(mocked_device):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    migrated_entry = entity_registry.async_get(original_entity_id)
+    assert migrated_entry is not None
+    assert migrated_entry.unique_id == "mac_zone_extOutput_zone_zone_1"
+    assert migrated_entry.entity_id == "media_player.main_zone"
+
+    assert (
+        entity_registry.async_get_entity_id(
+            media_player.DOMAIN,
+            songpal.DOMAIN,
+            MAC,
+        )
+        is None
+    )
+
+
 async def test_websocket_events(hass: HomeAssistant) -> None:
     """Test websocket events."""
     mocked_device = _create_mocked_device()

--- a/tests/components/songpal/test_media_player.py
+++ b/tests/components/songpal/test_media_player.py
@@ -357,6 +357,58 @@ async def test_services(hass: HomeAssistant) -> None:
     mocked_device.set_sound_settings.assert_called_with("soundField", "sound_mode1")
 
 
+async def test_zone_entities(hass: HomeAssistant, entity_registry: er.EntityRegistry) -> None:
+    """Test zone entities are exposed and controllable as media players."""
+    mocked_device = _create_mocked_device(with_zones=True)
+    entry = MockConfigEntry(domain=songpal.DOMAIN, data=CONF_DATA)
+    entry.add_to_hass(hass)
+
+    with _patch_media_player_device(mocked_device):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    zone_entries = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+    assert len(zone_entries) == 3
+    assert hass.states.get(ENTITY_ID) is None
+
+    device_ids = {zone_entity.device_id for zone_entity in zone_entries}
+    assert len(device_ids) == 1
+
+    zone2_entity = next(
+        zone_entity
+        for zone_entity in zone_entries
+        if "zone_2" in zone_entity.unique_id
+    )
+
+    zone2_state = hass.states.get(zone2_entity.entity_id)
+    assert zone2_state
+    assert zone2_state.attributes["source_list"] == ["title1"]
+
+    await hass.services.async_call(
+        media_player.DOMAIN,
+        media_player.SERVICE_TURN_OFF,
+        {"entity_id": zone2_entity.entity_id},
+        blocking=True,
+    )
+    mocked_device.zone2.activate.assert_called_once_with(False)
+
+    await hass.services.async_call(
+        media_player.DOMAIN,
+        media_player.SERVICE_VOLUME_SET,
+        {"entity_id": zone2_entity.entity_id, "volume_level": 0.25},
+        blocking=True,
+    )
+    mocked_device.volume2.set_volume.assert_called_once_with(25)
+
+    await hass.services.async_call(
+        media_player.DOMAIN,
+        media_player.SERVICE_SELECT_SOURCE,
+        {"entity_id": zone2_entity.entity_id, "source": "title1"},
+        blocking=True,
+    )
+    mocked_device.input1.activate.assert_called_once_with(mocked_device.zone2)
+
+
 async def test_websocket_events(hass: HomeAssistant) -> None:
     """Test websocket events."""
     mocked_device = _create_mocked_device()

--- a/tests/components/songpal/test_media_player.py
+++ b/tests/components/songpal/test_media_player.py
@@ -357,7 +357,9 @@ async def test_services(hass: HomeAssistant) -> None:
     mocked_device.set_sound_settings.assert_called_with("soundField", "sound_mode1")
 
 
-async def test_zone_entities(hass: HomeAssistant, entity_registry: er.EntityRegistry) -> None:
+async def test_zone_entities(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test zone entities are exposed and controllable as media players."""
     mocked_device = _create_mocked_device(with_zones=True)
     entry = MockConfigEntry(domain=songpal.DOMAIN, data=CONF_DATA)
@@ -375,9 +377,7 @@ async def test_zone_entities(hass: HomeAssistant, entity_registry: er.EntityRegi
     assert len(device_ids) == 1
 
     zone2_entity = next(
-        zone_entity
-        for zone_entity in zone_entries
-        if "zone_2" in zone_entity.unique_id
+        zone_entity for zone_entity in zone_entries if "zone_2" in zone_entity.unique_id
     )
 
     zone2_state = hass.states.get(zone2_entity.entity_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds zone support for the songpal integration so you can individually control zones on your receiver. This was only tested on a STR-DN1080.

Exiting media player is remapped to the first zone discovered.

<img width="695" height="749" alt="image" src="https://github.com/user-attachments/assets/1f6e9996-5ee8-4d66-a13d-6ad16645cb9d" />


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
