### PR TITLE
Return 404 instead of 500 when media player artwork is unavailable

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -1296,7 +1296,7 @@ class MediaPlayerImageView(HomeAssistantView):
             data, content_type = await player.async_get_media_image()
 
         if data is None:
-            return web.Response(status=HTTPStatus.INTERNAL_SERVER_ERROR)
+            return web.Response(status=HTTPStatus.NOT_FOUND)
 
         headers: LooseHeaders = {CACHE_CONTROL: "max-age=3600"}
         return web.Response(body=data, content_type=content_type, headers=headers)

--- a/tests/components/forked_daapd/test_browse_media.py
+++ b/tests/components/forked_daapd/test_browse_media.py
@@ -447,4 +447,4 @@ async def test_async_browse_image_missing(
         resp = await client.get(
             f"/api/media_player_proxy/{TEST_MASTER_ENTITY_NAME}/browse_media/{MediaType.TRACK}/{media_content_id}"
         )
-        assert resp.status == HTTPStatus.INTERNAL_SERVER_ERROR
+        assert resp.status == HTTPStatus.NOT_FOUND

--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -169,7 +169,7 @@ async def test_get_image_http_log_credentials_redacted(
 
         resp = await client.get(state.attributes["entity_picture"])
 
-    assert resp.status == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert resp.status == HTTPStatus.NOT_FOUND
     assert f"Error retrieving proxied image from {url}" not in caplog.text
     assert (
         "Error retrieving proxied image from "

--- a/tests/components/shelly/test_media_player.py
+++ b/tests/components/shelly/test_media_player.py
@@ -422,7 +422,7 @@ async def test_get_image_http_stale_url_after_thumb_invalidated(
 
     client = await hass_client_no_auth()
     resp = await client.get(entity_picture)
-    assert resp.status == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert resp.status == HTTPStatus.NOT_FOUND
 
 
 async def test_entity_picture_absent_base64_data_invalid(
@@ -444,7 +444,7 @@ async def test_entity_picture_absent_base64_data_invalid(
 
     client = await hass_client()
     resp = await client.get(f"/api/media_player_proxy/{ENTITY_ID}")
-    assert resp.status == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert resp.status == HTTPStatus.NOT_FOUND
 
 
 @pytest.mark.parametrize(
@@ -474,7 +474,7 @@ async def test_entity_picture_absent_thumb_string_invalid(
 
     client = await hass_client()
     resp = await client.get(f"/api/media_player_proxy/{ENTITY_ID}")
-    assert resp.status == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert resp.status == HTTPStatus.NOT_FOUND
 
 
 async def test_entity_picture_absent_mime_type_not_allowed(
@@ -496,7 +496,7 @@ async def test_entity_picture_absent_mime_type_not_allowed(
 
     client = await hass_client()
     resp = await client.get(f"/api/media_player_proxy/{ENTITY_ID}")
-    assert resp.status == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert resp.status == HTTPStatus.NOT_FOUND
 
 
 async def test_rpc_media_player_browse_media_root(

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -822,7 +822,7 @@ async def test_get_image_http_error(
     resp = await client.get(attrs["entity_picture"])
     content = await resp.read()
 
-    assert resp.status == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert resp.status == HTTPStatus.NOT_FOUND
     assert f"Error retrieving proxied image from {url}" in caplog.text
     assert content == b""
 


### PR DESCRIPTION
## Proposed change

When a media player entity advertises artwork (`media_image_hash` is set) but the actual fetch returns no bytes, `MediaPlayerImageView` responds with HTTP 500. A missing image is not a server error.

Return 404 instead, which correctly signals that the resource is not available and stops the frontend from logging server errors on every poll cycle.

This commonly occurs with Apple TV playing YouTube or radio streams, where artwork is advertised optimistically but no bytes are available at fetch time.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #172632
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr