### PR TITLE
Show error about missing api permissions while browsing Immich media

### DIFF
--- a/homeassistant/components/immich/media_source.py
+++ b/homeassistant/components/immich/media_source.py
@@ -4,7 +4,7 @@ from logging import getLogger
 
 from aiohttp.web import HTTPNotFound, Request, Response, StreamResponse
 from aioimmich.assets.models import ImmichAsset
-from aioimmich.exceptions import ImmichError
+from aioimmich.exceptions import ImmichError, ImmichForbiddenError
 
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.media_player import BrowseError, MediaClass
@@ -79,7 +79,7 @@ class ImmichMediaSource(MediaSource):
             ],
         )
 
-    async def _async_build_immich(
+    async def _async_build_immich(  # noqa: C901
         self, item: MediaSourceItem, entries: list[ConfigEntry]
     ) -> list[BrowseMediaSource]:
         """Handle browsing different immich instances."""
@@ -137,6 +137,12 @@ class ImmichMediaSource(MediaSource):
                 LOGGER.debug("Render all albums for %s", entry.title)
                 try:
                     albums = await immich_api.albums.async_get_all_albums()
+                except ImmichForbiddenError as err:
+                    raise BrowseError(
+                        translation_domain=DOMAIN,
+                        translation_key="missing_api_permission",
+                        translation_placeholders={"msg": str(err)},
+                    ) from err
                 except ImmichError:
                     return []
 
@@ -158,6 +164,12 @@ class ImmichMediaSource(MediaSource):
                 LOGGER.debug("Render all tags for %s", entry.title)
                 try:
                     tags = await immich_api.tags.async_get_all_tags()
+                except ImmichForbiddenError as err:
+                    raise BrowseError(
+                        translation_domain=DOMAIN,
+                        translation_key="missing_api_permission",
+                        translation_placeholders={"msg": str(err)},
+                    ) from err
                 except ImmichError:
                     return []
 
@@ -178,6 +190,12 @@ class ImmichMediaSource(MediaSource):
                 LOGGER.debug("Render all people for %s", entry.title)
                 try:
                     people = await immich_api.people.async_get_all_people()
+                except ImmichForbiddenError as err:
+                    raise BrowseError(
+                        translation_domain=DOMAIN,
+                        translation_key="missing_api_permission",
+                        translation_placeholders={"msg": str(err)},
+                    ) from err
                 except ImmichError:
                     return []
 
@@ -211,6 +229,12 @@ class ImmichMediaSource(MediaSource):
                     identifier.collection_id
                 )
                 assets = album_info.assets
+            except ImmichForbiddenError as err:
+                raise BrowseError(
+                    translation_domain=DOMAIN,
+                    translation_key="missing_api_permission",
+                    translation_placeholders={"msg": str(err)},
+                ) from err
             except ImmichError:
                 return []
 
@@ -223,6 +247,12 @@ class ImmichMediaSource(MediaSource):
                 assets = await immich_api.search.async_get_all_by_tag_ids(
                     [identifier.collection_id]
                 )
+            except ImmichForbiddenError as err:
+                raise BrowseError(
+                    translation_domain=DOMAIN,
+                    translation_key="missing_api_permission",
+                    translation_placeholders={"msg": str(err)},
+                ) from err
             except ImmichError:
                 return []
 
@@ -235,12 +265,24 @@ class ImmichMediaSource(MediaSource):
                 assets = await immich_api.search.async_get_all_by_person_ids(
                     [identifier.collection_id]
                 )
+            except ImmichForbiddenError as err:
+                raise BrowseError(
+                    translation_domain=DOMAIN,
+                    translation_key="missing_api_permission",
+                    translation_placeholders={"msg": str(err)},
+                ) from err
             except ImmichError:
                 return []
         elif identifier.collection == "favorites":
             LOGGER.debug("Render all assets for favorites collection")
             try:
                 assets = await immich_api.search.async_get_all_favorites()
+            except ImmichForbiddenError as err:
+                raise BrowseError(
+                    translation_domain=DOMAIN,
+                    translation_key="missing_api_permission",
+                    translation_placeholders={"msg": str(err)},
+                ) from err
             except ImmichError:
                 return []
 

--- a/homeassistant/components/immich/strings.json
+++ b/homeassistant/components/immich/strings.json
@@ -102,6 +102,9 @@
     "identifier_unresolvable": {
       "message": "Could not parse identifier: {identifier}"
     },
+    "missing_api_permission": {
+      "message": "Missing API permission ({msg})."
+    },
     "not_configured": {
       "message": "Immich is not configured."
     },

--- a/tests/components/immich/test_media_source.py
+++ b/tests/components/immich/test_media_source.py
@@ -5,7 +5,7 @@ import tempfile
 from unittest.mock import Mock, patch
 
 from aiohttp import web
-from aioimmich.exceptions import ImmichError
+from aioimmich.exceptions import ImmichError, ImmichForbiddenError
 import pytest
 
 from homeassistant.components.immich.const import DOMAIN
@@ -252,6 +252,12 @@ async def test_browse_media_collections_error(
     with patch("homeassistant.components.immich.PLATFORMS", []):
         await setup_integration(hass, mock_config_entry)
 
+    item = MediaSourceItem(
+        hass, DOMAIN, f"{mock_config_entry.unique_id}|{collection}", None
+    )
+    source = await async_get_media_source(hass)
+
+    # test generic ImmichError
     getattr(
         getattr(mock_immich, mocked_get_fn[0]), mocked_get_fn[1]
     ).side_effect = ImmichError(
@@ -263,16 +269,25 @@ async def test_browse_media_collections_error(
         }
     )
 
-    source = await async_get_media_source(hass)
-
-    item = MediaSourceItem(
-        hass, DOMAIN, f"{mock_config_entry.unique_id}|{collection}", None
-    )
     result = await source.async_browse_media(item)
 
     assert result
     assert result.identifier is None
     assert len(result.children) == 0
+
+    # test specific ImmichForbiddenError
+    getattr(
+        getattr(mock_immich, mocked_get_fn[0]), mocked_get_fn[1]
+    ).side_effect = ImmichForbiddenError(
+        {
+            "message": "Missing required permission: asset.read",
+            "error": "Forbidden",
+            "statusCode": 403,
+            "correlationId": "e0hlizyl",
+        }
+    )
+    with pytest.raises(BrowseError, match="Missing API permission"):
+        result = await source.async_browse_media(item)
 
 
 @pytest.mark.parametrize(
@@ -297,8 +312,15 @@ async def test_browse_media_collection_items_error(
     with patch("homeassistant.components.immich.PLATFORMS", []):
         await setup_integration(hass, mock_config_entry)
 
+    item = MediaSourceItem(
+        hass,
+        DOMAIN,
+        f"{mock_config_entry.unique_id}|{collection}|721e1a4b-aa12-441e-8d3b-5ac7ab283bb6",
+        None,
+    )
     source = await async_get_media_source(hass)
 
+    # test generic ImmichError
     getattr(
         getattr(mock_immich, mocked_get_fn[0]), mocked_get_fn[1]
     ).side_effect = ImmichError(
@@ -309,17 +331,26 @@ async def test_browse_media_collection_items_error(
             "correlationId": "e0hlizyl",
         }
     )
-    item = MediaSourceItem(
-        hass,
-        DOMAIN,
-        f"{mock_config_entry.unique_id}|{collection}|721e1a4b-aa12-441e-8d3b-5ac7ab283bb6",
-        None,
-    )
+
     result = await source.async_browse_media(item)
 
     assert result
     assert result.identifier is None
     assert len(result.children) == 0
+
+    # test specific ImmichForbiddenError
+    getattr(
+        getattr(mock_immich, mocked_get_fn[0]), mocked_get_fn[1]
+    ).side_effect = ImmichForbiddenError(
+        {
+            "message": "Missing required permission: asset.read",
+            "error": "Forbidden",
+            "statusCode": 403,
+            "correlationId": "e0hlizyl",
+        }
+    )
+    with pytest.raises(BrowseError, match="Missing API permission"):
+        result = await source.async_browse_media(item)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/immich/test_media_source.py
+++ b/tests/components/immich/test_media_source.py
@@ -287,7 +287,7 @@ async def test_browse_media_collections_error(
         }
     )
     with pytest.raises(BrowseError, match="Missing API permission"):
-        result = await source.async_browse_media(item)
+        await source.async_browse_media(item)
 
 
 @pytest.mark.parametrize(
@@ -350,7 +350,7 @@ async def test_browse_media_collection_items_error(
         }
     )
     with pytest.raises(BrowseError, match="Missing API permission"):
-        result = await source.async_browse_media(item)
+        await source.async_browse_media(item)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With this we raise a proper `BrowseError` which informs the user that there are required api permissions missing. Would be good to have this in the next release, as there were some API permission changes _lately_ in the immich server which caused empty "person", "tags" and "favorite" folders in the media browser.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45654
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
