### PR TITLE
Use DataUpdateCoordinator in openSenseMap

### DIFF
--- a/homeassistant/components/opensensemap/__init__.py
+++ b/homeassistant/components/opensensemap/__init__.py
@@ -1,19 +1,15 @@
 """The openSenseMap integration."""
 
 from opensensemap_api import OpenSenseMap
-from opensensemap_api.exceptions import OpenSenseMapError
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import CONF_STATION_ID
+from .coordinator import OpenSenseMapConfigEntry, OpenSenseMapCoordinator
 
 PLATFORMS: list[Platform] = [Platform.AIR_QUALITY]
-
-type OpenSenseMapConfigEntry = ConfigEntry[OpenSenseMap]
 
 
 async def async_setup_entry(
@@ -22,14 +18,10 @@ async def async_setup_entry(
     """Set up openSenseMap from a config entry."""
     session = async_get_clientsession(hass)
     api = OpenSenseMap(entry.data[CONF_STATION_ID], session)
-    try:
-        await api.get_data()
-    except OpenSenseMapError as err:
-        raise ConfigEntryNotReady(
-            f"Unable to fetch data from openSenseMap: {err}"
-        ) from err
+    coordinator = OpenSenseMapCoordinator(hass, entry, api)
+    await coordinator.async_config_entry_first_refresh()
 
-    entry.runtime_data = api
+    entry.runtime_data = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 

--- a/homeassistant/components/opensensemap/air_quality.py
+++ b/homeassistant/components/opensensemap/air_quality.py
@@ -1,9 +1,5 @@
 """Support for openSenseMap Air Quality data."""
 
-from datetime import timedelta
-
-from opensensemap_api import OpenSenseMap
-from opensensemap_api.exceptions import OpenSenseMapError
 import voluptuous as vol
 
 from homeassistant.components.air_quality import (
@@ -20,18 +16,16 @@ from homeassistant.helpers.entity_platform import (
     AddEntitiesCallback,
 )
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import OpenSenseMapConfigEntry
 from .const import (
     CONF_STATION_ID,
     DEPRECATED_YAML_BREAKS_IN_VERSION,
     DOMAIN,
     INTEGRATION_TITLE,
     KNOWN_IMPORT_ABORT_REASONS,
-    LOGGER,
 )
-
-SCAN_INTERVAL = timedelta(minutes=10)
+from .coordinator import OpenSenseMapConfigEntry, OpenSenseMapCoordinator
 
 PLATFORM_SCHEMA = AIR_QUALITY_PLATFORM_SCHEMA.extend(
     {vol.Required(CONF_STATION_ID): cv.string, vol.Optional(CONF_NAME): cv.string}
@@ -107,33 +101,25 @@ async def async_setup_entry(
     )
 
 
-class OpenSenseMapQuality(AirQualityEntity):
+class OpenSenseMapQuality(CoordinatorEntity[OpenSenseMapCoordinator], AirQualityEntity):
     """Implementation of an openSenseMap air quality entity."""
 
     _attr_attribution = "Data provided by openSenseMap"
 
-    def __init__(self, api: OpenSenseMap, station_id: str, name: str) -> None:
+    def __init__(
+        self, coordinator: OpenSenseMapCoordinator, station_id: str, name: str
+    ) -> None:
         """Initialize the air quality entity."""
-        self._api = api
+        super().__init__(coordinator)
         self._attr_name = name
         self._attr_unique_id = station_id
 
     @property
     def particulate_matter_2_5(self) -> float | None:
         """Return the particulate matter 2.5 level."""
-        return self._api.pm2_5
+        return self.coordinator.data.pm2_5
 
     @property
     def particulate_matter_10(self) -> float | None:
         """Return the particulate matter 10 level."""
-        return self._api.pm10
-
-    async def async_update(self) -> None:
-        """Fetch latest data from the openSenseMap API."""
-        try:
-            await self._api.get_data()
-        except OpenSenseMapError as err:
-            LOGGER.warning("Unable to fetch data from openSenseMap: %s", err)
-            self._attr_available = False
-        else:
-            self._attr_available = True
+        return self.coordinator.data.pm10

--- a/homeassistant/components/opensensemap/coordinator.py
+++ b/homeassistant/components/opensensemap/coordinator.py
@@ -1,0 +1,58 @@
+"""Data update coordinator for the openSenseMap integration."""
+
+from dataclasses import dataclass
+from datetime import timedelta
+
+from opensensemap_api import OpenSenseMap
+from opensensemap_api.exceptions import OpenSenseMapError
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN, LOGGER
+
+SCAN_INTERVAL = timedelta(minutes=10)
+
+
+@dataclass(slots=True, frozen=True)
+class OpenSenseMapStationData:
+    """Immutable measurements for an openSenseMap station."""
+
+    pm2_5: float | None
+    pm10: float | None
+
+
+type OpenSenseMapConfigEntry = ConfigEntry[OpenSenseMapCoordinator]
+
+
+class OpenSenseMapCoordinator(DataUpdateCoordinator[OpenSenseMapStationData]):
+    """Coordinator to manage data updates for an openSenseMap station."""
+
+    config_entry: OpenSenseMapConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: OpenSenseMapConfigEntry,
+        api: OpenSenseMap,
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            LOGGER,
+            config_entry=config_entry,
+            name=DOMAIN,
+            update_interval=SCAN_INTERVAL,
+        )
+        self.api = api
+
+    async def _async_update_data(self) -> OpenSenseMapStationData:
+        """Fetch latest data from the openSenseMap API."""
+        try:
+            await self.api.get_data()
+        except OpenSenseMapError as err:
+            raise UpdateFailed(
+                f"Unable to fetch data from openSenseMap: {err}"
+            ) from err
+        return OpenSenseMapStationData(pm2_5=self.api.pm2_5, pm10=self.api.pm10)


### PR DESCRIPTION
Replace the per-entity async_update polling pattern with a DataUpdateCoordinator that fetches the station data once per update cycle and exposes it as an immutable OpenSenseMapStationData dataclass.

This prepares the integration for additional entity platforms (sensors) without each entity having to poll the API independently.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works. - **Existing tests are covering the API fetching**
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
