### PR TITLE
Do not use `_attr_location_name` for MQTT device_tracker entity

### DIFF
--- a/homeassistant/components/mqtt/device_tracker.py
+++ b/homeassistant/components/mqtt/device_tracker.py
@@ -149,6 +149,7 @@ class MqttDeviceTracker(MqttEntity, TrackerEntity):
             self._location_name = payload
             self._attr_latitude = None
             self._attr_longitude = None
+        if self._location_name is not None:
             self._attr_extra_state_attributes = (
                 dict(self.extra_state_attributes)
                 if self.extra_state_attributes is not None

--- a/homeassistant/components/mqtt/device_tracker.py
+++ b/homeassistant/components/mqtt/device_tracker.py
@@ -8,6 +8,7 @@ import voluptuous as vol
 
 from homeassistant.components import device_tracker
 from homeassistant.components.device_tracker import SourceType, TrackerEntity
+from homeassistant.components.zone import ENTITY_ID_HOME
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_GPS_ACCURACY,
@@ -130,7 +131,7 @@ class MqttDeviceTracker(MqttEntity, TrackerEntity):
             )
             return
         if payload == self._config[CONF_PAYLOAD_HOME]:
-            self._attr_in_zones = ["zone.home"]
+            self._attr_in_zones = [ENTITY_ID_HOME]
             self._location_name = payload
             self._attr_latitude = None
             self._attr_longitude = None

--- a/homeassistant/components/mqtt/device_tracker.py
+++ b/homeassistant/components/mqtt/device_tracker.py
@@ -163,6 +163,12 @@ class MqttDeviceTracker(MqttEntity, TrackerEntity):
                 if self.extra_state_attributes is not None
                 else {}
             ) | {ATTR_LOCATION_NAME: self._location_name}
+            return
+        if (
+            extra_state_attributes := self.extra_state_attributes
+        ) is not None and ATTR_LOCATION_NAME in extra_state_attributes:
+            self._attr_extra_state_attributes = dict(extra_state_attributes)
+            self._attr_extra_state_attributes.pop(ATTR_LOCATION_NAME)
 
     @callback
     def _prepare_subscribe_topics(self) -> None:

--- a/homeassistant/components/mqtt/device_tracker.py
+++ b/homeassistant/components/mqtt/device_tracker.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import voluptuous as vol
 
@@ -121,7 +121,7 @@ class MqttDeviceTracker(MqttEntity, TrackerEntity):
     @callback
     def _tracker_message_received(self, msg: ReceiveMessage) -> None:
         """Handle new MQTT messages."""
-        payload = self._value_template(msg.payload)
+        payload = str(self._value_template(msg.payload))
         if not payload.strip():  # No output from template, ignore
             _LOGGER.debug(
                 "Ignoring empty payload '%s' after rendering for topic %s",
@@ -130,21 +130,38 @@ class MqttDeviceTracker(MqttEntity, TrackerEntity):
             )
             return
         if payload == self._config[CONF_PAYLOAD_HOME]:
-            self._attr_location_name = STATE_HOME
+            self._attr_in_zones = ["zone.home"]
+            self._location_name = payload
+            self._attr_latitude = None
+            self._attr_longitude = None
         elif payload == self._config[CONF_PAYLOAD_NOT_HOME]:
-            self._attr_location_name = STATE_NOT_HOME
+            self._attr_in_zones = []
+            self._location_name = payload
+            self._attr_latitude = None
+            self._attr_longitude = None
         elif payload == self._config[CONF_PAYLOAD_RESET]:
-            self._attr_location_name = None
+            self._attr_in_zones = None
+            self._location_name = None
+            self._attr_latitude = None
+            self._attr_longitude = None
         else:
-            if TYPE_CHECKING:
-                assert isinstance(msg.payload, str)
-            self._attr_location_name = msg.payload
+            self._attr_in_zones = []
+            self._location_name = payload
+            self._attr_latitude = None
+            self._attr_longitude = None
+            self._attr_extra_state_attributes = (
+                dict(self.extra_state_attributes)
+                if self.extra_state_attributes is not None
+                else {}
+            ) | {"location_name": self._location_name}
 
     @callback
     def _prepare_subscribe_topics(self) -> None:
         """(Re)Subscribe to topics."""
         self.add_subscription(
-            CONF_STATE_TOPIC, self._tracker_message_received, {"_attr_location_name"}
+            CONF_STATE_TOPIC,
+            self._tracker_message_received,
+            {"_attr_in_zones", "_attr_latitude", "_attr_longitude", "_location_name"},
         )
 
     async def _subscribe_topics(self) -> None:
@@ -170,6 +187,8 @@ class MqttDeviceTracker(MqttEntity, TrackerEntity):
             ):
                 self._attr_latitude = latitude
                 self._attr_longitude = longitude
+                self._attr_in_zones = None
+                self._location_name = None
             else:
                 # Invalid or incomplete coordinates, reset location
                 self._attr_latitude = None
@@ -201,6 +220,9 @@ class MqttDeviceTracker(MqttEntity, TrackerEntity):
 
             else:
                 self._attr_location_accuracy = 0
+
+        if self._location_name is not None:
+            extra_state_attributes["location_name"] = self._location_name
 
         self._attr_extra_state_attributes = {
             attribute: value

--- a/homeassistant/components/mqtt/device_tracker.py
+++ b/homeassistant/components/mqtt/device_tracker.py
@@ -7,7 +7,11 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant.components import device_tracker
-from homeassistant.components.device_tracker import SourceType, TrackerEntity
+from homeassistant.components.device_tracker import (
+    ATTR_LOCATION_NAME,
+    SourceType,
+    TrackerEntity,
+)
 from homeassistant.components.zone import ENTITY_ID_HOME
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -81,6 +85,8 @@ DISCOVERY_SCHEMA = vol.All(
     PLATFORM_SCHEMA_MODERN_BASE.extend({}, extra=vol.REMOVE_EXTRA), valid_config
 )
 
+MQTT_DEVICE_TRACKER_ATTRIBUTES_BLOCKED = frozenset({ATTR_LOCATION_NAME})
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -106,6 +112,7 @@ class MqttDeviceTracker(MqttEntity, TrackerEntity):
     _entity_id_format = device_tracker.ENTITY_ID_FORMAT
     _location_name: str | None = None
     _value_template: Callable[[ReceivePayloadType], ReceivePayloadType]
+    _attributes_extra_blocked = MQTT_DEVICE_TRACKER_ATTRIBUTES_BLOCKED
 
     @staticmethod
     def config_schema() -> VolSchemaType:
@@ -155,7 +162,7 @@ class MqttDeviceTracker(MqttEntity, TrackerEntity):
                 dict(self.extra_state_attributes)
                 if self.extra_state_attributes is not None
                 else {}
-            ) | {"location_name": self._location_name}
+            ) | {ATTR_LOCATION_NAME: self._location_name}
 
     @callback
     def _prepare_subscribe_topics(self) -> None:
@@ -224,7 +231,7 @@ class MqttDeviceTracker(MqttEntity, TrackerEntity):
                 self._attr_location_accuracy = 0
 
         if self._location_name is not None:
-            extra_state_attributes["location_name"] = self._location_name
+            extra_state_attributes[ATTR_LOCATION_NAME] = self._location_name
 
         self._attr_extra_state_attributes = {
             attribute: value

--- a/homeassistant/components/mqtt/entity.py
+++ b/homeassistant/components/mqtt/entity.py
@@ -532,7 +532,7 @@ class MqttAttributesMixin(Entity):
                             "_attr_extra_state_attributes",
                             "_attr_gps_accuracy",
                             "_attr_latitude",
-                            "_attr_location_name",
+                            "_attr_in_zones",
                             "_attr_longitude",
                         },
                     ),

--- a/tests/components/mqtt/test_device_tracker.py
+++ b/tests/components/mqtt/test_device_tracker.py
@@ -687,7 +687,7 @@ async def test_setting_device_tracker_location_via_abbr_reset_message(
     assert state.attributes.get("location_name") == "office"
 
     # Reset the manual set location
-    # Resent the GPS attributes
+    # Resend the GPS attributes
     # This should calculate the location from GPS attributes
     async_fire_mqtt_message(hass, "test-topic", "reset")
     state = hass.states.get("device_tracker.test")

--- a/tests/components/mqtt/test_device_tracker.py
+++ b/tests/components/mqtt/test_device_tracker.py
@@ -627,6 +627,7 @@ async def test_setting_device_tracker_location_via_reset_message(
     async_fire_mqtt_message(hass, "test-topic", "None")
     state = hass.states.get("device_tracker.test")
     assert state.state == STATE_UNKNOWN
+    assert state.attributes.get(device_tracker.ATTR_LOCATION_NAME) is None
     async_fire_mqtt_message(
         hass,
         "attributes-topic",

--- a/tests/components/mqtt/test_device_tracker.py
+++ b/tests/components/mqtt/test_device_tracker.py
@@ -683,8 +683,9 @@ async def test_setting_device_tracker_location_via_abbr_reset_message(
         '{"latitude":32.87336,"longitude": -117.22743, "gps_accuracy":1.5}',
     )
 
-    assert state.state == STATE_NOT_HOME
-    assert state.attributes.get("location_name") == "office"
+    state = hass.states.get("device_tracker.test")
+    assert state.state == STATE_HOME
+    assert state.attributes.get("location_name") is None
 
     # Reset the manual set location
     # Resend the GPS attributes

--- a/tests/components/mqtt/test_device_tracker.py
+++ b/tests/components/mqtt/test_device_tracker.py
@@ -312,32 +312,49 @@ async def test_setting_device_tracker_value_via_mqtt_message(
     mqtt_mock_entry: MqttMockHAClientGenerator,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test the setting of the value via MQTT."""
+    """Test the setting of the value and extra state attributes ia MQTT."""
     await mqtt_mock_entry()
     async_fire_mqtt_message(
         hass,
         "homeassistant/device_tracker/bla/config",
-        '{ "name": "test", "state_topic": "test-topic" }',
+        '{ "name": "test", "state_topic": "test-topic", '
+        '"json_attributes_topic": "attributes-topic" }',
     )
 
     await hass.async_block_till_done()
 
     state = hass.states.get("device_tracker.test")
-
     assert state.state == STATE_UNKNOWN
+    assert state.attributes.get(device_tracker.ATTR_LOCATION_NAME) is None
 
     async_fire_mqtt_message(hass, "test-topic", "home")
     state = hass.states.get("device_tracker.test")
     assert state.state == STATE_HOME
+    assert state.attributes.get(device_tracker.ATTR_LOCATION_NAME) == "home"
 
     async_fire_mqtt_message(hass, "test-topic", "not_home")
     state = hass.states.get("device_tracker.test")
     assert state.state == STATE_NOT_HOME
+    assert state.attributes.get(device_tracker.ATTR_LOCATION_NAME) == "not_home"
 
     # Test an empty value is ignored and the state is retained
     async_fire_mqtt_message(hass, "test-topic", "")
     state = hass.states.get("device_tracker.test")
     assert state.state == STATE_NOT_HOME
+    assert state.attributes.get(device_tracker.ATTR_LOCATION_NAME) == "not_home"
+
+    async_fire_mqtt_message(hass, "attributes-topic", '{"quality": "good"}')
+    state = hass.states.get("device_tracker.test")
+    assert state.state == STATE_NOT_HOME
+    assert state.attributes.get(device_tracker.ATTR_LOCATION_NAME) == "not_home"
+    assert state.attributes.get("quality") == "good"
+
+    # Reset the state and location_name attribute
+    async_fire_mqtt_message(hass, "test-topic", "None")
+    state = hass.states.get("device_tracker.test")
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes.get(device_tracker.ATTR_LOCATION_NAME) is None
+    assert state.attributes.get("quality") == "good"
 
 
 async def test_setting_device_tracker_value_via_mqtt_message_and_template(
@@ -660,12 +677,12 @@ async def test_setting_device_tracker_location_via_abbr_reset_message(
     async_fire_mqtt_message(hass, "test-topic", "reset")
     state = hass.states.get("device_tracker.test")
     assert state.state == STATE_UNKNOWN
+
     async_fire_mqtt_message(
         hass,
         "attributes-topic",
         '{"latitude":32.87336,"longitude": -117.22743, "gps_accuracy":1.5}',
     )
-
     state = hass.states.get("device_tracker.test")
     assert state.attributes["latitude"] == 32.87336
     assert state.attributes["longitude"] == -117.22743

--- a/tests/components/mqtt/test_device_tracker.py
+++ b/tests/components/mqtt/test_device_tracker.py
@@ -7,6 +7,9 @@ import pytest
 
 from homeassistant.components import device_tracker, mqtt
 from homeassistant.components.mqtt.const import DOMAIN
+from homeassistant.components.mqtt.device_tracker import (
+    MQTT_DEVICE_TRACKER_ATTRIBUTES_BLOCKED,
+)
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -381,17 +384,17 @@ async def test_setting_device_tracker_value_via_mqtt_message_and_template2(
 
     state = hass.states.get("device_tracker.test")
     assert state.state == STATE_UNKNOWN
-    assert state.attributes.get("location_name") is None
+    assert state.attributes.get(device_tracker.ATTR_LOCATION_NAME) is None
 
     async_fire_mqtt_message(hass, "test-topic", "HOME")
     state = hass.states.get("device_tracker.test")
     assert state.state == STATE_HOME
-    assert state.attributes.get("location_name") == "home"
+    assert state.attributes.get(device_tracker.ATTR_LOCATION_NAME) == "home"
 
     async_fire_mqtt_message(hass, "test-topic", "NOT_HOME")
     state = hass.states.get("device_tracker.test")
     assert state.state == STATE_NOT_HOME
-    assert state.attributes.get("location_name") == "not_home"
+    assert state.attributes.get(device_tracker.ATTR_LOCATION_NAME) == "not_home"
 
 
 async def test_setting_device_tracker_location_via_mqtt_message(
@@ -414,7 +417,7 @@ async def test_setting_device_tracker_location_via_mqtt_message(
     async_fire_mqtt_message(hass, "test-topic", "test-location")
     state = hass.states.get("device_tracker.test")
     assert state.state == STATE_NOT_HOME
-    assert state.attributes.get("location_name") == "test-location"
+    assert state.attributes.get(device_tracker.ATTR_LOCATION_NAME) == "test-location"
 
 
 async def test_setting_device_tracker_location_via_lat_lon_message(
@@ -601,7 +604,7 @@ async def test_setting_device_tracker_location_via_reset_message(
 
     state = hass.states.get("device_tracker.test")
     assert state.state == STATE_NOT_HOME
-    assert state.attributes.get("location_name") == "Work"
+    assert state.attributes.get(device_tracker.ATTR_LOCATION_NAME) == "Work"
 
     # test reset and submitting GPS coordinates
     async_fire_mqtt_message(hass, "test-topic", "None")
@@ -674,7 +677,7 @@ async def test_setting_device_tracker_location_via_abbr_reset_message(
     async_fire_mqtt_message(hass, "test-topic", "office")
     state = hass.states.get("device_tracker.test")
     assert state.state == STATE_NOT_HOME
-    assert state.attributes.get("location_name") == "office"
+    assert state.attributes.get(device_tracker.ATTR_LOCATION_NAME) == "office"
 
     # Test a GPS attributes update without a reset
     async_fire_mqtt_message(
@@ -685,7 +688,7 @@ async def test_setting_device_tracker_location_via_abbr_reset_message(
 
     state = hass.states.get("device_tracker.test")
     assert state.state == STATE_HOME
-    assert state.attributes.get("location_name") is None
+    assert state.attributes.get(device_tracker.ATTR_LOCATION_NAME) is None
 
     # Reset the manual set location
     # Resend the GPS attributes
@@ -711,7 +714,11 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
 ) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_blocked_attribute_via_mqtt_json_message(
-        hass, mqtt_mock_entry, device_tracker.DOMAIN, DEFAULT_CONFIG, None
+        hass,
+        mqtt_mock_entry,
+        device_tracker.DOMAIN,
+        DEFAULT_CONFIG,
+        MQTT_DEVICE_TRACKER_ATTRIBUTES_BLOCKED,
     )
 
 

--- a/tests/components/mqtt/test_device_tracker.py
+++ b/tests/components/mqtt/test_device_tracker.py
@@ -381,14 +381,17 @@ async def test_setting_device_tracker_value_via_mqtt_message_and_template2(
 
     state = hass.states.get("device_tracker.test")
     assert state.state == STATE_UNKNOWN
+    assert state.attributes.get("location_name") is None
 
     async_fire_mqtt_message(hass, "test-topic", "HOME")
     state = hass.states.get("device_Tracker.test")
     assert state.state == STATE_HOME
+    assert state.attributes.get("location_name") is None
 
     async_fire_mqtt_message(hass, "test-topic", "NOT_HOME")
     state = hass.states.get("device_tracker.test")
     assert state.state == STATE_NOT_HOME
+    assert state.attributes.get("location_name") is None
 
 
 async def test_setting_device_tracker_location_via_mqtt_message(
@@ -410,7 +413,8 @@ async def test_setting_device_tracker_location_via_mqtt_message(
 
     async_fire_mqtt_message(hass, "test-topic", "test-location")
     state = hass.states.get("device_tracker.test")
-    assert state.state == "test-location"
+    assert state.state == STATE_NOT_HOME
+    assert state.attributes.get("location_name") == "test-location"
 
 
 async def test_setting_device_tracker_location_via_lat_lon_message(
@@ -576,12 +580,14 @@ async def test_setting_device_tracker_location_via_reset_message(
     hass.config.longitude = -117.22743
 
     # test reset and gps attributes
+    async_fire_mqtt_message(hass, "test-topic", "None")
+    state = hass.states.get("device_tracker.test")
+    assert state.state == STATE_UNKNOWN
     async_fire_mqtt_message(
         hass,
         "attributes-topic",
         '{"latitude":32.87336,"longitude": -117.22743, "gps_accuracy":1.5}',
     )
-    async_fire_mqtt_message(hass, "test-topic", "None")
 
     state = hass.states.get("device_tracker.test")
     assert state.attributes["latitude"] == 32.87336
@@ -594,10 +600,18 @@ async def test_setting_device_tracker_location_via_reset_message(
     async_fire_mqtt_message(hass, "test-topic", "Work")
 
     state = hass.states.get("device_tracker.test")
-    assert state.state == "Work"
+    assert state.state == STATE_NOT_HOME
+    assert state.attributes.get("location_name") == "Work"
 
-    # test reset
+    # test reset and submitting GPS coordinates
     async_fire_mqtt_message(hass, "test-topic", "None")
+    state = hass.states.get("device_tracker.test")
+    assert state.state == STATE_UNKNOWN
+    async_fire_mqtt_message(
+        hass,
+        "attributes-topic",
+        '{"latitude":32.87336,"longitude": -117.22743, "gps_accuracy":1.5}',
+    )
 
     state = hass.states.get("device_tracker.test")
     assert state.state == STATE_HOME
@@ -639,13 +653,15 @@ async def test_setting_device_tracker_location_via_abbr_reset_message(
     hass.config.latitude = 32.87336
     hass.config.longitude = -117.22743
 
-    # test custom reset payload and gps attributes
+    # test custom reset payload and sent gps attributes
+    async_fire_mqtt_message(hass, "test-topic", "reset")
+    state = hass.states.get("device_tracker.test")
+    assert state.state == STATE_UNKNOWN
     async_fire_mqtt_message(
         hass,
         "attributes-topic",
         '{"latitude":32.87336,"longitude": -117.22743, "gps_accuracy":1.5}',
     )
-    async_fire_mqtt_message(hass, "test-topic", "reset")
 
     state = hass.states.get("device_tracker.test")
     assert state.attributes["latitude"] == 32.87336
@@ -657,7 +673,8 @@ async def test_setting_device_tracker_location_via_abbr_reset_message(
     # Override the GPS state via a direct state update
     async_fire_mqtt_message(hass, "test-topic", "office")
     state = hass.states.get("device_tracker.test")
-    assert state.state == "office"
+    assert state.state == STATE_NOT_HOME
+    assert state.attributes.get("location_name") == "office"
 
     # Test a GPS attributes update without a reset
     async_fire_mqtt_message(
@@ -666,12 +683,20 @@ async def test_setting_device_tracker_location_via_abbr_reset_message(
         '{"latitude":32.87336,"longitude": -117.22743, "gps_accuracy":1.5}',
     )
 
-    state = hass.states.get("device_tracker.test")
-    assert state.state == "office"
+    assert state.state == STATE_NOT_HOME
+    assert state.attributes.get("location_name") == "office"
 
     # Reset the manual set location
+    # Resent the GPS attributes
     # This should calculate the location from GPS attributes
     async_fire_mqtt_message(hass, "test-topic", "reset")
+    state = hass.states.get("device_tracker.test")
+    assert state.state == STATE_UNKNOWN
+    async_fire_mqtt_message(
+        hass,
+        "attributes-topic",
+        '{"latitude":32.87336,"longitude": -117.22743, "gps_accuracy":1.5}',
+    )
     state = hass.states.get("device_tracker.test")
     assert state.attributes["latitude"] == 32.87336
     assert state.attributes["longitude"] == -117.22743

--- a/tests/components/mqtt/test_device_tracker.py
+++ b/tests/components/mqtt/test_device_tracker.py
@@ -386,12 +386,12 @@ async def test_setting_device_tracker_value_via_mqtt_message_and_template2(
     async_fire_mqtt_message(hass, "test-topic", "HOME")
     state = hass.states.get("device_Tracker.test")
     assert state.state == STATE_HOME
-    assert state.attributes.get("location_name") is None
+    assert state.attributes.get("location_name") == "home"
 
     async_fire_mqtt_message(hass, "test-topic", "NOT_HOME")
     state = hass.states.get("device_tracker.test")
     assert state.state == STATE_NOT_HOME
-    assert state.attributes.get("location_name") is None
+    assert state.attributes.get("location_name") == "not_home"
 
 
 async def test_setting_device_tracker_location_via_mqtt_message(

--- a/tests/components/mqtt/test_device_tracker.py
+++ b/tests/components/mqtt/test_device_tracker.py
@@ -384,7 +384,7 @@ async def test_setting_device_tracker_value_via_mqtt_message_and_template2(
     assert state.attributes.get("location_name") is None
 
     async_fire_mqtt_message(hass, "test-topic", "HOME")
-    state = hass.states.get("device_Tracker.test")
+    state = hass.states.get("device_tracker.test")
     assert state.state == STATE_HOME
     assert state.attributes.get("location_name") == "home"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
MQTT device tracker entities that support custom location names (other than `home ` or `not_home` ) will no longer update the state to the location name value. Instead the extra state attribute `location_name` will hold the custom name instead of the state. The entity's state will become `not_home` if a custom location name is received.

Users should update their scripts and automations if they make use of the custom location name, and use the `location_name` attrbute instead of the state.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Do no longer set the `location_name` property as its use is deprecated.
See: https://github.com/home-assistant/architecture/discussions/1387

Instead of setting the location name when the device is `home` or `not_home`, it will set the `in_zones` attribute to configure if the entity is in zone `zone.home`, it will be set to an empty zone list if the device is `not_home` or is a custom location. The custom location now will be set as via the additional entity state attribute `location_name`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #172435
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
