### PR TITLE
Fix Google AI TTS ignoring configured voice in subentry

### DIFF
--- a/homeassistant/components/google_generative_ai_conversation/tts.py
+++ b/homeassistant/components/google_generative_ai_conversation/tts.py
@@ -183,8 +183,9 @@ class GoogleGenerativeAITextToSpeechEntity(
     @cached_property
     def default_options(self) -> Mapping[str, Any]:
         """Return a mapping with the default options."""
+        voice = self.subentry.data.get(ATTR_VOICE) or self._supported_voices[0].voice_id
         return {
-            ATTR_VOICE: self._supported_voices[0].voice_id,
+            ATTR_VOICE: voice,
         }
 
     async def async_get_tts_audio(


### PR DESCRIPTION
## Problem

The `GoogleGenerativeAITextToSpeechEntity.default_options` cached_property always returns `ATTR_VOICE: self._supported_voices[0].voice_id` (Zephyr/Bright), regardless of what voice is configured in the TTS subentry data. Any voice setting chosen via the HA UI is silently ignored.

## Root cause

`default_options` reads from the hardcoded `_supported_voices` list instead of checking `self.subentry.data.get(ATTR_VOICE)`.

## Fix

`default_options` now checks `self.subentry.data.get(ATTR_VOICE)` first, falling back to `self._supported_voices[0].voice_id` if no voice is configured in the subentry.

## Testing

- Configured `voice: charon` in the Google AI TTS subentry data
- Before fix: spoken output used Zephyr (first/default voice) regardless
- After fix: spoken output correctly uses the configured voice
- Tested via `tts.speak` service and through the Assist pipeline

Fixes #172944