### PR TITLE
Cancel iCloud polling timer on config entry unload

### DIFF
--- a/homeassistant/components/icloud/__init__.py
+++ b/homeassistant/components/icloud/__init__.py
@@ -59,6 +59,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: IcloudConfigEntry) -> bo
     await hass.async_add_executor_job(account.setup)
 
     entry.runtime_data = account
+    entry.async_on_unload(account.cancel_fetch)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -92,6 +92,7 @@ class IcloudAccount:
         self._retried_fetch = False
         self._config_entry = config_entry
 
+        self._unsub_fetch: CALLBACK_TYPE | None = None
         self.listeners: list[CALLBACK_TYPE] = []
 
     def setup(self) -> None:
@@ -293,9 +294,16 @@ class IcloudAccount:
             self._max_interval,
         )
 
+    def cancel_fetch(self) -> None:
+        """Cancel the scheduled fetch timer."""
+        if self._unsub_fetch is not None:
+            self._unsub_fetch()
+            self._unsub_fetch = None
+
     def _schedule_next_fetch(self) -> None:
+        self.cancel_fetch()
         if not self._config_entry.pref_disable_polling:
-            track_point_in_utc_time(
+            self._unsub_fetch = track_point_in_utc_time(
                 self.hass,
                 self.keep_alive,
                 utcnow() + timedelta(minutes=self._fetch_interval),


### PR DESCRIPTION
## Proposed change

The iCloud integration schedules a recurring polling timer via `track_point_in_utc_time` but never stores the unsubscribe callback. On reload, the old timer keeps firing, and each reload spawns a new polling loop while previous ones remain active. This leads to zombie timers that accumulate and hit Apple's servers.

Store the timer's unsubscribe callback, cancel any existing timer before scheduling a new one, and register cleanup via `async_on_unload` so the timer is cancelled when the config entry is unloaded.

Note: I was unable to find a good way to test this without touching internals that shouldn't be accessed in tests.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #172792
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr