### PR TITLE
Bump vsure to 2.7.0

### DIFF
--- a/homeassistant/components/verisure/manifest.json
+++ b/homeassistant/components/verisure/manifest.json
@@ -12,5 +12,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "loggers": ["verisure"],
-  "requirements": ["vsure==2.6.7"]
+  "requirements": ["vsure==2.7.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3320,7 +3320,7 @@ volkszaehler==0.4.0
 volvocarsapi==0.4.3
 
 # homeassistant.components.verisure
-vsure==2.6.7
+vsure==2.7.0
 
 # homeassistant.components.vasttrafik
 vtjp==0.2.1

--- a/tests/components/verisure/test_config_flow.py
+++ b/tests/components/verisure/test_config_flow.py
@@ -225,7 +225,7 @@ async def test_full_user_flow_multiple_installations_with_mfa(
     ("side_effect", "error"),
     [
         (VerisureLoginError("Login failed"), "invalid_auth"),
-        (VerisureError, "unknown"),
+        (VerisureError(), "unknown"),
     ],
 )
 async def test_verisure_errors(
@@ -434,7 +434,7 @@ async def test_reauth_flow_with_mfa(
     ("side_effect", "error"),
     [
         (VerisureLoginError("Login failed"), "invalid_auth"),
-        (VerisureError, "unknown"),
+        (VerisureError(), "unknown"),
     ],
 )
 async def test_reauth_flow_errors(

--- a/tests/components/verisure/test_config_flow.py
+++ b/tests/components/verisure/test_config_flow.py
@@ -224,7 +224,7 @@ async def test_full_user_flow_multiple_installations_with_mfa(
 @pytest.mark.parametrize(
     ("side_effect", "error"),
     [
-        (VerisureLoginError, "invalid_auth"),
+        (VerisureLoginError("Login failed"), "invalid_auth"),
         (VerisureError, "unknown"),
     ],
 )
@@ -433,7 +433,7 @@ async def test_reauth_flow_with_mfa(
 @pytest.mark.parametrize(
     ("side_effect", "error"),
     [
-        (VerisureLoginError, "invalid_auth"),
+        (VerisureLoginError("Login failed"), "invalid_auth"),
         (VerisureError, "unknown"),
     ],
 )

--- a/tests/components/verisure/test_config_flow.py
+++ b/tests/components/verisure/test_config_flow.py
@@ -225,7 +225,7 @@ async def test_full_user_flow_multiple_installations_with_mfa(
     ("side_effect", "error"),
     [
         (VerisureLoginError("Login failed"), "invalid_auth"),
-        (VerisureError(), "unknown"),
+        (VerisureError("Unknown error"), "unknown"),
     ],
 )
 async def test_verisure_errors(
@@ -434,7 +434,7 @@ async def test_reauth_flow_with_mfa(
     ("side_effect", "error"),
     [
         (VerisureLoginError("Login failed"), "invalid_auth"),
-        (VerisureError(), "unknown"),
+        (VerisureError("Unknown error"), "unknown"),
     ],
 )
 async def test_reauth_flow_errors(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump the Verisure integration dependency to `vsure==2.7.0`.

This is a dependency-only change, split out from #171317 per maintainer feedback. The library release adds structured session error types (`AuthenticationError`, `CookieReadError`, `RateLimitError`), HTTP status mapping on `ResponseError`/`LoginError`, and a retrying `Session.update_cookie()` helper.

Integration behavior changes will follow in a separate PR after this merges.

**Dependency diff (2.6.7 → 2.7.0):** https://github.com/persandstrom/python-verisure/compare/a0b644a...f81d3c4

**Changelog / release notes:**
- Version history: https://github.com/persandstrom/python-verisure/blob/version-2/README.md#version-history
- 2.7.0 release PR: https://github.com/persandstrom/python-verisure/pull/182
- PyPI: https://pypi.org/project/vsure/2.7.0/


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #171317
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr