### PR TITLE
Bump victron-mqtt to 2026.5.15

### DIFF
--- a/homeassistant/components/victron_gx/manifest.json
+++ b/homeassistant/components/victron_gx/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "quality_scale": "platinum",
-  "requirements": ["victron-mqtt==2026.5.4"],
+  "requirements": ["victron-mqtt==2026.5.15"],
   "ssdp": [
     {
       "X_MqttOnLan": "1",

--- a/homeassistant/components/victron_gx/strings.json
+++ b/homeassistant/components/victron_gx/strings.json
@@ -47,6 +47,7 @@
     "inverter_only": "Inverter only",
     "inverting": "Inverting",
     "lost_communication_with_device": "Lost communication with device",
+    "low_battery_alarm": "Low battery alarm",
     "low_power": "Low power",
     "max_power_today": "Max power today",
     "max_power_yesterday": "Max power yesterday",
@@ -70,6 +71,7 @@
     "power_phase": "Power {phase}",
     "power_supply": "Power supply",
     "pv_bus_voltage": "PV bus voltage",
+    "pv_current": "PV current",
     "pv_power_total": "PV power total",
     "recharging": "Recharging",
     "repeated_absorption": "Repeated absorption",
@@ -228,6 +230,9 @@
       },
       "vebus_inverter_connected": {
         "name": "[%key:common::state::connected%]"
+      },
+      "vebus_inverter_remote_generator_selected": {
+        "name": "Remote generator selected"
       }
     },
     "button": {
@@ -562,7 +567,8 @@
         "unit_of_measurement": "syncs"
       },
       "battery_average_discharge": {
-        "name": "Average discharge"
+        "name": "Average discharge",
+        "unit_of_measurement": "Ah"
       },
       "battery_capacity": {
         "name": "Capacity",
@@ -597,7 +603,8 @@
         "name": "DC bus current"
       },
       "battery_deepest_discharge": {
-        "name": "Deepest discharge"
+        "name": "Deepest discharge",
+        "unit_of_measurement": "Ah"
       },
       "battery_discharged_energy": {
         "name": "Discharged energy"
@@ -639,7 +646,8 @@
         }
       },
       "battery_last_discharge": {
-        "name": "Last discharge"
+        "name": "Last discharge",
+        "unit_of_measurement": "Ah"
       },
       "battery_low_cell_voltage": {
         "name": "Low cell voltage",
@@ -989,6 +997,9 @@
       "evcharger_total_energy": {
         "name": "Total energy"
       },
+      "generator_next_test_run": {
+        "name": "Next test run"
+      },
       "generator_run_state": {
         "name": "Run state",
         "state": {
@@ -1144,6 +1155,32 @@
       "inverter_total_pv_yield_user": {
         "name": "[%key:component::victron_gx::common::total_pv_yield_user%]"
       },
+      "meteo_alarm_low_battery": {
+        "name": "[%key:component::victron_gx::common::low_battery_alarm%]",
+        "state": {
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
+        }
+      },
+      "meteo_battery_voltage": {
+        "name": "Battery voltage"
+      },
+      "meteo_cell_temperature": {
+        "name": "Cell temperature"
+      },
+      "meteo_installation_power": {
+        "name": "Installation power"
+      },
+      "meteo_irradiance": {
+        "name": "Irradiance"
+      },
+      "meteo_time_since_last_sun": {
+        "name": "Time since last sun"
+      },
+      "meteo_todays_yield": {
+        "name": "Today's yield"
+      },
       "multi_acin1_to_acout": {
         "name": "AC-in-1 to AC-out"
       },
@@ -1214,6 +1251,9 @@
       },
       "multi_mppt_mppt_id_yield_yesterday": {
         "name": "MPPT {mppt_id} yield yesterday"
+      },
+      "multi_mppt_mpptnumber_current": {
+        "name": "MPPT {mpptnumber} current"
       },
       "multi_mppt_mpptnumber_power": {
         "name": "MPPT {mpptnumber} power"
@@ -1382,6 +1422,9 @@
           "voltage_current_limited": "[%key:component::victron_gx::common::voltage_current_limited%]"
         }
       },
+      "solarcharger_pv_current": {
+        "name": "[%key:component::victron_gx::common::pv_current%]"
+      },
       "solarcharger_state": {
         "name": "[%key:component::victron_gx::common::state%]",
         "state": {
@@ -1417,6 +1460,9 @@
       },
       "solarcharger_time_in_float_today": {
         "name": "Time in float today"
+      },
+      "solarcharger_tracker_tracker_current": {
+        "name": "PV tracker {tracker} current"
       },
       "solarcharger_tracker_tracker_max_power_today": {
         "name": "Tracker {tracker} max power today"
@@ -1532,7 +1578,7 @@
         "name": "DC consumption"
       },
       "system_dc_pv_current": {
-        "name": "PV current"
+        "name": "[%key:component::victron_gx::common::pv_current%]"
       },
       "system_dc_pv_energy": {
         "name": "PV energy"
@@ -1844,7 +1890,7 @@
         }
       },
       "vebus_inverter_alarm_low_battery": {
-        "name": "Low battery alarm",
+        "name": "[%key:component::victron_gx::common::low_battery_alarm%]",
         "state": {
           "alarm": "[%key:component::victron_gx::common::alarm%]",
           "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
@@ -1999,6 +2045,9 @@
       "generator_manual_start": {
         "name": "Manual start"
       },
+      "hub4_force_charge": {
+        "name": "Force charge"
+      },
       "multi_disable_charge": {
         "name": "ESS disable charge"
       },
@@ -2027,16 +2076,19 @@
         "name": "Relay {relay} state"
       },
       "system_settings_overvoltage_feedin": {
-        "name": "ESS feed-in excess solar charger power"
+        "name": "DC-coupled PV - feed in excess"
       },
       "system_settings_prevent_ac_feedin": {
-        "name": "ESS PV inverter zero feed-in"
+        "name": "AC-coupled PV - feed in excess"
       },
       "vebus_device_device_number_power_assist_enabled": {
         "name": "{device_number} PowerAssist enabled"
       },
       "vebus_inverter_ignoreacin1_onoff_control": {
         "name": "Control ignore AC-in-1"
+      },
+      "vebus_inverter_prefer_renewable_energy": {
+        "name": "Prefer renewable energy"
       },
       "vebus_inverter_setting_alarm_grid_lost": {
         "name": "Grid lost alarm setting"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3287,7 +3287,7 @@ viaggiatreno_ha==0.2.4
 victron-ble-ha-parser==0.7.0
 
 # homeassistant.components.victron_gx
-victron-mqtt==2026.5.4
+victron-mqtt==2026.5.15
 
 # homeassistant.components.victron_remote_monitoring
 victron-vrm==0.1.8


### PR DESCRIPTION
## Proposed change

Bump `victron-mqtt` library from `2026.5.4` to `2026.5.15` for the `victron_gx` integration.

Changes include:
- Update `victron-mqtt` dependency version in `manifest.json` and requirements files
- Update entity translations (`strings.json`) from latest topic definitions

Changelog: https://github.com/tomer-w/victron_mqtt/compare/v2026.5.4...v2026.5.15

## Type of change

- [x] Dependency upgrade

## Additional information

- This PR is related to issue:
- Link to documentation pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40m+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr