### PR TITLE
Use proper user-agent to fetch feeds

### DIFF
--- a/homeassistant/components/feedreader/config_flow.py
+++ b/homeassistant/components/feedreader/config_flow.py
@@ -23,14 +23,18 @@ from homeassistant.helpers.selector import (
     TextSelectorType,
 )
 
-from .const import CONF_MAX_ENTRIES, DEFAULT_MAX_ENTRIES, DOMAIN
+from .const import CONF_MAX_ENTRIES, DEFAULT_MAX_ENTRIES, DOMAIN, USER_AGENT
 
 LOGGER = logging.getLogger(__name__)
 
 
 async def async_fetch_feed(hass: HomeAssistant, url: str) -> feedparser.FeedParserDict:
     """Fetch the feed."""
-    return await hass.async_add_executor_job(feedparser.parse, url)
+
+    def _parse_feed() -> feedparser.FeedParserDict:
+        return feedparser.parse(url, agent=USER_AGENT)
+
+    return await hass.async_add_executor_job(_parse_feed)
 
 
 class FeedReaderConfigFlow(ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/feedreader/const.py
+++ b/homeassistant/components/feedreader/const.py
@@ -3,6 +3,8 @@
 from datetime import timedelta
 from typing import Final
 
+from homeassistant.const import APPLICATION_NAME, __version__ as ha_version
+
 DOMAIN: Final[str] = "feedreader"
 
 CONF_MAX_ENTRIES: Final[str] = "max_entries"
@@ -10,3 +12,5 @@ DEFAULT_MAX_ENTRIES: Final[int] = 20
 DEFAULT_SCAN_INTERVAL: Final[timedelta] = timedelta(hours=1)
 
 EVENT_FEEDREADER: Final[str] = "feedreader"
+
+USER_AGENT: Final[str] = f"{APPLICATION_NAME}/{ha_version}"

--- a/homeassistant/components/feedreader/coordinator.py
+++ b/homeassistant/components/feedreader/coordinator.py
@@ -18,7 +18,13 @@ from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
-from .const import CONF_MAX_ENTRIES, DEFAULT_SCAN_INTERVAL, DOMAIN, EVENT_FEEDREADER
+from .const import (
+    CONF_MAX_ENTRIES,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    EVENT_FEEDREADER,
+    USER_AGENT,
+)
 
 DELAY_SAVE = 30
 STORAGE_VERSION = 1
@@ -74,6 +80,7 @@ class FeedReaderCoordinator(
                 self.url,
                 etag=None if not self._feed else self._feed.get("etag"),
                 modified=None if not self._feed else self._feed.get("modified"),
+                agent=USER_AGENT,
             )
 
         feed = await self.hass.async_add_executor_job(_parse_feed)

--- a/tests/components/feedreader/const.py
+++ b/tests/components/feedreader/const.py
@@ -4,9 +4,10 @@ from homeassistant.components.feedreader.const import (
     CONF_MAX_ENTRIES,
     DEFAULT_MAX_ENTRIES,
 )
-from homeassistant.const import CONF_URL
+from homeassistant.const import APPLICATION_NAME, CONF_URL, __version__ as ha_version
 
 URL = "http://some.rss.local/rss_feed.xml"
+USER_AGENT = f"{APPLICATION_NAME}/{ha_version}"
 FEED_TITLE = "RSS Sample"
 VALID_CONFIG_DEFAULT = {CONF_URL: URL, CONF_MAX_ENTRIES: DEFAULT_MAX_ENTRIES}
 VALID_CONFIG_100 = {CONF_URL: URL, CONF_MAX_ENTRIES: 100}

--- a/tests/components/feedreader/test_config_flow.py
+++ b/tests/components/feedreader/test_config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import create_mock_entry
-from .const import FEED_TITLE, URL, VALID_CONFIG_DEFAULT
+from .const import FEED_TITLE, URL, USER_AGENT, VALID_CONFIG_DEFAULT
 
 
 @pytest.fixture(name="feedparser")
@@ -53,6 +53,9 @@ async def test_user(hass: HomeAssistant, feedparser, setup_entry) -> None:
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_URL: URL}
     )
+    # check user-agent
+    assert feedparser.call_args.args[3] == USER_AGENT
+    # check flow result
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == FEED_TITLE
     assert result["data"][CONF_URL] == URL

--- a/tests/components/feedreader/test_init.py
+++ b/tests/components/feedreader/test_init.py
@@ -19,6 +19,7 @@ from homeassistant.util import dt as dt_util
 from . import async_setup_config_entry, create_mock_entry
 from .const import (
     URL,
+    USER_AGENT,
     VALID_CONFIG_1,
     VALID_CONFIG_5,
     VALID_CONFIG_100,
@@ -398,3 +399,17 @@ async def test_feed_atom_htmlentities(
             identifiers={(DOMAIN, entry.entry_id)}
         )
         assert device_entry.manufacturer == "Juan Pérez"
+
+
+async def test_feedparser_user_agent(hass: HomeAssistant, feed_one_event) -> None:
+    """Test that the correct user-agent is used for feedparser requests."""
+    entry = create_mock_entry(VALID_CONFIG_DEFAULT)
+    entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.feedreader.coordinator.feedparser.http.get"
+    ) as feedparser:
+        feedparser.return_value = feed_one_event
+        await hass.config_entries.async_setup(entry.entry_id)
+
+        # check user-agent
+        assert feedparser.call_args.args[3] == USER_AGENT


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The default user-agent of the `feedparser` lib is `f"feedparser/{version} +https://github.com/kurtmckee/feedparser/"` which cause some feed provider to block the request. We now use `f"HomeAssistant/{ha_version}"` (_eq `HomeAssistant/2026.5.4`_) as user-agent.
As the `feedparser` lib doesn't take a httpx or aiohttp session as argument, I decided to not use `homeassistant.helpers.aiohttp_client.SERVER_SOFTWARE` nor `homeassistant.helpers.httpx_client.SERVER_SOFTWARE` as user-agent, rather to create an own for the feedreader integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #159250
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
