### PR TITLE
Add capacity to battery energy source

### DIFF
--- a/homeassistant/components/energy/data.py
+++ b/homeassistant/components/energy/data.py
@@ -172,6 +172,9 @@ class BatterySourceType(TypedDict):
     # statistic_id of a sensor (unit %) reporting the battery state of charge
     stat_soc: NotRequired[str]
 
+    # usable capacity in kWh, used to weight the combined state of charge
+    capacity: NotRequired[float]
+
     # An optional custom name for display in energy graphs
     name: NotRequired[str]
 
@@ -506,6 +509,7 @@ BATTERY_SOURCE_SCHEMA = vol.Schema(
         vol.Optional("stat_rate"): str,
         vol.Optional("power_config"): POWER_CONFIG_SCHEMA,
         vol.Optional("stat_soc"): str,
+        vol.Optional("capacity"): vol.Coerce(float),
         vol.Optional("name"): str,
     }
 )

--- a/homeassistant/components/energy/data.py
+++ b/homeassistant/components/energy/data.py
@@ -509,7 +509,7 @@ BATTERY_SOURCE_SCHEMA = vol.Schema(
         vol.Optional("stat_rate"): str,
         vol.Optional("power_config"): POWER_CONFIG_SCHEMA,
         vol.Optional("stat_soc"): str,
-        vol.Optional("capacity"): vol.Coerce(float),
+        vol.Optional("capacity"): vol.All(vol.Coerce(float), vol.Range(min=0, min_included=False)),
         vol.Optional("name"): str,
     }
 )

--- a/homeassistant/components/energy/data.py
+++ b/homeassistant/components/energy/data.py
@@ -509,7 +509,9 @@ BATTERY_SOURCE_SCHEMA = vol.Schema(
         vol.Optional("stat_rate"): str,
         vol.Optional("power_config"): POWER_CONFIG_SCHEMA,
         vol.Optional("stat_soc"): str,
-        vol.Optional("capacity"): vol.All(vol.Coerce(float), vol.Range(min=0, min_included=False)),
+        vol.Optional("capacity"): vol.All(
+            vol.Coerce(float), vol.Range(min=0, min_included=False)
+        ),
         vol.Optional("name"): str,
     }
 )

--- a/tests/components/energy/test_data.py
+++ b/tests/components/energy/test_data.py
@@ -176,6 +176,32 @@ async def test_battery_stat_soc_round_trip(
     assert source["stat_soc"] == "sensor.battery_state_of_charge"
 
 
+async def test_battery_capacity_round_trip(
+    hass: HomeAssistant,
+) -> None:
+    """Test that battery capacity is preserved through async_update."""
+    manager = EnergyManager(hass)
+    await manager.async_initialize()
+    manager.data = manager.default_preferences()
+
+    await manager.async_update(
+        {
+            "energy_sources": [
+                {
+                    "type": "battery",
+                    "stat_energy_from": "sensor.battery_energy_from",
+                    "stat_energy_to": "sensor.battery_energy_to",
+                    "capacity": 13.5,
+                }
+            ],
+        }
+    )
+
+    assert manager.data is not None
+    source = manager.data["energy_sources"][0]
+    assert source["capacity"] == 13.5
+
+
 async def test_grid_power_config_inverted_sets_stat_rate(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/components/energy/test_data.py
+++ b/tests/components/energy/test_data.py
@@ -184,23 +184,22 @@ async def test_battery_capacity_round_trip(
     await manager.async_initialize()
     manager.data = manager.default_preferences()
 
-    await manager.async_update(
-        {
-            "energy_sources": [
-                {
-                    "type": "battery",
-                    "stat_energy_from": "sensor.battery_energy_from",
-                    "stat_energy_to": "sensor.battery_energy_to",
-                    "capacity": 13.5,
-                }
-            ],
-        }
-    )
+    battery_source = {
+        "type": "battery",
+        "stat_energy_from": "sensor.battery_energy_from",
+        "stat_energy_to": "sensor.battery_energy_to",
+        "capacity": 13.5,
+    }
+    sources = ENERGY_SOURCE_SCHEMA([battery_source])
+
+    await manager.async_update({"energy_sources": sources})
 
     assert manager.data is not None
-    source = manager.data["energy_sources"][0]
-    assert source["capacity"] == 13.5
-
+    assert manager.data["energy_sources"][0]["capacity"] == 13.5
+    with pytest.raises(vol.Invalid):
+        ENERGY_SOURCE_SCHEMA([{**battery_source, "capacity": 0}])
+    with pytest.raises(vol.Invalid):
+        ENERGY_SOURCE_SCHEMA([{**battery_source, "capacity": -1}])
 
 async def test_grid_power_config_inverted_sets_stat_rate(
     hass: HomeAssistant,

--- a/tests/components/energy/test_data.py
+++ b/tests/components/energy/test_data.py
@@ -201,6 +201,7 @@ async def test_battery_capacity_round_trip(
     with pytest.raises(vol.Invalid):
         ENERGY_SOURCE_SCHEMA([{**battery_source, "capacity": -1}])
 
+
 async def test_grid_power_config_inverted_sets_stat_rate(
     hass: HomeAssistant,
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds an optional `capacity` field (usable battery capacity in kWh) to battery energy sources, in both `BatterySourceType` and `BATTERY_SOURCE_SCHEMA`.

This lets the frontend compute a capacity-weighted combined state of charge when multiple batteries of different sizes are configured, rather than a plain average. The field is optional and additive, so existing configurations are unaffected.

Companion to the frontend pull request, and a follow-up to #51812 (which added the battery state of charge sensor).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/52355 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
