### PR TITLE
llm: Fix DEFAULT_INSTRUCTIONS_PROMPT to not suppress tool use

### DIFF
--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -63,7 +63,7 @@ DATE_TIME_PROMPT = (
 
 DEFAULT_INSTRUCTIONS_PROMPT = """You are a voice assistant for Home Assistant.
 Answer questions about the world truthfully.
-Answer in plain text. Keep it simple and to the point.
+Respond simply and to the point in plain text.
 """
 
 NO_ENTITIES_PROMPT = (

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -49,7 +49,7 @@ DATE_TIME_PROMPT = (
 
 DEFAULT_INSTRUCTIONS_PROMPT = """You are a voice assistant for Home Assistant.
 Answer questions about the world truthfully.
-Answer in plain text. Keep it simple and to the point.
+Respond simply and to the point in plain text.
 """
 
 

--- a/tests/components/anthropic/snapshots/test_conversation.ambr
+++ b/tests/components/anthropic/snapshots/test_conversation.ambr
@@ -201,7 +201,7 @@
       'content': '''
         You are a voice assistant for Home Assistant.
         Answer questions about the world truthfully.
-        Answer in plain text. Keep it simple and to the point.
+        Respond simply and to the point in plain text.
         Only if the user wants to control a device, tell them to expose entities to their voice assistant in Home Assistant.
       ''',
       'created': HAFakeDatetime(2024, 5, 24, 12, 0, tzinfo=datetime.timezone.utc),
@@ -248,7 +248,7 @@
         'text': '''
           You are a voice assistant for Home Assistant.
           Answer questions about the world truthfully.
-          Answer in plain text. Keep it simple and to the point.
+          Respond simply and to the point in plain text.
           Only if the user wants to control a device, tell them to expose entities to their voice assistant in Home Assistant.
         ''',
         'type': 'text',
@@ -265,7 +265,7 @@
       'content': '''
         You are a voice assistant for Home Assistant.
         Answer questions about the world truthfully.
-        Answer in plain text. Keep it simple and to the point.
+        Respond simply and to the point in plain text.
         Only if the user wants to control a device, tell them to expose entities to their voice assistant in Home Assistant.
       ''',
       'created': HAFakeDatetime(2024, 5, 24, 12, 0, tzinfo=datetime.timezone.utc),
@@ -312,7 +312,7 @@
         'text': '''
           You are a voice assistant for Home Assistant.
           Answer questions about the world truthfully.
-          Answer in plain text. Keep it simple and to the point.
+          Respond simply and to the point in plain text.
           Only if the user wants to control a device, tell them to expose entities to their voice assistant in Home Assistant.
         ''',
         'type': 'text',
@@ -360,7 +360,7 @@
         'text': '''
           You are a voice assistant for Home Assistant.
           Answer questions about the world truthfully.
-          Answer in plain text. Keep it simple and to the point.
+          Respond simply and to the point in plain text.
           Only if the user wants to control a device, tell them to expose entities to their voice assistant in Home Assistant.
         ''',
         'type': 'text',
@@ -379,7 +379,7 @@
       'content': '''
         You are a voice assistant for Home Assistant.
         Answer questions about the world truthfully.
-        Answer in plain text. Keep it simple and to the point.
+        Respond simply and to the point in plain text.
         Only if the user wants to control a device, tell them to expose entities to their voice assistant in Home Assistant.
         Current time is 16:00:00. Today's date is 2024-06-03.
       ''',

--- a/tests/components/anthropic/snapshots/test_conversation.ambr
+++ b/tests/components/anthropic/snapshots/test_conversation.ambr
@@ -201,7 +201,7 @@
       'content': '''
         You are a voice assistant for Home Assistant.
         Answer questions about the world truthfully.
-        Answer in plain text. Keep it simple and to the point.
+        Respond simply and to the point in plain text.
         Only if the user wants to control a device, tell them to expose entities to their voice assistant in Home Assistant.
       ''',
       'created': HAFakeDatetime(2024, 5, 24, 12, 0, tzinfo=datetime.timezone.utc),
@@ -248,7 +248,7 @@
         'text': '''
           You are a voice assistant for Home Assistant.
           Answer questions about the world truthfully.
-          Answer in plain text. Keep it simple and to the point.
+          Respond simply and to the point in plain text.
           Only if the user wants to control a device, tell them to expose entities to their voice assistant in Home Assistant.
         ''',
         'type': 'text',
@@ -265,7 +265,7 @@
       'content': '''
         You are a voice assistant for Home Assistant.
         Answer questions about the world truthfully.
-        Answer in plain text. Keep it simple and to the point.
+        Respond simply and to the point in plain text.
         Only if the user wants to control a device, tell them to expose entities to their voice assistant in Home Assistant.
       ''',
       'created': HAFakeDatetime(2024, 5, 24, 12, 0, tzinfo=datetime.timezone.utc),
@@ -312,7 +312,7 @@
         'text': '''
           You are a voice assistant for Home Assistant.
           Answer questions about the world truthfully.
-          Answer in plain text. Keep it simple and to the point.
+          Respond simply and to the point in plain text.
           Only if the user wants to control a device, tell them to expose entities to their voice assistant in Home Assistant.
         ''',
         'type': 'text',
@@ -360,7 +360,7 @@
         'text': '''
           You are a voice assistant for Home Assistant.
           Answer questions about the world truthfully.
-          Answer in plain text. Keep it simple and to the point.
+          Respond simply and to the point in plain text.
           Only if the user wants to control a device, tell them to expose entities to their voice assistant in Home Assistant.
         ''',
         'type': 'text',
@@ -379,7 +379,7 @@
       'content': '''
         You are a voice assistant for Home Assistant.
         Answer questions about the world truthfully.
-        Answer in plain text. Keep it simple and to the point.
+        Respond simply and to the point in plain text.
         
         Current time is 16:00:00. Today's date is 2024-06-03.
       ''',


### PR DESCRIPTION
## Proposed change

The 'Answer in plain text' instruction causes smaller LLMs (such as `gemma4:e4b`) to write tool call syntax as literal text output rather than invoking tool APIs. For example:

```
Assistant: How can I assist?

User: Set the living room lights to cozy

Assistant: SetLightingScene(area_ids=["Living room"], mood="Cozy")
```

Replace 'Answer in plain text' with 'Respond in plain text' to preserve the intent without implying that tool invocations should be avoided.

Add an explicit instruction to use available tools when the user asks to control a home device, and to confirm the result briefly. Scoping the instruction to explicit user requests avoids the model invoking tools for hypothetical or exploratory questions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
