### PR TITLE
Bump pyroute2 to 0.9.6

### DIFF
--- a/homeassistant/components/thread/manifest.json
+++ b/homeassistant/components/thread/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://www.home-assistant.io/integrations/thread",
   "integration_type": "service",
   "iot_class": "local_polling",
-  "requirements": ["python-otbr-api==2.10.0", "pyroute2==0.7.5"],
+  "requirements": ["python-otbr-api==2.10.0", "pyroute2==0.9.6"],
   "single_config_entry": true,
   "zeroconf": ["_meshcop._udp.local."]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2492,7 +2492,7 @@ pyrisco==0.7.0
 pyrituals==0.0.7
 
 # homeassistant.components.thread
-pyroute2==0.7.5
+pyroute2==0.9.6
 
 # homeassistant.components.rympro
 pyrympro==0.0.9


### PR DESCRIPTION
## Breaking change


## Proposed change

Bumps pyroute2 from 0.7.5 to 0.9.6; this is used by the thread integration for diagnostics.

Changelog between the two versions:

- 0.9.6: DHCP call UNBOUND hook upon NAK; NDB support replacement policies for routes; NDB support localns setup and fix object cache; IPRoute fix set_netnsid to be a coroutine; CI drop support for Python versions earlier than 3.10
- 0.9.5: Async AsyncIPSet, AsyncIPVS, AsyncWiSet implementations; NDB fix snapshot cleanup; WiRouting initial version; Process use poll instead of select
- 0.9.4: IWUtil fix get_interfaces_dict
- 0.9.3: packaging use only pyproject files; NDB use AsyncIPRoute as RTNL source; NDB deprecate and remove NDB cli; async versions for many protocols
- 0.9.2: IPRoute basic Darwin support; NFTables asynchronous API; Plan9 improvements
- 0.9.1: NFTables fixes, core rewritten using asyncio with compatibility synchronous API, DHCP reimplemented using asyncio, NetNS merged into core, Proxy removed
- 0.8.1: NDB fixes, RTNL probe API, TC htb rate64, IPVS basic support, ETHtool get/set channels

Full changelog: https://github.com/svinota/pyroute2/blob/master/CHANGELOG.rst

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
