### PR TITLE
Convert set_id to int in LG TV RS-232 config flow

### DIFF
--- a/homeassistant/components/lg_tv_rs232/config_flow.py
+++ b/homeassistant/components/lg_tv_rs232/config_flow.py
@@ -70,7 +70,7 @@ class LGTVRS232ConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             port = user_input[CONF_DEVICE]
-            set_id = user_input[CONF_SET_ID]
+            set_id = int(user_input[CONF_SET_ID])
 
             self._async_abort_entries_match({CONF_DEVICE: port, CONF_SET_ID: set_id})
             error = await _async_attempt_connect(port, set_id)

--- a/tests/components/lg_tv_rs232/test_config_flow.py
+++ b/tests/components/lg_tv_rs232/test_config_flow.py
@@ -55,6 +55,30 @@ async def test_user_form_creates_entry(
     mock_lgtv.disconnect.assert_awaited_once()
 
 
+async def test_user_form_float_set_id(
+    hass: HomeAssistant,
+    mock_lgtv: MagicMock,
+    mock_async_setup_entry: AsyncMock,
+) -> None:
+    """Test that a float set_id from NumberSelector is converted to int."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.lg_tv_rs232.config_flow.LGTV",
+        return_value=mock_lgtv,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_DEVICE: MOCK_DEVICE, CONF_SET_ID: 1.0},
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_SET_ID] == MOCK_SET_ID
+    assert isinstance(result["data"][CONF_SET_ID], int)
+
+
 async def test_user_form_no_tv_shows_troubleshooting(
     hass: HomeAssistant,
     mock_lgtv: MagicMock,


### PR DESCRIPTION
## Proposed change

The `NumberSelector` used for the `set_id` field returns a float (e.g. `1.0`), but the downstream `lg-rs232-tv` library formats it with `f"{set_id:02d}"` which requires an integer. This causes a `ValueError` that gets caught by the broad exception handler and surfaces as a generic "Failed to connect" error, hiding the real problem.

Convert `set_id` to `int` when reading from user input.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #172677
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr