### PR TITLE
Handle IPP sw_version returned as list from printer

### DIFF
--- a/homeassistant/components/ipp/entity.py
+++ b/homeassistant/components/ipp/entity.py
@@ -24,12 +24,16 @@ class IPPEntity(CoordinatorEntity[IPPDataUpdateCoordinator]):
         self.entity_description = description
 
         self._attr_unique_id = f"{coordinator.device_id}_{description.key}"
+        version = self.coordinator.data.info.version
+        if isinstance(version, list):
+            version = ", ".join(str(v) for v in version)
+
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, coordinator.device_id)},
             manufacturer=self.coordinator.data.info.manufacturer,
             model=self.coordinator.data.info.model,
             name=self.coordinator.data.info.name,
             serial_number=self.coordinator.data.info.serial,
-            sw_version=self.coordinator.data.info.version,
+            sw_version=version,
             configuration_url=self.coordinator.data.info.more_info,
         )


### PR DESCRIPTION

## Proposed change

Some printers return `printer-firmware-string-version` as a list of strings via IPP. The integration passes this directly as `sw_version` to the device registry, which expects a string.

Convert list values to a comma-separated string before passing to the device registry.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #172541
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr