### PR TITLE
Refactor Yardian zones into sub-devices using via_device

### DIFF
--- a/homeassistant/components/yardian/binary_sensor.py
+++ b/homeassistant/components/yardian/binary_sensor.py
@@ -93,7 +93,6 @@ async def async_setup_entry(
             entity_category=EntityCategory.DIAGNOSTIC,
             entity_registry_enabled_default=False,
             value_fn=_zone_value_factory(zone_id),
-            translation_placeholders={"zone": str(zone_id + 1)},
         )
         entities.append(YardianZoneBinarySensor(coordinator, description, zone_id))
 

--- a/homeassistant/components/yardian/binary_sensor.py
+++ b/homeassistant/components/yardian/binary_sensor.py
@@ -10,12 +10,10 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
 from .coordinator import YardianConfigEntry, YardianUpdateCoordinator
+from .entity import YardianEntity, YardianZoneEntity
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -81,13 +79,15 @@ async def async_setup_entry(
     """Set up Yardian binary sensors."""
     coordinator = config_entry.runtime_data
 
+    # 1. Global/Main device sensors
     entities: list[BinarySensorEntity] = [
         YardianBinarySensor(coordinator, description)
         for description in SENSOR_DESCRIPTIONS
     ]
 
-    zone_descriptions = [
-        YardianBinarySensorEntityDescription(
+    # 2. Zone/Child device sensors
+    for zone_id in range(len(coordinator.data.zones)):
+        description = YardianBinarySensorEntityDescription(
             key=f"zone_enabled_{zone_id}",
             translation_key="zone_enabled",
             entity_category=EntityCategory.DIAGNOSTIC,
@@ -95,24 +95,15 @@ async def async_setup_entry(
             value_fn=_zone_value_factory(zone_id),
             translation_placeholders={"zone": str(zone_id + 1)},
         )
-        for zone_id in range(len(coordinator.data.zones))
-    ]
-
-    entities.extend(
-        YardianBinarySensor(coordinator, description)
-        for description in zone_descriptions
-    )
+        entities.append(YardianZoneBinarySensor(coordinator, description, zone_id))
 
     async_add_entities(entities)
 
 
-class YardianBinarySensor(
-    CoordinatorEntity[YardianUpdateCoordinator], BinarySensorEntity
-):
-    """Representation of a Yardian binary sensor based on a description."""
+class YardianBinarySensor(YardianEntity, BinarySensorEntity):
+    """Representation of a Yardian binary sensor assigned to the main device."""
 
     entity_description: YardianBinarySensorEntityDescription
-    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -124,22 +115,27 @@ class YardianBinarySensor(
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.yid}-{description.key}"
 
-        # -----------------------------------------------------
-        # NEW LOGIC: Check if this is a zone-specific sensor
-        # -----------------------------------------------------
-        if description.key.startswith("zone_enabled_"):
-            # Extract the integer zone_id from the end of the string (e.g. "zone_enabled_0" -> 0)
-            zone_id = int(description.key.split("_")[-1])
+    @property
+    def is_on(self) -> bool | None:
+        """Return the current state based on the description's value function."""
+        return self.entity_description.value_fn(self.coordinator)
 
-            self._attr_device_info = DeviceInfo(
-                identifiers={(DOMAIN, f"{coordinator.yid}_{zone_id}")},
-                name=coordinator.data.zones[zone_id].name,
-                manufacturer="Aeon Matrix",
-                via_device=(DOMAIN, coordinator.yid),
-            )
-        else:
-            # It's a global sensor, attach it to the main controller
-            self._attr_device_info = coordinator.device_info
+
+class YardianZoneBinarySensor(YardianZoneEntity, BinarySensorEntity):
+    """Representation of a Yardian binary sensor assigned to a zone child device."""
+
+    entity_description: YardianBinarySensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: YardianUpdateCoordinator,
+        description: YardianBinarySensorEntityDescription,
+        zone_id: int,
+    ) -> None:
+        """Initialize the Yardian zone binary sensor."""
+        super().__init__(coordinator, zone_id)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.yid}-{description.key}"
 
     @property
     def is_on(self) -> bool | None:

--- a/homeassistant/components/yardian/binary_sensor.py
+++ b/homeassistant/components/yardian/binary_sensor.py
@@ -10,9 +10,11 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .const import DOMAIN
 from .coordinator import YardianConfigEntry, YardianUpdateCoordinator
 
 
@@ -121,7 +123,23 @@ class YardianBinarySensor(
         super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.yid}-{description.key}"
-        self._attr_device_info = coordinator.device_info
+
+        # -----------------------------------------------------
+        # NEW LOGIC: Check if this is a zone-specific sensor
+        # -----------------------------------------------------
+        if description.key.startswith("zone_enabled_"):
+            # Extract the integer zone_id from the end of the string (e.g. "zone_enabled_0" -> 0)
+            zone_id = int(description.key.split("_")[-1])
+
+            self._attr_device_info = DeviceInfo(
+                identifiers={(DOMAIN, f"{coordinator.yid}_{zone_id}")},
+                name=coordinator.data.zones[zone_id].name,
+                manufacturer="Aeon Matrix",
+                via_device=(DOMAIN, coordinator.yid),
+            )
+        else:
+            # It's a global sensor, attach it to the main controller
+            self._attr_device_info = coordinator.device_info
 
     @property
     def is_on(self) -> bool | None:

--- a/homeassistant/components/yardian/binary_sensor.py
+++ b/homeassistant/components/yardian/binary_sensor.py
@@ -89,7 +89,7 @@ async def async_setup_entry(
     for zone_id in range(len(coordinator.data.zones)):
         description = YardianBinarySensorEntityDescription(
             key=f"zone_enabled_{zone_id}",
-            translation_key="zone_enabled",
+            translation_key="enabled",
             entity_category=EntityCategory.DIAGNOSTIC,
             entity_registry_enabled_default=False,
             value_fn=_zone_value_factory(zone_id),

--- a/homeassistant/components/yardian/const.py
+++ b/homeassistant/components/yardian/const.py
@@ -2,6 +2,6 @@
 
 DOMAIN = "yardian"
 MANUFACTURER = "Aeon Matrix"
-PRODUCT_NAME = "Yardian Smart Sprinkler"
+PRODUCT_NAME = "Yardian Smart Sprinkler Controller"
 
 DEFAULT_WATERING_DURATION = 6

--- a/homeassistant/components/yardian/entity.py
+++ b/homeassistant/components/yardian/entity.py
@@ -1,0 +1,35 @@
+"""Base entities for Yardian integration."""
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import YardianUpdateCoordinator
+
+
+class YardianEntity(CoordinatorEntity[YardianUpdateCoordinator]):
+    """Base class for Yardian entities assigned to the main device."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: YardianUpdateCoordinator) -> None:
+        """Initialize the main device entity."""
+        super().__init__(coordinator)
+        self._attr_device_info = coordinator.device_info
+
+
+class YardianZoneEntity(CoordinatorEntity[YardianUpdateCoordinator]):
+    """Base class for Yardian entities assigned to a zone child device."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: YardianUpdateCoordinator, zone_id: int) -> None:
+        """Initialize the zone device entity."""
+        super().__init__(coordinator)
+        self._zone_id = zone_id
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"{coordinator.yid}_{zone_id}")},
+            name=coordinator.data.zones[zone_id].name,
+            manufacturer="Aeon Matrix",
+            via_device=(DOMAIN, coordinator.yid),
+        )

--- a/homeassistant/components/yardian/entity.py
+++ b/homeassistant/components/yardian/entity.py
@@ -3,7 +3,7 @@
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, MANUFACTURER
 from .coordinator import YardianUpdateCoordinator
 
 
@@ -30,6 +30,6 @@ class YardianZoneEntity(CoordinatorEntity[YardianUpdateCoordinator]):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, f"{coordinator.yid}_{zone_id}")},
             name=coordinator.data.zones[zone_id].name,
-            manufacturer="Aeon Matrix",
+            manufacturer=MANUFACTURER,
             via_device=(DOMAIN, coordinator.yid),
         )

--- a/homeassistant/components/yardian/sensor.py
+++ b/homeassistant/components/yardian/sensor.py
@@ -13,10 +13,10 @@ from homeassistant.const import EntityCategory, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
 from .coordinator import YardianConfigEntry, YardianUpdateCoordinator
+from .entity import YardianEntity
 
 # Values above this threshold indicate the API returned an absolute
 # timestamp instead of a relative delay, so convert to a remaining delta.
@@ -99,11 +99,10 @@ async def async_setup_entry(
     )
 
 
-class YardianSensor(CoordinatorEntity[YardianUpdateCoordinator], SensorEntity):
+class YardianSensor(YardianEntity, SensorEntity):
     """Representation of a Yardian sensor defined by description."""
 
     entity_description: YardianSensorEntityDescription
-    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -114,7 +113,6 @@ class YardianSensor(CoordinatorEntity[YardianUpdateCoordinator], SensorEntity):
         super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.yid}_{description.key}"
-        self._attr_device_info = coordinator.device_info
 
     @property
     def native_value(self) -> StateType:

--- a/homeassistant/components/yardian/strings.json
+++ b/homeassistant/components/yardian/strings.json
@@ -32,7 +32,7 @@
         "name": "Watering running"
       },
       "zone_enabled": {
-        "name": "Zone {zone} enabled"
+        "name": "Enabled"
       }
     },
     "sensor": {

--- a/homeassistant/components/yardian/switch.py
+++ b/homeassistant/components/yardian/switch.py
@@ -46,17 +46,12 @@ async def async_setup_entry(
 class YardianSwitch(YardianZoneEntity, SwitchEntity):
     """Representation of a Yardian switch."""
 
-    _attr_translation_key = "switch"
+    _attr_name = None
 
     def __init__(self, coordinator: YardianUpdateCoordinator, zone_id: int) -> None:
         """Initialize a Yardian Switch Device."""
         super().__init__(coordinator, zone_id)
         self._attr_unique_id = f"{coordinator.yid}-{zone_id}"
-
-    @property
-    def name(self) -> str:
-        """Return the zone name."""
-        return self.coordinator.data.zones[self._zone_id].name
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/yardian/switch.py
+++ b/homeassistant/components/yardian/switch.py
@@ -7,11 +7,12 @@ import voluptuous as vol
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import VolDictType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DEFAULT_WATERING_DURATION
+from .const import DEFAULT_WATERING_DURATION, DOMAIN
 from .coordinator import YardianConfigEntry, YardianUpdateCoordinator
 
 SERVICE_START_IRRIGATION = "start_irrigation"
@@ -54,7 +55,14 @@ class YardianSwitch(CoordinatorEntity[YardianUpdateCoordinator], SwitchEntity):
         super().__init__(coordinator)
         self._zone_id = zone_id
         self._attr_unique_id = f"{coordinator.yid}-{zone_id}"
-        self._attr_device_info = coordinator.device_info
+
+        # Define this zone as its own Device, linked to the main controller
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"{coordinator.yid}_{zone_id}")},
+            name=coordinator.data.zones[zone_id].name,
+            manufacturer="Aeon Matrix",
+            via_device=(DOMAIN, coordinator.yid),
+        )
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/yardian/switch.py
+++ b/homeassistant/components/yardian/switch.py
@@ -7,13 +7,12 @@ import voluptuous as vol
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import VolDictType
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DEFAULT_WATERING_DURATION, DOMAIN
+from .const import DEFAULT_WATERING_DURATION
 from .coordinator import YardianConfigEntry, YardianUpdateCoordinator
+from .entity import YardianZoneEntity
 
 SERVICE_START_IRRIGATION = "start_irrigation"
 SERVICE_SCHEMA_START_IRRIGATION: VolDictType = {
@@ -44,25 +43,15 @@ async def async_setup_entry(
     )
 
 
-class YardianSwitch(CoordinatorEntity[YardianUpdateCoordinator], SwitchEntity):
+class YardianSwitch(YardianZoneEntity, SwitchEntity):
     """Representation of a Yardian switch."""
 
-    _attr_has_entity_name = True
     _attr_translation_key = "switch"
 
-    def __init__(self, coordinator: YardianUpdateCoordinator, zone_id) -> None:
+    def __init__(self, coordinator: YardianUpdateCoordinator, zone_id: int) -> None:
         """Initialize a Yardian Switch Device."""
-        super().__init__(coordinator)
-        self._zone_id = zone_id
+        super().__init__(coordinator, zone_id)
         self._attr_unique_id = f"{coordinator.yid}-{zone_id}"
-
-        # Define this zone as its own Device, linked to the main controller
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{coordinator.yid}_{zone_id}")},
-            name=coordinator.data.zones[zone_id].name,
-            manufacturer="Aeon Matrix",
-            via_device=(DOMAIN, coordinator.yid),
-        )
 
     @property
     def name(self) -> str:

--- a/tests/components/yardian/snapshots/test_binary_sensor.ambr
+++ b/tests/components/yardian/snapshots/test_binary_sensor.ambr
@@ -151,7 +151,7 @@
     'state': 'on',
   })
 # ---
-# name: test_all_entities[binary_sensor.yardian_smart_sprinkler_zone_1_enabled-entry]
+# name: test_all_entities[binary_sensor.zone_1_zone_1_enabled-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -165,7 +165,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.yardian_smart_sprinkler_zone_1_enabled',
+    'entity_id': 'binary_sensor.zone_1_zone_1_enabled',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -188,20 +188,20 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[binary_sensor.yardian_smart_sprinkler_zone_1_enabled-state]
+# name: test_all_entities[binary_sensor.zone_1_zone_1_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Yardian Smart Sprinkler Zone 1 enabled',
+      'friendly_name': 'Zone 1 Zone 1 enabled',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.yardian_smart_sprinkler_zone_1_enabled',
+    'entity_id': 'binary_sensor.zone_1_zone_1_enabled',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_all_entities[binary_sensor.yardian_smart_sprinkler_zone_2_enabled-entry]
+# name: test_all_entities[binary_sensor.zone_2_zone_2_enabled-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -215,7 +215,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.yardian_smart_sprinkler_zone_2_enabled',
+    'entity_id': 'binary_sensor.zone_2_zone_2_enabled',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -238,13 +238,13 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[binary_sensor.yardian_smart_sprinkler_zone_2_enabled-state]
+# name: test_all_entities[binary_sensor.zone_2_zone_2_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Yardian Smart Sprinkler Zone 2 enabled',
+      'friendly_name': 'Zone 2 Zone 2 enabled',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.yardian_smart_sprinkler_zone_2_enabled',
+    'entity_id': 'binary_sensor.zone_2_zone_2_enabled',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/yardian/snapshots/test_binary_sensor.ambr
+++ b/tests/components/yardian/snapshots/test_binary_sensor.ambr
@@ -151,7 +151,7 @@
     'state': 'on',
   })
 # ---
-# name: test_all_entities[binary_sensor.zone_1_zone_1_enabled-entry]
+# name: test_all_entities[binary_sensor.zone_1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -165,7 +165,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.zone_1_zone_1_enabled',
+    'entity_id': 'binary_sensor.zone_1',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -173,35 +173,35 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Zone 1 enabled',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Zone 1 enabled',
+    'original_name': None,
     'platform': 'yardian',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'zone_enabled',
+    'translation_key': 'enabled',
     'unique_id': 'yid123-zone_enabled_0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[binary_sensor.zone_1_zone_1_enabled-state]
+# name: test_all_entities[binary_sensor.zone_1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Zone 1 Zone 1 enabled',
+      'friendly_name': 'Zone 1',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.zone_1_zone_1_enabled',
+    'entity_id': 'binary_sensor.zone_1',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_all_entities[binary_sensor.zone_2_zone_2_enabled-entry]
+# name: test_all_entities[binary_sensor.zone_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -215,7 +215,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.zone_2_zone_2_enabled',
+    'entity_id': 'binary_sensor.zone_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -223,28 +223,28 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Zone 2 enabled',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Zone 2 enabled',
+    'original_name': None,
     'platform': 'yardian',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'zone_enabled',
+    'translation_key': 'enabled',
     'unique_id': 'yid123-zone_enabled_1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[binary_sensor.zone_2_zone_2_enabled-state]
+# name: test_all_entities[binary_sensor.zone_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Zone 2 Zone 2 enabled',
+      'friendly_name': 'Zone 2',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.zone_2_zone_2_enabled',
+    'entity_id': 'binary_sensor.zone_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/yardian/snapshots/test_switch.ambr
+++ b/tests/components/yardian/snapshots/test_switch.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_all_entities[switch.yardian_smart_sprinkler_zone_1-entry]
+# name: test_all_entities[switch.zone_1_zone_1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -13,7 +13,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': None,
-    'entity_id': 'switch.yardian_smart_sprinkler_zone_1',
+    'entity_id': 'switch.zone_1_zone_1',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -36,20 +36,20 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[switch.yardian_smart_sprinkler_zone_1-state]
+# name: test_all_entities[switch.zone_1_zone_1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Yardian Smart Sprinkler Zone 1',
+      'friendly_name': 'Zone 1 Zone 1',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.yardian_smart_sprinkler_zone_1',
+    'entity_id': 'switch.zone_1_zone_1',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_all_entities[switch.yardian_smart_sprinkler_zone_2-entry]
+# name: test_all_entities[switch.zone_2_zone_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -63,7 +63,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': None,
-    'entity_id': 'switch.yardian_smart_sprinkler_zone_2',
+    'entity_id': 'switch.zone_2_zone_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -86,13 +86,13 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[switch.yardian_smart_sprinkler_zone_2-state]
+# name: test_all_entities[switch.zone_2_zone_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Yardian Smart Sprinkler Zone 2',
+      'friendly_name': 'Zone 2 Zone 2',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.yardian_smart_sprinkler_zone_2',
+    'entity_id': 'switch.zone_2_zone_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/yardian/snapshots/test_switch.ambr
+++ b/tests/components/yardian/snapshots/test_switch.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_all_entities[switch.zone_1_zone_1-entry]
+# name: test_all_entities[switch.zone_1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -13,7 +13,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': None,
-    'entity_id': 'switch.zone_1_zone_1',
+    'entity_id': 'switch.zone_1',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -21,35 +21,35 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Zone 1',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Zone 1',
+    'original_name': None,
     'platform': 'yardian',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'switch',
+    'translation_key': None,
     'unique_id': 'yid123-0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[switch.zone_1_zone_1-state]
+# name: test_all_entities[switch.zone_1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Zone 1 Zone 1',
+      'friendly_name': 'Zone 1',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.zone_1_zone_1',
+    'entity_id': 'switch.zone_1',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_all_entities[switch.zone_2_zone_2-entry]
+# name: test_all_entities[switch.zone_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -63,7 +63,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': None,
-    'entity_id': 'switch.zone_2_zone_2',
+    'entity_id': 'switch.zone_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -71,28 +71,28 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Zone 2',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Zone 2',
+    'original_name': None,
     'platform': 'yardian',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'switch',
+    'translation_key': None,
     'unique_id': 'yid123-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[switch.zone_2_zone_2-state]
+# name: test_all_entities[switch.zone_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Zone 2 Zone 2',
+      'friendly_name': 'Zone 2',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.zone_2_zone_2',
+    'entity_id': 'switch.zone_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/yardian/test_switch.py
+++ b/tests/components/yardian/test_switch.py
@@ -42,7 +42,16 @@ async def test_turn_on_switch(
     """Test turning on a switch."""
     await setup_integration(hass, mock_config_entry)
 
-    entity_id = "switch.zone_1"
+    entity_registry = er.async_get(hass)
+
+    # Dynamically resolve the entity_id from the config entry
+    entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    entity_id = next(
+        entry.entity_id for entry in entries if entry.domain == SWITCH_DOMAIN
+    )
+
     await hass.services.async_call(
         SWITCH_DOMAIN,
         SERVICE_TURN_ON,
@@ -61,7 +70,16 @@ async def test_turn_off_switch(
     """Test turning off a switch."""
     await setup_integration(hass, mock_config_entry)
 
-    entity_id = "switch.zone_1"
+    entity_registry = er.async_get(hass)
+
+    # Dynamically resolve the entity_id from the config entry
+    entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    entity_id = next(
+        entry.entity_id for entry in entries if entry.domain == SWITCH_DOMAIN
+    )
+
     await hass.services.async_call(
         SWITCH_DOMAIN,
         SERVICE_TURN_OFF,

--- a/tests/components/yardian/test_switch.py
+++ b/tests/components/yardian/test_switch.py
@@ -42,15 +42,7 @@ async def test_turn_on_switch(
     """Test turning on a switch."""
     await setup_integration(hass, mock_config_entry)
 
-    entity_registry = er.async_get(hass)
-
-    # Dynamically resolve the entity_id from the config entry
-    entries = er.async_entries_for_config_entry(
-        entity_registry, mock_config_entry.entry_id
-    )
-    entity_id = next(
-        entry.entity_id for entry in entries if entry.domain == SWITCH_DOMAIN
-    )
+    entity_id = "switch.zone_1"
 
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -70,15 +62,7 @@ async def test_turn_off_switch(
     """Test turning off a switch."""
     await setup_integration(hass, mock_config_entry)
 
-    entity_registry = er.async_get(hass)
-
-    # Dynamically resolve the entity_id from the config entry
-    entries = er.async_entries_for_config_entry(
-        entity_registry, mock_config_entry.entry_id
-    )
-    entity_id = next(
-        entry.entity_id for entry in entries if entry.domain == SWITCH_DOMAIN
-    )
+    entity_id = "switch.zone_1"
 
     await hass.services.async_call(
         SWITCH_DOMAIN,

--- a/tests/components/yardian/test_switch.py
+++ b/tests/components/yardian/test_switch.py
@@ -42,8 +42,7 @@ async def test_turn_on_switch(
     """Test turning on a switch."""
     await setup_integration(hass, mock_config_entry)
 
-    # UPDATED THIS LINE
-    entity_id = "switch.zone_1_zone_1"
+    entity_id = "switch.zone_1"
     await hass.services.async_call(
         SWITCH_DOMAIN,
         SERVICE_TURN_ON,
@@ -62,8 +61,7 @@ async def test_turn_off_switch(
     """Test turning off a switch."""
     await setup_integration(hass, mock_config_entry)
 
-    # UPDATED THIS LINE
-    entity_id = "switch.zone_1_zone_1"
+    entity_id = "switch.zone_1"
     await hass.services.async_call(
         SWITCH_DOMAIN,
         SERVICE_TURN_OFF,

--- a/tests/components/yardian/test_switch.py
+++ b/tests/components/yardian/test_switch.py
@@ -42,7 +42,8 @@ async def test_turn_on_switch(
     """Test turning on a switch."""
     await setup_integration(hass, mock_config_entry)
 
-    entity_id = "switch.yardian_smart_sprinkler_zone_1"
+    # UPDATED THIS LINE
+    entity_id = "switch.zone_1_zone_1"
     await hass.services.async_call(
         SWITCH_DOMAIN,
         SERVICE_TURN_ON,
@@ -61,7 +62,8 @@ async def test_turn_off_switch(
     """Test turning off a switch."""
     await setup_integration(hass, mock_config_entry)
 
-    entity_id = "switch.yardian_smart_sprinkler_zone_1"
+    # UPDATED THIS LINE
+    entity_id = "switch.zone_1_zone_1"
     await hass.services.async_call(
         SWITCH_DOMAIN,
         SERVICE_TURN_OFF,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactor Yardian zones into sub-devices using via_device

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
