### PR TITLE
Skip Overkiz events for unknown device URLs

### DIFF
--- a/homeassistant/components/overkiz/coordinator.py
+++ b/homeassistant/components/overkiz/coordinator.py
@@ -144,7 +144,7 @@ async def on_device_available(
     coordinator: OverkizDataUpdateCoordinator, event: Event
 ) -> None:
     """Handle device available event."""
-    if event.device_url:
+    if event.device_url and event.device_url in coordinator.devices:
         coordinator.devices[event.device_url].available = True
 
 
@@ -154,7 +154,7 @@ async def on_device_unavailable_disabled(
     coordinator: OverkizDataUpdateCoordinator, event: Event
 ) -> None:
     """Handle device unavailable / disabled event."""
-    if event.device_url:
+    if event.device_url and event.device_url in coordinator.devices:
         coordinator.devices[event.device_url].available = False
 
 
@@ -174,7 +174,7 @@ async def on_device_state_changed(
     coordinator: OverkizDataUpdateCoordinator, event: Event
 ) -> None:
     """Handle device state changed event."""
-    if not event.device_url:
+    if not event.device_url or event.device_url not in coordinator.devices:
         return
 
     for state in event.device_states:
@@ -198,7 +198,7 @@ async def on_device_removed(
     ):
         registry.async_remove_device(registered_device.id)
 
-    if event.device_url:
+    if event.device_url and event.device_url in coordinator.devices:
         del coordinator.devices[event.device_url]
 
 

--- a/tests/components/overkiz/test_climate.py
+++ b/tests/components/overkiz/test_climate.py
@@ -65,3 +65,40 @@ async def test_valve_hvac_action_none_state(
     state = hass.states.get(VALVE.entity_id)
     assert state is not None
     assert state.attributes.get(ATTR_HVAC_ACTION) is None
+
+
+@pytest.mark.parametrize(
+    "event_name",
+    [
+        EventName.DEVICE_AVAILABLE,
+        EventName.DEVICE_UNAVAILABLE,
+        EventName.DEVICE_STATE_CHANGED,
+        EventName.DEVICE_REMOVED,
+    ],
+)
+async def test_events_for_unknown_device_url(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_client: MockOverkizClient,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    event_name: EventName,
+) -> None:
+    """Test that events for unknown device URLs don't crash the coordinator."""
+    await setup_overkiz_integration(fixture=VALVE.fixture)
+
+    await async_deliver_events(
+        hass,
+        freezer,
+        mock_client,
+        [
+            build_event(
+                event_name,
+                device_url="zigbee://1234-5678-1698/65535",
+                device_states=[{"name": "core:OnOffState", "type": 3, "value": "on"}],
+            )
+        ],
+    )
+
+    # Should not crash; valve entity should still be available
+    state = hass.states.get(VALVE.entity_id)
+    assert state is not None

--- a/tests/components/overkiz/test_climate.py
+++ b/tests/components/overkiz/test_climate.py
@@ -1,6 +1,7 @@
 """Tests for the Overkiz climate platform."""
 
 from collections.abc import Generator
+from typing import Any
 from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory
@@ -68,12 +69,16 @@ async def test_valve_hvac_action_none_state(
 
 
 @pytest.mark.parametrize(
-    "event_name",
+    ("event_name", "device_states"),
     [
-        EventName.DEVICE_AVAILABLE,
-        EventName.DEVICE_UNAVAILABLE,
-        EventName.DEVICE_STATE_CHANGED,
-        EventName.DEVICE_REMOVED,
+        pytest.param(EventName.DEVICE_AVAILABLE, None, id="available"),
+        pytest.param(EventName.DEVICE_UNAVAILABLE, None, id="unavailable"),
+        pytest.param(
+            EventName.DEVICE_STATE_CHANGED,
+            [{"name": "core:OnOffState", "type": 3, "value": "on"}],
+            id="state_changed",
+        ),
+        pytest.param(EventName.DEVICE_REMOVED, None, id="removed"),
     ],
 )
 async def test_events_for_unknown_device_url(
@@ -82,6 +87,7 @@ async def test_events_for_unknown_device_url(
     mock_client: MockOverkizClient,
     setup_overkiz_integration: SetupOverkizIntegration,
     event_name: EventName,
+    device_states: list[dict[str, Any]] | None,
 ) -> None:
     """Test that events for unknown device URLs don't crash the coordinator."""
     await setup_overkiz_integration(fixture=VALVE.fixture)
@@ -94,7 +100,7 @@ async def test_events_for_unknown_device_url(
             build_event(
                 event_name,
                 device_url="zigbee://1234-5678-1698/65535",
-                device_states=[{"name": "core:OnOffState", "type": 3, "value": "on"}],
+                device_states=device_states,
             )
         ],
     )


### PR DESCRIPTION
## Proposed change

When a TaHoma hub sends events (available, unavailable, state changed, removed) for a device URL that isn't tracked by the coordinator (e.g. `zigbee://xxx/65535` for the gateway itself), the event handlers crash with `KeyError` because they access `coordinator.devices[event.device_url]` without checking if the key exists.

Add guards to skip events for unknown device URLs in all four affected handlers.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #172563
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr