### PR TITLE
Add airOS (insecure ssl) support for legacy v6 devices

### DIFF
--- a/homeassistant/components/airos/__init__.py
+++ b/homeassistant/components/airos/__init__.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from aiohttp import ClientSession, TCPConnector
 from airos.airos6 import AirOS6
 from airos.airos8 import AirOS8
 from airos.exceptions import (
@@ -10,6 +11,7 @@ from airos.exceptions import (
     AirOSDataMissingError,
     AirOSDeviceConnectionError,
     AirOSKeyDataMissingError,
+    AirOSTLSCompatibilityError,
 )
 from airos.helpers import DetectDeviceData, async_get_firmware_data
 
@@ -30,13 +32,20 @@ from homeassistant.exceptions import (
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DEFAULT_SSL, DEFAULT_VERIFY_SSL, DOMAIN, SECTION_ADDITIONAL_SETTINGS
+from .const import (
+    CONF_LEGACY_SSL,
+    DEFAULT_SSL,
+    DEFAULT_VERIFY_SSL,
+    DOMAIN,
+    SECTION_ADDITIONAL_SETTINGS,
+)
 from .coordinator import (
     AirOSConfigEntry,
     AirOSDataUpdateCoordinator,
     AirOSFirmwareUpdateCoordinator,
     AirOSRuntimeData,
 )
+from .helpers import build_legacy_context
 
 _PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
@@ -51,41 +60,62 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: AirOSConfigEntry) -> bool:
     """Set up Ubiquiti airOS from a config entry."""
+    owns_session = False
+    verify_ssl = entry.data[SECTION_ADDITIONAL_SETTINGS][CONF_VERIFY_SSL]
 
     # By default airOS 8 comes with self-signed SSL certificates,
     # with no option in the web UI to change or upload a custom certificate.
-    session = async_get_clientsession(
-        hass, verify_ssl=entry.data[SECTION_ADDITIONAL_SETTINGS][CONF_VERIFY_SSL]
-    )
+    session = async_get_clientsession(hass, verify_ssl=verify_ssl)
+
+    if entry.data.get(CONF_LEGACY_SSL, False):
+        session = ClientSession(
+            connector=TCPConnector(ssl=build_legacy_context(verify_ssl=verify_ssl))
+        )
+        owns_session = True
 
     conn_data = {
         CONF_HOST: entry.data[CONF_HOST],
         CONF_USERNAME: entry.data[CONF_USERNAME],
         CONF_PASSWORD: entry.data[CONF_PASSWORD],
-        "use_ssl": entry.data[SECTION_ADDITIONAL_SETTINGS][CONF_SSL],
         "session": session,
+        "use_ssl": entry.data[SECTION_ADDITIONAL_SETTINGS][CONF_SSL],
     }
+
+    async def close_session() -> None:
+        """Close legacy session before raising if needed."""
+        if owns_session:
+            await session.close()
 
     # Determine firmware version before creating the device instance
     try:
         device_data: DetectDeviceData = await async_get_firmware_data(**conn_data)
+
     except (
         AirOSConnectionSetupError,
         AirOSDeviceConnectionError,
+        AirOSTLSCompatibilityError,
         TimeoutError,
     ) as err:
+        await close_session()
         raise ConfigEntryNotReady from err
     except (
         AirOSConnectionAuthenticationError,
         AirOSDataMissingError,
     ) as err:
+        await close_session()
         raise ConfigEntryAuthFailed from err
     except AirOSKeyDataMissingError as err:
         # pylint: disable-next=home-assistant-exception-not-translated
-        raise ConfigEntryError("key_data_missing") from err
+        await close_session()
+        raise ConfigEntryError(
+            translation_domain=DOMAIN, translation_key="key_data_missing"
+        ) from err
     except Exception as err:
         # pylint: disable-next=home-assistant-exception-not-translated
-        raise ConfigEntryError("unknown") from err
+        await close_session()
+        raise ConfigEntryError(
+            translation_domain=DOMAIN, translation_key="unknown"
+        ) from err
 
     airos_class: type[AirOS8 | AirOS6] = (
         AirOS8 if device_data["fw_major"] == 8 else AirOS6
@@ -106,6 +136,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: AirOSConfigEntry) -> boo
     entry.runtime_data = AirOSRuntimeData(
         status=data_coordinator,
         firmware=firmware_coordinator,
+        owns_session=owns_session,
+        session=session,
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
@@ -182,4 +214,9 @@ async def async_migrate_entry(hass: HomeAssistant, entry: AirOSConfigEntry) -> b
 
 async def async_unload_entry(hass: HomeAssistant, entry: AirOSConfigEntry) -> bool:
     """Unload a config entry."""
-    return await hass.config_entries.async_unload_platforms(entry, _PLATFORMS)
+    unload_state = await hass.config_entries.async_unload_platforms(entry, _PLATFORMS)
+    # Clean up legacy session if needed
+    if unload_state and entry.runtime_data.owns_session:
+        await entry.runtime_data.session.close()
+
+    return unload_state

--- a/homeassistant/components/airos/__init__.py
+++ b/homeassistant/components/airos/__init__.py
@@ -105,13 +105,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: AirOSConfigEntry) -> boo
         await close_session()
         raise ConfigEntryAuthFailed from err
     except AirOSKeyDataMissingError as err:
-        # pylint: disable-next=home-assistant-exception-not-translated
         await close_session()
         raise ConfigEntryError(
             translation_domain=DOMAIN, translation_key="key_data_missing"
         ) from err
     except Exception as err:
-        # pylint: disable-next=home-assistant-exception-not-translated
         await close_session()
         raise ConfigEntryError(
             translation_domain=DOMAIN, translation_key="unknown"
@@ -126,12 +124,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: AirOSConfigEntry) -> boo
     data_coordinator = AirOSDataUpdateCoordinator(
         hass, entry, device_data, airos_device
     )
-    await data_coordinator.async_config_entry_first_refresh()
 
-    firmware_coordinator: AirOSFirmwareUpdateCoordinator | None = None
-    if device_data["fw_major"] >= 8:
-        firmware_coordinator = AirOSFirmwareUpdateCoordinator(hass, entry, airos_device)
-        await firmware_coordinator.async_config_entry_first_refresh()
+    try:
+        await data_coordinator.async_config_entry_first_refresh()
+
+        firmware_coordinator: AirOSFirmwareUpdateCoordinator | None = None
+        if device_data["fw_major"] >= 8:
+            firmware_coordinator = AirOSFirmwareUpdateCoordinator(
+                hass, entry, airos_device
+            )
+            await firmware_coordinator.async_config_entry_first_refresh()
+    except ConfigEntryNotReady, ConfigEntryAuthFailed:
+        await close_session()
+        raise
+    except Exception as err:
+        await close_session()
+        raise ConfigEntryError(
+            translation_domain=DOMAIN, translation_key="unknown"
+        ) from err
 
     entry.runtime_data = AirOSRuntimeData(
         status=data_coordinator,

--- a/homeassistant/components/airos/config_flow.py
+++ b/homeassistant/components/airos/config_flow.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping
 import logging
 from typing import Any
 
+from aiohttp import ClientSession, TCPConnector
 from airos.airos6 import AirOS6
 from airos.airos8 import AirOS8
 from airos.discovery import airos_discover_devices
@@ -16,6 +17,7 @@ from airos.exceptions import (
     AirOSEndpointError,
     AirOSKeyDataMissingError,
     AirOSListenerError,
+    AirOSTLSCompatibilityError,
 )
 from airos.helpers import DetectDeviceData, async_get_firmware_data
 import voluptuous as vol
@@ -44,6 +46,7 @@ from homeassistant.helpers.selector import (
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .const import (
+    CONF_LEGACY_SSL,
     DEFAULT_SSL,
     DEFAULT_USERNAME,
     DEFAULT_VERIFY_SSL,
@@ -54,6 +57,7 @@ from .const import (
     MAC_ADDRESS,
     SECTION_ADDITIONAL_SETTINGS,
 )
+from .helpers import build_legacy_context
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -127,15 +131,24 @@ class AirOSConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
     async def _validate_and_get_device_info(
-        self, config_data: dict[str, Any]
+        self,
+        config_data: dict[str, Any],
+        legacy: bool = False,
     ) -> dict[str, Any] | None:
         """Validate user input with the device API."""
         # By default airOS 8 comes with self-signed SSL certificates,
         # with no option in the web UI to change or upload a custom certificate.
-        session = async_get_clientsession(
-            self.hass,
-            verify_ssl=config_data[SECTION_ADDITIONAL_SETTINGS][CONF_VERIFY_SSL],
-        )
+        # Older airOS 6 devices may still lack proper levels
+
+        close_session = False
+        verify_ssl = config_data[SECTION_ADDITIONAL_SETTINGS][CONF_VERIFY_SSL]
+
+        session = async_get_clientsession(self.hass, verify_ssl=verify_ssl)
+        if legacy:
+            session = ClientSession(
+                connector=TCPConnector(ssl=build_legacy_context(verify_ssl=verify_ssl))
+            )
+            close_session = True
 
         try:
             device_data: DetectDeviceData = await async_get_firmware_data(
@@ -144,6 +157,15 @@ class AirOSConfigFlow(ConfigFlow, domain=DOMAIN):
                 password=config_data[CONF_PASSWORD],
                 session=session,
                 use_ssl=config_data[SECTION_ADDITIONAL_SETTINGS][CONF_SSL],
+            )
+
+        except AirOSTLSCompatibilityError:
+            if legacy:
+                raise
+            retry_config = dict(config_data)
+            retry_config[CONF_LEGACY_SSL] = True
+            return await self._validate_and_get_device_info(
+                config_data=retry_config, legacy=True
             )
 
         except (
@@ -167,6 +189,10 @@ class AirOSConfigFlow(ConfigFlow, domain=DOMAIN):
                 self._abort_if_unique_id_configured()
 
             return {"title": device_data["hostname"], "data": config_data}
+
+        finally:
+            if close_session:
+                await session.close()
 
         return None
 

--- a/homeassistant/components/airos/config_flow.py
+++ b/homeassistant/components/airos/config_flow.py
@@ -160,13 +160,15 @@ class AirOSConfigFlow(ConfigFlow, domain=DOMAIN):
             )
 
         except AirOSTLSCompatibilityError:
+            # If already in legacy, stop iteration
             if legacy:
-                raise
-            retry_config = dict(config_data)
-            retry_config[CONF_LEGACY_SSL] = True
-            return await self._validate_and_get_device_info(
-                config_data=retry_config, legacy=True
-            )
+                self.errors["base"] = "cannot_connect"
+            else:
+                retry_config = dict(config_data)
+                retry_config[CONF_LEGACY_SSL] = True
+                return await self._validate_and_get_device_info(
+                    config_data=retry_config, legacy=True
+                )
 
         except (
             AirOSConnectionSetupError,

--- a/homeassistant/components/airos/const.py
+++ b/homeassistant/components/airos/const.py
@@ -20,3 +20,5 @@ HOSTNAME = "hostname"
 IP_ADDRESS = "ip_address"
 MAC_ADDRESS = "mac_address"
 DEVICE_NAME = "airOS device"
+
+CONF_LEGACY_SSL = "legacy_ssl"

--- a/homeassistant/components/airos/coordinator.py
+++ b/homeassistant/components/airos/coordinator.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 import logging
 from typing import Any, TypeVar
 
+from aiohttp import ClientSession
 from airos.airos6 import AirOS6, AirOS6Data
 from airos.airos8 import AirOS8, AirOS8Data
 from airos.exceptions import (
@@ -39,6 +40,8 @@ class AirOSRuntimeData:
 
     status: AirOSDataUpdateCoordinator
     firmware: AirOSFirmwareUpdateCoordinator | None
+    session: ClientSession
+    owns_session: bool = False
 
 
 async def async_fetch_airos_data(

--- a/homeassistant/components/airos/helpers.py
+++ b/homeassistant/components/airos/helpers.py
@@ -1,0 +1,16 @@
+"""Helpers for airOS."""
+
+import ssl
+
+
+def build_legacy_context(*, verify_ssl: bool) -> ssl.SSLContext:
+    """Build an SSL context compatible with legacy airOS 6 devices."""
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    ctx.set_ciphers("DEFAULT:@SECLEVEL=0")
+    ctx.minimum_version = ssl.TLSVersion.TLSv1
+
+    if not verify_ssl:
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+
+    return ctx

--- a/homeassistant/components/airos/strings.json
+++ b/homeassistant/components/airos/strings.json
@@ -207,6 +207,9 @@
     "reboot_failed": {
       "message": "The device did not accept the reboot request. Try again, or check your device web interface for errors."
     },
+    "unknown": {
+      "message": "[%key:common::config_flow::error::unknown%]"
+    },
     "update_connection_authentication_error": {
       "message": "Authentication or connection failed during firmware update"
     },

--- a/tests/components/airos/test_config_flow.py
+++ b/tests/components/airos/test_config_flow.py
@@ -1,7 +1,7 @@
 """Test the Ubiquiti airOS config flow."""
 
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from airos.exceptions import (
     AirOSConnectionAuthenticationError,
@@ -10,12 +10,14 @@ from airos.exceptions import (
     AirOSEndpointError,
     AirOSKeyDataMissingError,
     AirOSListenerError,
+    AirOSTLSCompatibilityError,
 )
 from airos.helpers import DetectDeviceData
 import pytest
 import voluptuous as vol
 
 from homeassistant.components.airos.const import (
+    CONF_LEGACY_SSL,
     DEFAULT_USERNAME,
     DOMAIN,
     HOSTNAME,
@@ -876,3 +878,92 @@ async def test_dhcp_ip_unchanged(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_manual_flow_retries_with_legacy_tls(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_async_get_firmware_data: AsyncMock,
+    ap_status_fixture: dict[str, Any],
+) -> None:
+    """Test manual flow retries with legacy TLS and creates an entry."""
+    legacy_session = MagicMock()
+    legacy_session.close = AsyncMock()
+
+    mock_async_get_firmware_data.side_effect = [
+        AirOSTLSCompatibilityError(),
+        {
+            "mac": ap_status_fixture.derived.mac,
+            "hostname": ap_status_fixture.host.hostname,
+        },
+    ]
+
+    with (
+        patch(
+            "homeassistant.components.airos.config_flow.TCPConnector",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "homeassistant.components.airos.config_flow.ClientSession",
+            return_value=legacy_session,
+        ) as mock_client_session,
+        patch(
+            "homeassistant.components.airos.config_flow.build_legacy_context",
+            return_value=MagicMock(),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "manual"}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], MOCK_CONFIG
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_LEGACY_SSL] is True
+    assert mock_async_get_firmware_data.await_count == 2
+    mock_client_session.assert_called_once()
+    legacy_session.close.assert_awaited_once()
+
+
+async def test_validate_raise_on_attempted_legacy(
+    hass: HomeAssistant,
+) -> None:
+    """Test legacy mode re-raises TLS compatibility errors."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+
+    flow = hass.config_entries.flow._progress[result["flow_id"]]
+
+    legacy_session = MagicMock()
+    legacy_session.close = AsyncMock()
+
+    with (
+        patch(
+            "homeassistant.components.airos.config_flow.async_get_firmware_data",
+            side_effect=AirOSTLSCompatibilityError(),
+        ),
+        patch(
+            "homeassistant.components.airos.config_flow.TCPConnector",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "homeassistant.components.airos.config_flow.ClientSession",
+            return_value=legacy_session,
+        ) as mock_client_session,
+        patch(
+            "homeassistant.components.airos.config_flow.build_legacy_context",
+            return_value=MagicMock(),
+        ),
+        pytest.raises(AirOSTLSCompatibilityError),
+    ):
+        await flow._validate_and_get_device_info(MOCK_CONFIG, legacy=True)
+
+    mock_client_session.assert_called_once()
+    legacy_session.close.assert_awaited_once()

--- a/tests/components/airos/test_config_flow.py
+++ b/tests/components/airos/test_config_flow.py
@@ -1,6 +1,5 @@
 """Test the Ubiquiti airOS config flow."""
 
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from airos.exceptions import (
@@ -884,7 +883,7 @@ async def test_manual_flow_retries_with_legacy_tls(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
     mock_async_get_firmware_data: AsyncMock,
-    ap_status_fixture: dict[str, Any],
+    ap_status_fixture: AirOSData,
 ) -> None:
     """Test manual flow retries with legacy TLS and creates an entry."""
     legacy_session = MagicMock()
@@ -932,23 +931,15 @@ async def test_manual_flow_retries_with_legacy_tls(
 
 async def test_validate_raise_on_attempted_legacy(
     hass: HomeAssistant,
+    mock_async_get_firmware_data: AsyncMock,
 ) -> None:
     """Test legacy mode re-raises TLS compatibility errors."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-    )
-
-    flow = hass.config_entries.flow._progress[result["flow_id"]]
-
     legacy_session = MagicMock()
     legacy_session.close = AsyncMock()
 
+    mock_async_get_firmware_data.side_effect = AirOSTLSCompatibilityError()
+
     with (
-        patch(
-            "homeassistant.components.airos.config_flow.async_get_firmware_data",
-            side_effect=AirOSTLSCompatibilityError(),
-        ),
         patch(
             "homeassistant.components.airos.config_flow.TCPConnector",
             return_value=MagicMock(),
@@ -960,12 +951,25 @@ async def test_validate_raise_on_attempted_legacy(
         patch(
             "homeassistant.components.airos.config_flow.build_legacy_context",
             return_value=MagicMock(),
-        ),
+        ) as mock_build_legacy_context,
     ):
-        result = await flow._validate_and_get_device_info(MOCK_CONFIG, legacy=True)
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "manual"}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], MOCK_CONFIG
+        )
 
-    assert result is None
-    assert flow.errors == {"base": "cannot_connect"}
-
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "manual"
+    assert result["errors"] == {"base": "cannot_connect"}
+    assert mock_async_get_firmware_data.await_count == 2
     mock_client_session.assert_called_once()
+    mock_build_legacy_context.assert_called_once_with(
+        verify_ssl=MOCK_CONFIG[SECTION_ADVANCED_SETTINGS][CONF_VERIFY_SSL]
+    )
     legacy_session.close.assert_awaited_once()

--- a/tests/components/airos/test_config_flow.py
+++ b/tests/components/airos/test_config_flow.py
@@ -86,7 +86,7 @@ MOCK_DISC_EXISTS = {
 
 async def test_manual_flow_creates_entry(
     hass: HomeAssistant,
-    ap_status_fixture: dict[str, Any],
+    ap_status_fixture: AirOSData,
     mock_airos_client: AsyncMock,
     mock_async_get_firmware_data: AsyncMock,
     mock_setup_entry: AsyncMock,
@@ -161,7 +161,7 @@ async def test_form_duplicate_entry(
 async def test_form_exception_handling(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
-    ap_status_fixture: dict[str, Any],
+    ap_status_fixture: AirOSData,
     mock_airos_client: AsyncMock,
     mock_async_get_firmware_data: AsyncMock,
     exception: Exception,
@@ -961,9 +961,11 @@ async def test_validate_raise_on_attempted_legacy(
             "homeassistant.components.airos.config_flow.build_legacy_context",
             return_value=MagicMock(),
         ),
-        pytest.raises(AirOSTLSCompatibilityError),
     ):
-        await flow._validate_and_get_device_info(MOCK_CONFIG, legacy=True)
+        result = await flow._validate_and_get_device_info(MOCK_CONFIG, legacy=True)
+
+    assert result is None
+    assert flow.errors == {"base": "cannot_connect"}
 
     mock_client_session.assert_called_once()
     legacy_session.close.assert_awaited_once()

--- a/tests/components/airos/test_config_flow.py
+++ b/tests/components/airos/test_config_flow.py
@@ -970,6 +970,6 @@ async def test_validate_raise_on_attempted_legacy(
     assert mock_async_get_firmware_data.await_count == 2
     mock_client_session.assert_called_once()
     mock_build_legacy_context.assert_called_once_with(
-        verify_ssl=MOCK_CONFIG[SECTION_ADVANCED_SETTINGS][CONF_VERIFY_SSL]
+        verify_ssl=MOCK_CONFIG[SECTION_ADDITIONAL_SETTINGS][CONF_VERIFY_SSL]
     )
     legacy_session.close.assert_awaited_once()

--- a/tests/components/airos/test_helpers.py
+++ b/tests/components/airos/test_helpers.py
@@ -1,0 +1,24 @@
+"""Tests for airOS helpers."""
+
+import ssl
+
+from homeassistant.components.airos.helpers import build_legacy_context
+
+
+def test_build_legacy_context() -> None:
+    """Test building a legacy SSL context."""
+    context = build_legacy_context(verify_ssl=False)
+
+    assert isinstance(context, ssl.SSLContext)
+    assert context.minimum_version == ssl.TLSVersion.TLSv1
+    assert context.check_hostname is False
+    assert context.verify_mode == ssl.CERT_NONE
+
+
+def test_build_legacy_context_verify_ssl() -> None:
+    """Test building a legacy SSL context with verification enabled."""
+    context = build_legacy_context(verify_ssl=True)
+
+    assert isinstance(context, ssl.SSLContext)
+    assert context.minimum_version == ssl.TLSVersion.TLSv1
+    assert context.check_hostname is True

--- a/tests/components/airos/test_init.py
+++ b/tests/components/airos/test_init.py
@@ -1,6 +1,6 @@
 """Test for airOS integration setup."""
 
-from unittest.mock import ANY, AsyncMock, MagicMock
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 from airos.exceptions import (
     AirOSConnectionAuthenticationError,
@@ -11,6 +11,7 @@ from airos.exceptions import (
 import pytest
 
 from homeassistant.components.airos.const import (
+    CONF_LEGACY_SSL,
     DEFAULT_SSL,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
@@ -293,3 +294,89 @@ async def test_fetch_airos_data_auth_error(mock_airos_client: MagicMock) -> None
 
     with pytest.raises(ConfigEntryAuthFailed):
         await async_fetch_airos_data(mock_airos_client, mock_airos_client.status)
+
+
+async def test_setup_entry_with_legacy_ssl(
+    hass: HomeAssistant,
+    mock_airos_class: MagicMock,
+    mock_airos_client: MagicMock,
+    mock_async_get_firmware_data: AsyncMock,
+) -> None:
+    """Test setting up a config entry with legacy SSL session ownership."""
+    legacy_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="NanoStation",
+        unique_id="01:23:45:67:89:AB",
+        data={**MOCK_CONFIG_V1_2, CONF_LEGACY_SSL: True},
+    )
+    legacy_entry.add_to_hass(hass)
+
+    legacy_session = MagicMock()
+    legacy_session.close = AsyncMock()
+
+    with (
+        patch(
+            "homeassistant.components.airos.ClientSession",
+            return_value=legacy_session,
+        ) as mock_client_session,
+        patch(
+            "homeassistant.components.airos.TCPConnector",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "homeassistant.components.airos.build_legacy_context",
+            return_value=MagicMock(),
+        ) as mock_build_legacy_context,
+    ):
+        await hass.config_entries.async_setup(legacy_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert legacy_entry.state is ConfigEntryState.LOADED
+
+        mock_client_session.assert_called_once()
+        mock_build_legacy_context.assert_called_once_with(verify_ssl=DEFAULT_VERIFY_SSL)
+
+        mock_airos_class.assert_called_once_with(
+            host=MOCK_CONFIG_V1_2[CONF_HOST],
+            username=MOCK_CONFIG_V1_2[CONF_USERNAME],
+            password=MOCK_CONFIG_V1_2[CONF_PASSWORD],
+            session=legacy_session,
+            use_ssl=DEFAULT_SSL,
+        )
+
+        assert await hass.config_entries.async_unload(legacy_entry.entry_id)
+        await hass.async_block_till_done()
+
+    legacy_session.close.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ("exception", "state"),
+    [
+        (AirOSDeviceConnectionError, ConfigEntryState.SETUP_RETRY),
+    ],
+)
+async def test_setup_entry_with_legacy_ssl_connect_failure(
+    hass: HomeAssistant,
+    mock_airos_class: MagicMock,
+    mock_airos_client: MagicMock,
+    mock_async_get_firmware_data: AsyncMock,
+    exception: Exception,
+    state: ConfigEntryState,
+) -> None:
+    """Test handling legacy SSL connection failure."""
+    legacy_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="NanoStation",
+        unique_id="01:23:45:67:89:AB",
+        data={**MOCK_CONFIG_V1_2, CONF_LEGACY_SSL: True},
+    )
+
+    legacy_session = MagicMock()
+    legacy_session.close = AsyncMock()
+
+    mock_async_get_firmware_data.side_effect = exception
+    legacy_entry.add_to_hass(hass)
+    result = await hass.config_entries.async_setup(legacy_entry.entry_id)
+    assert result is False
+    assert legacy_entry.state is state

--- a/tests/components/airos/test_init.py
+++ b/tests/components/airos/test_init.py
@@ -23,6 +23,7 @@ from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import (
     SOURCE_USER,
     ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
     ConfigEntryState,
 )
 from homeassistant.const import (
@@ -356,7 +357,7 @@ async def test_setup_entry_with_legacy_ssl(
         (AirOSDeviceConnectionError, ConfigEntryState.SETUP_RETRY),
     ],
 )
-async def test_setup_entry_with_legacy_ssl_connect_failure(
+async def test_setup_entry_with_legacy_ssl_fails_firmware_detect(
     hass: HomeAssistant,
     mock_airos_class: MagicMock,
     mock_airos_client: MagicMock,
@@ -371,12 +372,92 @@ async def test_setup_entry_with_legacy_ssl_connect_failure(
         unique_id="01:23:45:67:89:AB",
         data={**MOCK_CONFIG_V1_2, CONF_LEGACY_SSL: True},
     )
+    legacy_entry.add_to_hass(hass)
 
     legacy_session = MagicMock()
     legacy_session.close = AsyncMock()
 
     mock_async_get_firmware_data.side_effect = exception
-    legacy_entry.add_to_hass(hass)
-    result = await hass.config_entries.async_setup(legacy_entry.entry_id)
+
+    with (
+        patch(
+            "homeassistant.components.airos.ClientSession",
+            return_value=legacy_session,
+        ) as mock_client_session,
+        patch(
+            "homeassistant.components.airos.TCPConnector",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "homeassistant.components.airos.build_legacy_context",
+            return_value=MagicMock(),
+        ) as mock_build_legacy_context,
+    ):
+        result = await hass.config_entries.async_setup(legacy_entry.entry_id)
+        await hass.async_block_till_done()
+
     assert result is False
     assert legacy_entry.state is state
+    mock_client_session.assert_called_once()
+    mock_build_legacy_context.assert_called_once_with(verify_ssl=DEFAULT_VERIFY_SSL)
+    legacy_session.close.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ("exception", "state"),
+    [
+        (ConfigEntryNotReady, ConfigEntryState.SETUP_RETRY),
+        (Exception, ConfigEntryState.SETUP_ERROR),
+    ],
+)
+async def test_setup_entry_with_legacy_ssl_fails_coordinator(
+    hass: HomeAssistant,
+    mock_airos_class: MagicMock,
+    mock_airos_client: MagicMock,
+    mock_async_get_firmware_data: AsyncMock,
+    exception: Exception,
+    state: ConfigEntryState,
+) -> None:
+    """Test legacy session is closed when status coordinator first refresh fails."""
+    legacy_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="NanoStation",
+        unique_id="01:23:45:67:89:AB",
+        data={**MOCK_CONFIG_V1_2, CONF_LEGACY_SSL: True},
+    )
+    legacy_entry.add_to_hass(hass)
+
+    legacy_session = MagicMock()
+    legacy_session.close = AsyncMock()
+
+    mock_status_coordinator = MagicMock()
+    mock_status_coordinator.async_config_entry_first_refresh = AsyncMock(
+        side_effect=exception
+    )
+
+    with (
+        patch(
+            "homeassistant.components.airos.ClientSession",
+            return_value=legacy_session,
+        ) as mock_client_session,
+        patch(
+            "homeassistant.components.airos.TCPConnector",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "homeassistant.components.airos.build_legacy_context",
+            return_value=MagicMock(),
+        ) as mock_build_legacy_context,
+        patch(
+            "homeassistant.components.airos.AirOSDataUpdateCoordinator",
+            return_value=mock_status_coordinator,
+        ),
+    ):
+        result = await hass.config_entries.async_setup(legacy_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert result is False
+    assert legacy_entry.state is state
+    mock_client_session.assert_called_once()
+    mock_build_legacy_context.assert_called_once_with(verify_ssl=DEFAULT_VERIFY_SSL)
+    legacy_session.close.assert_awaited_once()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
**Reviewer note** I did not find anything to use as an example on existing integrations and our internal aiohttp helper doesn't expose insecure SSL settings for good reasons. Given that, this PR still might need improvement. Ideas welcome. 

As I don't own any v6 devices, let alone legacy ones, see #169302 for more details by the reporter/requester.

Add legacy TLS fallback support for older airOS devices by retrying config flow validation with a compatible SSL context, persisting that choice in the config entry, and using a dedicated managed session during setup/unload for affected devices.

Side-fix for the hassfest reporting on translations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #169302
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
