### PR TITLE
Proximity: Fix/improve matching against trackers with `in_zones` attributes

### DIFF
--- a/homeassistant/components/proximity/coordinator.py
+++ b/homeassistant/components/proximity/coordinator.py
@@ -144,18 +144,33 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
             )
 
     def _device_in_zone(self, zone: State, device: State) -> bool:
-        """Return whether the tracked entity is currently in the proximity zone.
+        """Return whether the tracked entity is currently in the proximity zone."""
 
-        Trackers report zone membership in the ``in_zones`` attribute, which
-        holds zone entity IDs. Some trackers (e.g. Bluetooth) don't populate it
-        or report it as an empty list, so fall back to comparing the device
-        state against the zone's friendly name, which is what the device state
-        is set to for non-home zones.
-        """
+        # Modern entity-based trackers and person entities always report zone
+        # membership authoritatively in the ``in_zones`` attribute (a list of zone
+        # entity IDs), so a present, empty list genuinely means "in no zone".
+
+        # The state-based fallback below is a temporary shim for two deprecated
+        # producers whose ``in_zones`` cannot be trusted as authoritative:
+
+        # - Legacy (non-entity) device trackers omit ``in_zones`` entirely
+        # (deprecated, removed in HA Core 2027.5).
+        # - Trackers using the deprecated ``location_name`` report an empty
+        # ``in_zones`` while their state still names their location
+        # (deprecated, removed in HA Core 2027.7).
+
+        # For both, an empty or absent ``in_zones`` does not imply "in no zone", so we
+        # fall back to matching the device state against the zone's friendly name
+        # (what a tracker's state is set to for non-home zones), plus an explicit
+        # home-zone check. Once both deprecations are gone, ``in_zones`` is
+        # authoritative for every tracker and this method should reduce to the
+        # membership check alone; the fallback must be removed, as second-guessing an
+        # empty list would then be incorrect.
         if in_zones := device.attributes.get(ATTR_IN_ZONES):
             return zone.entity_id in in_zones
 
-        # This can be removed when legacy device trackers are removed.
+        # Remove once legacy device trackers (2027.5) and location_name (2027.7)
+        # are gone, see detailed comment above
         zone_friendly_name = zone.attributes.get(ATTR_FRIENDLY_NAME)
         return (
             zone_friendly_name is not None

--- a/homeassistant/components/proximity/coordinator.py
+++ b/homeassistant/components/proximity/coordinator.py
@@ -6,14 +6,16 @@ import logging
 from typing import cast
 
 from homeassistant.components.device_tracker import ATTR_IN_ZONES
-from homeassistant.components.zone import DOMAIN as ZONE_DOMAIN
+from homeassistant.components.zone import DOMAIN as ZONE_DOMAIN, ENTITY_ID_HOME
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    ATTR_FRIENDLY_NAME,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
     ATTR_NAME,
     CONF_UNIT_OF_MEASUREMENT,
     CONF_ZONE,
+    STATE_HOME,
 )
 from homeassistant.core import (
     Event,
@@ -141,7 +143,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
                 },
             )
 
-    def _device_in_zone(self, device: State) -> bool:
+    def _device_in_zone(self, zone: State, device: State) -> bool:
         """Return whether the tracked entity is currently in the proximity zone.
 
         Trackers report zone membership in the ``in_zones`` attribute, which
@@ -149,17 +151,14 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         so fall back to comparing the device state against the zone's friendly
         name, which is what the device state is set to for non-home zones.
         """
-        zone_id = self.proximity_zone_id
-
         if (in_zones := device.attributes.get(ATTR_IN_ZONES)) is not None:
-            return zone_id in in_zones
+            return zone.entity_id in in_zones
 
-        zone_state = self.hass.states.get(zone_id)
-        zone_friendly_name = zone_state.name if zone_state else None
+        zone_friendly_name = zone.attributes.get(ATTR_FRIENDLY_NAME)
         return (
             zone_friendly_name is not None
             and device.state.lower() == zone_friendly_name.lower()
-        )
+        ) or (device.state == STATE_HOME and zone.entity_id == ENTITY_ID_HOME)
 
     def _calc_distance_to_zone(
         self,
@@ -168,7 +167,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         latitude: float | None,
         longitude: float | None,
     ) -> int | None:
-        if self._device_in_zone(device):
+        if self._device_in_zone(zone, device):
             _LOGGER.debug(
                 "%s: %s in zone -> distance=0",
                 self.name,
@@ -210,7 +209,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         new_latitude: float | None,
         new_longitude: float | None,
     ) -> str | None:
-        if self._device_in_zone(device):
+        if self._device_in_zone(zone, device):
             _LOGGER.debug(
                 "%s: %s in zone -> direction_of_travel=arrived",
                 self.name,

--- a/homeassistant/components/proximity/coordinator.py
+++ b/homeassistant/components/proximity/coordinator.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 import logging
 from typing import cast
 
+from homeassistant.components.device_tracker import ATTR_IN_ZONES
 from homeassistant.components.zone import DOMAIN as ZONE_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -80,7 +81,6 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         self.tracked_entities: list[str] = config_entry.data[CONF_TRACKED_ENTITIES]
         self.tolerance: int = config_entry.data[CONF_TOLERANCE]
         self.proximity_zone_id: str = config_entry.data[CONF_ZONE]
-        self.proximity_zone_name: str = self.proximity_zone_id.split(".")[-1]
         self.unit_of_measurement: str = config_entry.data.get(
             CONF_UNIT_OF_MEASUREMENT, hass.config.units.length_unit
         )
@@ -141,6 +141,26 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
                 },
             )
 
+    def _device_in_zone(self, device: State) -> bool:
+        """Return whether the tracked entity is currently in the proximity zone.
+
+        Trackers report zone membership in the ``in_zones`` attribute, which
+        holds zone entity IDs. Some trackers (e.g. Bluetooth) don't populate it,
+        so fall back to comparing the device state against the zone's friendly
+        name, which is what the device state is set to for non-home zones.
+        """
+        zone_id = self.proximity_zone_id
+
+        if (in_zones := device.attributes.get(ATTR_IN_ZONES)) is not None:
+            return zone_id in in_zones
+
+        zone_state = self.hass.states.get(zone_id)
+        zone_friendly_name = zone_state.name if zone_state else None
+        return (
+            zone_friendly_name is not None
+            and device.state.lower() == zone_friendly_name.lower()
+        )
+
     def _calc_distance_to_zone(
         self,
         zone: State,
@@ -148,7 +168,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         latitude: float | None,
         longitude: float | None,
     ) -> int | None:
-        if device.state.lower() == self.proximity_zone_name.lower():
+        if self._device_in_zone(device):
             _LOGGER.debug(
                 "%s: %s in zone -> distance=0",
                 self.name,
@@ -190,7 +210,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         new_latitude: float | None,
         new_longitude: float | None,
     ) -> str | None:
-        if device.state.lower() == self.proximity_zone_name.lower():
+        if self._device_in_zone(device):
             _LOGGER.debug(
                 "%s: %s in zone -> direction_of_travel=arrived",
                 self.name,

--- a/homeassistant/components/proximity/coordinator.py
+++ b/homeassistant/components/proximity/coordinator.py
@@ -154,6 +154,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         if (in_zones := device.attributes.get(ATTR_IN_ZONES)) is not None:
             return zone.entity_id in in_zones
 
+        # This can be removed when legacy device trackers are removed.
         zone_friendly_name = zone.attributes.get(ATTR_FRIENDLY_NAME)
         return (
             zone_friendly_name is not None

--- a/homeassistant/components/proximity/coordinator.py
+++ b/homeassistant/components/proximity/coordinator.py
@@ -151,7 +151,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         so fall back to comparing the device state against the zone's friendly
         name, which is what the device state is set to for non-home zones.
         """
-        if (in_zones := device.attributes.get(ATTR_IN_ZONES)) is not None:
+        if in_zones := device.attributes.get(ATTR_IN_ZONES):
             return zone.entity_id in in_zones
 
         # This can be removed when legacy device trackers are removed.

--- a/homeassistant/components/proximity/coordinator.py
+++ b/homeassistant/components/proximity/coordinator.py
@@ -147,9 +147,10 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         """Return whether the tracked entity is currently in the proximity zone.
 
         Trackers report zone membership in the ``in_zones`` attribute, which
-        holds zone entity IDs. Some trackers (e.g. Bluetooth) don't populate it,
-        so fall back to comparing the device state against the zone's friendly
-        name, which is what the device state is set to for non-home zones.
+        holds zone entity IDs. Some trackers (e.g. Bluetooth) don't populate it
+        or report it as an empty list, so fall back to comparing the device
+        state against the zone's friendly name, which is what the device state
+        is set to for non-home zones.
         """
         if in_zones := device.attributes.get(ATTR_IN_ZONES):
             return zone.entity_id in in_zones

--- a/tests/components/proximity/test_init.py
+++ b/tests/components/proximity/test_init.py
@@ -335,6 +335,7 @@ async def test_device_trackers_in_zone(hass: HomeAssistant) -> None:
     "tracker_attributes",
     [
         pytest.param({"in_zones": ["zone.work_office"]}, id="in_zones_attribute"),
+        pytest.param({"in_zones": []}, id="empty_in_zones_fallback"),
         pytest.param({}, id="friendly_name_fallback"),
     ],
 )

--- a/tests/components/proximity/test_init.py
+++ b/tests/components/proximity/test_init.py
@@ -1,5 +1,7 @@
 """The tests for the Proximity component."""
 
+from typing import Any
+
 import pytest
 
 from homeassistant.components.proximity.const import (
@@ -338,7 +340,7 @@ async def test_device_trackers_in_zone(hass: HomeAssistant) -> None:
 )
 async def test_device_tracker_in_non_home_zone(
     hass: HomeAssistant,
-    tracker_attributes: dict[str, list[str]],
+    tracker_attributes: dict[str, Any],
 ) -> None:
     """Test that a tracker in a non-home zone reports arrived.
 
@@ -350,7 +352,12 @@ async def test_device_tracker_in_non_home_zone(
     hass.states.async_set(
         "zone.work_office",
         "zoning",
-        {"name": "Work Office", "latitude": 2.3, "longitude": 1.3, "radius": 10},
+        {
+            "friendly_name": "Work Office",
+            "latitude": 2.3,
+            "longitude": 1.3,
+            "radius": 10,
+        },
     )
 
     await async_setup_single_entry(

--- a/tests/components/proximity/test_init.py
+++ b/tests/components/proximity/test_init.py
@@ -387,6 +387,95 @@ async def test_device_tracker_in_non_home_zone(
     assert state.state == "arrived"
 
 
+async def test_overlapping_zones_in_zones_reports_arrived(
+    hass: HomeAssistant,
+) -> None:
+    """Test overlapping proximity zones both report arrived via in_zones.
+
+    Regression test for trackers that report membership in multiple overlapping
+    zones via the in_zones attribute while their state only reflects one zone.
+    """
+    hass.states.async_set(
+        "zone.backyard",
+        "zoning",
+        {
+            "friendly_name": "Backyard",
+            "latitude": 2.1,
+            "longitude": 1.1,
+            "radius": 10,
+        },
+    )
+
+    home_config = MockConfigEntry(
+        domain=DOMAIN,
+        title="Home",
+        data={
+            CONF_ZONE: "zone.home",
+            CONF_TRACKED_ENTITIES: ["device_tracker.test1"],
+            CONF_IGNORED_ZONES: [],
+            CONF_TOLERANCE: 1,
+        },
+    )
+    backyard_config = MockConfigEntry(
+        domain=DOMAIN,
+        title="Backyard",
+        data={
+            CONF_ZONE: "zone.backyard",
+            CONF_TRACKED_ENTITIES: ["device_tracker.test1"],
+            CONF_IGNORED_ZONES: [],
+            CONF_TOLERANCE: 1,
+        },
+    )
+    home_config.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(home_config.entry_id)
+    backyard_config.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(backyard_config.entry_id)
+    await hass.async_block_till_done()
+
+    hass.states.async_set(
+        "device_tracker.test1",
+        "home",
+        {
+            "friendly_name": "test1",
+            "latitude": 20.1,
+            "longitude": 10.1,
+            "in_zones": ["zone.home", "zone.backyard"],
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.home_test1_direction_of_travel")
+    assert state.state == "arrived"
+    state = hass.states.get("sensor.backyard_test1_direction_of_travel")
+    assert state.state == "arrived"
+
+
+async def test_legacy_device_tracker_home_with_empty_in_zones(
+    hass: HomeAssistant,
+) -> None:
+    """Test legacy tracker with empty in_zones and home state reports arrived.
+
+    Regression test for legacy device trackers that do not populate in_zones
+    but still report their state as home when inside the home zone.
+    """
+    await async_setup_single_entry(hass, "zone.home", ["device_tracker.test1"], [], 1)
+
+    hass.states.async_set(
+        "device_tracker.test1",
+        "home",
+        {
+            "friendly_name": "test1",
+            "latitude": 20.1,
+            "longitude": 10.1,
+            "in_zones": [],
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.home_test1_direction_of_travel")
+    assert state.state == "arrived"
+
+
 async def test_device_tracker_test1_awayfurther_than_test2_first_test1(
     hass: HomeAssistant, config_zones
 ) -> None:

--- a/tests/components/proximity/test_init.py
+++ b/tests/components/proximity/test_init.py
@@ -329,6 +329,56 @@ async def test_device_trackers_in_zone(hass: HomeAssistant) -> None:
         assert state.state == "arrived"
 
 
+@pytest.mark.parametrize(
+    "tracker_attributes",
+    [
+        pytest.param({"in_zones": ["zone.work_office"]}, id="in_zones_attribute"),
+        pytest.param({}, id="friendly_name_fallback"),
+    ],
+)
+async def test_device_tracker_in_non_home_zone(
+    hass: HomeAssistant,
+    tracker_attributes: dict[str, list[str]],
+) -> None:
+    """Test that a tracker in a non-home zone reports arrived.
+
+    Regression test for zones whose friendly name (which the tracker reports as
+    its state) differs from the zone entity id slug, e.g. names with spaces or
+    mixed case. The tracker is placed far from the zone centre so that only the
+    zone-membership check, not the distance calculation, can yield "arrived".
+    """
+    hass.states.async_set(
+        "zone.work_office",
+        "zoning",
+        {"name": "Work Office", "latitude": 2.3, "longitude": 1.3, "radius": 10},
+    )
+
+    await async_setup_single_entry(
+        hass, "zone.work_office", ["device_tracker.test1"], [], 1
+    )
+
+    hass.states.async_set(
+        "device_tracker.test1",
+        "Work Office",
+        {
+            "friendly_name": "test1",
+            "latitude": 20.1,
+            "longitude": 10.1,
+            **tracker_attributes,
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.home_nearest_device")
+    assert state.state == "test1"
+
+    entity_base_name = "sensor.home_test1"
+    state = hass.states.get(f"{entity_base_name}_distance")
+    assert state.state == "0"
+    state = hass.states.get(f"{entity_base_name}_direction_of_travel")
+    assert state.state == "arrived"
+
+
 async def test_device_tracker_test1_awayfurther_than_test2_first_test1(
     hass: HomeAssistant, config_zones
 ) -> None:


### PR DESCRIPTION
This causes Proximity to match against the zones listed in `in_zones` instead of attempting a string match on the tracker state. For trackers that do not report an `in_zones` state attribute, we fall back to the old behavior.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Proximity: Multiple `sensor.*_direction_of_travel` entities may now report "arrived" when previously only one would report this state.

(The new behavior is more expected/obvious than the previous behavior, so it's arguable whether this change constitutes significant breaking behavior.)

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This fixes a couple long-standing issues with the Proximity integration:
1. Zones where the name doesn't match the ID won't ever have their corresponding `direction_of_travel` entities marked as "arrived". (e.g. if a zone is named "Work Office" it will never show the "arrived" state, but a zone named "work_office" could.)
2. If a tracker is present in multiple zones, only one of them (and which specific one is somewhat arbitrary) will be marked as "arrived".

Issue (1) is particularly annoying since this behavior is completely opaque to the user; zone names with spaces will silently never work.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31347, #138347, #102733
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
