### PR TITLE
Don't log configuration errors when executing WS subscribe_trigger

### DIFF
--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -980,7 +980,24 @@ async def handle_subscribe_trigger(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
 ) -> None:
     """Handle subscribe trigger command."""
-    trigger_config = await async_validate_trigger_config(hass, msg["trigger"])
+    # Validating the trigger config can fail on bad user input. Handle those
+    # errors here so they are reported to the client without being logged as
+    # unexpected errors by the default websocket error handler.
+    try:
+        trigger_config = await async_validate_trigger_config(hass, msg["trigger"])
+    except vol.Invalid as err:
+        connection.send_error(msg["id"], const.ERR_INVALID_FORMAT, str(err))
+        return
+    except HomeAssistantError as err:
+        connection.send_error(
+            msg["id"],
+            const.ERR_HOME_ASSISTANT_ERROR,
+            str(err),
+            translation_domain=err.translation_domain,
+            translation_key=err.translation_key,
+            translation_placeholders=err.translation_placeholders,
+        )
+        return
 
     @callback
     def forward_triggers(

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -2745,6 +2745,95 @@ async def test_subscribe_trigger(
     assert sum(hass.bus.async_listeners().values()) == init_count
 
 
+@pytest.mark.parametrize(
+    ("trigger", "expected_error"),
+    [
+        # Unknown trigger platform
+        (
+            {"platform": "nonexistent"},
+            {
+                "code": "invalid_format",
+                "message": "Invalid trigger 'nonexistent' specified",
+            },
+        ),
+        # Missing mandatory config for the trigger platform
+        (
+            {"platform": "numeric_state"},
+            {
+                "code": "invalid_format",
+                "message": "required key not provided @ data['entity_id']",
+            },
+        ),
+    ],
+)
+async def test_subscribe_trigger_config_error(
+    hass: HomeAssistant,
+    websocket_client: MockHAClientWebSocket,
+    caplog: pytest.LogCaptureFixture,
+    trigger: dict,
+    expected_error: dict,
+) -> None:
+    """Test trigger config errors are reported to the client without logging."""
+    caplog.set_level(logging.ERROR)
+
+    await websocket_client.send_json_auto_id(
+        {"type": "subscribe_trigger", "trigger": trigger}
+    )
+
+    msg = await websocket_client.receive_json()
+    assert msg["type"] == const.TYPE_RESULT
+    assert not msg["success"]
+    assert msg["error"] == expected_error
+
+    # The expected error is not logged by the default websocket error handler
+    assert "Error handling message" not in caplog.text
+
+
+async def test_subscribe_trigger_template_error_spams_log(
+    hass: HomeAssistant,
+    websocket_client: MockHAClientWebSocket,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that a failing trigger template spams the log.
+
+    This documents unwanted behavior. Unlike subscribe_condition and
+    test_condition, subscribe_trigger does not suppress repeated template
+    variable errors: a trigger is evaluated event-driven by its platform (here
+    via async_track_template_result), outside any trace context, so the
+    trace-based suppression used for conditions does not apply. This should be
+    fixed in the future so the error is suppressed/forwarded instead of being
+    logged on every re-render.
+    """
+    caplog.set_level(logging.WARNING)
+    hass.states.async_set("sensor.test", "1")
+
+    await websocket_client.send_json_auto_id(
+        {
+            "type": "subscribe_trigger",
+            "trigger": {
+                "platform": "template",
+                "value_template": "{{ states('sensor.test') }}{{ undefined_variable }}",
+            },
+        }
+    )
+
+    msg = await websocket_client.receive_json()
+    assert msg["type"] == const.TYPE_RESULT
+    assert msg["success"]
+
+    # Each re-render of the template logs the undefined variable error again
+    for state in ("2", "3", "4"):
+        hass.states.async_set("sensor.test", state)
+        await hass.async_block_till_done()
+
+    assert (
+        caplog.text.count(
+            "Template variable warning: 'undefined_variable' is undefined"
+        )
+        > 1
+    )
+
+
 async def test_test_condition(
     hass: HomeAssistant, websocket_client: MockHAClientWebSocket
 ) -> None:

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -2764,6 +2764,14 @@ async def test_subscribe_trigger(
                 "message": "required key not provided @ data['entity_id']",
             },
         ),
+        # Unknown device, raised as a HomeAssistantError by the platform validator
+        (
+            {"platform": "device", "domain": "light", "device_id": "nonexistent"},
+            {
+                "code": "home_assistant_error",
+                "message": "Unknown device 'nonexistent'",
+            },
+        ),
     ],
 )
 async def test_subscribe_trigger_config_error(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Don't log configuration errors when executing WS subscribe_trigger

Same rationale as in https://github.com/home-assistant/core/pull/172897

Note that we can't easily suppress the logs in this case.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
