### PR TITLE
Add tests for Overkiz lock platform

### DIFF
--- a/tests/components/overkiz/fixtures/setup/cloud_somfy_tahoma_v2_europe.json
+++ b/tests/components/overkiz/fixtures/setup/cloud_somfy_tahoma_v2_europe.json
@@ -9201,6 +9201,278 @@
       "type": 1,
       "oid": "a7c3e8d1-5b92-4f1a-b8e6-9d2c4a7f3e01",
       "uiClass": "Siren"
+    },
+    {
+      "creationTime": 1706785990000,
+      "lastUpdateTime": 1706785990000,
+      "label": "Front Door",
+      "deviceURL": "io://1234-1234-6233/30",
+      "shortcut": false,
+      "controllableName": "io:DoorLockIOComponent",
+      "definition": {
+        "commands": [
+          {
+            "commandName": "addLockLevel",
+            "nparams": 2
+          },
+          {
+            "commandName": "advancedRefresh",
+            "nparams": 2
+          },
+          {
+            "commandName": "close",
+            "nparams": 0
+          },
+          {
+            "commandName": "delayedStopIdentify",
+            "nparams": 1
+          },
+          {
+            "commandName": "executeManufacturerProcedure",
+            "nparams": 2
+          },
+          {
+            "commandName": "getName",
+            "nparams": 0
+          },
+          {
+            "commandName": "getOpenClose",
+            "nparams": 0
+          },
+          {
+            "commandName": "identify",
+            "nparams": 0
+          },
+          {
+            "commandName": "lock",
+            "nparams": 0
+          },
+          {
+            "commandName": "open",
+            "nparams": 0
+          },
+          {
+            "commandName": "readManufacturerData",
+            "nparams": 1
+          },
+          {
+            "commandName": "refreshLockedUnlocked",
+            "nparams": 0
+          },
+          {
+            "commandName": "removeLockLevel",
+            "nparams": 1
+          },
+          {
+            "commandName": "resetLockLevels",
+            "nparams": 0
+          },
+          {
+            "commandName": "setLockedUnlocked",
+            "nparams": 1
+          },
+          {
+            "commandName": "setName",
+            "nparams": 1
+          },
+          {
+            "commandName": "setOpenClosed",
+            "nparams": 1
+          },
+          {
+            "commandName": "startIdentify",
+            "nparams": 0
+          },
+          {
+            "commandName": "stopIdentify",
+            "nparams": 0
+          },
+          {
+            "commandName": "unlock",
+            "nparams": 0
+          },
+          {
+            "commandName": "wink",
+            "nparams": 1
+          },
+          {
+            "commandName": "writeManufacturerData",
+            "nparams": 1
+          },
+          {
+            "commandName": "runManufacturerSettingsCommand",
+            "nparams": 2
+          },
+          {
+            "commandName": "keepOneWayControllersAndDeleteNode",
+            "nparams": 0
+          },
+          {
+            "commandName": "pairOneWayController",
+            "nparams": 2
+          },
+          {
+            "commandName": "sendIOKey",
+            "nparams": 0
+          },
+          {
+            "commandName": "setConfigState",
+            "nparams": 1
+          },
+          {
+            "commandName": "unpairAllOneWayControllersAndDeleteNode",
+            "nparams": 0
+          },
+          {
+            "commandName": "unpairAllOneWayControllers",
+            "nparams": 0
+          },
+          {
+            "commandName": "unpairOneWayController",
+            "nparams": 2
+          }
+        ],
+        "states": [
+          {
+            "qualifiedName": "core:AdditionalStatusState",
+            "type": "DataState"
+          },
+          {
+            "qualifiedName": "core:CommandLockLevelsState",
+            "eventBased": true,
+            "type": "DataState"
+          },
+          {
+            "qualifiedName": "core:DiscreteRSSILevelState",
+            "type": "DiscreteState",
+            "values": ["good", "low", "normal", "verylow"]
+          },
+          {
+            "qualifiedName": "core:LockedUnlockedState",
+            "type": "DiscreteState",
+            "values": ["locked", "unlocked"]
+          },
+          {
+            "qualifiedName": "core:ManufacturerDiagnosticsState",
+            "type": "DataState"
+          },
+          {
+            "qualifiedName": "core:ManufacturerSettingsState",
+            "type": "DataState"
+          },
+          {
+            "qualifiedName": "core:NameState",
+            "type": "DataState"
+          },
+          {
+            "qualifiedName": "core:OpenClosedState",
+            "type": "DiscreteState",
+            "values": ["closed", "open"]
+          },
+          {
+            "qualifiedName": "core:PriorityLockTimerState",
+            "type": "ContinuousState"
+          },
+          {
+            "qualifiedName": "core:RSSILevelState",
+            "type": "ContinuousState"
+          },
+          {
+            "qualifiedName": "core:StatusState",
+            "type": "DiscreteState",
+            "values": ["available", "unavailable"]
+          },
+          {
+            "qualifiedName": "io:PriorityLockLevelState",
+            "type": "DiscreteState",
+            "values": [
+              "comfortLevel1",
+              "comfortLevel2",
+              "comfortLevel3",
+              "comfortLevel4",
+              "environmentProtection",
+              "humanProtection",
+              "userLevel1",
+              "userLevel2"
+            ]
+          },
+          {
+            "qualifiedName": "io:PriorityLockOriginatorState",
+            "type": "DiscreteState",
+            "values": [
+              "LSC",
+              "SAAC",
+              "SFC",
+              "UPS",
+              "externalGateway",
+              "localUser",
+              "myself",
+              "rain",
+              "security",
+              "temperature",
+              "timer",
+              "user",
+              "wind"
+            ]
+          }
+        ],
+        "uiClassifiers": [],
+        "uiProfiles": [
+          "StatefulDoorLockWithOpeningStatus",
+          "StatefulLockWithOpeningStatus",
+          "StatefulLock",
+          "LockStatus",
+          "Lock",
+          "StatefulBasicOpenClose",
+          "BasicOpenClose"
+        ],
+        "dataProperties": [
+          {
+            "value": "500",
+            "qualifiedName": "core:identifyInterval"
+          }
+        ],
+        "widgetName": "DoorLock",
+        "uiClass": "DoorLock",
+        "qualifiedName": "io:DoorLockIOComponent",
+        "type": "ACTUATOR"
+      },
+      "states": [
+        {
+          "name": "core:NameState",
+          "type": 3,
+          "value": "Front Door"
+        },
+        {
+          "name": "core:LockedUnlockedState",
+          "type": 3,
+          "value": "locked"
+        },
+        {
+          "name": "core:OpenClosedState",
+          "type": 3,
+          "value": "closed"
+        },
+        {
+          "name": "core:StatusState",
+          "type": 3,
+          "value": "available"
+        }
+      ],
+      "attributes": [
+        {
+          "name": "core:Manufacturer",
+          "type": 3,
+          "value": "Public"
+        }
+      ],
+      "available": true,
+      "enabled": true,
+      "placeOID": "bcbb34ef-2241-43a1-9c5b-523aa0563ec3",
+      "widget": "DoorLock",
+      "type": 1,
+      "oid": "e01dc448-51ec-4b7e-b538-b8fd0e4a8375",
+      "uiClass": "DoorLock"
     }
   ],
   "zones": [],

--- a/tests/components/overkiz/snapshots/test_button.ambr
+++ b/tests/components/overkiz/snapshots/test_button.ambr
@@ -3690,6 +3690,160 @@
     'state': 'unknown',
   })
 # ---
+# name: test_button_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][button.living_room_front_door_identify-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'button.living_room_front_door_identify',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Identify',
+    'options': dict({
+    }),
+    'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
+    'original_icon': 'mdi:human-greeting-variant',
+    'original_name': 'Identify',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'io://1234-1234-6233/30-startIdentify',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][button.living_room_front_door_identify-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'identify',
+      'friendly_name': 'Front Door Identify',
+      'icon': 'mdi:human-greeting-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.living_room_front_door_identify',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][button.living_room_front_door_start_identify-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'button.living_room_front_door_start_identify',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Start identify',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:human-greeting-variant',
+    'original_name': 'Start identify',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'io://1234-1234-6233/30-identify',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][button.living_room_front_door_start_identify-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Front Door Start identify',
+      'icon': 'mdi:human-greeting-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.living_room_front_door_start_identify',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][button.living_room_front_door_stop_identify-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'button.living_room_front_door_stop_identify',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Stop identify',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:human-greeting-variant',
+    'original_name': 'Stop identify',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'io://1234-1234-6233/30-stopIdentify',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][button.living_room_front_door_stop_identify-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Front Door Stop identify',
+      'icon': 'mdi:human-greeting-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.living_room_front_door_stop_identify',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_button_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][button.living_room_garage_door_start_identify-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/overkiz/snapshots/test_lock.ambr
+++ b/tests/components/overkiz/snapshots/test_lock.ambr
@@ -1,0 +1,52 @@
+# serializer version: 1
+# name: test_lock_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][lock.living_room_front_door-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'lock',
+    'entity_category': None,
+    'entity_id': 'lock.living_room_front_door',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'io://1234-1234-6233/30',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_lock_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][lock.living_room_front_door-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Front Door',
+      'supported_features': <LockEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'lock.living_room_front_door',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'locked',
+  })
+# ---

--- a/tests/components/overkiz/test_lock.py
+++ b/tests/components/overkiz/test_lock.py
@@ -1,0 +1,153 @@
+"""Tests for the Overkiz lock platform."""
+
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import patch
+
+from freezegun.api import FrozenDateTimeFactory
+from pyoverkiz.enums import EventName, OverkizState
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.lock import (
+    DOMAIN as LOCK_DOMAIN,
+    SERVICE_LOCK,
+    SERVICE_UNLOCK,
+    LockState,
+)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .conftest import FixtureDevice, MockOverkizClient, SetupOverkizIntegration
+from .helpers import assert_command_call, async_deliver_events, build_event
+
+from tests.common import snapshot_platform
+
+DOOR_LOCK = FixtureDevice(
+    "setup/cloud_somfy_tahoma_v2_europe.json",
+    "io://1234-1234-6233/30",
+    "lock.living_room_front_door",
+)
+
+SNAPSHOT_FIXTURES = [
+    DOOR_LOCK,
+]
+
+
+@pytest.fixture(autouse=True)
+def fixture_platforms() -> Generator[None]:
+    """Limit platforms to lock only."""
+    with patch("homeassistant.components.overkiz.PLATFORMS", [Platform.LOCK]):
+        yield
+
+
+@pytest.mark.parametrize(
+    "device",
+    SNAPSHOT_FIXTURES,
+    ids=[Path(device.fixture).name for device in SNAPSHOT_FIXTURES],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_lock_entities_snapshot(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    device: FixtureDevice,
+) -> None:
+    """Test representative real setups via snapshot."""
+    config_entry = await setup_overkiz_integration(fixture=device.fixture)
+
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("service", "expected_command"),
+    [
+        pytest.param(SERVICE_LOCK, "lock", id="lock"),
+        pytest.param(SERVICE_UNLOCK, "unlock", id="unlock"),
+    ],
+)
+async def test_lock_service_call(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    service: str,
+    expected_command: str,
+) -> None:
+    """Test lock service calls send the correct commands."""
+    await setup_overkiz_integration(fixture=DOOR_LOCK.fixture)
+
+    await hass.services.async_call(
+        LOCK_DOMAIN,
+        service,
+        {ATTR_ENTITY_ID: DOOR_LOCK.entity_id},
+        blocking=True,
+    )
+
+    assert_command_call(
+        mock_client,
+        device_url=DOOR_LOCK.device_url,
+        command_name=expected_command,
+    )
+
+
+async def test_lock_state_update(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test lock reflects state changes from the device."""
+    await setup_overkiz_integration(fixture=DOOR_LOCK.fixture)
+
+    assert hass.states.get(DOOR_LOCK.entity_id).state == LockState.LOCKED
+
+    await async_deliver_events(
+        hass,
+        freezer,
+        mock_client,
+        [
+            build_event(
+                EventName.DEVICE_STATE_CHANGED.value,
+                device_url=DOOR_LOCK.device_url,
+                device_states=[
+                    {
+                        "name": OverkizState.CORE_LOCKED_UNLOCKED.value,
+                        "type": 3,
+                        "value": "unlocked",
+                    },
+                ],
+            )
+        ],
+    )
+
+    assert hass.states.get(DOOR_LOCK.entity_id).state == LockState.UNLOCKED
+
+
+async def test_lock_unavailability(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test lock becomes unavailable when device goes offline."""
+    await setup_overkiz_integration(fixture=DOOR_LOCK.fixture)
+
+    state = hass.states.get(DOOR_LOCK.entity_id)
+    assert state
+    assert state.state != STATE_UNAVAILABLE
+
+    await async_deliver_events(
+        hass,
+        freezer,
+        mock_client,
+        [
+            build_event(
+                EventName.DEVICE_UNAVAILABLE.value,
+                device_url=DOOR_LOCK.device_url,
+            )
+        ],
+    )
+
+    assert hass.states.get(DOOR_LOCK.entity_id).state == STATE_UNAVAILABLE


### PR DESCRIPTION
## Proposed change

Adds test coverage for the Overkiz `lock` platform, which previously had no tests.

The integration had no setup fixture containing a `DoorLock` device, so a real `io:DoorLockIOComponent` device (captured from a Somfy TaHoma setup) was added to the existing `cloud_somfy_tahoma_v2_europe.json` fixture. 

The new tests cover:
- Entity registry + state snapshot
- `lock` / `unlock` service calls (asserting the correct commands are sent)
- State updates driven by device events (`locked` → `unlocked`)
- Unavailability when the device goes offline

 100% test coverage of `homeassistant/components/overkiz/lock.py`.

Because the real `DoorLock` device legitimately exposes `identify`/`startIdentify`/`stopIdentify` commands, three corresponding buttons now appear in the shared `test_button` snapshot; the snapshot has been regenerated to reflect this.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
