### PR TITLE
Add filter reset button to Helty Flow

### DIFF
--- a/homeassistant/components/helty/__init__.py
+++ b/homeassistant/components/helty/__init__.py
@@ -7,7 +7,7 @@ from homeassistant.core import HomeAssistant
 
 from .coordinator import HeltyConfigEntry, HeltyDataUpdateCoordinator
 
-PLATFORMS: list[Platform] = [Platform.FAN, Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.BUTTON, Platform.FAN, Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: HeltyConfigEntry) -> bool:

--- a/homeassistant/components/helty/button.py
+++ b/homeassistant/components/helty/button.py
@@ -1,10 +1,14 @@
 """Button platform for the Helty Flow integration."""
 
+from pyhelty import HeltyError
+
 from homeassistant.components.button import ButtonEntity
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .const import DOMAIN
 from .coordinator import HeltyConfigEntry, HeltyDataUpdateCoordinator
 from .entity import HeltyEntity
 
@@ -33,5 +37,11 @@ class HeltyResetFilterButton(HeltyEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Reset the filter-life counter."""
-        await self.coordinator.client.async_reset_filter()
+        try:
+            await self.coordinator.client.async_reset_filter()
+        except HeltyError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="reset_filter_failed",
+            ) from err
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/helty/button.py
+++ b/homeassistant/components/helty/button.py
@@ -1,0 +1,37 @@
+"""Button platform for the Helty Flow integration."""
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import HeltyConfigEntry, HeltyDataUpdateCoordinator
+from .entity import HeltyEntity
+
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: HeltyConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Helty buttons."""
+    async_add_entities([HeltyResetFilterButton(entry.runtime_data)])
+
+
+class HeltyResetFilterButton(HeltyEntity, ButtonEntity):
+    """Resets the filter-life counter after the filter has been replaced."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_translation_key = "reset_filter"
+
+    def __init__(self, coordinator: HeltyDataUpdateCoordinator) -> None:
+        """Initialize the button."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{self._device_id}_reset_filter"
+
+    async def async_press(self) -> None:
+        """Reset the filter-life counter."""
+        await self.coordinator.client.async_reset_filter()
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/helty/fan.py
+++ b/homeassistant/components/helty/fan.py
@@ -2,17 +2,18 @@
 
 from typing import Any
 
-from pyhelty import FanMode
+from pyhelty import FanMode, HeltyError
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util.percentage import (
     ordered_list_item_to_percentage,
     percentage_to_ordered_list_item,
 )
 
-from .const import PRESET_BOOST, PRESET_FREE_COOLING, PRESET_NIGHT
+from .const import DOMAIN, PRESET_BOOST, PRESET_FREE_COOLING, PRESET_NIGHT
 from .coordinator import HeltyConfigEntry, HeltyDataUpdateCoordinator
 from .entity import HeltyEntity
 
@@ -116,5 +117,11 @@ class HeltyFan(HeltyEntity, FanEntity):
         await self._async_set_mode(FanMode.OFF)
 
     async def _async_set_mode(self, mode: FanMode) -> None:
-        await self.coordinator.client.async_set_fan_mode(mode)
+        try:
+            await self.coordinator.client.async_set_fan_mode(mode)
+        except HeltyError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="set_fan_mode_failed",
+            ) from err
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/helty/quality_scale.yaml
+++ b/homeassistant/components/helty/quality_scale.yaml
@@ -26,9 +26,7 @@ rules:
   unique-config-entry: done
 
   # Silver
-  action-exceptions:
-    status: exempt
-    comment: This integration does not provide additional actions.
+  action-exceptions: done
   config-entry-unloading: done
   docs-configuration-parameters:
     status: exempt

--- a/homeassistant/components/helty/strings.json
+++ b/homeassistant/components/helty/strings.json
@@ -36,5 +36,13 @@
         "name": "Outdoor temperature"
       }
     }
+  },
+  "exceptions": {
+    "reset_filter_failed": {
+      "message": "Failed to reset the filter."
+    },
+    "set_fan_mode_failed": {
+      "message": "Failed to set the ventilation mode."
+    }
   }
 }

--- a/homeassistant/components/helty/strings.json
+++ b/homeassistant/components/helty/strings.json
@@ -20,6 +20,11 @@
     }
   },
   "entity": {
+    "button": {
+      "reset_filter": {
+        "name": "Reset filter"
+      }
+    },
     "sensor": {
       "indoor_humidity": {
         "name": "Indoor humidity"

--- a/tests/components/helty/snapshots/test_button.ambr
+++ b/tests/components/helty/snapshots/test_button.ambr
@@ -1,0 +1,51 @@
+# serializer version: 1
+# name: test_all_entities[button.vmc_soggiorno_reset_filter-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.vmc_soggiorno_reset_filter',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Reset filter',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Reset filter',
+    'platform': 'helty',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'reset_filter',
+    'unique_id': '01HHHHHHHHHHHHHHHHHHHHHHHH_reset_filter',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[button.vmc_soggiorno_reset_filter-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VMC Soggiorno Reset filter',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.vmc_soggiorno_reset_filter',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/helty/test_button.py
+++ b/tests/components/helty/test_button.py
@@ -1,0 +1,47 @@
+"""Test the Helty Flow button platform."""
+
+from unittest.mock import AsyncMock, patch
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+RESET_FILTER_ENTITY = "button.vmc_soggiorno_reset_filter"
+
+
+async def test_all_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_helty_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test all entities."""
+    with patch("homeassistant.components.helty.PLATFORMS", [Platform.BUTTON]):
+        await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_reset_filter_press(
+    hass: HomeAssistant,
+    mock_helty_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test pressing the reset filter button calls the client."""
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: RESET_FILTER_ENTITY},
+        blocking=True,
+    )
+    mock_helty_client.async_reset_filter.assert_awaited_once()

--- a/tests/components/helty/test_button.py
+++ b/tests/components/helty/test_button.py
@@ -2,11 +2,14 @@
 
 from unittest.mock import AsyncMock, patch
 
+from pyhelty import HeltyError
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from . import setup_integration
@@ -45,3 +48,22 @@ async def test_reset_filter_press(
         blocking=True,
     )
     mock_helty_client.async_reset_filter.assert_awaited_once()
+
+
+async def test_reset_filter_press_error(
+    hass: HomeAssistant,
+    mock_helty_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a device failure during reset raises a HomeAssistantError."""
+    await setup_integration(hass, mock_config_entry)
+
+    mock_helty_client.async_reset_filter.side_effect = HeltyError
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: RESET_FILTER_ENTITY},
+            blocking=True,
+        )

--- a/tests/components/helty/test_fan.py
+++ b/tests/components/helty/test_fan.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import AsyncMock, patch
 
-from pyhelty import FanMode
+from pyhelty import FanMode, HeltyError
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -20,6 +20,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from . import setup_integration
@@ -166,3 +167,22 @@ async def test_fan_turn_on_with_preset(
         blocking=True,
     )
     mock_helty_client.async_set_fan_mode.assert_awaited_with(FanMode.FREE_COOLING)
+
+
+async def test_fan_set_mode_error(
+    hass: HomeAssistant,
+    mock_helty_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a device failure while setting the mode raises a HomeAssistantError."""
+    await setup_integration(hass, mock_config_entry)
+
+    mock_helty_client.async_set_fan_mode.side_effect = HeltyError
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            FAN_DOMAIN,
+            SERVICE_SET_PRESET_MODE,
+            {ATTR_ENTITY_ID: FAN_ENTITY, ATTR_PRESET_MODE: "boost"},
+            blocking=True,
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a button platform to the Helty Flow integration with a single **Reset filter** button.

Helty Flow units keep an internal filter-life counter. After replacing the physical filter, the counter needs to be reset on the device. This button performs that reset (the underlying library sends the dedicated reset command and the coordinator then refreshes), so users can clear it from Home Assistant instead of from the unit's own controls.

The entity is placed under the configuration category, as it is a maintenance action rather than runtime control.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#45717
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
