### PR TITLE
Fix Airzone grille angle select values

### DIFF
--- a/homeassistant/components/airzone/select.py
+++ b/homeassistant/components/airzone/select.py
@@ -44,10 +44,10 @@ class AirzoneSelectDescription(SelectEntityDescription):
 
 
 GRILLE_ANGLE_DICT: Final[dict[str, int]] = {
-    "90deg": GrilleAngle.DEG_90,
-    "50deg": GrilleAngle.DEG_50,
-    "45deg": GrilleAngle.DEG_45,
-    "40deg": GrilleAngle.DEG_40,
+    "90deg": 90,
+    "50deg": 50,
+    "45deg": 45,
+    "40deg": 40,
 }
 
 MODE_DICT: Final[dict[str, int]] = {


### PR DESCRIPTION
Fixes #165893

The Airzone local API expects grille angle values in degrees (90, 50, 45, 40).

The integration currently sends the corresponding `GrilleAngle` enum values instead (0, 1, 2, 3). For example, selecting `50deg` results in `coldangle=1`, which is rejected by the API:

`set_hvac: param not in data: coldangle=1`

Direct API testing confirms that `coldangle=50` succeeds and the API advertises the supported values as:

`cold_angle_values: [90, 50, 45, 40]`

This change updates `GRILLE_ANGLE_DICT` to send the actual angle values expected by the API.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

The Airzone local API expects grille angle values in degrees (90, 50, 45, 40).

The integration currently sends the corresponding GrilleAngle enum values instead (0, 1, 2, 3). For example, selecting 50deg results in coldangle=1, which is rejected by the API:

set_hvac: param not in data: coldangle=1

Direct API testing confirms that coldangle=50 succeeds and the API advertises the supported values as:

cold_angle_values: [90, 50, 45, 40]

This change updates GRILLE_ANGLE_DICT to send the actual angle values expected by the API.



## Type of change

- [ ] Dependency upgrade
- [ x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #165893
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ x ] I understand the code I am submitting and can explain how it works.
- [ x ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
