### PR TITLE
Add hass.states.async_entity_ids to domain constant checker

### DIFF
--- a/pylint/plugins/pylint_home_assistant/checkers/domain_constant.py
+++ b/pylint/plugins/pylint_home_assistant/checkers/domain_constant.py
@@ -6,16 +6,16 @@ from pylint.lint import PyLinter
 
 from pylint_home_assistant.helpers.module_info import is_test_module
 
-_FUNCTION_CHECKS: list[tuple[str, int | None, str]] = [
-    ("async_setup_component", 1, "domain"),
-    ("async_mock_service", 1, "domain"),
-    ("MockConfigEntry", None, "domain"),
+_FUNCTION_CHECKS: list[tuple[str, int | None, str, bool]] = [
+    ("MockConfigEntry", None, "domain", False),
+    ("async_mock_service", 1, "domain", False),
+    ("async_setup_component", 1, "domain", False),
 ]
-_METHOD_CHECKS: list[tuple[str, str, int | None, str]] = [
-    ("hass.services", "async_call", 0, "domain"),
-    ("hass.services", "call", 0, "domain"),
-    ("hass.config_entries.flow", "async_init", 0, "handler"),
-    ("hass.states", "async_entity_ids", 0, "domain"),
+_METHOD_CHECKS: list[tuple[str, str, int | None, str, bool]] = [
+    ("hass.config_entries.flow", "async_init", 0, "handler", False),
+    ("hass.services", "async_call", 0, "domain", False),
+    ("hass.services", "call", 0, "domain", False),
+    ("hass.states", "async_entity_ids", 0, "domain", True),
 ]
 
 _DOMAIN_CONSTANTS: set[str] = {"DOMAIN", "domain"}
@@ -34,19 +34,26 @@ def _check_call_node_domain_arguments(node: nodes.Call) -> nodes.NodeNG | None:
                 method_name,
                 arg_position,
                 kwarg_name,
+                allow_iterable,
             ) in _METHOD_CHECKS:
                 if (
                     node.func.attrname == method_name
                     and node.func.expr.as_string() == method_source
                 ):
                     return _check_call_node_domain_argument(
-                        node, arg_position=arg_position, kwarg_name=kwarg_name
+                        node,
+                        arg_position=arg_position,
+                        kwarg_name=kwarg_name,
+                        allow_iterable=allow_iterable,
                     )
         case nodes.Name():
-            for func_name, arg_position, kwarg_name in _FUNCTION_CHECKS:
+            for func_name, arg_position, kwarg_name, allow_iterable in _FUNCTION_CHECKS:
                 if node.func.name == func_name:
                     return _check_call_node_domain_argument(
-                        node, arg_position=arg_position, kwarg_name=kwarg_name
+                        node,
+                        arg_position=arg_position,
+                        kwarg_name=kwarg_name,
+                        allow_iterable=allow_iterable,
                     )
     return None
 
@@ -54,6 +61,7 @@ def _check_call_node_domain_arguments(node: nodes.Call) -> nodes.NodeNG | None:
 def _check_call_node_domain_argument(
     call_node: nodes.Call,
     *,
+    allow_iterable: bool,
     arg_position: int | None,
     kwarg_name: str,
 ) -> nodes.NodeNG | None:
@@ -73,13 +81,13 @@ def _check_call_node_domain_argument(
             None,
         )
 
-    if argument_node and not _check_domain_argument(argument_node):
+    if argument_node and not _check_domain_argument(argument_node, allow_iterable):
         return argument_node
 
     return None
 
 
-def _check_domain_argument(arg_node: nodes.NodeNG) -> bool:
+def _check_domain_argument(arg_node: nodes.NodeNG, allow_iterable: bool) -> bool:
     """Ensure the argument node is a domain constant or variable.
 
     We allow:
@@ -107,6 +115,12 @@ def _check_domain_argument(arg_node: nodes.NodeNG) -> bool:
         case nodes.Subscript():
             # Ignore subscripts like dict["key"]
             return True
+        case nodes.Tuple():
+            if allow_iterable:
+                return all(
+                    _check_domain_argument(element, allow_iterable=False)
+                    for element in arg_node.elts
+                )
 
     return False
 

--- a/pylint/plugins/pylint_home_assistant/checkers/domain_constant.py
+++ b/pylint/plugins/pylint_home_assistant/checkers/domain_constant.py
@@ -7,11 +7,20 @@ from pylint.lint import PyLinter
 from pylint_home_assistant.helpers.module_info import is_test_module
 
 _FUNCTION_CHECKS: list[tuple[str, int | None, str, bool]] = [
+    # - class/function name
+    # - position of domain argument
+    # - kwarg name for domain argument
+    # - allow iterable
     ("MockConfigEntry", None, "domain", False),
     ("async_mock_service", 1, "domain", False),
     ("async_setup_component", 1, "domain", False),
 ]
 _METHOD_CHECKS: list[tuple[str, str, int | None, str, bool]] = [
+    # - method source
+    # - method name
+    # - position of domain argument
+    # - kwarg name for domain argument
+    # - allow iterable
     ("hass.config_entries.flow", "async_init", 0, "handler", False),
     ("hass.services", "async_call", 0, "domain", False),
     ("hass.services", "call", 0, "domain", False),

--- a/pylint/plugins/pylint_home_assistant/checkers/domain_constant.py
+++ b/pylint/plugins/pylint_home_assistant/checkers/domain_constant.py
@@ -1,30 +1,33 @@
 """Plugin to encourage correct use of DOMAIN constants in tests."""
 
+from dataclasses import dataclass
+
 from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.lint import PyLinter
 
 from pylint_home_assistant.helpers.module_info import is_test_module
 
-_FUNCTION_CHECKS: list[tuple[str, int | None, str, bool]] = [
-    # - class/function name
-    # - position of domain argument
-    # - kwarg name for domain argument
-    # - allow iterable
-    ("MockConfigEntry", None, "domain", False),
-    ("async_mock_service", 1, "domain", False),
-    ("async_setup_component", 1, "domain", False),
+
+@dataclass
+class ArgumentCheckInfo:
+    """Data class for argument check information."""
+
+    position: int | None
+    name: str
+    allow_iterable: bool = False
+
+
+_FUNCTION_CHECKS: list[tuple[str, ArgumentCheckInfo]] = [
+    ("MockConfigEntry", ArgumentCheckInfo(None, "domain")),
+    ("async_mock_service", ArgumentCheckInfo(1, "domain")),
+    ("async_setup_component", ArgumentCheckInfo(1, "domain")),
 ]
-_METHOD_CHECKS: list[tuple[str, str, int | None, str, bool]] = [
-    # - method source
-    # - method name
-    # - position of domain argument
-    # - kwarg name for domain argument
-    # - allow iterable
-    ("hass.config_entries.flow", "async_init", 0, "handler", False),
-    ("hass.services", "async_call", 0, "domain", False),
-    ("hass.services", "call", 0, "domain", False),
-    ("hass.states", "async_entity_ids", 0, "domain", True),
+_METHOD_CHECKS: list[tuple[str, str, ArgumentCheckInfo]] = [
+    ("hass.config_entries.flow", "async_init", ArgumentCheckInfo(0, "handler")),
+    ("hass.services", "async_call", ArgumentCheckInfo(0, "domain")),
+    ("hass.services", "call", ArgumentCheckInfo(0, "domain")),
+    ("hass.states", "async_entity_ids", ArgumentCheckInfo(0, "domain", True)),
 ]
 
 _DOMAIN_CONSTANTS: set[str] = {"DOMAIN", "domain"}
@@ -38,59 +41,41 @@ def _check_call_node_domain_arguments(node: nodes.Call) -> nodes.NodeNG | None:
     """
     match node.func:
         case nodes.Attribute():
-            for (
-                method_source,
-                method_name,
-                arg_position,
-                kwarg_name,
-                allow_iterable,
-            ) in _METHOD_CHECKS:
+            for method_source, method_name, arg_info in _METHOD_CHECKS:
                 if (
                     node.func.attrname == method_name
                     and node.func.expr.as_string() == method_source
                 ):
-                    return _check_call_node_domain_argument(
-                        node,
-                        arg_position=arg_position,
-                        kwarg_name=kwarg_name,
-                        allow_iterable=allow_iterable,
-                    )
+                    return _check_call_node_domain_argument(node, arg_info)
         case nodes.Name():
-            for func_name, arg_position, kwarg_name, allow_iterable in _FUNCTION_CHECKS:
+            for func_name, arg_info in _FUNCTION_CHECKS:
                 if node.func.name == func_name:
-                    return _check_call_node_domain_argument(
-                        node,
-                        arg_position=arg_position,
-                        kwarg_name=kwarg_name,
-                        allow_iterable=allow_iterable,
-                    )
+                    return _check_call_node_domain_argument(node, arg_info)
     return None
 
 
 def _check_call_node_domain_argument(
-    call_node: nodes.Call,
-    *,
-    allow_iterable: bool,
-    arg_position: int | None,
-    kwarg_name: str,
+    call_node: nodes.Call, arg_info: ArgumentCheckInfo
 ) -> nodes.NodeNG | None:
     """Ensure the argument node is a domain constant or variable.
 
     Return None if the argument node is valid, or the argument node if it is invalid.
     """
-    if arg_position is not None and len(call_node.args) > arg_position:
-        argument_node = call_node.args[arg_position]
+    if arg_info.position is not None and len(call_node.args) > arg_info.position:
+        argument_node = call_node.args[arg_info.position]
     else:
         argument_node = next(
             iter(
                 keyword.value
                 for keyword in call_node.keywords
-                if keyword.arg == kwarg_name
+                if keyword.arg == arg_info.name
             ),
             None,
         )
 
-    if argument_node and not _check_domain_argument(argument_node, allow_iterable):
+    if argument_node and not _check_domain_argument(
+        argument_node, arg_info.allow_iterable
+    ):
         return argument_node
 
     return None

--- a/pylint/plugins/pylint_home_assistant/checkers/domain_constant.py
+++ b/pylint/plugins/pylint_home_assistant/checkers/domain_constant.py
@@ -27,7 +27,7 @@ _METHOD_CHECKS: list[tuple[str, str, ArgumentCheckInfo]] = [
     ("hass.config_entries.flow", "async_init", ArgumentCheckInfo(0, "handler")),
     ("hass.services", "async_call", ArgumentCheckInfo(0, "domain")),
     ("hass.services", "call", ArgumentCheckInfo(0, "domain")),
-    ("hass.states", "async_entity_ids", ArgumentCheckInfo(0, "domain", True)),
+    ("hass.states", "async_entity_ids", ArgumentCheckInfo(0, "domain_filter", True)),
 ]
 
 _DOMAIN_CONSTANTS: set[str] = {"DOMAIN", "domain"}

--- a/pylint/plugins/pylint_home_assistant/checkers/domain_constant.py
+++ b/pylint/plugins/pylint_home_assistant/checkers/domain_constant.py
@@ -15,6 +15,7 @@ _METHOD_CHECKS: list[tuple[str, str, int | None, str]] = [
     ("hass.services", "async_call", 0, "domain"),
     ("hass.services", "call", 0, "domain"),
     ("hass.config_entries.flow", "async_init", 0, "handler"),
+    ("hass.states", "async_entity_ids", 0, "domain"),
 ]
 
 _DOMAIN_CONSTANTS: set[str] = {"DOMAIN", "domain"}

--- a/tests/components/adax/test_climate.py
+++ b/tests/components/adax/test_climate.py
@@ -9,12 +9,7 @@ from homeassistant.components.climate import (
     SERVICE_SET_TEMPERATURE,
     HVACMode,
 )
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    ATTR_TEMPERATURE,
-    STATE_UNAVAILABLE,
-    Platform,
-)
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 
 from . import setup_integration
@@ -34,8 +29,8 @@ async def test_climate_cloud(
     await setup_integration(hass, mock_cloud_config_entry)
     mock_adax_cloud.fetch_rooms_info.assert_called_once()
 
-    assert len(hass.states.async_entity_ids(Platform.CLIMATE)) == 1
-    entity_id = hass.states.async_entity_ids(Platform.CLIMATE)[0]
+    assert len(hass.states.async_entity_ids(CLIMATE_DOMAIN)) == 1
+    entity_id = hass.states.async_entity_ids(CLIMATE_DOMAIN)[0]
 
     state = hass.states.get(entity_id)
 
@@ -69,8 +64,8 @@ async def test_climate_local(
     await setup_integration(hass, mock_local_config_entry)
     mock_adax_local.get_status.assert_called_once()
 
-    assert len(hass.states.async_entity_ids(Platform.CLIMATE)) == 1
-    entity_id = hass.states.async_entity_ids(Platform.CLIMATE)[0]
+    assert len(hass.states.async_entity_ids(CLIMATE_DOMAIN)) == 1
+    entity_id = hass.states.async_entity_ids(CLIMATE_DOMAIN)[0]
 
     freezer.tick(SCAN_INTERVAL)
     async_fire_time_changed(hass)
@@ -100,8 +95,8 @@ async def test_climate_local_initial_state_from_first_refresh(
     """Test that local climate state is initialized from first refresh data."""
     await setup_integration(hass, mock_local_config_entry)
 
-    assert len(hass.states.async_entity_ids(Platform.CLIMATE)) == 1
-    entity_id = hass.states.async_entity_ids(Platform.CLIMATE)[0]
+    assert len(hass.states.async_entity_ids(CLIMATE_DOMAIN)) == 1
+    entity_id = hass.states.async_entity_ids(CLIMATE_DOMAIN)[0]
 
     state = hass.states.get(entity_id)
     assert state
@@ -120,8 +115,8 @@ async def test_climate_local_initial_state_off_from_first_refresh(
 
     await setup_integration(hass, mock_local_config_entry)
 
-    assert len(hass.states.async_entity_ids(Platform.CLIMATE)) == 1
-    entity_id = hass.states.async_entity_ids(Platform.CLIMATE)[0]
+    assert len(hass.states.async_entity_ids(CLIMATE_DOMAIN)) == 1
+    entity_id = hass.states.async_entity_ids(CLIMATE_DOMAIN)[0]
 
     state = hass.states.get(entity_id)
     assert state
@@ -138,7 +133,7 @@ async def test_climate_local_set_hvac_mode_updates_state_immediately(
     """Test local hvac mode service updates both device and state immediately."""
     await setup_integration(hass, mock_local_config_entry)
 
-    entity_id = hass.states.async_entity_ids(Platform.CLIMATE)[0]
+    entity_id = hass.states.async_entity_ids(CLIMATE_DOMAIN)[0]
 
     await hass.services.async_call(
         CLIMATE_DOMAIN,
@@ -181,7 +176,7 @@ async def test_climate_local_set_temperature_when_off_does_not_change_hvac_mode(
     """Test setting target temperature while off does not send command or turn on."""
     await setup_integration(hass, mock_local_config_entry)
 
-    entity_id = hass.states.async_entity_ids(Platform.CLIMATE)[0]
+    entity_id = hass.states.async_entity_ids(CLIMATE_DOMAIN)[0]
 
     await hass.services.async_call(
         CLIMATE_DOMAIN,
@@ -219,7 +214,7 @@ async def test_climate_local_set_temperature_when_heat_calls_device(
     """Test setting target temperature while heating calls local API."""
     await setup_integration(hass, mock_local_config_entry)
 
-    entity_id = hass.states.async_entity_ids(Platform.CLIMATE)[0]
+    entity_id = hass.states.async_entity_ids(CLIMATE_DOMAIN)[0]
     state = hass.states.get(entity_id)
     assert state
     assert state.state == HVACMode.HEAT

--- a/tests/components/flipr/test_select.py
+++ b/tests/components/flipr/test_select.py
@@ -85,7 +85,7 @@ async def test_no_select_found(
 
     await setup_integration(hass, mock_config_entry)
 
-    assert not hass.states.async_entity_ids(SELECT_ENTITY_ID)
+    assert not hass.states.get(SELECT_ENTITY_ID)
 
 
 async def test_error_flipr_api(

--- a/tests/components/vizio/test_init.py
+++ b/tests/components/vizio/test_init.py
@@ -6,7 +6,10 @@ from unittest.mock import patch
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
-from homeassistant.components.media_player import MediaPlayerDeviceClass
+from homeassistant.components.media_player import (
+    DOMAIN as MEDIA_PLAYER_DOMAIN,
+    MediaPlayerDeviceClass,
+)
 from homeassistant.components.vizio import DATA_APPS
 from homeassistant.components.vizio.const import DOMAIN
 from homeassistant.const import (
@@ -15,7 +18,6 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
     STATE_UNAVAILABLE,
-    Platform,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -32,12 +34,12 @@ async def test_tv_load_and_unload(
 ) -> None:
     """Test loading and unloading TV entry."""
     await setup_integration(hass, mock_tv_config_entry)
-    assert len(hass.states.async_entity_ids(Platform.MEDIA_PLAYER)) == 1
+    assert len(hass.states.async_entity_ids(MEDIA_PLAYER_DOMAIN)) == 1
     assert DATA_APPS in hass.data
 
     assert await hass.config_entries.async_unload(mock_tv_config_entry.entry_id)
     await hass.async_block_till_done()
-    entities = hass.states.async_entity_ids(Platform.MEDIA_PLAYER)
+    entities = hass.states.async_entity_ids(MEDIA_PLAYER_DOMAIN)
     assert len(entities) == 1
     for entity in entities:
         assert hass.states.get(entity).state == STATE_UNAVAILABLE
@@ -50,11 +52,11 @@ async def test_speaker_load_and_unload(
 ) -> None:
     """Test loading and unloading speaker entry."""
     await setup_integration(hass, mock_speaker_config_entry)
-    assert len(hass.states.async_entity_ids(Platform.MEDIA_PLAYER)) == 1
+    assert len(hass.states.async_entity_ids(MEDIA_PLAYER_DOMAIN)) == 1
 
     assert await hass.config_entries.async_unload(mock_speaker_config_entry.entry_id)
     await hass.async_block_till_done()
-    entities = hass.states.async_entity_ids(Platform.MEDIA_PLAYER)
+    entities = hass.states.async_entity_ids(MEDIA_PLAYER_DOMAIN)
     assert len(entities) == 1
     for entity in entities:
         assert hass.states.get(entity).state == STATE_UNAVAILABLE
@@ -71,7 +73,7 @@ async def test_coordinator_update_failure(
 ) -> None:
     """Test coordinator update failure after 10 days."""
     await setup_integration(hass, mock_tv_config_entry)
-    assert len(hass.states.async_entity_ids(Platform.MEDIA_PLAYER)) == 1
+    assert len(hass.states.async_entity_ids(MEDIA_PLAYER_DOMAIN)) == 1
     assert DATA_APPS in hass.data
 
     # Failing 25 days in a row should result in a single log message
@@ -107,7 +109,7 @@ async def test_apps_coordinator_persists_until_last_tv_unloads(
     config_entry_2.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry_2.entry_id)
     await hass.async_block_till_done()
-    assert len(hass.states.async_entity_ids(Platform.MEDIA_PLAYER)) == 2
+    assert len(hass.states.async_entity_ids(MEDIA_PLAYER_DOMAIN)) == 2
 
     # Unload first TV — coordinator should still be fetching apps
     assert await hass.config_entries.async_unload(mock_tv_config_entry.entry_id)

--- a/tests/pylint/test_domain_constant.py
+++ b/tests/pylint/test_domain_constant.py
@@ -124,6 +124,18 @@ hass.config_entries.flow.async_init(handler=DOMAIN)
         ),
         pytest.param(
             """
+hass.states.async_entity_ids(DOMAIN)
+""",
+            id="async_entity_ids",
+        ),
+        pytest.param(
+            """
+hass.states.async_entity_ids((DOMAIN, SENSOR_DOMAIN))
+""",
+            id="async_entity_ids_tuple",
+        ),
+        pytest.param(
+            """
 some_other_function(hass, "other", {})
 """,
             id="unrelated_function",
@@ -215,6 +227,20 @@ hass.config_entries.flow.async_init(handler=OTHER)
 """,
             ("OTHER", "hass.config_entries.flow.async_init"),
             id="flow_async_init_kwarg",
+        ),
+        pytest.param(
+            """
+hass.states.async_entity_ids(OTHER)
+""",
+            ("OTHER", "hass.states.async_entity_ids"),
+            id="async_entity_ids",
+        ),
+        pytest.param(
+            """
+hass.states.async_entity_ids((DOMAIN, OTHER))
+""",
+            ("(DOMAIN, OTHER)", "hass.states.async_entity_ids"),
+            id="async_entity_ids_tuple",
         ),
     ],
 )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `hass.states.async_entity_ids` to pylint checker introduced in #172693

- `hass.states.async_entity_ids(...)` allows iterable for the domain filter argument, so group the settings into a new `ArgumentCheckInfo` class to hold argument name, argument position and allow_iterable
- reorder the function/method list to follow isort rules

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
