### PR TITLE
Add Helty Flow temperature and humidity sensors

### DIFF
--- a/homeassistant/components/helty/__init__.py
+++ b/homeassistant/components/helty/__init__.py
@@ -7,7 +7,7 @@ from homeassistant.core import HomeAssistant
 
 from .coordinator import HeltyConfigEntry, HeltyDataUpdateCoordinator
 
-PLATFORMS: list[Platform] = [Platform.FAN]
+PLATFORMS: list[Platform] = [Platform.FAN, Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: HeltyConfigEntry) -> bool:

--- a/homeassistant/components/helty/quality_scale.yaml
+++ b/homeassistant/components/helty/quality_scale.yaml
@@ -68,12 +68,8 @@ rules:
   entity-device-class: done
   entity-disabled-by-default:
     status: exempt
-    comment: The only entity is the primary fan, which is enabled by default.
-  entity-translations:
-    status: exempt
-    comment: |
-      The only entity is the primary fan, which uses the device name and has
-      no name of its own to translate.
+    comment: All entities expose primary device data and are enabled by default.
+  entity-translations: done
   exception-translations: todo
   icon-translations:
     status: exempt

--- a/homeassistant/components/helty/quality_scale.yaml
+++ b/homeassistant/components/helty/quality_scale.yaml
@@ -66,9 +66,7 @@ rules:
     comment: A config entry represents a single fixed device.
   entity-category: done
   entity-device-class: done
-  entity-disabled-by-default:
-    status: exempt
-    comment: All entities expose primary device data and are enabled by default.
+  entity-disabled-by-default: done
   entity-translations: done
   exception-translations: todo
   icon-translations:

--- a/homeassistant/components/helty/sensor.py
+++ b/homeassistant/components/helty/sensor.py
@@ -1,0 +1,87 @@
+"""Sensor platform for the Helty Flow integration."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from pyhelty import HeltyData
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import PERCENTAGE, UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import HeltyConfigEntry, HeltyDataUpdateCoordinator
+from .entity import HeltyEntity
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class HeltySensorEntityDescription(SensorEntityDescription):
+    """Describes a Helty sensor."""
+
+    value_fn: Callable[[HeltyData], float | None]
+
+
+SENSORS: tuple[HeltySensorEntityDescription, ...] = (
+    HeltySensorEntityDescription(
+        key="indoor_temperature",
+        translation_key="indoor_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.indoor_temperature,
+    ),
+    HeltySensorEntityDescription(
+        key="outdoor_temperature",
+        translation_key="outdoor_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.outdoor_temperature,
+    ),
+    HeltySensorEntityDescription(
+        key="indoor_humidity",
+        translation_key="indoor_humidity",
+        device_class=SensorDeviceClass.HUMIDITY,
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.indoor_humidity,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: HeltyConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Helty sensors."""
+    coordinator = entry.runtime_data
+    async_add_entities(HeltySensor(coordinator, description) for description in SENSORS)
+
+
+class HeltySensor(HeltyEntity, SensorEntity):
+    """An environmental sensor reported by the ventilation unit."""
+
+    entity_description: HeltySensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: HeltyDataUpdateCoordinator,
+        description: HeltySensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{self._device_id}_{description.key}"
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current sensor reading."""
+        return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/helty/strings.json
+++ b/homeassistant/components/helty/strings.json
@@ -18,5 +18,18 @@
         "title": "Connect to your Helty Flow"
       }
     }
+  },
+  "entity": {
+    "sensor": {
+      "indoor_temperature": {
+        "name": "Indoor temperature"
+      },
+      "outdoor_temperature": {
+        "name": "Outdoor temperature"
+      },
+      "indoor_humidity": {
+        "name": "Indoor humidity"
+      }
+    }
   }
 }

--- a/homeassistant/components/helty/strings.json
+++ b/homeassistant/components/helty/strings.json
@@ -21,14 +21,14 @@
   },
   "entity": {
     "sensor": {
+      "indoor_humidity": {
+        "name": "Indoor humidity"
+      },
       "indoor_temperature": {
         "name": "Indoor temperature"
       },
       "outdoor_temperature": {
         "name": "Outdoor temperature"
-      },
-      "indoor_humidity": {
-        "name": "Indoor humidity"
       }
     }
   }

--- a/tests/components/helty/snapshots/test_sensor.ambr
+++ b/tests/components/helty/snapshots/test_sensor.ambr
@@ -1,0 +1,172 @@
+# serializer version: 1
+# name: test_all_entities[sensor.vmc_soggiorno_indoor_humidity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.vmc_soggiorno_indoor_humidity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Indoor humidity',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'Indoor humidity',
+    'platform': 'helty',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'indoor_humidity',
+    'unique_id': '01HHHHHHHHHHHHHHHHHHHHHHHH_indoor_humidity',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_all_entities[sensor.vmc_soggiorno_indoor_humidity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'humidity',
+      'friendly_name': 'VMC Soggiorno Indoor humidity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vmc_soggiorno_indoor_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '42.2',
+  })
+# ---
+# name: test_all_entities[sensor.vmc_soggiorno_indoor_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.vmc_soggiorno_indoor_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Indoor temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Indoor temperature',
+    'platform': 'helty',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'indoor_temperature',
+    'unique_id': '01HHHHHHHHHHHHHHHHHHHHHHHH_indoor_temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_all_entities[sensor.vmc_soggiorno_indoor_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'VMC Soggiorno Indoor temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vmc_soggiorno_indoor_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '28.1',
+  })
+# ---
+# name: test_all_entities[sensor.vmc_soggiorno_outdoor_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.vmc_soggiorno_outdoor_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Outdoor temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Outdoor temperature',
+    'platform': 'helty',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'outdoor_temperature',
+    'unique_id': '01HHHHHHHHHHHHHHHHHHHHHHHH_outdoor_temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_all_entities[sensor.vmc_soggiorno_outdoor_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'VMC Soggiorno Outdoor temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vmc_soggiorno_outdoor_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '31.2',
+  })
+# ---

--- a/tests/components/helty/test_sensor.py
+++ b/tests/components/helty/test_sensor.py
@@ -1,0 +1,52 @@
+"""Test the Helty Flow sensor platform."""
+
+from dataclasses import replace
+from unittest.mock import AsyncMock, patch
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+from .conftest import make_data
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+async def test_all_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_helty_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test all entities."""
+    with patch("homeassistant.components.helty.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_missing_readings_are_unknown(
+    hass: HomeAssistant,
+    mock_helty_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test sensors report unknown when the unit omits a reading."""
+    mock_helty_client.async_get_data.return_value = replace(
+        make_data(),
+        indoor_temperature=None,
+        outdoor_temperature=None,
+        indoor_humidity=None,
+    )
+    with patch("homeassistant.components.helty.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    for entity_id in (
+        "sensor.vmc_soggiorno_indoor_temperature",
+        "sensor.vmc_soggiorno_outdoor_temperature",
+        "sensor.vmc_soggiorno_indoor_humidity",
+    ):
+        assert hass.states.get(entity_id).state == STATE_UNKNOWN

--- a/tests/components/helty/test_sensor.py
+++ b/tests/components/helty/test_sensor.py
@@ -1,16 +1,14 @@
 """Test the Helty Flow sensor platform."""
 
-from dataclasses import replace
 from unittest.mock import AsyncMock, patch
 
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import STATE_UNKNOWN, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from . import setup_integration
-from .conftest import make_data
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -27,26 +25,3 @@ async def test_all_entities(
         await setup_integration(hass, mock_config_entry)
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
-
-
-async def test_missing_readings_are_unknown(
-    hass: HomeAssistant,
-    mock_helty_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test sensors report unknown when the unit omits a reading."""
-    mock_helty_client.async_get_data.return_value = replace(
-        make_data(),
-        indoor_temperature=None,
-        outdoor_temperature=None,
-        indoor_humidity=None,
-    )
-    with patch("homeassistant.components.helty.PLATFORMS", [Platform.SENSOR]):
-        await setup_integration(hass, mock_config_entry)
-
-    for entity_id in (
-        "sensor.vmc_soggiorno_indoor_temperature",
-        "sensor.vmc_soggiorno_outdoor_temperature",
-        "sensor.vmc_soggiorno_indoor_humidity",
-    ):
-        assert hass.states.get(entity_id).state == STATE_UNKNOWN


### PR DESCRIPTION
## Breaking change

## Proposed change

Add a **sensor** platform to the Helty Flow integration, exposing the
environmental readings the unit already reports:

- Indoor temperature (°C)
- Outdoor temperature (°C)
- Indoor humidity (%)

All three are served from the existing `DataUpdateCoordinator` poll, so no
extra requests are made to the unit, and they report `unknown` when a given
model does not provide that reading. No new dependency is required — the values
are already returned by `pyhelty==0.2.0`.

Switch (panel LED) and button (filter-alarm reset) platforms will follow in
separate PRs.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#45695
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

