### PR TITLE
Add translations for template device trackers `in_zones` option

### DIFF
--- a/homeassistant/components/template/strings.json
+++ b/homeassistant/components/template/strings.json
@@ -139,12 +139,14 @@
       "device_tracker": {
         "data": {
           "device_id": "[%key:common::config_flow::data::device%]",
+          "in_zones": "In zones",
           "latitude": "Latitude",
           "longitude": "Longitude",
           "name": "[%key:common::config_flow::data::name%]"
         },
         "data_description": {
           "device_id": "[%key:component::template::common::device_id_description%]",
+          "in_zones": "Defines a template that returns a list of zones the device tracker is currently in. The template should return a list of zone entity IDs. If the device tracker is not in any zone, the template should return an empty list.",
           "latitude": "Defines a template to get the latitude of the device tracker. Valid values are numbers between `-90` and `90`.",
           "longitude": "Defines a template to get the longitude of the device tracker. Valid values are numbers between `-180` and `180`.",
           "name": "[%key:common::config_flow::data::name%]"
@@ -715,11 +717,13 @@
       "device_tracker": {
         "data": {
           "device_id": "[%key:common::config_flow::data::device%]",
+          "in_zones": "[%key:component::template::config::step::device_tracker::data::in_zones%]",
           "latitude": "[%key:component::template::config::step::device_tracker::data::latitude%]",
           "longitude": "[%key:component::template::config::step::device_tracker::data::longitude%]"
         },
         "data_description": {
           "device_id": "[%key:component::template::common::device_id_description%]",
+          "in_zones": "[%key:component::template::config::step::device_tracker::data_description::in_zones%]",
           "latitude": "[%key:component::template::config::step::device_tracker::data_description::latitude%]",
           "longitude": "[%key:component::template::config::step::device_tracker::data_description::longitude%]"
         },

--- a/homeassistant/components/template/strings.json
+++ b/homeassistant/components/template/strings.json
@@ -139,7 +139,7 @@
       "device_tracker": {
         "data": {
           "device_id": "[%key:common::config_flow::data::device%]",
-          "in_zones": "In zones",
+          "in_zones": "Zones",
           "latitude": "Latitude",
           "longitude": "Longitude",
           "name": "[%key:common::config_flow::data::name%]"

--- a/pylint/plugins/pylint_home_assistant/generated/mdi_icons.py
+++ b/pylint/plugins/pylint_home_assistant/generated/mdi_icons.py
@@ -5,7 +5,7 @@ To update, run python3 -m script.hassfest
 
 from typing import Final
 
-FRONTEND_VERSION: Final[str] = "20260527.1"
+FRONTEND_VERSION: Final[str] = "20260527.2"
 
 MDI_ICONS: Final[set[str]] = {
     "ab-testing",

--- a/pylint/plugins/pylint_home_assistant/generated/mdi_icons.py
+++ b/pylint/plugins/pylint_home_assistant/generated/mdi_icons.py
@@ -5,7 +5,7 @@ To update, run python3 -m script.hassfest
 
 from typing import Final
 
-FRONTEND_VERSION: Final[str] = "20260527.2"
+FRONTEND_VERSION: Final[str] = "20260527.1"
 
 MDI_ICONS: Final[set[str]] = {
     "ab-testing",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add translatiosn for device tracker `in_zones`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # https://github.com/home-assistant/core/issues/172775
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
