### PR TITLE
feat(climate): add preset_mode to set_temperature service

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -114,6 +114,7 @@ SET_TEMPERATURE_SCHEMA = vol.All(
             vol.Inclusive(ATTR_TARGET_TEMP_HIGH, "temperature"): vol.Coerce(float),
             vol.Inclusive(ATTR_TARGET_TEMP_LOW, "temperature"): vol.Coerce(float),
             vol.Optional(ATTR_HVAC_MODE): vol.Coerce(HVACMode),
+            vol.Optional(ATTR_PRESET_MODE): cv.string,
         }
     ),
 )
@@ -787,6 +788,14 @@ async def async_service_temperature_set(
             translation_domain=DOMAIN,
             translation_key="missing_target_temperature_range_entity_feature",
         )
+    if (
+        ATTR_PRESET_MODE in service_call.data
+        and not entity.supported_features & ClimateEntityFeature.PRESET_MODE
+    ):
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="missing_preset_mode_entity_feature",
+        )
 
     hass = entity.hass
     kwargs: dict[str, Any] = {}
@@ -834,5 +843,18 @@ async def async_service_temperature_set(
                 )
         else:
             kwargs[value] = temp
+
+    if ATTR_PRESET_MODE in kwargs:
+        preset_mode = kwargs[ATTR_PRESET_MODE]
+        if entity.preset_modes and preset_mode not in entity.preset_modes:
+            modes_str = ", ".join(entity.preset_modes)
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="not_valid_preset_mode",
+                translation_placeholders={
+                    "mode": preset_mode,
+                    "modes": modes_str,
+                },
+            )
 
     await entity.async_set_temperature(**kwargs)

--- a/homeassistant/components/climate/services.yaml
+++ b/homeassistant/components/climate/services.yaml
@@ -60,6 +60,13 @@ set_temperature:
           hide_states:
             - unavailable
             - unknown
+    preset_mode:
+      filter:
+        supported_features:
+          - climate.ClimateEntityFeature.PRESET_MODE
+      selector:
+        state:
+          attribute: preset_mode
 set_humidity:
   target:
     entity:

--- a/homeassistant/components/climate/strings.json
+++ b/homeassistant/components/climate/strings.json
@@ -267,6 +267,9 @@
     "low_temp_higher_than_high_temp": {
       "message": "'Lower target temperature' cannot be higher than 'Upper target temperature'."
     },
+    "missing_preset_mode_entity_feature": {
+      "message": "Set temperature action was used with the 'Preset mode' parameter but the entity does not support it."
+    },
     "missing_target_temperature_entity_feature": {
       "message": "Set temperature action was used with the 'Target temperature' parameter but the entity does not support it."
     },
@@ -359,6 +362,10 @@
         "hvac_mode": {
           "description": "HVAC operation mode.",
           "name": "HVAC mode"
+        },
+        "preset_mode": {
+          "description": "Preset mode.",
+          "name": "Preset mode"
         },
         "target_temp_high": {
           "description": "The max temperature setpoint.",

--- a/tests/components/climate/test_init.py
+++ b/tests/components/climate/test_init.py
@@ -144,6 +144,8 @@ class MockClimateEntity(MockEntity, ClimateEntity):
         """Set new target temperature."""
         if ATTR_TEMPERATURE in kwargs:
             self._attr_target_temperature = kwargs[ATTR_TEMPERATURE]
+        if ATTR_PRESET_MODE in kwargs:
+            self._attr_preset_mode = kwargs[ATTR_PRESET_MODE]
         if ATTR_TARGET_TEMP_HIGH in kwargs:
             self._attr_target_temperature_high = kwargs[ATTR_TARGET_TEMP_HIGH]
             self._attr_target_temperature_low = kwargs[ATTR_TARGET_TEMP_LOW]
@@ -734,3 +736,104 @@ async def test_target_temp_high_higher_than_low(
         == "'Lower target temperature' cannot be higher than 'Upper target temperature'"
     )
     assert exc.value.translation_key == "low_temp_higher_than_high_temp"
+
+
+async def test_set_temperature_with_preset_mode(
+    hass: HomeAssistant,
+    register_test_integration: MockConfigEntry,
+) -> None:
+    """Test set_temperature with preset_mode."""
+
+    class MockClimateEntityWithTemp(MockClimateEntity):
+        """Mock climate with TARGET_TEMPERATURE support."""
+
+        _attr_supported_features = (
+            ClimateEntityFeature.FAN_MODE
+            | ClimateEntityFeature.PRESET_MODE
+            | ClimateEntityFeature.SWING_MODE
+            | ClimateEntityFeature.SWING_HORIZONTAL_MODE
+            | ClimateEntityFeature.TARGET_TEMPERATURE
+        )
+        _attr_target_temperature = 20
+
+        def set_temperature(self, **kwargs: Any) -> None:
+            """Set new target temperature."""
+            if ATTR_TEMPERATURE in kwargs:
+                self._attr_target_temperature = kwargs[ATTR_TEMPERATURE]
+            if ATTR_PRESET_MODE in kwargs:
+                self._attr_preset_mode = kwargs[ATTR_PRESET_MODE]
+
+    climate_entity = MockClimateEntityWithTemp(name="test", entity_id="climate.test")
+
+    setup_test_component_platform(
+        hass, DOMAIN, entities=[climate_entity], from_config_entry=True
+    )
+    await hass.config_entries.async_setup(register_test_integration.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("climate.test")
+    assert state.attributes.get(ATTR_PRESET_MODE) == "home"
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_TEMPERATURE,
+        {
+            "entity_id": "climate.test",
+            "temperature": 20.0,
+            "preset_mode": "away",
+        },
+        blocking=True,
+    )
+
+    state = hass.states.get("climate.test")
+    assert state.attributes.get(ATTR_PRESET_MODE) == "away"
+
+    with pytest.raises(ServiceValidationError) as exc:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_TEMPERATURE,
+            {
+                "entity_id": "climate.test",
+                "temperature": 20.0,
+                "preset_mode": "invalid",
+            },
+            blocking=True,
+        )
+    assert exc.value.translation_key == "not_valid_preset_mode"
+
+
+async def test_set_temperature_preset_mode_missing_feature(
+    hass: HomeAssistant,
+    register_test_integration: MockConfigEntry,
+) -> None:
+    """Test set_temperature preset_mode on entity without PRESET_MODE."""
+
+    class MockClimateNoPreset(MockClimateEntity):
+        """Mock climate without preset mode support."""
+
+        _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
+        _attr_target_temperature = 15
+
+    test_climate = MockClimateNoPreset(
+        name="Test",
+        unique_id="unique_climate_test",
+    )
+
+    setup_test_component_platform(
+        hass, DOMAIN, entities=[test_climate], from_config_entry=True
+    )
+    await hass.config_entries.async_setup(register_test_integration.entry_id)
+    await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError) as exc:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_TEMPERATURE,
+            {
+                "entity_id": "climate.test",
+                "temperature": 20.0,
+                "preset_mode": "away",
+            },
+            blocking=True,
+        )
+    assert exc.value.translation_key == "missing_preset_mode_entity_feature"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow setting `preset_mode` via `climate.set_temperature`, so both temperature and preset can be set in a single service call instead of requiring two separate commands. This is useful for IR-controlled climate devices where sending two commands in quick succession can cause signal interference.

**Changes:**
- `services.yaml`: Add `preset_mode` field to `set_temperature`, filtered by `PRESET_MODE` feature
- `__init__.py`: Accept `preset_mode` in schema, validate feature support, validate preset value
- `strings.json`: Add translation strings for new field and error messages
- `test_init.py`: Add tests for set_temperature with preset_mode (valid, invalid, missing feature)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr