### PR TITLE
Explain why a Snooz device could not be found

### DIFF
--- a/homeassistant/components/snooz/__init__.py
+++ b/homeassistant/components/snooz/__init__.py
@@ -4,12 +4,16 @@ import logging
 
 from pysnooz.device import SnoozDevice
 
-from homeassistant.components.bluetooth import async_ble_device_from_address
+from homeassistant.components.bluetooth import (
+    BluetoothReachabilityIntent,
+    async_address_reachability_diagnostics,
+    async_ble_device_from_address,
+)
 from homeassistant.const import CONF_ADDRESS, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import PLATFORMS
+from .const import DOMAIN, PLATFORMS
 from .models import SnoozConfigEntry, SnoozConfigurationData
 
 
@@ -23,7 +27,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: SnoozConfigEntry) -> boo
 
     if not (ble_device := async_ble_device_from_address(hass, address)):
         raise ConfigEntryNotReady(
-            f"Could not find Snooz with address {address}. Try power cycling the device"
+            translation_domain=DOMAIN,
+            translation_key="device_not_found",
+            translation_placeholders={
+                "address": address,
+                "reason": async_address_reachability_diagnostics(
+                    hass,
+                    address.upper(),
+                    BluetoothReachabilityIntent.CONNECTION,
+                ),
+            },
         )
 
     device = SnoozDevice(ble_device, token)

--- a/homeassistant/components/snooz/strings.json
+++ b/homeassistant/components/snooz/strings.json
@@ -24,6 +24,11 @@
       }
     }
   },
+  "exceptions": {
+    "device_not_found": {
+      "message": "Could not find Snooz with address {address}: {reason}"
+    }
+  },
   "services": {
     "transition_off": {
       "description": "Transitions the volume level to the lowest setting over a specified duration, then powers off the device.",

--- a/tests/components/snooz/test_init.py
+++ b/tests/components/snooz/test_init.py
@@ -1,8 +1,49 @@
 """Test Snooz configuration."""
 
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.snooz.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_ADDRESS, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 
-from . import SnoozFixture
+from . import TEST_ADDRESS, TEST_PAIRING_TOKEN, SnoozFixture
+
+from tests.common import MockConfigEntry
+
+
+async def test_setup_retries_when_device_not_found(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test setup is retried with a diagnostic reason when the device is missing."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_ADDRESS,
+        data={CONF_ADDRESS: TEST_ADDRESS, CONF_TOKEN: TEST_PAIRING_TOKEN},
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.snooz.async_ble_device_from_address",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.snooz.async_address_reachability_diagnostics",
+            return_value="mock reachability reason",
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert (
+        f"Could not find Snooz with address {TEST_ADDRESS}: mock reachability reason"
+        in caplog.text
+    )
 
 
 async def test_removing_entry_cleans_up_connections(


### PR DESCRIPTION
## Breaking change


## Proposed change

When the Snooz device cannot be found during setup we only logged "Could not find Snooz with address X. Try power cycling the device", which does not tell the user why. This adds the reachability diagnostics from `async_address_reachability_diagnostics` to the `ConfigEntryNotReady` message, so the log explains why the device is unreachable, for example when it has never been seen by any scanner or is only reachable through a non connectable scanner. This mirrors the same change made for Switchbot in #172581.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
