### PR TITLE
Bump pygti to 1.1.1

### DIFF
--- a/homeassistant/components/hvv_departures/binary_sensor.py
+++ b/homeassistant/components/hvv_departures/binary_sensor.py
@@ -6,7 +6,8 @@ import logging
 from typing import Any
 
 from aiohttp import ClientConnectorError
-from pygti.exceptions import InvalidAuth
+from pygti.exceptions import GTIError
+from pygti.models import ElevatorState, SDName, SDNameType, StationInformationRequest
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -46,12 +47,12 @@ async def async_setup_entry(
         if station_information is None:
             return {}
 
-        for partial_station in station_information.get("partialStations", []):
-            for elevator in partial_station.get("elevators", []):
-                state = elevator.get("state") != "READY"
-                available = elevator.get("state") != "UNKNOWN"
-                label = elevator.get("label")
-                description = elevator.get("description")
+        for partial_station in station_information.partialStations or []:
+            for elevator in partial_station.elevators or []:
+                state = elevator.state != ElevatorState.READY
+                available = elevator.state != ElevatorState.UNKNOWN
+                label = elevator.label
+                description = elevator.description
 
                 if label is not None:
                     name = f"Elevator {label}"
@@ -61,7 +62,7 @@ async def async_setup_entry(
                 if description is not None:
                     name += f" ({description})"
 
-                lines = elevator.get("lines")
+                lines = elevator.lines
 
                 idx = f"{station_name}-{label}-{lines}"
 
@@ -70,12 +71,12 @@ async def async_setup_entry(
                     "name": name,
                     "available": available,
                     "attributes": {
-                        "cabin_width": elevator.get("cabinWidth"),
-                        "cabin_length": elevator.get("cabinLength"),
-                        "door_width": elevator.get("doorWidth"),
-                        "elevator_type": elevator.get("elevatorType"),
-                        "button_type": elevator.get("buttonType"),
-                        "cause": elevator.get("cause"),
+                        "cabin_width": elevator.cabinWidth,
+                        "cabin_length": elevator.cabinLength,
+                        "door_width": elevator.doorWidth,
+                        "elevator_type": elevator.elevatorType,
+                        "button_type": elevator.buttonType,
+                        "cause": elevator.cause,
                         "lines": lines,
                     },
                 }
@@ -88,15 +89,17 @@ async def async_setup_entry(
         so entities can quickly look up their data.
         """
 
-        payload = {"station": {"id": station["id"], "type": station["type"]}}
+        payload = StationInformationRequest(
+            station=SDName(id=station["id"], type=SDNameType(station["type"]))
+        )
 
         try:
             async with asyncio.timeout(10):
                 return get_elevator_entities_from_station_information(
-                    station_name, await hub.gti.stationInformation(payload)
+                    station_name, await hub.gti.getStationInformation(payload)
                 )
-        except InvalidAuth as err:
-            raise UpdateFailed(f"Authentication failed: {err}") from err
+        except GTIError as err:
+            raise UpdateFailed(f"GTI API error: {err}") from err
         except ClientConnectorError as err:
             raise UpdateFailed(f"Network not available: {err}") from err
         except Exception as err:

--- a/homeassistant/components/hvv_departures/config_flow.py
+++ b/homeassistant/components/hvv_departures/config_flow.py
@@ -132,7 +132,7 @@ class HVVDeparturesConfigFlow(ConfigFlow, domain=DOMAIN):
         self.data.update(
             {
                 "station": self.stations[user_input[CONF_STATION]].model_dump(
-                    exclude_none=True
+                    mode="json", exclude_none=True
                 )
             }
         )
@@ -187,7 +187,7 @@ class OptionsFlowHandler(OptionsFlow):
                 errors["base"] = "cannot_connect"
             else:
                 self.departure_filters = {
-                    str(i): f.model_dump(exclude_none=True)
+                    str(i): f.model_dump(mode="json", exclude_none=True)
                     for i, f in enumerate(departure_list.filter or [])
                 }
 

--- a/homeassistant/components/hvv_departures/config_flow.py
+++ b/homeassistant/components/hvv_departures/config_flow.py
@@ -3,8 +3,17 @@
 import logging
 from typing import Any
 
+from aiohttp import ClientConnectorError
 from pygti.auth import GTI_DEFAULT_HOST
-from pygti.exceptions import CannotConnect, InvalidAuth
+from pygti.exceptions import GTIError, GTIUnauthorizedError
+from pygti.models import (
+    CNRequest,
+    DLRequest,
+    GTITime,
+    RegionalSDNameType,
+    SDName,
+    SDNameType,
+)
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
@@ -66,10 +75,10 @@ class HVVDeparturesConfigFlow(ConfigFlow, domain=DOMAIN):
             try:
                 response = await self.hub.authenticate()
                 _LOGGER.debug("Init gti: %r", response)
-            except CannotConnect:
-                errors["base"] = "cannot_connect"
-            except InvalidAuth:
+            except GTIUnauthorizedError:
                 errors["base"] = "invalid_auth"
+            except GTIError, ClientConnectorError:
+                errors["base"] = "cannot_connect"
 
             if not errors:
                 self.data = user_input
@@ -87,15 +96,14 @@ class HVVDeparturesConfigFlow(ConfigFlow, domain=DOMAIN):
             errors = {}
 
             check_name = await self.hub.gti.checkName(
-                {"theName": {"name": user_input[CONF_STATION]}, "maxList": 20}
+                CNRequest(theName=SDName(name=user_input[CONF_STATION]), maxList=20)
             )
 
-            stations = check_name.get("results")
-
             self.stations = {
-                f"{station.get('name')}": station
-                for station in stations
-                if station.get("type") == "STATION"
+                station.name: station
+                for station in (check_name.results or [])
+                if station.type == RegionalSDNameType.STATION
+                and station.name is not None
             }
 
             if not self.stations:
@@ -121,7 +129,13 @@ class HVVDeparturesConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is None:
             return self.async_show_form(step_id="station_select", data_schema=schema)
 
-        self.data.update({"station": self.stations[user_input[CONF_STATION]]})
+        self.data.update(
+            {
+                "station": self.stations[user_input[CONF_STATION]].model_dump(
+                    exclude_none=True
+                )
+            }
+        )
 
         title = self.data[CONF_STATION]["name"]
 
@@ -151,32 +165,30 @@ class OptionsFlowHandler(OptionsFlow):
         """Manage the options."""
         errors = {}
         if not self.departure_filters:
-            departure_list = {}
             hub = self.config_entry.runtime_data
 
             try:
                 departure_list = await hub.gti.departureList(
-                    {
-                        "station": {
-                            "type": "STATION",
-                            "id": self.config_entry.data[CONF_STATION].get("id"),
-                        },
-                        "time": {"date": "heute", "time": "jetzt"},
-                        "maxList": 5,
-                        "maxTimeOffset": 200,
-                        "useRealtime": True,
-                        "returnFilters": True,
-                    }
+                    DLRequest(
+                        station=SDName(
+                            id=self.config_entry.data[CONF_STATION].get("id"),
+                            type=SDNameType.STATION,
+                        ),
+                        time=GTITime(date="heute", time="jetzt"),
+                        maxList=5,
+                        maxTimeOffset=200,
+                        useRealtime=True,
+                        returnFilters=True,
+                    )
                 )
-            except CannotConnect:
-                errors["base"] = "cannot_connect"
-            except InvalidAuth:
+            except GTIUnauthorizedError:
                 errors["base"] = "invalid_auth"
-
-            if not errors:
+            except GTIError, ClientConnectorError:
+                errors["base"] = "cannot_connect"
+            else:
                 self.departure_filters = {
-                    str(i): departure_filter
-                    for i, departure_filter in enumerate(departure_list["filter"])
+                    str(i): f.model_dump(exclude_none=True)
+                    for i, f in enumerate(departure_list.filter or [])
                 }
 
         if user_input is not None and not errors:
@@ -206,8 +218,8 @@ class OptionsFlowHandler(OptionsFlow):
                     vol.Optional(CONF_FILTER, default=old_filter): cv.multi_select(
                         {
                             key: (
-                                f"{departure_filter['serviceName']},"
-                                f" {departure_filter['label']}"
+                                f"{departure_filter.get('serviceName', '')},"
+                                f" {departure_filter.get('label', '')}"
                             )
                             for key, departure_filter in self.departure_filters.items()
                         }

--- a/homeassistant/components/hvv_departures/hub.py
+++ b/homeassistant/components/hvv_departures/hub.py
@@ -1,6 +1,7 @@
 """Hub."""
 
 from pygti.gti import GTI, Auth
+from pygti.models import InitRequest
 
 from homeassistant.config_entries import ConfigEntry
 
@@ -21,4 +22,4 @@ class GTIHub:
     async def authenticate(self):
         """Test if we can authenticate with the host."""
 
-        return await self.gti.init()
+        return await self.gti.init(InitRequest())

--- a/homeassistant/components/hvv_departures/manifest.json
+++ b/homeassistant/components/hvv_departures/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "loggers": ["pygti"],
-  "requirements": ["pygti==0.9.4"]
+  "requirements": ["pygti==1.1.1"]
 }

--- a/homeassistant/components/hvv_departures/sensor.py
+++ b/homeassistant/components/hvv_departures/sensor.py
@@ -5,7 +5,8 @@ import logging
 from typing import Any
 
 from aiohttp import ClientConnectorError
-from pygti.exceptions import InvalidAuth
+from pygti.exceptions import GTIError, GTIUnauthorizedError
+from pygti.models import DLRequest, GTITime, SDName, SDNameType
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.const import ATTR_ID, CONF_OFFSET
@@ -16,7 +17,14 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import Throttle
 from homeassistant.util.dt import get_time_zone, utcnow
 
-from .const import ATTRIBUTION, CONF_REAL_TIME, CONF_STATION, DOMAIN, MANUFACTURER
+from .const import (
+    ATTRIBUTION,
+    CONF_FILTER,
+    CONF_REAL_TIME,
+    CONF_STATION,
+    DOMAIN,
+    MANUFACTURER,
+)
 from .hub import HVVConfigEntry
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
@@ -99,39 +107,46 @@ class HVVDepartureSensor(SensorEntity):
 
         station = self.config_entry.data[CONF_STATION]
 
-        payload = {
-            "station": {"id": station["id"], "type": station["type"]},
-            "time": {
-                "date": departure_time_tz_berlin.strftime("%d.%m.%Y"),
-                "time": departure_time_tz_berlin.strftime("%H:%M"),
-            },
-            "maxList": MAX_LIST,
-            "maxTimeOffset": MAX_TIME_OFFSET,
-            "useRealtime": self.config_entry.options.get(CONF_REAL_TIME, False),
-        }
-
-        if "filter" in self.config_entry.options:
-            payload.update({"filter": self.config_entry.options["filter"]})
+        request = DLRequest(
+            station=SDName(id=station["id"], type=SDNameType(station["type"])),
+            time=GTITime(
+                date=departure_time_tz_berlin.strftime("%d.%m.%Y"),
+                time=departure_time_tz_berlin.strftime("%H:%M"),
+            ),
+            maxList=MAX_LIST,
+            maxTimeOffset=MAX_TIME_OFFSET,
+            useRealtime=self.config_entry.options.get(CONF_REAL_TIME, False),
+            filter=self.config_entry.options.get(CONF_FILTER),
+        )
 
         try:
-            data = await self.gti.departureList(payload)
-        except InvalidAuth as error:
-            if self._last_error != InvalidAuth:
+            data = await self.gti.departureList(request)
+        except GTIUnauthorizedError as error:
+            if self._last_error != GTIUnauthorizedError:
                 _LOGGER.error("Authentication failed: %r", error)
-                self._last_error = InvalidAuth
+                self._last_error = GTIUnauthorizedError
             self._attr_available = False
+            return
+        except GTIError as error:
+            if self._last_error != GTIError:
+                _LOGGER.warning("GTI API error: %r", error)
+                self._last_error = GTIError
+            self._attr_available = False
+            return
         except ClientConnectorError as error:
             if self._last_error != ClientConnectorError:
                 _LOGGER.warning("Network unavailable: %r", error)
                 self._last_error = ClientConnectorError
             self._attr_available = False
+            return
         except Exception as error:  # noqa: BLE001
             if self._last_error != error:
                 _LOGGER.error("Error occurred while fetching data: %r", error)
                 self._last_error = error
             self._attr_available = False
+            return
 
-        if not (data["returnCode"] == "OK" and data.get("departures")):
+        if not data.departures:
             self._attr_available = False
             return
 
@@ -140,25 +155,27 @@ class HVVDepartureSensor(SensorEntity):
 
         self._last_error = None
 
-        departure = data["departures"][0]
-        line = departure["line"]
-        delay = departure.get("delay", 0)
-        cancelled = departure.get("cancelled", False)
-        extra = departure.get("extra", False)
+        departure = data.departures[0]
+        line = departure.line
+        delay = departure.delay if departure.delay is not None else 0
+        cancelled = departure.cancelled if departure.cancelled is not None else False
+        extra = departure.extra if departure.extra is not None else False
         self._attr_available = True
         self._attr_native_value = (
             departure_time
-            + timedelta(minutes=departure["timeOffset"])
+            + timedelta(
+                minutes=departure.timeOffset if departure.timeOffset is not None else 0
+            )
             + timedelta(seconds=delay)
         )
 
         self._attr_extra_state_attributes.update(
             {
-                ATTR_LINE: line["name"],
-                ATTR_ORIGIN: line["origin"],
-                ATTR_DIRECTION: line["direction"],
-                ATTR_TYPE: line["type"]["shortInfo"],
-                ATTR_ID: line["id"],
+                ATTR_LINE: line.name,
+                ATTR_ORIGIN: line.origin,
+                ATTR_DIRECTION: line.direction,
+                ATTR_TYPE: line.type.shortInfo,
+                ATTR_ID: line.id,
                 ATTR_DELAY: delay,
                 ATTR_CANCELLED: cancelled,
                 ATTR_EXTRA: extra,
@@ -166,21 +183,27 @@ class HVVDepartureSensor(SensorEntity):
         )
 
         departures = []
-        for departure in data["departures"]:
-            line = departure["line"]
-            delay = departure.get("delay", 0)
-            cancelled = departure.get("cancelled", False)
-            extra = departure.get("extra", False)
+        for departure in data.departures:
+            line = departure.line
+            delay = departure.delay if departure.delay is not None else 0
+            cancelled = (
+                departure.cancelled if departure.cancelled is not None else False
+            )
+            extra = departure.extra if departure.extra is not None else False
             departures.append(
                 {
                     ATTR_DEPARTURE: departure_time
-                    + timedelta(minutes=departure["timeOffset"])
+                    + timedelta(
+                        minutes=departure.timeOffset
+                        if departure.timeOffset is not None
+                        else 0
+                    )
                     + timedelta(seconds=delay),
-                    ATTR_LINE: line["name"],
-                    ATTR_ORIGIN: line["origin"],
-                    ATTR_DIRECTION: line["direction"],
-                    ATTR_TYPE: line["type"]["shortInfo"],
-                    ATTR_ID: line["id"],
+                    ATTR_LINE: line.name,
+                    ATTR_ORIGIN: line.origin,
+                    ATTR_DIRECTION: line.direction,
+                    ATTR_TYPE: line.type.shortInfo,
+                    ATTR_ID: line.id,
                     ATTR_DELAY: delay,
                     ATTR_CANCELLED: cancelled,
                     ATTR_EXTRA: extra,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2196,7 +2196,7 @@ pygatt[GATTTOOL]==4.0.5
 pygtfs==0.1.9
 
 # homeassistant.components.hvv_departures
-pygti==0.9.4
+pygti==1.1.1
 
 # homeassistant.components.version
 pyhaversion==22.8.0

--- a/tests/components/hvv_departures/fixtures/departure_list.json
+++ b/tests/components/hvv_departures/fixtures/departure_list.json
@@ -19,7 +19,9 @@
       "delay": 0,
       "serviceId": 1482563187,
       "station": { "combinedName": "Wartenau", "id": "Master:10901" },
-      "attributes": [{ "isPlanned": true, "types": ["REALTIME", "ACCURATE"] }]
+      "attributes": [
+        { "isPlanned": true, "value": "", "types": ["REALTIME", "ACCURATE"] }
+      ]
     },
     {
       "line": {
@@ -38,7 +40,9 @@
       "delay": 0,
       "serviceId": 74567,
       "station": { "combinedName": "U Wartenau", "id": "Master:60015" },
-      "attributes": [{ "isPlanned": true, "types": ["REALTIME", "ACCURATE"] }]
+      "attributes": [
+        { "isPlanned": true, "value": "", "types": ["REALTIME", "ACCURATE"] }
+      ]
     },
     {
       "line": {
@@ -57,7 +61,9 @@
       "delay": 0,
       "serviceId": 74328,
       "station": { "combinedName": "U Wartenau", "id": "Master:60015" },
-      "attributes": [{ "isPlanned": true, "types": ["REALTIME", "ACCURATE"] }]
+      "attributes": [
+        { "isPlanned": true, "value": "", "types": ["REALTIME", "ACCURATE"] }
+      ]
     },
     {
       "line": {
@@ -75,7 +81,9 @@
       "timeOffset": 8,
       "delay": 0,
       "station": { "combinedName": "Wartenau", "id": "Master:10901" },
-      "attributes": [{ "isPlanned": true, "types": ["REALTIME", "ACCURATE"] }]
+      "attributes": [
+        { "isPlanned": true, "value": "", "types": ["REALTIME", "ACCURATE"] }
+      ]
     },
     {
       "line": {
@@ -93,7 +101,9 @@
       "timeOffset": 10,
       "delay": 0,
       "station": { "combinedName": "Wartenau", "id": "Master:10901" },
-      "attributes": [{ "isPlanned": true, "types": ["REALTIME", "ACCURATE"] }]
+      "attributes": [
+        { "isPlanned": true, "value": "", "types": ["REALTIME", "ACCURATE"] }
+      ]
     }
   ],
   "filter": [

--- a/tests/components/hvv_departures/fixtures/departure_list.json
+++ b/tests/components/hvv_departures/fixtures/departure_list.json
@@ -20,7 +20,7 @@
       "serviceId": 1482563187,
       "station": { "combinedName": "Wartenau", "id": "Master:10901" },
       "attributes": [
-        { "isPlanned": true, "value": "", "types": ["REALTIME", "ACCURATE"] }
+        { "isPlanned": true, "value": "Unbekannte Ursache", "types": ["REALTIME", "ACCURATE"] }
       ]
     },
     {
@@ -41,7 +41,7 @@
       "serviceId": 74567,
       "station": { "combinedName": "U Wartenau", "id": "Master:60015" },
       "attributes": [
-        { "isPlanned": true, "value": "", "types": ["REALTIME", "ACCURATE"] }
+        { "isPlanned": true, "value": "Unbekannte Ursache", "types": ["REALTIME", "ACCURATE"] }
       ]
     },
     {
@@ -62,7 +62,7 @@
       "serviceId": 74328,
       "station": { "combinedName": "U Wartenau", "id": "Master:60015" },
       "attributes": [
-        { "isPlanned": true, "value": "", "types": ["REALTIME", "ACCURATE"] }
+        { "isPlanned": true, "value": "Unbekannte Ursache", "types": ["REALTIME", "ACCURATE"] }
       ]
     },
     {
@@ -82,7 +82,7 @@
       "delay": 0,
       "station": { "combinedName": "Wartenau", "id": "Master:10901" },
       "attributes": [
-        { "isPlanned": true, "value": "", "types": ["REALTIME", "ACCURATE"] }
+        { "isPlanned": true, "value": "Unbekannte Ursache", "types": ["REALTIME", "ACCURATE"] }
       ]
     },
     {
@@ -102,7 +102,7 @@
       "delay": 0,
       "station": { "combinedName": "Wartenau", "id": "Master:10901" },
       "attributes": [
-        { "isPlanned": true, "value": "", "types": ["REALTIME", "ACCURATE"] }
+        { "isPlanned": true, "value": "Unbekannte Ursache", "types": ["REALTIME", "ACCURATE"] }
       ]
     }
   ],

--- a/tests/components/hvv_departures/fixtures/departure_list.json
+++ b/tests/components/hvv_departures/fixtures/departure_list.json
@@ -20,7 +20,11 @@
       "serviceId": 1482563187,
       "station": { "combinedName": "Wartenau", "id": "Master:10901" },
       "attributes": [
-        { "isPlanned": true, "value": "Unbekannte Ursache", "types": ["REALTIME", "ACCURATE"] }
+        {
+          "isPlanned": true,
+          "value": "Unbekannte Ursache",
+          "types": ["REALTIME", "ACCURATE"]
+        }
       ]
     },
     {
@@ -41,7 +45,11 @@
       "serviceId": 74567,
       "station": { "combinedName": "U Wartenau", "id": "Master:60015" },
       "attributes": [
-        { "isPlanned": true, "value": "Unbekannte Ursache", "types": ["REALTIME", "ACCURATE"] }
+        {
+          "isPlanned": true,
+          "value": "Unbekannte Ursache",
+          "types": ["REALTIME", "ACCURATE"]
+        }
       ]
     },
     {
@@ -62,7 +70,11 @@
       "serviceId": 74328,
       "station": { "combinedName": "U Wartenau", "id": "Master:60015" },
       "attributes": [
-        { "isPlanned": true, "value": "Unbekannte Ursache", "types": ["REALTIME", "ACCURATE"] }
+        {
+          "isPlanned": true,
+          "value": "Unbekannte Ursache",
+          "types": ["REALTIME", "ACCURATE"]
+        }
       ]
     },
     {
@@ -82,7 +94,11 @@
       "delay": 0,
       "station": { "combinedName": "Wartenau", "id": "Master:10901" },
       "attributes": [
-        { "isPlanned": true, "value": "Unbekannte Ursache", "types": ["REALTIME", "ACCURATE"] }
+        {
+          "isPlanned": true,
+          "value": "Unbekannte Ursache",
+          "types": ["REALTIME", "ACCURATE"]
+        }
       ]
     },
     {
@@ -102,7 +118,11 @@
       "delay": 0,
       "station": { "combinedName": "Wartenau", "id": "Master:10901" },
       "attributes": [
-        { "isPlanned": true, "value": "Unbekannte Ursache", "types": ["REALTIME", "ACCURATE"] }
+        {
+          "isPlanned": true,
+          "value": "Unbekannte Ursache",
+          "types": ["REALTIME", "ACCURATE"]
+        }
       ]
     }
   ],

--- a/tests/components/hvv_departures/test_config_flow.py
+++ b/tests/components/hvv_departures/test_config_flow.py
@@ -1,9 +1,11 @@
 """Test the HVV Departures config flow."""
 
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from pygti.exceptions import CannotConnect, InvalidAuth
+from aiohttp import ClientConnectorError
+from pygti.exceptions import GTIUnauthorizedError
+from pygti.models import CNResponse, DLResponse, StationInformationResponse
 
 from homeassistant.components.hvv_departures.const import (
     CONF_FILTER,
@@ -38,11 +40,13 @@ async def test_user_flow(hass: HomeAssistant) -> None:
         ),
         patch(
             "homeassistant.components.hvv_departures.hub.GTI.checkName",
-            return_value=FIXTURE_CHECK_NAME,
+            return_value=CNResponse.model_validate(FIXTURE_CHECK_NAME),
         ),
         patch(
-            "homeassistant.components.hvv_departures.hub.GTI.stationInformation",
-            return_value=FIXTURE_STATION_INFORMATION,
+            "homeassistant.components.hvv_departures.hub.GTI.getStationInformation",
+            return_value=StationInformationResponse.model_validate(
+                FIXTURE_STATION_INFORMATION
+            ),
         ),
         patch(
             "homeassistant.components.hvv_departures.async_setup_entry",
@@ -89,7 +93,7 @@ async def test_user_flow(hass: HomeAssistant) -> None:
                 "combinedName": "Wartenau",
                 "id": "Master:10901",
                 "type": "STATION",
-                "coordinate": {"x": 10.035515, "y": 53.56478},
+                "coordinate": {"x": 10.035515, "y": 53.56478, "type": "EPSG_4326"},
                 "serviceTypes": ["bus", "u"],
                 "hasStationInformation": True,
             },
@@ -106,7 +110,7 @@ async def test_user_flow_no_results(hass: HomeAssistant) -> None:
         ),
         patch(
             "homeassistant.components.hvv_departures.hub.GTI.checkName",
-            return_value={"returnCode": "OK", "results": []},
+            return_value=CNResponse.model_validate({"returnCode": "OK", "results": []}),
         ),
         patch(
             "homeassistant.components.hvv_departures.async_setup_entry",
@@ -134,7 +138,7 @@ async def test_user_flow_no_results(hass: HomeAssistant) -> None:
         )
 
         assert result_station["step_id"] == "station"
-        assert result_station["errors"]["base"] == "no_results"
+        assert result_station["errors"] == {"base": "no_results"}
 
 
 async def test_user_flow_invalid_auth(hass: HomeAssistant) -> None:
@@ -142,11 +146,7 @@ async def test_user_flow_invalid_auth(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.hvv_departures.hub.GTI.init",
-        side_effect=InvalidAuth(
-            "ERROR_TEXT",
-            "Bei der Verarbeitung der Anfrage ist ein technisches Problem aufgetreten.",  # codespell:ignore ist
-            "Authentication failed!",
-        ),
+        side_effect=GTIUnauthorizedError(),
     ):
         # step: user
         result_user = await hass.config_entries.flow.async_init(
@@ -168,7 +168,7 @@ async def test_user_flow_cannot_connect(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.hvv_departures.hub.GTI.init",
-        side_effect=CannotConnect(),
+        side_effect=ClientConnectorError(MagicMock(), MagicMock()),
     ):
         # step: user
         result_user = await hass.config_entries.flow.async_init(
@@ -195,7 +195,7 @@ async def test_user_flow_station(hass: HomeAssistant) -> None:
         ),
         patch(
             "homeassistant.components.hvv_departures.hub.GTI.checkName",
-            return_value={"returnCode": "OK", "results": []},
+            return_value=CNResponse.model_validate({"returnCode": "OK", "results": []}),
         ),
     ):
         # step: user
@@ -231,7 +231,7 @@ async def test_user_flow_station_select(hass: HomeAssistant) -> None:
         ),
         patch(
             "homeassistant.components.hvv_departures.hub.GTI.checkName",
-            return_value=FIXTURE_CHECK_NAME,
+            return_value=CNResponse.model_validate(FIXTURE_CHECK_NAME),
         ),
     ):
         result_user = await hass.config_entries.flow.async_init(
@@ -281,7 +281,7 @@ async def test_options_flow(hass: HomeAssistant) -> None:
         ),
         patch(
             "homeassistant.components.hvv_departures.hub.GTI.departureList",
-            return_value=FIXTURE_DEPARTURE_LIST,
+            return_value=DLResponse.model_validate(FIXTURE_DEPARTURE_LIST),
         ),
     ):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -338,7 +338,7 @@ async def test_options_flow_invalid_auth(hass: HomeAssistant) -> None:
         ),
         patch(
             "homeassistant.components.hvv_departures.hub.GTI.departureList",
-            return_value=FIXTURE_DEPARTURE_LIST,
+            return_value=DLResponse.model_validate(FIXTURE_DEPARTURE_LIST),
         ),
     ):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -346,11 +346,7 @@ async def test_options_flow_invalid_auth(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.hvv_departures.hub.GTI.departureList",
-        side_effect=InvalidAuth(
-            "ERROR_TEXT",
-            "Bei der Verarbeitung der Anfrage ist ein technisches Problem aufgetreten.",  # codespell:ignore ist
-            "Authentication failed!",
-        ),
+        side_effect=GTIUnauthorizedError(),
     ):
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
@@ -381,7 +377,7 @@ async def test_options_flow_cannot_connect(hass: HomeAssistant) -> None:
         ),
         patch(
             "homeassistant.components.hvv_departures.hub.GTI.departureList",
-            return_value=FIXTURE_DEPARTURE_LIST,
+            return_value=DLResponse.model_validate(FIXTURE_DEPARTURE_LIST),
         ),
     ):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -389,7 +385,7 @@ async def test_options_flow_cannot_connect(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.hvv_departures.hub.GTI.departureList",
-        side_effect=CannotConnect(),
+        side_effect=ClientConnectorError(MagicMock(), MagicMock()),
     ):
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I bumped pygti, the underlying library of `hvv_departures`. Therefore, I had to change the usages of this library to use the new object/model based syntax instead of relying on raw dicts. I only changed code that needed changing to be compatible with the new library version.

https://github.com/vigonotion/pygti/compare/1fd1af5...v1.1.1
(1fd1af5 is the equivalent commit of v0.9.4, just the rebased version, see thread below why that happened)

Library migration guide (because it was a rewrite I cannot provide a diff comparison): https://github.com/vigonotion/pygti/blob/main/MIGRATE_TO_V1.md


_This PR will be the base for https://github.com/home-assistant/core/pull/172595_

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
