### PR TITLE
Fix wirelesstag moisture arm switch crashing on toggle

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2012,6 +2012,7 @@ CLAUDE.md @home-assistant/core
 /homeassistant/components/window/ @home-assistant/core
 /tests/components/window/ @home-assistant/core
 /homeassistant/components/wirelesstag/ @sergeymaysak
+/tests/components/wirelesstag/ @sergeymaysak
 /homeassistant/components/withings/ @joostlek
 /tests/components/withings/ @joostlek
 /homeassistant/components/wiz/ @sbidy @arturpragacz

--- a/homeassistant/components/wirelesstag/__init__.py
+++ b/homeassistant/components/wirelesstag/__init__.py
@@ -77,16 +77,10 @@ class WirelessTagPlatform:
 
     def _set_monitoring(self, switch: WirelessTagSwitch, action: str) -> None:
         """Arm or disarm monitoring for the switch's sensor."""
-        key = switch.entity_description.key
-        func_name = f"{action}_{ARM_KEY_OVERRIDES.get(key, key)}"
-        if (func := getattr(self.api, func_name, None)) is None:
-            _LOGGER.error(
-                "Cannot %s %s monitoring: wirelesstagpy has no %s method",
-                action,
-                key,
-                func_name,
-            )
-            return
+        key = ARM_KEY_OVERRIDES.get(
+            switch.entity_description.key, switch.entity_description.key
+        )
+        func = getattr(self.api, f"{action}_{key}")
         func(switch.tag_id, switch.tag_manager_mac)
 
     def start_monitoring(self) -> None:

--- a/homeassistant/components/wirelesstag/__init__.py
+++ b/homeassistant/components/wirelesstag/__init__.py
@@ -28,6 +28,12 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# wirelesstagpy exposes the capacitive sensor under the "humidity" arm/disarm
+# endpoints (ArmCapSensor). Water tags report that same sensor as "moisture"
+# and have no dedicated arm_moisture/disarm_moisture method, so map it back to
+# the shared endpoint.
+ARM_KEY_OVERRIDES = {"moisture": "humidity"}
+
 NOTIFICATION_ID = "wirelesstag_notification"
 NOTIFICATION_TITLE = "Wireless Sensor Tag Setup"
 
@@ -63,15 +69,25 @@ class WirelessTagPlatform:
 
     def arm(self, switch: WirelessTagSwitch) -> None:
         """Arm entity sensor monitoring."""
-        func_name = f"arm_{switch.entity_description.key}"
-        if (arm_func := getattr(self.api, func_name)) is not None:
-            arm_func(switch.tag_id, switch.tag_manager_mac)
+        self._set_monitoring(switch, "arm")
 
     def disarm(self, switch: WirelessTagSwitch) -> None:
         """Disarm entity sensor monitoring."""
-        func_name = f"disarm_{switch.entity_description.key}"
-        if (disarm_func := getattr(self.api, func_name)) is not None:
-            disarm_func(switch.tag_id, switch.tag_manager_mac)
+        self._set_monitoring(switch, "disarm")
+
+    def _set_monitoring(self, switch: WirelessTagSwitch, action: str) -> None:
+        """Arm or disarm monitoring for the switch's sensor."""
+        key = switch.entity_description.key
+        func_name = f"{action}_{ARM_KEY_OVERRIDES.get(key, key)}"
+        if (func := getattr(self.api, func_name, None)) is None:
+            _LOGGER.error(
+                "Cannot %s %s monitoring: wirelesstagpy has no %s method",
+                action,
+                key,
+                func_name,
+            )
+            return
+        func(switch.tag_id, switch.tag_manager_mac)
 
     def start_monitoring(self) -> None:
         """Start monitoring push events."""

--- a/tests/components/wirelesstag/__init__.py
+++ b/tests/components/wirelesstag/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Wireless Sensor Tags integration."""

--- a/tests/components/wirelesstag/test_switch.py
+++ b/tests/components/wirelesstag/test_switch.py
@@ -1,0 +1,83 @@
+"""Tests for the Wireless Sensor Tags switch platform."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from homeassistant.const import SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+
+UUID = "00000000-0000-0000-0000-000000000003"
+TAG_ID = 3
+MAC = "ABCDEF012345"
+
+CONFIG = {
+    "wirelesstag": {"username": "foo@bar.com", "password": "secret"},
+    "switch": {"platform": "wirelesstag", "monitored_conditions": ["moisture"]},
+}
+
+
+def _mock_water_tag() -> MagicMock:
+    """Return a mocked water tag that exposes the moisture monitoring type."""
+    tag = MagicMock()
+    tag.uuid = UUID
+    tag.tag_id = TAG_ID
+    tag.tag_manager_mac = MAC
+    tag.name = "Basement"
+    tag.is_alive = True
+    tag.allowed_monitoring_types = ["temperature", "moisture"]
+    tag.is_moisture_sensor_armed = False
+    tag.battery_remaining = 0.9
+    tag.battery_volts = 3.0
+    tag.signal_strength = -55
+    tag.is_in_range = True
+    tag.power_consumption = 1.0
+    return tag
+
+
+@pytest.mark.parametrize(
+    ("service", "expected_method"),
+    [
+        (SERVICE_TURN_ON, "arm_humidity"),
+        (SERVICE_TURN_OFF, "disarm_humidity"),
+    ],
+)
+async def test_moisture_switch_uses_cap_sensor_endpoint(
+    hass: HomeAssistant,
+    service: str,
+    expected_method: str,
+) -> None:
+    """Test the moisture switch arms/disarms via the cap sensor endpoint.
+
+    Water tags expose the capacitive sensor as "moisture", but wirelesstagpy
+    only provides arm_humidity/disarm_humidity (ArmCapSensor). The switch must
+    map moisture to those endpoints instead of crashing on a missing
+    arm_moisture/disarm_moisture method.
+    """
+    tag = _mock_water_tag()
+    # autospec ensures the (non-existent) arm_moisture/disarm_moisture raise
+    # AttributeError, reproducing the crash without the fix.
+    with patch(
+        "homeassistant.components.wirelesstag.WirelessTags", autospec=True
+    ) as mock_class:
+        mock_api = mock_class.return_value
+        mock_api.load_tags.return_value = {tag.uuid: tag}
+
+        assert await async_setup_component(hass, "wirelesstag", CONFIG)
+        await hass.async_block_till_done()
+        assert await async_setup_component(hass, "switch", CONFIG)
+        await hass.async_block_till_done()
+
+        entity_id = er.async_get(hass).async_get_entity_id(
+            "switch", "wirelesstag", f"{UUID}_moisture"
+        )
+        assert entity_id is not None
+
+        await hass.services.async_call(
+            "switch", service, {"entity_id": entity_id}, blocking=True
+        )
+        await hass.async_block_till_done()
+
+    getattr(mock_api, expected_method).assert_called_once_with(TAG_ID, MAC)


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Water tags expose their capacitive sensor as the `moisture` monitoring type, so
`switch.py` offers an "Arm Moisture" switch for them (`moisture` is in the tag's
`allowed_monitoring_types`). However, `wirelesstagpy` has no
`arm_moisture`/`disarm_moisture` method — the capacitive sensor is armed through
`arm_humidity`/`disarm_humidity` (the `ArmCapSensor` endpoint), and the library
itself treats moisture as the humidity sensor (`is_moisture_sensor_armed` returns
`is_humidity_sensor_armed`).

Toggling the moisture switch called `getattr(self.api, "arm_moisture")` with no
default, raising `AttributeError` and failing the service call.

This maps the `moisture` monitoring type to the `humidity` (cap sensor) arm/disarm
endpoints, so the switch arms the correct sensor instead of crashing.

Found while reviewing the integration; no separate issue was filed.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

