### PR TITLE
Stop wirelesstag cloud push monitoring on shutdown

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2012,6 +2012,7 @@ CLAUDE.md @home-assistant/core
 /homeassistant/components/window/ @home-assistant/core
 /tests/components/window/ @home-assistant/core
 /homeassistant/components/wirelesstag/ @sergeymaysak
+/tests/components/wirelesstag/ @sergeymaysak
 /homeassistant/components/withings/ @joostlek
 /tests/components/withings/ @joostlek
 /homeassistant/components/wiz/ @sbidy @arturpragacz

--- a/homeassistant/components/wirelesstag/__init__.py
+++ b/homeassistant/components/wirelesstag/__init__.py
@@ -10,8 +10,8 @@ from wirelesstagpy.binaryevent import BinaryEvent
 from wirelesstagpy.exceptions import WirelessTagsException
 
 from homeassistant.components import persistent_notification
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.core import HomeAssistant
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers.typing import ConfigType
@@ -113,6 +113,10 @@ class WirelessTagPlatform:
 
         self.api.start_monitoring(push_callback)
 
+    def stop_monitoring(self) -> None:
+        """Stop monitoring push events."""
+        self.api.stop_monitoring()
+
 
 def setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Wireless Sensor Tag component."""
@@ -127,6 +131,12 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
         platform.load_tags()
         platform.start_monitoring()
         hass.data[WIRELESSTAG_DATA] = platform
+
+        def _stop_monitoring(event: Event) -> None:
+            """Stop cloud push monitoring on Home Assistant shutdown."""
+            platform.stop_monitoring()
+
+        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, _stop_monitoring)
     except (ConnectTimeout, HTTPError, WirelessTagsException) as ex:
         _LOGGER.error("Unable to connect to wirelesstag.net service: %s", str(ex))
         persistent_notification.create(

--- a/homeassistant/components/wirelesstag/__init__.py
+++ b/homeassistant/components/wirelesstag/__init__.py
@@ -132,7 +132,7 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
         platform.start_monitoring()
         hass.data[WIRELESSTAG_DATA] = platform
 
-        def _stop_monitoring(event: Event) -> None:
+        def _stop_monitoring(_event: Event) -> None:
             """Stop cloud push monitoring on Home Assistant shutdown."""
             platform.stop_monitoring()
 

--- a/homeassistant/components/wirelesstag/__init__.py
+++ b/homeassistant/components/wirelesstag/__init__.py
@@ -111,7 +111,12 @@ class WirelessTagPlatform:
                         str(ex),
                     )
 
+        def _stop_monitoring(_event: Event) -> None:
+            """Stop cloud push monitoring on Home Assistant shutdown."""
+            self.stop_monitoring()
+
         self.api.start_monitoring(push_callback)
+        self.hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, _stop_monitoring)
 
     def stop_monitoring(self) -> None:
         """Stop monitoring push events."""
@@ -131,12 +136,6 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
         platform.load_tags()
         platform.start_monitoring()
         hass.data[WIRELESSTAG_DATA] = platform
-
-        def _stop_monitoring(_event: Event) -> None:
-            """Stop cloud push monitoring on Home Assistant shutdown."""
-            platform.stop_monitoring()
-
-        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, _stop_monitoring)
     except (ConnectTimeout, HTTPError, WirelessTagsException) as ex:
         _LOGGER.error("Unable to connect to wirelesstag.net service: %s", str(ex))
         persistent_notification.create(

--- a/tests/components/wirelesstag/__init__.py
+++ b/tests/components/wirelesstag/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Wireless Sensor Tags integration."""

--- a/tests/components/wirelesstag/test_init.py
+++ b/tests/components/wirelesstag/test_init.py
@@ -22,10 +22,10 @@ async def test_stop_monitoring_on_homeassistant_stop(hass: HomeAssistant) -> Non
         assert await async_setup_component(hass, "wirelesstag", CONFIG)
         await hass.async_block_till_done()
 
-        assert mock_api.start_monitoring.called
-        assert not mock_api.stop_monitoring.called
+        mock_api.start_monitoring.assert_called_once()
+        mock_api.stop_monitoring.assert_not_called()
 
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
         await hass.async_block_till_done()
 
-    assert mock_api.stop_monitoring.called
+    mock_api.stop_monitoring.assert_called_once()

--- a/tests/components/wirelesstag/test_init.py
+++ b/tests/components/wirelesstag/test_init.py
@@ -1,0 +1,31 @@
+"""Tests for the Wireless Sensor Tags integration setup."""
+
+from unittest.mock import patch
+
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+CONFIG = {"wirelesstag": {"username": "foo@bar.com", "password": "secret"}}
+
+
+async def test_stop_monitoring_on_homeassistant_stop(hass: HomeAssistant) -> None:
+    """Test cloud push monitoring is stopped when Home Assistant stops.
+
+    The monitoring worker runs in a non-daemon thread, so it must be stopped on
+    shutdown; otherwise Home Assistant cannot exit cleanly.
+    """
+    with patch("homeassistant.components.wirelesstag.WirelessTags") as mock_api_class:
+        mock_api = mock_api_class.return_value
+        mock_api.load_tags.return_value = {}
+
+        assert await async_setup_component(hass, "wirelesstag", CONFIG)
+        await hass.async_block_till_done()
+
+        assert mock_api.start_monitoring.called
+        assert not mock_api.stop_monitoring.called
+
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+        await hass.async_block_till_done()
+
+    assert mock_api.stop_monitoring.called


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`WirelessTagPlatform.start_monitoring()` starts the cloud long-poll via
`wirelesstagpy`'s `start_monitoring()`, which runs a **non-daemon** worker
thread. That thread only exits once `stop_monitoring()` flips its active flag.
The integration never called `stop_monitoring()` and registered no shutdown
hook, so on shutdown the worker kept looping and the non-daemon thread
prevented Home Assistant from exiting cleanly.

Add a `stop_monitoring()` method and register an `EVENT_HOMEASSISTANT_STOP`
listener that calls it. The listener is a normal (sync) callback, so the
blocking `Thread.join` in the library runs in the executor during shutdown.

Found while reviewing the integration; no separate issue was filed.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
