### PR TITLE
Cancel timers for Sonos on shutdown/reload

### DIFF
--- a/homeassistant/components/sonos/household_coordinator.py
+++ b/homeassistant/components/sonos/household_coordinator.py
@@ -59,7 +59,6 @@ class SonosHouseholdCoordinator:
         if self._poll_debouncer is not None:
             self._poll_debouncer.async_shutdown()
             self._poll_debouncer = None
-        self.async_poll = None
 
     @property
     def class_type(self) -> str:

--- a/homeassistant/components/sonos/household_coordinator.py
+++ b/homeassistant/components/sonos/household_coordinator.py
@@ -59,6 +59,7 @@ class SonosHouseholdCoordinator:
         if self._poll_debouncer is not None:
             self._poll_debouncer.async_shutdown()
             self._poll_debouncer = None
+            self.async_poll = None
 
     @property
     def class_type(self) -> str:

--- a/homeassistant/components/sonos/household_coordinator.py
+++ b/homeassistant/components/sonos/household_coordinator.py
@@ -1,9 +1,9 @@
 """Class representing a Sonos household storage helper."""
 
 import asyncio
-from collections.abc import Callable, Coroutine
+from collections.abc import Awaitable, Callable
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from soco import SoCo
 
@@ -29,8 +29,8 @@ class SonosHouseholdCoordinator:
         """Initialize the data."""
         self.hass = hass
         self.household_id = household_id
-        self._poll_debouncer: Debouncer[Coroutine[Any, Any, None]] | None = None
-        self.async_poll: Callable[[], Coroutine[None, None, None]] | None = None
+        self._poll_debouncer: Debouncer[Awaitable[None]] | None = None
+        self.async_poll: Callable[[], Awaitable[None]] | None = None
         self.last_processed_event_id: int | None = None
         self.config_entry = config_entry
 
@@ -43,7 +43,7 @@ class SonosHouseholdCoordinator:
     def _async_setup(self) -> None:
         """Finish setup in async context."""
         self.cache_update_lock = asyncio.Lock()
-        self._poll_debouncer = Debouncer[Coroutine[Any, Any, None]](
+        self._poll_debouncer = Debouncer[Awaitable[None]](
             self.hass,
             _LOGGER,
             cooldown=3,

--- a/homeassistant/components/sonos/household_coordinator.py
+++ b/homeassistant/components/sonos/household_coordinator.py
@@ -29,6 +29,7 @@ class SonosHouseholdCoordinator:
         """Initialize the data."""
         self.hass = hass
         self.household_id = household_id
+        self._poll_debouncer: Debouncer[Coroutine[Any, Any, None]] | None = None
         self.async_poll: Callable[[], Coroutine[None, None, None]] | None = None
         self.last_processed_event_id: int | None = None
         self.config_entry = config_entry
@@ -42,13 +43,23 @@ class SonosHouseholdCoordinator:
     def _async_setup(self) -> None:
         """Finish setup in async context."""
         self.cache_update_lock = asyncio.Lock()
-        self.async_poll = Debouncer[Coroutine[Any, Any, None]](
+        self._poll_debouncer = Debouncer[Coroutine[Any, Any, None]](
             self.hass,
             _LOGGER,
             cooldown=3,
             immediate=False,
             function=self._async_poll,
-        ).async_call
+        )
+        self.async_poll = self._poll_debouncer.async_call
+        self.config_entry.async_on_unload(self.async_shutdown)
+
+    @callback
+    def async_shutdown(self) -> None:
+        """Cancel any scheduled household refreshes during unload."""
+        if self._poll_debouncer is not None:
+            self._poll_debouncer.async_shutdown()
+            self._poll_debouncer = None
+        self.async_poll = None
 
     @property
     def class_type(self) -> str:

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -198,6 +198,7 @@ class SonosSpeaker:
             self._battery_poll_timer = async_track_time_interval(
                 self.hass, self.async_poll_battery, BATTERY_SCAN_INTERVAL
             )
+        entry.async_on_unload(self.async_shutdown)
 
         self.websocket = SonosWebsocket(
             self.soco.ip_address,
@@ -438,6 +439,18 @@ class SonosSpeaker:
         for result in results:
             self.log_subscription_result(result, "Unsubscribe")
         self._subscriptions = []
+
+    async def async_shutdown(self) -> None:
+        """Cancel speaker-owned timers and subscriptions during unload."""
+        if self._battery_poll_timer:
+            self._battery_poll_timer()
+            self._battery_poll_timer = None
+
+        if self._poll_timer:
+            self._poll_timer()
+            self._poll_timer = None
+
+        await self.async_unsubscribe()
 
     @callback
     def async_renew_failed(self, exception: Exception) -> None:

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -440,8 +440,9 @@ class SonosSpeaker:
             self.log_subscription_result(result, "Unsubscribe")
         self._subscriptions = []
 
-    async def async_shutdown(self) -> None:
-        """Cancel speaker-owned timers and subscriptions during unload."""
+    @callback
+    def async_shutdown(self) -> None:
+        """Cancel speaker-owned timers during unload."""
         if self._battery_poll_timer:
             self._battery_poll_timer()
             self._battery_poll_timer = None

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -450,8 +450,6 @@ class SonosSpeaker:
             self._poll_timer()
             self._poll_timer = None
 
-        await self.async_unsubscribe()
-
     @callback
     def async_renew_failed(self, exception: Exception) -> None:
         """Handle a failed subscription renewal."""


### PR DESCRIPTION
## Proposed change

The Sonos integration was not cancelling active timers at unload time. This was discovered by examining test teardown logs. These timers would also not be cancelled on integration reload, which could create undefined behavior of timers calling back into objects from the prior load.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
