### PR TITLE
Bump python-roborock to 5.14.1 and revert defensive aiohttp catch

### DIFF
--- a/homeassistant/components/roborock/__init__.py
+++ b/homeassistant/components/roborock/__init__.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 import logging
 from typing import Any
 
-import aiohttp
 from roborock import (
     RoborockException,
     RoborockInvalidCredentials,
@@ -120,12 +119,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: RoborockConfigEntry) -> 
         raise ConfigEntryNotReady(
             translation_domain=DOMAIN,
             translation_key="home_data_fail",
-        ) from err
-    except (aiohttp.ClientError, TimeoutError) as err:
-        _LOGGER.debug("Network error setting up Roborock: %s", err)
-        raise ConfigEntryNotReady(
-            translation_domain=DOMAIN,
-            translation_key="network_error",
         ) from err
 
     async def shutdown_roborock(_: Event | None = None) -> None:

--- a/homeassistant/components/roborock/manifest.json
+++ b/homeassistant/components/roborock/manifest.json
@@ -20,7 +20,7 @@
   "loggers": ["roborock"],
   "quality_scale": "silver",
   "requirements": [
-    "python-roborock==5.12.0",
+    "python-roborock==5.14.1",
     "vacuum-map-parser-roborock==0.1.4"
   ]
 }

--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -677,9 +677,6 @@
     "mqtt_unauthorized": {
       "message": "Roborock MQTT servers rejected the connection due to rate limiting or invalid credentials. You may either attempt to reauthenticate or wait and reload the integration."
     },
-    "network_error": {
-      "message": "Network error connecting to Roborock servers. Check your internet connection and the Roborock service status."
-    },
     "no_coordinators": {
       "message": "No devices were able to successfully setup"
     },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2712,7 +2712,7 @@ python-rabbitair==0.0.8
 python-ripple-api==0.0.3
 
 # homeassistant.components.roborock
-python-roborock==5.12.0
+python-roborock==5.14.1
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.47

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -5,7 +5,6 @@ import pathlib
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
-import aiohttp
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from roborock import (
@@ -255,26 +254,6 @@ async def test_no_user_agreement(
         await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
         assert mock_roborock_entry.state is ConfigEntryState.SETUP_RETRY
         assert mock_roborock_entry.error_reason_translation_key == "no_user_agreement"
-
-
-@pytest.mark.parametrize(
-    "side_effect",
-    [aiohttp.ClientError(), TimeoutError()],
-    ids=["client_error", "timeout"],
-)
-async def test_network_error_during_setup(
-    hass: HomeAssistant,
-    mock_roborock_entry: MockConfigEntry,
-    side_effect: Exception,
-) -> None:
-    """Test that network errors during setup trigger retry, not terminal failure."""
-    with patch(
-        "homeassistant.components.roborock.create_device_manager",
-        side_effect=side_effect,
-    ):
-        await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
-        assert mock_roborock_entry.state is ConfigEntryState.SETUP_RETRY
-        assert mock_roborock_entry.error_reason_translation_key == "network_error"
 
 
 @pytest.mark.parametrize("platforms", [[Platform.SENSOR]])


### PR DESCRIPTION
## Proposed change

Bump `python-roborock` from 5.12.0 to 5.14.1 and revert the defensive `aiohttp.ClientError`/`TimeoutError` catch added in #172492.

The library v5.14.1 (via [Python-roborock/python-roborock#835][835]) now wraps network exceptions at the HTTP chokepoint (`PreparedRequest.request`) so they emerge as `RoborockException`. The integration's existing `except RoborockException` handler in `async_setup_entry` already catches that and raises `ConfigEntryNotReady`. The HA-side defensive catch is now redundant and is reverted per @allenporter's [review comment][allenporter] on #172492.

[835]: https://github.com/Python-roborock/python-roborock/pull/835
[allenporter]: https://github.com/home-assistant/core/pull/172492#issuecomment-4576280978

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #172492

Sequence:
1. Upstream fix merged: Python-roborock/python-roborock#835 (2026-06-01)
2. Library v5.14.1 released: 2026-06-01
3. This PR bumps + reverts.

Library diff: [v5.12.0...v5.14.1](https://github.com/Python-roborock/python-roborock/compare/v5.12.0...v5.14.1)

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: \`python3 -m script.hassfest\`.
- [x] New or updated dependencies have been added to \`requirements_all.txt\`.  
      Updated by running \`python3 -m script.gen_requirements_all\`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.