### PR TITLE
Bump victron-mqtt to 2026.6.1

### DIFF
--- a/homeassistant/components/victron_gx/entity.py
+++ b/homeassistant/components/victron_gx/entity.py
@@ -41,6 +41,7 @@ class VictronBaseEntity(Entity):
         self._attr_device_info = device_info
         self._attr_unique_id = f"{installation_id}_{metric.unique_id}"
         self._attr_suggested_display_precision = metric.precision
+        self._attr_native_unit_of_measurement = None
         # Always set translation_key so HA can resolve
         # state/option translations (e.g. select options).
         self._attr_translation_key = metric.generic_short_id.replace("{", "").replace(

--- a/homeassistant/components/victron_gx/entity.py
+++ b/homeassistant/components/victron_gx/entity.py
@@ -61,7 +61,7 @@ class VictronBaseEntity(Entity):
             metric.generic_short_id not in ENTITIES_DISABLE_BY_DEFAULT
         )
 
-    def _set_translation(self) -> None:
+    def _set_unit_translation(self) -> None:
         unit_of_measurement = self._metric.unit_of_measurement
         # We need to set the _attr_native_unit_of_measurement in three cases:
         if (

--- a/homeassistant/components/victron_gx/entity.py
+++ b/homeassistant/components/victron_gx/entity.py
@@ -41,7 +41,6 @@ class VictronBaseEntity(Entity):
         self._attr_device_info = device_info
         self._attr_unique_id = f"{installation_id}_{metric.unique_id}"
         self._attr_suggested_display_precision = metric.precision
-        self._attr_native_unit_of_measurement = None
         # Always set translation_key so HA can resolve
         # state/option translations (e.g. select options).
         self._attr_translation_key = metric.generic_short_id.replace("{", "").replace(
@@ -62,9 +61,9 @@ class VictronBaseEntity(Entity):
             metric.generic_short_id not in ENTITIES_DISABLE_BY_DEFAULT
         )
 
-    def _set_unit_translation(self) -> None:
+    def _native_unit_of_measurement(self) -> str | None:
         unit_of_measurement = self._metric.unit_of_measurement
-        # We need to set the _attr_native_unit_of_measurement in three cases:
+        # We need to provide a native unit in three cases:
         if (
             # 1. Special units which will never need a translation and therefore will not be included in the translation file.
             unit_of_measurement in SPECIAL_NATIVE_UNITS
@@ -78,7 +77,9 @@ class VictronBaseEntity(Entity):
             # entry, so we must set the unit programmatically.
             or self._metric.metric_type == MetricType.DYNAMIC
         ):
-            self._attr_native_unit_of_measurement = unit_of_measurement
+            return unit_of_measurement
+
+        return None
 
     @callback
     @abstractmethod

--- a/homeassistant/components/victron_gx/entity.py
+++ b/homeassistant/components/victron_gx/entity.py
@@ -3,7 +3,11 @@
 from abc import abstractmethod
 from typing import Any
 
-from victron_mqtt import Device as VictronVenusDevice, Metric as VictronVenusMetric
+from victron_mqtt import (
+    Device as VictronVenusDevice,
+    Metric as VictronVenusMetric,
+    MetricType,
+)
 
 from homeassistant.const import EntityCategory
 from homeassistant.core import callback
@@ -14,6 +18,8 @@ from homeassistant.helpers.entity import Entity
 ENTITIES_CATEGORY_DIAGNOSTIC = ["system_heartbeat", "platform_device_reboot"]
 # Entities that should be disabled by default
 ENTITIES_DISABLE_BY_DEFAULT = ["system_heartbeat", "platform_device_reboot"]
+# Units that must be provided directly instead of via localization.
+SPECIAL_NATIVE_UNITS = {"%", "Ah"}
 
 
 class VictronBaseEntity(Entity):
@@ -46,10 +52,6 @@ class VictronBaseEntity(Entity):
         if metric.main_topic:
             self._attr_name = None
 
-        # Special case for "%" as it should not be coming from the localization file
-        self._attr_native_unit_of_measurement = (
-            "%" if metric.unit_of_measurement == "%" else None
-        )
         self._attr_entity_category = (
             EntityCategory.DIAGNOSTIC
             if metric.generic_short_id in ENTITIES_CATEGORY_DIAGNOSTIC
@@ -58,6 +60,24 @@ class VictronBaseEntity(Entity):
         self._attr_entity_registry_enabled_default = (
             metric.generic_short_id not in ENTITIES_DISABLE_BY_DEFAULT
         )
+
+    def _set_translation(self) -> None:
+        unit_of_measurement = self._metric.unit_of_measurement
+        # We need to set the _attr_native_unit_of_measurement in three cases:
+        if (
+            # 1. Special units which will never need a translation and therefore will not be included in the translation file.
+            unit_of_measurement in SPECIAL_NATIVE_UNITS
+            # 2. When there is known device class which support multiple units. In this case
+            # we publish what we have and HA will allow conversion to other supported units.
+            # We specifically don't put those cases in the translation file by the merge script
+            # not to waste translation resources so it has to come from here.
+            or self._attr_device_class is not None
+            # 3. Dynamic units come from user-configured MQTT topics (e.g.
+            # SwitchableOutput Settings/Unit) and have no translation file
+            # entry, so we must set the unit programmatically.
+            or self._metric.metric_type == MetricType.DYNAMIC
+        ):
+            self._attr_native_unit_of_measurement = unit_of_measurement
 
     @callback
     @abstractmethod

--- a/homeassistant/components/victron_gx/manifest.json
+++ b/homeassistant/components/victron_gx/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "quality_scale": "platinum",
-  "requirements": ["victron-mqtt==2026.5.4"],
+  "requirements": ["victron-mqtt==2026.5.13"],
   "ssdp": [
     {
       "X_MqttOnLan": "1",

--- a/homeassistant/components/victron_gx/manifest.json
+++ b/homeassistant/components/victron_gx/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "quality_scale": "platinum",
-  "requirements": ["victron-mqtt==2026.5.13"],
+  "requirements": ["victron-mqtt==2026.6.1"],
   "ssdp": [
     {
       "X_MqttOnLan": "1",

--- a/homeassistant/components/victron_gx/number.py
+++ b/homeassistant/components/victron_gx/number.py
@@ -79,7 +79,7 @@ class VictronNumber(VictronBaseEntity, NumberEntity):
             # We need to set the _attr_native_unit_of_measurement in two cases:
             # 1. When there is known device class which support multiple units. In this case
             # we publish what we have and HA will allow conversion to other supported units.
-            # We specifically dont put those cases in the translation file by the merge script
+            # We specifically don't put those cases in the translation file by the merge script
             # not to waste translation resources so it has to come from here.
             # 2. Dynamic units come from user-configured MQTT topics (e.g.
             # SwitchableOutput Settings/Unit) and have no translation file

--- a/homeassistant/components/victron_gx/number.py
+++ b/homeassistant/components/victron_gx/number.py
@@ -72,10 +72,13 @@ class VictronNumber(VictronBaseEntity, NumberEntity):
         """Initialize the number entity."""
         super().__init__(device, metric, device_info, installation_id)
         self._attr_device_class = METRIC_TYPE_TO_DEVICE_CLASS.get(metric.metric_type)
-        if self._attr_device_class is not None or metric.metric_type == MetricType.DYNAMIC:
+        if (
+            self._attr_device_class is not None
+            or metric.metric_type == MetricType.DYNAMIC
+        ):
             # We need to set the _attr_native_unit_of_measurement in two cases:
             # 1. When there is known device class which support multiple units. In this case
-            # we publish what we have and HA will allow convertion to other supported units.
+            # we publish what we have and HA will allow conversion to other supported units.
             # We specifically dont put those cases in the translation file by the merge script
             # not to waste translation resources so it has to come from here.
             # 2. Dynamic units come from user-configured MQTT topics (e.g.

--- a/homeassistant/components/victron_gx/number.py
+++ b/homeassistant/components/victron_gx/number.py
@@ -32,6 +32,7 @@ METRIC_TYPE_TO_DEVICE_CLASS: dict[MetricType, NumberDeviceClass] = {
     MetricType.SPEED: NumberDeviceClass.SPEED,
     MetricType.LIQUID_VOLUME: NumberDeviceClass.VOLUME_STORAGE,
     MetricType.DURATION: NumberDeviceClass.DURATION,
+    MetricType.IRRADIANCE: NumberDeviceClass.IRRADIANCE,
 }
 
 
@@ -71,7 +72,15 @@ class VictronNumber(VictronBaseEntity, NumberEntity):
         """Initialize the number entity."""
         super().__init__(device, metric, device_info, installation_id)
         self._attr_device_class = METRIC_TYPE_TO_DEVICE_CLASS.get(metric.metric_type)
-        if self._attr_device_class is not None:
+        if self._attr_device_class is not None or metric.metric_type == MetricType.DYNAMIC:
+            # We need to set the _attr_native_unit_of_measurement in two cases:
+            # 1. When there is known device class which support multiple units. In this case
+            # we publish what we have and HA will allow convertion to other supported units.
+            # We specifically dont put those cases in the translation file by the merge script
+            # not to waste translation resources so it has to come from here.
+            # 2. Dynamic units come from user-configured MQTT topics (e.g.
+            # SwitchableOutput Settings/Unit) and have no translation file
+            # entry, so we must set the unit programmatically.
             self._attr_native_unit_of_measurement = metric.unit_of_measurement
         self._attr_native_value = metric.value
         if metric.min_value is not None:

--- a/homeassistant/components/victron_gx/number.py
+++ b/homeassistant/components/victron_gx/number.py
@@ -72,7 +72,7 @@ class VictronNumber(VictronBaseEntity, NumberEntity):
         """Initialize the number entity."""
         super().__init__(device, metric, device_info, installation_id)
         self._attr_device_class = METRIC_TYPE_TO_DEVICE_CLASS.get(metric.metric_type)
-        self._set_translation()
+        self._set_unit_translation()
         self._attr_native_value = metric.value
         if metric.min_value is not None:
             self._attr_native_min_value = metric.min_value

--- a/homeassistant/components/victron_gx/number.py
+++ b/homeassistant/components/victron_gx/number.py
@@ -72,19 +72,7 @@ class VictronNumber(VictronBaseEntity, NumberEntity):
         """Initialize the number entity."""
         super().__init__(device, metric, device_info, installation_id)
         self._attr_device_class = METRIC_TYPE_TO_DEVICE_CLASS.get(metric.metric_type)
-        if (
-            self._attr_device_class is not None
-            or metric.metric_type == MetricType.DYNAMIC
-        ):
-            # We need to set the _attr_native_unit_of_measurement in two cases:
-            # 1. When there is known device class which support multiple units. In this case
-            # we publish what we have and HA will allow conversion to other supported units.
-            # We specifically don't put those cases in the translation file by the merge script
-            # not to waste translation resources so it has to come from here.
-            # 2. Dynamic units come from user-configured MQTT topics (e.g.
-            # SwitchableOutput Settings/Unit) and have no translation file
-            # entry, so we must set the unit programmatically.
-            self._attr_native_unit_of_measurement = metric.unit_of_measurement
+        self._set_translation()
         self._attr_native_value = metric.value
         if metric.min_value is not None:
             self._attr_native_min_value = metric.min_value

--- a/homeassistant/components/victron_gx/number.py
+++ b/homeassistant/components/victron_gx/number.py
@@ -72,7 +72,7 @@ class VictronNumber(VictronBaseEntity, NumberEntity):
         """Initialize the number entity."""
         super().__init__(device, metric, device_info, installation_id)
         self._attr_device_class = METRIC_TYPE_TO_DEVICE_CLASS.get(metric.metric_type)
-        self._set_unit_translation()
+        self._attr_native_unit_of_measurement = self._native_unit_of_measurement()
         self._attr_native_value = metric.value
         if metric.min_value is not None:
             self._attr_native_min_value = metric.min_value

--- a/homeassistant/components/victron_gx/sensor.py
+++ b/homeassistant/components/victron_gx/sensor.py
@@ -38,6 +38,7 @@ METRIC_TYPE_TO_DEVICE_CLASS: dict[MetricType, SensorDeviceClass] = {
     MetricType.LIQUID_VOLUME: SensorDeviceClass.VOLUME_STORAGE,
     MetricType.DURATION: SensorDeviceClass.DURATION,
     MetricType.ENUM: SensorDeviceClass.ENUM,
+    MetricType.IRRADIANCE: SensorDeviceClass.IRRADIANCE,
 }
 
 METRIC_NATURE_TO_STATE_CLASS: dict[MetricNature, SensorStateClass] = {

--- a/homeassistant/components/victron_gx/sensor.py
+++ b/homeassistant/components/victron_gx/sensor.py
@@ -97,11 +97,7 @@ class VictronSensor(VictronBaseEntity, SensorEntity):
             self._attr_state_class = METRIC_NATURE_TO_STATE_CLASS.get(
                 metric.metric_nature
             )
-        # Only set native_unit_of_measurement when a device_class is present.
-        # Entities without a device_class get their display unit from
-        # the translation files instead.
-        if self._attr_device_class is not None:
-            self._attr_native_unit_of_measurement = metric.unit_of_measurement
+        self._set_translation()
         self._attr_native_value = VictronSensor._normalize_value(metric.value)
 
     @callback

--- a/homeassistant/components/victron_gx/sensor.py
+++ b/homeassistant/components/victron_gx/sensor.py
@@ -97,7 +97,7 @@ class VictronSensor(VictronBaseEntity, SensorEntity):
             self._attr_state_class = METRIC_NATURE_TO_STATE_CLASS.get(
                 metric.metric_nature
             )
-        self._set_unit_translation()
+        self._attr_native_unit_of_measurement = self._native_unit_of_measurement()
         self._attr_native_value = VictronSensor._normalize_value(metric.value)
 
     @callback

--- a/homeassistant/components/victron_gx/sensor.py
+++ b/homeassistant/components/victron_gx/sensor.py
@@ -97,7 +97,7 @@ class VictronSensor(VictronBaseEntity, SensorEntity):
             self._attr_state_class = METRIC_NATURE_TO_STATE_CLASS.get(
                 metric.metric_nature
             )
-        self._set_translation()
+        self._set_unit_translation()
         self._attr_native_value = VictronSensor._normalize_value(metric.value)
 
     @callback

--- a/homeassistant/components/victron_gx/strings.json
+++ b/homeassistant/components/victron_gx/strings.json
@@ -567,12 +567,10 @@
         "unit_of_measurement": "syncs"
       },
       "battery_average_discharge": {
-        "name": "Average discharge",
-        "unit_of_measurement": "Ah"
+        "name": "Average discharge"
       },
       "battery_capacity": {
-        "name": "Capacity",
-        "unit_of_measurement": "Ah"
+        "name": "Capacity"
       },
       "battery_cell_cell_id_voltage": {
         "name": "Cell {cell_id} voltage"
@@ -592,19 +590,16 @@
         "name": "Charged energy"
       },
       "battery_consumed_amphours": {
-        "name": "Consumed amp-hours",
-        "unit_of_measurement": "Ah"
+        "name": "Consumed amp-hours"
       },
       "battery_cumulative_ah_drawn": {
-        "name": "Cumulative Ah drawn",
-        "unit_of_measurement": "Ah"
+        "name": "Cumulative Ah drawn"
       },
       "battery_current": {
         "name": "DC bus current"
       },
       "battery_deepest_discharge": {
-        "name": "Deepest discharge",
-        "unit_of_measurement": "Ah"
+        "name": "Deepest discharge"
       },
       "battery_discharged_energy": {
         "name": "Discharged energy"
@@ -634,8 +629,7 @@
         }
       },
       "battery_installed_capacity": {
-        "name": "Installed capacity",
-        "unit_of_measurement": "Ah"
+        "name": "Installed capacity"
       },
       "battery_internal_failure": {
         "name": "Internal failure",
@@ -646,8 +640,7 @@
         }
       },
       "battery_last_discharge": {
-        "name": "Last discharge",
-        "unit_of_measurement": "Ah"
+        "name": "Last discharge"
       },
       "battery_low_cell_voltage": {
         "name": "Low cell voltage",

--- a/homeassistant/components/victron_gx/strings.json
+++ b/homeassistant/components/victron_gx/strings.json
@@ -1189,6 +1189,9 @@
       "multi_acin_voltage_phase": {
         "name": "[%key:component::victron_gx::common::voltage_on_phase%]"
       },
+      "multi_acout_current_phase": {
+        "name": "Output current on {phase}"
+      },
       "multi_acout_output_current_phase": {
         "name": "AC-out-{output} current on {phase}"
       },
@@ -1198,11 +1201,17 @@
       "multi_acout_output_voltage_phase": {
         "name": "AC-out-{output} voltage on {phase}"
       },
+      "multi_acout_power_phase": {
+        "name": "Output power on {phase}"
+      },
       "multi_acout_to_acin1": {
         "name": "AC-out to AC-in-1"
       },
       "multi_acout_to_inverter": {
         "name": "AC-out to inverter"
+      },
+      "multi_acout_voltage_phase": {
+        "name": "Output voltage on {phase}"
       },
       "multi_active_input": {
         "name": "[%key:component::victron_gx::common::active_ac_input%]",

--- a/homeassistant/components/victron_gx/strings.json
+++ b/homeassistant/components/victron_gx/strings.json
@@ -47,6 +47,7 @@
     "inverter_only": "Inverter only",
     "inverting": "Inverting",
     "lost_communication_with_device": "Lost communication with device",
+    "low_battery_alarm": "Low battery alarm",
     "low_power": "Low power",
     "max_power_today": "Max power today",
     "max_power_yesterday": "Max power yesterday",
@@ -70,6 +71,7 @@
     "power_phase": "Power {phase}",
     "power_supply": "Power supply",
     "pv_bus_voltage": "PV bus voltage",
+    "pv_current": "PV current",
     "pv_power_total": "PV power total",
     "recharging": "Recharging",
     "repeated_absorption": "Repeated absorption",
@@ -228,6 +230,9 @@
       },
       "vebus_inverter_connected": {
         "name": "[%key:common::state::connected%]"
+      },
+      "vebus_inverter_remote_generator_selected": {
+        "name": "Remote generator selected"
       }
     },
     "button": {
@@ -562,7 +567,8 @@
         "unit_of_measurement": "syncs"
       },
       "battery_average_discharge": {
-        "name": "Average discharge"
+        "name": "Average discharge",
+        "unit_of_measurement": "Ah"
       },
       "battery_capacity": {
         "name": "Capacity",
@@ -597,7 +603,8 @@
         "name": "DC bus current"
       },
       "battery_deepest_discharge": {
-        "name": "Deepest discharge"
+        "name": "Deepest discharge",
+        "unit_of_measurement": "Ah"
       },
       "battery_discharged_energy": {
         "name": "Discharged energy"
@@ -639,7 +646,8 @@
         }
       },
       "battery_last_discharge": {
-        "name": "Last discharge"
+        "name": "Last discharge",
+        "unit_of_measurement": "Ah"
       },
       "battery_low_cell_voltage": {
         "name": "Low cell voltage",
@@ -989,6 +997,9 @@
       "evcharger_total_energy": {
         "name": "Total energy"
       },
+      "generator_next_test_run": {
+        "name": "Next test run"
+      },
       "generator_run_state": {
         "name": "Run state",
         "state": {
@@ -1144,6 +1155,32 @@
       "inverter_total_pv_yield_user": {
         "name": "[%key:component::victron_gx::common::total_pv_yield_user%]"
       },
+      "meteo_alarm_low_battery": {
+        "name": "[%key:component::victron_gx::common::low_battery_alarm%]",
+        "state": {
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
+        }
+      },
+      "meteo_battery_voltage": {
+        "name": "Battery voltage"
+      },
+      "meteo_cell_temperature": {
+        "name": "Cell temperature"
+      },
+      "meteo_installation_power": {
+        "name": "Installation power"
+      },
+      "meteo_irradiance": {
+        "name": "Irradiance"
+      },
+      "meteo_time_since_last_sun": {
+        "name": "Time since last sun"
+      },
+      "meteo_todays_yield": {
+        "name": "Today's yield"
+      },
       "multi_acin1_to_acout": {
         "name": "AC-in-1 to AC-out"
       },
@@ -1214,6 +1251,9 @@
       },
       "multi_mppt_mppt_id_yield_yesterday": {
         "name": "MPPT {mppt_id} yield yesterday"
+      },
+      "multi_mppt_mpptnumber_current": {
+        "name": "MPPT {mpptnumber} current"
       },
       "multi_mppt_mpptnumber_power": {
         "name": "MPPT {mpptnumber} power"
@@ -1382,6 +1422,9 @@
           "voltage_current_limited": "[%key:component::victron_gx::common::voltage_current_limited%]"
         }
       },
+      "solarcharger_pv_current": {
+        "name": "[%key:component::victron_gx::common::pv_current%]"
+      },
       "solarcharger_state": {
         "name": "[%key:component::victron_gx::common::state%]",
         "state": {
@@ -1417,6 +1460,9 @@
       },
       "solarcharger_time_in_float_today": {
         "name": "Time in float today"
+      },
+      "solarcharger_tracker_tracker_current": {
+        "name": "PV tracker {tracker} current"
       },
       "solarcharger_tracker_tracker_max_power_today": {
         "name": "Tracker {tracker} max power today"
@@ -1532,7 +1578,7 @@
         "name": "DC consumption"
       },
       "system_dc_pv_current": {
-        "name": "PV current"
+        "name": "[%key:component::victron_gx::common::pv_current%]"
       },
       "system_dc_pv_energy": {
         "name": "PV energy"
@@ -1844,7 +1890,7 @@
         }
       },
       "vebus_inverter_alarm_low_battery": {
-        "name": "Low battery alarm",
+        "name": "[%key:component::victron_gx::common::low_battery_alarm%]",
         "state": {
           "alarm": "[%key:component::victron_gx::common::alarm%]",
           "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
@@ -1999,6 +2045,9 @@
       "generator_manual_start": {
         "name": "Manual start"
       },
+      "hub4_force_charge": {
+        "name": "Force charge"
+      },
       "multi_disable_charge": {
         "name": "ESS disable charge"
       },
@@ -2027,16 +2076,19 @@
         "name": "Relay {relay} state"
       },
       "system_settings_overvoltage_feedin": {
-        "name": "ESS feed-in excess solar charger power"
+        "name": "DC-coupled PV - feed in excess"
       },
       "system_settings_prevent_ac_feedin": {
-        "name": "ESS PV inverter zero feed-in"
+        "name": "AC-coupled PV - feed in excess"
       },
       "vebus_device_device_number_power_assist_enabled": {
         "name": "{device_number} PowerAssist enabled"
       },
       "vebus_inverter_ignoreacin1_onoff_control": {
         "name": "Control ignore AC-in-1"
+      },
+      "vebus_inverter_prefer_renewable_energy": {
+        "name": "Prefer renewable energy"
       },
       "vebus_inverter_setting_alarm_grid_lost": {
         "name": "Grid lost alarm setting"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3287,7 +3287,7 @@ viaggiatreno_ha==0.2.4
 victron-ble-ha-parser==0.7.0
 
 # homeassistant.components.victron_gx
-victron-mqtt==2026.5.4
+victron-mqtt==2026.5.13
 
 # homeassistant.components.victron_remote_monitoring
 victron-vrm==0.1.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3287,7 +3287,7 @@ viaggiatreno_ha==0.2.4
 victron-ble-ha-parser==0.7.0
 
 # homeassistant.components.victron_gx
-victron-mqtt==2026.5.13
+victron-mqtt==2026.6.1
 
 # homeassistant.components.victron_remote_monitoring
 victron-vrm==0.1.8


### PR DESCRIPTION
## Proposed change

Bump `victron-mqtt` library from `2026.5.4` to `2026.6.1` for the `victron_gx` integration.

Changes include:
- Update `victron-mqtt` dependency version in `manifest.json` and requirements files
- Update entity translations (`strings.json`) from latest topic definitions
- Update the logic for when we set units on entities based on CR comments.

Changelog: https://github.com/tomer-w/victron_mqtt/compare/v2026.5.4...v2026.6.1

## Type of change

- [x] Dependency upgrade

## Additional information

- This PR is related to issue:
- Link to documentation pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40m+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr