### PR TITLE
Remove name field from SolarEdge config

### DIFF
--- a/homeassistant/components/solaredge/config_flow.py
+++ b/homeassistant/components/solaredge/config_flow.py
@@ -13,19 +13,12 @@ from homeassistant.config_entries import (
     ConfigFlow,
     ConfigFlowResult,
 )
-from homeassistant.const import CONF_API_KEY, CONF_NAME, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_API_KEY, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import section
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.util import slugify
 
-from .const import (
-    CONF_SECTION_API_AUTH,
-    CONF_SECTION_WEB_AUTH,
-    CONF_SITE_ID,
-    DEFAULT_NAME,
-    DOMAIN,
-)
+from .const import CONF_SECTION_API_AUTH, CONF_SECTION_WEB_AUTH, CONF_SITE_ID, DOMAIN
 
 
 class SolarEdgeConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -100,7 +93,6 @@ class SolarEdgeConfigFlow(ConfigFlow, domain=DOMAIN):
             entry = self._get_reconfigure_entry()
 
         if user_input is not None:
-            name = slugify(user_input.get(CONF_NAME, DEFAULT_NAME))
             if self.source == SOURCE_RECONFIGURE:
                 if TYPE_CHECKING:
                     assert entry
@@ -142,7 +134,7 @@ class SolarEdgeConfigFlow(ConfigFlow, domain=DOMAIN):
                             assert entry
                         return self.async_update_reload_and_abort(entry, data=data)
 
-                    return self.async_create_entry(title=name, data=data)
+                    return self.async_create_entry(title=site_id, data=data)
         elif self.source == SOURCE_RECONFIGURE:
             if TYPE_CHECKING:
                 assert entry
@@ -158,11 +150,6 @@ class SolarEdgeConfigFlow(ConfigFlow, domain=DOMAIN):
 
         data_schema_dict: dict[vol.Marker, Any] = {}
         if self.source != SOURCE_RECONFIGURE:
-            data_schema_dict[
-                # Name field is no longer allowed in config flow schemas
-                # pylint: disable-next=home-assistant-config-flow-name-field
-                vol.Required(CONF_NAME, default=user_input.get(CONF_NAME, DEFAULT_NAME))
-            ] = str
             data_schema_dict[
                 vol.Required(CONF_SITE_ID, default=user_input.get(CONF_SITE_ID, ""))
             ] = str

--- a/tests/components/solaredge/test_config_flow.py
+++ b/tests/components/solaredge/test_config_flow.py
@@ -59,7 +59,7 @@ async def test_user_api_key(
         },
     )
     assert result.get("type") is FlowResultType.CREATE_ENTRY
-    assert result.get("title") == "solaredge_site_1_2_3"
+    assert result.get("title") == SITE_ID
 
     data = result.get("data")
     assert data
@@ -95,7 +95,7 @@ async def test_user_web_login(
     )
 
     assert result.get("type") is FlowResultType.CREATE_ENTRY
-    assert result.get("title") == "solaredge_site_1_2_3"
+    assert result.get("title") == SITE_ID
 
     data = result.get("data")
     assert data
@@ -185,7 +185,7 @@ async def test_ignored_entry_does_not_cause_error(
         },
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "test"
+    assert result["title"] == SITE_ID
 
     data = result["data"]
     assert data

--- a/tests/components/solaredge/test_config_flow.py
+++ b/tests/components/solaredge/test_config_flow.py
@@ -10,11 +10,10 @@ from homeassistant.components.solaredge.const import (
     CONF_SECTION_API_AUTH,
     CONF_SECTION_WEB_AUTH,
     CONF_SITE_ID,
-    DEFAULT_NAME,
     DOMAIN,
 )
 from homeassistant.config_entries import SOURCE_IGNORE, SOURCE_USER
-from homeassistant.const import CONF_API_KEY, CONF_NAME, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_API_KEY, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -51,7 +50,6 @@ async def test_user_api_key(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_NAME: NAME,
             CONF_SITE_ID: SITE_ID,
             CONF_SECTION_API_AUTH: {CONF_API_KEY: API_KEY},
             CONF_SECTION_WEB_AUTH: {
@@ -87,7 +85,6 @@ async def test_user_web_login(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_NAME: NAME,
             CONF_SITE_ID: SITE_ID,
             CONF_SECTION_API_AUTH: {CONF_API_KEY: ""},
             CONF_SECTION_WEB_AUTH: {
@@ -126,7 +123,6 @@ async def test_user_both_auth(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_NAME: NAME,
             CONF_SITE_ID: SITE_ID,
             CONF_SECTION_API_AUTH: {CONF_API_KEY: API_KEY},
             CONF_SECTION_WEB_AUTH: {
@@ -153,7 +149,7 @@ async def test_abort_if_already_setup(
     """Test we abort if the site_id is already setup."""
     MockConfigEntry(
         domain=DOMAIN,
-        data={CONF_NAME: DEFAULT_NAME, CONF_SITE_ID: SITE_ID, CONF_API_KEY: API_KEY},
+        data={CONF_SITE_ID: SITE_ID, CONF_API_KEY: API_KEY},
     ).add_to_hass(hass)
 
     # Should fail, same SITE_ID
@@ -161,7 +157,6 @@ async def test_abort_if_already_setup(
         DOMAIN,
         context={"source": SOURCE_USER},
         data={
-            CONF_NAME: "test",
             CONF_SITE_ID: SITE_ID,
             CONF_SECTION_API_AUTH: {CONF_API_KEY: "test"},
         },
@@ -176,7 +171,7 @@ async def test_ignored_entry_does_not_cause_error(
     """Test an ignored entry does not cause an error on new entry."""
     MockConfigEntry(
         domain="solaredge",
-        data={CONF_NAME: DEFAULT_NAME, CONF_API_KEY: API_KEY},
+        data={CONF_API_KEY: API_KEY},
         source=SOURCE_IGNORE,
     ).add_to_hass(hass)
 
@@ -185,7 +180,6 @@ async def test_ignored_entry_does_not_cause_error(
         DOMAIN,
         context={"source": SOURCE_USER},
         data={
-            CONF_NAME: "test",
             CONF_SITE_ID: SITE_ID,
             CONF_SECTION_API_AUTH: {CONF_API_KEY: "test"},
         },
@@ -206,7 +200,7 @@ async def test_no_auth_provided(recorder_mock: Recorder, hass: HomeAssistant) ->
     )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {CONF_NAME: NAME, CONF_SITE_ID: SITE_ID},
+        {CONF_SITE_ID: SITE_ID},
     )
     assert result.get("type") is FlowResultType.FORM
     assert result.get("errors") == {"base": "auth_missing"}
@@ -233,7 +227,6 @@ async def test_api_key_errors(
     solaredge_api.get_details = get_details_setup
 
     user_input = {
-        CONF_NAME: NAME,
         CONF_SITE_ID: SITE_ID,
         CONF_SECTION_API_AUTH: {CONF_API_KEY: API_KEY},
     }
@@ -285,7 +278,6 @@ async def test_web_login_errors(
 
     solaredge_web_api.async_get_equipment.side_effect = api_exception
     user_input = {
-        CONF_NAME: NAME,
         CONF_SITE_ID: SITE_ID,
         CONF_SECTION_WEB_AUTH: {
             CONF_USERNAME: USERNAME,


### PR DESCRIPTION
## Proposed change

Remove the name field from the SolarEdge config flow schema to comply with the `home-assistant-config-flow-name-field` rule.

This change:

* Removes `CONF_NAME` from the config flow schema.
* Removes unused `slugify` and `DEFAULT_NAME` usage.
* Updates the config entry title to use the site ID instead of a user-provided name.
* Updates the SolarEdge config flow tests accordingly.

## Type of change

* [ ] Dependency upgrade
* [ ] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] Code quality improvement

## Additional information

* Link to related issue: #168960
* This PR is part of the config flow name field removal effort.

## Checklist

* [x] The code change is tested and works locally.
* [x] The code has been formatted and passes linting.
* [x] I have read the contribution guidelines.
