### PR TITLE
Explain why an INKBIRD device could not be found

### DIFF
--- a/homeassistant/components/inkbird/coordinator.py
+++ b/homeassistant/components/inkbird/coordinator.py
@@ -7,9 +7,11 @@ from typing import Any
 from inkbird_ble import INKBIRDBluetoothDeviceData, SensorUpdate
 
 from homeassistant.components.bluetooth import (
+    BluetoothReachabilityIntent,
     BluetoothScanningMode,
     BluetoothServiceInfo,
     BluetoothServiceInfoBleak,
+    async_address_reachability_diagnostics,
     async_ble_device_from_address,
     async_last_service_info,
 )
@@ -84,7 +86,14 @@ class INKBIRDActiveBluetoothProcessorCoordinator(
             raise ConfigEntryNotReady(
                 translation_domain=DOMAIN,
                 translation_key="no_advertisement",
-                translation_placeholders={"address": self.address},
+                translation_placeholders={
+                    "address": self.address,
+                    "reason": async_address_reachability_diagnostics(
+                        self.hass,
+                        self.address.upper(),
+                        BluetoothReachabilityIntent.PASSIVE_ADVERTISEMENT,
+                    ),
+                },
             )
         await self._data.async_start(service_info, service_info.device)
         self._entry.async_on_unload(self._data.async_stop)

--- a/homeassistant/components/inkbird/coordinator.py
+++ b/homeassistant/components/inkbird/coordinator.py
@@ -91,7 +91,7 @@ class INKBIRDActiveBluetoothProcessorCoordinator(
                     "reason": async_address_reachability_diagnostics(
                         self.hass,
                         self.address.upper(),
-                        BluetoothReachabilityIntent.PASSIVE_ADVERTISEMENT,
+                        BluetoothReachabilityIntent.ACTIVE_ADVERTISEMENT,
                     ),
                 },
             )

--- a/homeassistant/components/inkbird/strings.json
+++ b/homeassistant/components/inkbird/strings.json
@@ -20,7 +20,7 @@
   },
   "exceptions": {
     "no_advertisement": {
-      "message": "The device with address {address} is not advertising; Make sure it is in range and powered on."
+      "message": "The device with address {address} is not advertising: {reason}"
     }
   }
 }

--- a/tests/components/inkbird/test_sensor.py
+++ b/tests/components/inkbird/test_sensor.py
@@ -232,8 +232,7 @@ async def test_notify_sensor_no_advertisement(
 
     assert entry.state is ConfigEntryState.SETUP_RETRY
     assert (
-        "62:00:A1:3C:AE:7B is not advertising: mock reachability reason"
-        in caplog.text
+        "62:00:A1:3C:AE:7B is not advertising: mock reachability reason" in caplog.text
     )
 
 

--- a/tests/components/inkbird/test_sensor.py
+++ b/tests/components/inkbird/test_sensor.py
@@ -14,6 +14,7 @@ from inkbird_ble import (
     Units,
 )
 from inkbird_ble.parser import Model
+import pytest
 from sensor_state_data import SensorDeviceClass
 
 from homeassistant.components.bluetooth import async_last_service_info
@@ -210,7 +211,9 @@ async def test_fallback_poll_queries_latest_service_info(hass: HomeAssistant) ->
     await hass.async_block_till_done()
 
 
-async def test_notify_sensor_no_advertisement(hass: HomeAssistant) -> None:
+async def test_notify_sensor_no_advertisement(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test setting up a notify sensor that has no advertisement."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -223,6 +226,7 @@ async def test_notify_sensor_no_advertisement(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert "62:00:A1:3C:AE:7B is not advertising" in caplog.text
 
 
 async def test_notify_sensor(hass: HomeAssistant) -> None:

--- a/tests/components/inkbird/test_sensor.py
+++ b/tests/components/inkbird/test_sensor.py
@@ -222,11 +222,19 @@ async def test_notify_sensor_no_advertisement(
     )
     entry.add_to_hass(hass)
 
-    assert not await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+    with patch(
+        "homeassistant.components.inkbird.coordinator."
+        "async_address_reachability_diagnostics",
+        return_value="mock reachability reason",
+    ):
+        assert not await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.SETUP_RETRY
-    assert "62:00:A1:3C:AE:7B is not advertising" in caplog.text
+    assert (
+        "62:00:A1:3C:AE:7B is not advertising: mock reachability reason"
+        in caplog.text
+    )
 
 
 async def test_notify_sensor(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Breaking change


## Proposed change

When an INKBIRD notify device is not advertising at setup we raised "ConfigEntryNotReady" with a generic "is not advertising; Make sure it is in range and powered on" message. This adds the reachability diagnostics from `async_address_reachability_diagnostics`, so the log explains why the device is not being seen, for example when it has never been seen by any scanner. This mirrors the same change made for Switchbot in #172581.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
