### PR TITLE
Improve Avea Bluetooth discovery flow

### DIFF
--- a/homeassistant/components/avea/config_flow.py
+++ b/homeassistant/components/avea/config_flow.py
@@ -8,6 +8,7 @@ import avea
 from bleak.exc import BleakError
 import voluptuous as vol
 
+from homeassistant.components import bluetooth
 from homeassistant.components.bluetooth import (
     BluetoothServiceInfoBleak,
     async_discovered_service_info,
@@ -64,6 +65,15 @@ def _validate_device(discovery_info: BluetoothServiceInfoBleak) -> str:
 def _is_avea_discovery(discovery_info: BluetoothServiceInfoBleak) -> bool:
     """Return if the bluetooth discovery matches an Avea bulb."""
     return AVEA_SERVICE_UUID in discovery_info.service_uuids
+
+
+def _discovery_label(discovery_info: BluetoothServiceInfoBleak) -> str:
+    """Return a label for a discovered Avea bulb."""
+    if (
+        name := _normalize_name(discovery_info.name)
+    ) and name != discovery_info.address:
+        return f"{name} ({discovery_info.address})"
+    return discovery_info.address
 
 
 class AveaConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -150,6 +160,7 @@ class AveaConfigFlow(ConfigFlow, domain=DOMAIN):
         if discovery := self._discovery_info:
             self._discovered_devices[discovery.address] = discovery
         else:
+            await bluetooth.async_request_active_scan(self.hass)
             current_addresses = self._async_current_ids(include_ignore=False)
             for discovery in async_discovered_service_info(self.hass):
                 if (
@@ -165,11 +176,10 @@ class AveaConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if self._discovery_info:
             disc = self._discovery_info
-            label = f"{disc.name or disc.address} ({disc.address})"
             data_schema = vol.Schema(
                 {
                     vol.Required(CONF_ADDRESS, default=disc.address): vol.In(
-                        {disc.address: label}
+                        {disc.address: _discovery_label(disc)}
                     )
                 }
             )
@@ -178,10 +188,7 @@ class AveaConfigFlow(ConfigFlow, domain=DOMAIN):
                 {
                     vol.Required(CONF_ADDRESS): vol.In(
                         {
-                            service_info.address: (
-                                f"{service_info.name or service_info.address}"
-                                f" ({service_info.address})"
-                            )
+                            service_info.address: _discovery_label(service_info)
                             for service_info in self._discovered_devices.values()
                         }
                     ),

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -14,8 +14,8 @@ if TYPE_CHECKING:
 
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2026
-MINOR_VERSION: Final = 6
-PATCH_VERSION: Final = "0b0"
+MINOR_VERSION: Final = 7
+PATCH_VERSION: Final = "0.dev0"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 14, 2)

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2026
 MINOR_VERSION: Final = 6
-PATCH_VERSION: Final = "0.dev0"
+PATCH_VERSION: Final = "0b0"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 14, 2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "homeassistant"
-version = "2026.6.0.dev0"
+version = "2026.6.0b0"
 license = "Apache-2.0"
 license-files = ["LICENSE*", "homeassistant/backports/LICENSE*"]
 description = "Open-source home automation platform running on Python 3."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "homeassistant"
-version = "2026.6.0b0"
+version = "2026.7.0.dev0"
 license = "Apache-2.0"
 license-files = ["LICENSE*", "homeassistant/backports/LICENSE*"]
 description = "Open-source home automation platform running on Python 3."

--- a/tests/components/avea/test_config_flow.py
+++ b/tests/components/avea/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test the Avea config flow."""
 
+from copy import copy
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -35,13 +36,22 @@ async def test_user_step_success(hass: HomeAssistant) -> None:
     inject_bluetooth_service_info(hass, AVEA_DISCOVERY_INFO)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
+    with patch(
+        "homeassistant.components.avea.config_flow.bluetooth.async_request_active_scan"
+    ) as mock_request_active_scan:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {}
+    assert result["data_schema"].schema[CONF_ADDRESS].container == {
+        AVEA_DISCOVERY_INFO.address: (
+            f"{AVEA_DISCOVERY_INFO.name} ({AVEA_DISCOVERY_INFO.address})"
+        )
+    }
+    mock_request_active_scan.assert_awaited_once_with(hass)
 
     with (
         patch(
@@ -67,12 +77,41 @@ async def test_user_step_no_devices_found(hass: HomeAssistant) -> None:
     inject_bluetooth_service_info(hass, NOT_AVEA_DISCOVERY_INFO)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
+    with patch(
+        "homeassistant.components.avea.config_flow.bluetooth.async_request_active_scan"
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "no_devices_found"
+
+
+async def test_user_step_unnamed_device_label(hass: HomeAssistant) -> None:
+    """Test unnamed discovered devices are shown without duplicating the address."""
+    discovery_info = copy(AVEA_DISCOVERY_INFO)
+    discovery_info.name = discovery_info.address
+
+    with (
+        patch(
+            "homeassistant.components.avea.config_flow.async_discovered_service_info",
+            return_value=[discovery_info],
+        ),
+        patch(
+            "homeassistant.components.avea.config_flow.bluetooth.async_request_active_scan"
+        ) as mock_request_active_scan,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["data_schema"].schema[CONF_ADDRESS].container == {
+        AVEA_DISCOVERY_INFO.address: AVEA_DISCOVERY_INFO.address
+    }
+    mock_request_active_scan.assert_awaited_once_with(hass)
 
 
 async def test_user_step_cannot_connect_recovers(hass: HomeAssistant) -> None:

--- a/tests/components/avea/test_config_flow.py
+++ b/tests/components/avea/test_config_flow.py
@@ -1,11 +1,10 @@
 """Test the Avea config flow."""
 
-from copy import copy
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from homeassistant.components.avea.const import DOMAIN
+from homeassistant.components.avea.const import AVEA_SERVICE_UUID, DOMAIN
 from homeassistant.config_entries import SOURCE_BLUETOOTH, SOURCE_IMPORT, SOURCE_USER
 from homeassistant.const import CONF_ADDRESS, CONF_NAME
 from homeassistant.core import HomeAssistant
@@ -13,7 +12,11 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from . import AVEA_DISCOVERY_INFO, NOT_AVEA_DISCOVERY_INFO
 
-from tests.components.bluetooth import inject_bluetooth_service_info
+from tests.components.bluetooth import (
+    generate_advertisement_data,
+    generate_ble_device,
+    inject_bluetooth_service_info,
+)
 
 pytestmark = pytest.mark.usefixtures("enable_bluetooth")
 
@@ -90,8 +93,27 @@ async def test_user_step_no_devices_found(hass: HomeAssistant) -> None:
 
 async def test_user_step_unnamed_device_label(hass: HomeAssistant) -> None:
     """Test unnamed discovered devices are shown without duplicating the address."""
-    discovery_info = copy(AVEA_DISCOVERY_INFO)
-    discovery_info.name = discovery_info.address
+    discovery_info = type(AVEA_DISCOVERY_INFO)(
+        name=AVEA_DISCOVERY_INFO.address,
+        address=AVEA_DISCOVERY_INFO.address,
+        rssi=-60,
+        manufacturer_data={},
+        service_uuids=[AVEA_SERVICE_UUID],
+        service_data={},
+        source="local",
+        device=generate_ble_device(
+            address=AVEA_DISCOVERY_INFO.address, name=AVEA_DISCOVERY_INFO.address
+        ),
+        advertisement=generate_advertisement_data(
+            local_name=AVEA_DISCOVERY_INFO.address,
+            manufacturer_data={},
+            service_data={},
+            service_uuids=[AVEA_SERVICE_UUID],
+        ),
+        time=0,
+        connectable=True,
+        tx_power=-127,
+    )
 
     with (
         patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This updates the Avea config flow after the Bluetooth scanner changes in the 2026.6 beta.

Following bdraco's suggestion on Discord, the manual user flow now requests an active Bluetooth scan before showing the list of discovered Avea devices. This follows the same pattern used by `inkbird_ble` and makes the `Add integration` flow more likely to show recently powered-on bulbs when Bluetooth scanning is set to `Auto`.

The selector label is also cleaned up for devices that do not advertise a useful name. Named devices still show as `Name (MAC)`, while unnamed devices show only the address instead of `MAC (MAC)`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
