### PR TITLE
Don't create switch entity for switch device type in XThings Cloud

### DIFF
--- a/homeassistant/components/xthings_cloud/switch.py
+++ b/homeassistant/components/xthings_cloud/switch.py
@@ -20,7 +20,7 @@ async def async_setup_entry(
     entities = [
         XthingsCloudSwitch(coordinator, device_id, device_data)
         for device_id, device_data in coordinator.data.items()
-        if device_data["type"] in ("switch", "plug")
+        if device_data["type"] == "plug"
     ]
     async_add_entities(entities)
 

--- a/tests/components/xthings_cloud/test_switch.py
+++ b/tests/components/xthings_cloud/test_switch.py
@@ -40,35 +40,19 @@ async def test_switches(
 
 
 @pytest.mark.parametrize(
-    ("entity_id", "device_id", "device_type", "service", "method"),
+    ("entity_id", "device_id", "service", "method"),
     [
         (
             "switch.smart_plug_50",
             "dev_plug_001",
-            "plug",
             SERVICE_TURN_ON,
             "async_plug_on",
         ),
         (
             "switch.smart_plug_50",
             "dev_plug_001",
-            "plug",
             SERVICE_TURN_OFF,
             "async_plug_off",
-        ),
-        (
-            "switch.smart_plug_100",
-            "dev_plug_002",
-            "switch",
-            SERVICE_TURN_ON,
-            "async_switch_on",
-        ),
-        (
-            "switch.smart_plug_100",
-            "dev_plug_002",
-            "switch",
-            SERVICE_TURN_OFF,
-            "async_switch_off",
         ),
     ],
 )
@@ -78,13 +62,10 @@ async def test_turn_on_off(
     mock_api_client: AsyncMock,
     entity_id: str,
     device_id: str,
-    device_type: str,
     service: str,
     method: str,
 ) -> None:
     """Test turning on and off a device."""
-    get_device_by_id(mock_api_client, device_id)["type"] = device_type
-
     with patch("homeassistant.components.xthings_cloud.PLATFORMS", [Platform.SWITCH]):
         await setup_integration(hass, mock_config_entry)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove switch device type from switch platform as it will be exposed as a light in the future and that saves us a deprecation

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44620
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
