### PR TITLE
Make the renamed trigger behavior options backwards compatible

### DIFF
--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -330,6 +330,16 @@ BEHAVIOR_FIRST: Final = "first"
 BEHAVIOR_ALL: Final = "all"
 BEHAVIOR_EACH: Final = "each"
 
+
+def _backwards_compatible_behavior(value: Any) -> Any:
+    """Convert legacy behavior values to new ones."""
+    if value == "any":
+        return BEHAVIOR_EACH
+    if value == "last":
+        return BEHAVIOR_ALL
+    return value
+
+
 ENTITY_STATE_TRIGGER_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_TARGET): cv.TARGET_FIELDS,
@@ -340,8 +350,9 @@ ENTITY_STATE_TRIGGER_SCHEMA = vol.Schema(
 ENTITY_STATE_TRIGGER_SCHEMA_WITH_BEHAVIOR = ENTITY_STATE_TRIGGER_SCHEMA.extend(
     {
         vol.Required(CONF_OPTIONS, default={}): {
-            vol.Required(ATTR_BEHAVIOR, default=BEHAVIOR_EACH): vol.In(
-                [BEHAVIOR_FIRST, BEHAVIOR_ALL, BEHAVIOR_EACH]
+            vol.Required(ATTR_BEHAVIOR, default=BEHAVIOR_EACH): vol.All(
+                _backwards_compatible_behavior,
+                vol.In([BEHAVIOR_FIRST, BEHAVIOR_ALL, BEHAVIOR_EACH]),
             ),
             vol.Optional(CONF_FOR): cv.positive_time_period,
         },

--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -53,6 +53,7 @@ from homeassistant.helpers.trigger import (
     BEHAVIOR_EACH,
     BEHAVIOR_FIRST,
     DATA_PLUGGABLE_ACTIONS,
+    ENTITY_STATE_TRIGGER_SCHEMA_WITH_BEHAVIOR,
     TRIGGERS,
     EntityNumericalStateChangedTriggerWithUnitBase,
     EntityNumericalStateCrossedThresholdTriggerWithUnitBase,
@@ -4787,3 +4788,48 @@ def test_async_extract_devices(
 ) -> None:
     """Test extracting devices from various trigger config shapes."""
     assert trigger.async_extract_devices(trigger_conf) == expected
+
+
+@pytest.mark.parametrize(
+    ("behavior", "expected"),
+    [
+        # Legacy values are converted to their new equivalents
+        ("any", BEHAVIOR_EACH),
+        ("last", BEHAVIOR_ALL),
+        # New values pass through unchanged
+        (BEHAVIOR_FIRST, BEHAVIOR_FIRST),
+        (BEHAVIOR_ALL, BEHAVIOR_ALL),
+        (BEHAVIOR_EACH, BEHAVIOR_EACH),
+    ],
+)
+def test_entity_state_trigger_schema_behavior_backwards_compatible(
+    behavior: str, expected: str
+) -> None:
+    """Test legacy behavior values are converted to their new equivalents."""
+    config = {
+        CONF_TARGET: {CONF_ENTITY_ID: "test.entity"},
+        CONF_OPTIONS: {ATTR_BEHAVIOR: behavior},
+    }
+    validated = ENTITY_STATE_TRIGGER_SCHEMA_WITH_BEHAVIOR(config)
+    assert validated[CONF_OPTIONS][ATTR_BEHAVIOR] == expected
+
+
+def test_entity_state_trigger_schema_behavior_default() -> None:
+    """Test the behavior defaults to 'each' when omitted."""
+    config = {
+        CONF_TARGET: {CONF_ENTITY_ID: "test.entity"},
+        CONF_OPTIONS: {},
+    }
+    validated = ENTITY_STATE_TRIGGER_SCHEMA_WITH_BEHAVIOR(config)
+    assert validated[CONF_OPTIONS][ATTR_BEHAVIOR] == BEHAVIOR_EACH
+
+
+@pytest.mark.parametrize("behavior", ["invalid", "anything", ""])
+def test_entity_state_trigger_schema_behavior_invalid(behavior: str) -> None:
+    """Test invalid behavior values are rejected."""
+    config = {
+        CONF_TARGET: {CONF_ENTITY_ID: "test.entity"},
+        CONF_OPTIONS: {ATTR_BEHAVIOR: behavior},
+    }
+    with pytest.raises(vol.Invalid):
+        ENTITY_STATE_TRIGGER_SCHEMA_WITH_BEHAVIOR(config)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We renamed trigger behavior options in https://github.com/home-assistant/core/pull/172348, in a breaking way: disable automations with triggers using renamed behaviors.

This PR softens that by making the renamed options still work.

I'm not sure how to communicate the renaming to users; when validating triggers we don't know what we're validating.
I suggest to merge this PR first and deal with that in a follow-up if we have a viable idea.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
