### PR TITLE
Add Helty Flow integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -718,6 +718,8 @@ CLAUDE.md @home-assistant/core
 /homeassistant/components/heatmiser/ @andylockran
 /homeassistant/components/hegel/ @boazca
 /tests/components/hegel/ @boazca
+/homeassistant/components/helty/ @ebaschiera
+/tests/components/helty/ @ebaschiera
 /homeassistant/components/heos/ @andrewsayre
 /tests/components/heos/ @andrewsayre
 /homeassistant/components/here_travel_time/ @eifinger

--- a/homeassistant/components/helty/__init__.py
+++ b/homeassistant/components/helty/__init__.py
@@ -2,7 +2,7 @@
 
 from pyhelty import HeltyClient
 
-from homeassistant.const import CONF_HOST, CONF_PORT, Platform
+from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 
 from .coordinator import HeltyConfigEntry, HeltyDataUpdateCoordinator
@@ -12,7 +12,7 @@ PLATFORMS: list[Platform] = [Platform.FAN]
 
 async def async_setup_entry(hass: HomeAssistant, entry: HeltyConfigEntry) -> bool:
     """Set up Helty Flow from a config entry."""
-    client = HeltyClient(entry.data[CONF_HOST], entry.data[CONF_PORT])
+    client = HeltyClient(entry.data[CONF_HOST])
     coordinator = HeltyDataUpdateCoordinator(hass, entry, client)
     await coordinator.async_config_entry_first_refresh()
 

--- a/homeassistant/components/helty/__init__.py
+++ b/homeassistant/components/helty/__init__.py
@@ -1,0 +1,26 @@
+"""The Helty Flow integration."""
+
+from pyhelty import HeltyClient
+
+from homeassistant.const import CONF_HOST, CONF_PORT, Platform
+from homeassistant.core import HomeAssistant
+
+from .coordinator import HeltyConfigEntry, HeltyDataUpdateCoordinator
+
+PLATFORMS: list[Platform] = [Platform.FAN]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: HeltyConfigEntry) -> bool:
+    """Set up Helty Flow from a config entry."""
+    client = HeltyClient(entry.data[CONF_HOST], entry.data[CONF_PORT])
+    coordinator = HeltyDataUpdateCoordinator(hass, entry, client)
+    await coordinator.async_config_entry_first_refresh()
+
+    entry.runtime_data = coordinator
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: HeltyConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/helty/config_flow.py
+++ b/homeassistant/components/helty/config_flow.py
@@ -2,35 +2,15 @@
 
 from typing import Any
 
-from pyhelty import (
-    DEFAULT_PORT,
-    HeltyClient,
-    HeltyConnectionError,
-    HeltyError,
-    HeltyResponseError,
-)
+from pyhelty import HeltyClient, HeltyConnectionError, HeltyError
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.const import CONF_HOST
 
 from .const import DOMAIN
 
-STEP_USER_DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_HOST): str,
-        vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
-    }
-)
-
-
-async def _async_validate(data: dict[str, Any]) -> str:
-    """Validate connectivity and return the device name (the stable unique id)."""
-    client = HeltyClient(data[CONF_HOST], data[CONF_PORT])
-    name = await client.async_get_name()
-    if not name:
-        raise HeltyResponseError("Device returned an empty name")
-    return name
+STEP_USER_DATA_SCHEMA = vol.Schema({vol.Required(CONF_HOST): str})
 
 
 class HeltyConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -42,45 +22,19 @@ class HeltyConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the initial setup step."""
         errors: dict[str, str] = {}
         if user_input is not None:
+            self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
+            client = HeltyClient(user_input[CONF_HOST])
             try:
-                name = await _async_validate(user_input)
+                name = await client.async_get_name()
             except HeltyConnectionError:
                 errors["base"] = "cannot_connect"
             except HeltyError:
                 errors["base"] = "unknown"
             else:
-                await self.async_set_unique_id(name)
-                self._abort_if_unique_id_configured()
-                return self.async_create_entry(title=name, data=user_input)
-
-        return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
-        )
-
-    async def async_step_reconfigure(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle reconfiguration (e.g. the unit's IP address changed)."""
-        errors: dict[str, str] = {}
-        reconfigure_entry = self._get_reconfigure_entry()
-        if user_input is not None:
-            try:
-                name = await _async_validate(user_input)
-            except HeltyConnectionError:
-                errors["base"] = "cannot_connect"
-            except HeltyError:
-                errors["base"] = "unknown"
-            else:
-                await self.async_set_unique_id(name)
-                self._abort_if_unique_id_mismatch()
-                return self.async_update_reload_and_abort(
-                    reconfigure_entry, data_updates=user_input
+                return self.async_create_entry(
+                    title=name or user_input[CONF_HOST], data=user_input
                 )
 
         return self.async_show_form(
-            step_id="reconfigure",
-            data_schema=self.add_suggested_values_to_schema(
-                STEP_USER_DATA_SCHEMA, reconfigure_entry.data
-            ),
-            errors=errors,
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
         )

--- a/homeassistant/components/helty/config_flow.py
+++ b/homeassistant/components/helty/config_flow.py
@@ -1,0 +1,86 @@
+"""Config flow for the Helty Flow integration."""
+
+from typing import Any
+
+from pyhelty import (
+    DEFAULT_PORT,
+    HeltyClient,
+    HeltyConnectionError,
+    HeltyError,
+    HeltyResponseError,
+)
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_HOST, CONF_PORT
+
+from .const import DOMAIN
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+    }
+)
+
+
+async def _async_validate(data: dict[str, Any]) -> str:
+    """Validate connectivity and return the device name (the stable unique id)."""
+    client = HeltyClient(data[CONF_HOST], data[CONF_PORT])
+    name = await client.async_get_name()
+    if not name:
+        raise HeltyResponseError("Device returned an empty name")
+    return name
+
+
+class HeltyConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Helty Flow."""
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial setup step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                name = await _async_validate(user_input)
+            except HeltyConnectionError:
+                errors["base"] = "cannot_connect"
+            except HeltyError:
+                errors["base"] = "unknown"
+            else:
+                await self.async_set_unique_id(name)
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(title=name, data=user_input)
+
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration (e.g. the unit's IP address changed)."""
+        errors: dict[str, str] = {}
+        reconfigure_entry = self._get_reconfigure_entry()
+        if user_input is not None:
+            try:
+                name = await _async_validate(user_input)
+            except HeltyConnectionError:
+                errors["base"] = "cannot_connect"
+            except HeltyError:
+                errors["base"] = "unknown"
+            else:
+                await self.async_set_unique_id(name)
+                self._abort_if_unique_id_mismatch()
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry, data_updates=user_input
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_USER_DATA_SCHEMA, reconfigure_entry.data
+            ),
+            errors=errors,
+        )

--- a/homeassistant/components/helty/const.py
+++ b/homeassistant/components/helty/const.py
@@ -1,0 +1,13 @@
+"""Constants for the Helty Flow integration."""
+
+from datetime import timedelta
+
+DOMAIN = "helty"
+
+#: How often the coordinator polls the unit.
+SCAN_INTERVAL = timedelta(seconds=60)
+
+# Fan preset mode identifiers (also used as translation keys).
+PRESET_BOOST = "boost"
+PRESET_NIGHT = "night"
+PRESET_FREE_COOLING = "free_cooling"

--- a/homeassistant/components/helty/coordinator.py
+++ b/homeassistant/components/helty/coordinator.py
@@ -1,0 +1,45 @@
+"""DataUpdateCoordinator for the Helty Flow integration."""
+
+import logging
+
+from pyhelty import HeltyClient, HeltyConnectionError, HeltyData, HeltyError
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN, SCAN_INTERVAL
+
+_LOGGER = logging.getLogger(__name__)
+
+type HeltyConfigEntry = ConfigEntry[HeltyDataUpdateCoordinator]
+
+
+class HeltyDataUpdateCoordinator(DataUpdateCoordinator[HeltyData]):
+    """Coordinate a single poll of the Helty unit for all entities."""
+
+    config_entry: HeltyConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: HeltyConfigEntry,
+        client: HeltyClient,
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name=DOMAIN,
+            update_interval=SCAN_INTERVAL,
+        )
+        self.client = client
+
+    async def _async_update_data(self) -> HeltyData:
+        try:
+            return await self.client.async_get_data()
+        except HeltyConnectionError as err:
+            raise UpdateFailed(f"Error communicating with Helty unit: {err}") from err
+        except HeltyError as err:
+            raise UpdateFailed(f"Unexpected response from Helty unit: {err}") from err

--- a/homeassistant/components/helty/entity.py
+++ b/homeassistant/components/helty/entity.py
@@ -1,0 +1,25 @@
+"""Base entity for the Helty Flow integration."""
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import HeltyDataUpdateCoordinator
+
+
+class HeltyEntity(CoordinatorEntity[HeltyDataUpdateCoordinator]):
+    """Common base for Helty entities sharing one device and coordinator."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: HeltyDataUpdateCoordinator) -> None:
+        """Initialize the entity and its shared device info."""
+        super().__init__(coordinator)
+        entry = coordinator.config_entry
+        self._device_id = entry.unique_id or entry.entry_id
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._device_id)},
+            name=coordinator.data.name,
+            manufacturer="Helty",
+            model="Flow",
+        )

--- a/homeassistant/components/helty/entity.py
+++ b/homeassistant/components/helty/entity.py
@@ -15,8 +15,8 @@ class HeltyEntity(CoordinatorEntity[HeltyDataUpdateCoordinator]):
     def __init__(self, coordinator: HeltyDataUpdateCoordinator) -> None:
         """Initialize the entity and its shared device info."""
         super().__init__(coordinator)
-        entry = coordinator.config_entry
-        self._device_id = entry.unique_id or entry.entry_id
+        # The unit exposes no serial/MAC, so the config entry id identifies it.
+        self._device_id = coordinator.config_entry.entry_id
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._device_id)},
             name=coordinator.data.name,

--- a/homeassistant/components/helty/fan.py
+++ b/homeassistant/components/helty/fan.py
@@ -60,7 +60,7 @@ class HeltyFan(HeltyEntity, FanEntity):
     def __init__(self, coordinator: HeltyDataUpdateCoordinator) -> None:
         """Initialize the fan."""
         super().__init__(coordinator)
-        self._attr_unique_id = f"{self._device_id}_fan"
+        self._attr_unique_id = self._device_id
         self._attr_preset_modes = list(PRESET_TO_MODE)
 
     @property

--- a/homeassistant/components/helty/fan.py
+++ b/homeassistant/components/helty/fan.py
@@ -49,6 +49,7 @@ class HeltyFan(HeltyEntity, FanEntity):
     """The ventilation unit's fan, the device's primary feature."""
 
     _attr_name = None
+    _attr_speed_count = len(ORDERED_SPEEDS)
     _attr_supported_features = (
         FanEntityFeature.SET_SPEED
         | FanEntityFeature.PRESET_MODE
@@ -59,7 +60,7 @@ class HeltyFan(HeltyEntity, FanEntity):
     def __init__(self, coordinator: HeltyDataUpdateCoordinator) -> None:
         """Initialize the fan."""
         super().__init__(coordinator)
-        self._attr_unique_id = self._device_id
+        self._attr_unique_id = f"{self._device_id}_fan"
         self._attr_preset_modes = list(PRESET_TO_MODE)
 
     @property
@@ -70,11 +71,6 @@ class HeltyFan(HeltyEntity, FanEntity):
     def is_on(self) -> bool:
         """Return whether the fan is running."""
         return self._mode is not FanMode.OFF
-
-    @property
-    def speed_count(self) -> int:
-        """Return the number of discrete speeds."""
-        return len(ORDERED_SPEEDS)
 
     @property
     def percentage(self) -> int | None:

--- a/homeassistant/components/helty/fan.py
+++ b/homeassistant/components/helty/fan.py
@@ -1,0 +1,124 @@
+"""Fan platform for the Helty Flow integration."""
+
+from typing import Any
+
+from pyhelty import FanMode
+
+from homeassistant.components.fan import FanEntity, FanEntityFeature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util.percentage import (
+    ordered_list_item_to_percentage,
+    percentage_to_ordered_list_item,
+)
+
+from .const import PRESET_BOOST, PRESET_FREE_COOLING, PRESET_NIGHT
+from .coordinator import HeltyConfigEntry, HeltyDataUpdateCoordinator
+from .entity import HeltyEntity
+
+PARALLEL_UPDATES = 1
+
+# Ordered list of discrete fan speeds, lowest to highest.
+ORDERED_SPEEDS: list[FanMode] = [
+    FanMode.LOW,
+    FanMode.MEDIUM,
+    FanMode.HIGH,
+    FanMode.MAX,
+]
+
+PRESET_TO_MODE: dict[str, FanMode] = {
+    PRESET_BOOST: FanMode.BOOST,
+    PRESET_NIGHT: FanMode.NIGHT,
+    PRESET_FREE_COOLING: FanMode.FREE_COOLING,
+}
+MODE_TO_PRESET: dict[FanMode, str] = {
+    mode: preset for preset, mode in PRESET_TO_MODE.items()
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: HeltyConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Helty fan."""
+    async_add_entities([HeltyFan(entry.runtime_data)])
+
+
+class HeltyFan(HeltyEntity, FanEntity):
+    """The ventilation unit's fan, the device's primary feature."""
+
+    _attr_name = None
+    _attr_supported_features = (
+        FanEntityFeature.SET_SPEED
+        | FanEntityFeature.PRESET_MODE
+        | FanEntityFeature.TURN_ON
+        | FanEntityFeature.TURN_OFF
+    )
+
+    def __init__(self, coordinator: HeltyDataUpdateCoordinator) -> None:
+        """Initialize the fan."""
+        super().__init__(coordinator)
+        self._attr_unique_id = self._device_id
+        self._attr_preset_modes = list(PRESET_TO_MODE)
+
+    @property
+    def _mode(self) -> FanMode:
+        return self.coordinator.data.fan_mode
+
+    @property
+    def is_on(self) -> bool:
+        """Return whether the fan is running."""
+        return self._mode is not FanMode.OFF
+
+    @property
+    def speed_count(self) -> int:
+        """Return the number of discrete speeds."""
+        return len(ORDERED_SPEEDS)
+
+    @property
+    def percentage(self) -> int | None:
+        """Return the current speed as a percentage, or None when on a preset."""
+        if self._mode in ORDERED_SPEEDS:
+            return ordered_list_item_to_percentage(ORDERED_SPEEDS, self._mode)
+        return None
+
+    @property
+    def preset_mode(self) -> str | None:
+        """Return the active preset, or None when running on a discrete speed."""
+        return MODE_TO_PRESET.get(self._mode)
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        """Set a discrete fan speed from a percentage."""
+        if percentage == 0:
+            await self._async_set_mode(FanMode.OFF)
+            return
+        await self._async_set_mode(
+            percentage_to_ordered_list_item(ORDERED_SPEEDS, percentage)
+        )
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set a preset mode."""
+        await self._async_set_mode(PRESET_TO_MODE[preset_mode])
+
+    async def async_turn_on(
+        self,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Turn the fan on."""
+        if preset_mode is not None:
+            await self.async_set_preset_mode(preset_mode)
+        elif percentage is not None:
+            await self.async_set_percentage(percentage)
+        else:
+            await self._async_set_mode(FanMode.LOW)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the fan off."""
+        await self._async_set_mode(FanMode.OFF)
+
+    async def _async_set_mode(self, mode: FanMode) -> None:
+        await self.coordinator.client.async_set_fan_mode(mode)
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/helty/manifest.json
+++ b/homeassistant/components/helty/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "helty",
+  "name": "Helty Flow",
+  "codeowners": ["@ebaschiera"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/helty",
+  "integration_type": "device",
+  "iot_class": "local_polling",
+  "loggers": ["pyhelty"],
+  "quality_scale": "bronze",
+  "requirements": ["pyhelty==0.2.0"]
+}

--- a/homeassistant/components/helty/quality_scale.yaml
+++ b/homeassistant/components/helty/quality_scale.yaml
@@ -78,7 +78,7 @@ rules:
   icon-translations:
     status: exempt
     comment: The fan entity uses the default fan icon.
-  reconfiguration-flow: done
+  reconfiguration-flow: todo
   repair-issues:
     status: exempt
     comment: This integration has no repairable issues to surface.

--- a/homeassistant/components/helty/quality_scale.yaml
+++ b/homeassistant/components/helty/quality_scale.yaml
@@ -1,0 +1,96 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: This integration does not provide additional actions.
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: This integration does not provide additional actions.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  entity-event-setup:
+    status: exempt
+    comment: This integration does not subscribe to external events.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: This integration does not provide additional actions.
+  config-entry-unloading: done
+  docs-configuration-parameters:
+    status: exempt
+    comment: This integration has no options to configure.
+  docs-installation-parameters: done
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: done
+  reauthentication-flow:
+    status: exempt
+    comment: This integration does not require authentication.
+  test-coverage: done
+
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info:
+    status: exempt
+    comment: The device does not support discovery.
+  discovery:
+    status: exempt
+    comment: |
+      The device exposes no discovery protocol (no mDNS/SSDP) and no stable
+      identifier such as a serial number or MAC over its interface.
+  docs-data-update: done
+  docs-examples: todo
+  docs-known-limitations: done
+  docs-supported-devices: done
+  docs-supported-functions: done
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices:
+    status: exempt
+    comment: A config entry represents a single fixed device.
+  entity-category: done
+  entity-device-class: done
+  entity-disabled-by-default:
+    status: exempt
+    comment: The only entity is the primary fan, which is enabled by default.
+  entity-translations:
+    status: exempt
+    comment: |
+      The only entity is the primary fan, which uses the device name and has
+      no name of its own to translate.
+  exception-translations: todo
+  icon-translations:
+    status: exempt
+    comment: The fan entity uses the default fan icon.
+  reconfiguration-flow: done
+  repair-issues:
+    status: exempt
+    comment: This integration has no repairable issues to surface.
+  stale-devices:
+    status: exempt
+    comment: A config entry represents a single fixed device.
+
+  # Platinum
+  async-dependency: done
+  inject-websession:
+    status: exempt
+    comment: |
+      The device is controlled over a raw TCP socket, not HTTP, so there is no
+      web session to inject.
+  strict-typing: todo

--- a/homeassistant/components/helty/strings.json
+++ b/homeassistant/components/helty/strings.json
@@ -1,0 +1,37 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to your Helty Flow",
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]"
+        },
+        "data_description": {
+          "host": "The IP address or hostname of the Helty Flow unit on your network.",
+          "port": "The TCP port of the unit's smart interface (usually 5001)."
+        }
+      },
+      "reconfigure": {
+        "title": "Update your Helty Flow connection",
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]"
+        },
+        "data_description": {
+          "host": "[%key:component::helty::config::step::user::data_description::host%]",
+          "port": "[%key:component::helty::config::step::user::data_description::port%]"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+      "unique_id_mismatch": "The unit at this address is a different Helty Flow than the one being reconfigured."
+    }
+  }
+}

--- a/homeassistant/components/helty/strings.json
+++ b/homeassistant/components/helty/strings.json
@@ -1,34 +1,19 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
-      "unique_id_mismatch": "The unit at this address is a different Helty Flow than the one being reconfigured."
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
-      "reconfigure": {
-        "data": {
-          "host": "[%key:common::config_flow::data::host%]",
-          "port": "[%key:common::config_flow::data::port%]"
-        },
-        "data_description": {
-          "host": "[%key:component::helty::config::step::user::data_description::host%]",
-          "port": "[%key:component::helty::config::step::user::data_description::port%]"
-        },
-        "title": "Update your Helty Flow connection"
-      },
       "user": {
         "data": {
-          "host": "[%key:common::config_flow::data::host%]",
-          "port": "[%key:common::config_flow::data::port%]"
+          "host": "[%key:common::config_flow::data::host%]"
         },
         "data_description": {
-          "host": "The IP address or hostname of the Helty Flow unit on your network.",
-          "port": "The TCP port of the unit's smart interface (usually 5001)."
+          "host": "The IP address or hostname of the Helty Flow unit on your network."
         },
         "title": "Connect to your Helty Flow"
       }

--- a/homeassistant/components/helty/strings.json
+++ b/homeassistant/components/helty/strings.json
@@ -1,19 +1,16 @@
 {
   "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+      "unique_id_mismatch": "The unit at this address is a different Helty Flow than the one being reconfigured."
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
     "step": {
-      "user": {
-        "title": "Connect to your Helty Flow",
-        "data": {
-          "host": "[%key:common::config_flow::data::host%]",
-          "port": "[%key:common::config_flow::data::port%]"
-        },
-        "data_description": {
-          "host": "The IP address or hostname of the Helty Flow unit on your network.",
-          "port": "The TCP port of the unit's smart interface (usually 5001)."
-        }
-      },
       "reconfigure": {
-        "title": "Update your Helty Flow connection",
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "port": "[%key:common::config_flow::data::port%]"
@@ -21,17 +18,20 @@
         "data_description": {
           "host": "[%key:component::helty::config::step::user::data_description::host%]",
           "port": "[%key:component::helty::config::step::user::data_description::port%]"
-        }
+        },
+        "title": "Update your Helty Flow connection"
+      },
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]"
+        },
+        "data_description": {
+          "host": "The IP address or hostname of the Helty Flow unit on your network.",
+          "port": "The TCP port of the unit's smart interface (usually 5001)."
+        },
+        "title": "Connect to your Helty Flow"
       }
-    },
-    "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
-    },
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
-      "unique_id_mismatch": "The unit at this address is a different Helty Flow than the one being reconfigured."
     }
   }
 }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -300,6 +300,7 @@ FLOWS = {
         "harmony",
         "hdfury",
         "hegel",
+        "helty",
         "heos",
         "here_travel_time",
         "hikvision",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -223,7 +223,6 @@
       "iot_class": "local_push"
     },
     "alert": {
-      "name": "Alert",
       "integration_type": "hub",
       "config_flow": false,
       "iot_class": "local_push"
@@ -438,8 +437,7 @@
         "homekit_controller": {
           "integration_type": "device",
           "config_flow": true,
-          "iot_class": "local_push",
-          "name": "HomeKit Device"
+          "iot_class": "local_push"
         },
         "homekit": {
           "integration_type": "hub",
@@ -633,7 +631,6 @@
       }
     },
     "aurora": {
-      "name": "Aurora",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "cloud_polling"
@@ -1007,7 +1004,6 @@
       "iot_class": "cloud_polling"
     },
     "cert_expiry": {
-      "name": "Certificate Expiry",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "cloud_polling"
@@ -1226,7 +1222,6 @@
       "supported_by": "overkiz"
     },
     "cpuspeed": {
-      "name": "CPU Speed",
       "integration_type": "device",
       "config_flow": true,
       "iot_class": "local_push",
@@ -1332,7 +1327,6 @@
       "iot_class": "local_polling"
     },
     "demo": {
-      "name": "Demo",
       "integration_type": "hub",
       "config_flow": false,
       "iot_class": "calculated",
@@ -1815,13 +1809,11 @@
       "iot_class": "local_push"
     },
     "emulated_roku": {
-      "name": "Emulated Roku",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_push"
     },
     "energenie_power_sockets": {
-      "name": "Energenie Power Sockets",
       "integration_type": "device",
       "config_flow": true,
       "iot_class": "local_polling"
@@ -2071,7 +2063,6 @@
       "iot_class": "local_polling"
     },
     "filesize": {
-      "name": "File Size",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_polling"
@@ -2395,7 +2386,6 @@
       "iot_class": "cloud_polling"
     },
     "garages_amsterdam": {
-      "name": "Garages Amsterdam",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "cloud_polling"
@@ -2418,7 +2408,6 @@
       "iot_class": "cloud_polling"
     },
     "generic": {
-      "name": "Generic Camera",
       "integration_type": "device",
       "config_flow": true,
       "iot_class": "local_push"
@@ -2625,8 +2614,7 @@
         "google_travel_time": {
           "integration_type": "service",
           "config_flow": true,
-          "iot_class": "cloud_polling",
-          "name": "Google Maps Travel Time"
+          "iot_class": "cloud_polling"
         },
         "google_weather": {
           "integration_type": "service",
@@ -2733,7 +2721,6 @@
       "iot_class": "local_polling"
     },
     "growatt_server": {
-      "name": "Growatt",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "cloud_polling"
@@ -2932,7 +2919,6 @@
       "iot_class": "local_push"
     },
     "holiday": {
-      "name": "Holiday",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_polling"
@@ -3377,7 +3363,6 @@
       "iot_class": "cloud_polling"
     },
     "irm_kmi": {
-      "name": "IRM KMI Weather Belgium",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "cloud_polling"
@@ -3395,7 +3380,6 @@
       "iot_class": "local_polling"
     },
     "islamic_prayer_times": {
-      "name": "Islamic Prayer Times",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "calculated"
@@ -3908,7 +3892,6 @@
       "iot_class": "cloud_push"
     },
     "local_calendar": {
-      "name": "Local Calendar",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_polling"
@@ -3920,14 +3903,12 @@
       "iot_class": "local_polling"
     },
     "local_ip": {
-      "name": "Local IP Address",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_polling",
       "single_config_entry": true
     },
     "local_todo": {
-      "name": "Local To-do",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_polling"
@@ -4394,7 +4375,6 @@
       "iot_class": "local_push"
     },
     "mobile_app": {
-      "name": "Mobile App",
       "integration_type": "device",
       "config_flow": true,
       "iot_class": "local_push"
@@ -4424,7 +4404,6 @@
       "iot_class": "local_polling"
     },
     "moehlenhoff_alpha2": {
-      "name": "M\u00f6hlenhoff Alpha 2",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_push"
@@ -4453,7 +4432,6 @@
       "iot_class": "cloud_polling"
     },
     "moon": {
-      "name": "Moon",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "calculated",
@@ -4716,7 +4694,6 @@
       "supported_by": "overkiz"
     },
     "nextbus": {
-      "name": "NextBus",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "cloud_polling"
@@ -4789,7 +4766,6 @@
       "iot_class": "cloud_polling"
     },
     "nmap_tracker": {
-      "name": "Nmap Tracker",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_polling"
@@ -5439,7 +5415,6 @@
       "iot_class": "cloud_push"
     },
     "plant": {
-      "name": "Plant Monitor",
       "integration_type": "hub",
       "config_flow": false
     },
@@ -5567,7 +5542,6 @@
       "iot_class": "cloud_push"
     },
     "proximity": {
-      "name": "Proximity",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "calculated"
@@ -5823,8 +5797,7 @@
         "rpi_power": {
           "integration_type": "hub",
           "config_flow": true,
-          "iot_class": "local_polling",
-          "name": "Raspberry Pi Power Supply Checker"
+          "iot_class": "local_polling"
         },
         "remote_rpi_gpio": {
           "integration_type": "hub",
@@ -5901,7 +5874,6 @@
       "iot_class": "cloud_push"
     },
     "remote_calendar": {
-      "name": "Remote Calendar",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "cloud_polling"
@@ -6230,7 +6202,6 @@
       "iot_class": "local_polling"
     },
     "season": {
-      "name": "Season",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "local_polling"
@@ -6386,7 +6357,6 @@
       "iot_class": "cloud_polling"
     },
     "shopping_list": {
-      "name": "Shopping List",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_push"
@@ -6860,7 +6830,6 @@
       "iot_class": "cloud_polling"
     },
     "sun": {
-      "name": "Sun",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "calculated",
@@ -7285,7 +7254,6 @@
       }
     },
     "time_date": {
-      "name": "Time & Date",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "local_push"
@@ -7652,7 +7620,6 @@
       "supported_by": "motion_blinds"
     },
     "uptime": {
-      "name": "Uptime",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "local_push",
@@ -7706,7 +7673,6 @@
       "iot_class": "cloud_polling"
     },
     "vegehub": {
-      "name": "Vegetronix VegeHub",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_push"
@@ -7753,7 +7719,6 @@
       "iot_class": "local_polling"
     },
     "version": {
-      "name": "Version",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_push"
@@ -7937,7 +7902,6 @@
       "iot_class": "cloud_polling"
     },
     "waze_travel_time": {
-      "name": "Waze Travel Time",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "cloud_polling"
@@ -8055,7 +8019,6 @@
       "iot_class": "cloud_polling"
     },
     "workday": {
-      "name": "Workday",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "local_polling"
@@ -8354,7 +8317,6 @@
       "iot_class": "cloud_polling"
     },
     "zodiac": {
-      "name": "Zodiac",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "calculated"
@@ -8397,78 +8359,64 @@
   },
   "helper": {
     "counter": {
-      "name": "Counter",
       "integration_type": "helper",
       "config_flow": false
     },
     "derivative": {
-      "name": "Derivative",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "calculated"
     },
     "filter": {
-      "name": "Filter",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "local_push"
     },
     "generic_hygrostat": {
-      "name": "Generic hygrostat",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "local_polling"
     },
     "generic_thermostat": {
-      "name": "Generic Thermostat",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "local_polling"
     },
     "group": {
-      "name": "Group",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "calculated"
     },
     "history_stats": {
-      "name": "History Stats",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "local_polling"
     },
     "input_boolean": {
-      "name": "Input Boolean",
       "integration_type": "helper",
       "config_flow": false
     },
     "input_button": {
-      "name": "Input Button",
       "integration_type": "helper",
       "config_flow": false
     },
     "input_datetime": {
-      "name": "Input Datetime",
       "integration_type": "helper",
       "config_flow": false
     },
     "input_number": {
-      "name": "Input Number",
       "integration_type": "helper",
       "config_flow": false
     },
     "input_select": {
-      "name": "Input Select",
       "integration_type": "helper",
       "config_flow": false
     },
     "input_text": {
-      "name": "Input Text",
       "integration_type": "helper",
       "config_flow": false
     },
     "integration": {
-      "name": "Integral",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "local_push"
@@ -8480,13 +8428,11 @@
       "iot_class": "calculated"
     },
     "min_max": {
-      "name": "Min/Max",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "calculated"
     },
     "mold_indicator": {
-      "name": "Mold Indicator",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "calculated"
@@ -8498,24 +8444,20 @@
       "iot_class": "local_polling"
     },
     "random": {
-      "name": "Random",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "calculated"
     },
     "schedule": {
-      "name": "Schedule",
       "integration_type": "helper",
       "config_flow": false
     },
     "statistics": {
-      "name": "Statistics",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "local_polling"
     },
     "switch_as_x": {
-      "name": "Change device type of a switch",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "calculated"
@@ -8527,34 +8469,93 @@
       "iot_class": "local_push"
     },
     "threshold": {
-      "name": "Threshold",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "local_polling"
     },
     "timer": {
-      "name": "Timer",
       "integration_type": "helper",
       "config_flow": false
     },
     "tod": {
-      "name": "Times of the Day",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "calculated"
     },
     "trend": {
-      "name": "Trend",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "calculated"
     },
     "utility_meter": {
-      "name": "Utility Meter",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "local_push"
     }
   },
-  "translated_name": []
+  "translated_name": [
+    "alert",
+    "aurora",
+    "cert_expiry",
+    "counter",
+    "cpuspeed",
+    "demo",
+    "derivative",
+    "emulated_roku",
+    "energenie_power_sockets",
+    "filesize",
+    "filter",
+    "garages_amsterdam",
+    "generic",
+    "generic_hygrostat",
+    "generic_thermostat",
+    "google_travel_time",
+    "group",
+    "growatt_server",
+    "history_stats",
+    "holiday",
+    "homekit_controller",
+    "input_boolean",
+    "input_button",
+    "input_datetime",
+    "input_number",
+    "input_select",
+    "input_text",
+    "integration",
+    "irm_kmi",
+    "islamic_prayer_times",
+    "local_calendar",
+    "local_ip",
+    "local_todo",
+    "min_max",
+    "mobile_app",
+    "moehlenhoff_alpha2",
+    "mold_indicator",
+    "moon",
+    "nextbus",
+    "nmap_tracker",
+    "plant",
+    "proximity",
+    "random",
+    "remote_calendar",
+    "rpi_power",
+    "schedule",
+    "season",
+    "shopping_list",
+    "statistics",
+    "sun",
+    "switch_as_x",
+    "threshold",
+    "time_date",
+    "timer",
+    "tod",
+    "trend",
+    "uptime",
+    "utility_meter",
+    "vegehub",
+    "version",
+    "waze_travel_time",
+    "workday",
+    "zodiac"
+  ]
 }

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -223,6 +223,7 @@
       "iot_class": "local_push"
     },
     "alert": {
+      "name": "Alert",
       "integration_type": "hub",
       "config_flow": false,
       "iot_class": "local_push"
@@ -437,7 +438,8 @@
         "homekit_controller": {
           "integration_type": "device",
           "config_flow": true,
-          "iot_class": "local_push"
+          "iot_class": "local_push",
+          "name": "HomeKit Device"
         },
         "homekit": {
           "integration_type": "hub",
@@ -631,6 +633,7 @@
       }
     },
     "aurora": {
+      "name": "Aurora",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "cloud_polling"
@@ -1004,6 +1007,7 @@
       "iot_class": "cloud_polling"
     },
     "cert_expiry": {
+      "name": "Certificate Expiry",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "cloud_polling"
@@ -1222,6 +1226,7 @@
       "supported_by": "overkiz"
     },
     "cpuspeed": {
+      "name": "CPU Speed",
       "integration_type": "device",
       "config_flow": true,
       "iot_class": "local_push",
@@ -1327,6 +1332,7 @@
       "iot_class": "local_polling"
     },
     "demo": {
+      "name": "Demo",
       "integration_type": "hub",
       "config_flow": false,
       "iot_class": "calculated",
@@ -1809,11 +1815,13 @@
       "iot_class": "local_push"
     },
     "emulated_roku": {
+      "name": "Emulated Roku",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_push"
     },
     "energenie_power_sockets": {
+      "name": "Energenie Power Sockets",
       "integration_type": "device",
       "config_flow": true,
       "iot_class": "local_polling"
@@ -2063,6 +2071,7 @@
       "iot_class": "local_polling"
     },
     "filesize": {
+      "name": "File Size",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_polling"
@@ -2386,6 +2395,7 @@
       "iot_class": "cloud_polling"
     },
     "garages_amsterdam": {
+      "name": "Garages Amsterdam",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "cloud_polling"
@@ -2408,6 +2418,7 @@
       "iot_class": "cloud_polling"
     },
     "generic": {
+      "name": "Generic Camera",
       "integration_type": "device",
       "config_flow": true,
       "iot_class": "local_push"
@@ -2614,7 +2625,8 @@
         "google_travel_time": {
           "integration_type": "service",
           "config_flow": true,
-          "iot_class": "cloud_polling"
+          "iot_class": "cloud_polling",
+          "name": "Google Maps Travel Time"
         },
         "google_weather": {
           "integration_type": "service",
@@ -2721,6 +2733,7 @@
       "iot_class": "local_polling"
     },
     "growatt_server": {
+      "name": "Growatt",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "cloud_polling"
@@ -2849,6 +2862,12 @@
         "zwave"
       ]
     },
+    "helty": {
+      "name": "Helty Flow",
+      "integration_type": "device",
+      "config_flow": true,
+      "iot_class": "local_polling"
+    },
     "here_travel_time": {
       "name": "HERE Travel Time",
       "integration_type": "service",
@@ -2913,6 +2932,7 @@
       "iot_class": "local_push"
     },
     "holiday": {
+      "name": "Holiday",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_polling"
@@ -3357,6 +3377,7 @@
       "iot_class": "cloud_polling"
     },
     "irm_kmi": {
+      "name": "IRM KMI Weather Belgium",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "cloud_polling"
@@ -3374,6 +3395,7 @@
       "iot_class": "local_polling"
     },
     "islamic_prayer_times": {
+      "name": "Islamic Prayer Times",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "calculated"
@@ -3886,6 +3908,7 @@
       "iot_class": "cloud_push"
     },
     "local_calendar": {
+      "name": "Local Calendar",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_polling"
@@ -3897,12 +3920,14 @@
       "iot_class": "local_polling"
     },
     "local_ip": {
+      "name": "Local IP Address",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_polling",
       "single_config_entry": true
     },
     "local_todo": {
+      "name": "Local To-do",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_polling"
@@ -4369,6 +4394,7 @@
       "iot_class": "local_push"
     },
     "mobile_app": {
+      "name": "Mobile App",
       "integration_type": "device",
       "config_flow": true,
       "iot_class": "local_push"
@@ -4398,6 +4424,7 @@
       "iot_class": "local_polling"
     },
     "moehlenhoff_alpha2": {
+      "name": "M\u00f6hlenhoff Alpha 2",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_push"
@@ -4426,6 +4453,7 @@
       "iot_class": "cloud_polling"
     },
     "moon": {
+      "name": "Moon",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "calculated",
@@ -4688,6 +4716,7 @@
       "supported_by": "overkiz"
     },
     "nextbus": {
+      "name": "NextBus",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "cloud_polling"
@@ -4760,6 +4789,7 @@
       "iot_class": "cloud_polling"
     },
     "nmap_tracker": {
+      "name": "Nmap Tracker",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_polling"
@@ -5409,6 +5439,7 @@
       "iot_class": "cloud_push"
     },
     "plant": {
+      "name": "Plant Monitor",
       "integration_type": "hub",
       "config_flow": false
     },
@@ -5536,6 +5567,7 @@
       "iot_class": "cloud_push"
     },
     "proximity": {
+      "name": "Proximity",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "calculated"
@@ -5791,7 +5823,8 @@
         "rpi_power": {
           "integration_type": "hub",
           "config_flow": true,
-          "iot_class": "local_polling"
+          "iot_class": "local_polling",
+          "name": "Raspberry Pi Power Supply Checker"
         },
         "remote_rpi_gpio": {
           "integration_type": "hub",
@@ -5868,6 +5901,7 @@
       "iot_class": "cloud_push"
     },
     "remote_calendar": {
+      "name": "Remote Calendar",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "cloud_polling"
@@ -6196,6 +6230,7 @@
       "iot_class": "local_polling"
     },
     "season": {
+      "name": "Season",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "local_polling"
@@ -6351,6 +6386,7 @@
       "iot_class": "cloud_polling"
     },
     "shopping_list": {
+      "name": "Shopping List",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_push"
@@ -6824,6 +6860,7 @@
       "iot_class": "cloud_polling"
     },
     "sun": {
+      "name": "Sun",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "calculated",
@@ -7248,6 +7285,7 @@
       }
     },
     "time_date": {
+      "name": "Time & Date",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "local_push"
@@ -7614,6 +7652,7 @@
       "supported_by": "motion_blinds"
     },
     "uptime": {
+      "name": "Uptime",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "local_push",
@@ -7667,6 +7706,7 @@
       "iot_class": "cloud_polling"
     },
     "vegehub": {
+      "name": "Vegetronix VegeHub",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_push"
@@ -7713,6 +7753,7 @@
       "iot_class": "local_polling"
     },
     "version": {
+      "name": "Version",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_push"
@@ -7896,6 +7937,7 @@
       "iot_class": "cloud_polling"
     },
     "waze_travel_time": {
+      "name": "Waze Travel Time",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "cloud_polling"
@@ -8013,6 +8055,7 @@
       "iot_class": "cloud_polling"
     },
     "workday": {
+      "name": "Workday",
       "integration_type": "service",
       "config_flow": true,
       "iot_class": "local_polling"
@@ -8311,6 +8354,7 @@
       "iot_class": "cloud_polling"
     },
     "zodiac": {
+      "name": "Zodiac",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "calculated"
@@ -8353,64 +8397,78 @@
   },
   "helper": {
     "counter": {
+      "name": "Counter",
       "integration_type": "helper",
       "config_flow": false
     },
     "derivative": {
+      "name": "Derivative",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "calculated"
     },
     "filter": {
+      "name": "Filter",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "local_push"
     },
     "generic_hygrostat": {
+      "name": "Generic hygrostat",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "local_polling"
     },
     "generic_thermostat": {
+      "name": "Generic Thermostat",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "local_polling"
     },
     "group": {
+      "name": "Group",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "calculated"
     },
     "history_stats": {
+      "name": "History Stats",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "local_polling"
     },
     "input_boolean": {
+      "name": "Input Boolean",
       "integration_type": "helper",
       "config_flow": false
     },
     "input_button": {
+      "name": "Input Button",
       "integration_type": "helper",
       "config_flow": false
     },
     "input_datetime": {
+      "name": "Input Datetime",
       "integration_type": "helper",
       "config_flow": false
     },
     "input_number": {
+      "name": "Input Number",
       "integration_type": "helper",
       "config_flow": false
     },
     "input_select": {
+      "name": "Input Select",
       "integration_type": "helper",
       "config_flow": false
     },
     "input_text": {
+      "name": "Input Text",
       "integration_type": "helper",
       "config_flow": false
     },
     "integration": {
+      "name": "Integral",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "local_push"
@@ -8422,11 +8480,13 @@
       "iot_class": "calculated"
     },
     "min_max": {
+      "name": "Min/Max",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "calculated"
     },
     "mold_indicator": {
+      "name": "Mold Indicator",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "calculated"
@@ -8438,20 +8498,24 @@
       "iot_class": "local_polling"
     },
     "random": {
+      "name": "Random",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "calculated"
     },
     "schedule": {
+      "name": "Schedule",
       "integration_type": "helper",
       "config_flow": false
     },
     "statistics": {
+      "name": "Statistics",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "local_polling"
     },
     "switch_as_x": {
+      "name": "Change device type of a switch",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "calculated"
@@ -8463,93 +8527,34 @@
       "iot_class": "local_push"
     },
     "threshold": {
+      "name": "Threshold",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "local_polling"
     },
     "timer": {
+      "name": "Timer",
       "integration_type": "helper",
       "config_flow": false
     },
     "tod": {
+      "name": "Times of the Day",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "calculated"
     },
     "trend": {
+      "name": "Trend",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "calculated"
     },
     "utility_meter": {
+      "name": "Utility Meter",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "local_push"
     }
   },
-  "translated_name": [
-    "alert",
-    "aurora",
-    "cert_expiry",
-    "counter",
-    "cpuspeed",
-    "demo",
-    "derivative",
-    "emulated_roku",
-    "energenie_power_sockets",
-    "filesize",
-    "filter",
-    "garages_amsterdam",
-    "generic",
-    "generic_hygrostat",
-    "generic_thermostat",
-    "google_travel_time",
-    "group",
-    "growatt_server",
-    "history_stats",
-    "holiday",
-    "homekit_controller",
-    "input_boolean",
-    "input_button",
-    "input_datetime",
-    "input_number",
-    "input_select",
-    "input_text",
-    "integration",
-    "irm_kmi",
-    "islamic_prayer_times",
-    "local_calendar",
-    "local_ip",
-    "local_todo",
-    "min_max",
-    "mobile_app",
-    "moehlenhoff_alpha2",
-    "mold_indicator",
-    "moon",
-    "nextbus",
-    "nmap_tracker",
-    "plant",
-    "proximity",
-    "random",
-    "remote_calendar",
-    "rpi_power",
-    "schedule",
-    "season",
-    "shopping_list",
-    "statistics",
-    "sun",
-    "switch_as_x",
-    "threshold",
-    "time_date",
-    "timer",
-    "tod",
-    "trend",
-    "uptime",
-    "utility_meter",
-    "vegehub",
-    "version",
-    "waze_travel_time",
-    "workday",
-    "zodiac"
-  ]
+  "translated_name": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2201,6 +2201,9 @@ pygti==0.9.4
 # homeassistant.components.version
 pyhaversion==22.8.0
 
+# homeassistant.components.helty
+pyhelty==0.2.0
+
 # homeassistant.components.heos
 pyheos==1.0.6
 

--- a/tests/components/helty/__init__.py
+++ b/tests/components/helty/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Helty Flow integration."""

--- a/tests/components/helty/__init__.py
+++ b/tests/components/helty/__init__.py
@@ -1,1 +1,12 @@
 """Tests for the Helty Flow integration."""
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+    """Set up the Helty Flow integration in Home Assistant."""
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/components/helty/conftest.py
+++ b/tests/components/helty/conftest.py
@@ -1,0 +1,73 @@
+"""Common fixtures for the Helty Flow tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+from pyhelty import FanMode, HeltyData
+import pytest
+
+from homeassistant.components.helty.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PORT
+
+from tests.common import MockConfigEntry
+
+DEVICE_NAME = "VMC Soggiorno"
+HOST = "192.168.20.232"
+PORT = 5001
+
+
+def make_data(fan_mode: FanMode = FanMode.LOW) -> HeltyData:
+    """Build a representative HeltyData snapshot."""
+    return HeltyData(
+        name=DEVICE_NAME,
+        fan_mode=fan_mode,
+        leds_on=True,
+        indoor_temperature=28.1,
+        outdoor_temperature=31.2,
+        indoor_humidity=42.2,
+        co2=0,
+        filter_hours=0,
+        light_level=0,
+        raw_sensors=tuple([281, 312, 422] + [0] * 12),
+        raw_status=tuple([int(fan_mode), 10] + [0] * 13),
+    )
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.helty.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
+@pytest.fixture
+def mock_helty_client() -> Generator[AsyncMock]:
+    """Mock a Helty client at both the integration and config flow import sites."""
+    with (
+        patch(
+            "homeassistant.components.helty.HeltyClient",
+            autospec=True,
+        ) as mock_client,
+        patch(
+            "homeassistant.components.helty.config_flow.HeltyClient",
+            new=mock_client,
+        ),
+    ):
+        client = mock_client.return_value
+        client.async_get_name.return_value = DEVICE_NAME
+        client.async_get_data.return_value = make_data()
+        yield client
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a configured Helty entry, unique_id = device name."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title=DEVICE_NAME,
+        unique_id=DEVICE_NAME,
+        data={CONF_HOST: HOST, CONF_PORT: PORT},
+    )

--- a/tests/components/helty/conftest.py
+++ b/tests/components/helty/conftest.py
@@ -7,13 +7,12 @@ from pyhelty import FanMode, HeltyData
 import pytest
 
 from homeassistant.components.helty.const import DOMAIN
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.const import CONF_HOST
 
 from tests.common import MockConfigEntry
 
 DEVICE_NAME = "VMC Soggiorno"
 HOST = "192.168.20.232"
-PORT = 5001
 
 
 def make_data(fan_mode: FanMode = FanMode.LOW) -> HeltyData:
@@ -64,10 +63,9 @@ def mock_helty_client() -> Generator[AsyncMock]:
 
 @pytest.fixture
 def mock_config_entry() -> MockConfigEntry:
-    """Return a configured Helty entry, unique_id = device name."""
+    """Return a configured Helty entry."""
     return MockConfigEntry(
         domain=DOMAIN,
         title=DEVICE_NAME,
-        unique_id=DEVICE_NAME,
-        data={CONF_HOST: HOST, CONF_PORT: PORT},
+        data={CONF_HOST: HOST},
     )

--- a/tests/components/helty/conftest.py
+++ b/tests/components/helty/conftest.py
@@ -68,4 +68,5 @@ def mock_config_entry() -> MockConfigEntry:
         domain=DOMAIN,
         title=DEVICE_NAME,
         data={CONF_HOST: HOST},
+        entry_id="01HHHHHHHHHHHHHHHHHHHHHHHH",
     )

--- a/tests/components/helty/snapshots/test_fan.ambr
+++ b/tests/components/helty/snapshots/test_fan.ambr
@@ -1,0 +1,66 @@
+# serializer version: 1
+# name: test_all_entities[fan.vmc_soggiorno-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'preset_modes': list([
+        'boost',
+        'night',
+        'free_cooling',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'fan',
+    'entity_category': None,
+    'entity_id': 'fan.vmc_soggiorno',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'helty',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <FanEntityFeature: 57>,
+    'translation_key': None,
+    'unique_id': '01HHHHHHHHHHHHHHHHHHHHHHHH',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[fan.vmc_soggiorno-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VMC Soggiorno',
+      'percentage': 25,
+      'percentage_step': 25.0,
+      'preset_mode': None,
+      'preset_modes': list([
+        'boost',
+        'night',
+        'free_cooling',
+      ]),
+      'supported_features': <FanEntityFeature: 57>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'fan.vmc_soggiorno',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/helty/test_config_flow.py
+++ b/tests/components/helty/test_config_flow.py
@@ -7,15 +7,15 @@ import pytest
 
 from homeassistant.components.helty.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from .conftest import DEVICE_NAME, HOST, PORT
+from .conftest import DEVICE_NAME, HOST
 
 from tests.common import MockConfigEntry
 
-USER_INPUT = {CONF_HOST: HOST, CONF_PORT: PORT}
+USER_INPUT = {CONF_HOST: HOST}
 
 
 async def test_user_flow(
@@ -37,32 +37,7 @@ async def test_user_flow(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == DEVICE_NAME
     assert result["data"] == USER_INPUT
-    assert result["result"].unique_id == DEVICE_NAME
     assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_user_flow_cannot_connect(
-    hass: HomeAssistant,
-    mock_helty_client: AsyncMock,
-    mock_setup_entry: AsyncMock,
-) -> None:
-    """Test a connection error is shown, then the flow recovers."""
-    mock_helty_client.async_get_name.side_effect = HeltyConnectionError
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], USER_INPUT
-    )
-    assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {"base": "cannot_connect"}
-
-    mock_helty_client.async_get_name.side_effect = None
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], USER_INPUT
-    )
-    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_user_flow_empty_name(
@@ -70,7 +45,7 @@ async def test_user_flow_empty_name(
     mock_helty_client: AsyncMock,
     mock_setup_entry: AsyncMock,
 ) -> None:
-    """Test an empty device name surfaces as an unknown error, then recovers."""
+    """Test the host is used as the title when the unit reports no name."""
     mock_helty_client.async_get_name.return_value = ""
 
     result = await hass.config_entries.flow.async_init(
@@ -79,10 +54,38 @@ async def test_user_flow_empty_name(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], USER_INPUT
     )
-    assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {"base": "unknown"}
 
-    mock_helty_client.async_get_name.return_value = DEVICE_NAME
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == HOST
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "error"),
+    [
+        (HeltyConnectionError, "cannot_connect"),
+        (HeltyError, "unknown"),
+    ],
+)
+async def test_user_flow_errors(
+    hass: HomeAssistant,
+    mock_helty_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+    side_effect: type[Exception],
+    error: str,
+) -> None:
+    """Test errors are shown, then the flow recovers."""
+    mock_helty_client.async_get_name.side_effect = side_effect
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": error}
+
+    mock_helty_client.async_get_name.side_effect = None
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], USER_INPUT
     )
@@ -95,7 +98,7 @@ async def test_already_configured(
     mock_setup_entry: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test we abort if the same unit is already configured."""
+    """Test we abort if a unit at the same host is already configured."""
     mock_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
@@ -106,76 +109,3 @@ async def test_already_configured(
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
-
-
-async def test_reconfigure(
-    hass: HomeAssistant,
-    mock_helty_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test reconfiguring an entry with a new address."""
-    mock_config_entry.add_to_hass(hass)
-
-    result = await mock_config_entry.start_reconfigure_flow(hass)
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure"
-
-    new_input = {CONF_HOST: "192.168.20.99", CONF_PORT: PORT}
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], new_input
-    )
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "reconfigure_successful"
-    assert mock_config_entry.data == new_input
-
-
-@pytest.mark.parametrize(
-    ("side_effect", "error"),
-    [
-        (HeltyConnectionError, "cannot_connect"),
-        (HeltyError, "unknown"),
-    ],
-)
-async def test_reconfigure_errors(
-    hass: HomeAssistant,
-    mock_helty_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-    side_effect: type[Exception],
-    error: str,
-) -> None:
-    """Test errors are shown during reconfigure, then the flow recovers."""
-    mock_config_entry.add_to_hass(hass)
-    mock_helty_client.async_get_name.side_effect = side_effect
-
-    result = await mock_config_entry.start_reconfigure_flow(hass)
-    new_input = {CONF_HOST: "192.168.20.99", CONF_PORT: PORT}
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], new_input
-    )
-    assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {"base": error}
-
-    mock_helty_client.async_get_name.side_effect = None
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], new_input
-    )
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "reconfigure_successful"
-    assert mock_config_entry.data == new_input
-
-
-async def test_reconfigure_wrong_device(
-    hass: HomeAssistant,
-    mock_helty_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test reconfiguring against a different unit is rejected."""
-    mock_config_entry.add_to_hass(hass)
-    mock_helty_client.async_get_name.return_value = "Another Helty"
-
-    result = await mock_config_entry.start_reconfigure_flow(hass)
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_HOST: "192.168.20.99", CONF_PORT: PORT}
-    )
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "unique_id_mismatch"

--- a/tests/components/helty/test_config_flow.py
+++ b/tests/components/helty/test_config_flow.py
@@ -1,0 +1,181 @@
+"""Test the Helty Flow config flow."""
+
+from unittest.mock import AsyncMock
+
+from pyhelty import HeltyConnectionError, HeltyError
+import pytest
+
+from homeassistant.components.helty.const import DOMAIN
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from .conftest import DEVICE_NAME, HOST, PORT
+
+from tests.common import MockConfigEntry
+
+USER_INPUT = {CONF_HOST: HOST, CONF_PORT: PORT}
+
+
+async def test_user_flow(
+    hass: HomeAssistant,
+    mock_helty_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test the happy path of the user flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == DEVICE_NAME
+    assert result["data"] == USER_INPUT
+    assert result["result"].unique_id == DEVICE_NAME
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_user_flow_cannot_connect(
+    hass: HomeAssistant,
+    mock_helty_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test a connection error is shown, then the flow recovers."""
+    mock_helty_client.async_get_name.side_effect = HeltyConnectionError
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+    mock_helty_client.async_get_name.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+async def test_user_flow_empty_name(
+    hass: HomeAssistant,
+    mock_helty_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test an empty device name surfaces as an unknown error, then recovers."""
+    mock_helty_client.async_get_name.return_value = ""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "unknown"}
+
+    mock_helty_client.async_get_name.return_value = DEVICE_NAME
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+async def test_already_configured(
+    hass: HomeAssistant,
+    mock_helty_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test we abort if the same unit is already configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_reconfigure(
+    hass: HomeAssistant,
+    mock_helty_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfiguring an entry with a new address."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    new_input = {CONF_HOST: "192.168.20.99", CONF_PORT: PORT}
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], new_input
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_config_entry.data == new_input
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "error"),
+    [
+        (HeltyConnectionError, "cannot_connect"),
+        (HeltyError, "unknown"),
+    ],
+)
+async def test_reconfigure_errors(
+    hass: HomeAssistant,
+    mock_helty_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    side_effect: type[Exception],
+    error: str,
+) -> None:
+    """Test errors are shown during reconfigure, then the flow recovers."""
+    mock_config_entry.add_to_hass(hass)
+    mock_helty_client.async_get_name.side_effect = side_effect
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+    new_input = {CONF_HOST: "192.168.20.99", CONF_PORT: PORT}
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], new_input
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": error}
+
+    mock_helty_client.async_get_name.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], new_input
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_config_entry.data == new_input
+
+
+async def test_reconfigure_wrong_device(
+    hass: HomeAssistant,
+    mock_helty_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfiguring against a different unit is rejected."""
+    mock_config_entry.add_to_hass(hass)
+    mock_helty_client.async_get_name.return_value = "Another Helty"
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "192.168.20.99", CONF_PORT: PORT}
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "unique_id_mismatch"

--- a/tests/components/helty/test_fan.py
+++ b/tests/components/helty/test_fan.py
@@ -1,9 +1,10 @@
 """Test the Helty Flow fan platform."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 from pyhelty import FanMode
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.fan import (
     ATTR_PERCENTAGE,
@@ -16,35 +17,31 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
-    STATE_ON,
+    Platform,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
+from . import setup_integration
 from .conftest import make_data
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, snapshot_platform
 
 FAN_ENTITY = "fan.vmc_soggiorno"
 
 
-async def _setup(hass: HomeAssistant, entry: MockConfigEntry) -> None:
-    entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
-
-async def test_fan_speed_state(
+async def test_all_entities(
     hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
     mock_helty_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test the fan reports a discrete speed."""
-    await _setup(hass, mock_config_entry)
+    """Test all entities."""
+    with patch("homeassistant.components.helty.PLATFORMS", [Platform.FAN]):
+        await setup_integration(hass, mock_config_entry)
 
-    state = hass.states.get(FAN_ENTITY)
-    assert state.state == STATE_ON
-    assert state.attributes[ATTR_PERCENTAGE] == 25  # LOW = 1/4
-    assert state.attributes[ATTR_PRESET_MODE] is None
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
 async def test_fan_preset_state(
@@ -54,7 +51,7 @@ async def test_fan_preset_state(
 ) -> None:
     """Test the fan reports an active preset."""
     mock_helty_client.async_get_data.return_value = make_data(fan_mode=FanMode.NIGHT)
-    await _setup(hass, mock_config_entry)
+    await setup_integration(hass, mock_config_entry)
 
     state = hass.states.get(FAN_ENTITY)
     assert state.attributes[ATTR_PRESET_MODE] == "night"
@@ -67,7 +64,7 @@ async def test_fan_set_preset(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test setting a preset mode."""
-    await _setup(hass, mock_config_entry)
+    await setup_integration(hass, mock_config_entry)
 
     await hass.services.async_call(
         FAN_DOMAIN,
@@ -90,7 +87,7 @@ async def test_fan_set_percentage(
     expected: FanMode,
 ) -> None:
     """Test mapping a percentage to a discrete speed."""
-    await _setup(hass, mock_config_entry)
+    await setup_integration(hass, mock_config_entry)
 
     await hass.services.async_call(
         FAN_DOMAIN,
@@ -107,7 +104,7 @@ async def test_fan_set_percentage_zero_turns_off(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test setting 0% turns the fan off."""
-    await _setup(hass, mock_config_entry)
+    await setup_integration(hass, mock_config_entry)
 
     await hass.services.async_call(
         FAN_DOMAIN,
@@ -124,7 +121,7 @@ async def test_fan_turn_off_and_on(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test turning the fan off and back on."""
-    await _setup(hass, mock_config_entry)
+    await setup_integration(hass, mock_config_entry)
 
     await hass.services.async_call(
         FAN_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: FAN_ENTITY}, blocking=True
@@ -143,7 +140,7 @@ async def test_fan_turn_on_with_percentage(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test turning on with an explicit percentage."""
-    await _setup(hass, mock_config_entry)
+    await setup_integration(hass, mock_config_entry)
 
     await hass.services.async_call(
         FAN_DOMAIN,
@@ -160,7 +157,7 @@ async def test_fan_turn_on_with_preset(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test turning on with an explicit preset."""
-    await _setup(hass, mock_config_entry)
+    await setup_integration(hass, mock_config_entry)
 
     await hass.services.async_call(
         FAN_DOMAIN,

--- a/tests/components/helty/test_fan.py
+++ b/tests/components/helty/test_fan.py
@@ -1,0 +1,171 @@
+"""Test the Helty Flow fan platform."""
+
+from unittest.mock import AsyncMock
+
+from pyhelty import FanMode
+import pytest
+
+from homeassistant.components.fan import (
+    ATTR_PERCENTAGE,
+    ATTR_PRESET_MODE,
+    DOMAIN as FAN_DOMAIN,
+    SERVICE_SET_PERCENTAGE,
+    SERVICE_SET_PRESET_MODE,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_ON,
+)
+from homeassistant.core import HomeAssistant
+
+from .conftest import make_data
+
+from tests.common import MockConfigEntry
+
+FAN_ENTITY = "fan.vmc_soggiorno"
+
+
+async def _setup(hass: HomeAssistant, entry: MockConfigEntry) -> None:
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_fan_speed_state(
+    hass: HomeAssistant,
+    mock_helty_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the fan reports a discrete speed."""
+    await _setup(hass, mock_config_entry)
+
+    state = hass.states.get(FAN_ENTITY)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_PERCENTAGE] == 25  # LOW = 1/4
+    assert state.attributes[ATTR_PRESET_MODE] is None
+
+
+async def test_fan_preset_state(
+    hass: HomeAssistant,
+    mock_helty_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the fan reports an active preset."""
+    mock_helty_client.async_get_data.return_value = make_data(fan_mode=FanMode.NIGHT)
+    await _setup(hass, mock_config_entry)
+
+    state = hass.states.get(FAN_ENTITY)
+    assert state.attributes[ATTR_PRESET_MODE] == "night"
+    assert state.attributes[ATTR_PERCENTAGE] is None
+
+
+async def test_fan_set_preset(
+    hass: HomeAssistant,
+    mock_helty_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test setting a preset mode."""
+    await _setup(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_SET_PRESET_MODE,
+        {ATTR_ENTITY_ID: FAN_ENTITY, ATTR_PRESET_MODE: "boost"},
+        blocking=True,
+    )
+    mock_helty_client.async_set_fan_mode.assert_awaited_with(FanMode.BOOST)
+
+
+@pytest.mark.parametrize(
+    ("percentage", "expected"),
+    [(25, FanMode.LOW), (50, FanMode.MEDIUM), (75, FanMode.HIGH), (100, FanMode.MAX)],
+)
+async def test_fan_set_percentage(
+    hass: HomeAssistant,
+    mock_helty_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    percentage: int,
+    expected: FanMode,
+) -> None:
+    """Test mapping a percentage to a discrete speed."""
+    await _setup(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_SET_PERCENTAGE,
+        {ATTR_ENTITY_ID: FAN_ENTITY, ATTR_PERCENTAGE: percentage},
+        blocking=True,
+    )
+    mock_helty_client.async_set_fan_mode.assert_awaited_with(expected)
+
+
+async def test_fan_set_percentage_zero_turns_off(
+    hass: HomeAssistant,
+    mock_helty_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test setting 0% turns the fan off."""
+    await _setup(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_SET_PERCENTAGE,
+        {ATTR_ENTITY_ID: FAN_ENTITY, ATTR_PERCENTAGE: 0},
+        blocking=True,
+    )
+    mock_helty_client.async_set_fan_mode.assert_awaited_with(FanMode.OFF)
+
+
+async def test_fan_turn_off_and_on(
+    hass: HomeAssistant,
+    mock_helty_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test turning the fan off and back on."""
+    await _setup(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        FAN_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: FAN_ENTITY}, blocking=True
+    )
+    mock_helty_client.async_set_fan_mode.assert_awaited_with(FanMode.OFF)
+
+    await hass.services.async_call(
+        FAN_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: FAN_ENTITY}, blocking=True
+    )
+    mock_helty_client.async_set_fan_mode.assert_awaited_with(FanMode.LOW)
+
+
+async def test_fan_turn_on_with_percentage(
+    hass: HomeAssistant,
+    mock_helty_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test turning on with an explicit percentage."""
+    await _setup(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: FAN_ENTITY, ATTR_PERCENTAGE: 100},
+        blocking=True,
+    )
+    mock_helty_client.async_set_fan_mode.assert_awaited_with(FanMode.MAX)
+
+
+async def test_fan_turn_on_with_preset(
+    hass: HomeAssistant,
+    mock_helty_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test turning on with an explicit preset."""
+    await _setup(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: FAN_ENTITY, ATTR_PRESET_MODE: "free_cooling"},
+        blocking=True,
+    )
+    mock_helty_client.async_set_fan_mode.assert_awaited_with(FanMode.FREE_COOLING)

--- a/tests/components/helty/test_init.py
+++ b/tests/components/helty/test_init.py
@@ -8,6 +8,8 @@ import pytest
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
+from . import setup_integration
+
 from tests.common import MockConfigEntry
 
 
@@ -17,10 +19,7 @@ async def test_setup_and_unload(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test a config entry sets up and tears down cleanly."""
-    mock_config_entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
+    await setup_integration(hass, mock_config_entry)
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(mock_config_entry.entry_id)

--- a/tests/components/helty/test_init.py
+++ b/tests/components/helty/test_init.py
@@ -1,0 +1,44 @@
+"""Test the Helty Flow setup."""
+
+from unittest.mock import AsyncMock
+
+from pyhelty import HeltyConnectionError, HeltyResponseError
+import pytest
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_setup_and_unload(
+    hass: HomeAssistant,
+    mock_helty_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a config entry sets up and tears down cleanly."""
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+@pytest.mark.parametrize("side_effect", [HeltyConnectionError, HeltyResponseError])
+async def test_setup_error(
+    hass: HomeAssistant,
+    mock_helty_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    side_effect: type[Exception],
+) -> None:
+    """Test an error talking to the unit during setup leads to a retry."""
+    mock_helty_client.async_get_data.side_effect = side_effect
+
+    mock_config_entry.add_to_hass(hass)
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION
## Breaking change

## Proposed change

Add a new integration for [Helty Flow](https://www.heltyair.com/) decentralised
heat-recovery ventilation units (MVHR / VMC) that expose the smart Wi-Fi
interface. The integration talks to the unit locally over TCP (`local_polling`)
through the new [`pyhelty`](https://github.com/ebaschiera/pyhelty) library
(PyPI, MIT, fully typed, async).

This first PR is intentionally minimal and ships a single platform — the
**fan** entity, which is the device's primary feature (on/off, four speeds and
the boost / night / free-cooling presets). A `DataUpdateCoordinator` polls the
unit once per cycle for all entities, and a reconfigure flow lets users update
the host/port if the unit's IP address changes (the device exposes no
serial/MAC, so its name is used as the stable unique id).

Sensor, switch and button platforms will follow in separate PRs.

New dependency: `pyhelty==0.2.0` — initial release, source and changelog at
https://github.com/ebaschiera/pyhelty/releases

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#45679
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
