### PR TITLE
Bump yoto-api to 3.1.5

### DIFF
--- a/homeassistant/components/yoto/manifest.json
+++ b/homeassistant/components/yoto/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_push",
   "loggers": ["yoto_api"],
   "quality_scale": "bronze",
-  "requirements": ["yoto-api==3.1.3"]
+  "requirements": ["yoto-api==3.1.5"]
 }

--- a/homeassistant/components/yoto/media_player.py
+++ b/homeassistant/components/yoto/media_player.py
@@ -80,9 +80,10 @@ class YotoMediaPlayer(YotoEntity, MediaPlayerEntity):
     @property
     def state(self) -> MediaPlayerState:
         """Return the playback state."""
-        return PLAYBACK_STATE_MAP.get(
-            self.player.last_event.playback_status, MediaPlayerState.IDLE
-        )
+        status = self.player.last_event.playback_status
+        if status is None:
+            return MediaPlayerState.IDLE
+        return PLAYBACK_STATE_MAP.get(status, MediaPlayerState.IDLE)
 
     @property
     def volume_level(self) -> float | None:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3415,7 +3415,7 @@ yeelightsunflower==0.0.10
 yolink-api==0.6.5
 
 # homeassistant.components.yoto
-yoto-api==3.1.3
+yoto-api==3.1.5
 
 # homeassistant.components.youless
 youless-api==2.2.0


### PR DESCRIPTION
## Proposed change

Bump `yoto-api` from 3.1.3 to 3.1.5.

Changelog ([3.1.3...3.1.5](https://github.com/cdnninja/yoto_api/compare/v3.1.3...v3.1.5)):

- [3.1.4](https://github.com/cdnninja/yoto_api/releases/tag/v3.1.4): tighten typing on `Card` and `Token` dataclasses ([#188](https://github.com/cdnninja/yoto_api/pull/188))
- [3.1.5](https://github.com/cdnninja/yoto_api/releases/tag/v3.1.5): stop logging access/refresh tokens, drop `pytz`, add `py.typed` ([#189](https://github.com/cdnninja/yoto_api/pull/189))


## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
