### PR TITLE
Retry ViCare setup when all devices are offline

### DIFF
--- a/homeassistant/components/vicare/__init__.py
+++ b/homeassistant/components/vicare/__init__.py
@@ -171,6 +171,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ViCareConfigEntry) -> bo
     ) as err:
         raise ConfigEntryAuthFailed("Authentication failed") from err
 
+    if not entry.runtime_data.devices:
+        # All known devices reported `isOnline() == False`. This is common when
+        # the integration is set up while the Viessmann gateway is still booting
+        # (e.g. after a power outage). Raise so HA core retries setup with
+        # backoff instead of leaving the entry permanently empty until a manual
+        # reload.
+        raise ConfigEntryNotReady("No online ViCare devices found")
+
     for device in entry.runtime_data.devices:
         # Migration can be removed in 2025.4.0
         await async_migrate_devices_and_entities(hass, entry, device)

--- a/homeassistant/components/vicare/__init__.py
+++ b/homeassistant/components/vicare/__init__.py
@@ -1,6 +1,7 @@
 """The ViCare integration."""
 
 from contextlib import suppress
+from datetime import datetime, timedelta
 import logging
 import os
 
@@ -34,6 +35,7 @@ from homeassistant.helpers import (
     issue_registry as ir,
 )
 from homeassistant.helpers.config_entry_oauth2_flow import MY_AUTH_CALLBACK_PATH
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.storage import STORAGE_DIR
 
 from .api import ConfigEntryAuth
@@ -49,6 +51,8 @@ from .types import ViCareConfigEntry, ViCareData, ViCareDevice
 from .utils import get_device_serial
 
 _LOGGER = logging.getLogger(__name__)
+
+EMPTY_ACCOUNT_RECHECK_INTERVAL = timedelta(hours=6)
 
 
 async def async_migrate_entry(
@@ -172,12 +176,33 @@ async def async_setup_entry(hass: HomeAssistant, entry: ViCareConfigEntry) -> bo
         raise ConfigEntryAuthFailed("Authentication failed") from err
 
     if not entry.runtime_data.devices:
-        # All known devices reported `isOnline() == False`. This is common when
-        # the integration is set up while the Viessmann gateway is still booting
-        # (e.g. after a power outage). Raise so HA core retries setup with
-        # backoff instead of leaving the entry permanently empty until a manual
-        # reload.
-        raise ConfigEntryNotReady("No online ViCare devices found")
+        if not entry.runtime_data.client.devices:
+            # The account itself has no devices attached. This happens when a
+            # user sets up the integration before registering hardware in the
+            # ViCare app. Schedule a periodic reload so new devices are picked
+            # up later, but keep the cadence low so an account that stays empty
+            # does not hammer the API.
+            _LOGGER.info(
+                "ViCare account has no devices; re-checking every %s",
+                EMPTY_ACCOUNT_RECHECK_INTERVAL,
+            )
+
+            async def _reload_entry(_now: datetime) -> None:
+                await hass.config_entries.async_reload(entry.entry_id)
+
+            entry.async_on_unload(
+                async_track_time_interval(
+                    hass, _reload_entry, EMPTY_ACCOUNT_RECHECK_INTERVAL
+                )
+            )
+            return True
+        # Devices exist on the account but every one reports
+        # `isOnline() == False`. Typical cause: the integration is set up while
+        # the Viessmann gateway is still booting (e.g. after a power outage)
+        # and HA was back faster than the gateway. Raise so HA core retries
+        # setup with its usual backoff instead of leaving the entry
+        # permanently empty until a manual reload.
+        raise ConfigEntryNotReady("All ViCare devices are currently offline")
 
     for device in entry.runtime_data.devices:
         # Migration can be removed in 2025.4.0

--- a/homeassistant/components/vicare/__init__.py
+++ b/homeassistant/components/vicare/__init__.py
@@ -1,7 +1,6 @@
 """The ViCare integration."""
 
 from contextlib import suppress
-from datetime import datetime, timedelta
 import logging
 import os
 
@@ -35,7 +34,6 @@ from homeassistant.helpers import (
     issue_registry as ir,
 )
 from homeassistant.helpers.config_entry_oauth2_flow import MY_AUTH_CALLBACK_PATH
-from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.storage import STORAGE_DIR
 
 from .api import ConfigEntryAuth
@@ -51,8 +49,6 @@ from .types import ViCareConfigEntry, ViCareData, ViCareDevice
 from .utils import get_device_serial
 
 _LOGGER = logging.getLogger(__name__)
-
-EMPTY_ACCOUNT_RECHECK_INTERVAL = timedelta(hours=6)
 
 
 async def async_migrate_entry(
@@ -175,27 +171,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ViCareConfigEntry) -> bo
     ) as err:
         raise ConfigEntryAuthFailed("Authentication failed") from err
 
-    if not entry.runtime_data.devices:
-        if not entry.runtime_data.client.devices:
-            # The account itself has no devices attached. This happens when a
-            # user sets up the integration before registering hardware in the
-            # ViCare app. Schedule a periodic reload so new devices are picked
-            # up later, but keep the cadence low so an account that stays empty
-            # does not hammer the API.
-            _LOGGER.info(
-                "ViCare account has no devices; re-checking every %s",
-                EMPTY_ACCOUNT_RECHECK_INTERVAL,
-            )
-
-            async def _reload_entry(_now: datetime) -> None:
-                await hass.config_entries.async_reload(entry.entry_id)
-
-            entry.async_on_unload(
-                async_track_time_interval(
-                    hass, _reload_entry, EMPTY_ACCOUNT_RECHECK_INTERVAL
-                )
-            )
-            return True
+    if entry.runtime_data.client.devices and not entry.runtime_data.devices:
         # Devices exist on the account but every one reports
         # `isOnline() == False`. Typical cause: the integration is set up while
         # the Viessmann gateway is still booting (e.g. after a power outage)

--- a/homeassistant/components/vicare/__init__.py
+++ b/homeassistant/components/vicare/__init__.py
@@ -171,13 +171,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ViCareConfigEntry) -> bo
     ) as err:
         raise ConfigEntryAuthFailed("Authentication failed") from err
 
-    if entry.runtime_data.client.devices and not entry.runtime_data.devices:
-        # Devices exist on the account but every one reports
-        # `isOnline() == False`. Typical cause: the integration is set up while
-        # the Viessmann gateway is still booting (e.g. after a power outage)
-        # and HA was back faster than the gateway. Raise so HA core retries
-        # setup with its usual backoff instead of leaving the entry
-        # permanently empty until a manual reload.
+    if (
+        get_supported_devices(entry.runtime_data.client.devices)
+        and not entry.runtime_data.devices
+    ):
+        # Supported devices exist but every one reports `isOnline() == False`.
+        # Typical cause: the integration is set up while the Viessmann gateway
+        # is still booting (e.g. after a power outage) and HA was back faster
+        # than the gateway. Raise so HA core retries setup with its usual
+        # backoff instead of leaving the entry permanently empty until a manual
+        # reload. Checked against the model-supported list, not the raw client
+        # list (which always carries the gateway), so an account with no
+        # supported device completes setup instead of retrying forever.
         raise ConfigEntryNotReady("All ViCare devices are currently offline")
 
     for device in entry.runtime_data.devices:

--- a/tests/components/vicare/test_init.py
+++ b/tests/components/vicare/test_init.py
@@ -317,12 +317,15 @@ async def test_setup_entry_invalid_credentials(
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
-async def test_setup_entry_no_online_devices(
+async def test_setup_entry_all_devices_offline(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test setup raises ConfigEntryNotReady when no devices are online."""
+    """Test setup raises ConfigEntryNotReady when all known devices are offline."""
     mock_config_entry.add_to_hass(hass)
+
+    client = Mock()
+    client.devices = [Mock()]  # account has at least one device, but all offline
 
     with (
         patch(
@@ -330,13 +333,38 @@ async def test_setup_entry_no_online_devices(
         ),
         patch(
             f"{MODULE}._setup_vicare_api",
-            return_value=ViCareData(client=Mock(), devices=[]),
+            return_value=ViCareData(client=client, devices=[]),
         ),
     ):
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_entry_empty_account(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test setup completes when the account has no devices, then reloads later."""
+    mock_config_entry.add_to_hass(hass)
+
+    client = Mock()
+    client.devices = []  # truly empty ViCare account
+
+    with (
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.OAuth2Session.async_ensure_token_valid",
+        ),
+        patch(
+            f"{MODULE}._setup_vicare_api",
+            return_value=ViCareData(client=client, devices=[]),
+        ),
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
 
 async def test_setup_entry_invalid_configuration(

--- a/tests/components/vicare/test_init.py
+++ b/tests/components/vicare/test_init.py
@@ -1,5 +1,6 @@
 """Test ViCare initialization and migration."""
 
+from datetime import timedelta
 from unittest.mock import Mock, patch
 
 from aiohttp import ClientError
@@ -346,7 +347,7 @@ async def test_setup_entry_empty_account(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test setup completes when the account has no devices, then reloads later."""
+    """Test setup completes for an empty account and schedules a 6h reload."""
     mock_config_entry.add_to_hass(hass)
 
     client = Mock()
@@ -360,11 +361,16 @@ async def test_setup_entry_empty_account(
             f"{MODULE}._setup_vicare_api",
             return_value=ViCareData(client=client, devices=[]),
         ),
+        patch(
+            f"{MODULE}.async_track_time_interval"
+        ) as mock_track_time_interval,
     ):
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
+    mock_track_time_interval.assert_called_once()
+    assert mock_track_time_interval.call_args.args[2] == timedelta(hours=6)
 
 
 async def test_setup_entry_invalid_configuration(

--- a/tests/components/vicare/test_init.py
+++ b/tests/components/vicare/test_init.py
@@ -10,6 +10,7 @@ from PyViCare.PyViCareUtils import (
 )
 
 from homeassistant.components.vicare.const import DOMAIN
+from homeassistant.components.vicare.types import ViCareData
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_CLIENT_ID, CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
@@ -314,6 +315,28 @@ async def test_setup_entry_invalid_credentials(
         await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+
+async def test_setup_entry_no_online_devices(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test setup raises ConfigEntryNotReady when no devices are online."""
+    mock_config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.OAuth2Session.async_ensure_token_valid",
+        ),
+        patch(
+            f"{MODULE}._setup_vicare_api",
+            return_value=ViCareData(client=Mock(), devices=[]),
+        ),
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_setup_entry_invalid_configuration(

--- a/tests/components/vicare/test_init.py
+++ b/tests/components/vicare/test_init.py
@@ -1,6 +1,5 @@
 """Test ViCare initialization and migration."""
 
-from datetime import timedelta
 from unittest.mock import Mock, patch
 
 from aiohttp import ClientError
@@ -347,7 +346,11 @@ async def test_setup_entry_empty_account(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test setup completes for an empty account and schedules a 6h reload."""
+    """Test setup completes for an empty account without retrying.
+
+    An account with no devices is not a transient failure, so it must not
+    raise ConfigEntryNotReady (which would retry forever).
+    """
     mock_config_entry.add_to_hass(hass)
 
     client = Mock()
@@ -361,16 +364,11 @@ async def test_setup_entry_empty_account(
             f"{MODULE}._setup_vicare_api",
             return_value=ViCareData(client=client, devices=[]),
         ),
-        patch(
-            f"{MODULE}.async_track_time_interval"
-        ) as mock_track_time_interval,
     ):
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
-    mock_track_time_interval.assert_called_once()
-    assert mock_track_time_interval.call_args.args[2] == timedelta(hours=6)
 
 
 async def test_setup_entry_invalid_configuration(

--- a/tests/components/vicare/test_init.py
+++ b/tests/components/vicare/test_init.py
@@ -321,11 +321,13 @@ async def test_setup_entry_all_devices_offline(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test setup raises ConfigEntryNotReady when all known devices are offline."""
+    """Test setup retries when a supported device exists but is offline."""
     mock_config_entry.add_to_hass(hass)
 
+    supported_device = Mock()
+    supported_device.getModel.return_value = "Vitodens300W"
     client = Mock()
-    client.devices = [Mock()]  # account has at least one device, but all offline
+    client.devices = [supported_device]  # supported, but offline -> filtered out
 
     with (
         patch(
@@ -342,19 +344,22 @@ async def test_setup_entry_all_devices_offline(
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_setup_entry_empty_account(
+async def test_setup_entry_no_supported_devices(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test setup completes for an empty account without retrying.
+    """Test setup completes when the account has no supported device.
 
-    An account with no devices is not a transient failure, so it must not
-    raise ConfigEntryNotReady (which would retry forever).
+    The gateway is always present in ``client.devices`` but is filtered out by
+    model. With no supported device this is not a transient failure, so it must
+    not raise ConfigEntryNotReady (which would retry forever).
     """
     mock_config_entry.add_to_hass(hass)
 
+    gateway = Mock()
+    gateway.getModel.return_value = "Heatbox1"  # in UNSUPPORTED_DEVICES
     client = Mock()
-    client.devices = []  # truly empty ViCare account
+    client.devices = [gateway]
 
     with (
         patch(


### PR DESCRIPTION
## Proposed change

When `_setup_vicare_api` returns zero online devices (because every
known device reports `isOnline() == False`), `async_setup_entry` now
raises `ConfigEntryNotReady` instead of completing with an empty
`runtime_data.devices` list. HA core will then retry setup with its
usual exponential backoff.

Symptom this fixes: after a power outage, the Viessmann gateway can
take a few minutes longer to come back online than Home Assistant.
ViCare currently completes setup during that window with no devices
attached. Pre-existing entities (from previous sessions) stay
permanently `unavailable` until the user reloads the integration
manually. With this change the integration self-heals as soon as the
gateway is reachable again.

If some devices are online and others offline, behaviour is unchanged
(online ones are set up, offline ones are skipped as before).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (\`ruff format homeassistant tests\`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.