### PR TITLE
Vistapool: add DHCP discovery on SugarWIFI hostname

### DIFF
--- a/homeassistant/components/vistapool/config_flow.py
+++ b/homeassistant/components/vistapool/config_flow.py
@@ -10,7 +10,6 @@ from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .const import DOMAIN
 
@@ -26,24 +25,6 @@ AUTH_SCHEMA = vol.Schema(
 
 class VistapoolConfigFlow(ConfigFlow, domain=DOMAIN):
     """Vistapool config flow (one entry per Hayward account)."""
-
-    async def async_step_dhcp(
-        self, discovery_info: DhcpServiceInfo
-    ) -> ConfigFlowResult:
-        """Handle DHCP discovery of a Sugar Valley / Hayward Wi-Fi module.
-
-        The Wi-Fi module that ships with Hayward / Vistapool / Sugar Valley /
-        AquaRite / Poolwatch / Kripsol / Dagen controllers announces itself
-        on DHCP with the hostname ``SugarWIFI``. We can't auto-configure
-        because the cloud API still needs the user's account credentials, so
-        the discovery card simply routes the user into the credentials form.
-        One Hayward account covers every pool and controller, so we abort
-        if any entry already exists.
-        """
-        if self._async_current_entries():
-            return self.async_abort(reason="already_configured")
-
-        return await self.async_step_user()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/vistapool/config_flow.py
+++ b/homeassistant/components/vistapool/config_flow.py
@@ -10,6 +10,7 @@ from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .const import DOMAIN
 
@@ -25,6 +26,24 @@ AUTH_SCHEMA = vol.Schema(
 
 class VistapoolConfigFlow(ConfigFlow, domain=DOMAIN):
     """Vistapool config flow (one entry per Hayward account)."""
+
+    async def async_step_dhcp(
+        self, discovery_info: DhcpServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle DHCP discovery of a Sugar Valley / Hayward Wi-Fi module.
+
+        The Wi-Fi module that ships with Hayward / Vistapool / Sugar Valley /
+        AquaRite / Poolwatch / Kripsol / Dagen controllers announces itself
+        on DHCP with the hostname ``SugarWIFI``. We can't auto-configure
+        because the cloud API still needs the user's account credentials, so
+        the discovery card simply routes the user into the credentials form.
+        One Hayward account covers every pool and controller, so we abort
+        if any entry already exists.
+        """
+        if self._async_current_entries():
+            return self.async_abort(reason="already_configured")
+
+        return await self.async_step_user()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/vistapool/manifest.json
+++ b/homeassistant/components/vistapool/manifest.json
@@ -3,6 +3,11 @@
   "name": "Vistapool",
   "codeowners": ["@fdebrus"],
   "config_flow": true,
+  "dhcp": [
+    {
+      "hostname": "sugarwifi*"
+    }
+  ],
   "documentation": "https://www.home-assistant.io/integrations/vistapool",
   "integration_type": "hub",
   "iot_class": "cloud_push",

--- a/homeassistant/components/vistapool/manifest.json
+++ b/homeassistant/components/vistapool/manifest.json
@@ -5,7 +5,7 @@
   "config_flow": true,
   "dhcp": [
     {
-      "hostname": "sugarwifi*"
+      "hostname": "sugarwifi"
     }
   ],
   "documentation": "https://www.home-assistant.io/integrations/vistapool",

--- a/homeassistant/components/vistapool/quality_scale.yaml
+++ b/homeassistant/components/vistapool/quality_scale.yaml
@@ -41,7 +41,7 @@ rules:
   # Gold
   devices: done
   diagnostics: todo
-  discovery: todo
+  discovery: done
   discovery-update-info: todo
   docs-data-update: todo
   docs-examples: todo

--- a/homeassistant/components/vistapool/strings.json
+++ b/homeassistant/components/vistapool/strings.json
@@ -1,5 +1,6 @@
 {
   "config": {
+    "flow_title": "Vistapool / Hayward pool controller",
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
     },

--- a/homeassistant/components/vistapool/strings.json
+++ b/homeassistant/components/vistapool/strings.json
@@ -2,7 +2,8 @@
   "config": {
     "flow_title": "Vistapool / Hayward pool controller",
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",

--- a/homeassistant/components/vistapool/strings.json
+++ b/homeassistant/components/vistapool/strings.json
@@ -1,6 +1,5 @@
 {
   "config": {
-    "flow_title": "Vistapool / Hayward pool controller",
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]"
@@ -11,6 +10,7 @@
       "no_pools": "No pools were found on this account.",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
+    "flow_title": "Vistapool pool controller",
     "step": {
       "user": {
         "data": {

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -1416,6 +1416,10 @@ DHCP: Final[list[dict[str, str | bool]]] = [
         "macaddress": "B87424*",
     },
     {
+        "domain": "vistapool",
+        "hostname": "sugarwifi",
+    },
+    {
         "domain": "withings",
         "macaddress": "0024E4*",
     },

--- a/tests/components/vistapool/test_config_flow.py
+++ b/tests/components/vistapool/test_config_flow.py
@@ -280,3 +280,26 @@ async def test_dhcp_discovery_aborts_when_configured(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_dhcp_discovery_aborts_when_in_progress(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_vistapool_client: AsyncMock,
+) -> None:
+    """Test a second DHCP discovery aborts while another flow is in progress."""
+    first = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_DHCP},
+        data=_DHCP_INFO,
+    )
+    assert first["type"] is FlowResultType.FORM
+
+    second = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_DHCP},
+        data=_DHCP_INFO,
+    )
+
+    assert second["type"] is FlowResultType.ABORT
+    assert second["reason"] == "already_in_progress"

--- a/tests/components/vistapool/test_config_flow.py
+++ b/tests/components/vistapool/test_config_flow.py
@@ -17,10 +17,17 @@ from homeassistant.components.vistapool.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .conftest import MOCK_PASSWORD, MOCK_POOLS, MOCK_USERNAME
 
 from tests.common import MockConfigEntry
+
+_DHCP_INFO = DhcpServiceInfo(
+    ip="192.168.2.70",
+    hostname="sugarwifi",
+    macaddress="aabbccddeeff",
+)
 
 
 @pytest.fixture
@@ -228,6 +235,48 @@ async def test_duplicate_account_aborts(
     mock_config_entry.add_to_hass(hass)
 
     result = await _configure(hass)
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+# ── DHCP discovery ────────────────────────────────────────────────
+
+
+async def test_dhcp_discovery_starts_user_flow(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_vistapool_client: AsyncMock,
+) -> None:
+    """Test DHCP discovery routes the user into the credentials step."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_DHCP},
+        data=_DHCP_INFO,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await _submit(hass, result["flow_id"])
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == MOCK_USERNAME
+
+
+async def test_dhcp_discovery_aborts_when_configured(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_vistapool_client: AsyncMock,
+) -> None:
+    """Test DHCP discovery aborts when an account is already configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_DHCP},
+        data=_DHCP_INFO,
+    )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"

--- a/tests/components/vistapool/test_config_flow.py
+++ b/tests/components/vistapool/test_config_flow.py
@@ -12,8 +12,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from aioaquarite import AquariteError, AuthenticationError
 import pytest
 
-from homeassistant import config_entries
 from homeassistant.components.vistapool.const import DOMAIN
+from homeassistant.config_entries import SOURCE_DHCP, SOURCE_USER
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -50,7 +50,7 @@ async def _submit(hass: HomeAssistant, flow_id: str) -> dict:
 async def _configure(hass: HomeAssistant) -> dict:
     """Run the user step from start to finish with the standard credentials."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": SOURCE_USER}
     )
     return await _submit(hass, result["flow_id"])
 
@@ -65,7 +65,7 @@ async def test_user_step(
 ) -> None:
     """Test the user step shows a form and creates an entry on submission."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": SOURCE_USER}
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
@@ -93,7 +93,7 @@ async def test_invalid_auth(
     mock_vistapool_auth.authenticate.side_effect = AuthenticationError
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": SOURCE_USER}
     )
     result = await _submit(hass, result["flow_id"])
 
@@ -118,7 +118,7 @@ async def test_cannot_connect(
     mock_vistapool_auth.authenticate.side_effect = AquariteError("network down")
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": SOURCE_USER}
     )
     result = await _submit(hass, result["flow_id"])
 
@@ -141,7 +141,7 @@ async def test_cannot_connect_during_pool_fetch(
     mock_vistapool_client.get_pools.side_effect = AquariteError("network down")
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": SOURCE_USER}
     )
     result = await _submit(hass, result["flow_id"])
 
@@ -165,7 +165,7 @@ async def test_unknown_exception(
     mock_vistapool_auth.authenticate.side_effect = RuntimeError("Connection refused")
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": SOURCE_USER}
     )
     result = await _submit(hass, result["flow_id"])
 
@@ -188,7 +188,7 @@ async def test_unknown_exception_during_pool_fetch(
     mock_vistapool_client.get_pools.side_effect = RuntimeError("boom")
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": SOURCE_USER}
     )
     result = await _submit(hass, result["flow_id"])
 
@@ -211,7 +211,7 @@ async def test_no_pools(
     mock_vistapool_client.get_pools.return_value = {}
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": SOURCE_USER}
     )
     result = await _submit(hass, result["flow_id"])
 
@@ -251,7 +251,7 @@ async def test_dhcp_discovery_starts_user_flow(
     """Test DHCP discovery routes the user into the credentials step."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        context={"source": config_entries.SOURCE_DHCP},
+        context={"source": SOURCE_DHCP},
         data=_DHCP_INFO,
     )
 
@@ -274,7 +274,7 @@ async def test_dhcp_discovery_aborts_when_configured(
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        context={"source": config_entries.SOURCE_DHCP},
+        context={"source": SOURCE_DHCP},
         data=_DHCP_INFO,
     )
 

--- a/tests/components/vistapool/test_config_flow.py
+++ b/tests/components/vistapool/test_config_flow.py
@@ -24,7 +24,7 @@ from .conftest import MOCK_PASSWORD, MOCK_POOLS, MOCK_USERNAME
 from tests.common import MockConfigEntry
 
 _DHCP_INFO = DhcpServiceInfo(
-    ip="192.168.2.70",
+    ip="1.2.3.4",
     hostname="sugarwifi",
     macaddress="aabbccddeeff",
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds DHCP discovery to the Vistapool integration. Sugar Valley S.L.'s Wi-Fi module — shipping in Hayward, Vistapool, Sugar Valley, AquaRite, Poolwatch, Kripsol, and Dagen pool controllers — announces itself on DHCP with the hostname `SugarWIFI`. HA matches the pattern in `manifest.json` and surfaces a discovery card.

The integration is `cloud_push`, so auto-configuration isn't possible — the discovery step delegates to the existing user step for credential entry. It aborts when an entry already exists, since one Hayward cloud account covers every pool and controller on it.

### Implementation notes

- `manifest.json`: single `dhcp` matcher on `hostname: "sugarwifi*"`. Case-insensitive (HA's DHCP matcher lowercases internally); wildcard suffix to tolerate hypothetical firmware variants that append a serial. MAC OUI not used as a matcher — the module is ESP32-based (Espressif OUI), generic to millions of unrelated IoT devices.
- `config_flow.py`: `async_step_dhcp` aborts on `_async_current_entries()` (one account → one entry covers all controllers); otherwise routes to the existing `async_step_user` so the user enters their Hayward cloud credentials. No `async_set_unique_id` on the discovery side — the eventual entry's `unique_id` is the cloud `user_id` (set in the user step), and HA's discovery system handles repeated DHCP events for the same device via its internal dedupe.
- `strings.json`: `flow_title` for the discovery card.
- `quality_scale.yaml`: Gold-tier `discovery` rule flipped from `todo` to `done`.

### Tests

`tests/components/vistapool/test_config_flow.py`:

- `test_dhcp_discovery_starts_user_flow` — fires a `DhcpServiceInfo`, asserts the flow shows the user form, submits credentials, asserts entry created.
- `test_dhcp_discovery_aborts_when_configured` — fires the same `DhcpServiceInfo` with an existing config entry, asserts `ABORT` / `already_configured`.

Hostname pattern verified on the original device (Vistapool/Hayward AquaRite) and cross-checked with a forum user reporting the same `SugarWIFI` hostname on a different Sugar Valley rebrand.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45699
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr