### PR TITLE
Add custom themes to Cloud support package

### DIFF
--- a/homeassistant/components/cloud/http_api.py
+++ b/homeassistant/components/cloud/http_api.py
@@ -24,6 +24,7 @@ from homeassistant.components.alexa import (
     entities as alexa_entities,
     errors as alexa_errors,
 )
+from homeassistant.components.frontend import DATA_THEMES
 from homeassistant.components.google_assistant import helpers as google_helpers
 from homeassistant.components.homeassistant import exposed_entities
 from homeassistant.components.http import KEY_HASS, HomeAssistantView, require_admin
@@ -508,6 +509,15 @@ class DownloadSupportPackageView(HomeAssistantView):
             "custom_integrations": custom_integrations,
         }
 
+    @callback
+    def _get_themes_info(self, hass: HomeAssistant) -> dict[str, Any]:
+        """Collect information about user-installed custom themes."""
+        themes: dict[str, Any] = hass.data.get(DATA_THEMES, {})
+        return {
+            "count": len(themes),
+            "themes": sorted(themes),
+        }
+
     async def _generate_markdown(
         self,
         hass: HomeAssistant,
@@ -567,6 +577,25 @@ class DownloadSupportPackageView(HomeAssistantView):
                         f"{integration['version']} | "
                         f"{doc_url}\n"
                     )
+                markdown += "\n</details>\n\n"
+
+        # Add custom themes information
+        try:
+            themes_info = self._get_themes_info(hass)
+        except Exception:  # noqa: BLE001
+            # Broad exception catch for robustness in support package generation
+            markdown += "## Custom Themes\n\n"
+            markdown += "Unable to collect themes information\n\n"
+        else:
+            markdown += "## Custom Themes\n\n"
+            markdown += f"Custom themes: {themes_info['count']}\n\n"
+
+            if themes_info["themes"]:
+                markdown += "<details><summary>Custom themes</summary>\n\n"
+                markdown += "Name\n"
+                markdown += "---\n"
+                for theme in themes_info["themes"]:
+                    markdown += f"{theme}\n"
                 markdown += "\n</details>\n\n"
 
         for domain, domain_info in domains_info.items():

--- a/tests/components/cloud/snapshots/test_http_api.ambr
+++ b/tests/components/cloud/snapshots/test_http_api.ambr
@@ -61,6 +61,19 @@
   
   </details>
   
+  ## Custom Themes
+  
+  Custom themes: 2
+  
+  <details><summary>Custom themes</summary>
+  
+  Name
+  ---
+  midnight
+  solarized-dark
+  
+  </details>
+  
   <details><summary>mock_no_info_integration</summary>
   
   No information available
@@ -173,6 +186,10 @@
   
   </details>
   
+  ## Custom Themes
+  
+  Custom themes: 0
+  
   <details><summary>mock_no_info_integration</summary>
   
   No information available
@@ -248,6 +265,10 @@
   ## Active integrations
   
   Unable to collect integration information
+  
+  ## Custom Themes
+  
+  Custom themes: 0
   
   <details><summary>mock_no_info_integration</summary>
   

--- a/tests/components/cloud/test_http_api.py
+++ b/tests/components/cloud/test_http_api.py
@@ -34,6 +34,7 @@ from homeassistant.components.assist_pipeline.pipeline import (  # pylint: disab
 )
 from homeassistant.components.cloud.const import DEFAULT_EXPOSED_DOMAINS, DOMAIN
 from homeassistant.components.cloud.http_api import validate_language_voice
+from homeassistant.components.frontend import DATA_THEMES
 from homeassistant.components.google_assistant.helpers import (  # pylint: disable=home-assistant-component-root-import
     GoogleEntity,
 )
@@ -1890,6 +1891,12 @@ async def test_download_support_package(
     hass.config.components.add("test")  # This is a custom integration from the fixture
 
     assert await async_setup_component(hass, "system_health", {})
+
+    # Register custom themes so the support package surfaces them
+    hass.data[DATA_THEMES] = {
+        "midnight": {"primary-color": "#000000"},
+        "solarized-dark": {"primary-color": "#002b36"},
+    }
 
     with patch("uuid.UUID.hex", new_callable=PropertyMock) as hexmock:
         hexmock.return_value = "12345678901234567890"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a new `Custom Themes` section to the Cloud support package markdown,
listing the names of user-installed themes. This mirrors the existing
Custom Integrations listing pattern and helps support narrow down
theme-related UI issues without asking the user separately which themes
they have installed.

The implementation reads `hass.data[DATA_THEMES]`, which only ever
contains user-defined themes (the built-in `default` theme is tracked
separately and never appears in this dict), so no filtering is required.
Themes have no version or documentation metadata in core, so the table
is a single `Name` column.

Rendering, with two themes installed:

```markdown
## Custom Themes

Custom themes: 2

<details><summary>Custom themes</summary>

Name
---
midnight
solarized-dark

</details>
```

When the user has no custom themes the section still renders with
`Custom themes: 0` for consistency with the always-present Active
Integrations counts.

This is intended as the first of a small series of additions to the
support package (custom templates, python scripts, and per-item
Lovelace resources are natural follow-ups in separate PRs).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an \`x\` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (\`ruff format homeassistant tests\`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: \`python3 -m script.hassfest\`.
- [ ] New or updated dependencies have been added to \`requirements_all.txt\`.  
      Updated by running \`python3 -m script.gen_requirements_all\`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr