### PR TITLE
Add all-zones climate and sleep controls to Airzone

### DIFF
--- a/homeassistant/components/airzone/climate.py
+++ b/homeassistant/components/airzone/climate.py
@@ -10,17 +10,22 @@ from aioairzone.const import (
     API_ON,
     API_SET_POINT,
     API_SPEED,
+    API_SYSTEM_ID,
+    API_ZONE_ID,
     AZD_ACTION,
     AZD_COOL_TEMP_SET,
     AZD_DOUBLE_SET_POINT,
     AZD_HEAT_TEMP_SET,
     AZD_HUMIDITY,
+    AZD_ID,
     AZD_MASTER,
     AZD_MODE,
     AZD_MODES,
     AZD_ON,
     AZD_SPEED,
     AZD_SPEEDS,
+    AZD_SYSTEM,
+    AZD_SYSTEMS,
     AZD_TEMP,
     AZD_TEMP_MAX,
     AZD_TEMP_MIN,
@@ -28,6 +33,7 @@ from aioairzone.const import (
     AZD_TEMP_UNIT,
     AZD_ZONES,
 )
+from aioairzone.exceptions import AirzoneError
 
 from homeassistant.components.climate import (
     ATTR_HVAC_MODE,
@@ -50,7 +56,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import API_TEMPERATURE_STEP, TEMP_UNIT_LIB_TO_HASS
 from .coordinator import AirzoneConfigEntry, AirzoneUpdateCoordinator
-from .entity import AirzoneZoneEntity
+from .entity import AirzoneSystemEntity, AirzoneZoneEntity
 
 BASE_FAN_SPEEDS: Final[dict[int, str]] = {
     0: FAN_AUTO,
@@ -103,16 +109,34 @@ async def async_setup_entry(
     """Add Airzone climate from a config_entry."""
     coordinator = entry.runtime_data
 
+    added_systems: set[str] = set()
     added_zones: set[str] = set()
 
     def _async_entity_listener() -> None:
         """Handle additions of climate."""
 
+        entities: list[ClimateEntity] = []
+
+        systems_data = coordinator.data.get(AZD_SYSTEMS, {})
+        received_systems = set(systems_data)
+        new_systems = received_systems - added_systems
+        if new_systems:
+            entities.extend(
+                AirzoneSystemClimate(
+                    coordinator,
+                    entry,
+                    system_id,
+                    systems_data.get(system_id),
+                )
+                for system_id in new_systems
+            )
+            added_systems.update(new_systems)
+
         zones_data = coordinator.data.get(AZD_ZONES, {})
         received_zones = set(zones_data)
         new_zones = received_zones - added_zones
         if new_zones:
-            async_add_entities(
+            entities.extend(
                 AirzoneClimate(
                     coordinator,
                     entry,
@@ -122,6 +146,8 @@ async def async_setup_entry(
                 for system_zone_id in new_zones
             )
             added_zones.update(new_zones)
+
+        async_add_entities(entities)
 
     entry.async_on_unload(coordinator.async_add_listener(_async_entity_listener))
     _async_entity_listener()
@@ -154,10 +180,15 @@ class AirzoneClimate(AirzoneZoneEntity, ClimateEntity):
         self._attr_temperature_unit = TEMP_UNIT_LIB_TO_HASS[
             self.get_airzone_value(AZD_TEMP_UNIT)
         ]
-        _attr_hvac_modes = [
-            HVAC_MODE_LIB_TO_HASS[mode] for mode in self.get_airzone_value(AZD_MODES)
-        ]
-        self._attr_hvac_modes = list(dict.fromkeys(_attr_hvac_modes))
+        self._is_master = bool(self.get_airzone_value(AZD_MASTER))
+        if self._is_master:
+            _attr_hvac_modes = [
+                HVAC_MODE_LIB_TO_HASS[mode]
+                for mode in self.get_airzone_value(AZD_MODES)
+            ]
+            self._attr_hvac_modes = list(dict.fromkeys(_attr_hvac_modes))
+        else:
+            self._update_slave_hvac_modes()
         if (
             self.get_airzone_value(AZD_SPEED) is not None
             and self.get_airzone_value(AZD_SPEEDS) is not None
@@ -169,6 +200,13 @@ class AirzoneClimate(AirzoneZoneEntity, ClimateEntity):
             )
 
         self._async_update_attrs()
+
+    def _update_slave_hvac_modes(self) -> None:
+        modes = [HVACMode.OFF]
+        current = HVAC_MODE_LIB_TO_HASS.get(self.get_airzone_value(AZD_MODE))
+        if current is not None and current != HVACMode.OFF:
+            modes.append(current)
+        self._attr_hvac_modes = modes
 
     def _set_fan_speeds(self) -> None:
         self._attr_supported_features |= ClimateEntityFeature.FAN_MODE
@@ -214,25 +252,19 @@ class AirzoneClimate(AirzoneZoneEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set hvac mode."""
-        slave_raise = False
-
         params = {}
         if hvac_mode == HVACMode.OFF:
             params[API_ON] = 0
         else:
             mode = HVAC_MODE_HASS_TO_LIB[hvac_mode]
-            if mode != self.get_airzone_value(AZD_MODE):
-                if self.get_airzone_value(AZD_MASTER):
-                    params[API_MODE] = mode
-                else:
-                    slave_raise = True
+            # The mode is system-wide; it can only be changed on the master zone.
+            # Slave zones only expose off and the current mode.
+            if mode != self.get_airzone_value(AZD_MODE) and self.get_airzone_value(
+                AZD_MASTER
+            ):
+                params[API_MODE] = mode
             params[API_ON] = 1
         await self._async_update_hvac_params(params)
-
-        if slave_raise:
-            raise HomeAssistantError(
-                f"Mode can't be changed on slave zone {self.entity_id}"
-            )
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
@@ -256,6 +288,8 @@ class AirzoneClimate(AirzoneZoneEntity, ClimateEntity):
     @callback
     def _async_update_attrs(self) -> None:
         """Update climate attributes."""
+        if not self._is_master:
+            self._update_slave_hvac_modes()
         self._attr_current_temperature = self.get_airzone_value(AZD_TEMP)
         self._attr_current_humidity = self.get_airzone_value(AZD_HUMIDITY)
         self._attr_hvac_action = HVAC_ACTION_LIB_TO_HASS[
@@ -286,3 +320,209 @@ class AirzoneClimate(AirzoneZoneEntity, ClimateEntity):
             self._attr_target_temperature_high = None
             self._attr_target_temperature_low = None
             self._attr_target_temperature = self.get_airzone_value(AZD_TEMP_SET)
+
+
+class AirzoneSystemClimate(AirzoneSystemEntity, ClimateEntity):
+    """Define an Airzone global (all zones) climate."""
+
+    _attr_translation_key = "all_zones"
+    _speeds: dict[int, str]
+    _speeds_reverse: dict[str, int]
+
+    def __init__(
+        self,
+        coordinator: AirzoneUpdateCoordinator,
+        entry: ConfigEntry,
+        system_id: str,
+        system_data: dict[str, Any],
+    ) -> None:
+        """Initialize Airzone global climate entity."""
+        super().__init__(coordinator, entry, system_data)
+
+        self._speeds = {}
+        self._speeds_reverse = {}
+
+        self._attr_unique_id = f"{self._attr_unique_id}_{system_id}_all_zones"
+        self._attr_supported_features = (
+            ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.TURN_OFF
+            | ClimateEntityFeature.TURN_ON
+        )
+        self._attr_target_temperature_step = API_TEMPERATURE_STEP
+        self._attr_temperature_unit = TEMP_UNIT_LIB_TO_HASS[
+            self._master_value(AZD_TEMP_UNIT)
+        ]
+
+        modes = self._master_value(AZD_MODES) or []
+        hvac_modes = [HVAC_MODE_LIB_TO_HASS[mode] for mode in modes]
+        self._attr_hvac_modes = list(dict.fromkeys(hvac_modes)) or [HVACMode.OFF]
+
+        if (
+            self._master_value(AZD_SPEED) is not None
+            and self._master_value(AZD_SPEEDS) is not None
+        ):
+            self._set_fan_speeds()
+        if self._master_value(AZD_DOUBLE_SET_POINT):
+            self._attr_supported_features |= (
+                ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+            )
+
+        self._async_update_attrs()
+
+    def _system_zones(self) -> list[dict[str, Any]]:
+        """Return the data of every zone belonging to this system."""
+        zones = self.coordinator.data.get(AZD_ZONES, {})
+        return [
+            zone for zone in zones.values() if zone.get(AZD_SYSTEM) == self.system_id
+        ]
+
+    def _master_zone(self) -> dict[str, Any] | None:
+        """Return the master zone of the system (fallback: first zone)."""
+        zones = self._system_zones()
+        for zone in zones:
+            if zone.get(AZD_MASTER):
+                return zone
+        return zones[0] if zones else None
+
+    def _master_value(self, key: str) -> Any:
+        """Return a value from the master zone."""
+        zone = self._master_zone()
+        return zone.get(key) if zone else None
+
+    def _zones_average(self, key: str) -> float | None:
+        """Return the average of a numeric key across all zones."""
+        values = [
+            zone[key] for zone in self._system_zones() if zone.get(key) is not None
+        ]
+        if not values:
+            return None
+        return round(sum(values) / len(values), 1)
+
+    def _set_fan_speeds(self) -> None:
+        self._attr_supported_features |= ClimateEntityFeature.FAN_MODE
+
+        speeds = self._master_value(AZD_SPEEDS)
+        max_speed = max(speeds)
+        if _speeds := FAN_SPEED_MAPS.get(max_speed):
+            self._speeds = _speeds
+        else:
+            for speed in speeds:
+                if speed == 0:
+                    self._speeds[speed] = FAN_AUTO
+                else:
+                    self._speeds[speed] = f"{int(round((speed * 100) / max_speed, 0))}%"
+
+            self._speeds[1] = FAN_LOW
+            self._speeds[int(round((max_speed + 1) / 2, 0))] = FAN_MEDIUM
+            self._speeds[max_speed] = FAN_HIGH
+
+        self._speeds_reverse = {v: k for k, v in self._speeds.items()}
+        self._attr_fan_modes = list(self._speeds_reverse)
+
+    async def _async_set_zones_params(
+        self, zones: list[dict[str, Any]], params: dict[str, Any]
+    ) -> None:
+        """Send the same HVAC parameters to each given zone (fan-out)."""
+        try:
+            for zone in zones:
+                _params = {
+                    API_SYSTEM_ID: zone[AZD_SYSTEM],
+                    API_ZONE_ID: zone[AZD_ID],
+                    **params,
+                }
+                await self.coordinator.airzone.set_hvac_parameters(_params)
+        except AirzoneError as error:
+            raise HomeAssistantError(
+                f"Failed to set system {self.entity_id}: {error}"
+            ) from error
+
+        self.coordinator.async_set_updated_data(self.coordinator.airzone.data())
+
+    async def async_turn_on(self) -> None:
+        """Turn all zones on."""
+        await self._async_set_zones_params(self._system_zones(), {API_ON: 1})
+
+    async def async_turn_off(self) -> None:
+        """Turn all zones off."""
+        await self._async_set_zones_params(self._system_zones(), {API_ON: 0})
+
+    async def async_set_fan_mode(self, fan_mode: str) -> None:
+        """Set fan mode on every zone that supports speeds."""
+        speed = self._speeds_reverse.get(fan_mode)
+        zones = [
+            zone for zone in self._system_zones() if zone.get(AZD_SPEEDS) is not None
+        ]
+        await self._async_set_zones_params(zones, {API_SPEED: speed})
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set hvac mode for all zones."""
+        if hvac_mode == HVACMode.OFF:
+            await self._async_set_zones_params(self._system_zones(), {API_ON: 0})
+            return
+
+        mode = HVAC_MODE_HASS_TO_LIB[hvac_mode]
+        # The mode is system-wide and can only be set on the master zone.
+        if mode != self._master_value(AZD_MODE):
+            master = self._master_zone()
+            if master is not None:
+                await self._async_set_zones_params(
+                    [master], {API_MODE: mode, API_ON: 1}
+                )
+        await self._async_set_zones_params(self._system_zones(), {API_ON: 1})
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set a common target temperature for all zones."""
+        params: dict[str, Any] = {}
+        if ATTR_TEMPERATURE in kwargs:
+            params[API_SET_POINT] = kwargs[ATTR_TEMPERATURE]
+        if ATTR_TARGET_TEMP_LOW in kwargs and ATTR_TARGET_TEMP_HIGH in kwargs:
+            params[API_COOL_SET_POINT] = kwargs[ATTR_TARGET_TEMP_HIGH]
+            params[API_HEAT_SET_POINT] = kwargs[ATTR_TARGET_TEMP_LOW]
+        if params:
+            await self._async_set_zones_params(self._system_zones(), params)
+
+        if ATTR_HVAC_MODE in kwargs:
+            await self.async_set_hvac_mode(kwargs[ATTR_HVAC_MODE])
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Update attributes when the coordinator updates."""
+        self._async_update_attrs()
+        super()._handle_coordinator_update()
+
+    @callback
+    def _async_update_attrs(self) -> None:
+        """Update global climate attributes."""
+        self._attr_current_temperature = self._zones_average(AZD_TEMP)
+        humidity = self._zones_average(AZD_HUMIDITY)
+        self._attr_current_humidity = round(humidity) if humidity is not None else None
+
+        action = self._master_value(AZD_ACTION)
+        self._attr_hvac_action = (
+            HVAC_ACTION_LIB_TO_HASS.get(action) if action is not None else None
+        )
+
+        if any(zone.get(AZD_ON) for zone in self._system_zones()):
+            self._attr_hvac_mode = HVAC_MODE_LIB_TO_HASS.get(
+                self._master_value(AZD_MODE)
+            )
+        else:
+            self._attr_hvac_mode = HVACMode.OFF
+
+        self._attr_max_temp = self._master_value(AZD_TEMP_MAX)
+        self._attr_min_temp = self._master_value(AZD_TEMP_MIN)
+
+        if self.supported_features & ClimateEntityFeature.FAN_MODE:
+            self._attr_fan_mode = self._speeds.get(self._master_value(AZD_SPEED))
+
+        if (
+            self.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+            and self._attr_hvac_mode == HVACMode.HEAT_COOL
+        ):
+            self._attr_target_temperature_high = self._master_value(AZD_COOL_TEMP_SET)
+            self._attr_target_temperature_low = self._master_value(AZD_HEAT_TEMP_SET)
+            self._attr_target_temperature = None
+        else:
+            self._attr_target_temperature_high = None
+            self._attr_target_temperature_low = None
+            self._attr_target_temperature = self._master_value(AZD_TEMP_SET)

--- a/homeassistant/components/airzone/climate.py
+++ b/homeassistant/components/airzone/climate.py
@@ -391,7 +391,7 @@ class AirzoneSystemClimate(AirzoneSystemEntity, ClimateEntity):
 
     def _zones_average(self, key: str) -> float | None:
         """Return the average of a numeric key across all zones."""
-        values = [
+        values: list[float] = [
             zone[key] for zone in self._system_zones() if zone.get(key) is not None
         ]
         if not values:

--- a/homeassistant/components/airzone/select.py
+++ b/homeassistant/components/airzone/select.py
@@ -11,21 +11,27 @@ from aioairzone.const import (
     API_MODE,
     API_Q_ADAPT,
     API_SLEEP,
+    API_SYSTEM_ID,
+    API_ZONE_ID,
     AZD_COLD_ANGLE,
     AZD_HEAT_ANGLE,
+    AZD_ID,
     AZD_MASTER,
     AZD_MODE,
     AZD_MODES,
     AZD_Q_ADAPT,
     AZD_SLEEP,
+    AZD_SYSTEM,
     AZD_SYSTEMS,
     AZD_ZONES,
 )
+from aioairzone.exceptions import AirzoneError
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import AirzoneConfigEntry, AirzoneUpdateCoordinator
@@ -92,6 +98,20 @@ SYSTEM_SELECT_TYPES: Final[tuple[AirzoneSelectDescription, ...]] = (
         options=list(Q_ADAPT_DICT),
         options_dict=Q_ADAPT_DICT,
         translation_key="q_adapt",
+    ),
+)
+
+
+# System-level selects that apply a zone parameter to every zone at once
+# (fan-out), reproducing a "global zone" control.
+SYSTEM_ZONES_SELECT_TYPES: Final[tuple[AirzoneSelectDescription, ...]] = (
+    AirzoneSelectDescription(
+        api_param=API_SLEEP,
+        entity_category=EntityCategory.CONFIG,
+        key=AZD_SLEEP,
+        options=list(SLEEP_DICT),
+        options_dict=SLEEP_DICT,
+        translation_key="all_zones_sleep",
     ),
 )
 
@@ -166,6 +186,16 @@ async def async_setup_entry(
                 for system_id in new_systems
                 for description in SYSTEM_SELECT_TYPES
                 if description.key in systems_data.get(system_id)
+            )
+            entities.extend(
+                AirzoneSystemZonesSelect(
+                    coordinator,
+                    description,
+                    entry,
+                    system_id,
+                )
+                for system_id in new_systems
+                for description in SYSTEM_ZONES_SELECT_TYPES
             )
             added_systems.update(new_systems)
 
@@ -258,6 +288,64 @@ class AirzoneSystemSelect(AirzoneSystemEntity, AirzoneBaseSelect):
         param = self.entity_description.api_param
         value = self.entity_description.options_dict[option]
         await self._async_update_sys_params({param: value})
+
+
+class AirzoneSystemZonesSelect(AirzoneSystemEntity, AirzoneBaseSelect):
+    """Define a global select that applies a zone parameter to all zones."""
+
+    def __init__(
+        self,
+        coordinator: AirzoneUpdateCoordinator,
+        description: AirzoneSelectDescription,
+        entry: ConfigEntry,
+        system_id: str,
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator, entry, coordinator.data[AZD_SYSTEMS][system_id])
+
+        self._attr_unique_id = (
+            f"{self._attr_unique_id}_{system_id}_all_zones_{description.key}"
+        )
+        self.entity_description = description
+        self._attr_options = list(description.options_dict)
+        self.values_dict = {v: k for k, v in description.options_dict.items()}
+
+        self._async_update_attrs()
+
+    def _system_zones(self) -> list[dict[str, Any]]:
+        """Return the data of every zone belonging to this system."""
+        zones = self.coordinator.data.get(AZD_ZONES, {})
+        return [
+            zone for zone in zones.values() if zone.get(AZD_SYSTEM) == self.system_id
+        ]
+
+    def get_airzone_value(self, key: str) -> Any:
+        """Return a representative value from the master zone of the system."""
+        zones = self._system_zones()
+        for zone in zones:
+            if zone.get(AZD_MASTER):
+                return zone.get(key)
+        return zones[0].get(key) if zones else None
+
+    async def async_select_option(self, option: str) -> None:
+        """Apply the selected option to every zone of the system (fan-out)."""
+        param = self.entity_description.api_param
+        value = self.entity_description.options_dict[option]
+        try:
+            for zone in self._system_zones():
+                await self.coordinator.airzone.set_hvac_parameters(
+                    {
+                        API_SYSTEM_ID: zone[AZD_SYSTEM],
+                        API_ZONE_ID: zone[AZD_ID],
+                        param: value,
+                    }
+                )
+        except AirzoneError as error:
+            raise HomeAssistantError(
+                f"Failed to set system {self.entity_id}: {error}"
+            ) from error
+
+        self.coordinator.async_set_updated_data(self.coordinator.airzone.data())
 
 
 class AirzoneZoneSelect(AirzoneZoneEntity, AirzoneBaseSelect):

--- a/homeassistant/components/airzone/strings.json
+++ b/homeassistant/components/airzone/strings.json
@@ -33,7 +33,21 @@
         "name": "Floor demand"
       }
     },
+    "climate": {
+      "all_zones": {
+        "name": "All zones"
+      }
+    },
     "select": {
+      "all_zones_sleep": {
+        "name": "Sleep (all zones)",
+        "state": {
+          "30m": "[%key:component::airzone::entity::select::sleep_times::state::30m%]",
+          "60m": "[%key:component::airzone::entity::select::sleep_times::state::60m%]",
+          "90m": "[%key:component::airzone::entity::select::sleep_times::state::90m%]",
+          "off": "[%key:common::state::off%]"
+        }
+      },
       "grille_angles": {
         "name": "Cold angle",
         "state": {

--- a/tests/components/airzone/test_climate.py
+++ b/tests/components/airzone/test_climate.py
@@ -78,12 +78,10 @@ async def test_airzone_create_climates(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_FAN_MODE) is None
     assert state.attributes.get(ATTR_FAN_MODES) is None
     assert state.attributes.get(ATTR_HVAC_ACTION) == HVACAction.OFF
+    # Slave zone: only off and the system's current mode are selectable.
     assert state.attributes.get(ATTR_HVAC_MODES) == [
         HVACMode.OFF,
-        HVACMode.FAN_ONLY,
-        HVACMode.COOL,
         HVACMode.HEAT,
-        HVACMode.DRY,
     ]
     assert state.attributes.get(ATTR_MAX_TEMP) == 30
     assert state.attributes.get(ATTR_MIN_TEMP) == 15
@@ -97,12 +95,10 @@ async def test_airzone_create_climates(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_FAN_MODE) is None
     assert state.attributes.get(ATTR_FAN_MODES) is None
     assert state.attributes.get(ATTR_HVAC_ACTION) == HVACAction.IDLE
+    # Slave zone: only off and the system's current mode are selectable.
     assert state.attributes.get(ATTR_HVAC_MODES) == [
         HVACMode.OFF,
-        HVACMode.FAN_ONLY,
-        HVACMode.COOL,
         HVACMode.HEAT,
-        HVACMode.DRY,
     ]
     assert state.attributes.get(ATTR_MAX_TEMP) == 30
     assert state.attributes.get(ATTR_MIN_TEMP) == 15
@@ -116,12 +112,10 @@ async def test_airzone_create_climates(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_FAN_MODE) is None
     assert state.attributes.get(ATTR_FAN_MODES) is None
     assert state.attributes.get(ATTR_HVAC_ACTION) == HVACAction.OFF
+    # Slave zone: only off and the system's current mode are selectable.
     assert state.attributes.get(ATTR_HVAC_MODES) == [
         HVACMode.OFF,
-        HVACMode.FAN_ONLY,
-        HVACMode.COOL,
         HVACMode.HEAT,
-        HVACMode.DRY,
     ]
     assert state.attributes.get(ATTR_MAX_TEMP) == 30
     assert state.attributes.get(ATTR_MIN_TEMP) == 15
@@ -139,12 +133,10 @@ async def test_airzone_create_climates(hass: HomeAssistant) -> None:
         FAN_HIGH,
     ]
     assert state.attributes.get(ATTR_HVAC_ACTION) == HVACAction.HEATING
+    # Slave zone: only off and the system's current mode are selectable.
     assert state.attributes.get(ATTR_HVAC_MODES) == [
         HVACMode.OFF,
-        HVACMode.FAN_ONLY,
-        HVACMode.COOL,
         HVACMode.HEAT,
-        HVACMode.DRY,
     ]
     assert state.attributes.get(ATTR_MAX_TEMP) == 30
     assert state.attributes.get(ATTR_MIN_TEMP) == 15
@@ -522,8 +514,10 @@ async def test_airzone_climate_set_hvac_slave_error(hass: HomeAssistant) -> None
             blocking=True,
         )
 
+    # The mode is not selectable on a slave zone, so the request is rejected
+    # before reaching the device and the zone stays off.
     state = hass.states.get("climate.dorm_2")
-    assert state.state == HVACMode.HEAT
+    assert state.state == HVACMode.OFF
 
 
 async def test_airzone_climate_set_fan_mode(hass: HomeAssistant) -> None:
@@ -655,3 +649,83 @@ async def test_airzone_climate_set_temp_range(hass: HomeAssistant) -> None:
     state = hass.states.get("climate.dkn_plus")
     assert state.attributes.get(ATTR_TARGET_TEMP_HIGH) == 25.0
     assert state.attributes.get(ATTR_TARGET_TEMP_LOW) == 20.0
+
+
+async def test_airzone_create_system_climate(hass: HomeAssistant) -> None:
+    """Test creation of the global (all zones) climate entity."""
+
+    await async_init_integration(hass)
+
+    state = hass.states.get("climate.system_1_all_zones")
+    assert state is not None
+    # At least one zone of the system is on, so the entity mirrors the
+    # master zone mode (heat).
+    assert state.state == HVACMode.HEAT
+    # Humidity (unitless) is the average across the system zones.
+    assert state.attributes.get(ATTR_CURRENT_HUMIDITY) == 37
+    # Temperature is averaged across the system zones.
+    assert isinstance(state.attributes.get(ATTR_CURRENT_TEMPERATURE), float)
+    # Limits come from the master zone.
+    assert state.attributes.get(ATTR_MAX_TEMP) == 30
+    assert state.attributes.get(ATTR_MIN_TEMP) == 15
+    assert state.attributes.get(ATTR_TARGET_TEMP_STEP) == API_TEMPERATURE_STEP
+
+
+async def test_airzone_system_climate_turn_off(hass: HomeAssistant) -> None:
+    """Test the global climate turns every zone of the system off."""
+
+    await async_init_integration(hass)
+
+    with patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.set_hvac_parameters",
+    ) as mock_set:
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "climate.system_1_all_zones"},
+            blocking=True,
+        )
+
+    # System 1 has five zones, each turned off individually.
+    assert mock_set.call_count == 5
+
+
+async def test_airzone_system_climate_set_temp(hass: HomeAssistant) -> None:
+    """Test the global climate sets a common target temperature."""
+
+    await async_init_integration(hass)
+
+    with patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.set_hvac_parameters",
+    ) as mock_set:
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_TEMPERATURE,
+            {
+                ATTR_ENTITY_ID: "climate.system_1_all_zones",
+                ATTR_TEMPERATURE: 22.0,
+            },
+            blocking=True,
+        )
+
+    assert mock_set.call_count == 5
+
+
+async def test_airzone_system_climate_error(hass: HomeAssistant) -> None:
+    """Test the global climate surfaces device errors."""
+
+    await async_init_integration(hass)
+
+    with (
+        patch(
+            "homeassistant.components.airzone.AirzoneLocalApi.set_hvac_parameters",
+            side_effect=AirzoneError,
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "climate.system_1_all_zones"},
+            blocking=True,
+        )

--- a/tests/components/airzone/test_select.py
+++ b/tests/components/airzone/test_select.py
@@ -13,6 +13,7 @@ from aioairzone.const import (
     API_SYSTEM_ID,
     API_ZONE_ID,
 )
+from aioairzone.exceptions import AirzoneError
 import pytest
 
 from homeassistant.components.select import ATTR_OPTIONS, DOMAIN as SELECT_DOMAIN
@@ -31,6 +32,10 @@ async def test_airzone_create_selects(hass: HomeAssistant) -> None:
     # Systems
     state = hass.states.get("select.system_1_q_adapt")
     assert state.state == "standard"
+
+    # Global (all zones) sleep, mirrored from the master zone.
+    state = hass.states.get("select.system_1_sleep_all_zones")
+    assert state.state == "off"
 
     # Zones
     state = hass.states.get("select.despacho_cold_angle")
@@ -315,3 +320,55 @@ async def test_airzone_select_grille_angle(hass: HomeAssistant) -> None:
 
     state = hass.states.get("select.dorm_1_heat_angle")
     assert state.state == "45deg"
+
+
+async def test_airzone_select_all_zones_sleep(hass: HomeAssistant) -> None:
+    """Test the global sleep select fans the value out to every zone."""
+
+    await async_init_integration(hass)
+
+    # Invalid option is rejected before reaching the device.
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: "select.system_1_sleep_all_zones",
+                ATTR_OPTION: "Invalid",
+            },
+            blocking=True,
+        )
+
+    with patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.set_hvac_parameters",
+    ) as mock_set:
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: "select.system_1_sleep_all_zones",
+                ATTR_OPTION: "30m",
+            },
+            blocking=True,
+        )
+
+    # System 1 has five zones, each one gets the parameter individually.
+    assert mock_set.call_count == 5
+
+    # A device error is surfaced as a HomeAssistantError.
+    with (
+        patch(
+            "homeassistant.components.airzone.AirzoneLocalApi.set_hvac_parameters",
+            side_effect=AirzoneError,
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: "select.system_1_sleep_all_zones",
+                ATTR_OPTION: "60m",
+            },
+            blocking=True,
+        )


### PR DESCRIPTION
## Proposed change

Add a **system-wide "all zones" control** to the existing **Airzone**
integration:

- A new **global climate entity** per system (`All zones`). It mirrors the
  master zone's HVAC mode (heat/cool), averages the zones' current
  temperature/humidity, and fans control out to every zone of the system
  (on/off, mode, fan speed, target temperature).
- A new **global select** `Sleep (all zones)` that applies the sleep timeout to
  every zone of the system at once.

It also refines slave-zone climate behaviour: a slave zone now only exposes
`off` and the system's current HVAC mode (previously it advertised the full
mode list but rejected any change with an error). No control is lost, since the
mode of a slave zone could never be changed directly anyway.

Tests and translations are included. No dependency change is required.

> [!NOTE]
> This is the second of a two-PR series splitting an Airzone feature branch.
> It also touches `select.py`/`strings.json`, so it should be merged **after**
> the entities PR (sensors / binary sensors / emission-type selects); a small
> rebase may be needed.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- Link to documentation pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
