### PR TITLE
Explain why a Yale Access Bluetooth device could not be found

### DIFF
--- a/homeassistant/components/yalexs_ble/__init__.py
+++ b/homeassistant/components/yalexs_ble/__init__.py
@@ -12,6 +12,7 @@ from yalexs_ble import (
 )
 
 from homeassistant.components import bluetooth
+from homeassistant.components.bluetooth import BluetoothReachabilityIntent
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ADDRESS, EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import CALLBACK_TYPE, CoreState, Event, HomeAssistant, callback
@@ -24,6 +25,7 @@ from .const import (
     CONF_LOCAL_NAME,
     CONF_SLOT,
     DEVICE_TIMEOUT,
+    DOMAIN,
 )
 from .models import YaleXSBLEData
 from .util import async_find_existing_service_info, bluetooth_callback_matcher
@@ -83,7 +85,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: YALEXSBLEConfigEntry) ->
         # If we are starting and the advertisement is not found, do not delay
         # the setup. We will wait for the advertisement to be found and then
         # discovery will trigger setup retry.
-        raise ConfigEntryNotReady("{local_name} ({address}) not advertising yet")
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="device_not_advertising",
+            translation_placeholders={
+                "local_name": local_name,
+                "address": address,
+                "reason": bluetooth.async_address_reachability_diagnostics(
+                    hass,
+                    address.upper(),
+                    BluetoothReachabilityIntent.PASSIVE_ADVERTISEMENT,
+                ),
+            },
+        )
 
     entry.async_on_unload(
         bluetooth.async_register_callback(

--- a/homeassistant/components/yalexs_ble/__init__.py
+++ b/homeassistant/components/yalexs_ble/__init__.py
@@ -94,7 +94,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: YALEXSBLEConfigEntry) ->
                 "reason": bluetooth.async_address_reachability_diagnostics(
                     hass,
                     address.upper(),
-                    BluetoothReachabilityIntent.PASSIVE_ADVERTISEMENT,
+                    BluetoothReachabilityIntent.CONNECTION,
                 ),
             },
         )

--- a/homeassistant/components/yalexs_ble/strings.json
+++ b/homeassistant/components/yalexs_ble/strings.json
@@ -53,6 +53,11 @@
       }
     }
   },
+  "exceptions": {
+    "device_not_advertising": {
+      "message": "{local_name} ({address}) is not advertising yet: {reason}"
+    }
+  },
   "options": {
     "step": {
       "device_options": {

--- a/tests/components/yalexs_ble/test_init.py
+++ b/tests/components/yalexs_ble/test_init.py
@@ -1,0 +1,56 @@
+"""Test the Yale Access Bluetooth init."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from homeassistant.components.yalexs_ble.const import (
+    CONF_KEY,
+    CONF_LOCAL_NAME,
+    CONF_SLOT,
+    DOMAIN,
+)
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_ADDRESS
+from homeassistant.core import CoreState, HomeAssistant
+
+from . import YALE_ACCESS_LOCK_DISCOVERY_INFO
+
+from tests.common import MockConfigEntry
+
+
+async def test_setup_retries_when_not_advertising_at_startup(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test setup is retried with a diagnostic reason when not advertising at startup."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_LOCAL_NAME: YALE_ACCESS_LOCK_DISCOVERY_INFO.name,
+            CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
+            CONF_KEY: "2fd51b8621c6a139eaffbedcb846b60f",
+            CONF_SLOT: 66,
+        },
+        unique_id=YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
+    )
+    entry.add_to_hass(hass)
+
+    hass.set_state(CoreState.starting)
+
+    push_lock = MagicMock()
+    push_lock.start = AsyncMock(return_value=MagicMock())
+
+    with (
+        patch("homeassistant.components.yalexs_ble.close_stale_connections_by_address"),
+        patch("homeassistant.components.yalexs_ble.PushLock", return_value=push_lock),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert (
+        f"{YALE_ACCESS_LOCK_DISCOVERY_INFO.name} "
+        f"({YALE_ACCESS_LOCK_DISCOVERY_INFO.address}) is not advertising yet"
+        in caplog.text
+    )

--- a/tests/components/yalexs_ble/test_init.py
+++ b/tests/components/yalexs_ble/test_init.py
@@ -44,6 +44,11 @@ async def test_setup_retries_when_not_advertising_at_startup(
     with (
         patch("homeassistant.components.yalexs_ble.close_stale_connections_by_address"),
         patch("homeassistant.components.yalexs_ble.PushLock", return_value=push_lock),
+        patch(
+            "homeassistant.components.yalexs_ble.bluetooth."
+            "async_address_reachability_diagnostics",
+            return_value="mock reachability reason",
+        ),
     ):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -51,6 +56,6 @@ async def test_setup_retries_when_not_advertising_at_startup(
     assert entry.state is ConfigEntryState.SETUP_RETRY
     assert (
         f"{YALE_ACCESS_LOCK_DISCOVERY_INFO.name} "
-        f"({YALE_ACCESS_LOCK_DISCOVERY_INFO.address}) is not advertising yet"
-        in caplog.text
+        f"({YALE_ACCESS_LOCK_DISCOVERY_INFO.address}) is not advertising yet: "
+        "mock reachability reason" in caplog.text
     )


### PR DESCRIPTION
## Breaking change


## Proposed change

When a Yale Access lock is not advertising yet at startup we raised "ConfigEntryNotReady" with a message that was never formatted, so it literally logged "{local_name} ({address}) not advertising yet" with the placeholders left intact. This fixes the message and adds the reachability diagnostics from `bluetooth.async_address_reachability_diagnostics`, so the log explains why the device is not being seen, for example when it has never been seen by any scanner or is only reachable through a non connectable scanner. This mirrors the same change made for Switchbot in #172581.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
