### PR TITLE
Restore last known Velux cover position across HA restarts

### DIFF
--- a/homeassistant/components/velux/cover.py
+++ b/homeassistant/components/velux/cover.py
@@ -1,7 +1,6 @@
 """Support for Velux covers."""
 
 from enum import StrEnum
-import logging
 from typing import Any
 
 from pyvlx import Node
@@ -31,8 +30,6 @@ from homeassistant.helpers.restore_state import RestoreEntity
 
 from . import VeluxConfigEntry
 from .entity import VeluxEntity, wrap_pyvlx_call_exceptions
-
-_LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 1
 

--- a/homeassistant/components/velux/cover.py
+++ b/homeassistant/components/velux/cover.py
@@ -1,8 +1,10 @@
 """Support for Velux covers."""
 
 from enum import StrEnum
+import logging
 from typing import Any
 
+from pyvlx import Node
 from pyvlx.opening_device import (
     Awning,
     Blind,
@@ -16,6 +18,7 @@ from pyvlx.opening_device import (
 )
 
 from homeassistant.components.cover import (
+    ATTR_CURRENT_POSITION,
     ATTR_POSITION,
     ATTR_TILT_POSITION,
     CoverDeviceClass,
@@ -24,9 +27,12 @@ from homeassistant.components.cover import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from . import VeluxConfigEntry
 from .entity import VeluxEntity, wrap_pyvlx_call_exceptions
+
+_LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 1
 
@@ -66,7 +72,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class VeluxCover(VeluxEntity, CoverEntity):
+class VeluxCover(VeluxEntity, RestoreEntity, CoverEntity):
     """Representation of a Velux cover."""
 
     node: OpeningDevice
@@ -78,6 +84,14 @@ class VeluxCover(VeluxEntity, CoverEntity):
         | CoverEntityFeature.SET_POSITION
         | CoverEntityFeature.STOP
     )
+
+    # Last position (HA percent: 0 = closed, 100 = open) carried across an
+    # HA restart. The KLF200 reboot triggered by async_unload_entry leaves
+    # the gateway reporting current_position = UNKNOWN for tens of seconds
+    # up to several minutes after a restart, during which HA would otherwise
+    # show every Velux cover as `unknown`. The cache is preferred over the
+    # live pyvlx position only while node.position is not known.
+    _restored_position_percent: int | None = None
 
     def __init__(self, node: OpeningDevice, config_entry_id: str) -> None:
         """Initialize VeluxCover."""
@@ -94,19 +108,67 @@ class VeluxCover(VeluxEntity, CoverEntity):
             case RollerShutter():
                 self._attr_device_class = CoverDeviceClass.SHUTTER
 
+    async def async_added_to_hass(self) -> None:
+        """Register pyvlx callbacks and seed the restore-position cache.
+
+        is_opening / is_closing are transient and not restored — pyvlx
+        initialises them to False on every (re-)connect, which is the correct
+        starting point after an HA restart. Only the position is brought back
+        so the entity does not stay `unknown` until the first House
+        Monitoring frame arrives.
+        """
+        await super().async_added_to_hass()
+        live = self._live_position_percent()
+        if live is not None:
+            self._restored_position_percent = live
+            return
+        last_state = await self.async_get_last_state()
+        if last_state is None:
+            return
+        restored = last_state.attributes.get(ATTR_CURRENT_POSITION)
+        # Accept the persisted attribute regardless of the persisted entity
+        # state string: HA may have written state="unknown" during a previous
+        # post-restart UNKNOWN window, but the current_position attribute is
+        # often still a usable number.
+        if isinstance(restored, (int, float)) and 0 <= restored <= 100:
+            self._restored_position_percent = int(restored)
+
     @property
     def current_cover_position(self) -> int | None:
         """Return the current position of the cover."""
-        if not self.node.position.known:
-            return None
-        return 100 - self.node.position.position_percent
+        if self.node.position.known:
+            return 100 - self.node.position.position_percent
+        return self._restored_position_percent
 
     @property
     def is_closed(self) -> bool | None:
         """Return if the cover is closed."""
+        if self.node.position.known:
+            return self.node.position.closed
+        if self._restored_position_percent is None:
+            return None
+        return self._restored_position_percent == 0
+
+    def _live_position_percent(self) -> int | None:
+        """Return the HA-percent position if pyvlx currently knows it.
+
+        Overridden by VeluxDualRollerShutter so each part refreshes from its
+        own pyvlx Position. Used by ``after_update_callback`` to keep the
+        restore cache fresh — if pyvlx ever transitions a known node back to
+        UNKNOWN (e.g. a fresh KLF200 reconnect mid-session), the fallback
+        should reflect the most recent known live value, not the startup
+        snapshot from ``async_get_last_state``.
+        """
         if not self.node.position.known:
             return None
-        return self.node.position.closed
+        return 100 - self.node.position.position_percent
+
+    async def after_update_callback(self, node: Node) -> None:
+        """Capture the latest known live position into the restore cache."""
+        live = self._live_position_percent()
+        if live is not None:
+            self._restored_position_percent = live
+        await super().after_update_callback(node)
 
     @property
     def is_opening(self) -> bool:
@@ -182,17 +244,31 @@ class VeluxDualRollerShutter(VeluxCover):
     def current_cover_position(self) -> int | None:
         """Return the current position of the cover."""
         position = self._part_position
-        if not position.known:
-            return None
-        return 100 - position.position_percent
+        if position.known:
+            return 100 - position.position_percent
+        return self._restored_position_percent
 
     @property
     def is_closed(self) -> bool | None:
         """Return if the cover is closed."""
         position = self._part_position
+        if position.known:
+            return position.closed
+        if self._restored_position_percent is None:
+            return None
+        return self._restored_position_percent == 0
+
+    def _live_position_percent(self) -> int | None:
+        """Return the HA-percent position of this part if pyvlx knows it.
+
+        Used by the inherited ``after_update_callback`` so the restore cache
+        is refreshed from the part-specific position rather than the
+        device-level ``node.position``.
+        """
+        position = self._part_position
         if not position.known:
             return None
-        return position.closed
+        return 100 - position.position_percent
 
     @wrap_pyvlx_call_exceptions
     async def async_close_cover(self, **kwargs: Any) -> None:

--- a/tests/components/velux/test_cover.py
+++ b/tests/components/velux/test_cover.py
@@ -479,20 +479,35 @@ async def test_non_blind_has_no_tilt_position(
 # Unknown position tests
 
 
-async def test_window_unknown_position(
+async def test_window_unknown_position_falls_back_to_last_known(
     hass: HomeAssistant, mock_window: AsyncMock
 ) -> None:
-    """When the device position is not known, state and position must be unknown."""
+    """When pyvlx loses position mid-session, fall back to the last known value.
+
+    The cover seeds a restore-position cache from every known live update.
+    A subsequent transient UNKNOWN frame (e.g. fresh KLF200 reconnect)
+    therefore must not flip the entity to `unknown` — it stays at the most
+    recent known position. See test_cover_restore_state.py for the seed
+    paths exercised at startup.
+    """
 
     entity_id = "cover.test_window"
+
+    # Initial state established by the setup fixture: known=True at position_percent=30
+    # (HA percent = 70).
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_OPEN
+    assert state.attributes.get("current_position") == 70
 
     mock_window.position.known = False
     await update_callback_entity(hass, mock_window)
 
     state = hass.states.get(entity_id)
     assert state is not None
-    assert state.state == STATE_UNKNOWN
-    assert state.attributes.get("current_position") is None
+    # Falls back to cached last known instead of going `unknown`.
+    assert state.state == STATE_OPEN
+    assert state.attributes.get("current_position") == 70
 
 
 @pytest.mark.parametrize(
@@ -503,13 +518,17 @@ async def test_window_unknown_position(
         ("position_lower_curtain", "cover.test_dual_roller_shutter_lower_shutter"),
     ],
 )
-async def test_dual_roller_shutter_unknown_position(
+async def test_dual_roller_shutter_unknown_position_falls_back_to_last_known(
     hass: HomeAssistant,
     mock_dual_roller_shutter: AsyncMock,
     unknown_attr: str,
     unknown_entity_id: str,
 ) -> None:
-    """Each part falls back to unknown when only its position is unknown."""
+    """Each part falls back to its last known position when only its part is unknown.
+
+    Same fallback semantics as ``test_window_unknown_position_falls_back_to_last_known``
+    but per dual-roller-shutter part (upper/lower/dual).
+    """
 
     all_entity_ids = {
         "cover.test_dual_roller_shutter",
@@ -522,8 +541,9 @@ async def test_dual_roller_shutter_unknown_position(
 
     state = hass.states.get(unknown_entity_id)
     assert state is not None
-    assert state.state == STATE_UNKNOWN
-    assert state.attributes.get("current_position") is None
+    # Falls back to cached last known instead of going `unknown`.
+    assert state.state == STATE_OPEN
+    assert state.attributes.get("current_position") == 70
 
     for entity_id in all_entity_ids - {unknown_entity_id}:
         state = hass.states.get(entity_id)

--- a/tests/components/velux/test_cover_restore_state.py
+++ b/tests/components/velux/test_cover_restore_state.py
@@ -1,0 +1,233 @@
+"""Tests for the Velux cover restore-state seeding."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.cover import ATTR_CURRENT_POSITION
+from homeassistant.const import (
+    STATE_CLOSED,
+    STATE_OPEN,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    Platform,
+)
+from homeassistant.core import HomeAssistant, State
+
+from . import update_callback_entity
+
+from tests.common import MockConfigEntry, mock_restore_cache
+
+
+async def _setup(hass: HomeAssistant, mock_config_entry: MockConfigEntry) -> None:
+    """Set up the velux integration with only the cover platform loaded."""
+    mock_config_entry.add_to_hass(hass)
+    with patch("homeassistant.components.velux.PLATFORMS", [Platform.COVER]):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+
+@pytest.mark.parametrize("mock_pyvlx", ["mock_window"], indirect=True)
+async def test_cover_seeds_position_from_live_pyvlx_when_known_at_startup(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_pyvlx: AsyncMock,
+    mock_window: AsyncMock,
+) -> None:
+    """If pyvlx already knows the position, seed the restore cache from it.
+
+    Subsequent transient UNKNOWN frames must then fall back to that cached
+    live value instead of dropping the entity to `unknown`.
+    """
+    # pyvlx already has a concrete position at startup.
+    mock_window.position.position_percent = 30  # HA = 70
+    mock_window.position.known = True
+    mock_window.position.closed = False
+
+    await _setup(hass, mock_config_entry)
+
+    entity_id = "cover.test_window"
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_OPEN
+    assert state.attributes.get(ATTR_CURRENT_POSITION) == 70
+
+    # pyvlx transitions back to UNKNOWN (e.g. reconnect mid-session).
+    mock_window.position.known = False
+    await update_callback_entity(hass, mock_window)
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    # Fallback uses the cached live value rather than going `unknown`.
+    assert state.state == STATE_OPEN
+    assert state.attributes.get(ATTR_CURRENT_POSITION) == 70
+
+
+@pytest.mark.parametrize("mock_pyvlx", ["mock_window"], indirect=True)
+async def test_cover_seeds_position_from_persisted_attribute_when_unknown_at_startup(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_pyvlx: AsyncMock,
+    mock_window: AsyncMock,
+) -> None:
+    """When pyvlx is UNKNOWN at startup, seed from the persisted attribute.
+
+    Reproduces the KLF200-reboot scenario: after async_unload_entry the
+    gateway is rebooted and reports `current_position = UNKNOWN` for tens
+    of seconds. HA persists the previous run's attribute and we use it to
+    avoid the `unknown` window.
+    """
+    mock_window.position.known = False
+
+    mock_restore_cache(
+        hass,
+        [
+            State(
+                "cover.test_window",
+                STATE_OPEN,
+                attributes={ATTR_CURRENT_POSITION: 70},
+            ),
+        ],
+    )
+
+    await _setup(hass, mock_config_entry)
+
+    state = hass.states.get("cover.test_window")
+    assert state is not None
+    assert state.state == STATE_OPEN
+    assert state.attributes.get(ATTR_CURRENT_POSITION) == 70
+
+
+@pytest.mark.parametrize("mock_pyvlx", ["mock_window"], indirect=True)
+async def test_cover_seeds_position_from_attribute_even_if_persisted_state_was_unknown(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_pyvlx: AsyncMock,
+    mock_window: AsyncMock,
+) -> None:
+    """A persisted attribute is honoured even if the persisted state was unknown.
+
+    HA may have written ``state="unknown"`` during a previous post-restart
+    UNKNOWN window while the ``current_position`` attribute was still a
+    usable number. We restore from the attribute regardless of the state
+    string.
+    """
+    mock_window.position.known = False
+
+    mock_restore_cache(
+        hass,
+        [
+            State(
+                "cover.test_window",
+                STATE_UNKNOWN,
+                attributes={ATTR_CURRENT_POSITION: 0},
+            ),
+        ],
+    )
+
+    await _setup(hass, mock_config_entry)
+
+    state = hass.states.get("cover.test_window")
+    assert state is not None
+    assert state.state == STATE_CLOSED
+    assert state.attributes.get(ATTR_CURRENT_POSITION) == 0
+
+
+@pytest.mark.parametrize("mock_pyvlx", ["mock_window"], indirect=True)
+@pytest.mark.parametrize(
+    "persisted_attribute",
+    [None, "not-a-number", -10, 150],
+    ids=["missing", "string", "below_zero", "above_hundred"],
+)
+async def test_cover_keeps_unknown_when_no_usable_seed(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_pyvlx: AsyncMock,
+    mock_window: AsyncMock,
+    persisted_attribute: object,
+) -> None:
+    """Without a usable live or persisted position the entity stays unknown."""
+    mock_window.position.known = False
+
+    attributes = (
+        {ATTR_CURRENT_POSITION: persisted_attribute}
+        if persisted_attribute is not None
+        else {}
+    )
+    mock_restore_cache(
+        hass,
+        [State("cover.test_window", STATE_UNAVAILABLE, attributes=attributes)],
+    )
+
+    await _setup(hass, mock_config_entry)
+
+    state = hass.states.get("cover.test_window")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes.get(ATTR_CURRENT_POSITION) is None
+
+
+@pytest.mark.parametrize("mock_pyvlx", ["mock_window"], indirect=True)
+async def test_cover_refreshes_cache_on_live_update(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_pyvlx: AsyncMock,
+    mock_window: AsyncMock,
+) -> None:
+    """Every concrete pyvlx update refreshes the restore cache.
+
+    Otherwise a transient UNKNOWN after a mid-session reconnect would
+    fall back to a stale value (the initial seed) rather than to the
+    most recent known live value.
+    """
+    mock_window.position.position_percent = 30  # HA = 70
+    mock_window.position.known = True
+    mock_window.position.closed = False
+
+    await _setup(hass, mock_config_entry)
+
+    # Live update moves the cover to HA position 20 (device 80%).
+    mock_window.position.position_percent = 80
+    await update_callback_entity(hass, mock_window)
+
+    # Now pyvlx transitions back to UNKNOWN.
+    mock_window.position.known = False
+    await update_callback_entity(hass, mock_window)
+
+    state = hass.states.get("cover.test_window")
+    assert state is not None
+    # Cache must reflect the most recent live value, not the startup seed.
+    assert state.attributes.get(ATTR_CURRENT_POSITION) == 20
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "part_attr"),
+    [
+        ("cover.test_dual_roller_shutter", "position"),
+        ("cover.test_dual_roller_shutter_upper_shutter", "position_upper_curtain"),
+        ("cover.test_dual_roller_shutter_lower_shutter", "position_lower_curtain"),
+    ],
+)
+@pytest.mark.parametrize("mock_pyvlx", ["mock_dual_roller_shutter"], indirect=True)
+async def test_dual_roller_shutter_parts_seed_from_persisted_attribute(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_pyvlx: AsyncMock,
+    mock_dual_roller_shutter: AsyncMock,
+    entity_id: str,
+    part_attr: str,
+) -> None:
+    """Each dual-roller-shutter part restores from its own persisted attribute."""
+    getattr(mock_dual_roller_shutter, part_attr).known = False
+
+    mock_restore_cache(
+        hass,
+        [State(entity_id, STATE_OPEN, attributes={ATTR_CURRENT_POSITION: 60})],
+    )
+
+    await _setup(hass, mock_config_entry)
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_OPEN
+    assert state.attributes.get(ATTR_CURRENT_POSITION) == 60


### PR DESCRIPTION
## Proposed change

After every Home Assistant restart, all Velux cover entities currently
render as `unknown` for tens of seconds — sometimes several minutes —
until pyvlx receives the first concrete House Monitoring frame for
each node. The window is opened by `pyvlx.disconnect()` in
`async_unload_entry`, which reboots the KLF200 as a load-bearing
workaround for several KLF firmware bugs (pyvlx
[#366](https://github.com/Julius2342/pyvlx/pull/366): hangs after
long sessions, failed SSL handshakes on reconnect). On
IGNORE-position actuators (gates, some garage doors) the window can
stretch into the minute range, breaking automations keyed on
`is_closed`.

Mix `RestoreEntity` into `VeluxCover` so the cached HA
`current_position` attribute is brought back at startup.
`current_cover_position` and `is_closed` fall back to that cache
while `node.position.known` is `False`; the first concrete House
Monitoring frame overrides it transparently.

`is_opening` / `is_closing` are deliberately NOT restored — pyvlx
initialises them to `False` on every (re-)connect, which is the
correct starting point after a restart.

Two seed sources, in priority order:

1. The live pyvlx position when it is already known at startup. Also
   covers a mid-session UNKNOWN drop: the cache is refreshed from
   every concrete update in `after_update_callback`, so a transient
   UNKNOWN later falls back to the most recent live value rather
   than to the startup snapshot.
2. The `current_position` attribute persisted by HA's standard
   restore-state machinery. Accepted regardless of the persisted
   entity state string — HA may have written `state="unknown"`
   during a previous post-restart UNKNOWN window while the attribute
   was still a usable number.

`VeluxDualRollerShutter` participates in the same fallback through a
small `_live_position_percent` override, so each part (upper / lower
/ dual) refreshes from its own `_part_position` instead of the
device-level `node.position`.

### Test changes

The two existing `test_..._unknown_position` tests previously
asserted that an UNKNOWN frame drops the entity to `unknown`. With
the cache in place the entity stays at the last known position.
Those tests are updated and renamed to document the new fallback
contract; the legacy `unknown` behaviour (no live seed and no
usable persisted attribute) is exercised in
`test_cover_keeps_unknown_when_no_usable_seed` in the new
`test_cover_restore_state.py` module.

The new test module covers the seed paths (live seed, persisted
attribute, persisted-state-unknown-but-attribute-usable, no usable
seed) as well as the cache-refresh-on-live-update path and the
dual-roller-shutter per-part seeding.

### Validated on a private installation

Tested against a 17-cover setup (`Window`, `RollerShutter`,
`GarageDoor`, `Gate`) before and after restart. Without the change,
gate and garage stayed `unknown` for ~30 s up to several minutes
after every restart; with the change all entities render the last
known position from the first state write.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr