### PR TITLE
Ignore Beacons security policy flag in Thread dataset comparison

### DIFF
--- a/homeassistant/components/thread/dataset_store.py
+++ b/homeassistant/components/thread/dataset_store.py
@@ -28,8 +28,9 @@ STORAGE_VERSION_MINOR = 4
 SAVE_DELAY = 10
 
 # Bit 0x08 of the first security policy flags byte is the legacy "Beacons"
-# flag. Newer OpenThread Border Router versions clear it by default without
-# incrementing the active timestamp, so it is ignored when comparing datasets.
+# flag. It was removed from the Thread security policy in v1.2.1 (2022), so
+# current Thread stacks no longer set it; datasets that still carry it were
+# created by older implementations. It is ignored when comparing datasets.
 SECURITY_POLICY_BEACONS_FLAG = 0x08
 
 _LOGGER = logging.getLogger(__name__)
@@ -58,14 +59,15 @@ def _normalize_dataset(
 ) -> dict[MeshcopTLVType | int, tlv_parser.MeshcopTLVItem]:
     """Normalize a dataset for equivalence comparison.
 
-    Newer OpenThread Border Router versions report functionally equivalent
-    datasets without incrementing the active timestamp. To recognize these as
-    equivalent, ignore the fields that don't affect how Home Assistant uses the
-    dataset:
-    - WAKEUP_CHANNEL: added in OpenThread but the wake-up protocol isn't defined
-      yet, so we treat it as if it were always present.
-    - The Beacons bit in the security policy flags: newer OpenThread versions
-      clear this legacy flag by default.
+    Thread Border Routers may report functionally equivalent datasets without
+    incrementing the active timestamp. To recognize these as equivalent, ignore
+    the fields that don't affect how Home Assistant uses the dataset:
+    - WAKEUP_CHANNEL: added in newer OpenThread Border Router versions, but the
+      wake-up protocol isn't defined yet, so we treat it as if it were always
+      present.
+    - The legacy Beacons bit in the security policy flags: it was removed from
+      the Thread security policy in v1.2.1, so datasets created by older
+      implementations may still set it while current routers don't.
     """
     normalized = {
         key: value

--- a/homeassistant/components/thread/dataset_store.py
+++ b/homeassistant/components/thread/dataset_store.py
@@ -27,6 +27,11 @@ STORAGE_VERSION_MAJOR = 1
 STORAGE_VERSION_MINOR = 4
 SAVE_DELAY = 10
 
+# Bit 0x08 of the first security policy flags byte is the legacy "Beacons"
+# flag. Newer OpenThread Border Router versions clear it by default without
+# incrementing the active timestamp, so it is ignored when comparing datasets.
+SECURITY_POLICY_BEACONS_FLAG = 0x08
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -46,6 +51,36 @@ def _format_dataset(
         else:
             result[name] = str(value)
     return result
+
+
+def _normalize_dataset(
+    dataset: dict[MeshcopTLVType | int, tlv_parser.MeshcopTLVItem],
+) -> dict[MeshcopTLVType | int, tlv_parser.MeshcopTLVItem]:
+    """Normalize a dataset for equivalence comparison.
+
+    Newer OpenThread Border Router versions report functionally equivalent
+    datasets without incrementing the active timestamp. To recognize these as
+    equivalent, ignore the fields that don't affect how Home Assistant uses the
+    dataset:
+    - WAKEUP_CHANNEL: added in OpenThread but the wake-up protocol isn't defined
+      yet, so we treat it as if it were always present.
+    - The Beacons bit in the security policy flags: newer OpenThread versions
+      clear this legacy flag by default.
+    """
+    normalized = {
+        key: value
+        for key, value in dataset.items()
+        if key != MeshcopTLVType.WAKEUP_CHANNEL
+    }
+    if (security_policy := normalized.get(MeshcopTLVType.SECURITYPOLICY)) and len(
+        security_policy.data
+    ) > 2:
+        flags = bytearray(security_policy.data)
+        flags[2] &= ~SECURITY_POLICY_BEACONS_FLAG
+        normalized[MeshcopTLVType.SECURITYPOLICY] = tlv_parser.MeshcopTLVItem(
+            security_policy.tag, bytes(flags)
+        )
+    return normalized
 
 
 class DatasetPreferredError(HomeAssistantError):
@@ -280,15 +315,12 @@ class DatasetStore:
             old_ts = (old_timestamp.seconds, old_timestamp.ticks)
             new_ts = (new_timestamp.seconds, new_timestamp.ticks)
             if old_ts >= new_ts:
-                # Silently accept if the only addition is WAKEUP_CHANNEL:
-                # it was added in OpenThread but the wake-up protocol isn't
-                # defined yet, so we treat it as if it were always present.
-                dataset_without_wakeup = {
-                    k: v
-                    for k, v in dataset.items()
-                    if k != MeshcopTLVType.WAKEUP_CHANNEL
-                }
-                if old_ts > new_ts or dataset_without_wakeup != entry.dataset:
+                # Silently accept datasets that are functionally equivalent but
+                # reported without a newer active timestamp by some OpenThread
+                # Border Router versions (see _normalize_dataset).
+                if old_ts > new_ts or _normalize_dataset(dataset) != _normalize_dataset(
+                    entry.dataset
+                ):
                     _LOGGER.warning(
                         "Got dataset with same extended PAN ID and same or older"
                         " active timestamp\nold:\n%s\nnew:\n%s",

--- a/tests/components/thread/test_dataset_store.py
+++ b/tests/components/thread/test_dataset_store.py
@@ -68,6 +68,23 @@ DATASET_1_WITH_WAKEUP_CHANNEL = (
     "0212340410445F2B5CA6F2A93A55CE570A70EFEECB0C0402A0F7F84A0300000B"
 )
 
+# Same as DATASET_1 but with the legacy Beacons bit set in the security policy
+# (02A0F7F8 -> 02A0FFF8), same timestamp. Newer OpenThread versions clear this
+# bit by default without bumping the active timestamp.
+DATASET_1_WITH_BEACONS_FLAG = (
+    "0E080000000000010000000300000F35060004001FFFE0020811111111222222220708FDAD70BF"
+    "E5AA15DD051000112233445566778899AABBCCDDEEFF030E4F70656E54687265616444656D6F01"
+    "0212340410445F2B5CA6F2A93A55CE570A70EFEECB0C0402A0FFF8"
+)
+
+# Same as DATASET_1 but with a different security policy rotation time (672h ->
+# 673h, 02A0F7F8 -> 02A1F7F8), same timestamp. A genuine security policy change.
+DATASET_1_OTHER_SECURITY_POLICY = (
+    "0E080000000000010000000300000F35060004001FFFE0020811111111222222220708FDAD70BF"
+    "E5AA15DD051000112233445566778899AABBCCDDEEFF030E4F70656E54687265616444656D6F01"
+    "0212340410445F2B5CA6F2A93A55CE570A70EFEECB0C0402A1F7F8"
+)
+
 
 async def test_add_invalid_dataset(hass: HomeAssistant) -> None:
     """Test adding an invalid dataset."""
@@ -262,25 +279,60 @@ async def test_update_dataset_older(
     )
 
 
-async def test_update_dataset_wakeup_channel(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+@pytest.mark.parametrize(
+    ("stored", "updated"),
+    [
+        # WAKEUP_CHANNEL was added to OpenThread but the wake-up protocol isn't
+        # defined yet, so a dataset that only adds this field is equivalent.
+        pytest.param(DATASET_1, DATASET_1_WITH_WAKEUP_CHANNEL, id="wakeup_channel"),
+        # Newer OpenThread versions clear the legacy Beacons bit in the security
+        # policy without bumping the active timestamp.
+        pytest.param(DATASET_1_WITH_BEACONS_FLAG, DATASET_1, id="beacons_flag"),
+    ],
+)
+async def test_update_dataset_equivalent(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    stored: str,
+    updated: str,
 ) -> None:
-    """Test that adding WAKEUP_CHANNEL with the same timestamp is silently accepted.
+    """Test that an equivalent dataset with the same timestamp is silently accepted.
 
-    WAKEUP_CHANNEL was added to OpenThread but the wake-up protocol isn't
-    defined yet. We treat a dataset that only adds this key as equivalent,
-    updating the stored TLV without logging a warning.
+    Some OpenThread Border Router versions report functionally equivalent
+    datasets without incrementing the active timestamp. We update the stored
+    TLV without logging a warning.
     """
-    await dataset_store.async_add_dataset(hass, "test", DATASET_1)
-    await dataset_store.async_add_dataset(hass, "test", DATASET_1_WITH_WAKEUP_CHANNEL)
+    await dataset_store.async_add_dataset(hass, "test", stored)
+    await dataset_store.async_add_dataset(hass, "test", updated)
 
     store = await dataset_store.async_get_store(hass)
     assert len(store.datasets) == 1
-    assert list(store.datasets.values())[0].tlv == DATASET_1_WITH_WAKEUP_CHANNEL
+    assert list(store.datasets.values())[0].tlv == updated
 
     assert (
         "Got dataset with same extended PAN ID and same or older active timestamp"
         not in caplog.text
+    )
+
+
+async def test_update_dataset_changed_security_policy(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test a genuine security policy change with the same timestamp warns.
+
+    Only the ignored Beacons bit and WAKEUP_CHANNEL are treated as equivalent;
+    any other change (here the rotation time) is still reported.
+    """
+    await dataset_store.async_add_dataset(hass, "test", DATASET_1)
+    await dataset_store.async_add_dataset(hass, "test", DATASET_1_OTHER_SECURITY_POLICY)
+
+    store = await dataset_store.async_get_store(hass)
+    assert len(store.datasets) == 1
+    assert list(store.datasets.values())[0].tlv == DATASET_1
+
+    assert (
+        "Got dataset with same extended PAN ID and same or older active timestamp"
+        in caplog.text
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
#163440 made the dataset store silently accept a dataset that only differs by the addition of `WAKEUP_CHANNEL`. However, the same OpenThread Border Router update (App version 2.12.0+) also clears the legacy "Beacons" bit in the security policy flags by default, again without incrementing the active timestamp:

- old (stored by HA): `SECURITYPOLICY` `02a0fff8`
- new (reported by the OTBR): `SECURITYPOLICY` `02a0f7f8`

Rotation time is unchanged (672 h); the only difference is bit `0x08` of the first flags byte (the legacy Beacons flag). Because the datasets are otherwise identical and the active timestamp is not incremented, the store kept logging `Got dataset with same extended PAN ID and same or older active timestamp` on every startup, even after #163440.

This generalizes the `WAKEUP_CHANNEL` special-case into a `_normalize_dataset()` helper that, when deciding whether an incoming dataset is functionally equivalent to the stored one, ignores both the `WAKEUP_CHANNEL` field and the Beacons bit. Equivalent datasets are silently stored instead of warning. A genuine security policy change (e.g. a different rotation time) with the same timestamp still logs the warning.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #134306
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: `https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure`

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

https://claude.ai/code/session_01XV91UyrPeQvmHBn3tu94Ap

---
_Generated by [Claude Code](https://claude.ai/code/session_01XV91UyrPeQvmHBn3tu94Ap)_