### PR TITLE
Use `homeassistant.util.dt.utcnow` instead of `datetime.now(UTC)` in Anthropic

### DIFF
--- a/homeassistant/components/anthropic/entity.py
+++ b/homeassistant/components/anthropic/entity.py
@@ -4,7 +4,6 @@ import base64
 from collections import deque
 from collections.abc import AsyncIterator, Callable, Iterable
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
 import json
 from mimetypes import guess_file_type
 from pathlib import Path
@@ -114,7 +113,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, llm
 from homeassistant.helpers.json import json_dumps
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util import slugify
+from homeassistant.util import dt as dt_util, slugify
 from homeassistant.util.json import JsonArrayType, JsonObjectType
 
 from .const import (
@@ -372,7 +371,7 @@ def _convert_content(  # noqa: C901
                     )
                 if (
                     content.native.container is not None
-                    and content.native.container.expires_at > datetime.now(UTC)  # pylint: disable=home-assistant-enforce-utcnow
+                    and content.native.container.expires_at > dt_util.utcnow()
                 ):
                     container_id = content.native.container.id
 

--- a/tests/components/anthropic/conftest.py
+++ b/tests/components/anthropic/conftest.py
@@ -29,6 +29,7 @@ from homeassistant.const import CONF_LLM_HASS_API
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import llm
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
 
 from . import model_list
 
@@ -170,9 +171,7 @@ def mock_create_stream() -> Generator[AsyncMock]:
             ):
                 container = Container(
                     id=kwargs.get("container_id", "container_1234567890ABCDEFGHIJKLMN"),
-                    # pylint: disable-next=home-assistant-enforce-utcnow
-                    expires_at=datetime.datetime.now(tz=datetime.UTC)
-                    + datetime.timedelta(minutes=5),
+                    expires_at=dt_util.utcnow() + datetime.timedelta(minutes=5),
                 )
 
             yield event

--- a/tests/components/anthropic/test_coordinator.py
+++ b/tests/components/anthropic/test_coordinator.py
@@ -1,6 +1,5 @@
 """Tests for the Anthropic integration."""
 
-import datetime
 from unittest.mock import AsyncMock, patch
 
 from anthropic import APITimeoutError, AuthenticationError, RateLimitError
@@ -16,6 +15,7 @@ from homeassistant.components.anthropic.coordinator import (
 from homeassistant.config_entries import SOURCE_REAUTH
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import intent
+from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -121,8 +121,7 @@ async def test_connection_error_handling(
     assert state.state == "2026-02-27T12:00:00+00:00"
 
     # Verify the background check period
-    # pylint: disable-next=home-assistant-enforce-utcnow
-    test_time = datetime.datetime.now(datetime.UTC) + UPDATE_INTERVAL_DISCONNECTED
+    test_time = dt_util.utcnow() + UPDATE_INTERVAL_DISCONNECTED
     async_fire_time_changed(hass, test_time)
     await hass.async_block_till_done()
     mock_model_list.assert_not_awaited()
@@ -152,8 +151,7 @@ async def test_connection_check_reauth(
 
     # Get timeout
     assert mock_model_list.await_count == 0
-    # pylint: disable-next=home-assistant-enforce-utcnow
-    test_time = datetime.datetime.now(datetime.UTC) + UPDATE_INTERVAL_CONNECTED
+    test_time = dt_util.utcnow() + UPDATE_INTERVAL_CONNECTED
     async_fire_time_changed(hass, test_time)
     await hass.async_block_till_done()
     assert mock_model_list.await_count == 1
@@ -232,8 +230,7 @@ async def test_connection_restore(
 
     # Wait for background check to run and fail
     assert mock_model_list.await_count == 0
-    # pylint: disable-next=home-assistant-enforce-utcnow
-    test_time = datetime.datetime.now(datetime.UTC) + UPDATE_INTERVAL_DISCONNECTED
+    test_time = dt_util.utcnow() + UPDATE_INTERVAL_DISCONNECTED
     async_fire_time_changed(hass, test_time)
     await hass.async_block_till_done()
     assert mock_model_list.await_count == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replace `datetime.now(UTC)` and `datetime.datetime.now(tz=datetime.UTC)` with `dt_util.utcnow()`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #172715
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
