### PR TITLE
Homee: Use constants for cover states for readability

### DIFF
--- a/homeassistant/components/homee/cover.py
+++ b/homeassistant/components/homee/cover.py
@@ -1,5 +1,6 @@
 """The homee cover platform."""
 
+from enum import Enum
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
@@ -36,14 +37,22 @@ IS_CLOSED_ATTRIBUTES = [
     AttributeType.SHUTTER_SLAT_POSITION,
 ]
 
-COVER_OPEN = 0.0
-COVER_CLOSED = 1.0
-COVER_STOPPED = 2.0
-COVER_OPENING = 3.0
-COVER_CLOSING = 4.0
 
-CLOSE_TILT = 1.0
-OPEN_TILT = 2.0
+class HomeeCoverState(float, Enum):
+    """Open/closed states for covers in homee."""
+
+    OPEN = 0.0
+    CLOSED = 1.0
+    STOPPED = 2.0
+    OPENING = 3.0
+    CLOSING = 4.0
+
+
+class HomeeSlatState(float, Enum):
+    """Slat states for covers in homee."""
+
+    CLOSED = 1.0
+    OPEN = 2.0
 
 
 def get_open_close_attribute(node: HomeeNode) -> HomeeAttribute | None:
@@ -190,9 +199,9 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
         """Return the opening status of the cover."""
         if self._open_close_attribute is not None:
             return (
-                self._open_close_attribute.get_value() == COVER_OPENING
+                self._open_close_attribute.get_value() == HomeeCoverState.OPENING
                 if not self._open_close_attribute.is_reversed
-                else self._open_close_attribute.get_value() == COVER_CLOSING
+                else self._open_close_attribute.get_value() == HomeeCoverState.CLOSING
             )
 
         return None
@@ -202,9 +211,9 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
         """Return the closing status of the cover."""
         if self._open_close_attribute is not None:
             return (
-                self._open_close_attribute.get_value() == COVER_CLOSING
+                self._open_close_attribute.get_value() == HomeeCoverState.CLOSING
                 if not self._open_close_attribute.is_reversed
-                else self._open_close_attribute.get_value() == COVER_OPENING
+                else self._open_close_attribute.get_value() == HomeeCoverState.OPENING
             )
 
         return None
@@ -219,9 +228,9 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
 
         if self._open_close_attribute is not None:
             if not self._open_close_attribute.is_reversed:
-                return self._open_close_attribute.get_value() == COVER_CLOSED
+                return self._open_close_attribute.get_value() == HomeeCoverState.CLOSED
 
-            return self._open_close_attribute.get_value() == COVER_OPEN
+            return self._open_close_attribute.get_value() == HomeeCoverState.OPEN
 
         # If none of the above is present, it will be a slat only cover.
         attribute = self._node.get_attribute_by_type(
@@ -238,17 +247,25 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
         """Open the cover."""
         assert self._open_close_attribute is not None
         if not self._open_close_attribute.is_reversed:
-            await self.async_set_homee_value(self._open_close_attribute, COVER_OPEN)
+            await self.async_set_homee_value(
+                self._open_close_attribute, HomeeCoverState.OPEN
+            )
         else:
-            await self.async_set_homee_value(self._open_close_attribute, COVER_CLOSED)
+            await self.async_set_homee_value(
+                self._open_close_attribute, HomeeCoverState.CLOSED
+            )
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
         assert self._open_close_attribute is not None
         if not self._open_close_attribute.is_reversed:
-            await self.async_set_homee_value(self._open_close_attribute, COVER_CLOSED)
+            await self.async_set_homee_value(
+                self._open_close_attribute, HomeeCoverState.CLOSED
+            )
         else:
-            await self.async_set_homee_value(self._open_close_attribute, COVER_OPEN)
+            await self.async_set_homee_value(
+                self._open_close_attribute, HomeeCoverState.OPEN
+            )
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
@@ -268,7 +285,9 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         if self._open_close_attribute is not None:
-            await self.async_set_homee_value(self._open_close_attribute, COVER_STOPPED)
+            await self.async_set_homee_value(
+                self._open_close_attribute, HomeeCoverState.STOPPED
+            )
 
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Open the cover tilt."""
@@ -278,9 +297,9 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
             )
         ) is not None:
             if not slat_attribute.is_reversed:
-                await self.async_set_homee_value(slat_attribute, OPEN_TILT)
+                await self.async_set_homee_value(slat_attribute, HomeeSlatState.OPEN)
             else:
-                await self.async_set_homee_value(slat_attribute, CLOSE_TILT)
+                await self.async_set_homee_value(slat_attribute, HomeeSlatState.CLOSED)
 
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Close the cover tilt."""
@@ -290,9 +309,9 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
             )
         ) is not None:
             if not slat_attribute.is_reversed:
-                await self.async_set_homee_value(slat_attribute, CLOSE_TILT)
+                await self.async_set_homee_value(slat_attribute, HomeeSlatState.CLOSED)
             else:
-                await self.async_set_homee_value(slat_attribute, OPEN_TILT)
+                await self.async_set_homee_value(slat_attribute, HomeeSlatState.OPEN)
 
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Move the cover tilt to a specific position."""

--- a/homeassistant/components/homee/cover.py
+++ b/homeassistant/components/homee/cover.py
@@ -24,17 +24,20 @@ _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
 
-OPEN_CLOSE_ATTRIBUTES = [
-    AttributeType.OPEN_CLOSE,
-    AttributeType.SLAT_ROTATION_IMPULSE,
-    AttributeType.UP_DOWN,
-]
-POSITION_ATTRIBUTES = [AttributeType.POSITION, AttributeType.SHUTTER_SLAT_POSITION]
 COVER_DEVICE_PROFILES = {
     NodeProfile.GARAGE_DOOR_OPERATOR: CoverDeviceClass.GARAGE,
     NodeProfile.ENTRANCE_GATE_OPERATOR: CoverDeviceClass.GATE,
     NodeProfile.SHUTTER_POSITION_SWITCH: CoverDeviceClass.SHUTTER,
 }
+
+COVER_OPEN = 0.0
+COVER_CLOSED = 1.0
+COVER_STOPPED = 2.0
+COVER_OPENING = 3.0
+COVER_CLOSING = 4.0
+
+CLOSE_TILT = 1.0
+OPEN_TILT = 2.0
 
 
 def get_open_close_attribute(node: HomeeNode) -> HomeeAttribute | None:
@@ -167,9 +170,9 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
         """Return the opening status of the cover."""
         if self._open_close_attribute is not None:
             return (
-                self._open_close_attribute.get_value() == 3
+                self._open_close_attribute.get_value() == COVER_OPENING
                 if not self._open_close_attribute.is_reversed
-                else self._open_close_attribute.get_value() == 4
+                else self._open_close_attribute.get_value() == COVER_CLOSING
             )
 
         return None
@@ -179,9 +182,9 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
         """Return the closing status of the cover."""
         if self._open_close_attribute is not None:
             return (
-                self._open_close_attribute.get_value() == 4
+                self._open_close_attribute.get_value() == COVER_CLOSING
                 if not self._open_close_attribute.is_reversed
-                else self._open_close_attribute.get_value() == 3
+                else self._open_close_attribute.get_value() == COVER_OPENING
             )
 
         return None
@@ -196,9 +199,9 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
 
         if self._open_close_attribute is not None:
             if not self._open_close_attribute.is_reversed:
-                return self._open_close_attribute.get_value() == 1
+                return self._open_close_attribute.get_value() == COVER_CLOSED
 
-            return self._open_close_attribute.get_value() == 0
+            return self._open_close_attribute.get_value() == COVER_OPEN
 
         # If none of the above is present, it might be a slat only cover.
         if (
@@ -214,17 +217,17 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
         """Open the cover."""
         assert self._open_close_attribute is not None
         if not self._open_close_attribute.is_reversed:
-            await self.async_set_homee_value(self._open_close_attribute, 0)
+            await self.async_set_homee_value(self._open_close_attribute, COVER_OPEN)
         else:
-            await self.async_set_homee_value(self._open_close_attribute, 1)
+            await self.async_set_homee_value(self._open_close_attribute, COVER_CLOSED)
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
         assert self._open_close_attribute is not None
         if not self._open_close_attribute.is_reversed:
-            await self.async_set_homee_value(self._open_close_attribute, 1)
+            await self.async_set_homee_value(self._open_close_attribute, COVER_CLOSED)
         else:
-            await self.async_set_homee_value(self._open_close_attribute, 0)
+            await self.async_set_homee_value(self._open_close_attribute, COVER_OPEN)
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
@@ -244,7 +247,7 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         if self._open_close_attribute is not None:
-            await self.async_set_homee_value(self._open_close_attribute, 2)
+            await self.async_set_homee_value(self._open_close_attribute, COVER_STOPPED)
 
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Open the cover tilt."""
@@ -254,9 +257,9 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
             )
         ) is not None:
             if not slat_attribute.is_reversed:
-                await self.async_set_homee_value(slat_attribute, 2)
+                await self.async_set_homee_value(slat_attribute, OPEN_TILT)
             else:
-                await self.async_set_homee_value(slat_attribute, 1)
+                await self.async_set_homee_value(slat_attribute, CLOSE_TILT)
 
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Close the cover tilt."""
@@ -266,9 +269,9 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
             )
         ) is not None:
             if not slat_attribute.is_reversed:
-                await self.async_set_homee_value(slat_attribute, 1)
+                await self.async_set_homee_value(slat_attribute, CLOSE_TILT)
             else:
-                await self.async_set_homee_value(slat_attribute, 2)
+                await self.async_set_homee_value(slat_attribute, OPEN_TILT)
 
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Move the cover tilt to a specific position."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add constants to cover.py, to enhance readability of code.

Also remove 2 old constant lists, that are not used anymore.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
