### PR TITLE
Modify stale policies for PRs and issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -26,17 +26,19 @@ jobs:
       # Used for:
       # - PRs
       # - No PRs marked as no-stale
-      # - No issues (-1)
-      - name: 60 days stale PRs policy
+      # The 90 day stale policy for issues
+      # Used for:
+      # - Issues
+      # - No issues marked as no-stale or help-wanted
+      - name: 60 days stale PRs policy and 90 days stale issue policy
         uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          days-before-stale: 60
-          days-before-close: 7
-          days-before-issue-stale: -1
-          days-before-issue-close: -1
-          operations-per-run: 150
           remove-stale-when-updated: true
+          operations-per-run: 350
+          # pr policy
+          days-before-pr-stale: 60
+          days-before-pr-close: 7
           stale-pr-label: "stale"
           exempt-pr-labels: "no-stale"
           stale-pr-message: >
@@ -49,65 +51,9 @@ jobs:
             branch to ensure that it's up to date with the latest changes.
 
             Thank you for your contribution!
-
-      # Generate a token for the GitHub App, we use this method to avoid
-      # hitting API limits for our GitHub actions + have a higher rate limit.
-      # This is only used for issues.
-      - name: Generate app token
-        id: token
-        # Pinned to a specific version of the action for security reasons
-        # v3.2.0
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
-        with:
-          client-id: ${{ secrets.ISSUE_TRIAGE_APP_ID }} # zizmor: ignore[secrets-outside-env]
-          private-key: ${{ secrets.ISSUE_TRIAGE_APP_PEM }} # zizmor: ignore[secrets-outside-env]
-
-      # The 90 day stale policy for issues
-      # Used for:
-      # - Issues
-      # - No issues marked as no-stale or help-wanted
-      # - No PRs (-1)
-      - name: 90 days stale issues
-        uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
-        with:
-          repo-token: ${{ steps.token.outputs.token }}
-          days-before-stale: 90
-          days-before-close: 7
-          days-before-pr-stale: -1
-          days-before-pr-close: -1
-          operations-per-run: 250
-          remove-stale-when-updated: true
-          stale-issue-label: "stale"
-          exempt-issue-labels: "no-stale,help-wanted,needs-more-information"
-          stale-issue-message: >
-            There hasn't been any activity on this issue recently. Due to the
-            high number of incoming GitHub notifications, we have to clean some
-            of the old issues, as many of them have already been resolved with
-            the latest updates.
-
-            Please make sure to update to the latest Home Assistant version and
-            check if that solves the issue. Let us know if that works for you by
-            adding a comment 👍
-
-            This issue has now been marked as stale and will be closed if no
-            further activity occurs. Thank you for your contributions.
-
-      # The 30 day stale policy for issues
-      # Used for:
-      # - Issues that are pending more information (incomplete issues)
-      # - No Issues marked as no-stale or help-wanted
-      # - No PRs (-1)
-      - name: Needs more information stale issues policy
-        uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
-        with:
-          repo-token: ${{ steps.token.outputs.token }}
-          only-labels: "needs-more-information"
-          days-before-stale: 14
-          days-before-close: 7
-          days-before-pr-stale: -1
-          days-before-pr-close: -1
-          operations-per-run: 250
-          remove-stale-when-updated: true
+          # issue policy
+          days-before-issue-stale: 90
+          days-before-issue-close: 7
           stale-issue-label: "stale"
           exempt-issue-labels: "no-stale,help-wanted"
           stale-issue-message: >

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,7 +24,6 @@ jobs:
     steps:
       # Generate a token for the GitHub App, we use this method to avoid
       # hitting API limits for our GitHub actions + have a higher rate limit.
-      # This is only used for issues.
       - name: Generate app token
         id: token
         # Pinned to a specific version of the action for security reasons

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,6 +22,18 @@ jobs:
       pull-requests: write # To label and close stale PRs
       actions: write # To delete stalebot state
     steps:
+      # Generate a token for the GitHub App, we use this method to avoid
+      # hitting API limits for our GitHub actions + have a higher rate limit.
+      # This is only used for issues.
+      - name: Generate app token
+        id: token
+        # Pinned to a specific version of the action for security reasons
+        # v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        with:
+          client-id: ${{ secrets.ISSUE_TRIAGE_APP_ID }} # zizmor: ignore[secrets-outside-env]
+          private-key: ${{ secrets.ISSUE_TRIAGE_APP_PEM }} # zizmor: ignore[secrets-outside-env]
+    
       # The 60 day stale policy for PRs
       # Used for:
       # - PRs
@@ -33,7 +45,7 @@ jobs:
       - name: 60 days stale PRs policy and 90 days stale issue policy
         uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ steps.token.outputs.token }}
           remove-stale-when-updated: true
           operations-per-run: 350
           # pr policy

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           client-id: ${{ secrets.ISSUE_TRIAGE_APP_ID }} # zizmor: ignore[secrets-outside-env]
           private-key: ${{ secrets.ISSUE_TRIAGE_APP_PEM }} # zizmor: ignore[secrets-outside-env]
-    
+
       # The 60 day stale policy for PRs
       # Used for:
       # - PRs


### PR DESCRIPTION
## Proposed change
So the stale policy doesn't run correctly, even after the fixes of yesterday. Turns out that multiple stale bots configurations are not really working the correct way: 
* every run takes pr and issues and processes them, even if you configured them as -1
* because of that, the next steps may not see stale issues or prs because they have been processed in the other step
* steps take operations that shouldn't have been taken hence we're reaching the api rate limit sooner
* the state cache key is not configurable and enabled by default and not configurable as well

So, to make it work correctly, we're in this PR removing the need more information so the regular issue handler can handle this and combining the pr and issue check together. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
