### PR TITLE
Add long_press support for HomeWorks QSX in lutron_caseta

### DIFF
--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -23,6 +23,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
+    ACTION_LONG_PRESS,
     ACTION_MULTITAP,
     ACTION_PRESS,
     ACTION_RELEASE,
@@ -35,6 +36,7 @@ from .const import (
     ATTR_SERIAL,
     ATTR_TYPE,
     BRIDGE_DEVICE_ID,
+    BUTTON_STATUS_LONG_HOLD,
     CONF_CA_CERTS,
     CONF_CERTFILE,
     CONF_KEYFILE,
@@ -450,6 +452,8 @@ def _async_subscribe_keypad_events(
             action = ACTION_PRESS
         elif event_type == BUTTON_STATUS_MULTITAP:
             action = ACTION_MULTITAP
+        elif event_type == BUTTON_STATUS_LONG_HOLD:
+            action = ACTION_LONG_PRESS
         else:
             action = ACTION_RELEASE
 

--- a/homeassistant/components/lutron_caseta/const.py
+++ b/homeassistant/components/lutron_caseta/const.py
@@ -29,9 +29,20 @@ ATTR_DEVICE_NAME = "device_name"
 ATTR_AREA_NAME = "area_name"
 ATTR_ACTION = "action"
 
+ACTION_LONG_PRESS = "long_press"
 ACTION_MULTITAP = "multi_tap"
 ACTION_PRESS = "press"
 ACTION_RELEASE = "release"
+
+# Raw EventType string sent by the Lutron LEAP protocol for a long hold.
+# pylutron-caseta passes all EventType values through without filtering.
+BUTTON_STATUS_LONG_HOLD = "LongHold"
+
+# Bridge DeviceType strings (bridge_device["type"]) that are known to send
+# native LongHold events over LEAP. Used to gate the long_press device
+# trigger so it only appears in the automation UI for supported hardware.
+# Caseta and RadioRA3 processors do not emit LongHold.
+BRIDGE_DEVICE_TYPES_WITH_LONG_HOLD = frozenset({"HWQSProcessor"})
 
 CONF_SUBTYPE = "subtype"
 

--- a/homeassistant/components/lutron_caseta/device_trigger.py
+++ b/homeassistant/components/lutron_caseta/device_trigger.py
@@ -19,11 +19,13 @@ from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
+    ACTION_LONG_PRESS,
     ACTION_MULTITAP,
     ACTION_PRESS,
     ACTION_RELEASE,
     ATTR_ACTION,
     ATTR_BUTTON_TYPE,
+    BRIDGE_DEVICE_TYPES_WITH_LONG_HOLD,
     CONF_SUBTYPE,
     DOMAIN,
     LUTRON_CASETA_BUTTON_EVENT,
@@ -38,7 +40,18 @@ def _reverse_dict(forward_dict: dict) -> dict:
     return {v: k for k, v in forward_dict.items()}
 
 
-SUPPORTED_INPUTS_EVENTS_TYPES = [ACTION_PRESS, ACTION_MULTITAP, ACTION_RELEASE]
+SUPPORTED_INPUTS_EVENTS_TYPES = [
+    ACTION_PRESS,
+    ACTION_LONG_PRESS,
+    ACTION_MULTITAP,
+    ACTION_RELEASE,
+]
+
+# Triggers that are only available on specific bridge types.
+# Actions absent from this dict are supported by all bridge types.
+TRIGGER_REQUIRED_BRIDGE_TYPES: dict[str, frozenset[str]] = {
+    ACTION_LONG_PRESS: BRIDGE_DEVICE_TYPES_WITH_LONG_HOLD,
+}
 
 LUTRON_BUTTON_TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
     {
@@ -414,6 +427,14 @@ async def async_get_triggers(
         keypad_button_names_to_leap[keypad["lutron_device_id"]],
     )
 
+    bridge_type = data.bridge_device.get("type", "")
+    supported_triggers = [
+        t
+        for t in SUPPORTED_INPUTS_EVENTS_TYPES
+        if t not in TRIGGER_REQUIRED_BRIDGE_TYPES
+        or bridge_type in TRIGGER_REQUIRED_BRIDGE_TYPES[t]
+    ]
+
     return [
         {
             CONF_PLATFORM: "device",
@@ -422,7 +443,7 @@ async def async_get_triggers(
             CONF_TYPE: trigger,
             CONF_SUBTYPE: subtype,
         }
-        for trigger in SUPPORTED_INPUTS_EVENTS_TYPES
+        for trigger in supported_triggers
         for subtype in valid_buttons
     ]
 

--- a/homeassistant/components/lutron_caseta/strings.json
+++ b/homeassistant/components/lutron_caseta/strings.json
@@ -75,6 +75,8 @@
       "stop_all": "Stop all"
     },
     "trigger_type": {
+      "long_press": "\"{subtype}\" long pressed",
+      "multi_tap": "\"{subtype}\" multi-tapped",
       "press": "\"{subtype}\" pressed",
       "release": "\"{subtype}\" released"
     }

--- a/tests/components/lutron_caseta/__init__.py
+++ b/tests/components/lutron_caseta/__init__.py
@@ -112,6 +112,7 @@ class MockBridge:
         self.battery_statuses = {"802": "Good"}
         self.buttons = self.load_buttons()
         self._subscribers: dict[str, list] = {}
+        self._button_subscribers: dict[str, list] = {}
         self.smart_away_state = smart_away_state
         self._smart_away_subscribers = []
 
@@ -149,6 +150,12 @@ class MockBridge:
 
     def add_button_subscriber(self, button_id: str, callback_):
         """Mock a listener for button presses."""
+        self._button_subscribers.setdefault(button_id, []).append(callback_)
+
+    def call_button_subscribers(self, button_id: str, event_type: str) -> None:
+        """Simulate a LEAP button event for the given button ID."""
+        for callback in self._button_subscribers.get(button_id, []):
+            callback(event_type)
 
     def call_subscribers(self, device_id: str):
         """Notify subscribers of a device state change."""

--- a/tests/components/lutron_caseta/test_device_trigger.py
+++ b/tests/components/lutron_caseta/test_device_trigger.py
@@ -13,8 +13,11 @@ from homeassistant.components.lutron_caseta import (
     ATTR_TYPE,
 )
 from homeassistant.components.lutron_caseta.const import (
+    ACTION_LONG_PRESS,
+    ACTION_RELEASE,
     ATTR_BUTTON_TYPE,
     ATTR_LEAP_BUTTON_NUMBER,
+    BUTTON_STATUS_LONG_HOLD,
     CONF_CA_CERTS,
     CONF_CERTFILE,
     CONF_KEYFILE,
@@ -37,7 +40,11 @@ from homeassistant.setup import async_setup_component
 
 from . import MockBridge, async_setup_integration
 
-from tests.common import MockConfigEntry, async_get_device_automations
+from tests.common import (
+    MockConfigEntry,
+    async_capture_events,
+    async_get_device_automations,
+)
 
 MOCK_BUTTON_DEVICES = [
     {
@@ -96,8 +103,10 @@ MOCK_BUTTON_DEVICES = [
 ]
 
 
-async def _async_setup_lutron_with_picos(hass: HomeAssistant) -> str:
-    """Setups a lutron bridge with picos."""
+async def _async_setup_lutron_with_picos(
+    hass: HomeAssistant, bridge_class: type[MockBridge] = MockBridge
+) -> str:
+    """Set up a lutron bridge with picos."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -110,7 +119,7 @@ async def _async_setup_lutron_with_picos(hass: HomeAssistant) -> str:
     )
     config_entry.add_to_hass(hass)
 
-    await async_setup_integration(hass, MockBridge, config_entry.entry_id)
+    await async_setup_integration(hass, bridge_class, config_entry.entry_id)
 
     return config_entry.entry_id
 
@@ -165,6 +174,51 @@ async def test_get_triggers(hass: HomeAssistant) -> None:
     )
 
     assert triggers == unordered(expected_triggers)
+
+
+class MockQSXBridge(MockBridge):
+    """Mock bridge that reports as a HomeWorks QSX processor."""
+
+    def load_devices(self):
+        """Load mock devices with QSX processor type."""
+        devices = super().load_devices()
+        devices["1"]["type"] = "HWQSProcessor"
+        return devices
+
+
+async def test_get_triggers_qsx_includes_long_press(hass: HomeAssistant) -> None:
+    """Test that long_press trigger is included for QSX bridges."""
+    config_entry_id = await _async_setup_lutron_with_picos(hass, MockQSXBridge)
+
+    data: LutronCasetaData = hass.config_entries.async_get_entry(
+        config_entry_id
+    ).runtime_data
+    keypads = data.keypad_data.keypads
+    device_id = keypads[list(keypads)[0]]["dr_device_id"]
+
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_id
+    )
+    trigger_types = {t[CONF_TYPE] for t in triggers}
+
+    assert ACTION_LONG_PRESS in trigger_types
+
+
+async def test_get_triggers_non_qsx_excludes_long_press(hass: HomeAssistant) -> None:
+    """Test that long_press trigger is not included for non-QSX bridges."""
+    config_entry_id = await _async_setup_lutron_with_picos(hass)
+    data: LutronCasetaData = hass.config_entries.async_get_entry(
+        config_entry_id
+    ).runtime_data
+    keypads = data.keypad_data.keypads
+    device_id = keypads[list(keypads)[0]]["dr_device_id"]
+
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_id
+    )
+    trigger_types = {t[CONF_TYPE] for t in triggers}
+
+    assert ACTION_LONG_PRESS not in trigger_types
 
 
 async def test_get_triggers_for_invalid_device_id(
@@ -268,6 +322,89 @@ async def test_if_fires_on_button_event(
 
     assert len(service_calls) == 1
     assert service_calls[0].data["some"] == "test_trigger_button_press"
+
+
+async def test_if_fires_on_long_press_button_event(
+    hass: HomeAssistant,
+    service_calls: list[ServiceCall],
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test for long_press trigger firing on a QSX bridge."""
+    await _async_setup_lutron_with_picos(hass, MockQSXBridge)
+
+    device = MOCK_BUTTON_DEVICES[0]
+    dr_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, device["serial"])}
+    )
+    device_id = dr_device.id
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        CONF_PLATFORM: "device",
+                        CONF_DOMAIN: DOMAIN,
+                        CONF_DEVICE_ID: device_id,
+                        CONF_TYPE: ACTION_LONG_PRESS,
+                        CONF_SUBTYPE: "on",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {"some": "test_trigger_long_press"},
+                    },
+                },
+            ]
+        },
+    )
+
+    message = {
+        ATTR_SERIAL: device.get("serial"),
+        ATTR_TYPE: device.get("type"),
+        ATTR_LEAP_BUTTON_NUMBER: 0,
+        ATTR_DEVICE_NAME: device["Name"],
+        ATTR_AREA_NAME: device.get("Area", {}).get("Name"),
+        ATTR_ACTION: ACTION_LONG_PRESS,
+        ATTR_DEVICE_ID: device_id,
+        ATTR_BUTTON_TYPE: "on",
+    }
+    hass.bus.async_fire(LUTRON_CASETA_BUTTON_EVENT, message)
+    await hass.async_block_till_done()
+
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "test_trigger_long_press"
+
+
+async def test_long_hold_leap_event_maps_to_long_press_action(
+    hass: HomeAssistant,
+) -> None:
+    """Test that a LongHold LEAP event is mapped to a long_press bus event."""
+    config_entry_id = await _async_setup_lutron_with_picos(hass, MockQSXBridge)
+    bridge = hass.config_entries.async_get_entry(config_entry_id).runtime_data.bridge
+    captured = async_capture_events(hass, LUTRON_CASETA_BUTTON_EVENT)
+
+    bridge.call_button_subscribers("111", BUTTON_STATUS_LONG_HOLD)
+    await hass.async_block_till_done()
+
+    assert len(captured) == 1
+    assert captured[0].data[ATTR_ACTION] == ACTION_LONG_PRESS
+
+
+async def test_unknown_leap_event_type_maps_to_release_action(
+    hass: HomeAssistant,
+) -> None:
+    """Test that an unrecognized LEAP event type falls back to release."""
+    config_entry_id = await _async_setup_lutron_with_picos(hass)
+    bridge = hass.config_entries.async_get_entry(config_entry_id).runtime_data.bridge
+    captured = async_capture_events(hass, LUTRON_CASETA_BUTTON_EVENT)
+
+    bridge.call_button_subscribers("111", "UnknownEventType")
+    await hass.async_block_till_done()
+
+    assert len(captured) == 1
+    assert captured[0].data[ATTR_ACTION] == ACTION_RELEASE
 
 
 async def test_if_fires_on_button_event_without_lip(
@@ -450,7 +587,8 @@ async def test_validate_trigger_invalid_triggers(
         },
     )
 
-    assert "value must be one of ['multi_tap', 'press', 'release']" in caplog.text
+    assert "value must be one of" in caplog.text
+    assert ACTION_LONG_PRESS in caplog.text
 
 
 async def test_if_fires_on_button_event_late_setup(


### PR DESCRIPTION
## Proposed change

The Lutron LEAP protocol natively emits a `LongHold` event when a keypad button is held for an extended duration, but the `lutron_caseta` integration was silently treating it as a `release` action, making it inaccessible to users.

This PR adds a `long_press` device trigger for keypad buttons, gated to **HomeWorks QSX** processors (`HWQSProcessor`) only, because:
- Only QSX bridges are confirmed to emit `LongHold` events via LEAP
- Caséta and RadioRA 3 bridges do not emit this event, so showing `long_press` in their automation editor would be misleading

The underlying `pylutron-caseta` library already passes `LongHold` event strings through verbatim, so no library changes are needed.

## Type of change

- [x] New feature (which adds functionality to an existing integration)

## Additional information

- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45658
- Tested on real HomeWorks QSX hardware (HQP7 processor) — `long_press` triggers fire correctly in HA automations

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


<img width="513" height="666" alt="Screenshot 2026-05-30 at 3 38 10 PM" src="https://github.com/user-attachments/assets/3b1dbd37-ffd1-4f1d-a6fe-e58dae12b468" />
