### PR TITLE
Bump pyschlage to 2026.5.0

### DIFF
--- a/homeassistant/components/schlage/manifest.json
+++ b/homeassistant/components/schlage/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/schlage",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
-  "requirements": ["pyschlage==2025.9.0"]
+  "requirements": ["pyschlage==2026.5.0"]
 }

--- a/homeassistant/components/schlage/strings.json
+++ b/homeassistant/components/schlage/strings.json
@@ -42,7 +42,9 @@
           "60": "1 minute",
           "120": "2 minutes",
           "240": "4 minutes",
-          "300": "5 minutes"
+          "300": "5 minutes",
+          "360": "6 minutes",
+          "600": "10 minutes"
         }
       }
     },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2507,7 +2507,7 @@ pysaj==0.0.16
 pysaunum==0.6.0
 
 # homeassistant.components.schlage
-pyschlage==2025.9.0
+pyschlage==2026.5.0
 
 # homeassistant.components.sensibo
 pysensibo==1.2.1


### PR DESCRIPTION
## Proposed change

Bumps `pyschlage` from `2025.9.0` to `2026.5.0`.

Changes relevant to this integration:
- Updated `AUTO_LOCK_TIMES` to match options available in the Schlage Encode App (adds 360s and 600s options)
- Support for `MultiRecurringSchedule` on access codes
- Fixed `AccessCode.notify_on_use` mapping

This PR updates the version in the manifest, `requirements_all.txt`, and adds translations for the two new auto-lock time values (`360` → "6 minutes", `600` → "10 minutes") in `strings.json`.

Diff: https://github.com/dknowles2/pyschlage/compare/2025.9.0...2026.5.0

## Type of change

- [x] Dependency upgrade

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr