### PR TITLE
Handle Rituals firmware version objects

### DIFF
--- a/homeassistant/components/rituals_perfume_genie/entity.py
+++ b/homeassistant/components/rituals_perfume_genie/entity.py
@@ -12,6 +12,17 @@ MODEL = "The Perfume Genie"
 MODEL2 = "The Perfume Genie 2.0"
 
 
+def _stringify_firmware_version(version: object) -> str | None:
+    """Return firmware version in the format expected by the device registry."""
+    if version is None:
+        return None
+    if isinstance(version, dict):
+        version = version.get("raw") or version.get("title")
+        if version is None:
+            return None
+    return str(version)
+
+
 class DiffuserEntity(CoordinatorEntity[RitualsDataUpdateCoordinator]):
     """Representation of a diffuser entity."""
 
@@ -31,7 +42,7 @@ class DiffuserEntity(CoordinatorEntity[RitualsDataUpdateCoordinator]):
             manufacturer=MANUFACTURER,
             model=MODEL if coordinator.diffuser.has_battery else MODEL2,
             name=coordinator.diffuser.name,
-            sw_version=coordinator.diffuser.version,
+            sw_version=_stringify_firmware_version(coordinator.diffuser.version),
         )
 
     @property

--- a/tests/components/rituals_perfume_genie/common.py
+++ b/tests/components/rituals_perfume_genie/common.py
@@ -38,7 +38,7 @@ def mock_diffuser(
     perfume: str = "Ritual of Sakura",
     perfume_amount: int = 2,
     room_size_square_meter: int = 60,
-    version: str = "4.0",
+    version: object = "4.0",
     wifi_percentage: int = 75,
 ) -> MagicMock:
     """Return a mock Diffuser initialized with the given data."""

--- a/tests/components/rituals_perfume_genie/test_switch.py
+++ b/tests/components/rituals_perfume_genie/test_switch.py
@@ -4,6 +4,7 @@ from homeassistant.components.homeassistant import (
     DOMAIN as HOMEASSISTANT_DOMAIN,
     SERVICE_UPDATE_ENTITY,
 )
+from homeassistant.components.rituals_perfume_genie.const import DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -13,12 +14,13 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from .common import (
     init_integration,
     mock_config_entry,
+    mock_diffuser,
     mock_diffuser_v1_battery_cartridge,
 )
 
@@ -38,6 +40,31 @@ async def test_switch_entity(
     entry = entity_registry.async_get("switch.genie")
     assert entry
     assert entry.unique_id == f"{diffuser.hublot}-is_on"
+
+
+async def test_switch_device_uses_string_firmware_version(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test firmware version object is stored as a string."""
+    config_entry = mock_config_entry(unique_id="id_123_switch_version_test")
+    diffuser = mock_diffuser(
+        hublot="lot123v2",
+        has_battery=False,
+        version={
+            "description": "",
+            "discover_url": "",
+            "icon": "",
+            "image": "",
+            "raw": "5.4",
+            "title": "5.4",
+        },
+    )
+    await init_integration(hass, config_entry, [diffuser])
+
+    device = device_registry.async_get_device(identifiers={(DOMAIN, diffuser.hublot)})
+
+    assert device
+    assert device.sw_version == "5.4"
 
 
 async def test_switch_handle_coordinator_update(hass: HomeAssistant) -> None:

--- a/tests/components/rituals_perfume_genie/test_switch.py
+++ b/tests/components/rituals_perfume_genie/test_switch.py
@@ -1,10 +1,15 @@
 """Tests for the Rituals Perfume Genie switch platform."""
 
+import pytest
+
 from homeassistant.components.homeassistant import (
     DOMAIN as HOMEASSISTANT_DOMAIN,
     SERVICE_UPDATE_ENTITY,
 )
 from homeassistant.components.rituals_perfume_genie.const import DOMAIN
+from homeassistant.components.rituals_perfume_genie.entity import (
+    _stringify_firmware_version,
+)
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -23,6 +28,21 @@ from .common import (
     mock_diffuser,
     mock_diffuser_v1_battery_cartridge,
 )
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("4.0", "4.0"),
+        (None, None),
+        ({"raw": "5.4", "title": "Version 5.4"}, "5.4"),
+        ({"title": "5.4"}, "5.4"),
+        ({"raw": None, "title": None}, None),
+    ],
+)
+def test_stringify_firmware_version(version: object, expected: str | None) -> None:
+    """Test stringifying firmware version values."""
+    assert _stringify_firmware_version(version) == expected
 
 
 async def test_switch_entity(


### PR DESCRIPTION
## Proposed change

The Rituals API can return the diffuser firmware version as a sensor object instead of a plain string. That object was passed straight into `DeviceInfo.sw_version`, which expects a string and can break consumers of the device registry data.

This normalizes the firmware version before storing it in the device registry, using the `raw` value from the API response when available and falling back to `title`.

Observed in Home Assistant as `Firmware: [object Object]`:

![Rituals firmware shown as object](https://raw.githubusercontent.com/hmmbob/core/pr-assets/rituals-firmware-object-screenshot/assets/rituals-firmware-object.png)

This also showed up when exposing the device to Google Assistant. HomeGraph rejected
the sync payload because `deviceInfo.swVersion` for the Rituals switch contained an
object instead of a string:

```text
SYNC failed: INVALID_ARGUMENT
Invalid value for expected type: STRING

deviceInfo:
  manufacturer: Rituals Cosmetics
  model: The Perfume Genie 2.0
  swVersion:
    raw: "5.4"
    title: "5.4"
```

After that failed sync, Home Assistant also logged failed HomeGraph
`requestSync` / `reportStateAndNotification` calls for Google Assistant.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
