### PR TITLE
Filter stale replayed BLE advertisements in Matter BLE proxy

### DIFF
--- a/homeassistant/components/matter/ble_proxy.py
+++ b/homeassistant/components/matter/ble_proxy.py
@@ -23,6 +23,7 @@ from matter_ble_proxy import (
 )
 
 from homeassistant.components.bluetooth import (
+    MONOTONIC_TIME,
     BluetoothScanningMode,
     async_ble_device_from_address,
     async_register_callback,
@@ -51,11 +52,18 @@ class HaBluetoothScanSource(BleScanSource):
         if self._cancel is not None:
             return
 
+        # Drop HA's synchronous replay of stale history on register; otherwise a
+        # rotating peripheral's old addresses each become a PASE connect candidate.
+        # `MONOTONIC_TIME` is the clock that stamps `service_info.time`.
+        scan_start = MONOTONIC_TIME()
+
         @callback
         def _on_advertisement(
             service_info: BluetoothServiceInfoBleak,
             _change: object,
         ) -> None:
+            if service_info.time < scan_start:
+                return
             try:
                 callback_fn(_to_advertisement_data(service_info))
             except Exception:

--- a/homeassistant/components/matter/ble_proxy.py
+++ b/homeassistant/components/matter/ble_proxy.py
@@ -53,7 +53,7 @@ class HaBluetoothScanSource(BleScanSource):
             return
 
         # Drop HA's synchronous replay of stale history on register; otherwise a
-        # rotating peripheral's old addresses each become a PASE connect candidate.
+        # rotating peripheral's old addresses each become a parallel connect candidate.
         # `MONOTONIC_TIME` is the clock that stamps `service_info.time`.
         scan_start = MONOTONIC_TIME()
 

--- a/tests/components/matter/test_ble_proxy.py
+++ b/tests/components/matter/test_ble_proxy.py
@@ -22,7 +22,7 @@ from homeassistant.components.matter.ble_proxy import (
 from homeassistant.core import HomeAssistant
 
 
-def _make_service_info() -> BluetoothServiceInfoBleak:
+def _make_service_info(time: float | None = None) -> BluetoothServiceInfoBleak:
     """Return a real BluetoothServiceInfoBleak with realistic field values."""
     address = "AA:BB:CC:DD:EE:FF"
     name = "TestDevice"
@@ -37,7 +37,7 @@ def _make_service_info() -> BluetoothServiceInfoBleak:
         device=BLEDevice(name=name, address=address, details={}),
         advertisement=None,
         connectable=True,
-        time=monotonic_time_coarse(),
+        time=monotonic_time_coarse() if time is None else time,
         tx_power=0,
         raw=None,
     )
@@ -150,6 +150,43 @@ async def test_scan_source_callback_forwards_advertisement(
 
     assert len(forwarded) == 1
     assert forwarded[0].address == "AA:BB:CC:DD:EE:FF"
+
+
+@pytest.mark.parametrize(
+    ("advert_time", "expected_count"),
+    [
+        pytest.param(999.0, 0, id="stale-before-scan-start-dropped"),
+        pytest.param(1000.0, 1, id="equal-scan-start-forwarded"),
+        pytest.param(1001.0, 1, id="fresh-after-scan-start-forwarded"),
+    ],
+)
+async def test_scan_source_drops_replayed_history(
+    hass: HomeAssistant, advert_time: float, expected_count: int
+) -> None:
+    """Adverts older than the registration instant (HA history replay) are dropped."""
+    forwarded: list[AdvertisementData] = []
+    captured: dict[str, object] = {}
+
+    def fake_register(hass_, cb, _matcher, _mode):
+        captured["cb"] = cb
+        return MagicMock()
+
+    source = HaBluetoothScanSource(hass)
+    with (
+        patch(
+            "homeassistant.components.matter.ble_proxy.async_register_callback",
+            side_effect=fake_register,
+        ),
+        patch(
+            "homeassistant.components.matter.ble_proxy.MONOTONIC_TIME",
+            return_value=1000.0,
+        ),
+    ):
+        await source.start(forwarded.append)
+
+    captured["cb"](_make_service_info(time=advert_time), object())
+
+    assert len(forwarded) == expected_count
 
 
 async def test_scan_source_callback_swallows_exceptions(


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Matter BLE proxy registers an advertisement callback via
`async_register_callback`. Home Assistant replays its advertisement history
synchronously on registration, including stale and rotated-away addresses that
are still inside the unavailable window. A single Matter peripheral that rotates
its random BLE address is therefore replayed as several addresses at once, and
each replayed address becomes a parallel PASE connect candidate downstream in
matterjs-server — a connect storm that can exhaust the proxy backend connect
slots.

This change captures the registration instant via `MONOTONIC_TIME` (the same
monotonic clock that stamps `BluetoothServiceInfoBleak.time`) and drops any
advertisement older than that instant, so only live advertisements reach the
proxy. Because both timestamps share one clock the comparison is direct — no
wire-protocol change and no wall-clock translation. Live, in-range devices
re-advertise within their advertising interval, so a dropped stale replay is
re-delivered shortly after as a fresh advert.

relates to https://github.com/matter-js/matterjs-server/issues/694

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
