### PR TITLE
Add template based climate entity

### DIFF
--- a/homeassistant/components/template/climate.py
+++ b/homeassistant/components/template/climate.py
@@ -1,17 +1,12 @@
 """Support for Template climates."""
 
+from decimal import ROUND_HALF_UP, Decimal
 from enum import IntFlag
 from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 
 from homeassistant.components.climate import (
-    DOMAIN as CLIMATE_DOMAIN,
-    ENTITY_ID_FORMAT,
-    ClimateEntity,
-    ClimateEntityFeature,
-)
-from homeassistant.components.climate.const import (
     ATTR_CURRENT_HUMIDITY,
     ATTR_CURRENT_TEMPERATURE,
     ATTR_FAN_MODE,
@@ -26,9 +21,13 @@ from homeassistant.components.climate.const import (
     DEFAULT_MAX_TEMP,
     DEFAULT_MIN_HUMIDITY,
     DEFAULT_MIN_TEMP,
+    DOMAIN as CLIMATE_DOMAIN,
+    ENTITY_ID_FORMAT,
     FAN_LOW,
     PRESET_COMFORT,
     SWING_OFF,
+    ClimateEntity,
+    ClimateEntityFeature,
     HVACAction,
     HVACMode,
 )
@@ -158,6 +157,15 @@ class TemplateClimateEntityPresetFeature(IntFlag):
 def _hvac_mode_list(value: Any) -> list[HVACMode]:
     """Validate and coerce a configured HVAC mode list."""
     return [HVACMode(item) for item in cv.ensure_list(value)]
+
+
+def _round_to_step(value: float, step: float) -> float:
+    """Round a temperature to the nearest step using half-up midpoint handling."""
+    decimal_value = Decimal(str(value))
+    decimal_step = Decimal(str(step))
+    return float(
+        (decimal_value / decimal_step).quantize(0, ROUND_HALF_UP) * decimal_step
+    )
 
 
 CLIMATE_COMMON_SCHEMA = vol.Schema(
@@ -581,10 +589,7 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
         if self._attr_target_temperature_step is None:
             return float(value)
 
-        return (
-            round(float(value) / self._attr_target_temperature_step)
-            * self._attr_target_temperature_step
-        )
+        return _round_to_step(float(value), self._attr_target_temperature_step)
 
     def _validate_target_temperature_low(self, result: Any) -> float | None:
         """Validate a low target temperature template result."""
@@ -948,7 +953,10 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
                 )
                 self._presets[self._attr_preset_mode]["hvac_mode"] = hvac_mode
 
-        if (target_temperature := kwargs.get(ATTR_TEMPERATURE)) is not None:
+        if (
+            (target_temperature := kwargs.get(ATTR_TEMPERATURE)) is not None
+            and self._attr_supported_features & ClimateEntityFeature.TARGET_TEMPERATURE
+        ):
             validated = self._validate_target_temperature(target_temperature)
             if validated is None:
                 raise ValueError(f"Invalid target temperature: {target_temperature}")
@@ -965,7 +973,11 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
                 ] = validated
                 self._presets[self._attr_preset_mode]["target_temperature"] = validated
 
-        if (target_temperature_low := kwargs.get(ATTR_TARGET_TEMP_LOW)) is not None:
+        if (
+            (target_temperature_low := kwargs.get(ATTR_TARGET_TEMP_LOW)) is not None
+            and self._attr_supported_features
+            & ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+        ):
             validated = self._validate_target_temperature_low(target_temperature_low)
             if validated is None:
                 raise ValueError(
@@ -986,7 +998,11 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
                     validated
                 )
 
-        if (target_temperature_high := kwargs.get(ATTR_TARGET_TEMP_HIGH)) is not None:
+        if (
+            (target_temperature_high := kwargs.get(ATTR_TARGET_TEMP_HIGH)) is not None
+            and self._attr_supported_features
+            & ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+        ):
             validated = self._validate_target_temperature_high(target_temperature_high)
             if validated is None:
                 raise ValueError(

--- a/homeassistant/components/template/climate.py
+++ b/homeassistant/components/template/climate.py
@@ -27,10 +27,10 @@ from homeassistant.components.climate.const import (
     DEFAULT_MIN_HUMIDITY,
     DEFAULT_MIN_TEMP,
     FAN_LOW,
-    HVACAction,
-    HVACMode,
     PRESET_COMFORT,
     SWING_OFF,
+    HVACAction,
+    HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -256,7 +256,7 @@ async def async_setup_entry(
 @callback
 def async_create_preview_climate(
     hass: HomeAssistant, name: str, config: dict[str, Any]
-) -> "StateClimateEntity":
+) -> StateClimateEntity:
     """Create a preview."""
     return async_setup_template_preview(
         hass,

--- a/homeassistant/components/template/climate.py
+++ b/homeassistant/components/template/climate.py
@@ -181,7 +181,9 @@ CLIMATE_COMMON_SCHEMA = vol.Schema(
         vol.Optional(CONF_SET_PRESET_MODE_ACTION): cv.SCRIPT_SCHEMA,
         vol.Optional(CONF_SET_SWING_MODE_ACTION): cv.SCRIPT_SCHEMA,
         vol.Optional(CONF_SET_PRESETS_ACTION): cv.SCRIPT_SCHEMA,
-        vol.Optional(CONF_HVAC_MODE_LIST, default=DEFAULT_HVAC_MODE_LIST): _hvac_mode_list,
+        vol.Optional(
+            CONF_HVAC_MODE_LIST, default=DEFAULT_HVAC_MODE_LIST
+        ): _hvac_mode_list,
         vol.Optional(CONF_PRESET_MODE_LIST, default=DEFAULT_PRESET_MODE_LIST): vol.All(
             cv.ensure_list, [cv.string]
         ),
@@ -198,14 +200,14 @@ CLIMATE_COMMON_SCHEMA = vol.Schema(
         vol.Optional(CONF_PRECISION): vol.In(
             [PRECISION_TENTHS, PRECISION_HALVES, PRECISION_WHOLE]
         ),
-        vol.Optional(CONF_TEMP_STEP, default=DEFAULT_TEMP_STEP): vol.Coerce(float),
+        vol.Optional(CONF_TEMP_STEP, default=DEFAULT_TEMP_STEP): cv.positive_float,
         vol.Optional(CONF_MODE_ACTION, default=DEFAULT_MODE_ACTION): vol.In(
             ["parallel", "queued", "restart", "single"]
         ),
         vol.Optional(CONF_MAX_ACTION, default=DEFAULT_MAX_ACTION): cv.positive_int,
-        vol.Optional(
-            CONF_PRESETS_FEATURES, default=DEFAULT_PRESETS_FEATURES
-        ): cv.positive_int,
+        vol.Optional(CONF_PRESETS_FEATURES, default=DEFAULT_PRESETS_FEATURES): vol.All(
+            vol.Coerce(int), vol.Range(min=0), vol.Range(max=255)
+        ),
     }
 )
 
@@ -307,17 +309,23 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
         self._attr_preset_mode = (
             DEFAULT_PRESET_MODE
             if DEFAULT_PRESET_MODE in self._attr_preset_modes
-            else self._attr_preset_modes[0] if self._attr_preset_modes else None
+            else self._attr_preset_modes[0]
+            if self._attr_preset_modes
+            else None
         )
         self._attr_fan_mode = (
             DEFAULT_FAN_MODE
             if DEFAULT_FAN_MODE in self._attr_fan_modes
-            else self._attr_fan_modes[0] if self._attr_fan_modes else None
+            else self._attr_fan_modes[0]
+            if self._attr_fan_modes
+            else None
         )
         self._attr_swing_mode = (
             DEFAULT_SWING_MODE
             if DEFAULT_SWING_MODE in self._attr_swing_modes
-            else self._attr_swing_modes[0] if self._attr_swing_modes else None
+            else self._attr_swing_modes[0]
+            if self._attr_swing_modes
+            else None
         )
         self._attr_target_temperature = DEFAULT_TEMPERATURE
         self._attr_target_temperature_low = DEFAULT_TEMPERATURE
@@ -361,12 +369,12 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
         self.setup_template(
             CONF_TARGET_TEMPERATURE_LOW_TEMPLATE,
             "_attr_target_temperature_low",
-            self._validate_target_temperature,
+            self._validate_target_temperature_low,
         )
         self.setup_template(
             CONF_TARGET_TEMPERATURE_HIGH_TEMPLATE,
             "_attr_target_temperature_high",
-            self._validate_target_temperature,
+            self._validate_target_temperature_high,
         )
         self.setup_template(
             CONF_TARGET_HUMIDITY_TEMPLATE,
@@ -429,7 +437,9 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
         if self._attr_swing_modes:
             self._attr_supported_features |= ClimateEntityFeature.SWING_MODE
         if HVACMode.HEAT_COOL in self._attr_hvac_modes:
-            self._attr_supported_features |= ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+            self._attr_supported_features |= (
+                ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+            )
         if any(
             mode in self._attr_hvac_modes
             for mode in (HVACMode.AUTO, HVACMode.HEAT, HVACMode.COOL)
@@ -443,7 +453,9 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
         ):
             self._attr_supported_features |= ClimateEntityFeature.TARGET_HUMIDITY
 
-    def _validate_choice(self, attribute: str, result: Any, valid: list[str]) -> str | None:
+    def _validate_choice(
+        self, attribute: str, result: Any, valid: list[str]
+    ) -> str | None:
         """Validate a string value against configured choices."""
         if template_validators.check_result_for_none(
             result, none_on_unknown_unavailable=True
@@ -488,15 +500,17 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
 
     def _validate_preset_mode(self, result: Any) -> str | None:
         return self._validate_choice(
-            CONF_PRESET_MODE_TEMPLATE, result, self._attr_preset_modes
+            CONF_PRESET_MODE_TEMPLATE, result, self._attr_preset_modes or []
         )
 
     def _validate_fan_mode(self, result: Any) -> str | None:
-        return self._validate_choice(CONF_FAN_MODE_TEMPLATE, result, self._attr_fan_modes)
+        return self._validate_choice(
+            CONF_FAN_MODE_TEMPLATE, result, self._attr_fan_modes or []
+        )
 
     def _validate_swing_mode(self, result: Any) -> str | None:
         return self._validate_choice(
-            CONF_SWING_MODE_TEMPLATE, result, self._attr_swing_modes
+            CONF_SWING_MODE_TEMPLATE, result, self._attr_swing_modes or []
         )
 
     def _validate_hvac_action(self, result: Any) -> HVACAction | None:
@@ -517,6 +531,22 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
             )
             return None
 
+    def _restore_mode_state(self, result: Any) -> dict[str, Any]:
+        """Normalize restored mode state attributes."""
+        if not isinstance(result, dict):
+            return {}
+
+        restored = dict(result)
+        if "hvac_mode" not in restored:
+            return restored
+
+        if (hvac_mode := self._validate_hvac_mode(restored["hvac_mode"])) is None:
+            restored.pop("hvac_mode")
+        else:
+            restored["hvac_mode"] = hvac_mode
+
+        return restored
+
     def _validate_current_temperature(self, result: Any) -> float | None:
         """Validate a current temperature template result."""
         if (
@@ -532,42 +562,63 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
             return round(float(value), 1)
         return round(float(value))
 
-    def _validate_target_temperature(self, result: Any) -> float | None:
+    def _validate_target_temperature(
+        self,
+        result: Any,
+        attribute: str = CONF_TARGET_TEMPERATURE_TEMPLATE,
+    ) -> float | None:
         """Validate a target temperature template result."""
         if (
             value := template_validators.number(
                 self,
-                CONF_TARGET_TEMPERATURE_TEMPLATE,
+                attribute,
                 self._attr_min_temp,
                 self._attr_max_temp,
             )(result)
         ) is None:
             return None
 
+        if self._attr_target_temperature_step is None:
+            return float(value)
+
         return (
             round(float(value) / self._attr_target_temperature_step)
             * self._attr_target_temperature_step
         )
 
+    def _validate_target_temperature_low(self, result: Any) -> float | None:
+        """Validate a low target temperature template result."""
+        return self._validate_target_temperature(
+            result, CONF_TARGET_TEMPERATURE_LOW_TEMPLATE
+        )
+
+    def _validate_target_temperature_high(self, result: Any) -> float | None:
+        """Validate a high target temperature template result."""
+        return self._validate_target_temperature(
+            result, CONF_TARGET_TEMPERATURE_HIGH_TEMPLATE
+        )
+
     def _validate_current_humidity(self, result: Any) -> int | None:
         """Validate a current humidity template result."""
-        return template_validators.number(
+        validated = template_validators.number(
             self,
             CONF_CURRENT_HUMIDITY_TEMPLATE,
             0,
             100,
             int,
         )(result)
+        return None if validated is None else int(validated)
 
     def _validate_target_humidity(self, result: Any) -> int | None:
         """Validate a target humidity template result."""
-        return template_validators.number(
+        validated = template_validators.number(
             self,
             CONF_TARGET_HUMIDITY_TEMPLATE,
             self._attr_min_humidity,
             self._attr_max_humidity,
             int,
         )(result)
+        return None if validated is None else int(validated)
 
     def _empty_preset(self) -> dict[str, Any]:
         """Return the default structure for a preset."""
@@ -578,7 +629,10 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
             preset["fan_mode"] = None
         if self._presets_features & TemplateClimateEntityPresetFeature.SWING_MODE:
             preset["swing_mode"] = None
-        if self._presets_features & TemplateClimateEntityPresetFeature.TARGET_TEMPERATURE:
+        if (
+            self._presets_features
+            & TemplateClimateEntityPresetFeature.TARGET_TEMPERATURE
+        ):
             preset["target_temperature"] = None
         if (
             self._presets_features
@@ -604,7 +658,7 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
             return {}
 
         validated: dict[str, dict[str, Any]] = {}
-        for mode in self._attr_preset_modes:
+        for mode in self._attr_preset_modes or []:
             raw_preset = result.get(mode)
             preset = self._empty_preset()
             if not isinstance(raw_preset, dict):
@@ -621,14 +675,14 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
                 and (value := raw_preset.get("fan_mode")) is not None
             ):
                 preset["fan_mode"] = self._validate_choice(
-                    "fan_mode", value, self._attr_fan_modes
+                    "fan_mode", value, self._attr_fan_modes or []
                 )
             if (
                 self._presets_features & TemplateClimateEntityPresetFeature.SWING_MODE
                 and (value := raw_preset.get("swing_mode")) is not None
             ):
                 preset["swing_mode"] = self._validate_choice(
-                    "swing_mode", value, self._attr_swing_modes
+                    "swing_mode", value, self._attr_swing_modes or []
                 )
             if (
                 self._presets_features
@@ -641,15 +695,16 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
                 & TemplateClimateEntityPresetFeature.TARGET_TEMPERATURE_RANGE
             ):
                 if (value := raw_preset.get("target_temperature_low")) is not None:
-                    preset["target_temperature_low"] = self._validate_target_temperature(
-                        value
+                    preset["target_temperature_low"] = (
+                        self._validate_target_temperature_low(value)
                     )
                 if (value := raw_preset.get("target_temperature_high")) is not None:
-                    preset["target_temperature_high"] = self._validate_target_temperature(
-                        value
+                    preset["target_temperature_high"] = (
+                        self._validate_target_temperature_high(value)
                     )
             if (
-                self._presets_features & TemplateClimateEntityPresetFeature.TARGET_HUMIDITY
+                self._presets_features
+                & TemplateClimateEntityPresetFeature.TARGET_HUMIDITY
                 and (value := raw_preset.get("target_humidity")) is not None
             ):
                 preset["target_humidity"] = self._validate_target_humidity(value)
@@ -700,14 +755,14 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
         if (
             CONF_TARGET_TEMPERATURE_LOW_TEMPLATE not in self._templates
             and (value := last_state.attributes.get(ATTR_TARGET_TEMP_LOW)) is not None
-            and (validated := self._validate_target_temperature(value)) is not None
+            and (validated := self._validate_target_temperature_low(value)) is not None
         ):
             self._attr_target_temperature_low = validated
 
         if (
             CONF_TARGET_TEMPERATURE_HIGH_TEMPLATE not in self._templates
             and (value := last_state.attributes.get(ATTR_TARGET_TEMP_HIGH)) is not None
-            and (validated := self._validate_target_temperature(value)) is not None
+            and (validated := self._validate_target_temperature_high(value)) is not None
         ):
             self._attr_target_temperature_high = validated
 
@@ -720,7 +775,8 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
 
         if (
             CONF_CURRENT_TEMPERATURE_TEMPLATE not in self._templates
-            and (value := last_state.attributes.get(ATTR_CURRENT_TEMPERATURE)) is not None
+            and (value := last_state.attributes.get(ATTR_CURRENT_TEMPERATURE))
+            is not None
             and (validated := self._validate_current_temperature(value)) is not None
         ):
             self._attr_current_temperature = validated
@@ -738,10 +794,10 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
         ):
             self._attr_hvac_action = self._validate_hvac_action(value)
 
-        if (value := last_state.attributes.get("last_on_mode")) and isinstance(value, dict):
-            self._last_on_mode.update(value)
-        if (value := last_state.attributes.get("off_mode")) and isinstance(value, dict):
-            self._off_mode.update(value)
+        if (value := last_state.attributes.get("last_on_mode")) is not None:
+            self._last_on_mode.update(self._restore_mode_state(value))
+        if (value := last_state.attributes.get("off_mode")) is not None:
+            self._off_mode.update(self._restore_mode_state(value))
         if (
             CONF_PRESETS_TEMPLATE not in self._templates
             and (value := last_state.attributes.get("presets")) is not None
@@ -806,7 +862,7 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode."""
-        if preset_mode not in self._attr_preset_modes:
+        if preset_mode not in (self._attr_preset_modes or []):
             raise ValueError(f"Unsupported preset mode: {preset_mode}")
 
         self._attr_preset_mode = preset_mode
@@ -822,7 +878,7 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set the fan mode."""
-        if fan_mode not in self._attr_fan_modes:
+        if fan_mode not in (self._attr_fan_modes or []):
             raise ValueError(f"Unsupported fan mode: {fan_mode}")
 
         self._attr_fan_mode = fan_mode
@@ -835,7 +891,7 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
 
     async def async_set_swing_mode(self, swing_mode: str) -> None:
         """Set the swing mode."""
-        if swing_mode not in self._attr_swing_modes:
+        if swing_mode not in (self._attr_swing_modes or []):
             raise ValueError(f"Unsupported swing mode: {swing_mode}")
 
         self._attr_swing_mode = swing_mode
@@ -887,7 +943,9 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
                 and self._attr_preset_mode in self._presets
                 and "hvac_mode" in self._presets[self._attr_preset_mode]
             ):
-                changed_presets.setdefault(self._attr_preset_mode, {})["hvac_mode"] = hvac_mode
+                changed_presets.setdefault(self._attr_preset_mode, {})["hvac_mode"] = (
+                    hvac_mode
+                )
                 self._presets[self._attr_preset_mode]["hvac_mode"] = hvac_mode
 
         if (target_temperature := kwargs.get(ATTR_TEMPERATURE)) is not None:
@@ -908,7 +966,7 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
                 self._presets[self._attr_preset_mode]["target_temperature"] = validated
 
         if (target_temperature_low := kwargs.get(ATTR_TARGET_TEMP_LOW)) is not None:
-            validated = self._validate_target_temperature(target_temperature_low)
+            validated = self._validate_target_temperature_low(target_temperature_low)
             if validated is None:
                 raise ValueError(
                     f"Invalid low target temperature: {target_temperature_low}"
@@ -929,7 +987,7 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
                 )
 
         if (target_temperature_high := kwargs.get(ATTR_TARGET_TEMP_HIGH)) is not None:
-            validated = self._validate_target_temperature(target_temperature_high)
+            validated = self._validate_target_temperature_high(target_temperature_high)
             if validated is None:
                 raise ValueError(
                     f"Invalid high target temperature: {target_temperature_high}"
@@ -966,12 +1024,13 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
             temperature_data[ATTR_TARGET_TEMP_LOW] = value
         if (value := preset.get("target_temperature_high")) is not None:
             temperature_data[ATTR_TARGET_TEMP_HIGH] = value
-        if (value := preset.get("hvac_mode")) is not None:
-            temperature_data[ATTR_HVAC_MODE] = value
+        hvac_mode = preset.get("hvac_mode")
         if temperature_data:
+            if hvac_mode is not None:
+                temperature_data[ATTR_HVAC_MODE] = hvac_mode
             await self.async_set_temperature(**temperature_data)
-        elif (value := preset.get("hvac_mode")) is not None:
-            await self.async_set_hvac_mode(value)
+        elif hvac_mode is not None:
+            await self.async_set_hvac_mode(hvac_mode)
 
         if (value := preset.get("fan_mode")) is not None:
             await self.async_set_fan_mode(value)
@@ -1002,7 +1061,7 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
         return self._attr_target_temperature_high
 
     @property
-    def extra_state_attributes(self) -> dict[str, Any]:
+    def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return climate-specific extra attributes."""
         return {
             "presets": self._presets,

--- a/homeassistant/components/template/climate.py
+++ b/homeassistant/components/template/climate.py
@@ -1,0 +1,1057 @@
+"""Support for Template climates."""
+
+from enum import IntFlag
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from homeassistant.components.climate import (
+    DOMAIN as CLIMATE_DOMAIN,
+    ENTITY_ID_FORMAT,
+    ClimateEntity,
+    ClimateEntityFeature,
+)
+from homeassistant.components.climate.const import (
+    ATTR_CURRENT_HUMIDITY,
+    ATTR_CURRENT_TEMPERATURE,
+    ATTR_FAN_MODE,
+    ATTR_HUMIDITY,
+    ATTR_HVAC_ACTION,
+    ATTR_HVAC_MODE,
+    ATTR_PRESET_MODE,
+    ATTR_SWING_MODE,
+    ATTR_TARGET_TEMP_HIGH,
+    ATTR_TARGET_TEMP_LOW,
+    DEFAULT_MAX_HUMIDITY,
+    DEFAULT_MAX_TEMP,
+    DEFAULT_MIN_HUMIDITY,
+    DEFAULT_MIN_TEMP,
+    FAN_LOW,
+    HVACAction,
+    HVACMode,
+    PRESET_COMFORT,
+    SWING_OFF,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    ATTR_TEMPERATURE,
+    CONF_NAME,
+    PRECISION_HALVES,
+    PRECISION_TENTHS,
+    PRECISION_WHOLE,
+)
+from homeassistant.core import Context, HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.entity_platform import (
+    AddConfigEntryEntitiesCallback,
+    AddEntitiesCallback,
+)
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.script import Script
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+from . import TriggerUpdateCoordinator, validators as template_validators
+from .const import DOMAIN
+from .entity import AbstractTemplateEntity
+from .helpers import (
+    async_setup_template_entry,
+    async_setup_template_platform,
+    async_setup_template_preview,
+)
+from .schemas import (
+    TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA,
+    TEMPLATE_ENTITY_OPTIMISTIC_SCHEMA,
+    make_template_entity_common_modern_schema,
+)
+from .template_entity import TemplateEntity
+from .trigger_entity import TriggerEntity
+
+CONF_HVAC_MODE_LIST = "hvac_modes"
+CONF_PRESET_MODE_LIST = "preset_modes"
+CONF_FAN_MODE_LIST = "fan_modes"
+CONF_SWING_MODE_LIST = "swing_modes"
+CONF_TEMPERATURE_MIN = "min_temp"
+CONF_TEMPERATURE_MAX = "max_temp"
+CONF_HUMIDITY_MIN = "min_humidity"
+CONF_HUMIDITY_MAX = "max_humidity"
+CONF_PRECISION = "precision"
+CONF_TEMP_STEP = "temp_step"
+CONF_MODE_ACTION = "mode_action"
+CONF_MAX_ACTION = "max_action"
+CONF_PRESETS_FEATURES = "presets_features"
+
+CONF_CURRENT_TEMPERATURE_TEMPLATE = "current_temperature_template"
+CONF_CURRENT_HUMIDITY_TEMPLATE = "current_humidity_template"
+CONF_TARGET_TEMPERATURE_TEMPLATE = "target_temperature_template"
+CONF_TARGET_TEMPERATURE_HIGH_TEMPLATE = "target_temperature_high_template"
+CONF_TARGET_TEMPERATURE_LOW_TEMPLATE = "target_temperature_low_template"
+CONF_TARGET_HUMIDITY_TEMPLATE = "target_humidity_template"
+CONF_HVAC_MODE_TEMPLATE = "hvac_mode_template"
+CONF_FAN_MODE_TEMPLATE = "fan_mode_template"
+CONF_PRESET_MODE_TEMPLATE = "preset_mode_template"
+CONF_SWING_MODE_TEMPLATE = "swing_mode_template"
+CONF_HVAC_ACTION_TEMPLATE = "hvac_action_template"
+CONF_PRESETS_TEMPLATE = "presets_template"
+
+CONF_SET_TEMPERATURE_ACTION = "set_temperature"
+CONF_SET_HUMIDITY_ACTION = "set_humidity"
+CONF_SET_HVAC_MODE_ACTION = "set_hvac_mode"
+CONF_SET_FAN_MODE_ACTION = "set_fan_mode"
+CONF_SET_PRESET_MODE_ACTION = "set_preset_mode"
+CONF_SET_SWING_MODE_ACTION = "set_swing_mode"
+CONF_SET_PRESETS_ACTION = "set_presets"
+
+DEFAULT_NAME = "Template Climate"
+DEFAULT_TEMPERATURE = 21.0
+DEFAULT_HUMIDITY = 50
+DEFAULT_HVAC_MODE = HVACMode.OFF
+DEFAULT_PRESET_MODE = PRESET_COMFORT
+DEFAULT_FAN_MODE = FAN_LOW
+DEFAULT_SWING_MODE = SWING_OFF
+DEFAULT_HVAC_MODE_LIST = [HVACMode.OFF, HVACMode.HEAT]
+DEFAULT_PRESET_MODE_LIST: list[str] = []
+DEFAULT_FAN_MODE_LIST: list[str] = []
+DEFAULT_SWING_MODE_LIST: list[str] = []
+DEFAULT_TEMP_STEP = 1.0
+DEFAULT_MODE_ACTION = "single"
+DEFAULT_MAX_ACTION = 1
+DEFAULT_PRESETS_FEATURES = 0
+
+SCRIPT_FIELDS = (
+    CONF_SET_TEMPERATURE_ACTION,
+    CONF_SET_HUMIDITY_ACTION,
+    CONF_SET_HVAC_MODE_ACTION,
+    CONF_SET_FAN_MODE_ACTION,
+    CONF_SET_PRESET_MODE_ACTION,
+    CONF_SET_SWING_MODE_ACTION,
+    CONF_SET_PRESETS_ACTION,
+)
+
+_EXTRA_OPTIMISTIC_OPTIONS = (
+    CONF_CURRENT_TEMPERATURE_TEMPLATE,
+    CONF_CURRENT_HUMIDITY_TEMPLATE,
+    CONF_TARGET_TEMPERATURE_TEMPLATE,
+    CONF_TARGET_TEMPERATURE_HIGH_TEMPLATE,
+    CONF_TARGET_TEMPERATURE_LOW_TEMPLATE,
+    CONF_TARGET_HUMIDITY_TEMPLATE,
+    CONF_FAN_MODE_TEMPLATE,
+    CONF_PRESET_MODE_TEMPLATE,
+    CONF_SWING_MODE_TEMPLATE,
+    CONF_HVAC_ACTION_TEMPLATE,
+    CONF_PRESETS_TEMPLATE,
+)
+
+
+class TemplateClimateEntityPresetFeature(IntFlag):
+    """Supported preset features for template climates."""
+
+    EDITABLE = 1
+    PRESERVED = 2
+    HVAC_MODE = 4
+    FAN_MODE = 8
+    SWING_MODE = 16
+    TARGET_TEMPERATURE = 32
+    TARGET_TEMPERATURE_RANGE = 64
+    TARGET_HUMIDITY = 128
+
+
+def _hvac_mode_list(value: Any) -> list[HVACMode]:
+    """Validate and coerce a configured HVAC mode list."""
+    return [HVACMode(item) for item in cv.ensure_list(value)]
+
+
+CLIMATE_COMMON_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_CURRENT_TEMPERATURE_TEMPLATE): cv.template,
+        vol.Optional(CONF_CURRENT_HUMIDITY_TEMPLATE): cv.template,
+        vol.Optional(CONF_TARGET_HUMIDITY_TEMPLATE): cv.template,
+        vol.Optional(CONF_TARGET_TEMPERATURE_TEMPLATE): cv.template,
+        vol.Optional(CONF_TARGET_TEMPERATURE_HIGH_TEMPLATE): cv.template,
+        vol.Optional(CONF_TARGET_TEMPERATURE_LOW_TEMPLATE): cv.template,
+        vol.Optional(CONF_HVAC_MODE_TEMPLATE): cv.template,
+        vol.Optional(CONF_FAN_MODE_TEMPLATE): cv.template,
+        vol.Optional(CONF_PRESET_MODE_TEMPLATE): cv.template,
+        vol.Optional(CONF_SWING_MODE_TEMPLATE): cv.template,
+        vol.Optional(CONF_HVAC_ACTION_TEMPLATE): cv.template,
+        vol.Optional(CONF_PRESETS_TEMPLATE): cv.template,
+        vol.Optional(CONF_SET_TEMPERATURE_ACTION): cv.SCRIPT_SCHEMA,
+        vol.Optional(CONF_SET_HUMIDITY_ACTION): cv.SCRIPT_SCHEMA,
+        vol.Optional(CONF_SET_HVAC_MODE_ACTION): cv.SCRIPT_SCHEMA,
+        vol.Optional(CONF_SET_FAN_MODE_ACTION): cv.SCRIPT_SCHEMA,
+        vol.Optional(CONF_SET_PRESET_MODE_ACTION): cv.SCRIPT_SCHEMA,
+        vol.Optional(CONF_SET_SWING_MODE_ACTION): cv.SCRIPT_SCHEMA,
+        vol.Optional(CONF_SET_PRESETS_ACTION): cv.SCRIPT_SCHEMA,
+        vol.Optional(CONF_HVAC_MODE_LIST, default=DEFAULT_HVAC_MODE_LIST): _hvac_mode_list,
+        vol.Optional(CONF_PRESET_MODE_LIST, default=DEFAULT_PRESET_MODE_LIST): vol.All(
+            cv.ensure_list, [cv.string]
+        ),
+        vol.Optional(CONF_FAN_MODE_LIST, default=DEFAULT_FAN_MODE_LIST): vol.All(
+            cv.ensure_list, [cv.string]
+        ),
+        vol.Optional(CONF_SWING_MODE_LIST, default=DEFAULT_SWING_MODE_LIST): vol.All(
+            cv.ensure_list, [cv.string]
+        ),
+        vol.Optional(CONF_TEMPERATURE_MIN, default=DEFAULT_MIN_TEMP): vol.Coerce(float),
+        vol.Optional(CONF_TEMPERATURE_MAX, default=DEFAULT_MAX_TEMP): vol.Coerce(float),
+        vol.Optional(CONF_HUMIDITY_MIN, default=DEFAULT_MIN_HUMIDITY): vol.Coerce(int),
+        vol.Optional(CONF_HUMIDITY_MAX, default=DEFAULT_MAX_HUMIDITY): vol.Coerce(int),
+        vol.Optional(CONF_PRECISION): vol.In(
+            [PRECISION_TENTHS, PRECISION_HALVES, PRECISION_WHOLE]
+        ),
+        vol.Optional(CONF_TEMP_STEP, default=DEFAULT_TEMP_STEP): vol.Coerce(float),
+        vol.Optional(CONF_MODE_ACTION, default=DEFAULT_MODE_ACTION): vol.In(
+            ["parallel", "queued", "restart", "single"]
+        ),
+        vol.Optional(CONF_MAX_ACTION, default=DEFAULT_MAX_ACTION): cv.positive_int,
+        vol.Optional(
+            CONF_PRESETS_FEATURES, default=DEFAULT_PRESETS_FEATURES
+        ): cv.positive_int,
+    }
+)
+
+CLIMATE_YAML_SCHEMA = CLIMATE_COMMON_SCHEMA.extend(
+    TEMPLATE_ENTITY_OPTIMISTIC_SCHEMA
+).extend(make_template_entity_common_modern_schema(CLIMATE_DOMAIN, DEFAULT_NAME).schema)
+
+CLIMATE_CONFIG_ENTRY_SCHEMA = CLIMATE_COMMON_SCHEMA.extend(
+    TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA.schema
+)
+
+
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up the template climates."""
+    await async_setup_template_platform(
+        hass,
+        CLIMATE_DOMAIN,
+        config,
+        StateClimateEntity,
+        TriggerClimateEntity,
+        async_add_entities,
+        discovery_info,
+        script_options=SCRIPT_FIELDS,
+    )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Initialize config entry."""
+    await async_setup_template_entry(
+        hass,
+        config_entry,
+        async_add_entities,
+        StateClimateEntity,
+        CLIMATE_CONFIG_ENTRY_SCHEMA,
+        script_options=SCRIPT_FIELDS,
+    )
+
+
+@callback
+def async_create_preview_climate(
+    hass: HomeAssistant, name: str, config: dict[str, Any]
+) -> "StateClimateEntity":
+    """Create a preview."""
+    return async_setup_template_preview(
+        hass,
+        name,
+        config,
+        StateClimateEntity,
+        CLIMATE_CONFIG_ENTRY_SCHEMA,
+    )
+
+
+class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEntity):
+    """Representation of a template climate entity."""
+
+    _entity_id_format = ENTITY_ID_FORMAT
+    _optimistic_entity = True
+    _state_option = CONF_HVAC_MODE_TEMPLATE
+    _extra_optimistic_options = _EXTRA_OPTIMISTIC_OPTIONS
+    _enable_turn_on_off_backwards_compatibility = False
+
+    def __init__(self, hass: HomeAssistant, name: str, config: dict[str, Any]) -> None:  # pylint: disable=super-init-not-called
+        """Initialize the template climate."""
+        self.hass = hass
+        self._config = config
+
+        self._attr_temperature_unit = hass.config.units.temperature_unit
+        if CONF_PRECISION in config:
+            self._attr_precision = config[CONF_PRECISION]
+        self._attr_target_temperature_step = config[CONF_TEMP_STEP]
+        self._attr_min_temp = config[CONF_TEMPERATURE_MIN]
+        self._attr_max_temp = config[CONF_TEMPERATURE_MAX]
+        self._attr_min_humidity = config[CONF_HUMIDITY_MIN]
+        self._attr_max_humidity = config[CONF_HUMIDITY_MAX]
+        self._attr_supported_features = ClimateEntityFeature(0)
+
+        self._attr_hvac_modes = list(config[CONF_HVAC_MODE_LIST])
+        self._attr_preset_modes = list(config[CONF_PRESET_MODE_LIST])
+        self._attr_fan_modes = list(config[CONF_FAN_MODE_LIST])
+        self._attr_swing_modes = list(config[CONF_SWING_MODE_LIST])
+
+        self._attr_current_temperature: float | None = None
+        self._attr_current_humidity: int | None = None
+        self._attr_hvac_action: HVACAction | None = None
+        self._attr_hvac_mode = (
+            DEFAULT_HVAC_MODE
+            if DEFAULT_HVAC_MODE in self._attr_hvac_modes
+            else self._attr_hvac_modes[0]
+        )
+        self._attr_preset_mode = (
+            DEFAULT_PRESET_MODE
+            if DEFAULT_PRESET_MODE in self._attr_preset_modes
+            else self._attr_preset_modes[0] if self._attr_preset_modes else None
+        )
+        self._attr_fan_mode = (
+            DEFAULT_FAN_MODE
+            if DEFAULT_FAN_MODE in self._attr_fan_modes
+            else self._attr_fan_modes[0] if self._attr_fan_modes else None
+        )
+        self._attr_swing_mode = (
+            DEFAULT_SWING_MODE
+            if DEFAULT_SWING_MODE in self._attr_swing_modes
+            else self._attr_swing_modes[0] if self._attr_swing_modes else None
+        )
+        self._attr_target_temperature = DEFAULT_TEMPERATURE
+        self._attr_target_temperature_low = DEFAULT_TEMPERATURE
+        self._attr_target_temperature_high = DEFAULT_TEMPERATURE
+        self._attr_target_humidity = DEFAULT_HUMIDITY
+
+        self._presets_features = TemplateClimateEntityPresetFeature(
+            config[CONF_PRESETS_FEATURES]
+        )
+        self._presets: dict[str, dict[str, Any]] = {}
+        self._off_mode: dict[str, Any] = {}
+        self._last_on_mode: dict[str, Any] = {}
+
+        self._configure_supported_features()
+
+        self.setup_state_template(
+            "_attr_hvac_mode",
+            self._validate_hvac_mode,
+            self._update_hvac_mode_state,
+        )
+        self.setup_template(
+            CONF_PRESET_MODE_TEMPLATE,
+            "_attr_preset_mode",
+            self._validate_preset_mode,
+        )
+        self.setup_template(
+            CONF_FAN_MODE_TEMPLATE,
+            "_attr_fan_mode",
+            self._validate_fan_mode,
+        )
+        self.setup_template(
+            CONF_SWING_MODE_TEMPLATE,
+            "_attr_swing_mode",
+            self._validate_swing_mode,
+        )
+        self.setup_template(
+            CONF_TARGET_TEMPERATURE_TEMPLATE,
+            "_attr_target_temperature",
+            self._validate_target_temperature,
+        )
+        self.setup_template(
+            CONF_TARGET_TEMPERATURE_LOW_TEMPLATE,
+            "_attr_target_temperature_low",
+            self._validate_target_temperature,
+        )
+        self.setup_template(
+            CONF_TARGET_TEMPERATURE_HIGH_TEMPLATE,
+            "_attr_target_temperature_high",
+            self._validate_target_temperature,
+        )
+        self.setup_template(
+            CONF_TARGET_HUMIDITY_TEMPLATE,
+            "_attr_target_humidity",
+            self._validate_target_humidity,
+        )
+        self.setup_template(
+            CONF_CURRENT_TEMPERATURE_TEMPLATE,
+            "_attr_current_temperature",
+            self._validate_current_temperature,
+        )
+        self.setup_template(
+            CONF_CURRENT_HUMIDITY_TEMPLATE,
+            "_attr_current_humidity",
+            self._validate_current_humidity,
+        )
+        self.setup_template(
+            CONF_HVAC_ACTION_TEMPLATE,
+            "_attr_hvac_action",
+            self._validate_hvac_action,
+        )
+        self.setup_template(
+            CONF_PRESETS_TEMPLATE,
+            "_presets",
+            self._validate_presets,
+            render_complex=True,
+        )
+
+        for script_id in SCRIPT_FIELDS:
+            if (action_config := config.get(script_id)) is not None:
+                self._action_scripts[script_id] = Script(
+                    hass,
+                    action_config,
+                    f"{name} {script_id}",
+                    DOMAIN,
+                    script_mode=config[CONF_MODE_ACTION],
+                    max_runs=config[CONF_MAX_ACTION],
+                )
+
+    def _configure_supported_features(self) -> None:
+        """Compute supported features from the configured templates and actions."""
+        if len(self._attr_hvac_modes) >= 2 and HVACMode.OFF in self._attr_hvac_modes:
+            self._off_mode["hvac_mode"] = HVACMode.OFF
+            self._attr_supported_features |= (
+                ClimateEntityFeature.TURN_OFF | ClimateEntityFeature.TURN_ON
+            )
+            self._last_on_mode["hvac_mode"] = next(
+                (
+                    mode
+                    for mode in self._attr_hvac_modes
+                    if mode != self._off_mode["hvac_mode"]
+                ),
+                self._attr_hvac_modes[0],
+            )
+
+        if self._attr_preset_modes:
+            self._attr_supported_features |= ClimateEntityFeature.PRESET_MODE
+        if self._attr_fan_modes:
+            self._attr_supported_features |= ClimateEntityFeature.FAN_MODE
+        if self._attr_swing_modes:
+            self._attr_supported_features |= ClimateEntityFeature.SWING_MODE
+        if HVACMode.HEAT_COOL in self._attr_hvac_modes:
+            self._attr_supported_features |= ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+        if any(
+            mode in self._attr_hvac_modes
+            for mode in (HVACMode.AUTO, HVACMode.HEAT, HVACMode.COOL)
+        ):
+            self._attr_supported_features |= ClimateEntityFeature.TARGET_TEMPERATURE
+        if (
+            CONF_SET_HUMIDITY_ACTION in self._config
+            or CONF_TARGET_HUMIDITY_TEMPLATE in self._config
+            or self._presets_features
+            & TemplateClimateEntityPresetFeature.TARGET_HUMIDITY
+        ):
+            self._attr_supported_features |= ClimateEntityFeature.TARGET_HUMIDITY
+
+    def _validate_choice(self, attribute: str, result: Any, valid: list[str]) -> str | None:
+        """Validate a string value against configured choices."""
+        if template_validators.check_result_for_none(
+            result, none_on_unknown_unavailable=True
+        ):
+            return None
+
+        value = str(result)
+        if value not in valid:
+            template_validators.log_validation_result_error(
+                self, attribute, result, tuple(valid)
+            )
+            return None
+        return value
+
+    def _validate_hvac_mode(self, result: Any) -> HVACMode | None:
+        """Validate the HVAC mode template result."""
+        if template_validators.check_result_for_none(
+            result, none_on_unknown_unavailable=True
+        ):
+            return None
+
+        try:
+            value = HVACMode(str(result).lower().strip())
+        except ValueError:
+            template_validators.log_validation_result_error(
+                self,
+                CONF_HVAC_MODE_TEMPLATE,
+                result,
+                tuple(mode.value for mode in self._attr_hvac_modes),
+            )
+            return None
+
+        if value not in self._attr_hvac_modes:
+            template_validators.log_validation_result_error(
+                self,
+                CONF_HVAC_MODE_TEMPLATE,
+                result,
+                tuple(mode.value for mode in self._attr_hvac_modes),
+            )
+            return None
+        return value
+
+    def _validate_preset_mode(self, result: Any) -> str | None:
+        return self._validate_choice(
+            CONF_PRESET_MODE_TEMPLATE, result, self._attr_preset_modes
+        )
+
+    def _validate_fan_mode(self, result: Any) -> str | None:
+        return self._validate_choice(CONF_FAN_MODE_TEMPLATE, result, self._attr_fan_modes)
+
+    def _validate_swing_mode(self, result: Any) -> str | None:
+        return self._validate_choice(
+            CONF_SWING_MODE_TEMPLATE, result, self._attr_swing_modes
+        )
+
+    def _validate_hvac_action(self, result: Any) -> HVACAction | None:
+        """Validate the HVAC action template result."""
+        if template_validators.check_result_for_none(
+            result, none_on_unknown_unavailable=True
+        ):
+            return None
+
+        try:
+            return HVACAction(str(result).lower().strip())
+        except ValueError:
+            template_validators.log_validation_result_error(
+                self,
+                CONF_HVAC_ACTION_TEMPLATE,
+                result,
+                tuple(action.value for action in HVACAction),
+            )
+            return None
+
+    def _validate_current_temperature(self, result: Any) -> float | None:
+        """Validate a current temperature template result."""
+        if (
+            value := template_validators.number(
+                self, CONF_CURRENT_TEMPERATURE_TEMPLATE
+            )(result)
+        ) is None:
+            return None
+
+        if self.precision == PRECISION_HALVES:
+            return round(float(value) / 0.5) * 0.5
+        if self.precision == PRECISION_TENTHS:
+            return round(float(value), 1)
+        return round(float(value))
+
+    def _validate_target_temperature(self, result: Any) -> float | None:
+        """Validate a target temperature template result."""
+        if (
+            value := template_validators.number(
+                self,
+                CONF_TARGET_TEMPERATURE_TEMPLATE,
+                self._attr_min_temp,
+                self._attr_max_temp,
+            )(result)
+        ) is None:
+            return None
+
+        return (
+            round(float(value) / self._attr_target_temperature_step)
+            * self._attr_target_temperature_step
+        )
+
+    def _validate_current_humidity(self, result: Any) -> int | None:
+        """Validate a current humidity template result."""
+        return template_validators.number(
+            self,
+            CONF_CURRENT_HUMIDITY_TEMPLATE,
+            0,
+            100,
+            int,
+        )(result)
+
+    def _validate_target_humidity(self, result: Any) -> int | None:
+        """Validate a target humidity template result."""
+        return template_validators.number(
+            self,
+            CONF_TARGET_HUMIDITY_TEMPLATE,
+            self._attr_min_humidity,
+            self._attr_max_humidity,
+            int,
+        )(result)
+
+    def _empty_preset(self) -> dict[str, Any]:
+        """Return the default structure for a preset."""
+        preset: dict[str, Any] = {}
+        if self._presets_features & TemplateClimateEntityPresetFeature.HVAC_MODE:
+            preset["hvac_mode"] = None
+        if self._presets_features & TemplateClimateEntityPresetFeature.FAN_MODE:
+            preset["fan_mode"] = None
+        if self._presets_features & TemplateClimateEntityPresetFeature.SWING_MODE:
+            preset["swing_mode"] = None
+        if self._presets_features & TemplateClimateEntityPresetFeature.TARGET_TEMPERATURE:
+            preset["target_temperature"] = None
+        if (
+            self._presets_features
+            & TemplateClimateEntityPresetFeature.TARGET_TEMPERATURE_RANGE
+        ):
+            preset["target_temperature_low"] = None
+            preset["target_temperature_high"] = None
+        if self._presets_features & TemplateClimateEntityPresetFeature.TARGET_HUMIDITY:
+            preset["target_humidity"] = None
+        return preset
+
+    def _validate_presets(self, result: Any) -> dict[str, dict[str, Any]]:
+        """Validate the presets template result."""
+        if template_validators.check_result_for_none(
+            result, none_on_unknown_unavailable=True
+        ):
+            return {}
+
+        if not isinstance(result, dict):
+            template_validators.log_validation_result_error(
+                self, CONF_PRESETS_TEMPLATE, result, "expected a dictionary"
+            )
+            return {}
+
+        validated: dict[str, dict[str, Any]] = {}
+        for mode in self._attr_preset_modes:
+            raw_preset = result.get(mode)
+            preset = self._empty_preset()
+            if not isinstance(raw_preset, dict):
+                validated[mode] = preset
+                continue
+
+            if (
+                self._presets_features & TemplateClimateEntityPresetFeature.HVAC_MODE
+                and (value := raw_preset.get("hvac_mode")) is not None
+            ):
+                preset["hvac_mode"] = self._validate_hvac_mode(value)
+            if (
+                self._presets_features & TemplateClimateEntityPresetFeature.FAN_MODE
+                and (value := raw_preset.get("fan_mode")) is not None
+            ):
+                preset["fan_mode"] = self._validate_choice(
+                    "fan_mode", value, self._attr_fan_modes
+                )
+            if (
+                self._presets_features & TemplateClimateEntityPresetFeature.SWING_MODE
+                and (value := raw_preset.get("swing_mode")) is not None
+            ):
+                preset["swing_mode"] = self._validate_choice(
+                    "swing_mode", value, self._attr_swing_modes
+                )
+            if (
+                self._presets_features
+                & TemplateClimateEntityPresetFeature.TARGET_TEMPERATURE
+                and (value := raw_preset.get("target_temperature")) is not None
+            ):
+                preset["target_temperature"] = self._validate_target_temperature(value)
+            if (
+                self._presets_features
+                & TemplateClimateEntityPresetFeature.TARGET_TEMPERATURE_RANGE
+            ):
+                if (value := raw_preset.get("target_temperature_low")) is not None:
+                    preset["target_temperature_low"] = self._validate_target_temperature(
+                        value
+                    )
+                if (value := raw_preset.get("target_temperature_high")) is not None:
+                    preset["target_temperature_high"] = self._validate_target_temperature(
+                        value
+                    )
+            if (
+                self._presets_features & TemplateClimateEntityPresetFeature.TARGET_HUMIDITY
+                and (value := raw_preset.get("target_humidity")) is not None
+            ):
+                preset["target_humidity"] = self._validate_target_humidity(value)
+            validated[mode] = preset
+
+        return validated
+
+    @callback
+    def _update_hvac_mode_state(self, hvac_mode: HVACMode | None) -> None:
+        """Update the HVAC mode and tracked last-on mode."""
+        self._attr_hvac_mode = hvac_mode
+        if hvac_mode is not None and self._off_mode.get("hvac_mode") != hvac_mode:
+            self._last_on_mode["hvac_mode"] = hvac_mode
+
+    async def _async_restore_state(self) -> None:
+        """Restore state for optimistic climates."""
+        if (last_state := await self.async_get_last_state()) is None:
+            return
+
+        if CONF_HVAC_MODE_TEMPLATE not in self._templates:
+            self._update_hvac_mode_state(self._validate_hvac_mode(last_state.state))
+
+        if (
+            CONF_PRESET_MODE_TEMPLATE not in self._templates
+            and (value := last_state.attributes.get(ATTR_PRESET_MODE)) is not None
+        ):
+            self._attr_preset_mode = self._validate_preset_mode(value)
+
+        if (
+            CONF_FAN_MODE_TEMPLATE not in self._templates
+            and (value := last_state.attributes.get(ATTR_FAN_MODE)) is not None
+        ):
+            self._attr_fan_mode = self._validate_fan_mode(value)
+
+        if (
+            CONF_SWING_MODE_TEMPLATE not in self._templates
+            and (value := last_state.attributes.get(ATTR_SWING_MODE)) is not None
+        ):
+            self._attr_swing_mode = self._validate_swing_mode(value)
+
+        if (
+            CONF_TARGET_TEMPERATURE_TEMPLATE not in self._templates
+            and (value := last_state.attributes.get(ATTR_TEMPERATURE)) is not None
+            and (validated := self._validate_target_temperature(value)) is not None
+        ):
+            self._attr_target_temperature = validated
+
+        if (
+            CONF_TARGET_TEMPERATURE_LOW_TEMPLATE not in self._templates
+            and (value := last_state.attributes.get(ATTR_TARGET_TEMP_LOW)) is not None
+            and (validated := self._validate_target_temperature(value)) is not None
+        ):
+            self._attr_target_temperature_low = validated
+
+        if (
+            CONF_TARGET_TEMPERATURE_HIGH_TEMPLATE not in self._templates
+            and (value := last_state.attributes.get(ATTR_TARGET_TEMP_HIGH)) is not None
+            and (validated := self._validate_target_temperature(value)) is not None
+        ):
+            self._attr_target_temperature_high = validated
+
+        if (
+            CONF_TARGET_HUMIDITY_TEMPLATE not in self._templates
+            and (value := last_state.attributes.get(ATTR_HUMIDITY)) is not None
+            and (validated := self._validate_target_humidity(value)) is not None
+        ):
+            self._attr_target_humidity = validated
+
+        if (
+            CONF_CURRENT_TEMPERATURE_TEMPLATE not in self._templates
+            and (value := last_state.attributes.get(ATTR_CURRENT_TEMPERATURE)) is not None
+            and (validated := self._validate_current_temperature(value)) is not None
+        ):
+            self._attr_current_temperature = validated
+
+        if (
+            CONF_CURRENT_HUMIDITY_TEMPLATE not in self._templates
+            and (value := last_state.attributes.get(ATTR_CURRENT_HUMIDITY)) is not None
+            and (validated := self._validate_current_humidity(value)) is not None
+        ):
+            self._attr_current_humidity = validated
+
+        if (
+            CONF_HVAC_ACTION_TEMPLATE not in self._templates
+            and (value := last_state.attributes.get(ATTR_HVAC_ACTION)) is not None
+        ):
+            self._attr_hvac_action = self._validate_hvac_action(value)
+
+        if (value := last_state.attributes.get("last_on_mode")) and isinstance(value, dict):
+            self._last_on_mode.update(value)
+        if (value := last_state.attributes.get("off_mode")) and isinstance(value, dict):
+            self._off_mode.update(value)
+        if (
+            CONF_PRESETS_TEMPLATE not in self._templates
+            and (value := last_state.attributes.get("presets")) is not None
+        ):
+            self._presets = self._validate_presets(value)
+
+    def _write_state_for(self, template_options: set[str]) -> bool:
+        """Return if local state should be written after an action."""
+        return self._attr_assumed_state or any(
+            option not in self._templates for option in template_options
+        )
+
+    async def _async_run_action(
+        self, script_id: str, variables: dict[str, Any]
+    ) -> None:
+        """Run a configured action script."""
+        if not variables or (script := self._action_scripts.get(script_id)) is None:
+            return
+
+        trigger_context_id = None if self._context is None else self._context.id
+        script_context = Context(parent_id=trigger_context_id)
+        await self.async_run_script(
+            script,
+            run_variables=variables,
+            context=script_context,
+        )
+
+    async def _async_run_presets_action(
+        self, changed_presets: dict[str, dict[str, Any]]
+    ) -> None:
+        """Persist editable preset changes via the optional presets action."""
+        if not changed_presets:
+            return
+
+        await self._async_run_action(
+            CONF_SET_PRESETS_ACTION,
+            {"presets": self._presets, "changed": changed_presets},
+        )
+
+    async def async_turn_off(self) -> None:
+        """Turn the climate off."""
+        if (off_mode := self._off_mode.get("hvac_mode")) is not None:
+            await self.async_set_hvac_mode(off_mode)
+
+    async def async_turn_on(self) -> None:
+        """Turn the climate on."""
+        if (last_on_mode := self._last_on_mode.get("hvac_mode")) is not None:
+            await self.async_set_hvac_mode(last_on_mode)
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set the HVAC mode."""
+        if hvac_mode not in self._attr_hvac_modes:
+            raise ValueError(f"Unsupported HVAC mode: {hvac_mode}")
+
+        self._update_hvac_mode_state(hvac_mode)
+        if self._write_state_for({CONF_HVAC_MODE_TEMPLATE}):
+            self.async_write_ha_state()
+        await self._async_run_action(
+            CONF_SET_HVAC_MODE_ACTION,
+            {ATTR_HVAC_MODE: hvac_mode},
+        )
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set the preset mode."""
+        if preset_mode not in self._attr_preset_modes:
+            raise ValueError(f"Unsupported preset mode: {preset_mode}")
+
+        self._attr_preset_mode = preset_mode
+        if self._write_state_for({CONF_PRESET_MODE_TEMPLATE}):
+            self.async_write_ha_state()
+        await self._async_run_action(
+            CONF_SET_PRESET_MODE_ACTION,
+            {ATTR_PRESET_MODE: preset_mode},
+        )
+
+        if preset_mode in self._presets:
+            await self.async_set_presets(self._presets[preset_mode])
+
+    async def async_set_fan_mode(self, fan_mode: str) -> None:
+        """Set the fan mode."""
+        if fan_mode not in self._attr_fan_modes:
+            raise ValueError(f"Unsupported fan mode: {fan_mode}")
+
+        self._attr_fan_mode = fan_mode
+        if self._write_state_for({CONF_FAN_MODE_TEMPLATE}):
+            self.async_write_ha_state()
+        await self._async_run_action(
+            CONF_SET_FAN_MODE_ACTION,
+            {ATTR_FAN_MODE: fan_mode},
+        )
+
+    async def async_set_swing_mode(self, swing_mode: str) -> None:
+        """Set the swing mode."""
+        if swing_mode not in self._attr_swing_modes:
+            raise ValueError(f"Unsupported swing mode: {swing_mode}")
+
+        self._attr_swing_mode = swing_mode
+        if self._write_state_for({CONF_SWING_MODE_TEMPLATE}):
+            self.async_write_ha_state()
+        await self._async_run_action(
+            CONF_SET_SWING_MODE_ACTION,
+            {ATTR_SWING_MODE: swing_mode},
+        )
+
+    async def async_set_humidity(self, humidity: int) -> None:
+        """Set the target humidity."""
+        validated = self._validate_target_humidity(humidity)
+        if validated is None:
+            raise ValueError(f"Invalid humidity: {humidity}")
+
+        changed_presets: dict[str, dict[str, Any]] = {}
+        self._attr_target_humidity = validated
+        if (
+            self._presets_features & TemplateClimateEntityPresetFeature.EDITABLE
+            and self._attr_preset_mode in self._presets
+            and "target_humidity" in self._presets[self._attr_preset_mode]
+        ):
+            self._presets[self._attr_preset_mode]["target_humidity"] = validated
+            changed_presets[self._attr_preset_mode] = {"target_humidity": validated}
+
+        if self._write_state_for({CONF_TARGET_HUMIDITY_TEMPLATE}):
+            self.async_write_ha_state()
+        await self._async_run_action(
+            CONF_SET_HUMIDITY_ACTION,
+            {ATTR_HUMIDITY: validated},
+        )
+        await self._async_run_presets_action(changed_presets)
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set one or more target temperatures."""
+        run_variables: dict[str, Any] = {}
+        changed_presets: dict[str, dict[str, Any]] = {}
+        template_options: set[str] = set()
+
+        if (hvac_mode := kwargs.get(ATTR_HVAC_MODE)) is not None:
+            if hvac_mode not in self._attr_hvac_modes:
+                raise ValueError(f"Unsupported HVAC mode: {hvac_mode}")
+            self._update_hvac_mode_state(hvac_mode)
+            run_variables[ATTR_HVAC_MODE] = hvac_mode
+            template_options.add(CONF_HVAC_MODE_TEMPLATE)
+            if (
+                self._presets_features & TemplateClimateEntityPresetFeature.EDITABLE
+                and self._attr_preset_mode in self._presets
+                and "hvac_mode" in self._presets[self._attr_preset_mode]
+            ):
+                changed_presets.setdefault(self._attr_preset_mode, {})["hvac_mode"] = hvac_mode
+                self._presets[self._attr_preset_mode]["hvac_mode"] = hvac_mode
+
+        if (target_temperature := kwargs.get(ATTR_TEMPERATURE)) is not None:
+            validated = self._validate_target_temperature(target_temperature)
+            if validated is None:
+                raise ValueError(f"Invalid target temperature: {target_temperature}")
+            self._attr_target_temperature = validated
+            run_variables[ATTR_TEMPERATURE] = validated
+            template_options.add(CONF_TARGET_TEMPERATURE_TEMPLATE)
+            if (
+                self._presets_features & TemplateClimateEntityPresetFeature.EDITABLE
+                and self._attr_preset_mode in self._presets
+                and "target_temperature" in self._presets[self._attr_preset_mode]
+            ):
+                changed_presets.setdefault(self._attr_preset_mode, {})[
+                    "target_temperature"
+                ] = validated
+                self._presets[self._attr_preset_mode]["target_temperature"] = validated
+
+        if (target_temperature_low := kwargs.get(ATTR_TARGET_TEMP_LOW)) is not None:
+            validated = self._validate_target_temperature(target_temperature_low)
+            if validated is None:
+                raise ValueError(
+                    f"Invalid low target temperature: {target_temperature_low}"
+                )
+            self._attr_target_temperature_low = validated
+            run_variables[ATTR_TARGET_TEMP_LOW] = validated
+            template_options.add(CONF_TARGET_TEMPERATURE_LOW_TEMPLATE)
+            if (
+                self._presets_features & TemplateClimateEntityPresetFeature.EDITABLE
+                and self._attr_preset_mode in self._presets
+                and "target_temperature_low" in self._presets[self._attr_preset_mode]
+            ):
+                changed_presets.setdefault(self._attr_preset_mode, {})[
+                    "target_temperature_low"
+                ] = validated
+                self._presets[self._attr_preset_mode]["target_temperature_low"] = (
+                    validated
+                )
+
+        if (target_temperature_high := kwargs.get(ATTR_TARGET_TEMP_HIGH)) is not None:
+            validated = self._validate_target_temperature(target_temperature_high)
+            if validated is None:
+                raise ValueError(
+                    f"Invalid high target temperature: {target_temperature_high}"
+                )
+            self._attr_target_temperature_high = validated
+            run_variables[ATTR_TARGET_TEMP_HIGH] = validated
+            template_options.add(CONF_TARGET_TEMPERATURE_HIGH_TEMPLATE)
+            if (
+                self._presets_features & TemplateClimateEntityPresetFeature.EDITABLE
+                and self._attr_preset_mode in self._presets
+                and "target_temperature_high" in self._presets[self._attr_preset_mode]
+            ):
+                changed_presets.setdefault(self._attr_preset_mode, {})[
+                    "target_temperature_high"
+                ] = validated
+                self._presets[self._attr_preset_mode]["target_temperature_high"] = (
+                    validated
+                )
+
+        if not run_variables:
+            return
+
+        if self._write_state_for(template_options):
+            self.async_write_ha_state()
+        await self._async_run_action(CONF_SET_TEMPERATURE_ACTION, run_variables)
+        await self._async_run_presets_action(changed_presets)
+
+    async def async_set_presets(self, preset: dict[str, Any]) -> None:
+        """Apply values stored in a preset definition."""
+        temperature_data: dict[str, Any] = {}
+        if (value := preset.get("target_temperature")) is not None:
+            temperature_data[ATTR_TEMPERATURE] = value
+        if (value := preset.get("target_temperature_low")) is not None:
+            temperature_data[ATTR_TARGET_TEMP_LOW] = value
+        if (value := preset.get("target_temperature_high")) is not None:
+            temperature_data[ATTR_TARGET_TEMP_HIGH] = value
+        if (value := preset.get("hvac_mode")) is not None:
+            temperature_data[ATTR_HVAC_MODE] = value
+        if temperature_data:
+            await self.async_set_temperature(**temperature_data)
+        elif (value := preset.get("hvac_mode")) is not None:
+            await self.async_set_hvac_mode(value)
+
+        if (value := preset.get("fan_mode")) is not None:
+            await self.async_set_fan_mode(value)
+        if (value := preset.get("swing_mode")) is not None:
+            await self.async_set_swing_mode(value)
+        if (value := preset.get("target_humidity")) is not None:
+            await self.async_set_humidity(value)
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Return the active single target temperature."""
+        if self._attr_hvac_mode == HVACMode.HEAT_COOL:
+            return None
+        return self._attr_target_temperature
+
+    @property
+    def target_temperature_low(self) -> float | None:
+        """Return the low target temperature for range mode."""
+        if self._attr_hvac_mode != HVACMode.HEAT_COOL:
+            return None
+        return self._attr_target_temperature_low
+
+    @property
+    def target_temperature_high(self) -> float | None:
+        """Return the high target temperature for range mode."""
+        if self._attr_hvac_mode != HVACMode.HEAT_COOL:
+            return None
+        return self._attr_target_temperature_high
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return climate-specific extra attributes."""
+        return {
+            "presets": self._presets,
+            "last_on_mode": self._last_on_mode,
+            "off_mode": self._off_mode,
+        }
+
+
+class StateClimateEntity(TemplateEntity, AbstractTemplateClimate):
+    """Representation of a state-based template climate."""
+
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config: ConfigType,
+        unique_id: str | None,
+    ) -> None:
+        """Initialize the state-based template climate."""
+        TemplateEntity.__init__(self, hass, config, unique_id)
+        name = self._attr_name
+        if TYPE_CHECKING:
+            assert name is not None
+        AbstractTemplateClimate.__init__(self, hass, name, config)
+
+    async def async_added_to_hass(self) -> None:
+        """Restore state after entity has been added."""
+        await super().async_added_to_hass()
+        await self._async_restore_state()
+
+
+class TriggerClimateEntity(TriggerEntity, AbstractTemplateClimate):
+    """Representation of a trigger-based template climate."""
+
+    domain = CLIMATE_DOMAIN
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        coordinator: TriggerUpdateCoordinator,
+        config: ConfigType,
+    ) -> None:
+        """Initialize the trigger-based template climate."""
+        TriggerEntity.__init__(self, hass, coordinator, config)
+        self._attr_name = name = self._rendered.get(CONF_NAME, DEFAULT_NAME)
+        AbstractTemplateClimate.__init__(self, hass, name, config)
+
+    async def async_added_to_hass(self) -> None:
+        """Restore state after entity has been added."""
+        await super().async_added_to_hass()
+        await self._async_restore_state()

--- a/homeassistant/components/template/climate.py
+++ b/homeassistant/components/template/climate.py
@@ -154,6 +154,21 @@ class TemplateClimateEntityPresetFeature(IntFlag):
     TARGET_HUMIDITY = 128
 
 
+class TemplateClimateEntityPresetFeatureOptions:
+    """Mapping of preset feature options for template climates."""
+
+    CLIMATE_PRESET_FEATURE_OPTIONS: dict[str, TemplateClimateEntityPresetFeature] = {
+        "editable": TemplateClimateEntityPresetFeature.EDITABLE,
+        "preserved": TemplateClimateEntityPresetFeature.PRESERVED,
+        "hvac_mode": TemplateClimateEntityPresetFeature.HVAC_MODE,
+        "fan_mode": TemplateClimateEntityPresetFeature.FAN_MODE,
+        "swing_mode": TemplateClimateEntityPresetFeature.SWING_MODE,
+        "target_temperature": TemplateClimateEntityPresetFeature.TARGET_TEMPERATURE,
+        "target_temperature_range": TemplateClimateEntityPresetFeature.TARGET_TEMPERATURE_RANGE,
+        "target_humidity": TemplateClimateEntityPresetFeature.TARGET_HUMIDITY,
+    }
+
+
 def _hvac_mode_list(value: Any) -> list[HVACMode]:
     """Validate and coerce a configured HVAC mode list."""
     return [HVACMode(item) for item in cv.ensure_list(value)]
@@ -953,10 +968,13 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
                 )
                 self._presets[self._attr_preset_mode]["hvac_mode"] = hvac_mode
 
-        if (
-            (target_temperature := kwargs.get(ATTR_TEMPERATURE)) is not None
-            and self._attr_supported_features & ClimateEntityFeature.TARGET_TEMPERATURE
-        ):
+        if (target_temperature := kwargs.get(ATTR_TEMPERATURE)) is not None:
+            if (
+                not self._attr_supported_features
+                & ClimateEntityFeature.TARGET_TEMPERATURE
+            ):
+                raise ValueError("Unsupported target temperature")
+
             validated = self._validate_target_temperature(target_temperature)
             if validated is None:
                 raise ValueError(f"Invalid target temperature: {target_temperature}")
@@ -973,11 +991,13 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
                 ] = validated
                 self._presets[self._attr_preset_mode]["target_temperature"] = validated
 
-        if (
-            (target_temperature_low := kwargs.get(ATTR_TARGET_TEMP_LOW)) is not None
-            and self._attr_supported_features
-            & ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
-        ):
+        if (target_temperature_low := kwargs.get(ATTR_TARGET_TEMP_LOW)) is not None:
+            if (
+                not self._attr_supported_features
+                & ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+            ):
+                raise ValueError("Unsupported target temperature range")
+
             validated = self._validate_target_temperature_low(target_temperature_low)
             if validated is None:
                 raise ValueError(
@@ -998,11 +1018,13 @@ class AbstractTemplateClimate(AbstractTemplateEntity, ClimateEntity, RestoreEnti
                     validated
                 )
 
-        if (
-            (target_temperature_high := kwargs.get(ATTR_TARGET_TEMP_HIGH)) is not None
-            and self._attr_supported_features
-            & ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
-        ):
+        if (target_temperature_high := kwargs.get(ATTR_TARGET_TEMP_HIGH)) is not None:
+            if (
+                not self._attr_supported_features
+                & ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+            ):
+                raise ValueError("Unsupported target temperature range")
+
             validated = self._validate_target_temperature_high(target_temperature_high)
             if validated is None:
                 raise ValueError(

--- a/homeassistant/components/template/config.py
+++ b/homeassistant/components/template/config.py
@@ -17,6 +17,7 @@ from homeassistant.components.blueprint import (
     schemas as blueprint_schemas,
 )
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
+from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
 from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
 from homeassistant.components.event import DOMAIN as EVENT_DOMAIN
@@ -59,6 +60,7 @@ from . import (
     alarm_control_panel as alarm_control_panel_platform,
     binary_sensor as binary_sensor_platform,
     button as button_platform,
+    climate as climate_platform,
     cover as cover_platform,
     device_tracker as device_tracker_platform,
     event as event_platform,
@@ -197,6 +199,9 @@ CONFIG_SECTION_SCHEMA = vol.All(
             ),
             vol.Optional(BUTTON_DOMAIN): vol.All(
                 cv.ensure_list, [button_platform.BUTTON_YAML_SCHEMA]
+            ),
+            vol.Optional(CLIMATE_DOMAIN): vol.All(
+                cv.ensure_list, [climate_platform.CLIMATE_YAML_SCHEMA]
             ),
             vol.Optional(COVER_DOMAIN): vol.All(
                 cv.ensure_list, [cover_platform.COVER_YAML_SCHEMA]

--- a/homeassistant/components/template/config_flow.py
+++ b/homeassistant/components/template/config_flow.py
@@ -9,9 +9,9 @@ import voluptuous as vol
 from homeassistant.components import websocket_api
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.button import ButtonDeviceClass
+from homeassistant.components.climate.const import HVACMode
 from homeassistant.components.cover import CoverDeviceClass
 from homeassistant.components.event import EventDeviceClass
-from homeassistant.components.climate.const import HVACMode
 from homeassistant.components.number import NumberDeviceClass
 from homeassistant.components.sensor import (
     CONF_STATE_CLASS,
@@ -88,9 +88,9 @@ from .climate import (
     CONF_TARGET_TEMPERATURE_HIGH_TEMPLATE,
     CONF_TARGET_TEMPERATURE_LOW_TEMPLATE,
     CONF_TARGET_TEMPERATURE_TEMPLATE,
+    CONF_TEMP_STEP,
     CONF_TEMPERATURE_MAX,
     CONF_TEMPERATURE_MIN,
-    CONF_TEMP_STEP,
     async_create_preview_climate,
 )
 from .const import (
@@ -251,11 +251,17 @@ def generate_schema(domain: str, flow_type: str) -> vol.Schema:
     if domain == Platform.CLIMATE:
         schema |= {
             vol.Optional(CONF_HVAC_MODE_TEMPLATE): selector.TemplateSelector(),
-            vol.Optional(CONF_CURRENT_TEMPERATURE_TEMPLATE): selector.TemplateSelector(),
+            vol.Optional(
+                CONF_CURRENT_TEMPERATURE_TEMPLATE
+            ): selector.TemplateSelector(),
             vol.Optional(CONF_CURRENT_HUMIDITY_TEMPLATE): selector.TemplateSelector(),
             vol.Optional(CONF_TARGET_TEMPERATURE_TEMPLATE): selector.TemplateSelector(),
-            vol.Optional(CONF_TARGET_TEMPERATURE_LOW_TEMPLATE): selector.TemplateSelector(),
-            vol.Optional(CONF_TARGET_TEMPERATURE_HIGH_TEMPLATE): selector.TemplateSelector(),
+            vol.Optional(
+                CONF_TARGET_TEMPERATURE_LOW_TEMPLATE
+            ): selector.TemplateSelector(),
+            vol.Optional(
+                CONF_TARGET_TEMPERATURE_HIGH_TEMPLATE
+            ): selector.TemplateSelector(),
             vol.Optional(CONF_TARGET_HUMIDITY_TEMPLATE): selector.TemplateSelector(),
             vol.Optional(CONF_FAN_MODE_TEMPLATE): selector.TemplateSelector(),
             vol.Optional(CONF_PRESET_MODE_TEMPLATE): selector.TemplateSelector(),
@@ -268,7 +274,9 @@ def generate_schema(domain: str, flow_type: str) -> vol.Schema:
             vol.Optional(CONF_SET_FAN_MODE_ACTION): selector.ActionSelector(),
             vol.Optional(CONF_SET_PRESET_MODE_ACTION): selector.ActionSelector(),
             vol.Optional(CONF_SET_SWING_MODE_ACTION): selector.ActionSelector(),
-            vol.Optional(CONF_HVAC_MODE_LIST, default=[HVACMode.OFF, HVACMode.HEAT]): selector.SelectSelector(
+            vol.Optional(
+                CONF_HVAC_MODE_LIST, default=[HVACMode.OFF, HVACMode.HEAT]
+            ): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=[mode.value for mode in HVACMode],
                     multiple=True,
@@ -318,7 +326,9 @@ def generate_schema(domain: str, flow_type: str) -> vol.Schema:
                 )
             ),
             vol.Optional(CONF_TEMP_STEP): selector.NumberSelector(
-                selector.NumberSelectorConfig(mode=selector.NumberSelectorMode.BOX)
+                selector.NumberSelectorConfig(
+                    min=0.1, mode=selector.NumberSelectorMode.BOX
+                )
             ),
             vol.Optional(CONF_PRESETS_FEATURES): selector.NumberSelector(
                 selector.NumberSelectorConfig(

--- a/homeassistant/components/template/config_flow.py
+++ b/homeassistant/components/template/config_flow.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 from homeassistant.components import websocket_api
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.button import ButtonDeviceClass
-from homeassistant.components.climate.const import HVACMode
+from homeassistant.components.climate import HVACMode
 from homeassistant.components.cover import CoverDeviceClass
 from homeassistant.components.event import EventDeviceClass
 from homeassistant.components.number import NumberDeviceClass
@@ -80,6 +80,7 @@ from .climate import (
     CONF_SET_HUMIDITY_ACTION,
     CONF_SET_HVAC_MODE_ACTION,
     CONF_SET_PRESET_MODE_ACTION,
+    CONF_SET_PRESETS_ACTION,
     CONF_SET_SWING_MODE_ACTION,
     CONF_SET_TEMPERATURE_ACTION,
     CONF_SWING_MODE_LIST,
@@ -91,6 +92,7 @@ from .climate import (
     CONF_TEMP_STEP,
     CONF_TEMPERATURE_MAX,
     CONF_TEMPERATURE_MIN,
+    TemplateClimateEntityPresetFeatureOptions,
     async_create_preview_climate,
 )
 from .const import (
@@ -273,6 +275,7 @@ def generate_schema(domain: str, flow_type: str) -> vol.Schema:
             vol.Optional(CONF_SET_HUMIDITY_ACTION): selector.ActionSelector(),
             vol.Optional(CONF_SET_FAN_MODE_ACTION): selector.ActionSelector(),
             vol.Optional(CONF_SET_PRESET_MODE_ACTION): selector.ActionSelector(),
+            vol.Optional(CONF_SET_PRESETS_ACTION): selector.ActionSelector(),
             vol.Optional(CONF_SET_SWING_MODE_ACTION): selector.ActionSelector(),
             vol.Optional(
                 CONF_HVAC_MODE_LIST, default=[HVACMode.OFF.value, HVACMode.HEAT.value]
@@ -330,9 +333,30 @@ def generate_schema(domain: str, flow_type: str) -> vol.Schema:
                     min=0.1, mode=selector.NumberSelectorMode.BOX
                 )
             ),
-            vol.Optional(CONF_PRESETS_FEATURES): selector.NumberSelector(
-                selector.NumberSelectorConfig(
-                    min=0, max=255, step=1, mode=selector.NumberSelectorMode.BOX
+            vol.Optional(CONF_PRESETS_FEATURES): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[
+                        selector.SelectOptionDict(value="editable", label="Editable"),
+                        selector.SelectOptionDict(value="preserved", label="Preserved"),
+                        selector.SelectOptionDict(value="hvac_mode", label="HVAC mode"),
+                        selector.SelectOptionDict(value="fan_mode", label="Fan mode"),
+                        selector.SelectOptionDict(
+                            value="swing_mode", label="Swing mode"
+                        ),
+                        selector.SelectOptionDict(
+                            value="target_temperature",
+                            label="Target temperature",
+                        ),
+                        selector.SelectOptionDict(
+                            value="target_temperature_range",
+                            label="Target temperature range",
+                        ),
+                        selector.SelectOptionDict(
+                            value="target_humidity", label="Target humidity"
+                        ),
+                    ],
+                    multiple=True,
+                    mode=selector.SelectSelectorMode.DROPDOWN,
                 )
             ),
             vol.Optional(CONF_MAX_ACTION): selector.NumberSelector(
@@ -612,6 +636,37 @@ async def choose_options_step(options: dict[str, Any]) -> str:
     return cast(str, options["template_type"])
 
 
+def _normalize_climate_preset_features(user_input: dict[str, Any]) -> None:
+    """Normalize climate preset features from multi-select values to bitmask."""
+    if not isinstance(advanced_options := user_input.get(CONF_ADVANCED_OPTIONS), dict):
+        return
+
+    if (selected := advanced_options.get(CONF_PRESETS_FEATURES)) is None:
+        return
+
+    if isinstance(selected, int):
+        return
+
+    if not isinstance(selected, list):
+        raise vol.Invalid("Invalid presets features")
+
+    bitmask = 0
+    for item in selected:
+        if (
+            not isinstance(item, str)
+            or item
+            not in TemplateClimateEntityPresetFeatureOptions.CLIMATE_PRESET_FEATURE_OPTIONS
+        ):
+            raise vol.Invalid("Invalid presets features")
+        bitmask |= int(
+            TemplateClimateEntityPresetFeatureOptions.CLIMATE_PRESET_FEATURE_OPTIONS[
+                item
+            ]
+        )
+
+    advanced_options[CONF_PRESETS_FEATURES] = bitmask
+
+
 def _validate_unit(options: dict[str, Any]) -> None:
     """Validate unit of measurement."""
     if (
@@ -683,6 +738,8 @@ def validate_user_input(
         if template_type == Platform.SENSOR:
             _validate_unit(user_input)
             _validate_state_class(user_input)
+        if template_type == Platform.CLIMATE:
+            _normalize_climate_preset_features(user_input)
         return {"template_type": template_type} | user_input
 
     return _validate_user_input

--- a/homeassistant/components/template/config_flow.py
+++ b/homeassistant/components/template/config_flow.py
@@ -11,6 +11,7 @@ from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.button import ButtonDeviceClass
 from homeassistant.components.cover import CoverDeviceClass
 from homeassistant.components.event import EventDeviceClass
+from homeassistant.components.climate.const import HVACMode
 from homeassistant.components.number import NumberDeviceClass
 from homeassistant.components.sensor import (
     CONF_STATE_CLASS,
@@ -59,6 +60,39 @@ from .alarm_control_panel import (
     async_create_preview_alarm_control_panel,
 )
 from .binary_sensor import async_create_preview_binary_sensor
+from .climate import (
+    CONF_CURRENT_HUMIDITY_TEMPLATE,
+    CONF_CURRENT_TEMPERATURE_TEMPLATE,
+    CONF_FAN_MODE_LIST,
+    CONF_FAN_MODE_TEMPLATE,
+    CONF_HUMIDITY_MAX,
+    CONF_HUMIDITY_MIN,
+    CONF_HVAC_ACTION_TEMPLATE,
+    CONF_HVAC_MODE_LIST,
+    CONF_HVAC_MODE_TEMPLATE,
+    CONF_MAX_ACTION,
+    CONF_MODE_ACTION,
+    CONF_PRESET_MODE_LIST,
+    CONF_PRESET_MODE_TEMPLATE,
+    CONF_PRESETS_FEATURES,
+    CONF_PRESETS_TEMPLATE,
+    CONF_SET_FAN_MODE_ACTION,
+    CONF_SET_HUMIDITY_ACTION,
+    CONF_SET_HVAC_MODE_ACTION,
+    CONF_SET_PRESET_MODE_ACTION,
+    CONF_SET_SWING_MODE_ACTION,
+    CONF_SET_TEMPERATURE_ACTION,
+    CONF_SWING_MODE_LIST,
+    CONF_SWING_MODE_TEMPLATE,
+    CONF_TARGET_HUMIDITY_TEMPLATE,
+    CONF_TARGET_TEMPERATURE_HIGH_TEMPLATE,
+    CONF_TARGET_TEMPERATURE_LOW_TEMPLATE,
+    CONF_TARGET_TEMPERATURE_TEMPLATE,
+    CONF_TEMPERATURE_MAX,
+    CONF_TEMPERATURE_MIN,
+    CONF_TEMP_STEP,
+    async_create_preview_climate,
+)
 from .const import (
     CONF_ADVANCED_OPTIONS,
     CONF_AVAILABILITY,
@@ -213,6 +247,96 @@ def generate_schema(domain: str, flow_type: str) -> vol.Schema:
                     ),
                 )
             }
+
+    if domain == Platform.CLIMATE:
+        schema |= {
+            vol.Optional(CONF_HVAC_MODE_TEMPLATE): selector.TemplateSelector(),
+            vol.Optional(CONF_CURRENT_TEMPERATURE_TEMPLATE): selector.TemplateSelector(),
+            vol.Optional(CONF_CURRENT_HUMIDITY_TEMPLATE): selector.TemplateSelector(),
+            vol.Optional(CONF_TARGET_TEMPERATURE_TEMPLATE): selector.TemplateSelector(),
+            vol.Optional(CONF_TARGET_TEMPERATURE_LOW_TEMPLATE): selector.TemplateSelector(),
+            vol.Optional(CONF_TARGET_TEMPERATURE_HIGH_TEMPLATE): selector.TemplateSelector(),
+            vol.Optional(CONF_TARGET_HUMIDITY_TEMPLATE): selector.TemplateSelector(),
+            vol.Optional(CONF_FAN_MODE_TEMPLATE): selector.TemplateSelector(),
+            vol.Optional(CONF_PRESET_MODE_TEMPLATE): selector.TemplateSelector(),
+            vol.Optional(CONF_SWING_MODE_TEMPLATE): selector.TemplateSelector(),
+            vol.Optional(CONF_HVAC_ACTION_TEMPLATE): selector.TemplateSelector(),
+            vol.Optional(CONF_PRESETS_TEMPLATE): selector.TemplateSelector(),
+            vol.Optional(CONF_SET_HVAC_MODE_ACTION): selector.ActionSelector(),
+            vol.Optional(CONF_SET_TEMPERATURE_ACTION): selector.ActionSelector(),
+            vol.Optional(CONF_SET_HUMIDITY_ACTION): selector.ActionSelector(),
+            vol.Optional(CONF_SET_FAN_MODE_ACTION): selector.ActionSelector(),
+            vol.Optional(CONF_SET_PRESET_MODE_ACTION): selector.ActionSelector(),
+            vol.Optional(CONF_SET_SWING_MODE_ACTION): selector.ActionSelector(),
+            vol.Optional(CONF_HVAC_MODE_LIST, default=[HVACMode.OFF, HVACMode.HEAT]): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[mode.value for mode in HVACMode],
+                    multiple=True,
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
+            vol.Optional(CONF_PRESET_MODE_LIST): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[],
+                    multiple=True,
+                    custom_value=True,
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
+            vol.Optional(CONF_FAN_MODE_LIST): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[],
+                    multiple=True,
+                    custom_value=True,
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
+            vol.Optional(CONF_SWING_MODE_LIST): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[],
+                    multiple=True,
+                    custom_value=True,
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
+        }
+        advanced_options |= {
+            vol.Optional(CONF_TEMPERATURE_MIN): selector.NumberSelector(
+                selector.NumberSelectorConfig(mode=selector.NumberSelectorMode.BOX)
+            ),
+            vol.Optional(CONF_TEMPERATURE_MAX): selector.NumberSelector(
+                selector.NumberSelectorConfig(mode=selector.NumberSelectorMode.BOX)
+            ),
+            vol.Optional(CONF_HUMIDITY_MIN): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0, max=100, step=1, mode=selector.NumberSelectorMode.BOX
+                )
+            ),
+            vol.Optional(CONF_HUMIDITY_MAX): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0, max=100, step=1, mode=selector.NumberSelectorMode.BOX
+                )
+            ),
+            vol.Optional(CONF_TEMP_STEP): selector.NumberSelector(
+                selector.NumberSelectorConfig(mode=selector.NumberSelectorMode.BOX)
+            ),
+            vol.Optional(CONF_PRESETS_FEATURES): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0, step=1, mode=selector.NumberSelectorMode.BOX
+                )
+            ),
+            vol.Optional(CONF_MAX_ACTION): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=1, step=1, mode=selector.NumberSelectorMode.BOX
+                )
+            ),
+            vol.Optional(CONF_MODE_ACTION): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=["parallel", "queued", "restart", "single"],
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
+        }
 
     if domain == Platform.COVER:
         schema |= _SCHEMA_STATE | {
@@ -558,6 +682,7 @@ TEMPLATE_TYPES = [
     Platform.ALARM_CONTROL_PANEL,
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
+    Platform.CLIMATE,
     Platform.COVER,
     Platform.DEVICE_TRACKER,
     Platform.EVENT,
@@ -589,6 +714,11 @@ CONFIG_FLOW = {
     Platform.BUTTON: SchemaFlowFormStep(
         config_schema(Platform.BUTTON),
         validate_user_input=validate_user_input(Platform.BUTTON),
+    ),
+    Platform.CLIMATE: SchemaFlowFormStep(
+        config_schema(Platform.CLIMATE),
+        preview="template",
+        validate_user_input=validate_user_input(Platform.CLIMATE),
     ),
     Platform.COVER: SchemaFlowFormStep(
         config_schema(Platform.COVER),
@@ -680,6 +810,11 @@ OPTIONS_FLOW = {
         options_schema(Platform.BUTTON),
         validate_user_input=validate_user_input(Platform.BUTTON),
     ),
+    Platform.CLIMATE: SchemaFlowFormStep(
+        options_schema(Platform.CLIMATE),
+        preview="template",
+        validate_user_input=validate_user_input(Platform.CLIMATE),
+    ),
     Platform.COVER: SchemaFlowFormStep(
         options_schema(Platform.COVER),
         preview="template",
@@ -759,6 +894,7 @@ CREATE_PREVIEW_ENTITY: dict[
 ] = {
     Platform.ALARM_CONTROL_PANEL: async_create_preview_alarm_control_panel,
     Platform.BINARY_SENSOR: async_create_preview_binary_sensor,
+    Platform.CLIMATE: async_create_preview_climate,
     Platform.COVER: async_create_preview_cover,
     Platform.DEVICE_TRACKER: async_create_preview_tracker,
     Platform.EVENT: async_create_preview_event,

--- a/homeassistant/components/template/config_flow.py
+++ b/homeassistant/components/template/config_flow.py
@@ -332,7 +332,7 @@ def generate_schema(domain: str, flow_type: str) -> vol.Schema:
             ),
             vol.Optional(CONF_PRESETS_FEATURES): selector.NumberSelector(
                 selector.NumberSelectorConfig(
-                    min=0, step=1, mode=selector.NumberSelectorMode.BOX
+                    min=0, max=255,step=1, mode=selector.NumberSelectorMode.BOX
                 )
             ),
             vol.Optional(CONF_MAX_ACTION): selector.NumberSelector(

--- a/homeassistant/components/template/config_flow.py
+++ b/homeassistant/components/template/config_flow.py
@@ -275,7 +275,7 @@ def generate_schema(domain: str, flow_type: str) -> vol.Schema:
             vol.Optional(CONF_SET_PRESET_MODE_ACTION): selector.ActionSelector(),
             vol.Optional(CONF_SET_SWING_MODE_ACTION): selector.ActionSelector(),
             vol.Optional(
-                CONF_HVAC_MODE_LIST, default=[HVACMode.OFF, HVACMode.HEAT]
+                CONF_HVAC_MODE_LIST, default=[HVACMode.OFF.value, HVACMode.HEAT.value]
             ): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=[mode.value for mode in HVACMode],
@@ -332,7 +332,7 @@ def generate_schema(domain: str, flow_type: str) -> vol.Schema:
             ),
             vol.Optional(CONF_PRESETS_FEATURES): selector.NumberSelector(
                 selector.NumberSelectorConfig(
-                    min=0, max=255,step=1, mode=selector.NumberSelectorMode.BOX
+                    min=0, max=255, step=1, mode=selector.NumberSelectorMode.BOX
                 )
             ),
             vol.Optional(CONF_MAX_ACTION): selector.NumberSelector(

--- a/homeassistant/components/template/config_flow.py
+++ b/homeassistant/components/template/config_flow.py
@@ -672,7 +672,7 @@ def validate_user_input(
     """Do post validation of user input.
 
     For sensors: Validate unit of measurement.
-    For all domaines: Set template type.
+    For all domains: Set template type.
     """
 
     async def _validate_user_input(

--- a/homeassistant/components/template/const.py
+++ b/homeassistant/components/template/const.py
@@ -25,6 +25,7 @@ PLATFORMS = [
     Platform.ALARM_CONTROL_PANEL,
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
+    Platform.CLIMATE,
     Platform.COVER,
     Platform.DEVICE_TRACKER,
     Platform.EVENT,

--- a/tests/components/template/test_climate.py
+++ b/tests/components/template/test_climate.py
@@ -4,6 +4,7 @@ import pytest
 
 from homeassistant.components import climate
 from homeassistant.components.climate import (
+    ATTR_HUMIDITY,
     ATTR_HVAC_MODE,
     ATTR_PRESET_MODE,
     ATTR_TARGET_TEMP_HIGH,
@@ -54,6 +55,17 @@ SET_TEMPERATURE_ACTION = make_test_action(
         ATTR_TARGET_TEMP_LOW: "{{ target_temp_low | default(None) }}",
         ATTR_TARGET_TEMP_HIGH: "{{ target_temp_high | default(None) }}",
         ATTR_HVAC_MODE: "{{ hvac_mode | default(None) }}",
+    },
+)
+SET_HUMIDITY_ACTION = make_test_action(
+    "set_humidity",
+    {ATTR_HUMIDITY: "{{ humidity }}"},
+)
+SET_PRESETS_ACTION = make_test_action(
+    "set_presets",
+    {
+        "presets": "{{ presets }}",
+        "changed": "{{ changed }}",
     },
 )
 
@@ -311,6 +323,52 @@ async def test_set_temperature_action_with_explicit_precision(
 
 
 @pytest.mark.parametrize(
+    ("count", "config"),
+    [
+        (
+            1,
+            {
+                "hvac_modes": [HVACMode.OFF, HVACMode.HEAT],
+                "temp_step": 0.5,
+                **SET_TEMPERATURE_ACTION,
+            },
+        )
+    ],
+)
+@pytest.mark.parametrize(
+    "style",
+    [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
+)
+@pytest.mark.usefixtures("setup_climate")
+async def test_set_temperature_action_rounds_midpoint_up(
+    hass: HomeAssistant,
+    calls: list[ServiceCall],
+) -> None:
+    """Test midpoint temperatures round up to the next configured step."""
+    await hass.services.async_call(
+        climate.DOMAIN,
+        climate.SERVICE_SET_TEMPERATURE,
+        {
+            ATTR_ENTITY_ID: TEST_CLIMATE.entity_id,
+            ATTR_TEMPERATURE: 20.25,
+        },
+        blocking=True,
+    )
+
+    state = hass.states.get(TEST_CLIMATE.entity_id)
+    assert state is not None
+    assert state.attributes[ATTR_TEMPERATURE] == 20.5
+
+    assert_action(
+        TEST_CLIMATE,
+        calls,
+        1,
+        "set_temperature",
+        temperature=20.5,
+    )
+
+
+@pytest.mark.parametrize(
     "style",
     [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
 )
@@ -422,3 +480,182 @@ async def test_apply_preset_with_hvac_mode_only_uses_set_hvac_mode_action(
     assert state.state == HVACMode.HEAT
 
     assert_action(TEST_CLIMATE, calls, 1, "set_hvac_mode", hvac_mode=HVACMode.HEAT)
+
+
+@pytest.mark.parametrize(
+    "style",
+    [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
+)
+async def test_apply_preset_with_unsupported_single_target_temperature_raises(
+    hass: HomeAssistant,
+    style: ConfigurationStyle,
+    calls: list[ServiceCall],
+) -> None:
+    """Test presets cannot apply single target temp when feature is unsupported."""
+    mock_restore_cache(
+        hass,
+        (
+            State(
+                TEST_CLIMATE.entity_id,
+                HVACMode.OFF,
+                {
+                    "presets": {"eco": {"target_temperature": 20}},
+                },
+            ),
+        ),
+    )
+
+    hass.set_state(CoreState.starting)
+    mock_component(hass, "recorder")
+
+    await setup_entity(
+        hass,
+        TEST_CLIMATE,
+        style,
+        1,
+        {
+            "hvac_modes": [HVACMode.OFF, HVACMode.HEAT_COOL],
+            "preset_modes": ["eco"],
+            CONF_PRESETS_FEATURES: TemplateClimateEntityPresetFeature.TARGET_TEMPERATURE,
+            **SET_TEMPERATURE_ACTION,
+        },
+    )
+
+    with pytest.raises(ValueError):
+        await hass.services.async_call(
+            climate.DOMAIN,
+            climate.SERVICE_SET_PRESET_MODE,
+            {ATTR_ENTITY_ID: TEST_CLIMATE.entity_id, ATTR_PRESET_MODE: "eco"},
+            blocking=True,
+        )
+
+    assert len(calls) == 0
+
+
+@pytest.mark.parametrize(
+    "style",
+    [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
+)
+async def test_apply_preset_with_unsupported_target_temperature_range_raises(
+    hass: HomeAssistant,
+    style: ConfigurationStyle,
+    calls: list[ServiceCall],
+) -> None:
+    """Test presets cannot apply target temp range when feature is unsupported."""
+    mock_restore_cache(
+        hass,
+        (
+            State(
+                TEST_CLIMATE.entity_id,
+                HVACMode.OFF,
+                {
+                    "presets": {
+                        "eco": {
+                            "target_temperature_low": 19,
+                            "target_temperature_high": 22,
+                        }
+                    },
+                },
+            ),
+        ),
+    )
+
+    hass.set_state(CoreState.starting)
+    mock_component(hass, "recorder")
+
+    await setup_entity(
+        hass,
+        TEST_CLIMATE,
+        style,
+        1,
+        {
+            "hvac_modes": [HVACMode.OFF, HVACMode.HEAT],
+            "preset_modes": ["eco"],
+            CONF_PRESETS_FEATURES: TemplateClimateEntityPresetFeature.TARGET_TEMPERATURE_RANGE,
+            **SET_TEMPERATURE_ACTION,
+        },
+    )
+
+    with pytest.raises(ValueError):
+        await hass.services.async_call(
+            climate.DOMAIN,
+            climate.SERVICE_SET_PRESET_MODE,
+            {ATTR_ENTITY_ID: TEST_CLIMATE.entity_id, ATTR_PRESET_MODE: "eco"},
+            blocking=True,
+        )
+
+    assert len(calls) == 0
+
+
+@pytest.mark.parametrize(
+    "style",
+    [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
+)
+async def test_set_humidity_updates_editable_preset_and_runs_set_presets_action(
+    hass: HomeAssistant,
+    style: ConfigurationStyle,
+    calls: list[ServiceCall],
+) -> None:
+    """Test setting humidity updates editable preset and runs set_presets action."""
+    mock_restore_cache(
+        hass,
+        (
+            State(
+                TEST_CLIMATE.entity_id,
+                HVACMode.HEAT,
+                {
+                    ATTR_PRESET_MODE: "eco",
+                    "presets": {"eco": {"target_humidity": 45}},
+                },
+            ),
+        ),
+    )
+
+    hass.set_state(CoreState.starting)
+    mock_component(hass, "recorder")
+
+    await setup_entity(
+        hass,
+        TEST_CLIMATE,
+        style,
+        1,
+        {
+            "hvac_modes": [HVACMode.OFF, HVACMode.HEAT],
+            "preset_modes": ["eco"],
+            CONF_PRESETS_FEATURES: (
+                TemplateClimateEntityPresetFeature.EDITABLE
+                | TemplateClimateEntityPresetFeature.TARGET_HUMIDITY
+            ),
+            **SET_HUMIDITY_ACTION,
+            **SET_PRESETS_ACTION,
+        },
+    )
+
+    await hass.services.async_call(
+        climate.DOMAIN,
+        climate.SERVICE_SET_HUMIDITY,
+        {ATTR_ENTITY_ID: TEST_CLIMATE.entity_id, ATTR_HUMIDITY: 55},
+        blocking=True,
+    )
+
+    state = hass.states.get(TEST_CLIMATE.entity_id)
+    assert state is not None
+    assert state.attributes[ATTR_HUMIDITY] == 55
+
+    assert_action(
+        TEST_CLIMATE,
+        calls,
+        2,
+        "set_humidity",
+        index=0,
+        humidity=55,
+    )
+    assert_action(
+        TEST_CLIMATE,
+        calls,
+        2,
+        "set_presets",
+        index=1,
+        presets={"eco": {"target_humidity": 55}},
+        changed={"eco": {"target_humidity": 55}},
+    )

--- a/tests/components/template/test_climate.py
+++ b/tests/components/template/test_climate.py
@@ -5,9 +5,14 @@ import pytest
 from homeassistant.components import climate
 from homeassistant.components.climate.const import (
     ATTR_HVAC_MODE,
+    ATTR_PRESET_MODE,
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
     HVACMode,
+)
+from homeassistant.components.template.climate import (
+    CONF_PRESETS_FEATURES,
+    TemplateClimateEntityPresetFeature,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -17,7 +22,7 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
     STATE_UNKNOWN,
 )
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import CoreState, HomeAssistant, ServiceCall, State
 from homeassistant.helpers.typing import ConfigType
 
 from .conftest import (
@@ -29,6 +34,8 @@ from .conftest import (
     make_test_trigger,
     setup_entity,
 )
+
+from tests.common import mock_component, mock_restore_cache
 
 TEST_STATE_ENTITY_ID = "sensor.test_climate_state"
 TEST_CLIMATE = TemplatePlatformSetup(
@@ -186,9 +193,15 @@ async def test_turn_on_off_uses_last_hvac_mode(
     assert state is not None
     assert state.state == HVACMode.HEAT
 
-    assert_action(TEST_CLIMATE, calls, 3, "set_hvac_mode", index=0, hvac_mode=HVACMode.HEAT)
-    assert_action(TEST_CLIMATE, calls, 3, "set_hvac_mode", index=1, hvac_mode=HVACMode.OFF)
-    assert_action(TEST_CLIMATE, calls, 3, "set_hvac_mode", index=2, hvac_mode=HVACMode.HEAT)
+    assert_action(
+        TEST_CLIMATE, calls, 3, "set_hvac_mode", index=0, hvac_mode=HVACMode.HEAT
+    )
+    assert_action(
+        TEST_CLIMATE, calls, 3, "set_hvac_mode", index=1, hvac_mode=HVACMode.OFF
+    )
+    assert_action(
+        TEST_CLIMATE, calls, 3, "set_hvac_mode", index=2, hvac_mode=HVACMode.HEAT
+    )
 
 
 @pytest.mark.parametrize(
@@ -295,3 +308,117 @@ async def test_set_temperature_action_with_explicit_precision(
         target_temp_high=22.5,
         hvac_mode=HVACMode.HEAT_COOL,
     )
+
+
+@pytest.mark.parametrize(
+    "style",
+    [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
+)
+async def test_restore_turn_on_off_with_string_hvac_mode_attributes(
+    hass: HomeAssistant,
+    style: ConfigurationStyle,
+    calls: list[ServiceCall],
+) -> None:
+    """Test restoring last_on_mode/off_mode with string values works."""
+    mock_restore_cache(
+        hass,
+        (
+            State(
+                TEST_CLIMATE.entity_id,
+                HVACMode.OFF,
+                {
+                    "last_on_mode": {"hvac_mode": HVACMode.HEAT.value},
+                    "off_mode": {"hvac_mode": HVACMode.OFF.value},
+                },
+            ),
+        ),
+    )
+
+    hass.set_state(CoreState.starting)
+    mock_component(hass, "recorder")
+
+    await setup_entity(
+        hass,
+        TEST_CLIMATE,
+        style,
+        1,
+        {"hvac_modes": [HVACMode.OFF, HVACMode.HEAT], **SET_HVAC_MODE_ACTION},
+    )
+
+    await hass.services.async_call(
+        climate.DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: TEST_CLIMATE.entity_id},
+        blocking=True,
+    )
+    await hass.services.async_call(
+        climate.DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: TEST_CLIMATE.entity_id},
+        blocking=True,
+    )
+
+    state = hass.states.get(TEST_CLIMATE.entity_id)
+    assert state is not None
+    assert state.state == HVACMode.OFF
+
+    assert_action(
+        TEST_CLIMATE, calls, 2, "set_hvac_mode", index=0, hvac_mode=HVACMode.HEAT
+    )
+    assert_action(
+        TEST_CLIMATE, calls, 2, "set_hvac_mode", index=1, hvac_mode=HVACMode.OFF
+    )
+
+
+@pytest.mark.parametrize(
+    "style",
+    [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
+)
+async def test_apply_preset_with_hvac_mode_only_uses_set_hvac_mode_action(
+    hass: HomeAssistant,
+    style: ConfigurationStyle,
+    calls: list[ServiceCall],
+) -> None:
+    """Test hvac-only presets route through set_hvac_mode, not set_temperature."""
+    mock_restore_cache(
+        hass,
+        (
+            State(
+                TEST_CLIMATE.entity_id,
+                HVACMode.OFF,
+                {
+                    "presets": {"eco": {"hvac_mode": HVACMode.HEAT.value}},
+                },
+            ),
+        ),
+    )
+
+    hass.set_state(CoreState.starting)
+    mock_component(hass, "recorder")
+
+    await setup_entity(
+        hass,
+        TEST_CLIMATE,
+        style,
+        1,
+        {
+            "hvac_modes": [HVACMode.OFF, HVACMode.HEAT],
+            "preset_modes": ["eco"],
+            CONF_PRESETS_FEATURES: TemplateClimateEntityPresetFeature.HVAC_MODE,
+            **SET_HVAC_MODE_ACTION,
+            **SET_TEMPERATURE_ACTION,
+        },
+    )
+
+    await hass.services.async_call(
+        climate.DOMAIN,
+        climate.SERVICE_SET_PRESET_MODE,
+        {ATTR_ENTITY_ID: TEST_CLIMATE.entity_id, ATTR_PRESET_MODE: "eco"},
+        blocking=True,
+    )
+
+    state = hass.states.get(TEST_CLIMATE.entity_id)
+    assert state is not None
+    assert state.state == HVACMode.HEAT
+
+    assert_action(TEST_CLIMATE, calls, 1, "set_hvac_mode", hvac_mode=HVACMode.HEAT)

--- a/tests/components/template/test_climate.py
+++ b/tests/components/template/test_climate.py
@@ -3,7 +3,7 @@
 import pytest
 
 from homeassistant.components import climate
-from homeassistant.components.climate.const import (
+from homeassistant.components.climate import (
     ATTR_HVAC_MODE,
     ATTR_PRESET_MODE,
     ATTR_TARGET_TEMP_HIGH,

--- a/tests/components/template/test_climate.py
+++ b/tests/components/template/test_climate.py
@@ -1,0 +1,244 @@
+"""Tests for the template climate platform."""
+
+import pytest
+
+from homeassistant.components import climate
+from homeassistant.components.climate.const import (
+    ATTR_HVAC_MODE,
+    ATTR_TARGET_TEMP_HIGH,
+    ATTR_TARGET_TEMP_LOW,
+    HVACMode,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_TEMPERATURE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers.typing import ConfigType
+
+from .conftest import (
+    ConfigurationStyle,
+    TemplatePlatformSetup,
+    assert_action,
+    async_trigger,
+    make_test_action,
+    make_test_trigger,
+    setup_entity,
+)
+
+TEST_STATE_ENTITY_ID = "sensor.test_climate_state"
+TEST_CLIMATE = TemplatePlatformSetup(
+    climate.DOMAIN,
+    "test_template_climate",
+    make_test_trigger(TEST_STATE_ENTITY_ID),
+)
+
+SET_HVAC_MODE_ACTION = make_test_action(
+    "set_hvac_mode", {ATTR_HVAC_MODE: "{{ hvac_mode }}"}
+)
+SET_TEMPERATURE_ACTION = make_test_action(
+    "set_temperature",
+    {
+        ATTR_TEMPERATURE: "{{ temperature }}",
+        ATTR_TARGET_TEMP_LOW: "{{ target_temp_low | default(None) }}",
+        ATTR_TARGET_TEMP_HIGH: "{{ target_temp_high | default(None) }}",
+        ATTR_HVAC_MODE: "{{ hvac_mode | default(None) }}",
+    },
+)
+
+
+@pytest.fixture
+async def setup_climate(
+    hass: HomeAssistant,
+    count: int,
+    style: ConfigurationStyle,
+    config: ConfigType,
+) -> None:
+    """Set up a climate entity."""
+    await setup_entity(hass, TEST_CLIMATE, style, count, config)
+
+
+@pytest.mark.parametrize(
+    ("count", "config"),
+    [
+        (
+            1,
+            {
+                "hvac_mode_template": "{{ states('sensor.test_climate_state') }}",
+                "hvac_modes": [HVACMode.OFF, HVACMode.HEAT],
+            },
+        )
+    ],
+)
+@pytest.mark.parametrize(
+    "style",
+    [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
+)
+@pytest.mark.parametrize(
+    ("source_state", "expected_state"),
+    [
+        (HVACMode.OFF, HVACMode.OFF),
+        (HVACMode.HEAT, HVACMode.HEAT),
+        ("bogus", STATE_UNKNOWN),
+    ],
+)
+@pytest.mark.usefixtures("setup_climate")
+async def test_hvac_mode_template(
+    hass: HomeAssistant,
+    source_state: str,
+    expected_state: str,
+) -> None:
+    """Test the HVAC mode template."""
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, source_state)
+
+    state = hass.states.get(TEST_CLIMATE.entity_id)
+    assert state is not None
+    assert state.state == expected_state
+
+
+@pytest.mark.parametrize(
+    ("count", "config"),
+    [
+        (
+            1,
+            {
+                "hvac_modes": [HVACMode.OFF, HVACMode.HEAT],
+                **SET_HVAC_MODE_ACTION,
+            },
+        )
+    ],
+)
+@pytest.mark.parametrize(
+    "style",
+    [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
+)
+@pytest.mark.usefixtures("setup_climate")
+async def test_set_hvac_mode_action(
+    hass: HomeAssistant,
+    calls: list[ServiceCall],
+) -> None:
+    """Test setting the HVAC mode runs the configured action."""
+    await hass.services.async_call(
+        climate.DOMAIN,
+        climate.SERVICE_SET_HVAC_MODE,
+        {ATTR_ENTITY_ID: TEST_CLIMATE.entity_id, ATTR_HVAC_MODE: HVACMode.HEAT},
+        blocking=True,
+    )
+
+    state = hass.states.get(TEST_CLIMATE.entity_id)
+    assert state is not None
+    assert state.state == HVACMode.HEAT
+    assert_action(
+        TEST_CLIMATE,
+        calls,
+        1,
+        "set_hvac_mode",
+        hvac_mode=HVACMode.HEAT,
+    )
+
+
+@pytest.mark.parametrize(
+    ("count", "config"),
+    [
+        (
+            1,
+            {
+                "hvac_modes": [HVACMode.OFF, HVACMode.HEAT],
+                **SET_HVAC_MODE_ACTION,
+            },
+        )
+    ],
+)
+@pytest.mark.parametrize(
+    "style",
+    [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
+)
+@pytest.mark.usefixtures("setup_climate")
+async def test_turn_on_off_uses_last_hvac_mode(
+    hass: HomeAssistant,
+    calls: list[ServiceCall],
+) -> None:
+    """Test turn on/off reuses the last non-off HVAC mode."""
+    await hass.services.async_call(
+        climate.DOMAIN,
+        climate.SERVICE_SET_HVAC_MODE,
+        {ATTR_ENTITY_ID: TEST_CLIMATE.entity_id, ATTR_HVAC_MODE: HVACMode.HEAT},
+        blocking=True,
+    )
+    await hass.services.async_call(
+        climate.DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: TEST_CLIMATE.entity_id},
+        blocking=True,
+    )
+    await hass.services.async_call(
+        climate.DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: TEST_CLIMATE.entity_id},
+        blocking=True,
+    )
+
+    state = hass.states.get(TEST_CLIMATE.entity_id)
+    assert state is not None
+    assert state.state == HVACMode.HEAT
+
+    assert_action(TEST_CLIMATE, calls, 3, "set_hvac_mode", index=0, hvac_mode=HVACMode.HEAT)
+    assert_action(TEST_CLIMATE, calls, 3, "set_hvac_mode", index=1, hvac_mode=HVACMode.OFF)
+    assert_action(TEST_CLIMATE, calls, 3, "set_hvac_mode", index=2, hvac_mode=HVACMode.HEAT)
+
+
+@pytest.mark.parametrize(
+    ("count", "config"),
+    [
+        (
+            1,
+            {
+                "hvac_modes": [HVACMode.OFF, HVACMode.HEAT, HVACMode.HEAT_COOL],
+                "temp_step": 0.5,
+                **SET_TEMPERATURE_ACTION,
+            },
+        )
+    ],
+)
+@pytest.mark.parametrize(
+    "style",
+    [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
+)
+@pytest.mark.usefixtures("setup_climate")
+async def test_set_temperature_action(
+    hass: HomeAssistant,
+    calls: list[ServiceCall],
+) -> None:
+    """Test setting target temperatures runs the configured action."""
+    await hass.services.async_call(
+        climate.DOMAIN,
+        climate.SERVICE_SET_TEMPERATURE,
+        {
+            ATTR_ENTITY_ID: TEST_CLIMATE.entity_id,
+            ATTR_TEMPERATURE: 20.3,
+            ATTR_TARGET_TEMP_LOW: 18.2,
+            ATTR_TARGET_TEMP_HIGH: 22.6,
+            ATTR_HVAC_MODE: HVACMode.HEAT_COOL,
+        },
+        blocking=True,
+    )
+
+    state = hass.states.get(TEST_CLIMATE.entity_id)
+    assert state is not None
+    assert state.state == HVACMode.HEAT_COOL
+    assert state.attributes[ATTR_TARGET_TEMP_LOW] == 18.0
+    assert state.attributes[ATTR_TARGET_TEMP_HIGH] == 22.5
+
+    assert_action(
+        TEST_CLIMATE,
+        calls,
+        1,
+        "set_temperature",
+        temperature=20.5,
+        target_temp_low=18.0,
+        target_temp_high=22.5,
+        hvac_mode=HVACMode.HEAT_COOL,
+    )

--- a/tests/components/template/test_climate.py
+++ b/tests/components/template/test_climate.py
@@ -12,6 +12,7 @@ from homeassistant.components.climate.const import (
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_TEMPERATURE,
+    PRECISION_WHOLE,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
     STATE_UNKNOWN,
@@ -238,6 +239,58 @@ async def test_set_temperature_action(
         1,
         "set_temperature",
         temperature=20.5,
+        target_temp_low=18.0,
+        target_temp_high=22.5,
+        hvac_mode=HVACMode.HEAT_COOL,
+    )
+
+
+@pytest.mark.parametrize(
+    ("count", "config"),
+    [
+        (
+            1,
+            {
+                "hvac_modes": [HVACMode.OFF, HVACMode.HEAT, HVACMode.HEAT_COOL],
+                "temp_step": 0.5,
+                "precision": PRECISION_WHOLE,
+                **SET_TEMPERATURE_ACTION,
+            },
+        )
+    ],
+)
+@pytest.mark.parametrize(
+    "style",
+    [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
+)
+@pytest.mark.usefixtures("setup_climate")
+async def test_set_temperature_action_with_explicit_precision(
+    hass: HomeAssistant,
+    calls: list[ServiceCall],
+) -> None:
+    """Test explicit precision affects displayed state temperature values."""
+    await hass.services.async_call(
+        climate.DOMAIN,
+        climate.SERVICE_SET_TEMPERATURE,
+        {
+            ATTR_ENTITY_ID: TEST_CLIMATE.entity_id,
+            ATTR_TARGET_TEMP_LOW: 18.2,
+            ATTR_TARGET_TEMP_HIGH: 22.6,
+            ATTR_HVAC_MODE: HVACMode.HEAT_COOL,
+        },
+        blocking=True,
+    )
+
+    state = hass.states.get(TEST_CLIMATE.entity_id)
+    assert state is not None
+    assert state.state == HVACMode.HEAT_COOL
+    assert state.attributes[ATTR_TARGET_TEMP_HIGH] == 22
+
+    assert_action(
+        TEST_CLIMATE,
+        calls,
+        1,
+        "set_temperature",
         target_temp_low=18.0,
         target_temp_high=22.5,
         hvac_mode=HVACMode.HEAT_COOL,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
NO


## Proposed change
<!--
  The proposed change is to implement
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR extends template based integrations by adding climate domain. Implementation is originally based on custom integration created by @jcwillox and maintained by me. It allows for entity to have template based read state / attributes and script / action based write of state / attributes, thus simulating the climate entity fully controllable from UI by generic thermostat card. This PR was preliminary discussed with @Petro31 as a maintainer of the template based integrations.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: TBD after preliminary review
- Link to developer documentation pull request: TBD after preliminary review
- Link to frontend pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

TBD after preliminary review, based on the [current documentation](https://github.com/litinoveweedle/hass-template-climate/blob/main/README.md)

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

N/A

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
