### PR TITLE
Run Overkiz unique ID migration only once via config entry version

### DIFF
--- a/homeassistant/components/overkiz/__init__.py
+++ b/homeassistant/components/overkiz/__init__.py
@@ -199,16 +199,16 @@ async def async_migrate_entry(
 ) -> bool:
     """Migrate old entry."""
     if entry.version == 1 and entry.minor_version < 2:
-        await _async_migrate_unique_ids(hass, entry)
+        await _async_migrate_strenum_unique_ids(hass, entry)
         hass.config_entries.async_update_entry(entry, minor_version=2)
 
     return True
 
 
-async def _async_migrate_unique_ids(
+async def _async_migrate_strenum_unique_ids(
     hass: HomeAssistant, config_entry: OverkizDataConfigEntry
 ) -> None:
-    """Migrate entities to new unique IDs."""
+    """Migrate entities to the StrEnum-style unique IDs."""
     entity_registry = er.async_get(hass)
 
     @callback

--- a/homeassistant/components/overkiz/__init__.py
+++ b/homeassistant/components/overkiz/__init__.py
@@ -93,8 +93,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: OverkizDataConfigEntry) 
             server=SUPPORTED_SERVERS[entry.data[CONF_HUB]],
         )
 
-    await _async_migrate_entries(hass, entry)
-
     try:
         await client.login()
         setup = await client.get_setup()
@@ -196,9 +194,20 @@ async def async_unload_entry(
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
+async def async_migrate_entry(
+    hass: HomeAssistant, entry: OverkizDataConfigEntry
+) -> bool:
+    """Migrate old entry."""
+    if entry.version == 1 and entry.minor_version < 2:
+        await _async_migrate_entries(hass, entry)
+        hass.config_entries.async_update_entry(entry, minor_version=2)
+
+    return True
+
+
 async def _async_migrate_entries(
     hass: HomeAssistant, config_entry: OverkizDataConfigEntry
-) -> bool:
+) -> None:
     """Migrate old entries to new unique IDs."""
     entity_registry = er.async_get(hass)
 
@@ -255,8 +264,6 @@ async def _async_migrate_entries(
         return None
 
     await er.async_migrate_entries(hass, config_entry.entry_id, update_unique_id)
-
-    return True
 
 
 def create_local_client(

--- a/homeassistant/components/overkiz/__init__.py
+++ b/homeassistant/components/overkiz/__init__.py
@@ -199,16 +199,16 @@ async def async_migrate_entry(
 ) -> bool:
     """Migrate old entry."""
     if entry.version == 1 and entry.minor_version < 2:
-        await _async_migrate_entries(hass, entry)
+        await _async_migrate_unique_ids(hass, entry)
         hass.config_entries.async_update_entry(entry, minor_version=2)
 
     return True
 
 
-async def _async_migrate_entries(
+async def _async_migrate_unique_ids(
     hass: HomeAssistant, config_entry: OverkizDataConfigEntry
 ) -> None:
-    """Migrate old entries to new unique IDs."""
+    """Migrate entities to new unique IDs."""
     entity_registry = er.async_get(hass)
 
     @callback

--- a/homeassistant/components/overkiz/__init__.py
+++ b/homeassistant/components/overkiz/__init__.py
@@ -198,6 +198,9 @@ async def async_migrate_entry(
     hass: HomeAssistant, entry: OverkizDataConfigEntry
 ) -> bool:
     """Migrate old entry."""
+    if entry.version > 1:
+        return False
+
     if entry.version == 1 and entry.minor_version < 2:
         await _async_migrate_strenum_unique_ids(hass, entry)
         hass.config_entries.async_update_entry(entry, minor_version=2)

--- a/homeassistant/components/overkiz/config_flow.py
+++ b/homeassistant/components/overkiz/config_flow.py
@@ -40,6 +40,7 @@ class OverkizConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Overkiz (by Somfy)."""
 
     VERSION = 1
+    MINOR_VERSION = 2
 
     _verify_ssl: bool = True
     _api_type: APIType = APIType.CLOUD

--- a/tests/components/overkiz/test_init.py
+++ b/tests/components/overkiz/test_init.py
@@ -25,6 +25,7 @@ async def test_unique_id_migration(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         unique_id=TEST_GATEWAY_ID,
         data={"username": TEST_EMAIL, "password": TEST_PASSWORD, "hub": TEST_SERVER},
+        minor_version=1,
     )
 
     mock_entry.add_to_hass(hass)
@@ -90,3 +91,6 @@ async def test_unique_id_migration(hass: HomeAssistant) -> None:
     for entity_id, unique_id in unique_id_map.items():
         entry = ent_reg.async_get(entity_id)
         assert entry.unique_id == unique_id
+
+    # Test if the config entry is migrated to the latest minor version
+    assert mock_entry.minor_version == 2


### PR DESCRIPTION
## Proposed change

The Overkiz StrEnum unique ID migration (`_async_migrate_strenum_unique_ids`, previously `_async_migrate_entries`) used to run unconditionally on every `async_setup_entry`, iterating the entire entity registry on every Home Assistant startup. This work only ever needs to happen once, when migrating old enum-member-style unique IDs to the StrEnum string values that were introduced when pyOverkiz switched to `StrEnum`.

This PR gates the migration behind the config entry version:

- Added `MINOR_VERSION = 2` to the config flow.
- Added an `async_migrate_entry` hook that runs `_async_migrate_strenum_unique_ids` only when `entry.minor_version < 2`, then bumps the entry to minor version 2.
- Renamed the generic `_async_migrate_entries` helper to `_async_migrate_strenum_unique_ids` to disambiguate it from the new `async_migrate_entry` config-entry hook and to describe what it actually does (rewriting old enum-member-style unique IDs to the StrEnum string values).
- Updated the test so the mock config entry starts at `minor_version=1` and asserts it migrates to `2`.

As a result, the migration runs once per install and is skipped on every subsequent startup. This does not change user-facing behavior for already-migrated installs; it simply stops the one-time migration from re-running on every startup.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr