### PR TITLE
Add tests for the envisalink integration

### DIFF
--- a/tests/components/envisalink/__init__.py
+++ b/tests/components/envisalink/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Envisalink integration."""

--- a/tests/components/envisalink/conftest.py
+++ b/tests/components/envisalink/conftest.py
@@ -8,18 +8,25 @@ from pyenvisalink.alarm_state import AlarmState
 import pytest
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.setup import async_setup_component
 
 DOMAIN = "envisalink"
 
-# Mirrors the YAML config keys (CONF_USERNAME == "user_name", CONF_PASS == "password").
+# The configured alarm code, shared with the tests so the service-call
+# assertions stay in sync with the code HA injects as the default.
+MOCK_CODE = "1234"
+
+# Mirrors the legacy YAML config keys (CONF_USERNAME == "user_name", CONF_PASS
+# == "password"). The integration is YAML-only (no config entry), so a future
+# config-entry migration replaces this whole fixture.
 MOCK_CONFIG = {
     DOMAIN: {
         "host": "1.2.3.4",
         "panel_type": "DSC",
         "user_name": "user",
         "password": "pass",
-        "code": "1234",
+        "code": MOCK_CODE,
         "partitions": {1: {"name": "Main Home"}},
         "zones": {1: {"name": "Front Door", "type": "door"}},
     }
@@ -36,9 +43,12 @@ def mock_controller() -> Generator[MagicMock]:
     """Patch EnvisalinkAlarmPanel with a spec'd mock controller.
 
     The integration waits on a connection future that is resolved by the
-    login-success callback, so the mock's start() invokes it.
+    login-success callback, so the mock's start() invokes it. Tests can
+    reassign ``controller.start.side_effect`` to ``callback_login_failure`` or
+    ``callback_login_timeout`` to exercise alternate connection outcomes.
     """
     controller = MagicMock(spec=EnvisalinkAlarmPanel)
+    # (max_zones=64, max_partitions=8) — sized to the panel's hardware limits.
     controller.alarm_state = AlarmState.get_initial_alarm_state(64, 8)
     # A non-empty alpha makes the initial partition state DISARMED (not None).
     controller.alarm_state["partition"][1]["status"]["alpha"] = "Ready"
@@ -51,7 +61,9 @@ def mock_controller() -> Generator[MagicMock]:
         yield controller
 
 
-async def setup_envisalink(hass: HomeAssistant, config: dict | None = None) -> bool:
+async def setup_envisalink(
+    hass: HomeAssistant, config: ConfigType | None = None
+) -> bool:
     """Set up the envisalink component and wait for it to finish."""
     result = await async_setup_component(hass, DOMAIN, config or MOCK_CONFIG)
     await hass.async_block_till_done()

--- a/tests/components/envisalink/conftest.py
+++ b/tests/components/envisalink/conftest.py
@@ -1,0 +1,58 @@
+"""Fixtures for Envisalink tests."""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+from pyenvisalink import EnvisalinkAlarmPanel
+from pyenvisalink.alarm_state import AlarmState
+import pytest
+
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+DOMAIN = "envisalink"
+
+# Mirrors the YAML config keys (CONF_USERNAME == "user_name", CONF_PASS == "password").
+MOCK_CONFIG = {
+    DOMAIN: {
+        "host": "1.2.3.4",
+        "panel_type": "DSC",
+        "user_name": "user",
+        "password": "pass",
+        "code": "1234",
+        "partitions": {1: {"name": "Main Home"}},
+        "zones": {1: {"name": "Front Door", "type": "door"}},
+    }
+}
+
+# Entity ids derived from the configured names.
+ALARM_ENTITY = "alarm_control_panel.main_home"
+KEYPAD_ENTITY = "sensor.main_home_keypad"
+ZONE_ENTITY = "binary_sensor.front_door"
+
+
+@pytest.fixture
+def mock_controller() -> Generator[MagicMock]:
+    """Patch EnvisalinkAlarmPanel with a spec'd mock controller.
+
+    The integration waits on a connection future that is resolved by the
+    login-success callback, so the mock's start() invokes it.
+    """
+    controller = MagicMock(spec=EnvisalinkAlarmPanel)
+    controller.alarm_state = AlarmState.get_initial_alarm_state(64, 8)
+    # A non-empty alpha makes the initial partition state DISARMED (not None).
+    controller.alarm_state["partition"][1]["status"]["alpha"] = "Ready"
+    controller.start.side_effect = lambda: controller.callback_login_success(None)
+
+    with patch(
+        "homeassistant.components.envisalink.EnvisalinkAlarmPanel",
+        return_value=controller,
+    ):
+        yield controller
+
+
+async def setup_envisalink(hass: HomeAssistant, config: dict | None = None) -> bool:
+    """Set up the envisalink component and wait for it to finish."""
+    result = await async_setup_component(hass, DOMAIN, config or MOCK_CONFIG)
+    await hass.async_block_till_done()
+    return result

--- a/tests/components/envisalink/conftest.py
+++ b/tests/components/envisalink/conftest.py
@@ -3,15 +3,13 @@
 from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
-from pyenvisalink import EnvisalinkAlarmPanel
 from pyenvisalink.alarm_state import AlarmState
 import pytest
 
+from homeassistant.components.envisalink import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.setup import async_setup_component
-
-DOMAIN = "envisalink"
 
 # The configured alarm code, shared with the tests so the service-call
 # assertions stay in sync with the code HA injects as the default.
@@ -40,24 +38,22 @@ ZONE_ENTITY = "binary_sensor.front_door"
 
 @pytest.fixture
 def mock_controller() -> Generator[MagicMock]:
-    """Patch EnvisalinkAlarmPanel with a spec'd mock controller.
+    """Patch EnvisalinkAlarmPanel with an autospec'd mock controller.
 
     The integration waits on a connection future that is resolved by the
     login-success callback, so the mock's start() invokes it. Tests can
     reassign ``controller.start.side_effect`` to ``callback_login_failure`` or
     ``callback_login_timeout`` to exercise alternate connection outcomes.
     """
-    controller = MagicMock(spec=EnvisalinkAlarmPanel)
-    # (max_zones=64, max_partitions=8) — sized to the panel's hardware limits.
-    controller.alarm_state = AlarmState.get_initial_alarm_state(64, 8)
-    # A non-empty alpha makes the initial partition state DISARMED (not None).
-    controller.alarm_state["partition"][1]["status"]["alpha"] = "Ready"
-    controller.start.side_effect = lambda: controller.callback_login_success(None)
-
     with patch(
-        "homeassistant.components.envisalink.EnvisalinkAlarmPanel",
-        return_value=controller,
-    ):
+        "homeassistant.components.envisalink.EnvisalinkAlarmPanel", autospec=True
+    ) as mock_panel:
+        controller = mock_panel.return_value
+        # (max_zones=64, max_partitions=8) — sized to the panel's hardware limits.
+        controller.alarm_state = AlarmState.get_initial_alarm_state(64, 8)
+        # A non-empty alpha makes the initial partition state DISARMED (not None).
+        controller.alarm_state["partition"][1]["status"]["alpha"] = "Ready"
+        controller.start.side_effect = lambda: controller.callback_login_success(None)
         yield controller
 
 

--- a/tests/components/envisalink/test_alarm_control_panel.py
+++ b/tests/components/envisalink/test_alarm_control_panel.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from homeassistant.components.alarm_control_panel import (
+    DOMAIN as ALARM_CONTROL_PANEL_DOMAIN,
     AlarmControlPanelState,
     CodeFormat,
 )
@@ -16,7 +17,6 @@ from homeassistant.const import (
     SERVICE_ALARM_DISARM,
     SERVICE_ALARM_TRIGGER,
     STATE_UNKNOWN,
-    Platform,
 )
 from homeassistant.core import HomeAssistant
 
@@ -77,7 +77,7 @@ async def test_arm_disarm_commands(
     assert await setup_envisalink(hass)
 
     await hass.services.async_call(
-        Platform.ALARM_CONTROL_PANEL,
+        ALARM_CONTROL_PANEL_DOMAIN,
         service,
         {"entity_id": ALARM_ENTITY},
         blocking=True,
@@ -93,7 +93,7 @@ async def test_trigger_calls_panic(
     assert await setup_envisalink(hass)
 
     await hass.services.async_call(
-        Platform.ALARM_CONTROL_PANEL,
+        ALARM_CONTROL_PANEL_DOMAIN,
         SERVICE_ALARM_TRIGGER,
         {"entity_id": ALARM_ENTITY},
         blocking=True,

--- a/tests/components/envisalink/test_alarm_control_panel.py
+++ b/tests/components/envisalink/test_alarm_control_panel.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from .conftest import ALARM_ENTITY, DOMAIN, MOCK_CONFIG, setup_envisalink
+from .conftest import ALARM_ENTITY, DOMAIN, MOCK_CODE, MOCK_CONFIG, setup_envisalink
 
 
 @pytest.mark.parametrize(
@@ -39,7 +39,7 @@ from .conftest import ALARM_ENTITY, DOMAIN, MOCK_CONFIG, setup_envisalink
 async def test_alarm_states(
     hass: HomeAssistant,
     mock_controller: MagicMock,
-    status_overrides: dict[str, object],
+    status_overrides: dict[str, bool | str],
     expected_state: str,
 ) -> None:
     """Test the partition status maps to the correct alarm state."""
@@ -68,17 +68,22 @@ async def test_arm_disarm_commands(
     service: str,
     method: str,
 ) -> None:
-    """Test arm/disarm services call the controller with code and partition."""
+    """Test arm/disarm services call the controller with code and partition.
+
+    No code is supplied in the call: the keypad is hidden when a code is
+    configured, so HA injects the configured default code. This proves the
+    default-code path, not just an echo of a code we passed in.
+    """
     assert await setup_envisalink(hass)
 
     await hass.services.async_call(
         Platform.ALARM_CONTROL_PANEL,
         service,
-        {"entity_id": ALARM_ENTITY, "code": "1234"},
+        {"entity_id": ALARM_ENTITY},
         blocking=True,
     )
 
-    getattr(mock_controller, method).assert_called_once_with("1234", 1)
+    getattr(mock_controller, method).assert_called_once_with(MOCK_CODE, 1)
 
 
 async def test_trigger_calls_panic(
@@ -94,6 +99,7 @@ async def test_trigger_calls_panic(
         blocking=True,
     )
 
+    # "Police" is the default panic type when none is configured.
     mock_controller.panic_alarm.assert_called_once_with("Police")
 
 
@@ -120,19 +126,26 @@ async def test_code_format_without_configured_code(
 async def test_partition_update_filtering(
     hass: HomeAssistant, mock_controller: MagicMock
 ) -> None:
-    """Test updates for other partitions are ignored, None applies to all."""
+    """Test partition updates are filtered by number; None applies to all."""
     assert await setup_envisalink(hass)
-    mock_controller.alarm_state["partition"][1]["status"]["alarm"] = True
+    status = mock_controller.alarm_state["partition"][1]["status"]
+    status["alarm"] = True
 
-    # Update targeting a different partition is ignored.
+    # Update targeting a different partition is ignored (stays disarmed).
     mock_controller.callback_partition_state_change(2)
     await hass.async_block_till_done()
-    assert hass.states.get(ALARM_ENTITY).state != AlarmControlPanelState.TRIGGERED
+    assert hass.states.get(ALARM_ENTITY).state == AlarmControlPanelState.DISARMED
 
-    # A None partition applies to every entity.
-    mock_controller.callback_partition_state_change(None)
+    # A matching partition delivered as a string is coerced and applies.
+    mock_controller.callback_partition_state_change("1")
     await hass.async_block_till_done()
     assert hass.states.get(ALARM_ENTITY).state == AlarmControlPanelState.TRIGGERED
+
+    # A None partition applies to every entity.
+    status["alarm"] = False
+    mock_controller.callback_partition_state_change(None)
+    await hass.async_block_till_done()
+    assert hass.states.get(ALARM_ENTITY).state == AlarmControlPanelState.DISARMED
 
 
 async def test_alarm_keypress_service(

--- a/tests/components/envisalink/test_alarm_control_panel.py
+++ b/tests/components/envisalink/test_alarm_control_panel.py
@@ -1,0 +1,151 @@
+"""Tests for the Envisalink alarm control panel."""
+
+from copy import deepcopy
+from unittest.mock import MagicMock
+
+import pytest
+
+from homeassistant.components.alarm_control_panel import (
+    AlarmControlPanelState,
+    CodeFormat,
+)
+from homeassistant.const import (
+    SERVICE_ALARM_ARM_AWAY,
+    SERVICE_ALARM_ARM_HOME,
+    SERVICE_ALARM_ARM_NIGHT,
+    SERVICE_ALARM_DISARM,
+    SERVICE_ALARM_TRIGGER,
+    STATE_UNKNOWN,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+
+from .conftest import ALARM_ENTITY, DOMAIN, MOCK_CONFIG, setup_envisalink
+
+
+@pytest.mark.parametrize(
+    ("status_overrides", "expected_state"),
+    [
+        ({"alarm": True}, AlarmControlPanelState.TRIGGERED),
+        ({"armed_zero_entry_delay": True}, AlarmControlPanelState.ARMED_NIGHT),
+        ({"armed_away": True}, AlarmControlPanelState.ARMED_AWAY),
+        ({"armed_stay": True}, AlarmControlPanelState.ARMED_HOME),
+        ({"exit_delay": True}, AlarmControlPanelState.ARMING),
+        ({"entry_delay": True}, AlarmControlPanelState.PENDING),
+        ({}, AlarmControlPanelState.DISARMED),
+        ({"alpha": ""}, STATE_UNKNOWN),
+    ],
+)
+async def test_alarm_states(
+    hass: HomeAssistant,
+    mock_controller: MagicMock,
+    status_overrides: dict[str, object],
+    expected_state: str,
+) -> None:
+    """Test the partition status maps to the correct alarm state."""
+    assert await setup_envisalink(hass)
+
+    status = mock_controller.alarm_state["partition"][1]["status"]
+    status.update(status_overrides)
+    mock_controller.callback_partition_state_change(1)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(ALARM_ENTITY).state == expected_state
+
+
+@pytest.mark.parametrize(
+    ("service", "method"),
+    [
+        (SERVICE_ALARM_ARM_HOME, "arm_stay_partition"),
+        (SERVICE_ALARM_ARM_AWAY, "arm_away_partition"),
+        (SERVICE_ALARM_ARM_NIGHT, "arm_night_partition"),
+        (SERVICE_ALARM_DISARM, "disarm_partition"),
+    ],
+)
+async def test_arm_disarm_commands(
+    hass: HomeAssistant,
+    mock_controller: MagicMock,
+    service: str,
+    method: str,
+) -> None:
+    """Test arm/disarm services call the controller with code and partition."""
+    assert await setup_envisalink(hass)
+
+    await hass.services.async_call(
+        Platform.ALARM_CONTROL_PANEL,
+        service,
+        {"entity_id": ALARM_ENTITY, "code": "1234"},
+        blocking=True,
+    )
+
+    getattr(mock_controller, method).assert_called_once_with("1234", 1)
+
+
+async def test_trigger_calls_panic(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test the trigger service fires a panic alarm of the configured type."""
+    assert await setup_envisalink(hass)
+
+    await hass.services.async_call(
+        Platform.ALARM_CONTROL_PANEL,
+        SERVICE_ALARM_TRIGGER,
+        {"entity_id": ALARM_ENTITY},
+        blocking=True,
+    )
+
+    mock_controller.panic_alarm.assert_called_once_with("Police")
+
+
+async def test_code_format_with_configured_code(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test the keypad is hidden (no code_format) when a code is configured."""
+    assert await setup_envisalink(hass)
+
+    assert hass.states.get(ALARM_ENTITY).attributes.get("code_format") is None
+
+
+async def test_code_format_without_configured_code(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test the numeric keypad shows when no code is configured."""
+    config = deepcopy(MOCK_CONFIG)
+    del config[DOMAIN]["code"]
+    assert await setup_envisalink(hass, config)
+
+    assert hass.states.get(ALARM_ENTITY).attributes["code_format"] == CodeFormat.NUMBER
+
+
+async def test_partition_update_filtering(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test updates for other partitions are ignored, None applies to all."""
+    assert await setup_envisalink(hass)
+    mock_controller.alarm_state["partition"][1]["status"]["alarm"] = True
+
+    # Update targeting a different partition is ignored.
+    mock_controller.callback_partition_state_change(2)
+    await hass.async_block_till_done()
+    assert hass.states.get(ALARM_ENTITY).state != AlarmControlPanelState.TRIGGERED
+
+    # A None partition applies to every entity.
+    mock_controller.callback_partition_state_change(None)
+    await hass.async_block_till_done()
+    assert hass.states.get(ALARM_ENTITY).state == AlarmControlPanelState.TRIGGERED
+
+
+async def test_alarm_keypress_service(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test the custom alarm_keypress service forwards to the partition."""
+    assert await setup_envisalink(hass)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "alarm_keypress",
+        {"entity_id": ALARM_ENTITY, "keypress": "*71"},
+        blocking=True,
+    )
+
+    mock_controller.keypresses_to_partition.assert_called_once_with(1, "*71")

--- a/tests/components/envisalink/test_binary_sensor.py
+++ b/tests/components/envisalink/test_binary_sensor.py
@@ -1,0 +1,66 @@
+"""Tests for the Envisalink zone binary sensors."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_LAST_TRIP_TIME,
+    STATE_OFF,
+    STATE_ON,
+)
+from homeassistant.core import HomeAssistant
+
+from .conftest import ZONE_ENTITY, setup_envisalink
+
+# Library caps last_fault at 65536 5-second ticks; at/above that it's unknown.
+LAST_FAULT_MAX = 65536 * 5
+
+
+async def test_zone_is_on(hass: HomeAssistant, mock_controller: MagicMock) -> None:
+    """Test the zone reflects its open status on a zone update."""
+    assert await setup_envisalink(hass)
+    assert hass.states.get(ZONE_ENTITY).state == STATE_OFF
+
+    mock_controller.alarm_state["zone"][1]["status"]["open"] = True
+    mock_controller.callback_zone_state_change(1)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(ZONE_ENTITY).state == STATE_ON
+
+
+async def test_zone_attributes(hass: HomeAssistant, mock_controller: MagicMock) -> None:
+    """Test the zone exposes device class, zone number, and last trip time."""
+    assert await setup_envisalink(hass)
+
+    attrs = hass.states.get(ZONE_ENTITY).attributes
+    assert attrs[ATTR_DEVICE_CLASS] == BinarySensorDeviceClass.DOOR
+    assert attrs["zone"] == 1
+    # last_fault defaults to 0 → a concrete (recent) timestamp.
+    assert attrs[ATTR_LAST_TRIP_TIME] is not None
+
+
+async def test_zone_last_trip_time_unknown_at_max(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test last trip time is None once the library caps the fault counter."""
+    mock_controller.alarm_state["zone"][1]["last_fault"] = LAST_FAULT_MAX
+    assert await setup_envisalink(hass)
+
+    assert hass.states.get(ZONE_ENTITY).attributes[ATTR_LAST_TRIP_TIME] is None
+
+
+async def test_zone_update_filtering(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test updates for other zones are ignored, None applies to all."""
+    assert await setup_envisalink(hass)
+    mock_controller.alarm_state["zone"][1]["status"]["open"] = True
+
+    mock_controller.callback_zone_state_change(2)
+    await hass.async_block_till_done()
+    assert hass.states.get(ZONE_ENTITY).state == STATE_OFF
+
+    mock_controller.callback_zone_state_change(None)
+    await hass.async_block_till_done()
+    assert hass.states.get(ZONE_ENTITY).state == STATE_ON

--- a/tests/components/envisalink/test_binary_sensor.py
+++ b/tests/components/envisalink/test_binary_sensor.py
@@ -1,6 +1,9 @@
 """Tests for the Envisalink zone binary sensors."""
 
+from datetime import timedelta
 from unittest.mock import MagicMock
+
+from freezegun.api import FrozenDateTimeFactory
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.const import (
@@ -10,6 +13,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from .conftest import ZONE_ENTITY, setup_envisalink
 
@@ -30,15 +34,21 @@ async def test_zone_is_on(hass: HomeAssistant, mock_controller: MagicMock) -> No
     assert hass.states.get(ZONE_ENTITY).state == STATE_ON
 
 
-async def test_zone_attributes(hass: HomeAssistant, mock_controller: MagicMock) -> None:
+async def test_zone_attributes(
+    hass: HomeAssistant, mock_controller: MagicMock, freezer: FrozenDateTimeFactory
+) -> None:
     """Test the zone exposes device class, zone number, and last trip time."""
+    freezer.move_to("2026-01-01 12:00:00+00:00")
+    # last_fault is the number of seconds since the fault; it is subtracted
+    # from the current (second-accurate) time to get the last trip time.
+    mock_controller.alarm_state["zone"][1]["last_fault"] = 300
     assert await setup_envisalink(hass)
 
     attrs = hass.states.get(ZONE_ENTITY).attributes
     assert attrs[ATTR_DEVICE_CLASS] == BinarySensorDeviceClass.DOOR
     assert attrs["zone"] == 1
-    # last_fault defaults to 0 → a concrete (recent) timestamp.
-    assert attrs[ATTR_LAST_TRIP_TIME] is not None
+    expected = dt_util.now().replace(microsecond=0) - timedelta(seconds=300)
+    assert attrs[ATTR_LAST_TRIP_TIME] == expected.isoformat()
 
 
 async def test_zone_last_trip_time_unknown_at_max(
@@ -54,14 +64,23 @@ async def test_zone_last_trip_time_unknown_at_max(
 async def test_zone_update_filtering(
     hass: HomeAssistant, mock_controller: MagicMock
 ) -> None:
-    """Test updates for other zones are ignored, None applies to all."""
+    """Test zone updates are filtered by number; None applies to all."""
     assert await setup_envisalink(hass)
-    mock_controller.alarm_state["zone"][1]["status"]["open"] = True
+    zone_status = mock_controller.alarm_state["zone"][1]["status"]
+    zone_status["open"] = True
 
+    # Update for a different zone (int) is ignored.
     mock_controller.callback_zone_state_change(2)
     await hass.async_block_till_done()
     assert hass.states.get(ZONE_ENTITY).state == STATE_OFF
 
-    mock_controller.callback_zone_state_change(None)
+    # A matching zone delivered as a string is coerced and applies.
+    mock_controller.callback_zone_state_change("1")
     await hass.async_block_till_done()
     assert hass.states.get(ZONE_ENTITY).state == STATE_ON
+
+    # A None zone applies to every entity.
+    zone_status["open"] = False
+    mock_controller.callback_zone_state_change(None)
+    await hass.async_block_till_done()
+    assert hass.states.get(ZONE_ENTITY).state == STATE_OFF

--- a/tests/components/envisalink/test_binary_sensor.py
+++ b/tests/components/envisalink/test_binary_sensor.py
@@ -13,8 +13,9 @@ from homeassistant.core import HomeAssistant
 
 from .conftest import ZONE_ENTITY, setup_envisalink
 
-# Library caps last_fault at 65536 5-second ticks; at/above that it's unknown.
-LAST_FAULT_MAX = 65536 * 5
+# The library reports last_fault in seconds, capped at 327680 (65536 five-second
+# ticks); at or above the cap the real value is unknown.
+LAST_FAULT_MAX_SECONDS = 65536 * 5
 
 
 async def test_zone_is_on(hass: HomeAssistant, mock_controller: MagicMock) -> None:
@@ -44,7 +45,7 @@ async def test_zone_last_trip_time_unknown_at_max(
     hass: HomeAssistant, mock_controller: MagicMock
 ) -> None:
     """Test last trip time is None once the library caps the fault counter."""
-    mock_controller.alarm_state["zone"][1]["last_fault"] = LAST_FAULT_MAX
+    mock_controller.alarm_state["zone"][1]["last_fault"] = LAST_FAULT_MAX_SECONDS
     assert await setup_envisalink(hass)
 
     assert hass.states.get(ZONE_ENTITY).attributes[ATTR_LAST_TRIP_TIME] is None

--- a/tests/components/envisalink/test_init.py
+++ b/tests/components/envisalink/test_init.py
@@ -1,0 +1,100 @@
+"""Tests for the Envisalink setup."""
+
+from collections.abc import Callable
+from unittest.mock import MagicMock
+
+import pytest
+
+from homeassistant.components.envisalink.alarm_control_panel import (
+    async_setup_platform as alarm_setup_platform,
+)
+from homeassistant.components.envisalink.binary_sensor import (
+    async_setup_platform as binary_sensor_setup_platform,
+)
+from homeassistant.components.envisalink.sensor import (
+    async_setup_platform as sensor_setup_platform,
+)
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import HomeAssistant
+
+from .conftest import ALARM_ENTITY, DOMAIN, KEYPAD_ENTITY, ZONE_ENTITY, setup_envisalink
+
+
+async def test_setup_creates_entities(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test setup creates the alarm, keypad and zone entities."""
+    assert await setup_envisalink(hass)
+
+    assert hass.states.get(ALARM_ENTITY) is not None
+    assert hass.states.get(KEYPAD_ENTITY) is not None
+    assert hass.states.get(ZONE_ENTITY) is not None
+
+
+async def test_setup_fails_on_login_failure(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test setup returns False when the Envisalink rejects the login."""
+    mock_controller.start.side_effect = lambda: mock_controller.callback_login_failure(
+        None
+    )
+
+    assert await setup_envisalink(hass) is False
+    assert hass.states.get(ALARM_ENTITY) is None
+
+
+async def test_setup_succeeds_on_connection_timeout(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test setup proceeds (retry mode) when the first connection times out."""
+    mock_controller.start.side_effect = lambda: mock_controller.callback_login_timeout(
+        None
+    )
+
+    assert await setup_envisalink(hass)
+    assert hass.states.get(ALARM_ENTITY) is not None
+
+
+async def test_controller_stopped_on_shutdown(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test the controller connection is stopped on Home Assistant shutdown."""
+    assert await setup_envisalink(hass)
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+    await hass.async_block_till_done()
+
+    mock_controller.stop.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "setup_platform",
+    [
+        alarm_setup_platform,
+        binary_sensor_setup_platform,
+        sensor_setup_platform,
+    ],
+)
+async def test_platform_setup_without_discovery_is_noop(
+    hass: HomeAssistant, setup_platform: Callable
+) -> None:
+    """Test a platform set up directly (no discovery info) adds no entities."""
+    add_entities = MagicMock()
+    await setup_platform(hass, {}, add_entities, None)
+    add_entities.assert_not_called()
+
+
+async def test_invoke_custom_function_service(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test the PGM service forwards the code, partition and function."""
+    assert await setup_envisalink(hass)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "invoke_custom_function",
+        {"pgm": "1", "partition": "1"},
+        blocking=True,
+    )
+
+    mock_controller.command_output.assert_called_once_with("1234", "1", "1")

--- a/tests/components/envisalink/test_init.py
+++ b/tests/components/envisalink/test_init.py
@@ -1,6 +1,6 @@
 """Tests for the Envisalink setup."""
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from unittest.mock import MagicMock
 
 import pytest
@@ -16,8 +16,22 @@ from homeassistant.components.envisalink.sensor import (
 )
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from .conftest import ALARM_ENTITY, DOMAIN, KEYPAD_ENTITY, ZONE_ENTITY, setup_envisalink
+from .conftest import (
+    ALARM_ENTITY,
+    DOMAIN,
+    KEYPAD_ENTITY,
+    MOCK_CODE,
+    ZONE_ENTITY,
+    setup_envisalink,
+)
+
+SetupPlatform = Callable[
+    [HomeAssistant, ConfigType, AddEntitiesCallback, DiscoveryInfoType | None],
+    Awaitable[None],
+]
 
 
 async def test_setup_creates_entities(
@@ -76,7 +90,7 @@ async def test_controller_stopped_on_shutdown(
     ],
 )
 async def test_platform_setup_without_discovery_is_noop(
-    hass: HomeAssistant, setup_platform: Callable
+    hass: HomeAssistant, setup_platform: SetupPlatform
 ) -> None:
     """Test a platform set up directly (no discovery info) adds no entities."""
     add_entities = MagicMock()
@@ -90,11 +104,13 @@ async def test_invoke_custom_function_service(
     """Test the PGM service forwards the code, partition and function."""
     assert await setup_envisalink(hass)
 
+    # Distinct pgm/partition values so the assertion pins each positional arg
+    # of command_output(code, partition, custom_function).
     await hass.services.async_call(
         DOMAIN,
         "invoke_custom_function",
-        {"pgm": "1", "partition": "1"},
+        {"pgm": "7", "partition": "2"},
         blocking=True,
     )
 
-    mock_controller.command_output.assert_called_once_with("1234", "1", "1")
+    mock_controller.command_output.assert_called_once_with(MOCK_CODE, "2", "7")

--- a/tests/components/envisalink/test_sensor.py
+++ b/tests/components/envisalink/test_sensor.py
@@ -1,0 +1,32 @@
+"""Tests for the Envisalink keypad sensor."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.core import HomeAssistant
+
+from .conftest import KEYPAD_ENTITY, setup_envisalink
+
+
+async def test_keypad_native_value(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test the keypad sensor shows the partition alpha text."""
+    assert await setup_envisalink(hass)
+    assert hass.states.get(KEYPAD_ENTITY).state == "Ready"
+
+    mock_controller.alarm_state["partition"][1]["status"]["alpha"] = "Armed Away"
+    mock_controller.callback_keypad_update(1)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(KEYPAD_ENTITY).state == "Armed Away"
+
+
+async def test_keypad_attributes_expose_status(
+    hass: HomeAssistant, mock_controller: MagicMock
+) -> None:
+    """Test the keypad sensor exposes the full partition status as attributes."""
+    assert await setup_envisalink(hass)
+
+    attrs = hass.states.get(KEYPAD_ENTITY).attributes
+    assert attrs["armed_away"] is False
+    assert attrs["alpha"] == "Ready"

--- a/tests/components/envisalink/test_sensor.py
+++ b/tests/components/envisalink/test_sensor.py
@@ -15,7 +15,8 @@ async def test_keypad_native_value(
     assert hass.states.get(KEYPAD_ENTITY).state == "Ready"
 
     mock_controller.alarm_state["partition"][1]["status"]["alpha"] = "Armed Away"
-    mock_controller.callback_keypad_update(1)
+    # A matching partition delivered as a string is coerced and applies.
+    mock_controller.callback_keypad_update("1")
     await hass.async_block_till_done()
 
     assert hass.states.get(KEYPAD_ENTITY).state == "Armed Away"


### PR DESCRIPTION
## Breaking change


## Proposed change

Adds the first test suite for the `envisalink` integration, which previously had
no test coverage.

The tests are integration-level: they patch the `pyenvisalink`
`EnvisalinkAlarmPanel` (spec'd so a non-existent library call would fail), set up
the component via `async_setup_component`, resolve the connection future through
the controller's registered `callback_login_success`, and drive entity updates
through the controller's registered state-change callbacks (the real
library → dispatcher → entity path).

Coverage:
- Alarm panel: the full partition-status → state mapping, arm/disarm/night/away
  commands, panic trigger, `code_format` (with/without a configured code),
  partition-update filtering, and the custom `alarm_keypress` service.
- Zone binary sensors: open state, device class, zone/last-trip-time attributes,
  zone-update filtering.
- Keypad sensor: alpha value + status attributes.
- Setup: success, login failure, connection-timeout (retry), shutdown, the custom
  `invoke_custom_function` service, and the no-discovery platform guard.

This is **100% coverage of every loaded module**. The unused zone-bypass
`switch.py` platform is intentionally excluded — it is never loaded (its signal is
never dispatched) and was disabled "due to an issue with some panels"; touching it
is out of scope here.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
