### PR TITLE
Vistapool: add diagnostics support

### DIFF
--- a/homeassistant/components/vistapool/diagnostics.py
+++ b/homeassistant/components/vistapool/diagnostics.py
@@ -1,0 +1,36 @@
+"""Diagnostics support for Vistapool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+
+from . import VistapoolConfigEntry
+
+TO_REDACT = {
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    "city",
+    "lat",
+    "lng",
+    "street",
+    "wifi",
+    "zipcode",
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant,
+    entry: VistapoolConfigEntry,
+) -> dict[str, Any]:
+    """Return diagnostics for a Vistapool config entry."""
+    return {
+        "entry": async_redact_data(entry.as_dict(), TO_REDACT),
+        "pools": [
+            async_redact_data(coordinator.data, TO_REDACT)
+            for coordinator in entry.runtime_data.coordinators.values()
+        ],
+    }

--- a/homeassistant/components/vistapool/diagnostics.py
+++ b/homeassistant/components/vistapool/diagnostics.py
@@ -1,7 +1,5 @@
 """Diagnostics support for Vistapool."""
 
-from __future__ import annotations
-
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data

--- a/homeassistant/components/vistapool/diagnostics.py
+++ b/homeassistant/components/vistapool/diagnostics.py
@@ -15,6 +15,8 @@ TO_REDACT = {
     "lat",
     "lng",
     "street",
+    "title",
+    "unique_id",
     "wifi",
     "zipcode",
 }

--- a/homeassistant/components/vistapool/quality_scale.yaml
+++ b/homeassistant/components/vistapool/quality_scale.yaml
@@ -40,7 +40,7 @@ rules:
 
   # Gold
   devices: done
-  diagnostics: todo
+  diagnostics: done
   discovery: todo
   discovery-update-info: todo
   docs-data-update: todo

--- a/tests/components/vistapool/snapshots/test_diagnostics.ambr
+++ b/tests/components/vistapool/snapshots/test_diagnostics.ambr
@@ -18,8 +18,8 @@
       'source': 'user',
       'subentries': list([
       ]),
-      'title': 'testuser@example.com',
-      'unique_id': 'firebase-uid-testuser',
+      'title': '**REDACTED**',
+      'unique_id': '**REDACTED**',
       'version': 1,
     }),
     'pools': list([

--- a/tests/components/vistapool/snapshots/test_diagnostics.ambr
+++ b/tests/components/vistapool/snapshots/test_diagnostics.ambr
@@ -1,0 +1,148 @@
+# serializer version: 1
+# name: test_entry_diagnostics
+  dict({
+    'entry': dict({
+      'data': dict({
+        'password': '**REDACTED**',
+        'username': '**REDACTED**',
+      }),
+      'disabled_by': None,
+      'discovery_keys': dict({
+      }),
+      'domain': 'vistapool',
+      'minor_version': 1,
+      'options': dict({
+      }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'user',
+      'subentries': list([
+      ]),
+      'title': 'testuser@example.com',
+      'unique_id': 'firebase-uid-testuser',
+      'version': 1,
+    }),
+    'pools': list([
+      dict({
+        'backwash': dict({
+          'status': 0,
+        }),
+        'filtration': dict({
+          'intel': dict({
+            'temp': 24,
+            'time': '600',
+          }),
+          'interval1': dict({
+            'from': 28800,
+            'to': 36000,
+          }),
+          'interval2': dict({
+            'from': 46800,
+            'to': 50400,
+          }),
+          'interval3': dict({
+            'from': 68400,
+            'to': 70200,
+          }),
+          'manVel': 2,
+          'mode': 1,
+          'status': 1,
+          'timerVel1': 1,
+          'timerVel2': 1,
+          'timerVel3': 0,
+        }),
+        'form': dict({
+          'city': '**REDACTED**',
+          'country': 'BE',
+          'lat': '**REDACTED**',
+          'lng': '**REDACTED**',
+          'street': '**REDACTED**',
+          'zipcode': '**REDACTED**',
+        }),
+        'hidro': dict({
+          'cloration_enabled': 0,
+          'cover': 0,
+          'cover_enabled': 0,
+          'current': 50,
+          'fl1': 0,
+          'fl2': 0,
+          'is_electrolysis': True,
+          'level': 100,
+          'low': 0,
+          'maxAllowedValue': 220,
+        }),
+        'light': dict({
+          'status': 0,
+        }),
+        'main': dict({
+          'RSSI': -65,
+          'hasCD': 0,
+          'hasCL': 0,
+          'hasHidro': 1,
+          'hasIO': 0,
+          'hasLED': 0,
+          'hasPH': 1,
+          'hasRX': 1,
+          'hasUV': 0,
+          'localTime': 1775995380,
+          'temperature': 25.5,
+          'version': 825,
+        }),
+        'modules': dict({
+          'ph': dict({
+            'al3': 0,
+            'current': '742',
+            'pump_high_on': 0,
+            'pump_low_on': 0,
+            'status': dict({
+              'high_value': '751',
+              'low_value': '650',
+            }),
+            'tank': 0,
+          }),
+          'rx': dict({
+            'current': 707,
+            'pump_status': 0,
+            'status': dict({
+              'value': 700,
+            }),
+            'tank': 0,
+          }),
+        }),
+        'present': True,
+        'relays': dict({
+          'filtration': dict({
+            'heating': dict({
+              'status': 0,
+            }),
+          }),
+          'relay1': dict({
+            'info': dict({
+              'onoff': 0,
+              'status': 0,
+            }),
+          }),
+          'relay2': dict({
+            'info': dict({
+              'onoff': 0,
+              'status': 0,
+            }),
+          }),
+          'relay3': dict({
+            'info': dict({
+              'onoff': 0,
+              'status': 0,
+            }),
+          }),
+          'relay4': dict({
+            'info': dict({
+              'onoff': 0,
+              'status': 0,
+            }),
+          }),
+        }),
+        'wifi': '**REDACTED**',
+      }),
+    ]),
+  })
+# ---

--- a/tests/components/vistapool/test_diagnostics.py
+++ b/tests/components/vistapool/test_diagnostics.py
@@ -1,0 +1,43 @@
+"""Tests for the Vistapool diagnostics."""
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+from homeassistant.components.diagnostics import REDACTED
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+
+async def test_entry_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_config_entry: MockConfigEntry,
+    mock_vistapool_client: AsyncMock,
+    mock_pool_data: dict[str, Any],
+) -> None:
+    """Test diagnostics redact credentials and pool location data."""
+    mock_vistapool_client.fetch_pool_data.return_value = mock_pool_data
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await get_diagnostics_for_config_entry(
+        hass, hass_client, mock_config_entry
+    )
+
+    assert result["entry"]["data"][CONF_USERNAME] == REDACTED
+    assert result["entry"]["data"][CONF_PASSWORD] == REDACTED
+
+    pool = result["pools"][0]
+    assert pool["form"]["lat"] == REDACTED
+    assert pool["form"]["lng"] == REDACTED
+    assert pool["form"]["city"] == REDACTED
+    assert pool["form"]["street"] == REDACTED
+    assert pool["form"]["zipcode"] == REDACTED
+
+    assert pool["main"]["temperature"] == mock_pool_data["main"]["temperature"]

--- a/tests/components/vistapool/test_diagnostics.py
+++ b/tests/components/vistapool/test_diagnostics.py
@@ -33,11 +33,10 @@ async def test_entry_diagnostics(
     assert result["entry"]["data"][CONF_USERNAME] == REDACTED
     assert result["entry"]["data"][CONF_PASSWORD] == REDACTED
 
-    pool = result["pools"][0]
-    assert pool["form"]["lat"] == REDACTED
-    assert pool["form"]["lng"] == REDACTED
-    assert pool["form"]["city"] == REDACTED
-    assert pool["form"]["street"] == REDACTED
-    assert pool["form"]["zipcode"] == REDACTED
-
-    assert pool["main"]["temperature"] == mock_pool_data["main"]["temperature"]
+    for pool in result["pools"]:
+        assert pool["form"]["lat"] == REDACTED
+        assert pool["form"]["lng"] == REDACTED
+        assert pool["form"]["city"] == REDACTED
+        assert pool["form"]["street"] == REDACTED
+        assert pool["form"]["zipcode"] == REDACTED
+        assert pool["main"]["temperature"] == mock_pool_data["main"]["temperature"]

--- a/tests/components/vistapool/test_diagnostics.py
+++ b/tests/components/vistapool/test_diagnostics.py
@@ -20,6 +20,7 @@ async def test_entry_diagnostics(
     mock_pool_data: dict[str, Any],
 ) -> None:
     """Test diagnostics redact credentials and pool location data."""
+    mock_pool_data["wifi"] = "gateway-serial-id"
     mock_vistapool_client.fetch_pool_data.return_value = mock_pool_data
     mock_config_entry.add_to_hass(hass)
 
@@ -33,10 +34,12 @@ async def test_entry_diagnostics(
     assert result["entry"]["data"][CONF_USERNAME] == REDACTED
     assert result["entry"]["data"][CONF_PASSWORD] == REDACTED
 
+    assert len(result["pools"]) == 1
     for pool in result["pools"]:
         assert pool["form"]["lat"] == REDACTED
         assert pool["form"]["lng"] == REDACTED
         assert pool["form"]["city"] == REDACTED
         assert pool["form"]["street"] == REDACTED
         assert pool["form"]["zipcode"] == REDACTED
+        assert pool["wifi"] == REDACTED
         assert pool["main"]["temperature"] == mock_pool_data["main"]["temperature"]

--- a/tests/components/vistapool/test_diagnostics.py
+++ b/tests/components/vistapool/test_diagnostics.py
@@ -3,8 +3,9 @@
 from typing import Any
 from unittest.mock import AsyncMock
 
-from homeassistant.components.diagnostics import REDACTED
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from syrupy.assertion import SnapshotAssertion
+from syrupy.filters import props
+
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -15,11 +16,12 @@ from tests.typing import ClientSessionGenerator
 async def test_entry_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
+    snapshot: SnapshotAssertion,
     mock_config_entry: MockConfigEntry,
     mock_vistapool_client: AsyncMock,
     mock_pool_data: dict[str, Any],
 ) -> None:
-    """Test diagnostics redact credentials and pool location data."""
+    """Test config entry diagnostics."""
     mock_pool_data["wifi"] = "gateway-serial-id"
     mock_vistapool_client.fetch_pool_data.return_value = mock_pool_data
     mock_config_entry.add_to_hass(hass)
@@ -31,15 +33,4 @@ async def test_entry_diagnostics(
         hass, hass_client, mock_config_entry
     )
 
-    assert result["entry"]["data"][CONF_USERNAME] == REDACTED
-    assert result["entry"]["data"][CONF_PASSWORD] == REDACTED
-
-    assert len(result["pools"]) == 1
-    for pool in result["pools"]:
-        assert pool["form"]["lat"] == REDACTED
-        assert pool["form"]["lng"] == REDACTED
-        assert pool["form"]["city"] == REDACTED
-        assert pool["form"]["street"] == REDACTED
-        assert pool["form"]["zipcode"] == REDACTED
-        assert pool["wifi"] == REDACTED
-        assert pool["main"]["temperature"] == mock_pool_data["main"]["temperature"]
+    assert result == snapshot(exclude=props("created_at", "modified_at", "entry_id"))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds diagnostics support to Vistapool. `async_get_config_entry_diagnostics` returns the config entry data and each pool's coordinator data, with credentials and pool location fields (`username`, `password`, `lat`, `lng`, `city`, `street`, `zipcode`, `wifi`) redacted via `async_redact_data`. Pools are returned as a list rather than a dict keyed by pool ID, so pool identifiers themselves aren't leaked.

Flips the Gold-tier `diagnostics` quality-scale rule from `todo` to `done`.

### Tests

`tests/components/vistapool/test_diagnostics.py::test_entry_diagnostics` asserts each sensitive field redacts to `REDACTED` and a non-sensitive field (water temperature) passes through unchanged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr