### PR TITLE
Fix Pi-hole v6 authentication detection

### DIFF
--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -32,6 +32,7 @@ from .coordinator import PiHoleConfigEntry, PiHoleData, PiHoleUpdateCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 DATA_V6_CLIENTSESSIONS = f"{DOMAIN}_v6_clientsessions"
+V6_API_RESPONSE_EXCEPTIONS = (aiohttp.ContentTypeError, ValueError)
 
 
 PLATFORMS = [
@@ -166,7 +167,10 @@ def _async_get_v6_session(
 
         @callback
         def _close(_event: Event) -> None:
-            session.detach()
+            if sessions.get(verify_ssl) is not session:
+                return
+            if not session.closed:
+                session.detach()
             sessions.pop(verify_ssl, None)
 
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_CLOSE, _close)
@@ -185,7 +189,7 @@ async def _async_v6_api_authentication_required(
         async with session.get(url) as response:
             try:
                 data: Any = await response.json()
-            except aiohttp.ContentTypeError, ValueError:
+            except V6_API_RESPONSE_EXCEPTIONS:
                 return None
 
             if not isinstance(data, dict):

--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -1,13 +1,14 @@
 """The pi_hole component."""
 
-import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 import logging
 from typing import Any, Literal
 
 import aiohttp
 from aiohttp import DummyCookieJar
 from hole import Hole, HoleV5, HoleV6
-from hole.exceptions import HoleConnectionError, HoleError
+from hole.exceptions import HoleAuthenticationError, HoleConnectionError, HoleError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -16,10 +17,9 @@ from homeassistant.const import (
     CONF_LOCATION,
     CONF_SSL,
     CONF_VERIFY_SSL,
-    EVENT_HOMEASSISTANT_CLOSE,
     Platform,
 )
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import (
     async_create_clientsession,
@@ -30,10 +30,6 @@ from .const import CONF_STATISTICS_ONLY, DOMAIN
 from .coordinator import PiHoleConfigEntry, PiHoleData, PiHoleUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
-
-DATA_V6_CLIENTSESSIONS = f"{DOMAIN}_v6_clientsessions"
-V6_API_RESPONSE_EXCEPTIONS = (aiohttp.ContentTypeError, ValueError)
-
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
@@ -115,6 +111,7 @@ def api_by_version(
     entry: dict[str, Any],
     version: int,
     password: str | None = None,
+    session: aiohttp.ClientSession | None = None,
 ) -> HoleV5 | HoleV6:
     """Create a pi-hole API object by API version number.
 
@@ -124,7 +121,7 @@ def api_by_version(
     if password is None:
         password = entry.get(CONF_API_KEY, "")
     if version == 6:
-        session = _async_get_v6_session(hass, entry[CONF_VERIFY_SSL])
+        session = session or _async_create_v6_session(hass, entry[CONF_VERIFY_SSL])
     else:
         session = async_get_clientsession(hass, entry[CONF_VERIFY_SSL])
     hole_kwargs = {
@@ -145,72 +142,46 @@ def api_by_version(
 
 
 @callback
-def _async_get_v6_session(
-    hass: HomeAssistant, verify_ssl: bool
+def _async_create_v6_session(
+    hass: HomeAssistant, verify_ssl: bool, *, auto_cleanup: bool = True
 ) -> aiohttp.ClientSession:
-    """Get a session with an isolated cookie jar for the Pi-hole v6 API.
-
-    The session opts out of the auto-cleanup tied to the current config entry,
-    since the cache is shared across entries — otherwise the first entry to
-    unload would detach a session still in use by the others. Lifetime is
-    bound to Home Assistant shutdown instead.
-    """
-    sessions: dict[bool, aiohttp.ClientSession] = hass.data.setdefault(
-        DATA_V6_CLIENTSESSIONS, {}
+    """Create a session with an isolated cookie jar for the Pi-hole v6 API."""
+    return async_create_clientsession(
+        hass,
+        verify_ssl,
+        auto_cleanup=auto_cleanup,
+        cookie_jar=DummyCookieJar(),
     )
-    session = sessions.get(verify_ssl)
-    if session is None or session.closed:
-        session = async_create_clientsession(
-            hass, verify_ssl, auto_cleanup=False, cookie_jar=DummyCookieJar()
-        )
-        sessions[verify_ssl] = session
 
-        @callback
-        def _close(_event: Event) -> None:
-            if sessions.get(verify_ssl) is not session:
-                return
-            if not session.closed:
-                session.detach()
-            sessions.pop(verify_ssl, None)
 
-        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_CLOSE, _close)
-    return session
+@asynccontextmanager
+async def _async_v6_session(
+    hass: HomeAssistant, verify_ssl: bool
+) -> AsyncIterator[aiohttp.ClientSession]:
+    """Yield a short-lived isolated session for one-shot Pi-hole v6 requests."""
+    session = _async_create_v6_session(hass, verify_ssl, auto_cleanup=False)
+    try:
+        yield session
+    finally:
+        session.detach()
 
 
 async def _async_v6_api_authentication_required(
     hass: HomeAssistant, entry: dict[str, Any]
 ) -> bool | None:
     """Return if the v6 API requires auth, or None when v6 is not detected."""
-    protocol = "https" if entry.get(CONF_SSL) else "http"
-    session = _async_get_v6_session(hass, entry[CONF_VERIFY_SSL])
-    url = f"{protocol}://{entry[CONF_HOST]}/api/info/version"
+    async with _async_v6_session(hass, entry[CONF_VERIFY_SSL]) as session:
+        hole_v6 = api_by_version(hass, entry, 6, password="", session=session)
+        try:
+            await hole_v6.get_versions()
+        except HoleConnectionError:
+            raise
+        except HoleAuthenticationError:
+            return True
+        except HoleError:
+            return None
 
-    async with asyncio.timeout(5):
-        async with session.get(url) as response:
-            try:
-                data: Any = await response.json()
-            except V6_API_RESPONSE_EXCEPTIONS:
-                return None
-
-            if not isinstance(data, dict):
-                return None
-
-            if response.status == 200:
-                if isinstance(data.get("version"), dict):
-                    return False
-                return None
-
-            if response.status == 401:
-                error = data.get("error")
-                if isinstance(error, dict) and error.get("key") == "unauthorized":
-                    return True
-
-    return None
-
-
-async def _async_is_v6_api(hass: HomeAssistant, entry: dict[str, Any]) -> bool:
-    """Check if the Pi-hole instance exposes the v6 API."""
-    return (await _async_v6_api_authentication_required(hass, entry)) is not None
+        return False
 
 
 async def determine_api_version(
@@ -226,14 +197,14 @@ async def determine_api_version(
     """
 
     try:
-        if await _async_is_v6_api(hass, entry):
+        if await _async_v6_api_authentication_required(hass, entry) is not None:
             _LOGGER.debug(
                 "Response from v6 API without auth, Pi-hole API version 6 probably"
                 " detected at %s",
                 entry[CONF_HOST],
             )
             return 6
-    except (TimeoutError, aiohttp.ClientError) as err:
+    except HoleConnectionError as err:
         _LOGGER.error(
             "Unexpected error connecting to Pi-hole v6 API at %s: %s. Trying version"
             " 5 API",

--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -1,8 +1,11 @@
 """The pi_hole component."""
 
+import asyncio
 import logging
 from typing import Any, Literal
 
+import aiohttp
+from aiohttp import DummyCookieJar
 from hole import Hole, HoleV5, HoleV6
 from hole.exceptions import HoleConnectionError, HoleError
 
@@ -13,16 +16,22 @@ from homeassistant.const import (
     CONF_LOCATION,
     CONF_SSL,
     CONF_VERIFY_SSL,
+    EVENT_HOMEASSISTANT_CLOSE,
     Platform,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.aiohttp_client import (
+    async_create_clientsession,
+    async_get_clientsession,
+)
 
 from .const import CONF_STATISTICS_ONLY, DOMAIN
 from .coordinator import PiHoleConfigEntry, PiHoleData, PiHoleUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
+DATA_V6_CLIENTSESSIONS = f"{DOMAIN}_v6_clientsessions"
 
 
 PLATFORMS = [
@@ -113,7 +122,10 @@ def api_by_version(
 
     if password is None:
         password = entry.get(CONF_API_KEY, "")
-    session = async_get_clientsession(hass, entry[CONF_VERIFY_SSL])
+    if version == 6:
+        session = _async_get_v6_session(hass, entry[CONF_VERIFY_SSL])
+    else:
+        session = async_get_clientsession(hass, entry[CONF_VERIFY_SSL])
     hole_kwargs = {
         "host": entry[CONF_HOST],
         "session": session,
@@ -131,53 +143,100 @@ def api_by_version(
     return Hole(**hole_kwargs)
 
 
+@callback
+def _async_get_v6_session(
+    hass: HomeAssistant, verify_ssl: bool
+) -> aiohttp.ClientSession:
+    """Get a session with an isolated cookie jar for the Pi-hole v6 API.
+
+    The session opts out of the auto-cleanup tied to the current config entry,
+    since the cache is shared across entries — otherwise the first entry to
+    unload would detach a session still in use by the others. Lifetime is
+    bound to Home Assistant shutdown instead.
+    """
+    sessions: dict[bool, aiohttp.ClientSession] = hass.data.setdefault(
+        DATA_V6_CLIENTSESSIONS, {}
+    )
+    session = sessions.get(verify_ssl)
+    if session is None or session.closed:
+        session = async_create_clientsession(
+            hass, verify_ssl, auto_cleanup=False, cookie_jar=DummyCookieJar()
+        )
+        sessions[verify_ssl] = session
+
+        @callback
+        def _close(_event: Event) -> None:
+            session.detach()
+            sessions.pop(verify_ssl, None)
+
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_CLOSE, _close)
+    return session
+
+
+async def _async_v6_api_authentication_required(
+    hass: HomeAssistant, entry: dict[str, Any]
+) -> bool | None:
+    """Return if the v6 API requires auth, or None when v6 is not detected."""
+    protocol = "https" if entry.get(CONF_SSL) else "http"
+    session = _async_get_v6_session(hass, entry[CONF_VERIFY_SSL])
+    url = f"{protocol}://{entry[CONF_HOST]}/api/info/version"
+
+    async with asyncio.timeout(5):
+        async with session.get(url) as response:
+            try:
+                data: Any = await response.json()
+            except aiohttp.ContentTypeError, ValueError:
+                return None
+
+            if not isinstance(data, dict):
+                return None
+
+            if response.status == 200:
+                if isinstance(data.get("version"), dict):
+                    return False
+                return None
+
+            if response.status == 401:
+                error = data.get("error")
+                if isinstance(error, dict) and error.get("key") == "unauthorized":
+                    return True
+
+    return None
+
+
+async def _async_is_v6_api(hass: HomeAssistant, entry: dict[str, Any]) -> bool:
+    """Check if the Pi-hole instance exposes the v6 API."""
+    return (await _async_v6_api_authentication_required(hass, entry)) is not None
+
+
 async def determine_api_version(
     hass: HomeAssistant, entry: dict[str, Any]
 ) -> Literal[5, 6]:
-    """Determine the API version of the Pi-hole instance.
+    """Determine the API version of the Pi-hole instance without authentication.
 
-    Neither API v5 or v6 provides an endpoint to check the
-    version without authentication. Version 6 provides other
-    endpoints that do not require authentication, so we can
-    use those to determine the version. Version 5 returns an
-    empty list in response to unauthenticated requests.
-    Because we are using endpoints that are not designed for
-    this purpose, we should log liberally to help with
-    debugging.
+    Version 6 returns either version data or a distinct unauthorized error from
+    /api/info/version, so we can use that endpoint to determine the version.
+    Version 5 returns an empty list in response to unauthenticated requests.
+    Because we are using endpoints that are not designed for this purpose, we should
+    log liberally to help with debugging.
     """
 
-    hole_v6 = api_by_version(hass, entry, 6, password="wrong_password")
     try:
-        await hole_v6.authenticate()
-    except HoleConnectionError as err:
-        _LOGGER.error(
-            "Unexpected error connecting to Pi-hole v6 API"
-            " at %s: %s. Trying version 5 API",
-            hole_v6.base_url,
-            err,
-        )
-    # Ideally python-hole would raise a specific exception for authentication failures
-    except HoleError as ex_v6:
-        if str(ex_v6) == "Authentication failed: Invalid password":
+        if await _async_is_v6_api(hass, entry):
             _LOGGER.debug(
-                "Success connecting to Pi-hole at %s without auth, API version is : %s",
-                hole_v6.base_url,
-                6,
+                "Response from v6 API without auth, Pi-hole API version 6 probably"
+                " detected at %s",
+                entry[CONF_HOST],
             )
             return 6
-        _LOGGER.debug(
-            "Connection to %s failed: %s, trying API version 5", hole_v6.base_url, ex_v6
+    except (TimeoutError, aiohttp.ClientError) as err:
+        _LOGGER.error(
+            "Unexpected error connecting to Pi-hole v6 API at %s: %s. Trying version"
+            " 5 API",
+            entry[CONF_HOST],
+            err,
         )
-    else:
-        # It seems that occasionally the auth can succeed
-        # unexpectedly when there is a valid session
-        _LOGGER.warning(
-            "Authenticated with %s through v6 API, but"
-            " succeeded with an incorrect password."
-            " This is a known bug",
-            hole_v6.base_url,
-        )
-        return 6
+
     hole_v5 = api_by_version(hass, entry, 5, password="wrong_token")
     try:
         await hole_v5.get_data()
@@ -203,6 +262,6 @@ async def determine_api_version(
         )
     _LOGGER.debug(
         "Could not determine pi-hole API version at: %s",
-        hole_v6.base_url,
+        entry[CONF_HOST],
     )
     raise HoleError("Could not determine Pi-hole API version")

--- a/homeassistant/components/pi_hole/config_flow.py
+++ b/homeassistant/components/pi_hole/config_flow.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 import logging
 from typing import Any
 
+import aiohttp
 from hole.exceptions import HoleError
 import voluptuous as vol
 
@@ -18,7 +19,12 @@ from homeassistant.const import (
     CONF_VERIFY_SSL,
 )
 
-from . import Hole, api_by_version, determine_api_version
+from . import (
+    Hole,
+    _async_v6_api_authentication_required,
+    api_by_version,
+    determine_api_version,
+)
 from .const import (
     DEFAULT_LOCATION,
     DEFAULT_NAME,
@@ -37,7 +43,14 @@ class PiHoleFlowHandler(ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Initialize the config flow."""
-        self._config: dict = {}
+        self._config: dict[str, Any] = {}
+
+    def _update_api_key(self, api_key: str | None) -> None:
+        """Update the stored API key config from user input."""
+        if api_key:
+            self._config[CONF_API_KEY] = api_key
+        else:
+            self._config.pop(CONF_API_KEY, None)
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -52,8 +65,8 @@ class PiHoleFlowHandler(ConfigFlow, domain=DOMAIN):
                 CONF_LOCATION: user_input[CONF_LOCATION],
                 CONF_SSL: user_input[CONF_SSL],
                 CONF_VERIFY_SSL: user_input[CONF_VERIFY_SSL],
-                CONF_API_KEY: user_input[CONF_API_KEY],
             }
+            self._update_api_key(user_input.get(CONF_API_KEY))
 
             self._async_abort_entries_match(
                 {
@@ -85,9 +98,9 @@ class PiHoleFlowHandler(ConfigFlow, domain=DOMAIN):
                         CONF_LOCATION,
                         default=user_input.get(CONF_LOCATION, DEFAULT_LOCATION),
                     ): str,
-                    vol.Required(
+                    vol.Optional(
                         CONF_API_KEY,
-                        default=user_input.get(CONF_API_KEY),
+                        default=user_input.get(CONF_API_KEY, ""),
                     ): str,
                     vol.Required(
                         CONF_SSL,
@@ -116,7 +129,7 @@ class PiHoleFlowHandler(ConfigFlow, domain=DOMAIN):
         """Perform reauth confirm upon an API authentication error."""
         errors = {}
         if user_input is not None:
-            self._config = {**self._config, CONF_API_KEY: user_input[CONF_API_KEY]}
+            self._update_api_key(user_input.get(CONF_API_KEY))
             if not (errors := await self._async_try_connect()):
                 return self.async_update_reload_and_abort(
                     self._get_reauth_entry(), data=self._config
@@ -128,7 +141,14 @@ class PiHoleFlowHandler(ConfigFlow, domain=DOMAIN):
                 CONF_HOST: self._config[CONF_HOST],
                 CONF_LOCATION: self._config[CONF_LOCATION],
             },
-            data_schema=vol.Schema({vol.Required(CONF_API_KEY): str}),
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_API_KEY,
+                        default=self._config.get(CONF_API_KEY, ""),
+                    ): str
+                }
+            ),
             errors=errors,
         )
 
@@ -138,9 +158,28 @@ class PiHoleFlowHandler(ConfigFlow, domain=DOMAIN):
             version = await determine_api_version(hass=self.hass, entry=self._config)
         except HoleError:
             return {"base": "cannot_connect"}
-        pi_hole: Hole = api_by_version(self.hass, self._config, version)
 
         if version == 6:
+            try:
+                authentication_required = await _async_v6_api_authentication_required(
+                    self.hass, self._config
+                )
+            except TimeoutError, aiohttp.ClientError:
+                return {"base": "cannot_connect"}
+
+            if authentication_required is False:
+                self._config.pop(CONF_API_KEY, None)
+                _LOGGER.debug(
+                    "Success connecting to Pi-hole API version %s without"
+                    " authentication",
+                    6,
+                )
+                return {}
+
+            if not self._config.get(CONF_API_KEY):
+                return {CONF_API_KEY: "invalid_auth"}
+
+            pi_hole: Hole = api_by_version(self.hass, self._config, version)
             try:
                 await pi_hole.authenticate()
                 _LOGGER.debug("Success authenticating with pihole API version: %s", 6)
@@ -149,6 +188,7 @@ class PiHoleFlowHandler(ConfigFlow, domain=DOMAIN):
                 return {CONF_API_KEY: "invalid_auth"}
 
         elif version == 5:
+            pi_hole = api_by_version(self.hass, self._config, version)
             try:
                 await pi_hole.get_data()
                 if pi_hole.data is not None and "error" in pi_hole.data:

--- a/homeassistant/components/pi_hole/config_flow.py
+++ b/homeassistant/components/pi_hole/config_flow.py
@@ -35,6 +35,8 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+V6_API_CONNECTION_EXCEPTIONS = (TimeoutError, aiohttp.ClientError)
+
 
 class PiHoleFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a Pi-hole config flow."""
@@ -164,7 +166,7 @@ class PiHoleFlowHandler(ConfigFlow, domain=DOMAIN):
                 authentication_required = await _async_v6_api_authentication_required(
                     self.hass, self._config
                 )
-            except TimeoutError, aiohttp.ClientError:
+            except V6_API_CONNECTION_EXCEPTIONS:
                 return {"base": "cannot_connect"}
 
             if authentication_required is False:

--- a/homeassistant/components/pi_hole/config_flow.py
+++ b/homeassistant/components/pi_hole/config_flow.py
@@ -4,8 +4,7 @@ from collections.abc import Mapping
 import logging
 from typing import Any
 
-import aiohttp
-from hole.exceptions import HoleError
+from hole.exceptions import HoleConnectionError, HoleError
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
@@ -22,6 +21,7 @@ from homeassistant.const import (
 from . import (
     Hole,
     _async_v6_api_authentication_required,
+    _async_v6_session,
     api_by_version,
     determine_api_version,
 )
@@ -34,8 +34,6 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-V6_API_CONNECTION_EXCEPTIONS = (TimeoutError, aiohttp.ClientError)
 
 
 class PiHoleFlowHandler(ConfigFlow, domain=DOMAIN):
@@ -143,14 +141,7 @@ class PiHoleFlowHandler(ConfigFlow, domain=DOMAIN):
                 CONF_HOST: self._config[CONF_HOST],
                 CONF_LOCATION: self._config[CONF_LOCATION],
             },
-            data_schema=vol.Schema(
-                {
-                    vol.Optional(
-                        CONF_API_KEY,
-                        default=self._config.get(CONF_API_KEY, ""),
-                    ): str
-                }
-            ),
+            data_schema=vol.Schema({vol.Optional(CONF_API_KEY): str}),
             errors=errors,
         )
 
@@ -166,7 +157,7 @@ class PiHoleFlowHandler(ConfigFlow, domain=DOMAIN):
                 authentication_required = await _async_v6_api_authentication_required(
                     self.hass, self._config
                 )
-            except V6_API_CONNECTION_EXCEPTIONS:
+            except HoleConnectionError:
                 return {"base": "cannot_connect"}
 
             if authentication_required is False:
@@ -181,13 +172,22 @@ class PiHoleFlowHandler(ConfigFlow, domain=DOMAIN):
             if not self._config.get(CONF_API_KEY):
                 return {CONF_API_KEY: "invalid_auth"}
 
-            pi_hole: Hole = api_by_version(self.hass, self._config, version)
-            try:
-                await pi_hole.authenticate()
-                _LOGGER.debug("Success authenticating with pihole API version: %s", 6)
-            except HoleError:
-                _LOGGER.debug("Failed authenticating with pihole API version: %s", 6)
-                return {CONF_API_KEY: "invalid_auth"}
+            async with _async_v6_session(
+                self.hass, self._config[CONF_VERIFY_SSL]
+            ) as session:
+                try:
+                    pi_hole: Hole = api_by_version(
+                        self.hass, self._config, version, session=session
+                    )
+                    await pi_hole.authenticate()
+                    _LOGGER.debug(
+                        "Success authenticating with pihole API version: %s", 6
+                    )
+                except HoleError:
+                    _LOGGER.debug(
+                        "Failed authenticating with pihole API version: %s", 6
+                    )
+                    return {CONF_API_KEY: "invalid_auth"}
 
         elif version == 5:
             pi_hole = api_by_version(self.hass, self._config, version)

--- a/homeassistant/components/pi_hole/manifest.json
+++ b/homeassistant/components/pi_hole/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["hole"],
-  "requirements": ["hole==0.9.0"]
+  "requirements": ["hole==0.9.2"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1262,7 +1262,7 @@ hko==0.3.2
 hlk-sw16==0.0.9
 
 # homeassistant.components.pi_hole
-hole==0.9.0
+hole==0.9.2
 
 # homeassistant.components.holiday
 # homeassistant.components.workday

--- a/tests/components/pi_hole/__init__.py
+++ b/tests/components/pi_hole/__init__.py
@@ -325,11 +325,8 @@ def _create_mocked_hole(
 
 
 @contextmanager
-def _patch_hole(mocked_hole: MagicMock, patch_target: str) -> Generator[MagicMock]:
-    """Patch the Hole class and API version detection."""
-
-    def side_effect(*args, **kwargs):
-        return mocked_hole(**kwargs)
+def _patch_api_version_detection(mocked_hole: MagicMock) -> Generator[None]:
+    """Patch API version detection."""
 
     async def is_v6_api_side_effect(*_args, **_kwargs) -> bool:
         if mocked_hole.wrong_host:
@@ -344,7 +341,6 @@ def _patch_hole(mocked_hole: MagicMock, patch_target: str) -> Generator[MagicMoc
         return mocked_hole.v6_authentication_required
 
     with ExitStack() as stack:
-        patched_hole = stack.enter_context(patch(patch_target, side_effect=side_effect))
         stack.enter_context(
             patch(
                 "homeassistant.components.pi_hole._async_is_v6_api",
@@ -363,13 +359,31 @@ def _patch_hole(mocked_hole: MagicMock, patch_target: str) -> Generator[MagicMoc
                 side_effect=v6_api_authentication_required_side_effect,
             )
         )
+        yield
+
+
+@contextmanager
+def _patch_hole(mocked_hole: MagicMock, patch_target: str) -> Generator[MagicMock]:
+    """Patch the Hole class."""
+
+    def side_effect(*args, **kwargs):
+        return mocked_hole(**kwargs)
+
+    with patch(patch_target, side_effect=side_effect) as patched_hole:
         yield patched_hole
 
 
+@contextmanager
 def _patch_init_hole(mocked_hole):
     """Patch the Hole class in the main integration."""
 
-    return _patch_hole(mocked_hole, "homeassistant.components.pi_hole.Hole")
+    with (
+        _patch_hole(
+            mocked_hole, "homeassistant.components.pi_hole.Hole"
+        ) as patched_hole,
+        _patch_api_version_detection(mocked_hole),
+    ):
+        yield patched_hole
 
 
 def _patch_config_flow_hole(mocked_hole):

--- a/tests/components/pi_hole/__init__.py
+++ b/tests/components/pi_hole/__init__.py
@@ -328,11 +328,6 @@ def _create_mocked_hole(
 def _patch_api_version_detection(mocked_hole: MagicMock) -> Generator[None]:
     """Patch API version detection."""
 
-    async def is_v6_api_side_effect(*_args, **_kwargs) -> bool:
-        if mocked_hole.wrong_host:
-            raise HoleConnectionError("Cannot fetch data from Pi-hole: err")
-        return mocked_hole.api_version == 6
-
     async def v6_api_authentication_required_side_effect(*_args, **_kwargs):
         if mocked_hole.wrong_host:
             raise HoleConnectionError("Cannot fetch data from Pi-hole: err")
@@ -341,12 +336,6 @@ def _patch_api_version_detection(mocked_hole: MagicMock) -> Generator[None]:
         return mocked_hole.v6_authentication_required
 
     with ExitStack() as stack:
-        stack.enter_context(
-            patch(
-                "homeassistant.components.pi_hole._async_is_v6_api",
-                side_effect=is_v6_api_side_effect,
-            )
-        )
         stack.enter_context(
             patch(
                 "homeassistant.components.pi_hole._async_v6_api_authentication_required",

--- a/tests/components/pi_hole/__init__.py
+++ b/tests/components/pi_hole/__init__.py
@@ -1,8 +1,11 @@
 """Tests for the pi_hole component."""
 
+from collections.abc import Generator
+from contextlib import ExitStack, contextmanager
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from aiohttp import DummyCookieJar
 from hole.exceptions import HoleConnectionError, HoleError
 
 from homeassistant.components.pi_hole.const import (
@@ -140,6 +143,8 @@ PORT = 80
 LOCATION = "location"
 NAME = "Pi hole"
 API_KEY = "apikey"
+APP_PASSWORD = "app_password"
+VALID_V6_PASSWORDS = ("newkey", "apikey", APP_PASSWORD)
 API_VERSION = 6
 SSL = False
 VERIFY_SSL = True
@@ -169,6 +174,16 @@ CONFIG_FLOW_USER = {
     CONF_PORT: PORT,
     CONF_LOCATION: LOCATION,
     CONF_API_KEY: API_KEY,
+    CONF_NAME: NAME,
+    CONF_SSL: SSL,
+    CONF_VERIFY_SSL: VERIFY_SSL,
+}
+
+CONFIG_FLOW_USER_WITHOUT_API_KEY = {
+    CONF_HOST: HOST,
+    CONF_PORT: PORT,
+    CONF_LOCATION: LOCATION,
+    CONF_API_KEY: "",
     CONF_NAME: NAME,
     CONF_SSL: SSL,
     CONF_VERIFY_SSL: VERIFY_SSL,
@@ -206,6 +221,8 @@ def _create_mocked_hole(
     incorrect_app_password: bool = False,
     wrong_host: bool = False,
     ftl_error: bool = False,
+    require_cookie_free_app_password: bool = False,
+    v6_authentication_required: bool = True,
 ) -> MagicMock:
     """Return a mocked Hole API object with side effects based on constructor args."""
 
@@ -220,18 +237,25 @@ def _create_mocked_hole(
         async def authenticate_side_effect(*_args, **_kwargs):
             if wrong_host:
                 raise HoleConnectionError("Cannot authenticate with Pi-hole: err")
+            if api_version == 6 and not v6_authentication_required:
+                return
             password = getattr(mocked_hole, "password", None)
+            cookie_jar = getattr(
+                getattr(mocked_hole, "session", None), "cookie_jar", None
+            )
 
             if (
-                raise_exception
-                or incorrect_app_password
-                or api_version == 5
-                or (api_version == 6 and password not in ["newkey", "apikey"])
+                require_cookie_free_app_password
+                and password == APP_PASSWORD
+                and not isinstance(cookie_jar, DummyCookieJar)
             ):
-                if api_version == 6 and (
-                    incorrect_app_password or password not in ["newkey", "apikey"]
-                ):
-                    raise HoleError("Authentication failed: Invalid password")
+                raise HoleError("Authentication failed: Invalid password")
+
+            if api_version == 6 and (
+                incorrect_app_password or password not in VALID_V6_PASSWORDS
+            ):
+                raise HoleError("Authentication failed: Invalid password")
+            if raise_exception or incorrect_app_password or api_version == 5:
                 raise HoleConnectionError
 
         async def get_data_side_effect(*_args, **_kwargs):
@@ -240,14 +264,16 @@ def _create_mocked_hole(
                 raise HoleConnectionError("Cannot fetch data from Pi-hole: err")
             password = getattr(mocked_hole, "password", None)
             api_token = getattr(mocked_hole, "api_token", None)
-            if (
+            if api_version == 6 and not v6_authentication_required:
+                mocked_hole.data = ZERO_DATA_V6
+            elif (
                 raise_exception
                 or incorrect_app_password
                 or (api_version == 5 and (not api_token or api_token == "wrong_token"))
-                or (api_version == 6 and password not in ["newkey", "apikey"])
+                or (api_version == 6 and password not in VALID_V6_PASSWORDS)
             ):
                 mocked_hole.data = [] if api_version == 5 else {}
-            elif password in ["newkey", "apikey"] or api_token in ["newkey", "apikey"]:
+            elif password in VALID_V6_PASSWORDS or api_token in ("newkey", "apikey"):
                 mocked_hole.data = ZERO_DATA_V6 if api_version == 6 else ZERO_DATA
 
         async def ftl_side_effect():
@@ -256,11 +282,8 @@ def _create_mocked_hole(
         mocked_hole.authenticate = AsyncMock(side_effect=authenticate_side_effect)
         mocked_hole.get_data = AsyncMock(side_effect=get_data_side_effect)
 
-        if ftl_error:
-            # two unauthenticated instances are created in
-            # `determine_api_version` before aync_try_connect is called
-            if len(instances) > 1:
-                mocked_hole.get_data = AsyncMock(side_effect=ftl_side_effect)
+        if ftl_error and instances:
+            mocked_hole.get_data = AsyncMock(side_effect=ftl_side_effect)
         mocked_hole.get_versions = AsyncMock(return_value=None)
         mocked_hole.enable = AsyncMock()
         mocked_hole.disable = AsyncMock()
@@ -294,28 +317,65 @@ def _create_mocked_hole(
         return mocked_hole
 
     # Return a factory function for patching
+    make_mock.api_version = api_version
     make_mock.instances = instances
+    make_mock.wrong_host = wrong_host
+    make_mock.v6_authentication_required = v6_authentication_required
     return make_mock
+
+
+@contextmanager
+def _patch_hole(mocked_hole: MagicMock, patch_target: str) -> Generator[MagicMock]:
+    """Patch the Hole class and API version detection."""
+
+    def side_effect(*args, **kwargs):
+        return mocked_hole(**kwargs)
+
+    async def is_v6_api_side_effect(*_args, **_kwargs) -> bool:
+        if mocked_hole.wrong_host:
+            raise HoleConnectionError("Cannot fetch data from Pi-hole: err")
+        return mocked_hole.api_version == 6
+
+    async def v6_api_authentication_required_side_effect(*_args, **_kwargs):
+        if mocked_hole.wrong_host:
+            raise HoleConnectionError("Cannot fetch data from Pi-hole: err")
+        if mocked_hole.api_version != 6:
+            return None
+        return mocked_hole.v6_authentication_required
+
+    with ExitStack() as stack:
+        patched_hole = stack.enter_context(patch(patch_target, side_effect=side_effect))
+        stack.enter_context(
+            patch(
+                "homeassistant.components.pi_hole._async_is_v6_api",
+                side_effect=is_v6_api_side_effect,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "homeassistant.components.pi_hole._async_v6_api_authentication_required",
+                side_effect=v6_api_authentication_required_side_effect,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "homeassistant.components.pi_hole.config_flow._async_v6_api_authentication_required",
+                side_effect=v6_api_authentication_required_side_effect,
+            )
+        )
+        yield patched_hole
 
 
 def _patch_init_hole(mocked_hole):
     """Patch the Hole class in the main integration."""
 
-    def side_effect(*args, **kwargs):
-        return mocked_hole(**kwargs)
-
-    return patch("homeassistant.components.pi_hole.Hole", side_effect=side_effect)
+    return _patch_hole(mocked_hole, "homeassistant.components.pi_hole.Hole")
 
 
 def _patch_config_flow_hole(mocked_hole):
     """Patch the Hole class in the config flow."""
 
-    def side_effect(*args, **kwargs):
-        return mocked_hole(**kwargs)
-
-    return patch(
-        "homeassistant.components.pi_hole.config_flow.Hole", side_effect=side_effect
-    )
+    return _patch_hole(mocked_hole, "homeassistant.components.pi_hole.config_flow.Hole")
 
 
 def _patch_setup_hole():

--- a/tests/components/pi_hole/test_config_flow.py
+++ b/tests/components/pi_hole/test_config_flow.py
@@ -2,15 +2,18 @@
 
 from homeassistant.components import pi_hole
 from homeassistant.components.pi_hole.const import DOMAIN
-from homeassistant.config_entries import SOURCE_USER
+from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import (
+    APP_PASSWORD,
     CONFIG_DATA_DEFAULTS,
     CONFIG_ENTRY_WITH_API_KEY,
+    CONFIG_ENTRY_WITHOUT_API_KEY,
     CONFIG_FLOW_USER,
+    CONFIG_FLOW_USER_WITHOUT_API_KEY,
     FTL_ERROR,
     NAME,
     ZERO_DATA,
@@ -65,6 +68,81 @@ async def test_flow_user_with_api_key_v6(hass: HomeAssistant) -> None:
         )
         assert result["type"] is FlowResultType.ABORT
         assert result["reason"] == "already_configured"
+
+
+async def test_flow_user_with_app_password_v6(hass: HomeAssistant) -> None:
+    """Test user initialized flow with a v6 app password."""
+    mocked_hole = _create_mocked_hole(
+        has_data=False, api_version=6, require_cookie_free_app_password=True
+    )
+    app_password_input = {**CONFIG_FLOW_USER, CONF_API_KEY: APP_PASSWORD}
+    with (
+        _patch_init_hole(mocked_hole),
+        _patch_config_flow_hole(mocked_hole),
+        _patch_setup_hole() as mock_setup,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+        )
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input=app_password_input,
+        )
+
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert result["data"] == {
+            **CONFIG_ENTRY_WITH_API_KEY,
+            CONF_API_KEY: APP_PASSWORD,
+        }
+        mock_setup.assert_called_once()
+
+
+async def test_flow_user_without_api_key_v6_auth_disabled(
+    hass: HomeAssistant,
+) -> None:
+    """Test user initialized flow with v6 authentication disabled."""
+    mocked_hole = _create_mocked_hole(
+        has_data=False,
+        api_version=6,
+        v6_authentication_required=False,
+    )
+    with (
+        _patch_init_hole(mocked_hole),
+        _patch_config_flow_hole(mocked_hole),
+        _patch_setup_hole() as mock_setup,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+        )
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input=CONFIG_FLOW_USER_WITHOUT_API_KEY,
+        )
+
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert result["data"] == CONFIG_ENTRY_WITHOUT_API_KEY
+        mock_setup.assert_called_once()
+
+
+async def test_flow_user_without_api_key_v6_auth_required(
+    hass: HomeAssistant,
+) -> None:
+    """Test user initialized flow with v6 authentication required."""
+    mocked_hole = _create_mocked_hole(has_data=False, api_version=6)
+    with _patch_init_hole(mocked_hole), _patch_config_flow_hole(mocked_hole):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+            data=CONFIG_FLOW_USER_WITHOUT_API_KEY,
+        )
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+        assert result["errors"] == {CONF_API_KEY: "invalid_auth"}
 
 
 async def test_flow_user_with_api_key_v5(hass: HomeAssistant) -> None:
@@ -169,6 +247,39 @@ async def test_flow_reauth(hass: HomeAssistant) -> None:
         assert result["type"] is FlowResultType.ABORT
         assert result["reason"] == "reauth_successful"
         assert entry.data[CONF_API_KEY] == "newkey"
+
+
+async def test_flow_reauth_without_api_key_v6_auth_disabled(
+    hass: HomeAssistant,
+) -> None:
+    """Test reauth flow when v6 authentication has been disabled."""
+    mocked_hole = _create_mocked_hole(
+        has_data=False,
+        api_version=6,
+        v6_authentication_required=False,
+    )
+    entry = MockConfigEntry(
+        domain=pi_hole.DOMAIN,
+        data=CONFIG_ENTRY_WITH_API_KEY,
+    )
+    entry.add_to_hass(hass)
+    with _patch_init_hole(mocked_hole), _patch_config_flow_hole(mocked_hole):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_REAUTH, "entry_id": entry.entry_id},
+            data=entry.data,
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "reauth_confirm"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_API_KEY: ""},
+        )
+
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "reauth_successful"
+        assert entry.data == CONFIG_ENTRY_WITHOUT_API_KEY
 
 
 async def test_flow_user_invalid_host(hass: HomeAssistant) -> None:

--- a/tests/components/pi_hole/test_config_flow.py
+++ b/tests/components/pi_hole/test_config_flow.py
@@ -1,5 +1,9 @@
 """Test pi_hole config flow."""
 
+from unittest.mock import patch
+
+from hole.exceptions import HoleConnectionError
+
 from homeassistant.components import pi_hole
 from homeassistant.components.pi_hole.const import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
@@ -48,6 +52,7 @@ async def test_flow_user_with_api_key_v6(hass: HomeAssistant) -> None:
         )
         # we have had no response from the server yet, so we expect an error
         assert result["errors"] == {CONF_API_KEY: "invalid_auth"}
+        assert mocked_hole.instances[-1].session.closed
 
         # now we have a valid passiword
         result = await hass.config_entries.flow.async_configure(
@@ -59,6 +64,7 @@ async def test_flow_user_with_api_key_v6(hass: HomeAssistant) -> None:
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["data"] == CONFIG_ENTRY_WITH_API_KEY
         mock_setup.assert_called_once()
+        assert mocked_hole.instances[-1].session.closed
 
         # duplicated server
         result = await hass.config_entries.flow.async_init(
@@ -143,6 +149,27 @@ async def test_flow_user_without_api_key_v6_auth_required(
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["errors"] == {CONF_API_KEY: "invalid_auth"}
+
+
+async def test_flow_user_v6_auth_probe_error(hass: HomeAssistant) -> None:
+    """Test user initialized flow with a v6 auth probe connection error."""
+    mocked_hole = _create_mocked_hole(has_data=False, api_version=6)
+    with (
+        _patch_init_hole(mocked_hole),
+        patch(
+            "homeassistant.components.pi_hole.config_flow._async_v6_api_authentication_required",
+            side_effect=HoleConnectionError("err"),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+            data=CONFIG_FLOW_USER,
+        )
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+        assert result["errors"] == {"base": "cannot_connect"}
 
 
 async def test_flow_user_with_api_key_v5(hass: HomeAssistant) -> None:

--- a/tests/components/pi_hole/test_init.py
+++ b/tests/components/pi_hole/test_init.py
@@ -35,6 +35,56 @@ from . import (
 )
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+
+async def test_determine_api_version_v6(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test detecting a Pi-hole v6 API without authentication."""
+    aioclient_mock.get(
+        "http://1.2.3.4:80/api/info/version",
+        status=401,
+        json={"error": {"key": "unauthorized", "message": "Unauthorized"}},
+    )
+
+    assert await pi_hole.determine_api_version(hass, CONFIG_DATA_DEFAULTS) == 6
+
+
+async def test_determine_api_version_v6_without_authentication(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test detecting a Pi-hole v6 API with authentication disabled."""
+    aioclient_mock.get(
+        "http://1.2.3.4:80/api/info/version",
+        status=200,
+        json={"version": {"core": {"local": {"version": "v6.0.0"}}}},
+    )
+
+    assert await pi_hole.determine_api_version(hass, CONFIG_DATA_DEFAULTS) == 6
+
+
+@pytest.mark.parametrize(
+    ("status", "response_json"),
+    [
+        (200, []),
+        (500, {"error": {"key": "internal_error"}}),
+    ],
+)
+async def test_is_v6_api_with_unexpected_response(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    status: int,
+    response_json: object,
+) -> None:
+    """Test ignoring unexpected responses from the Pi-hole v6 version API."""
+    aioclient_mock.get(
+        "http://1.2.3.4:80/api/info/version",
+        status=status,
+        json=response_json,
+    )
+
+    assert not await pi_hole._async_is_v6_api(hass, CONFIG_DATA_DEFAULTS)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/pi_hole/test_init.py
+++ b/tests/components/pi_hole/test_init.py
@@ -1,9 +1,10 @@
 """Test pi_hole component."""
 
 import logging
-from unittest.mock import ANY, AsyncMock
+from unittest.mock import ANY, AsyncMock, patch
 
-from hole.exceptions import HoleError
+from aiohttp import DummyCookieJar
+from hole.exceptions import HoleConnectionError, HoleError
 import pytest
 
 from homeassistant.components import pi_hole, switch
@@ -68,10 +69,13 @@ async def test_determine_api_version_v6_without_authentication(
     ("status", "response_json"),
     [
         (200, []),
+        (200, {}),
+        (200, {"foo": "bar"}),
+        (200, {"version": "v6.0.0"}),
         (500, {"error": {"key": "internal_error"}}),
     ],
 )
-async def test_is_v6_api_with_unexpected_response(
+async def test_v6_api_authentication_required_with_unexpected_response(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     status: int,
@@ -84,7 +88,72 @@ async def test_is_v6_api_with_unexpected_response(
         json=response_json,
     )
 
-    assert not await pi_hole._async_is_v6_api(hass, CONFIG_DATA_DEFAULTS)
+    assert (
+        await pi_hole._async_v6_api_authentication_required(hass, CONFIG_DATA_DEFAULTS)
+        is None
+    )
+
+
+async def test_v6_api_authentication_required_with_invalid_json(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test ignoring invalid JSON from the Pi-hole v6 version API."""
+    aioclient_mock.get(
+        "http://1.2.3.4:80/api/info/version",
+        status=200,
+        text="not-json",
+    )
+
+    assert (
+        await pi_hole._async_v6_api_authentication_required(hass, CONFIG_DATA_DEFAULTS)
+        is None
+    )
+
+
+async def test_v6_api_authentication_required_with_connection_error(
+    hass: HomeAssistant,
+) -> None:
+    """Test raising connection errors from the Pi-hole v6 version API."""
+    with (
+        patch(
+            "homeassistant.components.pi_hole.api_by_version",
+            return_value=AsyncMock(
+                get_versions=AsyncMock(side_effect=HoleConnectionError("err"))
+            ),
+        ),
+        pytest.raises(HoleConnectionError),
+    ):
+        await pi_hole._async_v6_api_authentication_required(hass, CONFIG_DATA_DEFAULTS)
+
+
+async def test_v6_probe_session_cleanup(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test cleaning up the temporary v6 probe session."""
+    aioclient_mock.get(
+        "http://1.2.3.4:80/api/info/version",
+        status=401,
+        json={"error": {"key": "unauthorized", "message": "Unauthorized"}},
+    )
+    session = pi_hole._async_create_v6_session(
+        hass, DEFAULT_VERIFY_SSL, auto_cleanup=False
+    )
+
+    with patch(
+        "homeassistant.components.pi_hole._async_create_v6_session",
+        return_value=session,
+    ) as create_session:
+        assert (
+            await pi_hole._async_v6_api_authentication_required(
+                hass, CONFIG_DATA_DEFAULTS
+            )
+            is True
+        )
+
+    create_session.assert_called_once_with(hass, DEFAULT_VERIFY_SSL, auto_cleanup=False)
+    assert session.closed
 
 
 @pytest.mark.parametrize(
@@ -109,6 +178,9 @@ async def test_setup_api_v6(
             protocol="http",
             version=6,
             verify_tls=DEFAULT_VERIFY_SSL,
+        )
+        assert isinstance(
+            patched_init_hole.call_args.kwargs["session"].cookie_jar, DummyCookieJar
         )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Pi-hole v6 app passwords can successfully authenticate against `/api/auth`, but Home Assistant could still reject them during config flow because API version detection intentionally authenticated with an invalid password immediately before validating the real credential.

This changes Pi-hole v6 detection to use `/api/info/version` instead of an invalid `/api/auth` attempt. The detection accepts both v6 response shapes:

- `401 unauthorized` JSON when authentication is enabled
- `200` version JSON when authentication is disabled

This also creates Pi-hole v6 client sessions with an isolated `DummyCookieJar`, so Pi-hole session cookies do not interfere with SID-header-based v6 authentication.

The config flow now supports Pi-hole v6 instances where the web UI does not have a password set. In that case, the API key field can be left blank and Home Assistant stores the entry without an API key.

This supersedes #169706.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #150151
- This PR is related to issue: #149769
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
