### PR TITLE
Add template functions for area temperature and humidity sensors

### DIFF
--- a/homeassistant/helpers/template/extensions/areas.py
+++ b/homeassistant/helpers/template/extensions/areas.py
@@ -62,6 +62,20 @@ class AreaExtension(BaseTemplateExtension):
                     as_filter=True,
                     requires_hass=True,
                 ),
+                TemplateFunction(
+                    "area_temperature_sensor",
+                    self.area_temperature_sensor,
+                    as_global=True,
+                    as_filter=True,
+                    requires_hass=True,
+                ),
+                TemplateFunction(
+                    "area_humidity_sensor",
+                    self.area_humidity_sensor,
+                    as_global=True,
+                    as_filter=True,
+                    requires_hass=True,
+                ),
             ],
         )
 
@@ -157,3 +171,31 @@ class AreaExtension(BaseTemplateExtension):
         dev_reg = dr.async_get(self.hass)
         entries = dr.async_entries_for_area(dev_reg, _area_id)
         return [entry.id for entry in entries]
+
+    def area_temperature_sensor(self, area_id_or_name: str) -> str | None:
+        """Return the temperature sensor entity for a given area ID or name."""
+        # get the area registry
+        area_reg = ar.async_get(self.hass)
+        # check if area_id_or_name is either a valid area ID or name
+        # if so, get the area and return its temperature_entity_id
+        # if not, return None
+        # temperature_entity_id can still be None
+        if (area := area_reg.async_get_area(area_id_or_name)) or (
+            area := area_reg.async_get_area_by_name(area_id_or_name)
+        ):
+            return area.temperature_entity_id
+        return None
+
+    def area_humidity_sensor(self, area_id_or_name: str) -> str | None:
+        """Return the humidity sensor entity for a given area ID or name."""
+        # get the area registry
+        area_reg = ar.async_get(self.hass)
+        # check if area_id_or_name is either a valid area ID or name
+        # if so, get the area and return its humidity_entity_id
+        # if not, return None
+        # humidity_entity_id can still be None
+        if (area := area_reg.async_get_area(area_id_or_name)) or (
+            area := area_reg.async_get_area_by_name(area_id_or_name)
+        ):
+            return area.humidity_entity_id
+        return None

--- a/tests/helpers/template/extensions/test_areas.py
+++ b/tests/helpers/template/extensions/test_areas.py
@@ -380,7 +380,7 @@ async def test_area_humidity_sensor(
     area = area_registry.async_get_or_create("Area")
 
     # Test with no humidity sensor set
-    # Test with invalid area, area name and area id
+    # Test with invalid area, valid area name and valid area id
     for test in [("", None), (area.name, None), (area.id, None)]:
         # Test function
         info = render_to_info(hass, f'{{{{ area_humidity_sensor("{test[0]}") }}}}')
@@ -408,7 +408,7 @@ async def test_area_humidity_sensor(
     area_registry.async_update(area.id, humidity_entity_id=entity_entry.entity_id)
 
     # Test with humidity sensor set
-    # Test with invalid area, area name and area id
+    # Test with invalid area, valid area name and valid area id
     for test in [
         ("", None),
         (area.name, entity_entry.entity_id),

--- a/tests/helpers/template/extensions/test_areas.py
+++ b/tests/helpers/template/extensions/test_areas.py
@@ -310,3 +310,114 @@ async def test_area_devices(
     info = render_to_info(hass, f"{{{{ '{area_entry.name}' | area_devices }}}}")
     assert_result_info(info, [device_entry.id])
     assert info.rate_limit is None
+
+
+async def test_area_temperature_sensor(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test area_temperature_sensor function."""
+
+    config_entry = MockConfigEntry()
+    config_entry.add_to_hass(hass)
+
+    area = area_registry.async_get_or_create("Area")
+
+    # Test with no temperature sensor set
+    # Test with invalid area, area name and area id
+    for test in [("", None), (area.name, None), (area.id, None)]:
+        # Test function
+        info = render_to_info(hass, f'{{{{ area_temperature_sensor("{test[0]}") }}}}')
+        assert_result_info(info, test[1])
+
+        # Test filter
+        info = render_to_info(hass, f'{{{{ "{test[0]}" | area_temperature_sensor }}}}')
+        assert_result_info(info, test[1])
+
+    # Add a temperature sensor
+    entity_entry = entity_registry.async_get_or_create(
+        "sensor",
+        "template",
+        "temperature",
+        config_entry=config_entry,
+    )
+    # Set its state
+    hass.states.async_set(
+        entity_entry.entity_id,
+        "20",
+        {"device_class": "temperature", "unit_of_measurement": "°C"},
+    )
+    # Add it to area
+    area_registry.async_update(area.id, temperature_entity_id=entity_entry.entity_id)
+
+    # Test with temperature sensor set
+    # Test with invalid area, area name and area id
+    for test in [
+        ("", None),
+        (area.name, entity_entry.entity_id),
+        (area.id, entity_entry.entity_id),
+    ]:
+        # Test function
+        info = render_to_info(hass, f'{{{{ area_temperature_sensor("{test[0]}") }}}}')
+        assert_result_info(info, test[1])
+
+        # Test filter
+        info = render_to_info(hass, f'{{{{ "{test[0]}" | area_temperature_sensor }}}}')
+        assert_result_info(info, test[1])
+
+
+async def test_area_humidity_sensor(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test area_humidity_sensor function."""
+
+    config_entry = MockConfigEntry()
+    config_entry.add_to_hass(hass)
+
+    area = area_registry.async_get_or_create("Area")
+
+    # Test with no humidity sensor set
+    # Test with invalid area, area name and area id
+    for test in [("", None), (area.name, None), (area.id, None)]:
+        # Test function
+        info = render_to_info(hass, f'{{{{ area_humidity_sensor("{test[0]}") }}}}')
+        assert_result_info(info, test[1])
+
+        # Test filter
+        info = render_to_info(hass, f'{{{{ "{test[0]}" | area_humidity_sensor }}}}')
+        assert_result_info(info, test[1])
+
+    # Add a humidity sensor
+    entity_entry = entity_registry.async_get_or_create(
+        "sensor",
+        "template",
+        "humidity",
+        config_entry=config_entry,
+        original_device_class="humidity",
+    )
+    # Set its state
+    hass.states.async_set(
+        entity_entry.entity_id,
+        "50",
+        {"device_class": "humidity", "unit_of_measurement": "%"},
+    )
+    # Add it to area
+    area_registry.async_update(area.id, humidity_entity_id=entity_entry.entity_id)
+
+    # Test with humidity sensor set
+    # Test with invalid area, area name and area id
+    for test in [
+        ("", None),
+        (area.name, entity_entry.entity_id),
+        (area.id, entity_entry.entity_id),
+    ]:
+        # Test function
+        info = render_to_info(hass, f'{{{{ area_humidity_sensor("{test[0]}") }}}}')
+        assert_result_info(info, test[1])
+
+        # Test filter
+        info = render_to_info(hass, f'{{{{ "{test[0]}" | area_humidity_sensor }}}}')
+        assert_result_info(info, test[1])

--- a/tests/helpers/template/extensions/test_areas.py
+++ b/tests/helpers/template/extensions/test_areas.py
@@ -330,10 +330,12 @@ async def test_area_temperature_sensor(
         # Test function
         info = render_to_info(hass, f'{{{{ area_temperature_sensor("{test[0]}") }}}}')
         assert_result_info(info, test[1])
+        assert info.rate_limit is None
 
         # Test filter
         info = render_to_info(hass, f'{{{{ "{test[0]}" | area_temperature_sensor }}}}')
         assert_result_info(info, test[1])
+        assert info.rate_limit is None
 
     # Add a temperature sensor
     entity_entry = entity_registry.async_get_or_create(
@@ -361,10 +363,12 @@ async def test_area_temperature_sensor(
         # Test function
         info = render_to_info(hass, f'{{{{ area_temperature_sensor("{test[0]}") }}}}')
         assert_result_info(info, test[1])
+        assert info.rate_limit is None
 
         # Test filter
         info = render_to_info(hass, f'{{{{ "{test[0]}" | area_temperature_sensor }}}}')
         assert_result_info(info, test[1])
+        assert info.rate_limit is None
 
 
 async def test_area_humidity_sensor(
@@ -385,10 +389,12 @@ async def test_area_humidity_sensor(
         # Test function
         info = render_to_info(hass, f'{{{{ area_humidity_sensor("{test[0]}") }}}}')
         assert_result_info(info, test[1])
+        assert info.rate_limit is None
 
         # Test filter
         info = render_to_info(hass, f'{{{{ "{test[0]}" | area_humidity_sensor }}}}')
         assert_result_info(info, test[1])
+        assert info.rate_limit is None
 
     # Add a humidity sensor
     entity_entry = entity_registry.async_get_or_create(
@@ -417,7 +423,9 @@ async def test_area_humidity_sensor(
         # Test function
         info = render_to_info(hass, f'{{{{ area_humidity_sensor("{test[0]}") }}}}')
         assert_result_info(info, test[1])
+        assert info.rate_limit is None
 
         # Test filter
         info = render_to_info(hass, f'{{{{ "{test[0]}" | area_humidity_sensor }}}}')
         assert_result_info(info, test[1])
+        assert info.rate_limit is None

--- a/tests/helpers/template/extensions/test_areas.py
+++ b/tests/helpers/template/extensions/test_areas.py
@@ -352,7 +352,7 @@ async def test_area_temperature_sensor(
     area_registry.async_update(area.id, temperature_entity_id=entity_entry.entity_id)
 
     # Test with temperature sensor set
-    # Test with invalid area, area name and area id
+    # Test with invalid area, valid area name and valid area id
     for test in [
         ("", None),
         (area.name, entity_entry.entity_id),

--- a/tests/helpers/template/extensions/test_areas.py
+++ b/tests/helpers/template/extensions/test_areas.py
@@ -325,7 +325,7 @@ async def test_area_temperature_sensor(
     area = area_registry.async_get_or_create("Area")
 
     # Test with no temperature sensor set
-    # Test with invalid area, area name and area id
+    # Test with invalid area, valid area name and valid area id
     for test in [("", None), (area.name, None), (area.id, None)]:
         # Test function
         info = render_to_info(hass, f'{{{{ area_temperature_sensor("{test[0]}") }}}}')


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Temperature and humidity sensors can already be assigned to areas. However, templating support for this feature was missing. 

This PR adds two news templating functions, `area_temperature_sensor` and `area_humidity_sensor`, which returns the entity ID of the temperature or humidity sensor, respectively, using the area ID or name. If no sensor is configured or the given area is invalid, `None` is returned.

The function names were chosen deliberately to prevent confusion about whether the function returns the sensors entity ID or its value.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45736
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
