### PR TITLE
Derive zone entity state from person `in_zones` state attribute

### DIFF
--- a/homeassistant/components/zone/__init__.py
+++ b/homeassistant/components/zone/__init__.py
@@ -9,6 +9,7 @@ from typing import Any, Self, cast
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.components import device_tracker
 from homeassistant.const import (
     ATTR_EDITABLE,
     ATTR_LATITUDE,
@@ -22,10 +23,7 @@ from homeassistant.const import (
     CONF_RADIUS,
     EVENT_CORE_CONFIG_UPDATE,
     SERVICE_RELOAD,
-    STATE_HOME,
-    STATE_NOT_HOME,
     STATE_UNAVAILABLE,
-    STATE_UNKNOWN,
 )
 from homeassistant.core import (
     Event,
@@ -516,14 +514,6 @@ class Zone(collection.CollectionEntity):
         """Return if given state is in zone."""
         return (
             state is not None
-            and state.state
-            not in (
-                STATE_NOT_HOME,
-                STATE_UNKNOWN,
-                STATE_UNAVAILABLE,
-            )
-            and (
-                state.state.casefold() == self._case_folded_name
-                or (state.state == STATE_HOME and self.entity_id == ENTITY_ID_HOME)
-            )
+            and device_tracker.ATTR_IN_ZONES in state.attributes
+            and self.entity_id in state.attributes[device_tracker.ATTR_IN_ZONES]
         )

--- a/homeassistant/components/zone/__init__.py
+++ b/homeassistant/components/zone/__init__.py
@@ -430,7 +430,6 @@ class Zone(collection.CollectionEntity):
         config = self._config
         name: str = config[CONF_NAME]
         self._attr_name = name
-        self._case_folded_name = name.casefold()
         self._attr_unique_id = config.get(CONF_ID)
         self._attr_icon = config.get(CONF_ICON)
 

--- a/homeassistant/components/zone/__init__.py
+++ b/homeassistant/components/zone/__init__.py
@@ -9,7 +9,6 @@ from typing import Any, Self, cast
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components import device_tracker
 from homeassistant.const import (
     ATTR_EDITABLE,
     ATTR_LATITUDE,
@@ -511,8 +510,13 @@ class Zone(collection.CollectionEntity):
     @callback
     def _state_is_in_zone(self, state: State | None) -> bool:
         """Return if given state is in zone."""
+
+        from homeassistant.components.device_tracker import (  # noqa: PLC0415
+            ATTR_IN_ZONES,
+        )
+
         return (
             state is not None
-            and device_tracker.ATTR_IN_ZONES in state.attributes
-            and self.entity_id in state.attributes[device_tracker.ATTR_IN_ZONES]
+            and ATTR_IN_ZONES in state.attributes
+            and self.entity_id in state.attributes[ATTR_IN_ZONES]
         )

--- a/tests/components/zone/test_init.py
+++ b/tests/components/zone/test_init.py
@@ -883,8 +883,11 @@ async def test_state(hass: HomeAssistant) -> None:
 
     state = hass.states.get("zone.test_zone")
     assert state
-    assert state.state == "1"
-    assert state.attributes[ATTR_PERSONS] == ["person.person2"]
+    assert state.state == "2"
+    assert sorted(state.attributes[ATTR_PERSONS]) == [
+        "person.person1",
+        "person.person2",
+    ]
 
     state = hass.states.get("zone.home")
     assert state

--- a/tests/helpers/template/extensions/test_state.py
+++ b/tests/helpers/template/extensions/test_state.py
@@ -880,6 +880,7 @@ async def test_expand(hass: HomeAssistant) -> None:
     hass.states.async_set(
         "person.person1",
         "test",
+        {"in_zones": ["zone.test"]},
     )
     await hass.async_block_till_done()
 
@@ -900,6 +901,7 @@ async def test_expand(hass: HomeAssistant) -> None:
     hass.states.async_set(
         "person.person2",
         "test",
+        {"in_zones": ["zone.test"]},
     )
     await hass.async_block_till_done()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
The state (person count) and `persons` state attribute of zone entities is now calculated from person entities' `in_zones` state attribute. This mean a person can now be counted in more than one zone's state at the same time.

Example where person.1 state: "home", in_zones: ["home", "near_home"]

Zone states before the change (person.1 not counted in zone.near_home):
zone.home: state: 1, persons: ["person.1"]
zone.near_home: state: 0, persons: []

Zone states after the change (person.1 counted in zone.near_home):
zone.home: state: 1, persons: ["person.1"]
zone.near_home: state: 1, persons: ["person.1"]

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Derive zone entity state from person in_zones state attribute

Background in https://github.com/home-assistant/architecture/discussions/1401

~~Note: This PR depends on and includes commits from https://github.com/home-assistant/core/pull/172941~~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/architecture/discussions/1401
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
