### PR TITLE
Explain why a Husqvarna Automower BLE device could not be connected to

### DIFF
--- a/homeassistant/components/husqvarna_automower_ble/__init__.py
+++ b/homeassistant/components/husqvarna_automower_ble/__init__.py
@@ -6,6 +6,7 @@ from bleak import BleakError
 from bleak_retry_connector import close_stale_connections_by_address, get_device
 
 from homeassistant.components import bluetooth
+from homeassistant.components.bluetooth import BluetoothReachabilityIntent
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ADDRESS, CONF_CLIENT_ID, CONF_PIN, Platform
 from homeassistant.core import HomeAssistant
@@ -56,7 +57,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: HusqvarnaConfigEntry) ->
             )
     except (TimeoutError, BleakError) as exception:
         raise ConfigEntryNotReady(
-            f"Unable to connect to device {address} due to {exception}"
+            translation_domain=DOMAIN,
+            translation_key="device_not_found",
+            translation_placeholders={
+                "address": address,
+                "error": str(exception),
+                "reason": bluetooth.async_address_reachability_diagnostics(
+                    hass,
+                    address.upper(),
+                    BluetoothReachabilityIntent.CONNECTION,
+                ),
+            },
         ) from exception
 
     LOGGER.debug("connected and paired")

--- a/homeassistant/components/husqvarna_automower_ble/__init__.py
+++ b/homeassistant/components/husqvarna_automower_ble/__init__.py
@@ -58,10 +58,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: HusqvarnaConfigEntry) ->
     except (TimeoutError, BleakError) as exception:
         raise ConfigEntryNotReady(
             translation_domain=DOMAIN,
-            translation_key="device_not_found",
+            translation_key="connection_failed",
             translation_placeholders={
                 "address": address,
-                "error": str(exception),
+                "error": str(exception) or type(exception).__name__,
                 "reason": bluetooth.async_address_reachability_diagnostics(
                     hass,
                     address.upper(),

--- a/homeassistant/components/husqvarna_automower_ble/strings.json
+++ b/homeassistant/components/husqvarna_automower_ble/strings.json
@@ -45,6 +45,9 @@
     }
   },
   "exceptions": {
+    "device_not_found": {
+      "message": "Unable to connect to device {address} due to {error}: {reason}"
+    },
     "pin_required": {
       "message": "PIN is required for {domain_name}"
     }

--- a/homeassistant/components/husqvarna_automower_ble/strings.json
+++ b/homeassistant/components/husqvarna_automower_ble/strings.json
@@ -45,7 +45,7 @@
     }
   },
   "exceptions": {
-    "device_not_found": {
+    "connection_failed": {
       "message": "Unable to connect to device {address} due to {error}: {reason}"
     },
     "pin_required": {

--- a/tests/components/husqvarna_automower_ble/test_init.py
+++ b/tests/components/husqvarna_automower_ble/test_init.py
@@ -79,7 +79,7 @@ async def test_setup_failed_connect(
 ) -> None:
     """Test setup retries with a diagnostic reason when the device cannot connect."""
 
-    mock_automower_client.connect.side_effect = TimeoutError("timed out")
+    mock_automower_client.connect.side_effect = TimeoutError
 
     mock_config_entry.add_to_hass(hass)
     with patch(
@@ -91,9 +91,11 @@ async def test_setup_failed_connect(
         await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    # A bare TimeoutError has an empty str(), so the error falls back to the
+    # exception class name; both the error and the reachability reason appear.
     assert (
         f"Unable to connect to device {mock_config_entry.data[CONF_ADDRESS]} "
-        "due to timed out: mock reachability reason" in caplog.text
+        "due to TimeoutError: mock reachability reason" in caplog.text
     )
 
 

--- a/tests/components/husqvarna_automower_ble/test_init.py
+++ b/tests/components/husqvarna_automower_ble/test_init.py
@@ -1,6 +1,6 @@
 """Test the Husqvarna Automower Bluetooth setup."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from automower_ble.protocol import ResponseResult
 import pytest
@@ -75,16 +75,26 @@ async def test_setup_failed_connect(
     hass: HomeAssistant,
     mock_automower_client: Mock,
     mock_config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test setup creates expected devices."""
+    """Test setup retries with a diagnostic reason when the device cannot connect."""
 
-    mock_automower_client.connect.side_effect = TimeoutError
+    mock_automower_client.connect.side_effect = TimeoutError("timed out")
 
     mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
+    with patch(
+        "homeassistant.components.husqvarna_automower_ble.bluetooth."
+        "async_address_reachability_diagnostics",
+        return_value="mock reachability reason",
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert (
+        f"Unable to connect to device {mock_config_entry.data[CONF_ADDRESS]} "
+        "due to timed out: mock reachability reason" in caplog.text
+    )
 
 
 async def test_setup_unknown_error(


### PR DESCRIPTION
## Breaking change


## Proposed change

When the Husqvarna Automower cannot be connected to during setup, the `ConfigEntryNotReady` message now includes the reachability diagnostics from `bluetooth.async_address_reachability_diagnostics(..., CONNECTION)`, so the log explains why the mower is unreachable, for example when it has never been seen by any scanner or is only reachable through a non connectable scanner. The original connection error is kept in the message, and falls back to the exception class name when the error has no message. This mirrors the same change made for Switchbot in #172581.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
