### PR TITLE
Add binary sensor platform to openevse

### DIFF
--- a/homeassistant/components/openevse/__init__.py
+++ b/homeassistant/components/openevse/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from .const import DOMAIN
 from .coordinator import OpenEVSEConfigEntry, OpenEVSEDataUpdateCoordinator
 
-PLATFORMS = [Platform.NUMBER, Platform.SENSOR]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.NUMBER, Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: OpenEVSEConfigEntry) -> bool:

--- a/homeassistant/components/openevse/binary_sensor.py
+++ b/homeassistant/components/openevse/binary_sensor.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-import logging
 
 from openevsehttp.__main__ import OpenEVSE
 
@@ -19,8 +18,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import OpenEVSEConfigEntry, OpenEVSEDataUpdateCoordinator
-
-_LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
 

--- a/homeassistant/components/openevse/binary_sensor.py
+++ b/homeassistant/components/openevse/binary_sensor.py
@@ -11,7 +11,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.const import EntityCategory
+from homeassistant.const import ATTR_CONNECTIONS, ATTR_SERIAL_NUMBER, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -109,11 +109,14 @@ class OpenEVSEBinarySensor(
         self._attr_unique_id = f"{identifier}-{description.key}"
 
         self._attr_device_info = DeviceInfo(
-            connections={(CONNECTION_NETWORK_MAC, unique_id)} if unique_id else None,
             identifiers={(DOMAIN, identifier)},
             manufacturer="OpenEVSE",
-            serial_number=unique_id,
         )
+        if unique_id:
+            self._attr_device_info[ATTR_CONNECTIONS] = {
+                (CONNECTION_NETWORK_MAC, unique_id)
+            }
+            self._attr_device_info[ATTR_SERIAL_NUMBER] = unique_id
 
     @property
     def is_on(self) -> bool | None:

--- a/homeassistant/components/openevse/binary_sensor.py
+++ b/homeassistant/components/openevse/binary_sensor.py
@@ -1,0 +1,124 @@
+"""Support for monitoring an OpenEVSE Charger binary sensors."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import logging
+
+from openevsehttp.__main__ import OpenEVSE
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.const import ATTR_CONNECTIONS, ATTR_SERIAL_NUMBER, EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import OpenEVSEConfigEntry, OpenEVSEDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class OpenEVSEBinarySensorDescription(BinarySensorEntityDescription):
+    """Describes an OpenEVSE binary sensor entity."""
+
+    value_fn: Callable[[OpenEVSE], bool | None]
+
+
+BINARY_SENSOR_TYPES: tuple[OpenEVSEBinarySensorDescription, ...] = (
+    OpenEVSEBinarySensorDescription(
+        key="vehicle",
+        translation_key="vehicle",
+        device_class=BinarySensorDeviceClass.PLUG,
+        value_fn=lambda ev: ev.vehicle,
+    ),
+    OpenEVSEBinarySensorDescription(
+        key="divert_active",
+        translation_key="divert_active",
+        value_fn=lambda ev: ev.divert_active,
+    ),
+    OpenEVSEBinarySensorDescription(
+        key="using_ethernet",
+        translation_key="using_ethernet",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda ev: ev.using_ethernet,
+    ),
+    OpenEVSEBinarySensorDescription(
+        key="shaper_active",
+        translation_key="shaper_active",
+        value_fn=lambda ev: ev.shaper_active,
+    ),
+    OpenEVSEBinarySensorDescription(
+        key="has_limit",
+        translation_key="has_limit",
+        entity_registry_enabled_default=False,
+        value_fn=lambda ev: ev.has_limit,
+    ),
+    OpenEVSEBinarySensorDescription(
+        key="mqtt_connected",
+        translation_key="mqtt_connected",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda ev: ev.mqtt_connected,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: OpenEVSEConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up OpenEVSE binary sensors based on config entry."""
+    coordinator = entry.runtime_data
+    identifier = entry.unique_id or entry.entry_id
+    async_add_entities(
+        OpenEVSEBinarySensor(coordinator, description, identifier, entry.unique_id)
+        for description in BINARY_SENSOR_TYPES
+    )
+
+
+class OpenEVSEBinarySensor(
+    CoordinatorEntity[OpenEVSEDataUpdateCoordinator], BinarySensorEntity
+):
+    """Implementation of an OpenEVSE binary sensor."""
+
+    _attr_has_entity_name = True
+    entity_description: OpenEVSEBinarySensorDescription
+
+    def __init__(
+        self,
+        coordinator: OpenEVSEDataUpdateCoordinator,
+        description: OpenEVSEBinarySensorDescription,
+        identifier: str,
+        unique_id: str | None,
+    ) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{identifier}-{description.key}"
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, identifier)},
+            manufacturer="OpenEVSE",
+        )
+        if unique_id:
+            self._attr_device_info[ATTR_CONNECTIONS] = {
+                (CONNECTION_NETWORK_MAC, unique_id)
+            }
+            self._attr_device_info[ATTR_SERIAL_NUMBER] = unique_id
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if the binary sensor is on."""
+        return self.entity_description.value_fn(self.coordinator.charger)

--- a/homeassistant/components/openevse/binary_sensor.py
+++ b/homeassistant/components/openevse/binary_sensor.py
@@ -47,7 +47,6 @@ BINARY_SENSOR_TYPES: tuple[OpenEVSEBinarySensorDescription, ...] = (
     OpenEVSEBinarySensorDescription(
         key="using_ethernet",
         translation_key="using_ethernet",
-        device_class=BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         value_fn=lambda ev: ev.using_ethernet,

--- a/homeassistant/components/openevse/binary_sensor.py
+++ b/homeassistant/components/openevse/binary_sensor.py
@@ -11,7 +11,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.const import ATTR_CONNECTIONS, ATTR_SERIAL_NUMBER, EntityCategory
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -109,14 +109,11 @@ class OpenEVSEBinarySensor(
         self._attr_unique_id = f"{identifier}-{description.key}"
 
         self._attr_device_info = DeviceInfo(
+            connections={(CONNECTION_NETWORK_MAC, unique_id)} if unique_id else None,
             identifiers={(DOMAIN, identifier)},
             manufacturer="OpenEVSE",
+            serial_number=unique_id,
         )
-        if unique_id:
-            self._attr_device_info[ATTR_CONNECTIONS] = {
-                (CONNECTION_NETWORK_MAC, unique_id)
-            }
-            self._attr_device_info[ATTR_SERIAL_NUMBER] = unique_id
 
     @property
     def is_on(self) -> bool | None:

--- a/homeassistant/components/openevse/binary_sensor.py
+++ b/homeassistant/components/openevse/binary_sensor.py
@@ -1,4 +1,4 @@
-"""Support for monitoring an OpenEVSE Charger binary sensors."""
+"""Support for monitoring OpenEVSE Charger binary sensors."""
 
 from collections.abc import Callable
 from dataclasses import dataclass

--- a/homeassistant/components/openevse/strings.json
+++ b/homeassistant/components/openevse/strings.json
@@ -42,6 +42,26 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "divert_active": {
+        "name": "Divert active"
+      },
+      "has_limit": {
+        "name": "Limit active"
+      },
+      "mqtt_connected": {
+        "name": "MQTT connected"
+      },
+      "shaper_active": {
+        "name": "Shaper active"
+      },
+      "using_ethernet": {
+        "name": "Ethernet connected"
+      },
+      "vehicle": {
+        "name": "Vehicle connected"
+      }
+    },
     "number": {
       "charge_rate": {
         "name": "Charge rate"

--- a/tests/components/openevse/conftest.py
+++ b/tests/components/openevse/conftest.py
@@ -90,6 +90,12 @@ def mock_charger() -> Generator[MagicMock]:
         # System diagnostic sensors
         charger.uptime = 86400  # 1 day in seconds
         charger.freeram = 50000
+        # Binary sensors
+        charger.divert_active = False
+        charger.using_ethernet = False
+        charger.shaper_active = False
+        charger.has_limit = False
+        charger.mqtt_connected = False
         yield charger
 
 

--- a/tests/components/openevse/conftest.py
+++ b/tests/components/openevse/conftest.py
@@ -38,7 +38,6 @@ def mock_charger() -> Generator[MagicMock]:
         charger.callback = None
         # Status sensors
         charger.status = "Charging"
-        charger.vehicle = True
         charger.mode = "STA"
         charger.charge_mode = "fast"
         charger.divertmode = "normal"
@@ -91,6 +90,7 @@ def mock_charger() -> Generator[MagicMock]:
         charger.uptime = 86400  # 1 day in seconds
         charger.freeram = 50000
         # Binary sensors
+        charger.vehicle = True
         charger.divert_active = False
         charger.using_ethernet = False
         charger.shaper_active = False

--- a/tests/components/openevse/snapshots/test_binary_sensor.ambr
+++ b/tests/components/openevse/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,304 @@
+# serializer version: 1
+# name: test_entities[binary_sensor.openevse_mock_config_divert_active-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.openevse_mock_config_divert_active',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Divert active',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Divert active',
+    'platform': 'openevse',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'divert_active',
+    'unique_id': 'deadbeeffeed-divert_active',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.openevse_mock_config_divert_active-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'openevse_mock_config Divert active',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.openevse_mock_config_divert_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[binary_sensor.openevse_mock_config_ethernet_connected-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.openevse_mock_config_ethernet_connected',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Ethernet connected',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'Ethernet connected',
+    'platform': 'openevse',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'using_ethernet',
+    'unique_id': 'deadbeeffeed-using_ethernet',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.openevse_mock_config_ethernet_connected-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': 'openevse_mock_config Ethernet connected',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.openevse_mock_config_ethernet_connected',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[binary_sensor.openevse_mock_config_limit_active-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.openevse_mock_config_limit_active',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Limit active',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Limit active',
+    'platform': 'openevse',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'has_limit',
+    'unique_id': 'deadbeeffeed-has_limit',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.openevse_mock_config_limit_active-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'openevse_mock_config Limit active',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.openevse_mock_config_limit_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[binary_sensor.openevse_mock_config_mqtt_connected-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.openevse_mock_config_mqtt_connected',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'MQTT connected',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'MQTT connected',
+    'platform': 'openevse',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'mqtt_connected',
+    'unique_id': 'deadbeeffeed-mqtt_connected',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.openevse_mock_config_mqtt_connected-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': 'openevse_mock_config MQTT connected',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.openevse_mock_config_mqtt_connected',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[binary_sensor.openevse_mock_config_shaper_active-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.openevse_mock_config_shaper_active',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Shaper active',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Shaper active',
+    'platform': 'openevse',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'shaper_active',
+    'unique_id': 'deadbeeffeed-shaper_active',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.openevse_mock_config_shaper_active-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'openevse_mock_config Shaper active',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.openevse_mock_config_shaper_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[binary_sensor.openevse_mock_config_vehicle_connected-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.openevse_mock_config_vehicle_connected',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Vehicle connected',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PLUG: 'plug'>,
+    'original_icon': None,
+    'original_name': 'Vehicle connected',
+    'platform': 'openevse',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'vehicle',
+    'unique_id': 'deadbeeffeed-vehicle',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.openevse_mock_config_vehicle_connected-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'openevse_mock_config Vehicle connected',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.openevse_mock_config_vehicle_connected',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/openevse/snapshots/test_binary_sensor.ambr
+++ b/tests/components/openevse/snapshots/test_binary_sensor.ambr
@@ -74,7 +74,7 @@
     'object_id_base': 'Ethernet connected',
     'options': dict({
     }),
-    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_device_class': None,
     'original_icon': None,
     'original_name': 'Ethernet connected',
     'platform': 'openevse',
@@ -89,7 +89,6 @@
 # name: test_entities[binary_sensor.openevse_mock_config_ethernet_connected-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'connectivity',
       'friendly_name': 'openevse_mock_config Ethernet connected',
     }),
     'context': <ANY>,

--- a/tests/components/openevse/test_binary_sensor.py
+++ b/tests/components/openevse/test_binary_sensor.py
@@ -1,7 +1,9 @@
 """Tests for the OpenEVSE binary sensor platform."""
 
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -9,7 +11,7 @@ from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from tests.common import MockConfigEntry, snapshot_platform
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -93,6 +95,7 @@ async def test_missing_sensor_graceful_handling(
 
 async def test_binary_sensor_unavailable_on_coordinator_timeout(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
     mock_config_entry: MockConfigEntry,
     mock_charger: MagicMock,
 ) -> None:
@@ -107,7 +110,8 @@ async def test_binary_sensor_unavailable_on_coordinator_timeout(
     assert state.state != STATE_UNAVAILABLE
 
     mock_charger.update.side_effect = TimeoutError("Connection timed out")
-    await mock_config_entry.runtime_data.async_refresh()
+    freezer.tick(timedelta(minutes=5))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.openevse_mock_config_vehicle_connected")

--- a/tests/components/openevse/test_binary_sensor.py
+++ b/tests/components/openevse/test_binary_sensor.py
@@ -1,0 +1,115 @@
+"""Tests for the OpenEVSE binary sensor platform."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_entities(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    mock_config_entry: MockConfigEntry,
+    mock_charger: MagicMock,
+) -> None:
+    """Test the binary sensor entities."""
+    with patch("homeassistant.components.openevse.PLATFORMS", [Platform.BINARY_SENSOR]):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_disabled_by_default_entities(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_charger: MagicMock,
+) -> None:
+    """Test the disabled by default binary sensor entities."""
+    with patch("homeassistant.components.openevse.PLATFORMS", [Platform.BINARY_SENSOR]):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    state = hass.states.get("binary_sensor.openevse_mock_config_ethernet_connected")
+    assert state is None
+
+    entry = entity_registry.async_get(
+        "binary_sensor.openevse_mock_config_ethernet_connected"
+    )
+    assert entry
+    assert entry.disabled
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+
+    state = hass.states.get("binary_sensor.openevse_mock_config_limit_active")
+    assert state is None
+
+    entry = entity_registry.async_get("binary_sensor.openevse_mock_config_limit_active")
+    assert entry
+    assert entry.disabled
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+
+    state = hass.states.get("binary_sensor.openevse_mock_config_mqtt_connected")
+    assert state is None
+
+    entry = entity_registry.async_get(
+        "binary_sensor.openevse_mock_config_mqtt_connected"
+    )
+    assert entry
+    assert entry.disabled
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+
+
+async def test_missing_sensor_graceful_handling(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_charger: MagicMock,
+) -> None:
+    """Test that missing binary sensor attributes are handled gracefully."""
+    mock_charger.shaper_active = None
+
+    with patch("homeassistant.components.openevse.PLATFORMS", [Platform.BINARY_SENSOR]):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    # The binary sensor with missing attribute should be unknown
+    state = hass.states.get("binary_sensor.openevse_mock_config_shaper_active")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+    # Other binary sensors should still work
+    state = hass.states.get("binary_sensor.openevse_mock_config_vehicle_connected")
+    assert state is not None
+    assert state.state == "on"
+
+
+async def test_binary_sensor_unavailable_on_coordinator_timeout(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_charger: MagicMock,
+) -> None:
+    """Test binary sensors become unavailable when coordinator times out."""
+    with patch("homeassistant.components.openevse.PLATFORMS", [Platform.BINARY_SENSOR]):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.openevse_mock_config_vehicle_connected")
+    assert state
+    assert state.state != STATE_UNAVAILABLE
+
+    mock_charger.update.side_effect = TimeoutError("Connection timed out")
+    await mock_config_entry.runtime_data.async_refresh()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.openevse_mock_config_vehicle_connected")
+    assert state
+    assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add the `binary_sensor` platform to the OpenEVSE integration. This exposes the following binary sensors:
- `vehicle` (Vehicle Connected)
- `divert_active` (Divert Active)
- `using_ethernet` (Ethernet Connected)
- `shaper_active` (Shaper Active)
- `has_limit` (Limit Active)
- `mqtt_connected` (MQTT Connected)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45733
- Link to developer documentation pull request:
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
