### PR TITLE
Catch network errors during Loqed config entry unload

### DIFF
--- a/homeassistant/components/loqed/coordinator.py
+++ b/homeassistant/components/loqed/coordinator.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from typing import TypedDict
 
+import aiohttp
 from aiohttp.web import Request
 from loqedAPI import loqed
 
@@ -160,14 +161,20 @@ class LoqedDataCoordinator(DataUpdateCoordinator[StatusMessage]):
 
         _LOGGER.debug("Webhook URL: %s", webhook_url)
 
-        webhooks = await self.lock.getWebhooks()
+        try:
+            webhooks = await self.lock.getWebhooks()
 
-        webhook_index = next(
-            (x["id"] for x in webhooks if x["url"] == webhook_url), None
-        )
+            webhook_index = next(
+                (x["id"] for x in webhooks if x["url"] == webhook_url), None
+            )
 
-        if webhook_index:
-            await self.lock.deleteWebhook(webhook_index)
+            if webhook_index:
+                await self.lock.deleteWebhook(webhook_index)
+        except (TimeoutError, aiohttp.ClientError) as err:
+            _LOGGER.warning(
+                "Could not remove webhook from LOQED bridge; the bridge may be offline. Continuing to unload the entry anyway: %s",
+                err,
+            )
 
 
 async def async_cloudhook_generate_url(

--- a/tests/components/loqed/test_init.py
+++ b/tests/components/loqed/test_init.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, patch
 import aiohttp
 from freezegun.api import FrozenDateTimeFactory
 from loqedAPI import loqed
+import pytest
 
 from homeassistant.components.loqed.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -214,3 +215,22 @@ async def test_unload_entry_fails(
     lock.deleteWebhook = AsyncMock(side_effect=Exception)
 
     assert not await hass.config_entries.async_unload(integration.entry_id)
+
+
+@pytest.mark.parametrize("error", [aiohttp.ClientError, TimeoutError])
+async def test_unload_entry_with_unreachable_bridge(
+    hass: HomeAssistant,
+    integration: MockConfigEntry,
+    lock: loqed.Lock,
+    error: type[Exception],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test entry still unloads when the bridge is unreachable."""
+    lock.getWebhooks = AsyncMock(side_effect=error)
+
+    assert await hass.config_entries.async_unload(integration.entry_id)
+    await hass.async_block_till_done()
+
+    assert integration.state is ConfigEntryState.NOT_LOADED
+    assert not hass.data.get(DOMAIN)
+    assert "Could not remove webhook from LOQED bridge" in caplog.text


### PR DESCRIPTION
## Proposed change

This is the same class of bug — and essentially the same fix — as the recently merged #172492 ("Catch network errors during Roborock config entry setup"), but on the **unload** side of the `loqed` integration.

When the LOQED bridge is unreachable, unloading (or reloading) the config entry leaves the integration permanently broken until Home Assistant is restarted.

`async_unload_entry` calls `coordinator.remove_webhooks()`, which makes an outbound HTTP call to the bridge (`getWebhooks()` / `deleteWebhook()`) to clean up the bridge-side webhook. That call is not guarded, so if the bridge doesn't answer (powered off, or a brief network drop) it raises `aiohttp.ClientError` / `TimeoutError`. The exception propagates out of `async_unload_entry`, the unload fails, and the config entry gets stuck in the terminal `failed_unload` state. The lock and sensors stay `unavailable` and never recover on their own — only a full Home Assistant restart fixes it.

This is easy to hit in practice: it happens whenever the entry is reloaded while the bridge is momentarily unreachable — e.g. a Wi-Fi/AP reboot or any short network blip (the LOQED bridge is Wi-Fi only).

Real log from reproducing it (bridge powered off, then the entry reloaded):

```
ERROR (MainThread) [homeassistant.config_entries] Error unloading entry LOQED Touch Smart Lock for loqed
  File ".../components/loqed/__init__.py", line 55, in async_unload_entry
      await entry.runtime_data.remove_webhooks()
  File ".../components/loqed/coordinator.py", line 161, in remove_webhooks
      webhooks = await self.lock.getWebhooks()
  ...
aiohttp.client_exceptions.ConnectionTimeoutError: Connection timeout to host http://10.0.12.120/webhooks
```

**The fix:** wrap the bridge call in `remove_webhooks()` in `try/except (TimeoutError, aiohttp.ClientError)` and log a warning instead of letting the unload fail. Removing the webhook from the bridge is best-effort cleanup; if the bridge is offline there is nothing we can do about it during unload, and it should not block the entry from unloading. The Home Assistant-side webhook handler is unregistered separately via `async_on_unload`, so it is still cleaned up regardless.

This mirrors exactly what `async_setup_entry` already does for the same library calls — it catches `(TimeoutError, aiohttp.ClientError)` and raises `ConfigEntryNotReady`. With this change, an unload/reload while the bridge is offline drops the entry to `setup_retry` (self-healing) instead of `failed_unload` (terminal), and it recovers automatically once the bridge is reachable again — no restart needed.

Verified end-to-end (bridge powered off → reload → bridge powered back on):

```
WARNING [...loqed.coordinator] Could not remove webhook from LOQED bridge; the bridge may be
  offline. Continuing to unload the entry anyway: Cannot connect to host 10.0.12.120:80 ...
INFO  [...loqed] Config entry 'LOQED Touch Smart Lock' ... not ready yet:
  Unable to connect to bridge at 10.0.12.120; Retrying in 5 seconds
... (backoff 5 -> 10 -> 20 -> 40 -> 80s) ...
INFO  [homeassistant.components.lock] Setting up loqed.lock      <- auto-recovered when the bridge returned
```

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #122692 (closed; same root cause — the entry "failed to unload" when the bridge was unreachable).
- Same approach as the recently merged #172492 (Roborock), applied here to the unload path.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist].
- [x] I have followed the [perfect PR recommendations][perfect-pr].
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`).
- [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
