### PR TITLE
Avoid re-registering listeners at common.py from Home Connect

### DIFF
--- a/homeassistant/components/home_connect/common.py
+++ b/homeassistant/components/home_connect/common.py
@@ -108,27 +108,32 @@ def _handle_paired_or_connected_appliance(
                 )
                 if entity.unique_id not in known_entity_unique_ids
             )
-            for event_key in (
-                EventKey.BSH_COMMON_ROOT_ACTIVE_PROGRAM,
-                EventKey.BSH_COMMON_ROOT_SELECTED_PROGRAM,
+            if not (
+                callbacks_for_appliance := changed_options_listener_remove_callbacks[
+                    appliance_ha_id
+                ]
             ):
-                changed_options_listener_remove_callback = (
-                    appliance_coordinator.async_add_listener(
-                        partial(
-                            _create_option_entities,
-                            entity_registry,
-                            appliance_coordinator,
-                            known_entity_unique_ids,
-                            get_option_entities_for_appliance,
-                            async_add_entities,
-                        ),
-                        event_key,
+                for event_key in (
+                    EventKey.BSH_COMMON_ROOT_ACTIVE_PROGRAM,
+                    EventKey.BSH_COMMON_ROOT_SELECTED_PROGRAM,
+                ):
+                    changed_options_listener_remove_callback = (
+                        appliance_coordinator.async_add_listener(
+                            partial(
+                                _create_option_entities,
+                                entity_registry,
+                                appliance_coordinator,
+                                known_entity_unique_ids,
+                                get_option_entities_for_appliance,
+                                async_add_entities,
+                            ),
+                            event_key,
+                        )
                     )
-                )
-                entry.async_on_unload(changed_options_listener_remove_callback)
-                changed_options_listener_remove_callbacks[appliance_ha_id].append(
-                    changed_options_listener_remove_callback
-                )
+                    entry.async_on_unload(changed_options_listener_remove_callback)
+                    callbacks_for_appliance.append(
+                        changed_options_listener_remove_callback
+                    )
         known_entity_unique_ids.update(
             {cast(str, entity.unique_id): appliance_ha_id for entity in entities_to_add}
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This a suggestion from Copilot at https://github.com/home-assistant/core/pull/155983#pullrequestreview-3853405155 where it said:
> _handle_paired_or_connected_appliance registers appliance_coordinator.async_add_listener(...) callbacks inside the PAIRED/CONNECTED global handler. Since CONNECTED can fire repeatedly, this will accumulate duplicate listeners and cause the callback to run multiple times per event (and leak memory) over time. Track whether listeners have already been registered per appliance (e.g., via changed_options_listener_remove_callbacks) and skip re-registering them, or remove existing listeners before adding new ones.

After checking it and evaluating it, I thought it was a good idea to implement it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
