### PR TITLE
Remove `battery_level` property from Tractive device tracker 

### DIFF
--- a/homeassistant/components/tractive/device_tracker.py
+++ b/homeassistant/components/tractive/device_tracker.py
@@ -8,11 +8,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import Trackables, TractiveClient, TractiveConfigEntry
-from .const import (
-    SERVER_UNAVAILABLE,
-    TRACKER_HARDWARE_STATUS_UPDATED,
-    TRACKER_POSITION_UPDATED,
-)
+from .const import SERVER_UNAVAILABLE, TRACKER_POSITION_UPDATED
 from .entity import TractiveEntity
 
 
@@ -42,10 +38,9 @@ class TractiveDeviceTracker(TractiveEntity, TrackerEntity):
             client,
             item.trackable,
             item.tracker_details,
-            f"{TRACKER_HARDWARE_STATUS_UPDATED}-{item.tracker_details['_id']}",
+            f"{TRACKER_POSITION_UPDATED}-{item.tracker_details['_id']}",
         )
 
-        self._battery_level: int | None = item.hw_info.get("battery_level")
         self._attr_latitude = item.pos_report["latlong"][0]
         self._attr_longitude = item.pos_report["latlong"][1]
         self._attr_location_accuracy: float = item.pos_report["pos_uncertainty"]
@@ -58,17 +53,6 @@ class TractiveDeviceTracker(TractiveEntity, TrackerEntity):
         if self._source_type == "PHONE":
             return SourceType.BLUETOOTH
         return SourceType.GPS
-
-    @property
-    def battery_level(self) -> int | None:
-        """Return the battery level of the device."""
-        return self._battery_level
-
-    @callback
-    def _handle_hardware_status_update(self, event: dict[str, Any]) -> None:
-        self._battery_level = event["battery_level"]
-        self._attr_available = True
-        self.async_write_ha_state()
 
     @callback
     def _handle_position_update(self, event: dict[str, Any]) -> None:
@@ -84,14 +68,6 @@ class TractiveDeviceTracker(TractiveEntity, TrackerEntity):
         """Handle entity which will be added."""
         if not self._client.subscribed:
             self._client.subscribe()
-
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                self._dispatcher_signal,
-                self._handle_hardware_status_update,
-            )
-        )
 
         self.async_on_remove(
             async_dispatcher_connect(

--- a/tests/components/tractive/snapshots/test_device_tracker.ambr
+++ b/tests/components/tractive/snapshots/test_device_tracker.ambr
@@ -39,7 +39,6 @@
 # name: test_device_tracker[device_tracker.tracker_device_id_123-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'battery_level': 88,
       'friendly_name': 'Tracker device_id_123',
       'gps_accuracy': 99,
       'in_zones': list([

--- a/tests/components/tractive/test_device_tracker.py
+++ b/tests/components/tractive/test_device_tracker.py
@@ -94,27 +94,6 @@ async def test_source_type_gps(
     )
 
 
-async def test_device_tracker_with_empty_hw_info(
-    hass: HomeAssistant,
-    mock_tractive_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test that the device tracker sets up correctly when hw_info is empty."""
-    mock_tractive_client.tracker.return_value.hw_info = AsyncMock(return_value={})
-
-    with patch(
-        "homeassistant.components.tractive.PLATFORMS", [Platform.DEVICE_TRACKER]
-    ):
-        await init_integration(hass, mock_config_entry)
-
-        mock_tractive_client.send_position_event(mock_config_entry)
-        await hass.async_block_till_done()
-
-    state = hass.states.get("device_tracker.tracker_device_id_123")
-    assert state is not None
-    assert state.attributes.get("battery_level") is None
-
-
 async def test_device_tracker_device_assignment(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `battery_level` attribute of the device tracker entity has been removed. You can use the `battery` sensor in your automations and scripts instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Removes device tracker `battery_level` property.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #172421
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
