### PR TITLE
Fix ESPHome update entity stuck on for project versions with build suffix

### DIFF
--- a/homeassistant/components/esphome/update.py
+++ b/homeassistant/components/esphome/update.py
@@ -284,6 +284,19 @@ class ESPHomeUpdateEntity(EsphomeEntity[UpdateInfo, UpdateState], UpdateEntity):
             UpdateDeviceClass, static_info.device_class
         )
 
+    def version_is_newer(self, latest_version: str, installed_version: str) -> bool:
+        """Return True if latest_version is newer than installed_version.
+
+        ESPHome project versions can carry a build suffix (e.g.
+        2025.11.5_c51f7548) that AwesomeVersion cannot parse. Without stripping
+        it the base comparison raises and the entity is forced on for every
+        build mismatch. Drop the suffix so the versions compare cleanly and we
+        only report genuinely newer firmware.
+        """
+        return super().version_is_newer(
+            latest_version.partition("_")[0], installed_version.partition("_")[0]
+        )
+
     @property
     @esphome_state_property
     def installed_version(self) -> str:

--- a/tests/components/esphome/test_update.py
+++ b/tests/components/esphome/test_update.py
@@ -5,6 +5,8 @@ from typing import Any
 from unittest.mock import patch
 
 from aioesphomeapi import APIClient, UpdateCommand, UpdateInfo, UpdateState
+from awesomeversion import AwesomeVersion
+from awesomeversion.exceptions import AwesomeVersionCompareException
 import pytest
 
 from homeassistant.components.esphome.dashboard import async_get_dashboard
@@ -545,6 +547,128 @@ async def test_generic_device_update_entity_has_update(
     mock_client.update_command.assert_called_with(
         key=1, command=UpdateCommand.CHECK, device_id=0
     )
+
+
+@pytest.mark.parametrize(
+    ("current_version", "latest_version"),
+    [
+        ("2025.11.5_c51f7548", "2025.11.6_aabbccdd"),
+        ("2025.11.5_c51f7548", "2025.11.5_aabbccdd"),
+        ("2025.11.6_aabbccdd", "2025.11.5_c51f7548"),
+    ],
+    ids=["newer_base", "same_base_new_build", "older_base"],
+)
+def test_awesomeversion_cannot_compare_project_versions(
+    current_version: str, latest_version: str
+) -> None:
+    """Prove AwesomeVersion raises on ESPHome project versions.
+
+    ESPHome project versions carry a build suffix (e.g. 2025.11.5_c51f7548).
+    AwesomeVersion cannot parse these, so the base UpdateEntity comparison would
+    raise and force the entity on, which is why ESPHomeUpdateEntity mirrors the
+    device by comparing with a plain string inequality instead.
+    """
+    with pytest.raises(AwesomeVersionCompareException):
+        assert AwesomeVersion(latest_version) > current_version
+
+
+@pytest.mark.parametrize(
+    ("current_version", "latest_version", "expected_state"),
+    [
+        ("2025.11.5_c51f7548", "2025.11.6_aabbccdd", STATE_ON),
+        ("2025.11.5_c51f7548", "2025.11.5_aabbccdd", STATE_OFF),
+        ("2025.11.6_aabbccdd", "2025.11.5_c51f7548", STATE_OFF),
+        ("2025.11.5_c51f7548", "2025.11.5_c51f7548", STATE_OFF),
+    ],
+    ids=["newer_base", "same_base_new_build", "older_base", "identical"],
+)
+async def test_generic_device_update_entity_project_version(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_generic_device_entry: MockGenericDeviceEntryType,
+    current_version: str,
+    latest_version: str,
+    expected_state: str,
+) -> None:
+    """Test version comparison for ESPHome project versions.
+
+    AwesomeVersion cannot parse the build suffix, so the entity strips it and
+    compares the real versions: only a genuinely newer base version is offered;
+    a different build of the same version or an older version is not.
+    """
+    entity_info = [
+        UpdateInfo(
+            object_id="myupdate",
+            key=1,
+            name="my update",
+        )
+    ]
+    states = [
+        UpdateState(
+            key=1,
+            current_version=current_version,
+            latest_version=latest_version,
+            title="ESPHome Project",
+            release_summary=RELEASE_SUMMARY,
+            release_url=RELEASE_URL,
+        )
+    ]
+    await mock_generic_device_entry(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == expected_state
+
+
+async def test_generic_device_update_entity_clears_after_ota(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test a project version update clears once the device runs the new build."""
+    entity_info = [
+        UpdateInfo(
+            object_id="myupdate",
+            key=1,
+            name="my update",
+        )
+    ]
+    states = [
+        UpdateState(
+            key=1,
+            current_version="2025.11.5_c51f7548",
+            latest_version="2025.11.6_aabbccdd",
+            title="ESPHome Project",
+            release_summary=RELEASE_SUMMARY,
+            release_url=RELEASE_URL,
+        )
+    ]
+    mock_device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_ON
+
+    mock_device.set_state(
+        UpdateState(
+            key=1,
+            current_version="2025.11.6_aabbccdd",
+            latest_version="2025.11.6_aabbccdd",
+            title="ESPHome Project",
+            release_summary=RELEASE_SUMMARY,
+            release_url=RELEASE_URL,
+        )
+    )
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_OFF
 
 
 async def test_update_entity_release_notes(


### PR DESCRIPTION
## Breaking change


## Proposed change

ESPHome project versions carry a build suffix like `2025.11.5_c51f7548`; AwesomeVersion cannot parse that, so the base update entity comparison raised and the entity was forced on. The device reports its project version with the suffix while the manifest reports the clean version, so after a successful OTA they were the same release but never compared equal, leaving the update stuck as available. This strips the suffix before comparing, so we only offer genuinely newer firmware and the update clears once the device runs the new build.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #172428
- This PR is related to issue: #158959
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
