### PR TITLE
Refactor blebox integration to use DataUpdateCoordinator

### DIFF
--- a/homeassistant/components/blebox/__init__.py
+++ b/homeassistant/components/blebox/__init__.py
@@ -18,9 +18,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import DEFAULT_SETUP_TIMEOUT
+from .coordinator import BleBoxCoordinator
 from .helpers import get_maybe_authenticated_session
 
-type BleBoxConfigEntry = ConfigEntry[Box]
+type BleBoxConfigEntry = ConfigEntry[BleBoxCoordinator]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,8 +35,6 @@ PLATFORMS = [
     Platform.SWITCH,
     Platform.UPDATE,
 ]
-
-PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: BleBoxConfigEntry) -> bool:
@@ -58,7 +57,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: BleBoxConfigEntry) -> bo
         _LOGGER.error("Identify failed at %s:%d (%s)", api_host.host, api_host.port, ex)
         raise ConfigEntryNotReady from ex
 
-    entry.runtime_data = product
+    coordinator = BleBoxCoordinator(hass, entry, product)
+    await coordinator.async_config_entry_first_refresh()
+
+    entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/blebox/__init__.py
+++ b/homeassistant/components/blebox/__init__.py
@@ -6,7 +6,6 @@ from blebox_uniapi.box import Box
 from blebox_uniapi.error import Error
 from blebox_uniapi.session import ApiHost
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
@@ -18,10 +17,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import DEFAULT_SETUP_TIMEOUT
-from .coordinator import BleBoxCoordinator
+from .coordinator import BleBoxConfigEntry, BleBoxCoordinator
 from .helpers import get_maybe_authenticated_session
-
-type BleBoxConfigEntry = ConfigEntry[BleBoxCoordinator]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/blebox/binary_sensor.py
+++ b/homeassistant/components/blebox/binary_sensor.py
@@ -11,7 +11,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import BleBoxConfigEntry
+from .coordinator import BleBoxCoordinator
 from .entity import BleBoxEntity
+
+PARALLEL_UPDATES = 0
 
 BINARY_SENSOR_TYPES = (
     BinarySensorEntityDescription(
@@ -27,23 +30,27 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up a BleBox entry."""
+    coordinator = config_entry.runtime_data
     entities = [
-        BleBoxBinarySensorEntity(feature, description)
-        for feature in config_entry.runtime_data.features.get("binary_sensors", [])
+        BleBoxBinarySensorEntity(coordinator, feature, description)
+        for feature in coordinator.data.features.get("binary_sensors", [])
         for description in BINARY_SENSOR_TYPES
         if description.key == feature.device_class
     ]
-    async_add_entities(entities, True)
+    async_add_entities(entities)
 
 
 class BleBoxBinarySensorEntity(BleBoxEntity[BinarySensorFeature], BinarySensorEntity):
     """Representation of a BleBox binary sensor feature."""
 
     def __init__(
-        self, feature: BinarySensorFeature, description: BinarySensorEntityDescription
+        self,
+        coordinator: BleBoxCoordinator,
+        feature: BinarySensorFeature,
+        description: BinarySensorEntityDescription,
     ) -> None:
         """Initialize a BleBox binary sensor feature."""
-        super().__init__(feature)
+        super().__init__(coordinator, feature)
         self.entity_description = description
 
     @property

--- a/homeassistant/components/blebox/binary_sensor.py
+++ b/homeassistant/components/blebox/binary_sensor.py
@@ -33,7 +33,7 @@ async def async_setup_entry(
     coordinator = config_entry.runtime_data
     entities = [
         BleBoxBinarySensorEntity(coordinator, feature, description)
-        for feature in coordinator.data.features.get("binary_sensors", [])
+        for feature in coordinator.box.features.get("binary_sensors", [])
         for description in BINARY_SENSOR_TYPES
         if description.key == feature.device_class
     ]

--- a/homeassistant/components/blebox/button.py
+++ b/homeassistant/components/blebox/button.py
@@ -7,7 +7,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import BleBoxConfigEntry
+from .coordinator import BleBoxCoordinator
 from .entity import BleBoxEntity
+from .util import blebox_command
+
+PARALLEL_UPDATES = 1
 
 
 async def async_setup_entry(
@@ -16,19 +20,22 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up a BleBox button entry."""
+    coordinator = config_entry.runtime_data
     entities = [
-        BleBoxButtonEntity(feature)
-        for feature in config_entry.runtime_data.features.get("buttons", [])
+        BleBoxButtonEntity(coordinator, feature)
+        for feature in coordinator.data.features.get("buttons", [])
     ]
-    async_add_entities(entities, True)
+    async_add_entities(entities)
 
 
 class BleBoxButtonEntity(BleBoxEntity[blebox_uniapi.button.Button], ButtonEntity):
     """Representation of BleBox buttons."""
 
-    def __init__(self, feature: blebox_uniapi.button.Button) -> None:
+    def __init__(
+        self, coordinator: BleBoxCoordinator, feature: blebox_uniapi.button.Button
+    ) -> None:
         """Initialize a BleBox button feature."""
-        super().__init__(feature)
+        super().__init__(coordinator, feature)
         self._attr_icon = self.get_icon()
 
     def get_icon(self) -> str | None:
@@ -45,6 +52,7 @@ class BleBoxButtonEntity(BleBoxEntity[blebox_uniapi.button.Button], ButtonEntity
             return "mdi:arrow-down-circle"
         return None
 
+    @blebox_command
     async def async_press(self) -> None:
         """Handle the button press."""
         await self._feature.set()

--- a/homeassistant/components/blebox/button.py
+++ b/homeassistant/components/blebox/button.py
@@ -23,7 +23,7 @@ async def async_setup_entry(
     coordinator = config_entry.runtime_data
     entities = [
         BleBoxButtonEntity(coordinator, feature)
-        for feature in coordinator.data.features.get("buttons", [])
+        for feature in coordinator.box.features.get("buttons", [])
     ]
     async_add_entities(entities)
 

--- a/homeassistant/components/blebox/climate.py
+++ b/homeassistant/components/blebox/climate.py
@@ -43,7 +43,7 @@ async def async_setup_entry(
     coordinator = config_entry.runtime_data
     entities = [
         BleBoxClimateEntity(coordinator, feature)
-        for feature in coordinator.data.features.get("climates", [])
+        for feature in coordinator.box.features.get("climates", [])
     ]
     async_add_entities(entities)
 

--- a/homeassistant/components/blebox/climate.py
+++ b/homeassistant/components/blebox/climate.py
@@ -1,6 +1,5 @@
 """BleBox climate entity."""
 
-from datetime import timedelta
 from typing import Any
 
 import blebox_uniapi.climate
@@ -17,8 +16,9 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import BleBoxConfigEntry
 from .entity import BleBoxEntity
+from .util import blebox_command
 
-SCAN_INTERVAL = timedelta(seconds=5)
+PARALLEL_UPDATES = 1
 
 BLEBOX_TO_HVACMODE = {
     0: HVACMode.OFF,
@@ -40,11 +40,12 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up a BleBox climate entity."""
+    coordinator = config_entry.runtime_data
     entities = [
-        BleBoxClimateEntity(feature)
-        for feature in config_entry.runtime_data.features.get("climates", [])
+        BleBoxClimateEntity(coordinator, feature)
+        for feature in coordinator.data.features.get("climates", [])
     ]
-    async_add_entities(entities, True)
+    async_add_entities(entities)
 
 
 class BleBoxClimateEntity(BleBoxEntity[blebox_uniapi.climate.Climate], ClimateEntity):
@@ -108,6 +109,7 @@ class BleBoxClimateEntity(BleBoxEntity[blebox_uniapi.climate.Climate], ClimateEn
         """Return the desired thermostat temperature."""
         return self._feature.desired
 
+    @blebox_command
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the climate entity mode."""
         if hvac_mode in [HVACMode.HEAT, HVACMode.COOL]:
@@ -116,6 +118,7 @@ class BleBoxClimateEntity(BleBoxEntity[blebox_uniapi.climate.Climate], ClimateEn
 
         await self._feature.async_off()
 
+    @blebox_command
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set the thermostat temperature."""
         value = kwargs[ATTR_TEMPERATURE]

--- a/homeassistant/components/blebox/coordinator.py
+++ b/homeassistant/components/blebox/coordinator.py
@@ -31,12 +31,7 @@ class BleBoxCoordinator(DataUpdateCoordinator[None]):
             name=DOMAIN,
             update_interval=timedelta(seconds=5),
         )
-        self._box = box
-
-    @property
-    def box(self) -> Box:
-        """Return the BleBox device."""
-        return self._box
+        self.box = box
 
     async def _async_update_data(self) -> None:
         """Fetch data from the BleBox device."""

--- a/homeassistant/components/blebox/coordinator.py
+++ b/homeassistant/components/blebox/coordinator.py
@@ -15,13 +15,16 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
+type BleBoxConfigEntry = ConfigEntry[BleBoxCoordinator]
+
+
 class BleBoxCoordinator(DataUpdateCoordinator[None]):
     """Coordinator for a single BleBox device."""
 
-    config_entry: ConfigEntry
+    config_entry: BleBoxConfigEntry
 
     def __init__(
-        self, hass: HomeAssistant, config_entry: ConfigEntry, box: Box
+        self, hass: HomeAssistant, config_entry: BleBoxConfigEntry, box: Box
     ) -> None:
         """Initialize the coordinator."""
         super().__init__(

--- a/homeassistant/components/blebox/coordinator.py
+++ b/homeassistant/components/blebox/coordinator.py
@@ -1,0 +1,42 @@
+"""DataUpdateCoordinator for BleBox devices."""
+
+from datetime import timedelta
+import logging
+
+from blebox_uniapi.box import Box
+from blebox_uniapi.error import Error
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class BleBoxCoordinator(DataUpdateCoordinator[Box]):
+    """Coordinator for a single BleBox device."""
+
+    config_entry: ConfigEntry
+
+    def __init__(
+        self, hass: HomeAssistant, config_entry: ConfigEntry, box: Box
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name=DOMAIN,
+            update_interval=timedelta(seconds=5),
+        )
+        self._box = box
+
+    async def _async_update_data(self) -> Box:
+        """Fetch data from the BleBox device."""
+        try:
+            await self._box.async_update_data()
+        except Error as err:
+            raise UpdateFailed(str(err)) from err
+        return self._box

--- a/homeassistant/components/blebox/coordinator.py
+++ b/homeassistant/components/blebox/coordinator.py
@@ -38,4 +38,8 @@ class BleBoxCoordinator(DataUpdateCoordinator[None]):
         try:
             await self.box.async_update_data()
         except Error as err:
-            raise UpdateFailed(str(err)) from err
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="update_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err

--- a/homeassistant/components/blebox/coordinator.py
+++ b/homeassistant/components/blebox/coordinator.py
@@ -15,7 +15,7 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
-class BleBoxCoordinator(DataUpdateCoordinator[Box]):
+class BleBoxCoordinator(DataUpdateCoordinator[None]):
     """Coordinator for a single BleBox device."""
 
     config_entry: ConfigEntry
@@ -33,10 +33,14 @@ class BleBoxCoordinator(DataUpdateCoordinator[Box]):
         )
         self._box = box
 
-    async def _async_update_data(self) -> Box:
+    @property
+    def box(self) -> Box:
+        """Return the BleBox device."""
+        return self._box
+
+    async def _async_update_data(self) -> None:
         """Fetch data from the BleBox device."""
         try:
-            await self._box.async_update_data()
+            await self.box.async_update_data()
         except Error as err:
             raise UpdateFailed(str(err)) from err
-        return self._box

--- a/homeassistant/components/blebox/cover.py
+++ b/homeassistant/components/blebox/cover.py
@@ -17,7 +17,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import BleBoxConfigEntry
+from .coordinator import BleBoxCoordinator
 from .entity import BleBoxEntity
+from .util import blebox_command
+
+PARALLEL_UPDATES = 1
 
 BLEBOX_TO_COVER_DEVICE_CLASSES = {
     "gate": CoverDeviceClass.GATE,
@@ -59,19 +63,22 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up a BleBox entry."""
+    coordinator = config_entry.runtime_data
     entities = [
-        BleBoxCoverEntity(feature)
-        for feature in config_entry.runtime_data.features.get("covers", [])
+        BleBoxCoverEntity(coordinator, feature)
+        for feature in coordinator.data.features.get("covers", [])
     ]
-    async_add_entities(entities, True)
+    async_add_entities(entities)
 
 
 class BleBoxCoverEntity(BleBoxEntity[blebox_uniapi.cover.Cover], CoverEntity):
     """Representation of a BleBox cover feature."""
 
-    def __init__(self, feature: blebox_uniapi.cover.Cover) -> None:
+    def __init__(
+        self, coordinator: BleBoxCoordinator, feature: blebox_uniapi.cover.Cover
+    ) -> None:
         """Initialize a BleBox cover feature."""
-        super().__init__(feature)
+        super().__init__(coordinator, feature)
         self._attr_supported_features = (
             CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
         )
@@ -135,33 +142,40 @@ class BleBoxCoverEntity(BleBoxEntity[blebox_uniapi.cover.Cover], CoverEntity):
         """Return whether cover is closed."""
         return self._is_state(CoverState.CLOSED)
 
+    @blebox_command
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Fully open the cover position."""
         await self._feature.async_open()
 
+    @blebox_command
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Fully close the cover position."""
         await self._feature.async_close()
 
+    @blebox_command
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Fully open the cover tilt."""
         position = 50 if self._feature.is_tilt_180 else 0
         await self._feature.async_set_tilt_position(position)
 
+    @blebox_command
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Fully close the cover tilt."""
         # note: values are reversed
         await self._feature.async_set_tilt_position(100)
 
+    @blebox_command
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Set the cover position."""
         position = kwargs[ATTR_POSITION]
         await self._feature.async_set_position(100 - position)
 
+    @blebox_command
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         await self._feature.async_stop()
 
+    @blebox_command
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Set the tilt position."""
         position = kwargs[ATTR_TILT_POSITION]

--- a/homeassistant/components/blebox/cover.py
+++ b/homeassistant/components/blebox/cover.py
@@ -66,7 +66,7 @@ async def async_setup_entry(
     coordinator = config_entry.runtime_data
     entities = [
         BleBoxCoverEntity(coordinator, feature)
-        for feature in coordinator.data.features.get("covers", [])
+        for feature in coordinator.box.features.get("covers", [])
     ]
     async_add_entities(entities)
 

--- a/homeassistant/components/blebox/entity.py
+++ b/homeassistant/components/blebox/entity.py
@@ -1,23 +1,20 @@
 """Base entity for the BleBox devices integration."""
 
-import logging
-
-from blebox_uniapi.error import Error
 from blebox_uniapi.feature import Feature
 
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
+from .coordinator import BleBoxCoordinator
 
-_LOGGER = logging.getLogger(__name__)
 
-
-class BleBoxEntity[_FeatureT: Feature](Entity):
+class BleBoxEntity[_FeatureT: Feature](CoordinatorEntity[BleBoxCoordinator]):
     """Implements a common class for entities representing a BleBox feature."""
 
-    def __init__(self, feature: _FeatureT) -> None:
+    def __init__(self, coordinator: BleBoxCoordinator, feature: _FeatureT) -> None:
         """Initialize a BleBox entity."""
+        super().__init__(coordinator)
         self._feature = feature
         self._attr_name = feature.full_name
         self._attr_unique_id = feature.unique_id
@@ -30,10 +27,3 @@ class BleBoxEntity[_FeatureT: Feature](Entity):
             sw_version=product.firmware_version,
             configuration_url=f"http://{product.address}",
         )
-
-    async def async_update(self) -> None:
-        """Update the entity state."""
-        try:
-            await self._feature.async_update()
-        except Error as ex:
-            _LOGGER.error("Updating '%s' failed: %s", self.name, ex)

--- a/homeassistant/components/blebox/light.py
+++ b/homeassistant/components/blebox/light.py
@@ -41,7 +41,7 @@ async def async_setup_entry(
     coordinator = config_entry.runtime_data
     entities = [
         BleBoxLightEntity(coordinator, feature)
-        for feature in coordinator.data.features.get("lights", [])
+        for feature in coordinator.box.features.get("lights", [])
     ]
     async_add_entities(entities)
 

--- a/homeassistant/components/blebox/light.py
+++ b/homeassistant/components/blebox/light.py
@@ -1,6 +1,5 @@
 """BleBox light entities implementation."""
 
-from datetime import timedelta
 import logging
 import math
 from typing import Any
@@ -24,11 +23,13 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import BleBoxConfigEntry
 from .const import LIGHT_MAX_KELVINS, LIGHT_MIN_KELVINS
+from .coordinator import BleBoxCoordinator
 from .entity import BleBoxEntity
+from .util import blebox_command
 
 _LOGGER = logging.getLogger(__name__)
 
-SCAN_INTERVAL = timedelta(seconds=5)
+PARALLEL_UPDATES = 1
 
 
 async def async_setup_entry(
@@ -37,11 +38,12 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up a BleBox entry."""
+    coordinator = config_entry.runtime_data
     entities = [
-        BleBoxLightEntity(feature)
-        for feature in config_entry.runtime_data.features.get("lights", [])
+        BleBoxLightEntity(coordinator, feature)
+        for feature in coordinator.data.features.get("lights", [])
     ]
-    async_add_entities(entities, True)
+    async_add_entities(entities)
 
 
 COLOR_MODE_MAP = {
@@ -61,9 +63,11 @@ class BleBoxLightEntity(BleBoxEntity[blebox_uniapi.light.Light], LightEntity):
     _attr_min_color_temp_kelvin = LIGHT_MIN_KELVINS
     _attr_max_color_temp_kelvin = LIGHT_MAX_KELVINS
 
-    def __init__(self, feature: blebox_uniapi.light.Light) -> None:
+    def __init__(
+        self, coordinator: BleBoxCoordinator, feature: blebox_uniapi.light.Light
+    ) -> None:
         """Initialize a BleBox light."""
-        super().__init__(feature)
+        super().__init__(coordinator, feature)
         if feature.effect_list:
             self._attr_supported_features = LightEntityFeature.EFFECT
 
@@ -165,6 +169,7 @@ class BleBoxLightEntity(BleBoxEntity[blebox_uniapi.light.Light], LightEntity):
             return None
         return tuple(blebox_uniapi.light.Light.rgb_hex_to_rgb_list(rgbww_hex))
 
+    @blebox_command
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
 
@@ -224,6 +229,7 @@ class BleBoxLightEntity(BleBoxEntity[blebox_uniapi.light.Light], LightEntity):
                     " effect list."
                 ) from exc
 
+    @blebox_command
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         await self._feature.async_off()

--- a/homeassistant/components/blebox/sensor.py
+++ b/homeassistant/components/blebox/sensor.py
@@ -1,6 +1,6 @@
 """BleBox sensor entities."""
 
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import blebox_uniapi.sensor
 
@@ -28,9 +28,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import BleBoxConfigEntry
+from .coordinator import BleBoxCoordinator
 from .entity import BleBoxEntity
 
-SCAN_INTERVAL = timedelta(seconds=5)
+PARALLEL_UPDATES = 0
 
 
 SENSOR_TYPES = (
@@ -124,13 +125,14 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up a BleBox entry."""
+    coordinator = config_entry.runtime_data
     entities = [
-        BleBoxSensorEntity(feature, description)
-        for feature in config_entry.runtime_data.features.get("sensors", [])
+        BleBoxSensorEntity(coordinator, feature, description)
+        for feature in coordinator.data.features.get("sensors", [])
         for description in SENSOR_TYPES
         if description.key == feature.device_class
     ]
-    async_add_entities(entities, True)
+    async_add_entities(entities)
 
 
 class BleBoxSensorEntity(BleBoxEntity[blebox_uniapi.sensor.BaseSensor], SensorEntity):
@@ -138,11 +140,12 @@ class BleBoxSensorEntity(BleBoxEntity[blebox_uniapi.sensor.BaseSensor], SensorEn
 
     def __init__(
         self,
+        coordinator: BleBoxCoordinator,
         feature: blebox_uniapi.sensor.BaseSensor,
         description: SensorEntityDescription,
     ) -> None:
         """Initialize a BleBox sensor feature."""
-        super().__init__(feature)
+        super().__init__(coordinator, feature)
         self.entity_description = description
 
     @property

--- a/homeassistant/components/blebox/sensor.py
+++ b/homeassistant/components/blebox/sensor.py
@@ -128,7 +128,7 @@ async def async_setup_entry(
     coordinator = config_entry.runtime_data
     entities = [
         BleBoxSensorEntity(coordinator, feature, description)
-        for feature in coordinator.data.features.get("sensors", [])
+        for feature in coordinator.box.features.get("sensors", [])
         for description in SENSOR_TYPES
         if description.key == feature.device_class
     ]

--- a/homeassistant/components/blebox/strings.json
+++ b/homeassistant/components/blebox/strings.json
@@ -22,5 +22,10 @@
         "title": "Set up your BleBox device"
       }
     }
+  },
+  "exceptions": {
+    "update_failed": {
+      "message": "An error occurred while communicating with the BleBox device: {error}"
+    }
   }
 }

--- a/homeassistant/components/blebox/switch.py
+++ b/homeassistant/components/blebox/switch.py
@@ -24,7 +24,7 @@ async def async_setup_entry(
     coordinator = config_entry.runtime_data
     entities = [
         BleBoxSwitchEntity(coordinator, feature)
-        for feature in coordinator.data.features.get("switches", [])
+        for feature in coordinator.box.features.get("switches", [])
     ]
     async_add_entities(entities)
 

--- a/homeassistant/components/blebox/switch.py
+++ b/homeassistant/components/blebox/switch.py
@@ -1,6 +1,5 @@
 """BleBox switch implementation."""
 
-from datetime import timedelta
 from typing import Any
 
 import blebox_uniapi.switch
@@ -11,8 +10,9 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import BleBoxConfigEntry
 from .entity import BleBoxEntity
+from .util import blebox_command
 
-SCAN_INTERVAL = timedelta(seconds=5)
+PARALLEL_UPDATES = 1
 
 
 async def async_setup_entry(
@@ -21,11 +21,12 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up a BleBox switch entity."""
+    coordinator = config_entry.runtime_data
     entities = [
-        BleBoxSwitchEntity(feature)
-        for feature in config_entry.runtime_data.features.get("switches", [])
+        BleBoxSwitchEntity(coordinator, feature)
+        for feature in coordinator.data.features.get("switches", [])
     ]
-    async_add_entities(entities, True)
+    async_add_entities(entities)
 
 
 class BleBoxSwitchEntity(BleBoxEntity[blebox_uniapi.switch.Switch], SwitchEntity):
@@ -38,10 +39,12 @@ class BleBoxSwitchEntity(BleBoxEntity[blebox_uniapi.switch.Switch], SwitchEntity
         """Return whether switch is on."""
         return self._feature.is_on
 
+    @blebox_command
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
         await self._feature.async_turn_on()
 
+    @blebox_command
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
         await self._feature.async_turn_off()

--- a/homeassistant/components/blebox/update.py
+++ b/homeassistant/components/blebox/update.py
@@ -18,8 +18,10 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 
 from . import BleBoxConfigEntry
+from .coordinator import BleBoxCoordinator
 from .entity import BleBoxEntity
 
+PARALLEL_UPDATES = 0
 SCAN_INTERVAL = timedelta(hours=1)
 
 
@@ -33,11 +35,12 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up a BleBox update entry."""
+    coordinator = config_entry.runtime_data
     entities = [
-        BleBoxUpdateEntity(feature)
-        for feature in config_entry.runtime_data.features.get("updates", [])
+        BleBoxUpdateEntity(coordinator, feature)
+        for feature in coordinator.data.features.get("updates", [])
     ]
-    async_add_entities(entities, True)
+    async_add_entities(entities, update_before_add=True)
 
 
 class BleBoxUpdateEntity(BleBoxEntity[blebox_uniapi.update.Update], UpdateEntity):
@@ -47,10 +50,14 @@ class BleBoxUpdateEntity(BleBoxEntity[blebox_uniapi.update.Update], UpdateEntity
     _attr_supported_features = (
         UpdateEntityFeature.INSTALL | UpdateEntityFeature.PROGRESS
     )
+    # Firmware versions take a different code path in uniapi and cannot be fetched via coordinator.
+    _attr_should_poll = True
 
-    def __init__(self, feature: blebox_uniapi.update.Update) -> None:
+    def __init__(
+        self, coordinator: BleBoxCoordinator, feature: blebox_uniapi.update.Update
+    ) -> None:
         """Initialize the update entity."""
-        super().__init__(feature)
+        super().__init__(coordinator, feature)
         self._in_progress_old_version: str | None = None
         self._poll_cancel: CALLBACK_TYPE | None = None
         self._poll_attempts: int = 0

--- a/homeassistant/components/blebox/update.py
+++ b/homeassistant/components/blebox/update.py
@@ -50,8 +50,11 @@ class BleBoxUpdateEntity(BleBoxEntity[blebox_uniapi.update.Update], UpdateEntity
     _attr_supported_features = (
         UpdateEntityFeature.INSTALL | UpdateEntityFeature.PROGRESS
     )
-    # Firmware versions take a different code path in uniapi and cannot be fetched via coordinator.
-    _attr_should_poll = True
+
+    @property
+    def should_poll(self) -> bool:
+        """Return True because firmware versions cannot be fetched via coordinator."""
+        return True
 
     def __init__(
         self, coordinator: BleBoxCoordinator, feature: blebox_uniapi.update.Update

--- a/homeassistant/components/blebox/update.py
+++ b/homeassistant/components/blebox/update.py
@@ -38,7 +38,7 @@ async def async_setup_entry(
     coordinator = config_entry.runtime_data
     entities = [
         BleBoxUpdateEntity(coordinator, feature)
-        for feature in coordinator.data.features.get("updates", [])
+        for feature in coordinator.box.features.get("updates", [])
     ]
     async_add_entities(entities, update_before_add=True)
 

--- a/homeassistant/components/blebox/util.py
+++ b/homeassistant/components/blebox/util.py
@@ -1,0 +1,29 @@
+"""Utilities for BleBox."""
+
+from collections.abc import Awaitable, Callable, Coroutine
+from typing import Any, Concatenate
+
+from blebox_uniapi.error import Error
+
+from homeassistant.exceptions import HomeAssistantError
+
+from .entity import BleBoxEntity
+
+
+def blebox_command[_BleBoxEntityT: BleBoxEntity, **_P, _R](
+    func: Callable[Concatenate[_BleBoxEntityT, _P], Awaitable[_R]],
+) -> Callable[Concatenate[_BleBoxEntityT, _P], Coroutine[Any, Any, _R]]:
+    """Decorate BleBox calls that send commands to the device.
+
+    Catches BleBox errors and refreshes the coordinator after the command.
+    """
+
+    async def handler(self: _BleBoxEntityT, *args: _P.args, **kwargs: _P.kwargs) -> _R:
+        try:
+            return await func(self, *args, **kwargs)
+        except Error as err:
+            raise HomeAssistantError(str(err)) from err
+        finally:
+            await self.coordinator.async_refresh()
+
+    return handler

--- a/tests/components/blebox/conftest.py
+++ b/tests/components/blebox/conftest.py
@@ -65,6 +65,12 @@ def mock_config(ip_address="172.100.123.4"):
     return MockConfigEntry(domain=DOMAIN, data={CONF_HOST: ip_address, CONF_PORT: 80})
 
 
+@pytest.fixture(name="config_entry")
+def config_entry_fixture() -> MockConfigEntry:
+    """Return a MockConfigEntry for blebox."""
+    return mock_config()
+
+
 @pytest.fixture(name="config")
 def config_fixture():
     """Create hass config fixture."""

--- a/tests/components/blebox/conftest.py
+++ b/tests/components/blebox/conftest.py
@@ -48,7 +48,6 @@ def mock_only_feature(spec, set_spec: bool = True, **kwargs):
 def mock_feature(category, spec, set_spec: bool = True, **kwargs):
     """Mock a feature along with whole product setup."""
     feature_mock = mock_only_feature(spec, set_spec, **kwargs)
-    feature_mock.async_update = AsyncMock()
     product = setup_product_mock(category, [feature_mock])
 
     type(feature_mock.product).name = PropertyMock(return_value="Some name")

--- a/tests/components/blebox/conftest.py
+++ b/tests/components/blebox/conftest.py
@@ -83,6 +83,20 @@ def feature_fixture(request: pytest.FixtureRequest) -> Any:
     return request.getfixturevalue(request.param)
 
 
+async def async_setup_config_entry(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    *,
+    assert_success: bool = False,
+) -> None:
+    """Add and set up the given config entry."""
+    config_entry.add_to_hass(hass)
+    result = await hass.config_entries.async_setup(config_entry.entry_id)
+    if assert_success:
+        assert result
+    await hass.async_block_till_done()
+
+
 async def async_setup_entities(
     hass: HomeAssistant, entity_ids: list[str]
 ) -> list[er.RegistryEntry]:

--- a/tests/components/blebox/test_climate.py
+++ b/tests/components/blebox/test_climate.py
@@ -19,6 +19,7 @@ from homeassistant.components.climate import (
     HVACAction,
     HVACMode,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ENTITY_ID,
@@ -29,7 +30,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from .conftest import async_setup_entity, mock_feature
+from .conftest import async_setup_entity, mock_config, mock_feature
 
 
 @pytest.fixture(name="saunabox")
@@ -120,12 +121,9 @@ async def test_update(saunabox, hass: HomeAssistant, config) -> None:
 
     feature_mock, entity_id = saunabox
 
-    def initial_update():
-        feature_mock.is_on = False
-        feature_mock.desired = 64.3
-        feature_mock.current = 40.9
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.is_on = False
+    feature_mock.desired = 64.3
+    feature_mock.current = 40.9
     await async_setup_entity(hass, entity_id)
 
     state = hass.states.get(entity_id)
@@ -140,12 +138,8 @@ async def test_on_when_below_desired(saunabox, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = saunabox
 
-    def initial_update():
-        feature_mock.is_on = False
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.is_on = False
     await async_setup_entity(hass, entity_id)
-    feature_mock.async_update = AsyncMock()
 
     def turn_on():
         feature_mock.is_on = True
@@ -175,12 +169,8 @@ async def test_on_when_above_desired(saunabox, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = saunabox
 
-    def initial_update():
-        feature_mock.is_on = False
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.is_on = False
     await async_setup_entity(hass, entity_id)
-    feature_mock.async_update = AsyncMock()
 
     def turn_on():
         feature_mock.is_on = True
@@ -211,13 +201,9 @@ async def test_off(saunabox, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = saunabox
 
-    def initial_update():
-        feature_mock.is_on = True
-        feature_mock.is_heating = False
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.is_on = True
+    feature_mock.is_heating = False
     await async_setup_entity(hass, entity_id)
-    feature_mock.async_update = AsyncMock()
 
     def turn_off():
         feature_mock.is_on = False
@@ -246,13 +232,9 @@ async def test_set_thermo(saunabox, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = saunabox
 
-    def update():
-        feature_mock.is_on = False
-        feature_mock.is_heating = False
-
-    feature_mock.async_update = AsyncMock(side_effect=update)
+    feature_mock.is_on = False
+    feature_mock.is_heating = False
     await async_setup_entity(hass, entity_id)
-    feature_mock.async_update = AsyncMock()
 
     def set_temp(temp):
         feature_mock.is_on = True
@@ -278,15 +260,22 @@ async def test_set_thermo(saunabox, hass: HomeAssistant) -> None:
 async def test_update_failure(
     saunabox, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test that update failures are logged."""
+    """Test that update failures cause config entry setup retry."""
 
     caplog.set_level(logging.ERROR)
 
-    feature_mock, entity_id = saunabox
-    feature_mock.async_update = AsyncMock(side_effect=blebox_uniapi.error.ClientError)
-    await async_setup_entity(hass, entity_id)
+    feature_mock, _entity_id = saunabox
+    feature_mock.product.async_update_data = AsyncMock(
+        side_effect=blebox_uniapi.error.ClientError
+    )
 
-    assert f"Updating '{feature_mock.full_name}' failed: " in caplog.text
+    config_entry = mock_config()
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    feature_mock.product.async_update_data.assert_called()
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_reding_hvac_actions(
@@ -299,12 +288,12 @@ async def test_reding_hvac_actions(
     feature_mock, entity_id = saunabox
     await async_setup_entity(hass, entity_id)
 
-    def set_heating():
+    def set_temperature(temp):
         feature_mock.is_on = True
         feature_mock.hvac_action = 1
         feature_mock.mode = 1
 
-    feature_mock.async_update = AsyncMock(side_effect=set_heating)
+    feature_mock.async_set_temperature = AsyncMock(side_effect=set_temperature)
 
     await hass.services.async_call(
         "climate",
@@ -330,7 +319,7 @@ async def test_thermo_off(
         feature_mock.is_on = False
         feature_mock.hvac_action = 0
 
-    feature_mock.async_update = AsyncMock(side_effect=set_off)
+    feature_mock.async_off = AsyncMock(side_effect=set_off)
 
     await hass.services.async_call(
         "climate",

--- a/tests/components/blebox/test_climate.py
+++ b/tests/components/blebox/test_climate.py
@@ -30,7 +30,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from .conftest import async_setup_entity, mock_feature
+from .conftest import async_setup_config_entry, async_setup_entity, mock_feature
 
 from tests.common import MockConfigEntry
 
@@ -274,9 +274,7 @@ async def test_update_failure(
         side_effect=blebox_uniapi.error.ClientError
     )
 
-    config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await async_setup_config_entry(hass, config_entry)
 
     feature_mock.product.async_update_data.assert_called()
     assert config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/blebox/test_climate.py
+++ b/tests/components/blebox/test_climate.py
@@ -30,7 +30,9 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from .conftest import async_setup_entity, mock_config, mock_feature
+from .conftest import async_setup_entity, mock_feature
+
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture(name="saunabox")
@@ -258,7 +260,10 @@ async def test_set_thermo(saunabox, hass: HomeAssistant) -> None:
 
 
 async def test_update_failure(
-    saunabox, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    saunabox,
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that update failures cause config entry setup retry."""
 
@@ -269,7 +274,6 @@ async def test_update_failure(
         side_effect=blebox_uniapi.error.ClientError
     )
 
-    config_entry = mock_config()
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/blebox/test_config_flow.py
+++ b/tests/components/blebox/test_config_flow.py
@@ -15,7 +15,13 @@ from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from homeassistant.setup import async_setup_component
 
-from .conftest import mock_config, mock_feature, mock_only_feature, setup_product_mock
+from .conftest import (
+    async_setup_config_entry,
+    mock_config,
+    mock_feature,
+    mock_only_feature,
+    setup_product_mock,
+)
 
 from tests.common import MockConfigEntry
 
@@ -198,10 +204,7 @@ async def test_async_setup_entry(
 ) -> None:
     """Test async_setup_entry (for coverage)."""
 
-    config_entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await async_setup_config_entry(hass, config_entry, assert_success=True)
 
     assert hass.config_entries.async_entries() == [config_entry]
     assert config_entry.state is ConfigEntryState.LOADED
@@ -212,10 +215,7 @@ async def test_async_remove_entry(
 ) -> None:
     """Test async_setup_entry (for coverage)."""
 
-    config_entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await async_setup_config_entry(hass, config_entry, assert_success=True)
 
     assert await hass.config_entries.async_remove(config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/blebox/test_config_flow.py
+++ b/tests/components/blebox/test_config_flow.py
@@ -193,33 +193,35 @@ async def test_already_configured(hass: HomeAssistant, valid_feature_mock) -> No
     assert result["reason"] == "address_already_configured"
 
 
-async def test_async_setup_entry(hass: HomeAssistant, valid_feature_mock) -> None:
+async def test_async_setup_entry(
+    hass: HomeAssistant, valid_feature_mock, config_entry: MockConfigEntry
+) -> None:
     """Test async_setup_entry (for coverage)."""
 
-    config = mock_config()
-    config.add_to_hass(hass)
+    config_entry.add_to_hass(hass)
 
-    assert await hass.config_entries.async_setup(config.entry_id)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert hass.config_entries.async_entries() == [config]
-    assert config.state is ConfigEntryState.LOADED
+    assert hass.config_entries.async_entries() == [config_entry]
+    assert config_entry.state is ConfigEntryState.LOADED
 
 
-async def test_async_remove_entry(hass: HomeAssistant, valid_feature_mock) -> None:
+async def test_async_remove_entry(
+    hass: HomeAssistant, valid_feature_mock, config_entry: MockConfigEntry
+) -> None:
     """Test async_setup_entry (for coverage)."""
 
-    config = mock_config()
-    config.add_to_hass(hass)
+    config_entry.add_to_hass(hass)
 
-    assert await hass.config_entries.async_setup(config.entry_id)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert await hass.config_entries.async_remove(config.entry_id)
+    assert await hass.config_entries.async_remove(config_entry.entry_id)
     await hass.async_block_till_done()
 
     assert hass.config_entries.async_entries() == []
-    assert config.state is ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_flow_with_zeroconf(hass: HomeAssistant) -> None:

--- a/tests/components/blebox/test_cover.py
+++ b/tests/components/blebox/test_cover.py
@@ -32,7 +32,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from .conftest import async_setup_entity, mock_feature
+from .conftest import async_setup_config_entry, async_setup_entity, mock_feature
 
 from tests.common import MockConfigEntry
 
@@ -468,9 +468,7 @@ async def test_update_failure(
         side_effect=blebox_uniapi.error.ClientError
     )
 
-    config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await async_setup_config_entry(hass, config_entry)
 
     feature_mock.product.async_update_data.assert_called()
     assert config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/blebox/test_cover.py
+++ b/tests/components/blebox/test_cover.py
@@ -16,6 +16,7 @@ from homeassistant.components.cover import (
     CoverEntityFeature,
     CoverState,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_SUPPORTED_FEATURES,
@@ -31,7 +32,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from .conftest import async_setup_entity, mock_feature
+from .conftest import async_setup_entity, mock_config, mock_feature
 
 ALL_COVER_FIXTURES = ["gatecontroller", "shutterbox", "gatebox"]
 FIXTURES_SUPPORTING_STOP = ["gatecontroller", "shutterbox"]
@@ -255,19 +256,14 @@ async def test_open(feature, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = feature
 
-    def initial_update():
-        feature_mock.state = 3  # manually stopped
+    feature_mock.state = 3  # manually stopped
+    await async_setup_entity(hass, entity_id)
+    assert hass.states.get(entity_id).state == CoverState.CLOSED
 
     def open_gate():
         feature_mock.state = 1  # opening
 
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
     feature_mock.async_open = AsyncMock(side_effect=open_gate)
-
-    await async_setup_entity(hass, entity_id)
-    assert hass.states.get(entity_id).state == CoverState.CLOSED
-
-    feature_mock.async_update = AsyncMock()
     await hass.services.async_call(
         "cover",
         SERVICE_OPEN_COVER,
@@ -283,36 +279,18 @@ async def test_close(feature, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = feature
 
-    def initial_update():
-        feature_mock.state = 4  # open
+    feature_mock.state = 4  # open
+    await async_setup_entity(hass, entity_id)
+    assert hass.states.get(entity_id).state == CoverState.OPEN
 
     def close():
         feature_mock.state = 0  # closing
 
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
     feature_mock.async_close = AsyncMock(side_effect=close)
-
-    await async_setup_entity(hass, entity_id)
-    assert hass.states.get(entity_id).state == CoverState.OPEN
-
-    feature_mock.async_update = AsyncMock()
     await hass.services.async_call(
         "cover", SERVICE_CLOSE_COVER, {"entity_id": entity_id}, blocking=True
     )
     assert hass.states.get(entity_id).state == CoverState.CLOSING
-
-
-def opening_to_stop_feature_mock(feature_mock):
-    """Return an mocked feature which can be updated and stopped."""
-
-    def initial_update():
-        feature_mock.state = 1  # opening
-
-    def stop():
-        feature_mock.state = 2  # manually stopped
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
-    feature_mock.async_stop = AsyncMock(side_effect=stop)
 
 
 @pytest.mark.parametrize("feature", FIXTURES_SUPPORTING_STOP, indirect=["feature"])
@@ -320,12 +298,15 @@ async def test_stop(feature, hass: HomeAssistant) -> None:
     """Test cover stopping."""
 
     feature_mock, entity_id = feature
-    opening_to_stop_feature_mock(feature_mock)
 
+    feature_mock.state = 1  # opening
     await async_setup_entity(hass, entity_id)
     assert hass.states.get(entity_id).state == CoverState.OPENING
 
-    feature_mock.async_update = AsyncMock()
+    def stop():
+        feature_mock.state = 2  # manually stopped
+
+    feature_mock.async_stop = AsyncMock(side_effect=stop)
     await hass.services.async_call(
         "cover", SERVICE_STOP_COVER, {"entity_id": entity_id}, blocking=True
     )
@@ -340,12 +321,8 @@ async def test_update_inverted(feature, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = feature
 
-    def initial_update():
-        feature_mock.current = 29  # device: 29% closed = 71% open
-        feature_mock.state = 2  # manually stopped
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
-
+    feature_mock.current = 29  # device: 29% closed = 71% open
+    feature_mock.state = 2  # manually stopped
     await async_setup_entity(hass, entity_id)
 
     state = hass.states.get(entity_id)
@@ -358,12 +335,8 @@ async def test_update_not_inverted(gatebox, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = gatebox
 
-    def initial_update():
-        feature_mock.current = 100  # fully open
-        feature_mock.state = 4  # open
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
-
+    feature_mock.current = 100  # fully open
+    feature_mock.state = 4  # open
     await async_setup_entity(hass, entity_id)
 
     state = hass.states.get(entity_id)
@@ -379,21 +352,16 @@ async def test_set_position(feature, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = feature
 
-    def initial_update():
-        feature_mock.state = 3  # closed
+    feature_mock.state = 3  # closed
+    await async_setup_entity(hass, entity_id)
+    assert hass.states.get(entity_id).state == CoverState.CLOSED
 
     def set_position(position):
         assert position == 99  # inverted
         feature_mock.state = 1  # opening
         # feature_mock.current = position
 
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
     feature_mock.async_set_position = AsyncMock(side_effect=set_position)
-
-    await async_setup_entity(hass, entity_id)
-    assert hass.states.get(entity_id).state == CoverState.CLOSED
-
-    feature_mock.async_update = AsyncMock()
     await hass.services.async_call(
         "cover",
         SERVICE_SET_COVER_POSITION,
@@ -408,12 +376,8 @@ async def test_unknown_position(shutterbox, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = shutterbox
 
-    def initial_update():
-        feature_mock.state = 4  # opening
-        feature_mock.current = -1
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
-
+    feature_mock.state = 4  # opening
+    feature_mock.current = -1
     await async_setup_entity(hass, entity_id)
 
     state = hass.states.get(entity_id)
@@ -425,9 +389,9 @@ async def test_with_stop(gatebox, hass: HomeAssistant) -> None:
     """Test stop capability is available."""
 
     feature_mock, entity_id = gatebox
-    opening_to_stop_feature_mock(feature_mock)
-    feature_mock.has_stop = True
 
+    feature_mock.state = 1  # opening
+    feature_mock.has_stop = True
     await async_setup_entity(hass, entity_id)
 
     state = hass.states.get(entity_id)
@@ -439,9 +403,9 @@ async def test_with_no_stop(gatebox, hass: HomeAssistant) -> None:
     """Test stop capability is not available."""
 
     feature_mock, entity_id = gatebox
-    opening_to_stop_feature_mock(feature_mock)
-    feature_mock.has_stop = False
 
+    feature_mock.state = 1  # opening
+    feature_mock.has_stop = False
     await async_setup_entity(hass, entity_id)
 
     state = hass.states.get(entity_id)
@@ -490,15 +454,22 @@ async def test_tilt_with_position_supported_features(
 async def test_update_failure(
     feature, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test that update failures are logged."""
+    """Test that update failures cause config entry setup retry."""
 
     caplog.set_level(logging.ERROR)
 
-    feature_mock, entity_id = feature
-    feature_mock.async_update = AsyncMock(side_effect=blebox_uniapi.error.ClientError)
-    await async_setup_entity(hass, entity_id)
+    feature_mock, _entity_id = feature
+    feature_mock.product.async_update_data = AsyncMock(
+        side_effect=blebox_uniapi.error.ClientError
+    )
 
-    assert f"Updating '{feature_mock.full_name}' failed: " in caplog.text
+    config_entry = mock_config()
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    feature_mock.product.async_update_data.assert_called()
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 @pytest.mark.parametrize("feature", ALL_COVER_FIXTURES, indirect=["feature"])
@@ -507,10 +478,7 @@ async def test_opening_state(feature, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = feature
 
-    def initial_update():
-        feature_mock.state = 1  # opening
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.state = 1  # opening
     await async_setup_entity(hass, entity_id)
     assert hass.states.get(entity_id).state == CoverState.OPENING
 
@@ -521,10 +489,7 @@ async def test_closing_state(feature, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = feature
 
-    def initial_update():
-        feature_mock.state = 0  # closing
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.state = 0  # closing
     await async_setup_entity(hass, entity_id)
     assert hass.states.get(entity_id).state == CoverState.CLOSING
 
@@ -535,10 +500,7 @@ async def test_closed_state(feature, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = feature
 
-    def initial_update():
-        feature_mock.state = 3  # closed
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.state = 3  # closed
     await async_setup_entity(hass, entity_id)
     assert hass.states.get(entity_id).state == CoverState.CLOSED
 
@@ -548,11 +510,7 @@ async def test_tilt_position(shutterbox, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = shutterbox
 
-    def tilt_update():
-        feature_mock.tilt_current = 90
-
-    feature_mock.async_update = AsyncMock(side_effect=tilt_update)
-
+    feature_mock.tilt_current = 90
     await async_setup_entity(hass, entity_id)
 
     state = hass.states.get(entity_id)
@@ -564,20 +522,15 @@ async def test_set_tilt_position(shutterbox, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = shutterbox
 
-    def initial_update():
-        feature_mock.state = 3
+    feature_mock.state = 3
+    await async_setup_entity(hass, entity_id)
+    assert hass.states.get(entity_id).state == CoverState.CLOSED
 
     def set_tilt(tilt_position):
         assert tilt_position == 20
         feature_mock.state = 1
 
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
     feature_mock.async_set_tilt_position = AsyncMock(side_effect=set_tilt)
-
-    await async_setup_entity(hass, entity_id)
-    assert hass.states.get(entity_id).state == CoverState.CLOSED
-
-    feature_mock.async_update = AsyncMock()
     await hass.services.async_call(
         "cover",
         SERVICE_SET_COVER_TILT_POSITION,
@@ -604,19 +557,14 @@ async def test_open_tilt(
     """Test opening tilt for 90-degree and 180-degree tilt shutters."""
     feature_mock, entity_id = shutterbox
     feature_mock.is_tilt_180 = is_tilt_180
-
-    def initial_update():
-        feature_mock.tilt_current = 100
+    feature_mock.tilt_current = 100
+    await async_setup_entity(hass, entity_id)
 
     def set_tilt_position(tilt_position):
         assert tilt_position == expected_tilt_position
         feature_mock.tilt_current = tilt_position
 
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
     feature_mock.async_set_tilt_position = AsyncMock(side_effect=set_tilt_position)
-
-    await async_setup_entity(hass, entity_id)
-    feature_mock.async_update = AsyncMock()
 
     await hass.services.async_call(
         "cover",
@@ -634,18 +582,14 @@ async def test_close_tilt(shutterbox, hass: HomeAssistant) -> None:
     """Test closing tilt."""
     feature_mock, entity_id = shutterbox
 
-    def initial_update():
-        feature_mock.tilt_current = 0
+    feature_mock.tilt_current = 0
+    await async_setup_entity(hass, entity_id)
 
     def set_tilt_position(tilt_position):
         assert tilt_position == 100
         feature_mock.tilt_current = tilt_position
 
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
     feature_mock.async_set_tilt_position = AsyncMock(side_effect=set_tilt_position)
-
-    await async_setup_entity(hass, entity_id)
-    feature_mock.async_update = AsyncMock()
 
     await hass.services.async_call(
         "cover",

--- a/tests/components/blebox/test_cover.py
+++ b/tests/components/blebox/test_cover.py
@@ -32,7 +32,9 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from .conftest import async_setup_entity, mock_config, mock_feature
+from .conftest import async_setup_entity, mock_feature
+
+from tests.common import MockConfigEntry
 
 ALL_COVER_FIXTURES = ["gatecontroller", "shutterbox", "gatebox"]
 FIXTURES_SUPPORTING_STOP = ["gatecontroller", "shutterbox"]
@@ -452,7 +454,10 @@ async def test_tilt_with_position_supported_features(
 
 @pytest.mark.parametrize("feature", ALL_COVER_FIXTURES, indirect=["feature"])
 async def test_update_failure(
-    feature, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    feature,
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that update failures cause config entry setup retry."""
 
@@ -463,7 +468,6 @@ async def test_update_failure(
         side_effect=blebox_uniapi.error.ClientError
     )
 
-    config_entry = mock_config()
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/blebox/test_init.py
+++ b/tests/components/blebox/test_init.py
@@ -8,7 +8,11 @@ import pytest
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
-from .conftest import patch_product_identify, setup_product_mock
+from .conftest import (
+    async_setup_config_entry,
+    patch_product_identify,
+    setup_product_mock,
+)
 
 from tests.common import MockConfigEntry
 
@@ -22,11 +26,8 @@ async def test_setup_failure(
 
     patch_product_identify(None, side_effect=blebox_uniapi.error.ClientError)
 
-    config_entry.add_to_hass(hass)
-
     caplog.set_level(logging.ERROR)
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await async_setup_config_entry(hass, config_entry)
 
     assert "Identify failed at 172.100.123.4:80 ()" in caplog.text
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
@@ -41,11 +42,8 @@ async def test_setup_failure_on_connection(
 
     patch_product_identify(None, side_effect=blebox_uniapi.error.ConnectionError)
 
-    config_entry.add_to_hass(hass)
-
     caplog.set_level(logging.ERROR)
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await async_setup_config_entry(hass, config_entry)
 
     assert "Identify failed at 172.100.123.4:80 ()" in caplog.text
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
@@ -57,10 +55,7 @@ async def test_unload_config_entry(
     """Test that unloading works properly."""
     setup_product_mock("switches", [])
 
-    config_entry.add_to_hass(hass)
-
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await async_setup_config_entry(hass, config_entry)
     assert hasattr(config_entry, "runtime_data")
 
     await hass.config_entries.async_unload(config_entry.entry_id)

--- a/tests/components/blebox/test_init.py
+++ b/tests/components/blebox/test_init.py
@@ -8,58 +8,63 @@ import pytest
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
-from .conftest import mock_config, patch_product_identify, setup_product_mock
+from .conftest import patch_product_identify, setup_product_mock
+
+from tests.common import MockConfigEntry
 
 
 async def test_setup_failure(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that setup failure is handled and logged."""
 
     patch_product_identify(None, side_effect=blebox_uniapi.error.ClientError)
 
-    entry = mock_config()
-    entry.add_to_hass(hass)
+    config_entry.add_to_hass(hass)
 
     caplog.set_level(logging.ERROR)
-    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
     assert "Identify failed at 172.100.123.4:80 ()" in caplog.text
-    assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_setup_failure_on_connection(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that setup failure is handled and logged."""
 
     patch_product_identify(None, side_effect=blebox_uniapi.error.ConnectionError)
 
-    entry = mock_config()
-    entry.add_to_hass(hass)
+    config_entry.add_to_hass(hass)
 
     caplog.set_level(logging.ERROR)
-    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
     assert "Identify failed at 172.100.123.4:80 ()" in caplog.text
-    assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_unload_config_entry(hass: HomeAssistant) -> None:
+async def test_unload_config_entry(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
     """Test that unloading works properly."""
     setup_product_mock("switches", [])
 
-    entry = mock_config()
-    entry.add_to_hass(hass)
+    config_entry.add_to_hass(hass)
 
-    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
-    assert hasattr(entry, "runtime_data")
+    assert hasattr(config_entry, "runtime_data")
 
-    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
-    assert not hasattr(entry, "runtime_data")
+    assert not hasattr(config_entry, "runtime_data")
 
-    assert entry.state is ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/blebox/test_light.py
+++ b/tests/components/blebox/test_light.py
@@ -15,6 +15,7 @@ from homeassistant.components.light import (
     ATTR_SUPPORTED_COLOR_MODES,
     ColorMode,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
@@ -25,7 +26,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from .conftest import async_setup_entity, mock_feature
+from .conftest import async_setup_entity, mock_config, mock_feature
 
 ALL_LIGHT_FIXTURES = ["dimmer", "wlightbox_s", "wlightbox"]
 
@@ -85,10 +86,7 @@ async def test_dimmer_update(dimmer, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = dimmer
 
-    def initial_update():
-        feature_mock.brightness = 53
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.brightness = 53
     await async_setup_entity(hass, entity_id)
 
     state = hass.states.get(entity_id)
@@ -101,14 +99,10 @@ async def test_dimmer_on(dimmer, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = dimmer
 
-    def initial_update():
-        feature_mock.is_on = False
-        feature_mock.brightness = 0  # off
-        feature_mock.sensible_on_value = 254
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.is_on = False
+    feature_mock.brightness = 0  # off
+    feature_mock.sensible_on_value = 254
     await async_setup_entity(hass, entity_id)
-    feature_mock.async_update = AsyncMock()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_OFF
@@ -136,14 +130,10 @@ async def test_dimmer_on_with_brightness(dimmer, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = dimmer
 
-    def initial_update():
-        feature_mock.is_on = False
-        feature_mock.brightness = 0  # off
-        feature_mock.sensible_on_value = 254
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.is_on = False
+    feature_mock.brightness = 0  # off
+    feature_mock.sensible_on_value = 254
     await async_setup_entity(hass, entity_id)
-    feature_mock.async_update = AsyncMock()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_OFF
@@ -177,12 +167,8 @@ async def test_dimmer_off(dimmer, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = dimmer
 
-    def initial_update():
-        feature_mock.is_on = True
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.is_on = True
     await async_setup_entity(hass, entity_id)
-    feature_mock.async_update = AsyncMock()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
@@ -259,12 +245,8 @@ async def test_wlightbox_s_update(wlightbox_s, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = wlightbox_s
 
-    def initial_update():
-        feature_mock.brightness = 0xAB
-        feature_mock.is_on = True
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
-
+    feature_mock.brightness = 0xAB
+    feature_mock.is_on = True
     await async_setup_entity(hass, entity_id)
 
     state = hass.states.get(entity_id)
@@ -277,13 +259,9 @@ async def test_wlightbox_s_on(wlightbox_s, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = wlightbox_s
 
-    def initial_update():
-        feature_mock.is_on = False
-        feature_mock.sensible_on_value = 254
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.is_on = False
+    feature_mock.sensible_on_value = 254
     await async_setup_entity(hass, entity_id)
-    feature_mock.async_update = AsyncMock()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_OFF
@@ -431,12 +409,9 @@ async def test_wlightbox_update(wlightbox, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = wlightbox
 
-    def initial_update():
-        feature_mock.is_on = True
-        feature_mock.rgbw_hex = "fa00203A"
-        feature_mock.white_value = 0x3A
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.is_on = True
+    feature_mock.rgbw_hex = "fa00203A"
+    feature_mock.white_value = 0x3A
     await async_setup_entity(hass, entity_id)
 
     state = hass.states.get(entity_id)
@@ -449,12 +424,8 @@ async def test_wlightbox_on_rgbw(wlightbox, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = wlightbox
 
-    def initial_update():
-        feature_mock.is_on = False
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.is_on = False
     await async_setup_entity(hass, entity_id)
-    feature_mock.async_update = AsyncMock()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_OFF
@@ -499,12 +470,8 @@ async def test_wlightbox_on_to_last_color(wlightbox, hass: HomeAssistant) -> Non
 
     feature_mock, entity_id = wlightbox
 
-    def initial_update():
-        feature_mock.is_on = False
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.is_on = False
     await async_setup_entity(hass, entity_id)
-    feature_mock.async_update = AsyncMock()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_OFF
@@ -537,14 +504,10 @@ async def test_wlightbox_turn_on_with_zero_brightness_turns_off(
 
     feature_mock, entity_id = wlightbox
 
-    def initial_update():
-        feature_mock.is_on = True
-        feature_mock.rgbw_hex = "c1d2f3c7"
-        feature_mock.white_value = 0xC7
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.is_on = True
+    feature_mock.rgbw_hex = "c1d2f3c7"
+    feature_mock.white_value = 0xC7
     await async_setup_entity(hass, entity_id)
-    feature_mock.async_update = AsyncMock()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
@@ -577,12 +540,8 @@ async def test_wlightbox_off(wlightbox, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = wlightbox
 
-    def initial_update():
-        feature_mock.is_on = True
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.is_on = True
     await async_setup_entity(hass, entity_id)
-    feature_mock.async_update = AsyncMock()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
@@ -610,15 +569,22 @@ async def test_wlightbox_off(wlightbox, hass: HomeAssistant) -> None:
 async def test_update_failure(
     feature, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test that update failures are logged."""
+    """Test that update failures cause config entry setup retry."""
 
     caplog.set_level(logging.ERROR)
 
-    feature_mock, entity_id = feature
-    feature_mock.async_update = AsyncMock(side_effect=blebox_uniapi.error.ClientError)
-    await async_setup_entity(hass, entity_id)
+    feature_mock, _entity_id = feature
+    feature_mock.product.async_update_data = AsyncMock(
+        side_effect=blebox_uniapi.error.ClientError
+    )
 
-    assert f"Updating '{feature_mock.full_name}' failed: " in caplog.text
+    config_entry = mock_config()
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    feature_mock.product.async_update_data.assert_called()
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 @pytest.mark.parametrize("feature", ALL_LIGHT_FIXTURES, indirect=["feature"])
@@ -652,12 +618,8 @@ async def test_wlightbox_on_effect(wlightbox, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = wlightbox
 
-    def initial_update():
-        feature_mock.is_on = False
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.is_on = False
     await async_setup_entity(hass, entity_id)
-    feature_mock.async_update = AsyncMock()
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_OFF

--- a/tests/components/blebox/test_light.py
+++ b/tests/components/blebox/test_light.py
@@ -26,7 +26,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from .conftest import async_setup_entity, mock_feature
+from .conftest import async_setup_config_entry, async_setup_entity, mock_feature
 
 from tests.common import MockConfigEntry
 
@@ -583,9 +583,7 @@ async def test_update_failure(
         side_effect=blebox_uniapi.error.ClientError
     )
 
-    config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await async_setup_config_entry(hass, config_entry)
 
     feature_mock.product.async_update_data.assert_called()
     assert config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/blebox/test_light.py
+++ b/tests/components/blebox/test_light.py
@@ -26,7 +26,9 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from .conftest import async_setup_entity, mock_config, mock_feature
+from .conftest import async_setup_entity, mock_feature
+
+from tests.common import MockConfigEntry
 
 ALL_LIGHT_FIXTURES = ["dimmer", "wlightbox_s", "wlightbox"]
 
@@ -567,7 +569,10 @@ async def test_wlightbox_off(wlightbox, hass: HomeAssistant) -> None:
 
 @pytest.mark.parametrize("feature", ALL_LIGHT_FIXTURES, indirect=["feature"])
 async def test_update_failure(
-    feature, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    feature,
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that update failures cause config entry setup retry."""
 
@@ -578,7 +583,6 @@ async def test_update_failure(
         side_effect=blebox_uniapi.error.ClientError
     )
 
-    config_entry = mock_config()
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/blebox/test_sensor.py
+++ b/tests/components/blebox/test_sensor.py
@@ -7,6 +7,7 @@ import blebox_uniapi
 import pytest
 
 from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_UNIT_OF_MEASUREMENT,
@@ -17,7 +18,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from .conftest import async_setup_entity, mock_feature
+from .conftest import async_setup_entity, mock_config, mock_feature
 
 
 @pytest.fixture(name="airsensor")
@@ -87,10 +88,7 @@ async def test_update(tempsensor, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = tempsensor
 
-    def initial_update():
-        feature_mock.native_value = 25.18
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.native_value = 25.18
     await async_setup_entity(hass, entity_id)
 
     state = hass.states.get(entity_id)
@@ -101,15 +99,22 @@ async def test_update(tempsensor, hass: HomeAssistant) -> None:
 async def test_update_failure(
     tempsensor, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test that update failures are logged."""
+    """Test that update failures cause config entry setup retry."""
 
     caplog.set_level(logging.ERROR)
 
-    feature_mock, entity_id = tempsensor
-    feature_mock.async_update = AsyncMock(side_effect=blebox_uniapi.error.ClientError)
-    await async_setup_entity(hass, entity_id)
+    feature_mock, _entity_id = tempsensor
+    feature_mock.product.async_update_data = AsyncMock(
+        side_effect=blebox_uniapi.error.ClientError
+    )
 
-    assert f"Updating '{feature_mock.full_name}' failed: " in caplog.text
+    config_entry = mock_config()
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    feature_mock.product.async_update_data.assert_called()
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_airsensor_init(
@@ -141,10 +146,7 @@ async def test_airsensor_update(airsensor, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = airsensor
 
-    def initial_update():
-        feature_mock.native_value = 49
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.native_value = 49
     await async_setup_entity(hass, entity_id)
 
     state = hass.states.get(entity_id)

--- a/tests/components/blebox/test_sensor.py
+++ b/tests/components/blebox/test_sensor.py
@@ -18,7 +18,9 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from .conftest import async_setup_entity, mock_config, mock_feature
+from .conftest import async_setup_entity, mock_feature
+
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture(name="airsensor")
@@ -97,7 +99,10 @@ async def test_update(tempsensor, hass: HomeAssistant) -> None:
 
 
 async def test_update_failure(
-    tempsensor, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    tempsensor,
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that update failures cause config entry setup retry."""
 
@@ -108,7 +113,6 @@ async def test_update_failure(
         side_effect=blebox_uniapi.error.ClientError
     )
 
-    config_entry = mock_config()
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/blebox/test_sensor.py
+++ b/tests/components/blebox/test_sensor.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from .conftest import async_setup_entity, mock_feature
+from .conftest import async_setup_config_entry, async_setup_entity, mock_feature
 
 from tests.common import MockConfigEntry
 
@@ -113,9 +113,7 @@ async def test_update_failure(
         side_effect=blebox_uniapi.error.ClientError
     )
 
-    config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await async_setup_config_entry(hass, config_entry)
 
     feature_mock.product.async_update_data.assert_called()
     assert config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/blebox/test_switch.py
+++ b/tests/components/blebox/test_switch.py
@@ -7,6 +7,7 @@ import blebox_uniapi
 import pytest
 
 from homeassistant.components.switch import SwitchDeviceClass
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     SERVICE_TURN_OFF,
@@ -21,6 +22,7 @@ from homeassistant.helpers import device_registry as dr
 from .conftest import (
     async_setup_entities,
     async_setup_entity,
+    mock_config,
     mock_feature,
     mock_only_feature,
     setup_product_mock,
@@ -38,7 +40,6 @@ def switchbox_fixture():
         device_class="relay",
         is_on=False,
     )
-    feature.async_update = AsyncMock()
     product = feature.product
     type(product).name = PropertyMock(return_value="My switch box")
     type(product).model = PropertyMock(return_value="switchBox")
@@ -50,9 +51,8 @@ async def test_switchbox_init(
 ) -> None:
     """Test switch default state."""
 
-    feature_mock, entity_id = switchbox
+    _feature_mock, entity_id = switchbox
 
-    feature_mock.async_update = AsyncMock()
     entry = await async_setup_entity(hass, entity_id)
     assert entry.unique_id == "BleBox-switchBox-1afe34e750b8-0.relay"
 
@@ -77,10 +77,7 @@ async def test_switchbox_update_when_off(switchbox, hass: HomeAssistant) -> None
 
     feature_mock, entity_id = switchbox
 
-    def initial_update():
-        feature_mock.is_on = False
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.is_on = False
     await async_setup_entity(hass, entity_id)
 
     state = hass.states.get(entity_id)
@@ -92,10 +89,7 @@ async def test_switchbox_update_when_on(switchbox, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = switchbox
 
-    def initial_update():
-        feature_mock.is_on = True
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.is_on = True
     await async_setup_entity(hass, entity_id)
 
     state = hass.states.get(entity_id)
@@ -107,12 +101,8 @@ async def test_switchbox_on(switchbox, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = switchbox
 
-    def initial_update():
-        feature_mock.is_on = False
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.is_on = False
     await async_setup_entity(hass, entity_id)
-    feature_mock.async_update = AsyncMock()
 
     def turn_on():
         feature_mock.is_on = True
@@ -135,12 +125,8 @@ async def test_switchbox_off(switchbox, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = switchbox
 
-    def initial_update():
-        feature_mock.is_on = True
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.is_on = True
     await async_setup_entity(hass, entity_id)
-    feature_mock.async_update = AsyncMock()
 
     def turn_off():
         feature_mock.is_on = False
@@ -199,10 +185,8 @@ async def test_switchbox_d_init(
 ) -> None:
     """Test switch default state."""
 
-    feature_mocks, entity_ids = switchbox_d
+    _feature_mocks, entity_ids = switchbox_d
 
-    feature_mocks[0].async_update = AsyncMock()
-    feature_mocks[1].async_update = AsyncMock()
     entries = await async_setup_entities(hass, entity_ids)
 
     entry = entries[0]
@@ -243,12 +227,8 @@ async def test_switchbox_d_update_when_off(switchbox_d, hass: HomeAssistant) -> 
 
     feature_mocks, entity_ids = switchbox_d
 
-    def initial_update0():
-        feature_mocks[0].is_on = False
-        feature_mocks[1].is_on = False
-
-    feature_mocks[0].async_update = AsyncMock(side_effect=initial_update0)
-    feature_mocks[1].async_update = AsyncMock()
+    feature_mocks[0].is_on = False
+    feature_mocks[1].is_on = False
     await async_setup_entities(hass, entity_ids)
 
     assert hass.states.get(entity_ids[0]).state == STATE_OFF
@@ -262,12 +242,8 @@ async def test_switchbox_d_update_when_second_off(
 
     feature_mocks, entity_ids = switchbox_d
 
-    def initial_update0():
-        feature_mocks[0].is_on = True
-        feature_mocks[1].is_on = False
-
-    feature_mocks[0].async_update = AsyncMock(side_effect=initial_update0)
-    feature_mocks[1].async_update = AsyncMock()
+    feature_mocks[0].is_on = True
+    feature_mocks[1].is_on = False
     await async_setup_entities(hass, entity_ids)
 
     assert hass.states.get(entity_ids[0]).state == STATE_ON
@@ -279,14 +255,9 @@ async def test_switchbox_d_turn_first_on(switchbox_d, hass: HomeAssistant) -> No
 
     feature_mocks, entity_ids = switchbox_d
 
-    def initial_update0():
-        feature_mocks[0].is_on = False
-        feature_mocks[1].is_on = False
-
-    feature_mocks[0].async_update = AsyncMock(side_effect=initial_update0)
-    feature_mocks[1].async_update = AsyncMock()
+    feature_mocks[0].is_on = False
+    feature_mocks[1].is_on = False
     await async_setup_entities(hass, entity_ids)
-    feature_mocks[0].async_update = AsyncMock()
 
     def turn_on0():
         feature_mocks[0].is_on = True
@@ -308,14 +279,9 @@ async def test_switchbox_d_second_on(switchbox_d, hass: HomeAssistant) -> None:
 
     feature_mocks, entity_ids = switchbox_d
 
-    def initial_update0():
-        feature_mocks[0].is_on = False
-        feature_mocks[1].is_on = False
-
-    feature_mocks[0].async_update = AsyncMock(side_effect=initial_update0)
-    feature_mocks[1].async_update = AsyncMock()
+    feature_mocks[0].is_on = False
+    feature_mocks[1].is_on = False
     await async_setup_entities(hass, entity_ids)
-    feature_mocks[0].async_update = AsyncMock()
 
     def turn_on1():
         feature_mocks[1].is_on = True
@@ -337,14 +303,9 @@ async def test_switchbox_d_first_off(switchbox_d, hass: HomeAssistant) -> None:
 
     feature_mocks, entity_ids = switchbox_d
 
-    def initial_update_any():
-        feature_mocks[0].is_on = True
-        feature_mocks[1].is_on = True
-
-    feature_mocks[0].async_update = AsyncMock(side_effect=initial_update_any)
-    feature_mocks[1].async_update = AsyncMock()
+    feature_mocks[0].is_on = True
+    feature_mocks[1].is_on = True
     await async_setup_entities(hass, entity_ids)
-    feature_mocks[0].async_update = AsyncMock()
 
     def turn_off0():
         feature_mocks[0].is_on = False
@@ -366,14 +327,9 @@ async def test_switchbox_d_second_off(switchbox_d, hass: HomeAssistant) -> None:
 
     feature_mocks, entity_ids = switchbox_d
 
-    def initial_update_any():
-        feature_mocks[0].is_on = True
-        feature_mocks[1].is_on = True
-
-    feature_mocks[0].async_update = AsyncMock(side_effect=initial_update_any)
-    feature_mocks[1].async_update = AsyncMock()
+    feature_mocks[0].is_on = True
+    feature_mocks[1].is_on = True
     await async_setup_entities(hass, entity_ids)
-    feature_mocks[0].async_update = AsyncMock()
 
     def turn_off1():
         feature_mocks[1].is_on = False
@@ -396,19 +352,24 @@ ALL_SWITCH_FIXTURES = ["switchbox", "switchbox_d"]
 async def test_update_failure(
     feature, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test that update failures are logged."""
+    """Test that update failures cause config entry setup retry."""
 
     caplog.set_level(logging.ERROR)
 
     feature_mock, entity_id = feature
 
     if isinstance(feature_mock, list):
-        feature_mock[0].async_update = AsyncMock()
-        feature_mock[1].async_update = AsyncMock()
         feature_mock = feature_mock[0]
         entity_id = entity_id[0]
 
-    feature_mock.async_update = AsyncMock(side_effect=blebox_uniapi.error.ClientError)
-    await async_setup_entity(hass, entity_id)
+    feature_mock.product.async_update_data = AsyncMock(
+        side_effect=blebox_uniapi.error.ClientError
+    )
 
-    assert f"Updating '{feature_mock.full_name}' failed: " in caplog.text
+    config_entry = mock_config()
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    feature_mock.product.async_update_data.assert_called()
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/blebox/test_switch.py
+++ b/tests/components/blebox/test_switch.py
@@ -22,11 +22,12 @@ from homeassistant.helpers import device_registry as dr
 from .conftest import (
     async_setup_entities,
     async_setup_entity,
-    mock_config,
     mock_feature,
     mock_only_feature,
     setup_product_mock,
 )
+
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture(name="switchbox")
@@ -350,7 +351,10 @@ ALL_SWITCH_FIXTURES = ["switchbox", "switchbox_d"]
 
 @pytest.mark.parametrize("feature", ALL_SWITCH_FIXTURES, indirect=["feature"])
 async def test_update_failure(
-    feature, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    feature,
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that update failures cause config entry setup retry."""
 
@@ -366,7 +370,6 @@ async def test_update_failure(
         side_effect=blebox_uniapi.error.ClientError
     )
 
-    config_entry = mock_config()
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/blebox/test_switch.py
+++ b/tests/components/blebox/test_switch.py
@@ -20,6 +20,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from .conftest import (
+    async_setup_config_entry,
     async_setup_entities,
     async_setup_entity,
     mock_feature,
@@ -370,9 +371,7 @@ async def test_update_failure(
         side_effect=blebox_uniapi.error.ClientError
     )
 
-    config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await async_setup_config_entry(hass, config_entry)
 
     feature_mock.product.async_update_data.assert_called()
     assert config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/blebox/test_update.py
+++ b/tests/components/blebox/test_update.py
@@ -137,6 +137,25 @@ async def test_update_error(
 
 
 @pytest.mark.freeze_time("2026-05-21 00:00:00")
+async def test_scan_interval_triggers_update(
+    firmwareupdate: tuple[blebox_uniapi.update.Update, str],
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that the SCAN_INTERVAL-based poll fires async_update after one hour."""
+    feature_mock, entity_id = firmwareupdate
+
+    await async_setup_entity(hass, entity_id)
+
+    feature_mock.async_update = AsyncMock()
+    freezer.tick(timedelta(hours=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    feature_mock.async_update.assert_awaited_once()
+
+
+@pytest.mark.freeze_time("2026-05-21 00:00:00")
 async def test_install(
     firmwareupdate: tuple[blebox_uniapi.update.Update, str],
     hass: HomeAssistant,
@@ -258,9 +277,6 @@ async def test_poll_connection_error(
 
     entry = await async_setup_entity(hass, entity_id)
 
-    device = device_registry.async_get(entry.device_id)
-    sw_version_before_install = device.sw_version
-
     await hass.services.async_call(
         UPDATE_DOMAIN,
         SERVICE_INSTALL,
@@ -282,7 +298,7 @@ async def test_poll_connection_error(
     assert state.attributes[ATTR_IN_PROGRESS] is True
 
     device = device_registry.async_get(entry.device_id)
-    assert device.sw_version == sw_version_before_install
+    assert device.sw_version == "0.1"
 
     def recovery_update() -> None:
         feature_mock.installed_version = "0.2"

--- a/tests/components/blebox/test_update.py
+++ b/tests/components/blebox/test_update.py
@@ -168,19 +168,15 @@ async def test_install(
     assert state.attributes[ATTR_INSTALLED_VERSION] == "0.1"
 
 
+@pytest.mark.freeze_time("2026-05-21 00:00:00")
 async def test_install_error(
     firmwareupdate: tuple[blebox_uniapi.update.Update, str],
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test that an install failure clears in_progress and raises HomeAssistantError."""
+    """Test that an install failure clears in_progress, raises HomeAssistantError, and schedules no poll."""
     feature_mock, entity_id = firmwareupdate
 
-    def initial_update() -> None:
-        feature_mock.installed_version = "0.1"
-        feature_mock.latest_version = "0.2"
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
     await async_setup_entity(hass, entity_id)
 
     feature_mock.async_install = AsyncMock(
@@ -198,11 +194,12 @@ async def test_install_error(
     state = hass.states.get(entity_id)
     assert state.attributes[ATTR_IN_PROGRESS] is False
 
+    feature_mock.async_update = AsyncMock()
     freezer.tick(timedelta(seconds=11))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    feature_mock.async_update.assert_called_once()
+    feature_mock.async_update.assert_not_called()
 
 
 @pytest.mark.freeze_time("2026-05-21 00:00:00")
@@ -259,11 +256,8 @@ async def test_poll_connection_error(
     """Test that ConnectionError during poll reschedules the next poll without updating sw_version."""
     feature_mock, entity_id = firmwareupdate
 
-    def initial_update() -> None:
-        feature_mock.installed_version = "0.1"
-        feature_mock.latest_version = "0.2"
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.installed_version = "0.1"
+    feature_mock.latest_version = "0.2"
     entry = await async_setup_entity(hass, entity_id)
 
     await hass.services.async_call(
@@ -287,7 +281,7 @@ async def test_poll_connection_error(
     assert state.attributes[ATTR_IN_PROGRESS] is True
 
     device = device_registry.async_get(entry.device_id)
-    assert device.sw_version == "0.1"
+    assert device.sw_version != "0.2"
 
     def recovery_update() -> None:
         feature_mock.installed_version = "0.2"

--- a/tests/components/blebox/test_update.py
+++ b/tests/components/blebox/test_update.py
@@ -256,9 +256,10 @@ async def test_poll_connection_error(
     """Test that ConnectionError during poll reschedules the next poll without updating sw_version."""
     feature_mock, entity_id = firmwareupdate
 
-    feature_mock.installed_version = "0.1"
-    feature_mock.latest_version = "0.2"
     entry = await async_setup_entity(hass, entity_id)
+
+    device = device_registry.async_get(entry.device_id)
+    sw_version_before_install = device.sw_version
 
     await hass.services.async_call(
         UPDATE_DOMAIN,
@@ -281,7 +282,7 @@ async def test_poll_connection_error(
     assert state.attributes[ATTR_IN_PROGRESS] is True
 
     device = device_registry.async_get(entry.device_id)
-    assert device.sw_version != "0.2"
+    assert device.sw_version == sw_version_before_install
 
     def recovery_update() -> None:
         feature_mock.installed_version = "0.2"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Before this change, every BleBox entity polled the device independently. This PR replaces that with a standard DataUpdateCoordinator, using a single request per poll cycle shared across all entities on the same device.

A small @blebox_command decorator wraps all write operations, converting library errors into HomeAssistantError and triggering an immediate state refresh after each command so entities reflect the updated state without waiting for the next poll cycle.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
