### PR TITLE
Fix Yoto OAuth flow with cloud credentials

### DIFF
--- a/homeassistant/components/yoto/application_credentials.py
+++ b/homeassistant/components/yoto/application_credentials.py
@@ -6,8 +6,6 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
     LocalOAuth2ImplementationWithPkce,
 )
 
-from .const import YOTO_AUDIENCE, YOTO_SCOPES
-
 AUTHORIZE_URL = "https://login.yotoplay.com/authorize"
 TOKEN_URL = "https://login.yotoplay.com/oauth/token"
 
@@ -16,9 +14,9 @@ async def async_get_auth_implementation(
     hass: HomeAssistant,
     auth_domain: str,
     credential: ClientCredential,
-) -> YotoOAuth2Implementation:
-    """Return a Yoto OAuth2 implementation backed by the user's credential."""
-    return YotoOAuth2Implementation(
+) -> LocalOAuth2ImplementationWithPkce:
+    """Return a Yoto OAuth2 implementation with PKCE."""
+    return LocalOAuth2ImplementationWithPkce(
         hass,
         auth_domain,
         credential.client_id,
@@ -26,15 +24,3 @@ async def async_get_auth_implementation(
         TOKEN_URL,
         credential.client_secret,
     )
-
-
-class YotoOAuth2Implementation(LocalOAuth2ImplementationWithPkce):
-    """Yoto OAuth2 implementation with PKCE, audience and scopes."""
-
-    @property
-    def extra_authorize_data(self) -> dict:
-        """Append Yoto's audience and scopes to every authorize URL."""
-        return super().extra_authorize_data | {
-            "audience": YOTO_AUDIENCE,
-            "scope": " ".join(YOTO_SCOPES),
-        }

--- a/homeassistant/components/yoto/config_flow.py
+++ b/homeassistant/components/yoto/config_flow.py
@@ -8,7 +8,7 @@ from yoto_api import YotoError, get_account_id
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from .const import _LOGGER, DOMAIN
+from .const import _LOGGER, DOMAIN, YOTO_AUDIENCE, YOTO_SCOPES
 
 
 class YotoOAuth2FlowHandler(
@@ -22,6 +22,16 @@ class YotoOAuth2FlowHandler(
     def logger(self) -> logging.Logger:
         """Return the logger used for the OAuth2 flow."""
         return _LOGGER
+
+    @property
+    def extra_authorize_data(self) -> dict[str, Any]:
+        """Append Yoto's audience and scopes to the authorize URL."""
+        # Set at the flow level (not the implementation) so it applies to
+        # both application credentials and cloud credentials.
+        return {
+            "audience": YOTO_AUDIENCE,
+            "scope": " ".join(YOTO_SCOPES),
+        }
 
     async def async_oauth_create_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
         """Identify the Yoto account from the access token."""

--- a/homeassistant/components/yoto/config_flow.py
+++ b/homeassistant/components/yoto/config_flow.py
@@ -26,8 +26,6 @@ class YotoOAuth2FlowHandler(
     @property
     def extra_authorize_data(self) -> dict[str, Any]:
         """Append Yoto's audience and scopes to the authorize URL."""
-        # Set at the flow level (not the implementation) so it applies to
-        # both application credentials and cloud credentials.
         return {
             "audience": YOTO_AUDIENCE,
             "scope": " ".join(YOTO_SCOPES),


### PR DESCRIPTION
## Proposed change

Yoto uses Auth0, which requires an `audience` parameter on the authorize URL to issue a JWT scoped for the Yoto API. The custom `YotoOAuth2Implementation` injected this via `extra_authorize_data`. When cloud credentials are used, Nabu Casa provides its own OAuth2 implementation instead, so `audience` and `scope` never reached `/authorize` and the token exchange failed with "OAuth authorization error while obtaining access token".

Moves `extra_authorize_data` to the config flow handler, where it runs regardless of which implementation is used.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
