### PR TITLE
Remove name field from Xiaomi Aqara config flow

### DIFF
--- a/homeassistant/components/xiaomi_aqara/config_flow.py
+++ b/homeassistant/components/xiaomi_aqara/config_flow.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 from xiaomi_gateway import MULTICAST_PORT, XiaomiGateway, XiaomiGatewayDiscovery
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME, CONF_PORT, CONF_PROTOCOL
+from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PORT, CONF_PROTOCOL
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
@@ -25,7 +25,6 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_GATEWAY_NAME = "Xiaomi Aqara Gateway"
 DEFAULT_INTERFACE = "any"
 
 
@@ -38,12 +37,7 @@ CONFIG_HOST = {
 }
 GATEWAY_CONFIG_HOST = GATEWAY_CONFIG.extend(CONFIG_HOST)
 GATEWAY_SETTINGS = vol.Schema(
-    {
-        vol.Optional(CONF_KEY): vol.All(str, vol.Length(min=16, max=16)),
-        # Name field is no longer allowed in config flow schemas
-        # pylint: disable-next=home-assistant-config-flow-name-field
-        vol.Optional(CONF_NAME, default=DEFAULT_GATEWAY_NAME): str,
-    }
+    {vol.Optional(CONF_KEY): vol.All(str, vol.Length(min=16, max=16))}
 )
 
 ERROR_STEP_PLACEHOLDERS = {
@@ -213,7 +207,6 @@ class XiaomiAqaraFlowHandler(ConfigFlow, domain=DOMAIN):
         errors = {}
         if user_input is not None:
             # get all required data
-            name = user_input[CONF_NAME]
             key = user_input.get(CONF_KEY)
             ip_adress = self.selected_gateway.ip_adress
             port = self.selected_gateway.port
@@ -236,7 +229,7 @@ class XiaomiAqaraFlowHandler(ConfigFlow, domain=DOMAIN):
                 self._abort_if_unique_id_configured()
 
                 return self.async_create_entry(
-                    title=name,
+                    title=mac_address,
                     data={
                         CONF_HOST: ip_adress,
                         CONF_PORT: port,

--- a/tests/components/xiaomi_aqara/test_config_flow.py
+++ b/tests/components/xiaomi_aqara/test_config_flow.py
@@ -8,7 +8,7 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.xiaomi_aqara import config_flow, const
-from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME, CONF_PORT, CONF_PROTOCOL
+from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PORT, CONF_PROTOCOL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
@@ -21,7 +21,6 @@ TEST_HOST = "1.2.3.4"
 TEST_HOST_2 = "5.6.7.8"
 TEST_KEY = "1234567890123456"
 TEST_PORT = 1234
-TEST_NAME = "Test_Aqara_Gateway"
 TEST_SID = "abcdefghijkl"
 TEST_PROTOCOL = "1.1.1"
 TEST_MAC = "ab:cd:ef:gh:ij:kl"
@@ -104,12 +103,11 @@ async def test_config_flow_user_success(hass: HomeAssistant) -> None:
     assert result["errors"] == {}
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {const.CONF_KEY: TEST_KEY, CONF_NAME: TEST_NAME},
+        result["flow_id"], {const.CONF_KEY: TEST_KEY}
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == TEST_NAME
+    assert result["title"] == TEST_MAC
     assert result["data"] == {
         CONF_HOST: TEST_HOST,
         CONF_PORT: TEST_PORT,
@@ -156,12 +154,11 @@ async def test_config_flow_user_multiple_success(hass: HomeAssistant) -> None:
     assert result["errors"] == {}
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {const.CONF_KEY: TEST_KEY, CONF_NAME: TEST_NAME},
+        result["flow_id"], {const.CONF_KEY: TEST_KEY}
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == TEST_NAME
+    assert result["title"] == TEST_MAC
     assert result["data"] == {
         CONF_HOST: TEST_HOST_2,
         CONF_PORT: TEST_PORT,
@@ -194,11 +191,11 @@ async def test_config_flow_user_no_key_success(hass: HomeAssistant) -> None:
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {CONF_NAME: TEST_NAME},
+        {},
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == TEST_NAME
+    assert result["title"] == TEST_MAC
     assert result["data"] == {
         CONF_HOST: TEST_HOST,
         CONF_PORT: TEST_PORT,
@@ -241,11 +238,11 @@ async def test_config_flow_user_host_mac_success(hass: HomeAssistant) -> None:
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {CONF_NAME: TEST_NAME},
+        {},
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == TEST_NAME
+    assert result["title"] == TEST_MAC
     assert result["data"] == {
         CONF_HOST: TEST_HOST,
         CONF_PORT: TEST_PORT,
@@ -395,8 +392,7 @@ async def test_config_flow_user_invalid_key(hass: HomeAssistant) -> None:
     assert result["errors"] == {}
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {const.CONF_KEY: TEST_KEY, CONF_NAME: TEST_NAME},
+        result["flow_id"], {const.CONF_KEY: TEST_KEY}
     )
 
     assert result["type"] is FlowResultType.FORM
@@ -434,12 +430,11 @@ async def test_zeroconf_success(hass: HomeAssistant) -> None:
     assert result["errors"] == {}
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {const.CONF_KEY: TEST_KEY, CONF_NAME: TEST_NAME},
+        result["flow_id"], {const.CONF_KEY: TEST_KEY}
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == TEST_NAME
+    assert result["title"] == TEST_MAC
     assert result["data"] == {
         CONF_HOST: TEST_HOST,
         CONF_PORT: TEST_PORT,


### PR DESCRIPTION
## Proposed change

Remove the name field from the Xiaomi Aqara config flow schema to comply with the `home-assistant-config-flow-name-field` rule.

This change:

* Removes `CONF_NAME` from the config flow schema.
* Removes the unused default gateway name constant.
* Removes user-provided naming during setup.
* Uses the gateway MAC address as the config entry title.

Part of home-assistant/epics#47.

## Type of change

* [x] Dependency upgrade
* [x] Bugfix (non-breaking change which fixes an issue)
* [x] New integration (thank you!)
* [x] New feature (which adds functionality to an existing integration)
* [x] Deprecation (breaking change to happen in the future)
* [x] Breaking change (fix/feature causing existing functionality to break)
* [x] Code quality improvements to existing code or addition of tests

## Additional information

* This PR fixes or closes issue: fixes #168969 
* This PR is related to issue: home-assistant/epics#47
* Link to documentation pull request:
* Link to developer documentation pull request:
* Link to frontend pull request:

## Checklist

* [x] I understand the code I am submitting and can explain how it works.
* [x] The code change is tested and works locally.
* [x] Local tests pass. **Your PR cannot be merged unless tests pass**
* [x] There is no commented out code in this PR.
* [x] I have followed the development checklist.
* [x] I have followed the perfect PR recommendations.
* [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
* [ ] Tests have been added to verify that the new code works.
* [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

* [x] I have reviewed two other open pull requests in this repository.
