### PR TITLE
Fix SwitchBot Blind Tilt KeyError on idle BLE advertisements

### DIFF
--- a/homeassistant/components/switchbot/cover.py
+++ b/homeassistant/components/switchbot/cover.py
@@ -218,8 +218,8 @@ class SwitchBotBlindTiltEntity(SwitchbotEntity, CoverEntity, RestoreEntity):
         self._attr_is_closed = (_tilt < self.CLOSED_DOWN_THRESHOLD) or (
             _tilt > self.CLOSED_UP_THRESHOLD
         )
-        self._attr_is_opening = self.parsed_data["motionDirection"]["opening"]
-        self._attr_is_closing = self.parsed_data["motionDirection"]["closing"]
+        self._attr_is_opening = self._device.is_opening()
+        self._attr_is_closing = self._device.is_closing()
         self.async_write_ha_state()
 
 

--- a/tests/components/switchbot/test_cover.py
+++ b/tests/components/switchbot/test_cover.py
@@ -400,11 +400,10 @@ async def test_blindtilt_idle_advertisement(
 
     entry = mock_entry_factory(sensor_type="blind_tilt")
     entry.add_to_hass(hass)
-    # Idle advertisement: no motionDirection key
-    info_idle: dict = {}
+
     with patch(
         "homeassistant.components.switchbot.cover.switchbot.SwitchbotBlindTilt.get_basic_info",
-        new=AsyncMock(return_value=info_idle),
+        new=AsyncMock(return_value={}),
     ):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -414,14 +413,10 @@ async def test_blindtilt_idle_advertisement(
         service_data = b"x\x00*"
         manufacturer_data = b"\xfbgA`\x98\xe8\x1d%F\x12\x85"
 
-        with patch(
-            "homeassistant.components.switchbot.cover.switchbot.SwitchbotBlindTilt.get_basic_info",
-            return_value=info_idle,
-        ):
-            inject_bluetooth_service_info(
-                hass, make_advertisement(address, manufacturer_data, service_data)
-            )
-            await hass.async_block_till_done()
+        inject_bluetooth_service_info(
+            hass, make_advertisement(address, manufacturer_data, service_data)
+        )
+        await hass.async_block_till_done()
 
         # Should not crash; entity should still exist
         state = hass.states.get(entity_id)

--- a/tests/components/switchbot/test_cover.py
+++ b/tests/components/switchbot/test_cover.py
@@ -392,6 +392,42 @@ async def test_blindtilt_controlling(
             assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 50
 
 
+async def test_blindtilt_idle_advertisement(
+    hass: HomeAssistant, mock_entry_factory: Callable[[str], MockConfigEntry]
+) -> None:
+    """Test blindtilt handles BLE advertisement without motionDirection."""
+    inject_bluetooth_service_info(hass, WOBLINDTILT_SERVICE_INFO)
+
+    entry = mock_entry_factory(sensor_type="blind_tilt")
+    entry.add_to_hass(hass)
+    # Idle advertisement: no motionDirection key
+    info_idle: dict = {}
+    with patch(
+        "homeassistant.components.switchbot.cover.switchbot.SwitchbotBlindTilt.get_basic_info",
+        new=AsyncMock(return_value=info_idle),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        entity_id = "cover.test_name"
+        address = "AA:BB:CC:DD:EE:FF"
+        service_data = b"x\x00*"
+        manufacturer_data = b"\xfbgA`\x98\xe8\x1d%F\x12\x85"
+
+        with patch(
+            "homeassistant.components.switchbot.cover.switchbot.SwitchbotBlindTilt.get_basic_info",
+            return_value=info_idle,
+        ):
+            inject_bluetooth_service_info(
+                hass, make_advertisement(address, manufacturer_data, service_data)
+            )
+            await hass.async_block_till_done()
+
+        # Should not crash; entity should still exist
+        state = hass.states.get(entity_id)
+        assert state is not None
+
+
 async def test_roller_shade_setup(
     hass: HomeAssistant, mock_entry_factory: Callable[[str], MockConfigEntry]
 ) -> None:


### PR DESCRIPTION
## Proposed change

`SwitchBotBlindTiltEntity._handle_coordinator_update` crashes with `KeyError: 'motionDirection'` on every BLE advertisement when the blind tilt is idle, because idle devices don't include the `motionDirection` key in their parsed BLE data.

Use `self._device.is_opening()` / `self._device.is_closing()` instead of direct dict access, matching the pattern used by all other SwitchBot cover entities in the same file (`SwitchBotCurtainEntity`, `SwitchBotRollerShadeEntity`, etc.).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #172618
- This PR is related to issue: #160940
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr