### PR TITLE
Add sensors, binary sensors and emission-type selects to Airzone

### DIFF
--- a/homeassistant/components/airzone/binary_sensor.py
+++ b/homeassistant/components/airzone/binary_sensor.py
@@ -5,9 +5,13 @@ from typing import Any, Final
 
 from aioairzone.const import (
     AZD_AIR_DEMAND,
+    AZD_ANTI_FREEZE,
     AZD_BATTERY_LOW,
+    AZD_COLD_DEMAND,
+    AZD_DEMAND,
     AZD_ERRORS,
     AZD_FLOOR_DEMAND,
+    AZD_HEAT_DEMAND,
     AZD_PROBLEMS,
     AZD_SYSTEMS,
     AZD_ZONES,
@@ -52,13 +56,36 @@ ZONE_BINARY_SENSOR_TYPES: Final[tuple[AirzoneBinarySensorEntityDescription, ...]
         translation_key="air_demand",
     ),
     AirzoneBinarySensorEntityDescription(
+        entity_category=EntityCategory.DIAGNOSTIC,
+        key=AZD_ANTI_FREEZE,
+        translation_key="anti_freeze",
+    ),
+    AirzoneBinarySensorEntityDescription(
         device_class=BinarySensorDeviceClass.BATTERY,
         key=AZD_BATTERY_LOW,
     ),
     AirzoneBinarySensorEntityDescription(
         device_class=BinarySensorDeviceClass.RUNNING,
+        entity_registry_enabled_default=False,
+        key=AZD_COLD_DEMAND,
+        translation_key="cold_demand",
+    ),
+    AirzoneBinarySensorEntityDescription(
+        device_class=BinarySensorDeviceClass.RUNNING,
+        entity_registry_enabled_default=False,
+        key=AZD_DEMAND,
+        translation_key="demand",
+    ),
+    AirzoneBinarySensorEntityDescription(
+        device_class=BinarySensorDeviceClass.RUNNING,
         key=AZD_FLOOR_DEMAND,
         translation_key="floor_demand",
+    ),
+    AirzoneBinarySensorEntityDescription(
+        device_class=BinarySensorDeviceClass.RUNNING,
+        entity_registry_enabled_default=False,
+        key=AZD_HEAT_DEMAND,
+        translation_key="heat_demand",
     ),
     AirzoneBinarySensorEntityDescription(
         attributes={

--- a/homeassistant/components/airzone/select.py
+++ b/homeassistant/components/airzone/select.py
@@ -86,13 +86,7 @@ Q_ADAPT_DICT: Final[dict[str, int]] = {
     "maximum": QAdapt.MAXIMUM,
 }
 
-COLD_STAGE_DICT: Final[dict[str, int]] = {
-    "air": AirzoneStages.Air,
-    "radiant": AirzoneStages.Radiant,
-    "combined": AirzoneStages.Combined,
-}
-
-HEAT_STAGE_DICT: Final[dict[str, int]] = {
+STAGE_DICT: Final[dict[str, int]] = {
     "air": AirzoneStages.Air,
     "radiant": AirzoneStages.Radiant,
     "combined": AirzoneStages.Combined,
@@ -108,22 +102,16 @@ def main_zone_options(
     return [k for k, v in options.items() if v in modes]
 
 
-def cold_stage_options(
-    zone_data: dict[str, Any],
-    options: dict[str, int],
-) -> list[str]:
-    """Filter available cold stages."""
-    stages = zone_data.get(AZD_COLD_STAGES, [])
-    return [k for k, v in options.items() if v in stages]
+def stage_options(
+    stages_key: str,
+) -> Callable[[dict[str, Any], dict[str, int]], list[str]]:
+    """Build an options filter for the available stages of the given key."""
 
+    def _options(zone_data: dict[str, Any], options: dict[str, int]) -> list[str]:
+        stages = zone_data.get(stages_key, [])
+        return [k for k, v in options.items() if v in stages]
 
-def heat_stage_options(
-    zone_data: dict[str, Any],
-    options: dict[str, int],
-) -> list[str]:
-    """Filter available heat stages."""
-    stages = zone_data.get(AZD_HEAT_STAGES, [])
-    return [k for k, v in options.items() if v in stages]
+    return _options
 
 
 SYSTEM_SELECT_TYPES: Final[tuple[AirzoneSelectDescription, ...]] = (
@@ -178,16 +166,16 @@ ZONE_SELECT_TYPES: Final[tuple[AirzoneSelectDescription, ...]] = (
         api_param=API_COLD_STAGE,
         entity_category=EntityCategory.CONFIG,
         key=AZD_COLD_STAGE,
-        options_dict=COLD_STAGE_DICT,
-        options_fn=cold_stage_options,
+        options_dict=STAGE_DICT,
+        options_fn=stage_options(AZD_COLD_STAGES),
         translation_key="cold_stage",
     ),
     AirzoneSelectDescription(
         api_param=API_HEAT_STAGE,
         entity_category=EntityCategory.CONFIG,
         key=AZD_HEAT_STAGE,
-        options_dict=HEAT_STAGE_DICT,
-        options_fn=heat_stage_options,
+        options_dict=STAGE_DICT,
+        options_fn=stage_options(AZD_HEAT_STAGES),
         translation_key="heat_stage",
     ),
 )

--- a/homeassistant/components/airzone/select.py
+++ b/homeassistant/components/airzone/select.py
@@ -4,15 +4,27 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Final
 
-from aioairzone.common import GrilleAngle, OperationMode, QAdapt, SleepTimeout
+from aioairzone.common import (
+    AirzoneStages,
+    GrilleAngle,
+    OperationMode,
+    QAdapt,
+    SleepTimeout,
+)
 from aioairzone.const import (
     API_COLD_ANGLE,
+    API_COLD_STAGE,
     API_HEAT_ANGLE,
+    API_HEAT_STAGE,
     API_MODE,
     API_Q_ADAPT,
     API_SLEEP,
     AZD_COLD_ANGLE,
+    AZD_COLD_STAGE,
+    AZD_COLD_STAGES,
     AZD_HEAT_ANGLE,
+    AZD_HEAT_STAGE,
+    AZD_HEAT_STAGES,
     AZD_MASTER,
     AZD_MODE,
     AZD_MODES,
@@ -74,6 +86,18 @@ Q_ADAPT_DICT: Final[dict[str, int]] = {
     "maximum": QAdapt.MAXIMUM,
 }
 
+COLD_STAGE_DICT: Final[dict[str, int]] = {
+    "air": AirzoneStages.Air,
+    "radiant": AirzoneStages.Radiant,
+    "combined": AirzoneStages.Combined,
+}
+
+HEAT_STAGE_DICT: Final[dict[str, int]] = {
+    "air": AirzoneStages.Air,
+    "radiant": AirzoneStages.Radiant,
+    "combined": AirzoneStages.Combined,
+}
+
 
 def main_zone_options(
     zone_data: dict[str, Any],
@@ -82,6 +106,24 @@ def main_zone_options(
     """Filter available modes."""
     modes = zone_data.get(AZD_MODES, [])
     return [k for k, v in options.items() if v in modes]
+
+
+def cold_stage_options(
+    zone_data: dict[str, Any],
+    options: dict[str, int],
+) -> list[str]:
+    """Filter available cold stages."""
+    stages = zone_data.get(AZD_COLD_STAGES, [])
+    return [k for k, v in options.items() if v in stages]
+
+
+def heat_stage_options(
+    zone_data: dict[str, Any],
+    options: dict[str, int],
+) -> list[str]:
+    """Filter available heat stages."""
+    stages = zone_data.get(AZD_HEAT_STAGES, [])
+    return [k for k, v in options.items() if v in stages]
 
 
 SYSTEM_SELECT_TYPES: Final[tuple[AirzoneSelectDescription, ...]] = (
@@ -131,6 +173,22 @@ ZONE_SELECT_TYPES: Final[tuple[AirzoneSelectDescription, ...]] = (
         options=list(SLEEP_DICT),
         options_dict=SLEEP_DICT,
         translation_key="sleep_times",
+    ),
+    AirzoneSelectDescription(
+        api_param=API_COLD_STAGE,
+        entity_category=EntityCategory.CONFIG,
+        key=AZD_COLD_STAGE,
+        options_dict=COLD_STAGE_DICT,
+        options_fn=cold_stage_options,
+        translation_key="cold_stage",
+    ),
+    AirzoneSelectDescription(
+        api_param=API_HEAT_STAGE,
+        entity_category=EntityCategory.CONFIG,
+        key=AZD_HEAT_STAGE,
+        options_dict=HEAT_STAGE_DICT,
+        options_fn=heat_stage_options,
+        translation_key="heat_stage",
     ),
 )
 
@@ -282,6 +340,12 @@ class AirzoneZoneSelect(AirzoneZoneEntity, AirzoneBaseSelect):
         self._attr_options = self.entity_description.options_fn(
             zone_data, description.options_dict
         )
+
+        # A select with a single (or no) option cannot be acted upon, so
+        # disable it by default (e.g. cold/heat stage when the zone only
+        # exposes one stage). It can still be enabled manually.
+        if len(self._attr_options) <= 1:
+            self._attr_entity_registry_enabled_default = False
 
         self.values_dict = {v: k for k, v in description.options_dict.items()}
 

--- a/homeassistant/components/airzone/sensor.py
+++ b/homeassistant/components/airzone/sensor.py
@@ -63,6 +63,8 @@ SYSTEM_SENSOR_TYPES: Final[tuple[SensorEntityDescription, ...]] = (
         options=["off", "manual", "a", "a_p", "a_pp"],
         translation_key="eco_adapt",
     ),
+    # The aioairzone AZD_ENERGY value is the clamp meter instantaneous power
+    # reading (in watts), hence the power device class despite the name.
     SensorEntityDescription(
         device_class=SensorDeviceClass.POWER,
         key=AZD_ENERGY,

--- a/homeassistant/components/airzone/sensor.py
+++ b/homeassistant/components/airzone/sensor.py
@@ -3,13 +3,18 @@
 from typing import Any, Final
 
 from aioairzone.const import (
+    AZD_ECO_ADAPT,
+    AZD_ENERGY,
     AZD_HOT_WATER,
     AZD_HUMIDITY,
+    AZD_SYSTEMS,
     AZD_TEMP,
     AZD_TEMP_UNIT,
     AZD_THERMOSTAT_BATTERY,
     AZD_THERMOSTAT_SIGNAL,
     AZD_WEBSERVER,
+    AZD_WIFI_CHANNEL,
+    AZD_WIFI_QUALITY,
     AZD_WIFI_RSSI,
     AZD_ZONES,
 )
@@ -25,6 +30,7 @@ from homeassistant.const import (
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     EntityCategory,
+    UnitOfPower,
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, callback
@@ -35,6 +41,7 @@ from .coordinator import AirzoneConfigEntry, AirzoneUpdateCoordinator
 from .entity import (
     AirzoneEntity,
     AirzoneHotWaterEntity,
+    AirzoneSystemEntity,
     AirzoneWebServerEntity,
     AirzoneZoneEntity,
 )
@@ -48,6 +55,22 @@ HOT_WATER_SENSOR_TYPES: Final[tuple[SensorEntityDescription, ...]] = (
     ),
 )
 
+SYSTEM_SENSOR_TYPES: Final[tuple[SensorEntityDescription, ...]] = (
+    SensorEntityDescription(
+        device_class=SensorDeviceClass.ENUM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        key=AZD_ECO_ADAPT,
+        options=["off", "manual", "a", "a_p", "a_pp"],
+        translation_key="eco_adapt",
+    ),
+    SensorEntityDescription(
+        device_class=SensorDeviceClass.POWER,
+        key=AZD_ENERGY,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+)
+
 WEBSERVER_SENSOR_TYPES: Final[tuple[SensorEntityDescription, ...]] = (
     SensorEntityDescription(
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
@@ -57,6 +80,21 @@ WEBSERVER_SENSOR_TYPES: Final[tuple[SensorEntityDescription, ...]] = (
         translation_key="rssi",
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SensorEntityDescription(
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        key=AZD_WIFI_CHANNEL,
+        state_class=SensorStateClass.MEASUREMENT,
+        translation_key="wifi_channel",
+    ),
+    SensorEntityDescription(
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        key=AZD_WIFI_QUALITY,
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        translation_key="wifi_quality",
     ),
 )
 
@@ -98,12 +136,31 @@ async def async_setup_entry(
     """Add Airzone sensors from a config_entry."""
     coordinator = entry.runtime_data
 
+    added_systems: set[str] = set()
     added_zones: set[str] = set()
 
     def _async_entity_listener() -> None:
         """Handle additions of sensors."""
 
         entities: list[AirzoneSensor] = []
+
+        systems_data = coordinator.data.get(AZD_SYSTEMS, {})
+        received_systems = set(systems_data)
+        new_systems = received_systems - added_systems
+        if new_systems:
+            entities.extend(
+                AirzoneSystemSensor(
+                    coordinator,
+                    description,
+                    entry,
+                    system_id,
+                    systems_data.get(system_id),
+                )
+                for system_id in new_systems
+                for description in SYSTEM_SENSOR_TYPES
+                if description.key in systems_data.get(system_id)
+            )
+            added_systems.update(new_systems)
 
         zones_data = coordinator.data.get(AZD_ZONES, {})
         received_zones = set(zones_data)
@@ -205,6 +262,26 @@ class AirzoneWebServerSensor(AirzoneWebServerEntity, AirzoneSensor):
         super().__init__(coordinator, entry)
         self._attr_unique_id = f"{self._attr_unique_id}_ws_{description.key}"
         self.entity_description = description
+        self._async_update_attrs()
+
+
+class AirzoneSystemSensor(AirzoneSystemEntity, AirzoneSensor):
+    """Define an Airzone System sensor."""
+
+    def __init__(
+        self,
+        coordinator: AirzoneUpdateCoordinator,
+        description: SensorEntityDescription,
+        entry: ConfigEntry,
+        system_id: str,
+        system_data: dict[str, Any],
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator, entry, system_data)
+
+        self._attr_unique_id = f"{self._attr_unique_id}_{system_id}_{description.key}"
+        self.entity_description = description
+
         self._async_update_attrs()
 
 

--- a/homeassistant/components/airzone/strings.json
+++ b/homeassistant/components/airzone/strings.json
@@ -29,11 +29,31 @@
       "air_demand": {
         "name": "Air demand"
       },
+      "anti_freeze": {
+        "name": "Anti-freeze"
+      },
+      "cold_demand": {
+        "name": "Cold demand"
+      },
+      "demand": {
+        "name": "Demand"
+      },
       "floor_demand": {
         "name": "Floor demand"
+      },
+      "heat_demand": {
+        "name": "Heat demand"
       }
     },
     "select": {
+      "cold_stage": {
+        "name": "Cooling emission type",
+        "state": {
+          "air": "Air",
+          "combined": "Combined",
+          "radiant": "Radiant"
+        }
+      },
       "grille_angles": {
         "name": "Cold angle",
         "state": {
@@ -50,6 +70,14 @@
           "45deg": "[%key:component::airzone::entity::select::grille_angles::state::45deg%]",
           "50deg": "[%key:component::airzone::entity::select::grille_angles::state::50deg%]",
           "90deg": "[%key:component::airzone::entity::select::grille_angles::state::90deg%]"
+        }
+      },
+      "heat_stage": {
+        "name": "Heating emission type",
+        "state": {
+          "air": "[%key:component::airzone::entity::select::cold_stage::state::air%]",
+          "combined": "[%key:component::airzone::entity::select::cold_stage::state::combined%]",
+          "radiant": "[%key:component::airzone::entity::select::cold_stage::state::radiant%]"
         }
       },
       "modes": {
@@ -84,11 +112,27 @@
       }
     },
     "sensor": {
+      "eco_adapt": {
+        "name": "Eco-Adapt",
+        "state": {
+          "a": "A",
+          "a_p": "A+",
+          "a_pp": "A++",
+          "manual": "Manual",
+          "off": "[%key:common::state::off%]"
+        }
+      },
       "rssi": {
         "name": "RSSI"
       },
       "thermostat_signal": {
         "name": "Signal strength"
+      },
+      "wifi_channel": {
+        "name": "Wi-Fi channel"
+      },
+      "wifi_quality": {
+        "name": "Wi-Fi quality"
       }
     }
   }

--- a/tests/components/airzone/snapshots/test_diagnostics.ambr
+++ b/tests/components/airzone/snapshots/test_diagnostics.ambr
@@ -8,14 +8,18 @@
             'data': list([
               dict({
                 'air_demand': 0,
+                'antifreeze': 0,
                 'coldStage': 1,
                 'coldStages': 1,
+                'cold_demand': 0,
                 'coldangle': 0,
+                'eco_adapt': 'manual',
                 'errors': list([
                 ]),
                 'floor_demand': 0,
                 'heatStage': 1,
                 'heatStages': 1,
+                'heat_demand': 0,
                 'heatangle': 0,
                 'humidity': 34,
                 'maxTemp': 30,
@@ -44,9 +48,11 @@
               }),
               dict({
                 'air_demand': 1,
+                'antifreeze': 0,
                 'battery': 99,
                 'coldStage': 1,
                 'coldStages': 1,
+                'cold_demand': 0,
                 'coldangle': 2,
                 'coverage': 72,
                 'errors': list([
@@ -54,6 +60,7 @@
                 'floor_demand': 1,
                 'heatStage': 3,
                 'heatStages': 3,
+                'heat_demand': 1,
                 'heatangle': 1,
                 'humidity': 39,
                 'maxTemp': 30,
@@ -276,6 +283,7 @@
       'webserver': dict({
         'mac': '**REDACTED**',
         'wifi_channel': 6,
+        'wifi_quality': 84,
         'wifi_rssi': -42,
         'ws_type': 'ws_az',
       }),
@@ -325,6 +333,9 @@
       'systems': dict({
         '1': dict({
           'available': True,
+          'clamp-meter': True,
+          'eco-adapt': 'manual',
+          'energy': 100,
           'firmware': '3.31',
           'full-name': 'Airzone [1] System',
           'id': 1,
@@ -395,6 +406,7 @@
         'mac': '**REDACTED**',
         'model': 'Airzone WebServer',
         'wifi-channel': 6,
+        'wifi-quality': 84,
         'wifi-rssi': -42,
       }),
       'zones': dict({
@@ -403,8 +415,10 @@
           'absolute-temp-min': 15.0,
           'action': 6,
           'air-demand': False,
+          'anti-freeze': False,
           'available': True,
           'cold-angle': 0,
+          'cold-demand': False,
           'cold-stage': 1,
           'cold-stages': list([
             0,
@@ -412,8 +426,10 @@
           ]),
           'demand': False,
           'double-set-point': False,
+          'eco-adapt': 'manual',
           'full-name': 'Airzone [1:1] Salon',
           'heat-angle': 0,
+          'heat-demand': False,
           'heat-stage': 1,
           'heat-stages': list([
             0,
@@ -457,9 +473,11 @@
           'absolute-temp-min': 15.0,
           'action': 4,
           'air-demand': True,
+          'anti-freeze': False,
           'available': True,
           'battery-low': False,
           'cold-angle': 2,
+          'cold-demand': False,
           'cold-stage': 1,
           'cold-stages': list([
             0,
@@ -470,6 +488,7 @@
           'floor-demand': True,
           'full-name': 'Airzone [1:2] Dorm Ppal',
           'heat-angle': 1,
+          'heat-demand': True,
           'heat-stage': 3,
           'heat-stages': list([
             0,

--- a/tests/components/airzone/snapshots/test_sensor.ambr
+++ b/tests/components/airzone/snapshots/test_sensor.ambr
@@ -225,6 +225,113 @@
     'state': '-42',
   })
 # ---
+# name: test_airzone_create_sensors[sensor.airzone_webserver_wi_fi_channel-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.airzone_webserver_wi_fi_channel',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Wi-Fi channel',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Wi-Fi channel',
+    'platform': 'airzone',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'wifi_channel',
+    'unique_id': 'airzone_unique_id_ws_wifi-channel',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_airzone_create_sensors[sensor.airzone_webserver_wi_fi_channel-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Airzone WebServer Wi-Fi channel',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.airzone_webserver_wi_fi_channel',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '6',
+  })
+# ---
+# name: test_airzone_create_sensors[sensor.airzone_webserver_wi_fi_quality-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.airzone_webserver_wi_fi_quality',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Wi-Fi quality',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Wi-Fi quality',
+    'platform': 'airzone',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'wifi_quality',
+    'unique_id': 'airzone_unique_id_ws_wifi-quality',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_airzone_create_sensors[sensor.airzone_webserver_wi_fi_quality-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Airzone WebServer Wi-Fi quality',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.airzone_webserver_wi_fi_quality',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '84',
+  })
+# ---
 # name: test_airzone_create_sensors[sensor.aux_heat_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -1340,5 +1447,129 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '19.6',
+  })
+# ---
+# name: test_airzone_create_sensors[sensor.system_1_eco_adapt-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'off',
+        'manual',
+        'a',
+        'a_p',
+        'a_pp',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.system_1_eco_adapt',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Eco-Adapt',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Eco-Adapt',
+    'platform': 'airzone',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'eco_adapt',
+    'unique_id': 'airzone_unique_id_1_eco-adapt',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_airzone_create_sensors[sensor.system_1_eco_adapt-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'System 1 Eco-Adapt',
+      'options': list([
+        'off',
+        'manual',
+        'a',
+        'a_p',
+        'a_pp',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.system_1_eco_adapt',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'manual',
+  })
+# ---
+# name: test_airzone_create_sensors[sensor.system_1_power-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.system_1_power',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Power',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Power',
+    'platform': 'airzone',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'airzone_unique_id_1_energy',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+  })
+# ---
+# name: test_airzone_create_sensors[sensor.system_1_power-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'System 1 Power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.system_1_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100',
   })
 # ---

--- a/tests/components/airzone/test_binary_sensor.py
+++ b/tests/components/airzone/test_binary_sensor.py
@@ -1,6 +1,7 @@
 """The sensor tests for the Airzone platform."""
 
 from aioairzone.const import API_ERROR_LOW_BATTERY
+import pytest
 
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
@@ -70,6 +71,19 @@ async def test_airzone_create_binary_sensors(hass: HomeAssistant) -> None:
     state = hass.states.get("binary_sensor.salon_air_demand")
     assert state.state == STATE_OFF
 
+    state = hass.states.get("binary_sensor.salon_anti_freeze")
+    assert state.state == STATE_OFF
+
+    state = hass.states.get("binary_sensor.dorm_ppal_anti_freeze")
+    assert state.state == STATE_OFF
+
+    # Cold/heat/generic demand binary sensors are disabled by default.
+    state = hass.states.get("binary_sensor.dorm_ppal_demand")
+    assert state is None
+
+    state = hass.states.get("binary_sensor.dorm_ppal_heat_demand")
+    assert state is None
+
     state = hass.states.get("binary_sensor.salon_battery")
     assert state is None
 
@@ -90,3 +104,30 @@ async def test_airzone_create_binary_sensors(hass: HomeAssistant) -> None:
 
     state = hass.states.get("binary_sensor.dkn_plus_problem")
     assert state.state == STATE_OFF
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_airzone_create_binary_sensors_disabled_by_default(
+    hass: HomeAssistant,
+) -> None:
+    """Test creation of binary sensors that are disabled by default."""
+
+    await async_init_integration(hass)
+
+    # Generic demand (air OR floor demand).
+    state = hass.states.get("binary_sensor.salon_demand")
+    assert state.state == STATE_OFF
+
+    state = hass.states.get("binary_sensor.dorm_ppal_demand")
+    assert state.state == STATE_ON
+
+    # Cold demand.
+    state = hass.states.get("binary_sensor.salon_cold_demand")
+    assert state.state == STATE_OFF
+
+    # Heat demand.
+    state = hass.states.get("binary_sensor.salon_heat_demand")
+    assert state.state == STATE_OFF
+
+    state = hass.states.get("binary_sensor.dorm_ppal_heat_demand")
+    assert state.state == STATE_ON

--- a/tests/components/airzone/test_select.py
+++ b/tests/components/airzone/test_select.py
@@ -32,6 +32,10 @@ async def test_airzone_create_selects(hass: HomeAssistant) -> None:
     state = hass.states.get("select.system_1_q_adapt")
     assert state.state == "standard"
 
+    # Heat emission type (only enabled when more than one stage is available).
+    state = hass.states.get("select.dorm_ppal_heating_emission_type")
+    assert state.state == "combined"
+
     # Zones
     state = hass.states.get("select.despacho_cold_angle")
     assert state.state == "90deg"

--- a/tests/components/airzone/test_sensor.py
+++ b/tests/components/airzone/test_sensor.py
@@ -49,6 +49,18 @@ async def test_airzone_create_sensors(
     assert state is None
 
 
+async def test_airzone_system_sensors(hass: HomeAssistant) -> None:
+    """Test creation of the system sensors (Eco-Adapt and power)."""
+
+    await async_init_integration(hass)
+
+    state = hass.states.get("sensor.system_1_eco_adapt")
+    assert state.state == "manual"
+
+    state = hass.states.get("sensor.system_1_power")
+    assert state.state == "100"
+
+
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_airzone_sensors_availability(hass: HomeAssistant) -> None:
     """Test sensors availability."""

--- a/tests/components/airzone/util.py
+++ b/tests/components/airzone/util.py
@@ -3,6 +3,7 @@
 from copy import deepcopy
 from unittest.mock import patch
 
+from aioairzone.common import EcoAdapt
 from aioairzone.const import (
     API_ACS_MAX_TEMP,
     API_ACS_MIN_TEMP,
@@ -11,8 +12,10 @@ from aioairzone.const import (
     API_ACS_SET_POINT,
     API_ACS_TEMP,
     API_AIR_DEMAND,
+    API_ANTI_FREEZE,
     API_BATTERY,
     API_COLD_ANGLE,
+    API_COLD_DEMAND,
     API_COLD_STAGE,
     API_COLD_STAGES,
     API_COOL_MAX_TEMP,
@@ -20,9 +23,11 @@ from aioairzone.const import (
     API_COOL_SET_POINT,
     API_COVERAGE,
     API_DATA,
+    API_ECO_ADAPT,
     API_ERRORS,
     API_FLOOR_DEMAND,
     API_HEAT_ANGLE,
+    API_HEAT_DEMAND,
     API_HEAT_MAX_TEMP,
     API_HEAT_MIN_TEMP,
     API_HEAT_SET_POINT,
@@ -32,6 +37,7 @@ from aioairzone.const import (
     API_MAC,
     API_MASTER_ZONE_ID,
     API_MAX_TEMP,
+    API_MC_CONNECTED,
     API_MIN_TEMP,
     API_MODE,
     API_MODES,
@@ -54,6 +60,7 @@ from aioairzone.const import (
     API_UNITS,
     API_VERSION,
     API_WIFI_CHANNEL,
+    API_WIFI_QUALITY,
     API_WIFI_RSSI,
     API_WS_AZ,
     API_WS_TYPE,
@@ -110,6 +117,10 @@ HVAC_MOCK = {
                     API_ERRORS: [],
                     API_AIR_DEMAND: 0,
                     API_FLOOR_DEMAND: 0,
+                    API_ANTI_FREEZE: 0,
+                    API_COLD_DEMAND: 0,
+                    API_HEAT_DEMAND: 0,
+                    API_ECO_ADAPT: EcoAdapt.MANUAL,
                     API_HEAT_ANGLE: 0,
                     API_COLD_ANGLE: 0,
                     API_SPEED: 0,
@@ -140,6 +151,9 @@ HVAC_MOCK = {
                     API_ERRORS: [],
                     API_AIR_DEMAND: 1,
                     API_FLOOR_DEMAND: 1,
+                    API_ANTI_FREEZE: 0,
+                    API_COLD_DEMAND: 0,
+                    API_HEAT_DEMAND: 1,
                     API_HEAT_ANGLE: 1,
                     API_COLD_ANGLE: 2,
                     API_SPEED: 0,
@@ -351,7 +365,8 @@ HVAC_SYSTEMS_MOCK = {
     API_SYSTEMS: [
         {
             API_SYSTEM_ID: 1,
-            API_POWER: 0,
+            API_POWER: 100,
+            API_MC_CONNECTED: 1,
             API_SYSTEM_FIRMWARE: "3.31",
             API_SYSTEM_TYPE: 1,
             API_Q_ADAPT: 0,
@@ -367,6 +382,7 @@ HVAC_WEBSERVER_MOCK = {
     API_MAC: "11:22:33:44:55:66",
     API_WS_TYPE: API_WS_AZ,
     API_WIFI_CHANNEL: 6,
+    API_WIFI_QUALITY: 84,
     API_WIFI_RSSI: -42,
 }
 


### PR DESCRIPTION
## Proposed change

Add several new entities to the existing **Airzone** integration, all based on
data already exposed by the `aioairzone` library (no dependency change):

- **Binary sensors** (per zone): `Anti-freeze`, plus `Cold demand`, `Demand`
  and `Heat demand` (the running-demand ones are disabled by default).
- **Sensors**:
  - System: `Eco-Adapt` (enum) and `Power` (instantaneous power, W).
  - WebServer: `Wi-Fi channel` and `Wi-Fi quality` (diagnostic, disabled by
    default).
- **Selects** (per zone): `Cooling emission type` and `Heating emission type`
  (cold/heat stage). A select exposing a single option is disabled by default.

Tests and translations are included.

> [!NOTE]
> This is the first of a two-PR series splitting an Airzone feature branch.
> The follow-up PR (system-wide "all zones" climate and sleep controls) also
> touches `select.py`/`strings.json`, so please merge this one first.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- Link to documentation pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
