### PR TITLE
Migrate itach to pyitachip2ir2==0.0.8

### DIFF
--- a/homeassistant/components/itach/manifest.json
+++ b/homeassistant/components/itach/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/itach",
   "iot_class": "assumed_state",
   "quality_scale": "legacy",
-  "requirements": ["pyitachip2ir==0.0.7"]
+  "requirements": ["pyitachip2ir2==0.0.8"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2262,7 +2262,7 @@ pyiss==1.0.1
 pyisy==3.6.1
 
 # homeassistant.components.itach
-pyitachip2ir==0.0.7
+pyitachip2ir2==0.0.8
 
 # homeassistant.components.ituran
 pyituran==0.1.5


### PR DESCRIPTION
## Breaking change


## Proposed change

The `itach` integration depends on `pyitachip2ir`, which is no longer maintained (last release `0.0.7`, August 2017). This switches the dependency to `pyitachip2ir2==0.0.8`.

`pyitachip2ir2` is a fork of `pyitachip2ir`. The only change is a fix for compilation on macOS. The public API and the importable module name (`pyitachip2ir`) are identical, so no integration code changes are required.

https://github.com/alanfischer/itachip2ir/compare/alanfischer:2e1f7e355f0a7eef3e7d86f99bef549cd11ad4e7...e36d055

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: `https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure`

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

https://claude.ai/code/session_01UyrBpdLyVdevXuiYQJGu1W

---
_Generated by [Claude Code](https://claude.ai/code/session_01UyrBpdLyVdevXuiYQJGu1W)_