### PR TITLE
Fix/zha remove device tracker battery level

### DIFF
--- a/homeassistant/components/zha/device_tracker.py
+++ b/homeassistant/components/zha/device_tracker.py
@@ -51,14 +51,6 @@ class ZHADeviceScannerEntity(ScannerEntity, ZHAEntity):
         """Return true if the device is connected to the network."""
         return self.entity_data.entity.is_connected
 
-    @property
-    def battery_level(self) -> int | None:
-        """Return the battery level of the device.
-
-        Percentage from 0-100.
-        """
-        return self.entity_data.entity.battery_level
-
     @property  # type: ignore[misc]
     def device_info(self) -> DeviceInfo:
         """Return device info."""


### PR DESCRIPTION
## Proposed change

Remove the `battery_level` implementation from the ZHA device tracker entity and update the related device tracker test to stop checking `battery_level`.

This keeps the ZHA device tracker aligned with the current device tracker behavior.

## Type of change

* [ ] Dependency upgrade
* [x] Bugfix (non-breaking change which fixes an issue)
* [ ] New integration (thank you!)
* [ ] New feature (which adds functionality to an existing integration)
* [ ] Deprecation (breaking change to happen in the future)
* [ ] Breaking change (fix/feature causing existing functionality to break)
* [ ] Code quality improvements to existing code or addition of tests

## Additional information

* This PR fixes or closes issue: fixes #
* This PR is related to issue:
* Link to documentation pull request:
* Link to developer documentation pull request:
* Link to frontend pull request:

## Checklist

* [x] I understand the code I am submitting and can explain how it works.
* [x] The code change is tested and works locally.
* [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
* [x] There is no commented out code in this PR.
* [ ] I have followed the [development checklist][dev-checklist]
* [ ] I have followed the [perfect PR recommendations][perfect-pr]
* [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
* [x] Tests have been added to verify that the new code works.
* [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.
