### PR TITLE
Retry transient Overkiz server unavailable errors

### DIFF
--- a/homeassistant/components/overkiz/coordinator.py
+++ b/homeassistant/components/overkiz/coordinator.py
@@ -13,6 +13,7 @@ from pyoverkiz.exceptions import (
     InvalidEventListenerIdException,
     MaintenanceException,
     NotAuthenticatedException,
+    ServiceUnavailableException,
     TooManyConcurrentRequestsException,
     TooManyRequestsException,
 )
@@ -85,6 +86,8 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
             raise UpdateFailed("Too many requests, try again later.") from exception
         except MaintenanceException as exception:
             raise UpdateFailed("Server is down for maintenance.") from exception
+        except ServiceUnavailableException as exception:
+            raise UpdateFailed("Server is unavailable.") from exception
         except InvalidEventListenerIdException as exception:
             raise UpdateFailed(exception) from exception
         except (TimeoutError, ClientConnectorError) as exception:

--- a/tests/components/overkiz/test_coordinator.py
+++ b/tests/components/overkiz/test_coordinator.py
@@ -1,59 +1,24 @@
 """Tests for the Overkiz data update coordinator."""
 
-from freezegun.api import FrozenDateTimeFactory
-from pyoverkiz.exceptions import MaintenanceException, ServiceUnavailableException
-import pytest
+from pyoverkiz.exceptions import ServiceUnavailableException
 
-from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from .conftest import MockOverkizClient, SetupOverkizIntegration
 
-from tests.common import MockConfigEntry, async_fire_time_changed
 
-# A stateful setup so the coordinator polls on the regular update interval
-# (a fully stateless setup falls back to a 60 minute interval).
-STATEFUL_FIXTURE = "setup/cloud_somfy_tahoma_switch_europe.json"
-
-
-async def _trigger_refresh(
-    hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
-    config_entry: MockConfigEntry,
-) -> None:
-    """Advance time to trigger a single coordinator refresh."""
-    freezer.tick(config_entry.runtime_data.coordinator.update_interval)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-
-
-def _has_reauth(hass: HomeAssistant, config_entry: MockConfigEntry) -> bool:
-    """Return whether a reauthentication flow is in progress for the entry."""
-    return any(config_entry.async_get_active_flows(hass, {"reauth"}))
-
-
-@pytest.mark.parametrize(
-    "exception",
-    [
-        ServiceUnavailableException("Server is unavailable."),
-        MaintenanceException("Server is down for maintenance"),
-    ],
-    ids=["service_unavailable", "maintenance"],
-)
-async def test_transient_server_error_is_retried(
+async def test_service_unavailable_is_retried(
     hass: HomeAssistant,
     setup_overkiz_integration: SetupOverkizIntegration,
     mock_client: MockOverkizClient,
-    freezer: FrozenDateTimeFactory,
-    exception: Exception,
 ) -> None:
-    """Transient server errors fail the update without reauthenticating."""
-    config_entry = await setup_overkiz_integration(fixture=STATEFUL_FIXTURE)
-    assert config_entry.state is ConfigEntryState.LOADED
+    """A transient server error is translated into a retryable UpdateFailed."""
+    config_entry = await setup_overkiz_integration()
+    coordinator = config_entry.runtime_data.coordinator
 
-    mock_client.fetch_events.side_effect = exception
-    await _trigger_refresh(hass, freezer, config_entry)
+    mock_client.fetch_events.side_effect = ServiceUnavailableException("Server error")
+    await coordinator.async_refresh()
 
-    # The entry stays loaded (retried) and no reauth flow is started.
-    assert config_entry.state is ConfigEntryState.LOADED
-    assert not _has_reauth(hass, config_entry)
+    assert coordinator.last_update_success is False
+    assert isinstance(coordinator.last_exception, UpdateFailed)

--- a/tests/components/overkiz/test_coordinator.py
+++ b/tests/components/overkiz/test_coordinator.py
@@ -1,6 +1,16 @@
 """Tests for the Overkiz data update coordinator."""
 
-from pyoverkiz.exceptions import ServiceUnavailableException
+from unittest.mock import Mock
+
+from aiohttp import ClientConnectorError
+from pyoverkiz.exceptions import (
+    InvalidEventListenerIdException,
+    MaintenanceException,
+    ServiceUnavailableException,
+    TooManyConcurrentRequestsException,
+    TooManyRequestsException,
+)
+import pytest
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import UpdateFailed
@@ -8,16 +18,38 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 from .conftest import MockOverkizClient, SetupOverkizIntegration
 
 
-async def test_service_unavailable_is_retried(
+@pytest.mark.parametrize(
+    "exception",
+    [
+        TooManyConcurrentRequestsException("Too many concurrent requests"),
+        TooManyRequestsException("Too many requests"),
+        MaintenanceException("Server is down for maintenance"),
+        ServiceUnavailableException("Server is unavailable"),
+        InvalidEventListenerIdException("Invalid event listener id"),
+        TimeoutError("Timed out"),
+        ClientConnectorError(Mock(), Mock()),
+    ],
+    ids=[
+        "too_many_concurrent_requests",
+        "too_many_requests",
+        "maintenance",
+        "service_unavailable",
+        "invalid_event_listener_id",
+        "timeout",
+        "client_connector_error",
+    ],
+)
+async def test_transient_error_is_retried(
     hass: HomeAssistant,
     setup_overkiz_integration: SetupOverkizIntegration,
     mock_client: MockOverkizClient,
+    exception: Exception,
 ) -> None:
-    """A transient server error is translated into a retryable UpdateFailed."""
+    """Transient errors are translated into a retryable UpdateFailed."""
     config_entry = await setup_overkiz_integration()
     coordinator = config_entry.runtime_data.coordinator
 
-    mock_client.fetch_events.side_effect = ServiceUnavailableException("Server error")
+    mock_client.fetch_events.side_effect = exception
     await coordinator.async_refresh()
 
     assert coordinator.last_update_success is False

--- a/tests/components/overkiz/test_coordinator.py
+++ b/tests/components/overkiz/test_coordinator.py
@@ -54,7 +54,6 @@ async def test_transient_error_is_retried(
     setup_overkiz_integration: SetupOverkizIntegration,
     mock_client: MockOverkizClient,
     freezer: FrozenDateTimeFactory,
-    caplog: pytest.LogCaptureFixture,
     exception: Exception,
 ) -> None:
     """Transient errors are handled cleanly: entities go unavailable, then recover."""
@@ -63,15 +62,13 @@ async def test_transient_error_is_retried(
     initial_state = hass.states.get(TEMPERATURE_SENSOR.entity_id)
     assert initial_state.state != STATE_UNAVAILABLE
 
-    # A transient error during a refresh makes the entities unavailable, without
-    # surfacing it as an unexpected coordinator error.
+    # A transient error during a refresh makes the entities unavailable.
     mock_client.fetch_events.side_effect = exception
     freezer.tick(UPDATE_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     assert hass.states.get(TEMPERATURE_SENSOR.entity_id).state == STATE_UNAVAILABLE
-    assert "Unexpected error fetching" not in caplog.text
 
     # Once the server recovers, the next refresh restores the entities.
     mock_client.fetch_events.side_effect = None

--- a/tests/components/overkiz/test_coordinator.py
+++ b/tests/components/overkiz/test_coordinator.py
@@ -1,0 +1,59 @@
+"""Tests for the Overkiz data update coordinator."""
+
+from freezegun.api import FrozenDateTimeFactory
+from pyoverkiz.exceptions import MaintenanceException, ServiceUnavailableException
+import pytest
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from .conftest import MockOverkizClient, SetupOverkizIntegration
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+# A stateful setup so the coordinator polls on the regular update interval
+# (a fully stateless setup falls back to a 60 minute interval).
+STATEFUL_FIXTURE = "setup/cloud_nexity_rail_din_europe.json"
+
+
+async def _trigger_refresh(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Advance time to trigger a single coordinator refresh."""
+    freezer.tick(config_entry.runtime_data.coordinator.update_interval)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+
+def _has_reauth(hass: HomeAssistant, config_entry: MockConfigEntry) -> bool:
+    """Return whether a reauthentication flow is in progress for the entry."""
+    return any(config_entry.async_get_active_flows(hass, {"reauth"}))
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        ServiceUnavailableException("Server is unavailable."),
+        MaintenanceException("Server is down for maintenance"),
+    ],
+    ids=["service_unavailable", "maintenance"],
+)
+async def test_transient_server_error_is_retried(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+    exception: Exception,
+) -> None:
+    """Transient server errors fail the update without reauthenticating."""
+    config_entry = await setup_overkiz_integration(fixture=STATEFUL_FIXTURE)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    mock_client.fetch_events.side_effect = exception
+    await _trigger_refresh(hass, freezer, config_entry)
+
+    # The entry stays loaded (retried) and no reauth flow is started.
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert not _has_reauth(hass, config_entry)

--- a/tests/components/overkiz/test_coordinator.py
+++ b/tests/components/overkiz/test_coordinator.py
@@ -3,6 +3,7 @@
 from unittest.mock import Mock
 
 from aiohttp import ClientConnectorError
+from freezegun.api import FrozenDateTimeFactory
 from pyoverkiz.exceptions import (
     InvalidEventListenerIdException,
     MaintenanceException,
@@ -12,10 +13,19 @@ from pyoverkiz.exceptions import (
 )
 import pytest
 
+from homeassistant.components.overkiz.const import UPDATE_INTERVAL
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import UpdateFailed
 
-from .conftest import MockOverkizClient, SetupOverkizIntegration
+from .conftest import FixtureDevice, MockOverkizClient, SetupOverkizIntegration
+
+from tests.common import async_fire_time_changed
+
+TEMPERATURE_SENSOR = FixtureDevice(
+    "setup/cloud_nexity_rail_din_europe.json",
+    "io://1234-5678-1698/15702199#2",
+    "sensor.maple_residence_garden_radiator_bathroom_temperature_sensor_temperature",
+)
 
 
 @pytest.mark.parametrize(
@@ -43,14 +53,31 @@ async def test_transient_error_is_retried(
     hass: HomeAssistant,
     setup_overkiz_integration: SetupOverkizIntegration,
     mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
     exception: Exception,
 ) -> None:
-    """Transient errors are translated into a retryable UpdateFailed."""
-    config_entry = await setup_overkiz_integration()
-    coordinator = config_entry.runtime_data.coordinator
+    """Transient errors are handled cleanly: entities go unavailable, then recover."""
+    await setup_overkiz_integration(fixture=TEMPERATURE_SENSOR.fixture)
 
+    initial_state = hass.states.get(TEMPERATURE_SENSOR.entity_id)
+    assert initial_state.state != STATE_UNAVAILABLE
+
+    # A transient error during a refresh makes the entities unavailable, without
+    # surfacing it as an unexpected coordinator error.
     mock_client.fetch_events.side_effect = exception
-    await coordinator.async_refresh()
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
-    assert coordinator.last_update_success is False
-    assert isinstance(coordinator.last_exception, UpdateFailed)
+    assert hass.states.get(TEMPERATURE_SENSOR.entity_id).state == STATE_UNAVAILABLE
+    assert "Unexpected error fetching" not in caplog.text
+
+    # Once the server recovers, the next refresh restores the entities.
+    mock_client.fetch_events.side_effect = None
+    mock_client.fetch_events.return_value = []
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(TEMPERATURE_SENSOR.entity_id).state == initial_state.state

--- a/tests/components/overkiz/test_coordinator.py
+++ b/tests/components/overkiz/test_coordinator.py
@@ -13,7 +13,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 
 # A stateful setup so the coordinator polls on the regular update interval
 # (a fully stateless setup falls back to a 60 minute interval).
-STATEFUL_FIXTURE = "setup/cloud_nexity_rail_din_europe.json"
+STATEFUL_FIXTURE = "setup/cloud_somfy_tahoma_switch_europe.json"
 
 
 async def _trigger_refresh(


### PR DESCRIPTION
## Proposed change

First fix required for https://github.com/home-assistant/core/issues/160761; next to an pyOverkiz update (new PR).

The Overkiz data update coordinator escalated a transient `503 Service Unavailable` from the cloud servers into an unexpected coordinator error. pyoverkiz surfaces this as a typed `ServiceUnavailableException`, so this PR catches it in `_async_update_data` and raises `UpdateFailed("Server is unavailable.")`, allowing the coordinator to retry instead of logging it as an unexpected error.

A new `tests/components/overkiz/test_coordinator.py` parametrizes over all exceptions the coordinator translates into a retryable `UpdateFailed` (too many concurrent requests, too many requests, maintenance, service unavailable, invalid event listener id, timeout, client connector error), asserting `last_update_success is False` and that `last_exception` is an `UpdateFailed`. The `service_unavailable` case fails without the fix.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
