### PR TITLE
Use state-based icon for Hue grouped light

### DIFF
--- a/homeassistant/components/braviatv/manifest.json
+++ b/homeassistant/components/braviatv/manifest.json
@@ -3,6 +3,7 @@
   "name": "Sony Bravia TV",
   "codeowners": ["@bieniu", "@Drafteed"],
   "config_flow": true,
+  "dependencies": ["ssdp"],
   "documentation": "https://www.home-assistant.io/integrations/braviatv",
   "integration_type": "device",
   "iot_class": "local_polling",

--- a/homeassistant/components/braviatv/manifest.json
+++ b/homeassistant/components/braviatv/manifest.json
@@ -3,7 +3,6 @@
   "name": "Sony Bravia TV",
   "codeowners": ["@bieniu", "@Drafteed"],
   "config_flow": true,
-  "dependencies": ["ssdp"],
   "documentation": "https://www.home-assistant.io/integrations/braviatv",
   "integration_type": "device",
   "iot_class": "local_polling",

--- a/homeassistant/components/hue/icons.json
+++ b/homeassistant/components/hue/icons.json
@@ -1,6 +1,12 @@
 {
   "entity": {
     "light": {
+      "hue_grouped_light": {
+        "default": "mdi:lightbulb-group",
+        "state": {
+          "off": "mdi:lightbulb-group-off"
+        }
+      },
       "hue_light": {
         "state_attributes": {
           "effect": {

--- a/homeassistant/components/hue/v2/group.py
+++ b/homeassistant/components/hue/v2/group.py
@@ -85,6 +85,7 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
 
     entity_description = LightEntityDescription(
         key="hue_grouped_light",
+        translation_key="hue_grouped_light",
         has_entity_name=True,
         name=None,
     )

--- a/homeassistant/components/hue/v2/group.py
+++ b/homeassistant/components/hue/v2/group.py
@@ -85,7 +85,6 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
 
     entity_description = LightEntityDescription(
         key="hue_grouped_light",
-        icon="mdi:lightbulb-group",
         has_entity_name=True,
         name=None,
     )

--- a/homeassistant/components/hue/v2/group.py
+++ b/homeassistant/components/hue/v2/group.py
@@ -85,7 +85,6 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
 
     entity_description = LightEntityDescription(
         key="hue_grouped_light",
-        translation_key="hue_grouped_light",
         has_entity_name=True,
         name=None,
     )


### PR DESCRIPTION

## Proposed change

Hue light groups use a static `mdi:lightbulb-group` icon that doesn't change when the light is off, unlike all other Hue light entities which show a slashed icon when off.

Move the icon from a static entity description attribute to `icons.json` with state-based variants, so the group shows `mdi:lightbulb-group-off` when turned off.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #172519
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr