### PR TITLE
Fix wirelesstag dry/wet binary sensors never updating

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2012,6 +2012,7 @@ CLAUDE.md @home-assistant/core
 /homeassistant/components/window/ @home-assistant/core
 /tests/components/window/ @home-assistant/core
 /homeassistant/components/wirelesstag/ @sergeymaysak
+/tests/components/wirelesstag/ @sergeymaysak
 /homeassistant/components/withings/ @joostlek
 /tests/components/withings/ @joostlek
 /homeassistant/components/wiz/ @sbidy @arturpragacz

--- a/homeassistant/components/wirelesstag/binary_sensor.py
+++ b/homeassistant/components/wirelesstag/binary_sensor.py
@@ -82,7 +82,10 @@ class WirelessTagBinarySensor(WirelessTagBaseSensor, BinarySensorEntity):
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
         tag_id = self.tag_id
-        event_type = self.device_class
+        # Use the raw event type, not the device class: the push side dispatches
+        # with the library's event type, and device_class is None for some
+        # events (e.g. dry/wet), which would never match the dispatched signal.
+        event_type = self._sensor_type
         mac = self.tag_manager_mac
         self.async_on_remove(
             async_dispatcher_connect(

--- a/tests/components/wirelesstag/__init__.py
+++ b/tests/components/wirelesstag/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Wireless Sensor Tags integration."""

--- a/tests/components/wirelesstag/test_binary_sensor.py
+++ b/tests/components/wirelesstag/test_binary_sensor.py
@@ -1,0 +1,88 @@
+"""Tests for the Wireless Sensor Tags binary sensor platform."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from homeassistant.components.wirelesstag.const import SIGNAL_BINARY_EVENT_UPDATE
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.setup import async_setup_component
+
+CONFIG = {
+    "wirelesstag": {"username": "foo@bar.com", "password": "secret"},
+    "binary_sensor": {
+        "platform": "wirelesstag",
+        "monitored_conditions": ["motion", "dry", "wet"],
+    },
+}
+
+UUID = "00000000-0000-0000-0000-000000000001"
+TAG_ID = 1
+MAC = "ABCDEF012345"
+
+EVENT_NAMES = {"motion": "Motion", "dry": "Too dry", "wet": "Too wet"}
+
+
+def _mock_tag() -> MagicMock:
+    """Return a mocked wirelesstagpy SensorTag with motion/dry/wet events off."""
+    tag = MagicMock()
+    tag.uuid = UUID
+    tag.tag_id = TAG_ID
+    tag.tag_manager_mac = MAC
+    tag.name = "Bedroom"
+    tag.is_alive = True
+    tag.supported_binary_events_types = list(EVENT_NAMES)
+    tag.battery_remaining = 0.85
+    tag.battery_volts = 3.0
+    tag.signal_strength = -60
+    tag.is_in_range = True
+    tag.power_consumption = 1.5
+
+    events = {}
+    for event_type, human_readable_name in EVENT_NAMES.items():
+        event = MagicMock()
+        event.human_readable_name = human_readable_name
+        event.is_state_on = False
+        events[event_type] = event
+    tag.event.__getitem__.side_effect = events.__getitem__
+    return tag
+
+
+@pytest.mark.parametrize("event_type", ["motion", "dry", "wet"])
+async def test_binary_sensor_receives_push_update(
+    hass: HomeAssistant,
+    event_type: str,
+) -> None:
+    """Test binary sensors update from push events for every event type.
+
+    The push side dispatches the signal keyed by the library event type, so the
+    entity must subscribe with the same key. Events whose device_class is None
+    (dry/wet) previously subscribed with "None" and never updated.
+    """
+    tag = _mock_tag()
+    with patch("homeassistant.components.wirelesstag.WirelessTags") as mock_api_class:
+        mock_api = mock_api_class.return_value
+        mock_api.load_tags.return_value = {tag.uuid: tag}
+
+        assert await async_setup_component(hass, "wirelesstag", CONFIG)
+        await hass.async_block_till_done()
+        assert await async_setup_component(hass, "binary_sensor", CONFIG)
+        await hass.async_block_till_done()
+
+    entity_id = er.async_get(hass).async_get_entity_id(
+        "binary_sensor", "wirelesstag", f"{UUID}_{event_type}"
+    )
+    assert entity_id is not None
+    assert hass.states.get(entity_id).state == STATE_OFF
+
+    # Simulate a push notification turning the event on.
+    tag.event[event_type].is_state_on = True
+    async_dispatcher_send(
+        hass, SIGNAL_BINARY_EVENT_UPDATE.format(TAG_ID, event_type, MAC), tag
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == STATE_ON


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`wirelesstag` binary sensors subscribe to push updates via a dispatcher signal
keyed by the event type (`SIGNAL_BINARY_EVENT_UPDATE.format(tag_id, <type>, mac)`).
`async_added_to_hass` built that key from `self.device_class`, but the push side
in `__init__.py` dispatches the signal keyed by the library's raw `event.type`.

For events whose `device_class` is `None` — `dry` ("Too dry") and `wet`
("Too wet") — the entity subscribed to a `...None...` signal that never matches
the dispatched `...dry...` / `...wet...` signal. Those binary sensors therefore
never received push updates and stayed stuck at their initial state. (Other
event types coincidentally still matched because `BinarySensorDeviceClass` is a
`StrEnum` whose value equals the raw event type.)

This keys the subscription off `self._sensor_type` (the raw event type), which
matches the dispatched signal for every event type, including `dry`/`wet`.

I found this while investigating #162304 (missing temperature/humidity sensors,
addressed separately in #172590). This is a distinct defect in the binary
sensor platform.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #162304
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
