### PR TITLE
Automation choose: Add optional note to options

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1953,6 +1953,7 @@ _SCRIPT_CHOOSE_SCHEMA = vol.Schema(
             [
                 {
                     vol.Optional(CONF_ALIAS): string,
+                    vol.Remove(CONF_NOTE): str,  # Is only used in frontend
                     vol.Required(CONF_CONDITIONS): CONDITIONS_SCHEMA,
                     vol.Required(CONF_SEQUENCE): SCRIPT_SCHEMA,
                 }

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -2087,7 +2087,9 @@ def test_base_schemas_reject_invalid_note(
 
 
 _CHOOSE_OPTION_BASE_CONFIG = {
-    "conditions": [{"condition": "state", "entity_id": "sun.sun", "state": "above_horizon"}],
+    "conditions": [
+        {"condition": "state", "entity_id": "sun.sun", "state": "above_horizon"}
+    ],
     "sequence": [{"action": "test.foo"}],
 }
 

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -2084,3 +2084,37 @@ def test_base_schemas_reject_invalid_note(
     """Test that script, condition, trigger base schemas reject non-string notes."""
     with pytest.raises(vol.Invalid):
         validator({**base_config, "note": invalid_note})
+
+
+_CHOOSE_OPTION_BASE_CONFIG = {
+    "conditions": [{"condition": "state", "entity_id": "sun.sun", "state": "above_horizon"}],
+    "sequence": [{"action": "test.foo"}],
+}
+
+
+@pytest.mark.usefixtures("hass")
+def test_choose_option_accepts_note() -> None:
+    """Test that the note field is accepted and stripped from a choose option."""
+    validated = cv.script_action(
+        {"choose": [{**_CHOOSE_OPTION_BASE_CONFIG, "note": "Single line"}]}
+    )
+    assert "note" not in validated["choose"][0]
+
+
+@pytest.mark.parametrize(
+    "invalid_note",
+    [
+        pytest.param(None, id="none"),
+        pytest.param(42, id="int"),
+        pytest.param(True, id="bool"),
+        pytest.param([], id="list"),
+        pytest.param({}, id="dict"),
+    ],
+)
+@pytest.mark.usefixtures("hass")
+def test_choose_option_rejects_invalid_note(invalid_note: Any) -> None:
+    """Test that choose option schemas reject non-string notes."""
+    with pytest.raises(vol.Invalid):
+        cv.script_action(
+            {"choose": [{**_CHOOSE_OPTION_BASE_CONFIG, "note": invalid_note}]}
+        )


### PR DESCRIPTION
## Proposed change
- Somehow I missed to add note to choose options
- fix https://github.com/home-assistant/frontend/issues/52357


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes home-assistant/frontend#52357
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x]  I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
