### PR TITLE
Unwrap single-item lists for name/area/floor intent slots

### DIFF
--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -869,6 +869,19 @@ def non_empty_string(value: Any) -> str:
     return value_str
 
 
+def _single_value(value: Any) -> Any:
+    """Unwrap a single-item list into its only element.
+
+    Conversation agents backed by an LLM sometimes wrap a scalar slot value in
+    a list, mirroring the shape of the list-valued "domain" slot (for example
+    name: ["Kitchen Light"]). Accept that shape for the name/area/floor slots
+    rather than rejecting an otherwise valid request.
+    """
+    if isinstance(value, list) and len(value) == 1:
+        return value[0]
+    return value
+
+
 @dataclass(kw_only=True)
 class IntentSlotInfo:
     """Details about how intent slots are processed and validated."""
@@ -944,8 +957,8 @@ class DynamicServiceIntentHandler(IntentHandler):
         domain_validator = (
             vol.In(list(self.required_domains)) if self.required_domains else cv.string
         )
-        slot_schema = {
-            vol.Any("name", "area", "floor"): non_empty_string,
+        slot_schema: dict = {
+            vol.Any("name", "area", "floor"): vol.All(_single_value, non_empty_string),
             vol.Optional("domain"): vol.All(cv.ensure_list, [domain_validator]),
         }
         if self.device_classes:

--- a/tests/helpers/test_intent.py
+++ b/tests/helpers/test_intent.py
@@ -849,6 +849,47 @@ async def test_service_handler_empty_strings(hass: HomeAssistant) -> None:
             )
 
 
+async def test_service_handler_single_item_slot_list(hass: HomeAssistant) -> None:
+    """Test that a single-item list slot value is unwrapped before validation."""
+    hass.states.async_set("light.kitchen", "off")
+
+    calls = async_mock_service(hass, "light", "turn_on")
+    handler = intent.ServiceIntentHandler("TestType", "light", "turn_on")
+    intent.async_register(hass, handler)
+
+    # LLMs sometimes wrap a scalar name in a list; it should still match.
+    result = await intent.async_handle(
+        hass,
+        "test",
+        "TestType",
+        slots={"name": {"value": ["kitchen"]}},
+    )
+    assert result.response_type is intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+    assert calls[0].data == {"entity_id": "light.kitchen"}
+
+
+@pytest.mark.parametrize("slot_name", ["name", "area", "floor"])
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(["kitchen", "bedroom"], id="multi-item"),
+        pytest.param([], id="empty"),
+    ],
+)
+async def test_service_handler_invalid_slot_list(
+    hass: HomeAssistant, slot_name: str, value: list[str]
+) -> None:
+    """Test that a list slot value that is not a single item is rejected."""
+    handler = intent.ServiceIntentHandler("TestType", "light", "turn_on")
+    intent.async_register(hass, handler)
+
+    with pytest.raises(intent.InvalidSlotInfo):
+        await intent.async_handle(
+            hass, "test", "TestType", slots={slot_name: {"value": value}}
+        )
+
+
 async def test_service_handler_no_filter(hass: HomeAssistant) -> None:
     """Test that targeting all devices in the house fails."""
     handler = intent.ServiceIntentHandler("TestType", "light", "turn_on")


### PR DESCRIPTION
## Proposed change

As part of benchmarking #172755 - I found that LLM-backed conversation agents sometimes wrap a scalar name/area/floor slot value in a single-item list, mirroring the list-valued domain slot (for example name: ["Kitchen Light"]). That shape failed slot validation with InvalidSlotInfo even though the request was otherwise valid.

Unwrap a single-item list before validation so these requests succeed. Lists with more than one item are still rejected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
