### PR TITLE
Vistapool: Add reconfiguration flow

### DIFF
--- a/homeassistant/components/vistapool/config_flow.py
+++ b/homeassistant/components/vistapool/config_flow.py
@@ -22,6 +22,8 @@ AUTH_SCHEMA = vol.Schema(
     }
 )
 
+RECONFIGURE_SCHEMA = vol.Schema({vol.Required(CONF_PASSWORD): cv.string})
+
 
 class VistapoolConfigFlow(ConfigFlow, domain=DOMAIN):
     """Vistapool config flow (one entry per Hayward account)."""
@@ -73,4 +75,39 @@ class VistapoolConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user", data_schema=AUTH_SCHEMA, errors=errors
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Let the user proactively update the stored Vistapool password."""
+        errors: dict[str, str] = {}
+        entry = self._get_reconfigure_entry()
+        username = entry.data[CONF_USERNAME]
+
+        if user_input is not None:
+            password = user_input[CONF_PASSWORD]
+            session = async_get_clientsession(self.hass)
+            auth = AquariteAuth(session, username, password)
+            try:
+                await auth.authenticate()
+            except AuthenticationError:
+                errors["base"] = "invalid_auth"
+            except AquariteError:
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected error during reconfiguration")
+                errors["base"] = "unknown"
+            else:
+                await self.async_set_unique_id(auth.user_id)
+                self._abort_if_unique_id_mismatch(reason="account_mismatch")
+                return self.async_update_reload_and_abort(
+                    entry, data_updates={CONF_PASSWORD: password}
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=RECONFIGURE_SCHEMA,
+            description_placeholders={"username": username},
+            errors=errors,
         )

--- a/homeassistant/components/vistapool/quality_scale.yaml
+++ b/homeassistant/components/vistapool/quality_scale.yaml
@@ -53,7 +53,7 @@ rules:
   entity-translations: done
   exception-translations: done
   icon-translations: done
-  reconfiguration-flow: todo
+  reconfiguration-flow: done
   repair-issues:
     status: exempt
     comment: No known repair scenarios

--- a/homeassistant/components/vistapool/strings.json
+++ b/homeassistant/components/vistapool/strings.json
@@ -1,8 +1,10 @@
 {
   "config": {
     "abort": {
+      "account_mismatch": "The credentials entered are for a different Vistapool account than the one being reconfigured.",
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
-      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]"
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
@@ -12,6 +14,16 @@
     },
     "flow_title": "Vistapool pool controller",
     "step": {
+      "reconfigure": {
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "data_description": {
+          "password": "The new password for your Vistapool account."
+        },
+        "description": "Update the stored password for {username}.",
+        "title": "Reconfigure Vistapool"
+      },
       "user": {
         "data": {
           "password": "Password",

--- a/tests/components/vistapool/test_config_flow.py
+++ b/tests/components/vistapool/test_config_flow.py
@@ -328,11 +328,13 @@ async def test_reconfigure_flow(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
     assert mock_config_entry.data[CONF_PASSWORD] == _NEW_PASSWORD
+    assert mock_setup_entry.call_count == 1
 
 
 async def test_reconfigure_invalid_auth(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
+    mock_setup_entry: AsyncMock,
     mock_vistapool_client: AsyncMock,
     mock_vistapool_auth: MagicMock,
 ) -> None:
@@ -356,11 +358,13 @@ async def test_reconfigure_invalid_auth(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
     assert mock_config_entry.data[CONF_PASSWORD] == _NEW_PASSWORD
+    assert mock_setup_entry.call_count == 1
 
 
 async def test_reconfigure_account_mismatch(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
+    mock_setup_entry: AsyncMock,
     mock_vistapool_client: AsyncMock,
     mock_vistapool_auth: MagicMock,
 ) -> None:
@@ -375,3 +379,4 @@ async def test_reconfigure_account_mismatch(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "account_mismatch"
+    assert mock_setup_entry.call_count == 0

--- a/tests/components/vistapool/test_config_flow.py
+++ b/tests/components/vistapool/test_config_flow.py
@@ -303,3 +303,75 @@ async def test_dhcp_discovery_aborts_when_in_progress(
 
     assert second["type"] is FlowResultType.ABORT
     assert second["reason"] == "already_in_progress"
+
+
+_NEW_PASSWORD = "new-password"
+
+
+async def test_reconfigure_flow(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_setup_entry: AsyncMock,
+    mock_vistapool_client: AsyncMock,
+) -> None:
+    """Test the reconfigure flow updates the stored password and reloads the entry."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_PASSWORD: _NEW_PASSWORD}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_config_entry.data[CONF_PASSWORD] == _NEW_PASSWORD
+
+
+async def test_reconfigure_invalid_auth(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_vistapool_client: AsyncMock,
+    mock_vistapool_auth: MagicMock,
+) -> None:
+    """Test the reconfigure flow surfaces invalid_auth and recovers on retry."""
+    mock_config_entry.add_to_hass(hass)
+    mock_vistapool_auth.authenticate.side_effect = AuthenticationError
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_PASSWORD: _NEW_PASSWORD}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+
+    mock_vistapool_auth.authenticate.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_PASSWORD: _NEW_PASSWORD}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_config_entry.data[CONF_PASSWORD] == _NEW_PASSWORD
+
+
+async def test_reconfigure_account_mismatch(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_vistapool_client: AsyncMock,
+    mock_vistapool_auth: MagicMock,
+) -> None:
+    """Test the reconfigure flow aborts when credentials belong to a different account."""
+    mock_config_entry.add_to_hass(hass)
+    mock_vistapool_auth.user_id = "a-different-firebase-uid"
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_PASSWORD: _NEW_PASSWORD}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "account_mismatch"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a reconfiguration flow to the Vistapool integration so users can proactively update their stored Vistapool password without removing and re-adding the integration. Triggered from **Settings** > **Devices & services** > **Vistapool** > **Reconfigure**.

Follow-up to the reauthentication-flow PR per @zweckj's feedback on the docs/quality-scale PR: reauth only handles the *reactive* case (HA-detected auth failure); a user wanting to *proactively* rotate their password before HA notices a failure needs this flow.

### Implementation notes

- `async_step_reconfigure` shows a password-only form. The username is displayed in the description text but cannot be edited from here — changing it would mean switching cloud accounts, which we reject (see below).
- On successful authentication, `_abort_if_unique_id_mismatch(reason="account_mismatch")` refuses credentials that resolve to a different Hayward `user_id`, so the user can't accidentally swap the entry to a different account and orphan their existing devices and entities.
- On success, `async_update_reload_and_abort` writes the new password into `entry.data` and reloads the entry.
- Mirrors the established `async_step_reauth_confirm` shape from the reauth PR — same `AquariteAuth(...)` outside the `try:` block per @joostlek's earlier feedback, same `except AuthenticationError` / `AquariteError` / `Exception` triplet, same `_LOGGER.exception` pattern.

### Tests

`tests/components/vistapool/test_config_flow.py` gains three tests:

- `test_reconfigure_flow` — happy path; entry's password is updated and reload triggered.
- `test_reconfigure_invalid_auth` — surfaces `invalid_auth` and recovers on retry.
- `test_reconfigure_account_mismatch` — different `user_id` aborts with `account_mismatch`.

Flips the Gold-tier `reconfiguration-flow` quality-scale rule from `todo` to `done`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: [fixes #](https://github.com/home-assistant/core/pull/172827)
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr