### PR TITLE
Fix Mitsubishi Comfort devices skipped due to unresolved local address

### DIFF
--- a/homeassistant/components/mitsubishi_comfort/__init__.py
+++ b/homeassistant/components/mitsubishi_comfort/__init__.py
@@ -14,8 +14,8 @@ from mitsubishi_comfort.exceptions import AuthenticationError, DeviceConnectionE
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.device_registry import format_mac
 
 from .const import (
     CONF_ADDRESSES,
@@ -32,13 +32,14 @@ _LOGGER = logging.getLogger(__name__)
 def _make_device(
     info: DeviceInfo,
     serial: str,
+    address: str,
     session,
 ) -> IndoorUnit | KumoStation:
     """Create the appropriate device instance from DeviceInfo."""
     cls = IndoorUnit if info.is_indoor_unit else KumoStation
     return cls(
         name=info.label,
-        address=info.address,
+        address=address,
         password_b64=info.password,
         crypto_serial_hex=info.crypto_serial,
         serial=serial,
@@ -71,15 +72,25 @@ async def async_setup_entry(
             translation_key="no_devices",
         )
 
-    # The cloud supplies each device's password, crypto serial, and MAC, but not
-    # its LAN IP. Resolve the IP from the DHCP-discovered address cache (keyed by
-    # MAC) and register every owned MAC so async_step_dhcp knows which addresses
-    # belong to this entry.
+    # The cloud provides each device's MAC but never its LAN IP. Register every
+    # device with its MAC so the manifest's "registered_devices" DHCP matcher
+    # tracks it; DHCP discovery then supplies the IP via async_step_dhcp.
+    device_registry = dr.async_get(hass)
+    owned_macs = {dr.format_mac(info.mac) for info in devices.values()}
+    for serial, info in devices.items():
+        device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, serial)},
+            connections={(dr.CONNECTION_NETWORK_MAC, dr.format_mac(info.mac))},
+            manufacturer="Mitsubishi",
+            name=info.label,
+            serial_number=serial,
+        )
+
+    # Resolved IPs are stored keyed by MAC. Drop any for devices that are no
+    # longer on the account.
     stored: dict[str, str] = entry.data.get(CONF_ADDRESSES, {})
-    # Keep an entry for every owned MAC (defaulting to ""), dropping MACs for
-    # devices no longer on the account.
-    addresses = {format_mac(info.mac): "" for info in devices.values()}
-    addresses.update({mac: ip for mac, ip in stored.items() if mac in addresses})
+    addresses = {mac: ip for mac, ip in stored.items() if mac in owned_macs}
     if addresses != stored:
         hass.config_entries.async_update_entry(
             entry, data={**entry.data, CONF_ADDRESSES: addresses}
@@ -87,25 +98,15 @@ async def async_setup_entry(
 
     coordinators: dict[str, MitsubishiComfortCoordinator] = {}
     for serial, info in devices.items():
-        info.address = addresses.get(format_mac(info.mac)) or info.address
-        if not info.address or not info.password or not info.crypto_serial:
-            _LOGGER.debug(
-                "Device %s has no known LAN address yet; it will be added once "
-                "discovered on the network",
-                info.label,
-            )
+        address = addresses.get(dr.format_mac(info.mac))
+        if not address or not info.password or not info.crypto_serial:
+            # No LAN address yet: the device is registered, so DHCP discovery
+            # supplies its IP and reloads the entry to add it.
+            _LOGGER.debug("Device %s has no known LAN address yet", info.label)
             continue
-        device = _make_device(info, serial, session)
+        device = _make_device(info, serial, address, session)
         coordinators[serial] = MitsubishiComfortCoordinator(
             hass, entry, device, info.mac
-        )
-
-    if not coordinators:
-        # No device has a usable LAN address yet. Raise so Home Assistant retries
-        # with backoff; DHCP discovery will fill in addresses and reload the entry.
-        raise ConfigEntryNotReady(
-            translation_domain=DOMAIN,
-            translation_key="no_devices_reachable",
         )
 
     await asyncio.gather(

--- a/homeassistant/components/mitsubishi_comfort/__init__.py
+++ b/homeassistant/components/mitsubishi_comfort/__init__.py
@@ -15,8 +15,15 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import format_mac
 
-from .const import DEFAULT_CONNECT_TIMEOUT, DEFAULT_RESPONSE_TIMEOUT, DOMAIN, PLATFORMS
+from .const import (
+    CONF_ADDRESSES,
+    DEFAULT_CONNECT_TIMEOUT,
+    DEFAULT_RESPONSE_TIMEOUT,
+    DOMAIN,
+    PLATFORMS,
+)
 from .coordinator import MitsubishiComfortConfigEntry, MitsubishiComfortCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -64,14 +71,41 @@ async def async_setup_entry(
             translation_key="no_devices",
         )
 
+    # The cloud supplies each device's password, crypto serial, and MAC, but not
+    # its LAN IP. Resolve the IP from the DHCP-discovered address cache (keyed by
+    # MAC) and register every owned MAC so async_step_dhcp knows which addresses
+    # belong to this entry.
+    stored: dict[str, str] = entry.data.get(CONF_ADDRESSES, {})
+    # Keep an entry for every owned MAC (defaulting to ""), dropping MACs for
+    # devices no longer on the account.
+    addresses = {format_mac(info.mac): "" for info in devices.values()}
+    addresses.update({mac: ip for mac, ip in stored.items() if mac in addresses})
+    if addresses != stored:
+        hass.config_entries.async_update_entry(
+            entry, data={**entry.data, CONF_ADDRESSES: addresses}
+        )
+
     coordinators: dict[str, MitsubishiComfortCoordinator] = {}
     for serial, info in devices.items():
+        info.address = addresses.get(format_mac(info.mac)) or info.address
         if not info.address or not info.password or not info.crypto_serial:
-            _LOGGER.warning("Device %s missing credentials, skipping", info.label)
+            _LOGGER.debug(
+                "Device %s has no known LAN address yet; it will be added once "
+                "discovered on the network",
+                info.label,
+            )
             continue
         device = _make_device(info, serial, session)
         coordinators[serial] = MitsubishiComfortCoordinator(
             hass, entry, device, info.mac
+        )
+
+    if not coordinators:
+        # No device has a usable LAN address yet. Raise so Home Assistant retries
+        # with backoff; DHCP discovery will fill in addresses and reload the entry.
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="no_devices_reachable",
         )
 
     await asyncio.gather(

--- a/homeassistant/components/mitsubishi_comfort/config_flow.py
+++ b/homeassistant/components/mitsubishi_comfort/config_flow.py
@@ -10,8 +10,10 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
-from .const import DOMAIN
+from .const import CONF_ADDRESSES, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -71,3 +73,28 @@ class MitsubishiComfortConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user", data_schema=USER_SCHEMA, errors=errors
         )
+
+    async def async_step_dhcp(
+        self, discovery_info: DhcpServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle a device discovered on the local network via DHCP.
+
+        The cloud API never returns a device's LAN IP, so DHCP discovery is the
+        source of addresses. When a discovered MAC belongs to a configured
+        account, record its IP on that entry and reload so the device can be set
+        up (or recover a changed IP). Discovery never starts an account flow on
+        its own: an account must be added first so its device MACs are known.
+        """
+        mac = format_mac(discovery_info.macaddress)
+        for entry in self._async_current_entries(include_ignore=False):
+            addresses = entry.data.get(CONF_ADDRESSES, {})
+            if mac in addresses and addresses[mac] != discovery_info.ip:
+                self.hass.config_entries.async_update_entry(
+                    entry,
+                    data={
+                        **entry.data,
+                        CONF_ADDRESSES: {**addresses, mac: discovery_info.ip},
+                    },
+                )
+                self.hass.config_entries.async_schedule_reload(entry.entry_id)
+        return self.async_abort(reason="already_configured")

--- a/homeassistant/components/mitsubishi_comfort/config_flow.py
+++ b/homeassistant/components/mitsubishi_comfort/config_flow.py
@@ -9,8 +9,8 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .const import CONF_ADDRESSES, DOMAIN
@@ -77,24 +77,37 @@ class MitsubishiComfortConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:
-        """Handle a device discovered on the local network via DHCP.
+        """Handle a registered device discovered on the local network via DHCP.
 
         The cloud API never returns a device's LAN IP, so DHCP discovery is the
-        source of addresses. When a discovered MAC belongs to a configured
-        account, record its IP on that entry and reload so the device can be set
-        up (or recover a changed IP). Discovery never starts an account flow on
-        its own: an account must be added first so its device MACs are known.
+        source of addresses. Each device is registered with its MAC during setup,
+        so "registered_devices" discovery only fires for our own devices: record
+        the IP on the owning entry and reload to set the device up or recover a
+        changed IP.
         """
-        mac = format_mac(discovery_info.macaddress)
-        for entry in self._async_current_entries(include_ignore=False):
-            addresses = entry.data.get(CONF_ADDRESSES, {})
-            if mac in addresses and addresses[mac] != discovery_info.ip:
-                self.hass.config_entries.async_update_entry(
-                    entry,
-                    data={
-                        **entry.data,
-                        CONF_ADDRESSES: {**addresses, mac: discovery_info.ip},
-                    },
-                )
-                self.hass.config_entries.async_schedule_reload(entry.entry_id)
+        mac = dr.format_mac(discovery_info.macaddress)
+        device = dr.async_get(self.hass).async_get_device(
+            connections={(dr.CONNECTION_NETWORK_MAC, mac)}
+        )
+        entry = next(
+            (
+                entry
+                for entry in self._async_current_entries(include_ignore=False)
+                if device is not None and entry.entry_id in device.config_entries
+            ),
+            None,
+        )
+        if entry is None:
+            return self.async_abort(reason="already_configured")
+
+        addresses = entry.data.get(CONF_ADDRESSES, {})
+        if addresses.get(mac) != discovery_info.ip:
+            self.hass.config_entries.async_update_entry(
+                entry,
+                data={
+                    **entry.data,
+                    CONF_ADDRESSES: {**addresses, mac: discovery_info.ip},
+                },
+            )
+            self.hass.config_entries.async_schedule_reload(entry.entry_id)
         return self.async_abort(reason="already_configured")

--- a/homeassistant/components/mitsubishi_comfort/const.py
+++ b/homeassistant/components/mitsubishi_comfort/const.py
@@ -7,6 +7,13 @@ from homeassistant.const import Platform
 
 DOMAIN: Final = "mitsubishi_comfort"
 PLATFORMS: Final = [Platform.CLIMATE]
+
+# Config entry data key holding the per-device LAN address cache, keyed by the
+# device's formatted MAC. The cloud API only returns each device's MAC, never
+# its LAN IP, so addresses are resolved from DHCP discovery and persisted here
+# to survive restarts without re-discovery.
+CONF_ADDRESSES: Final = "addresses"
+
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=60)
 DEFAULT_CONNECT_TIMEOUT: Final = 1.2
 DEFAULT_RESPONSE_TIMEOUT: Final = 8.0

--- a/homeassistant/components/mitsubishi_comfort/manifest.json
+++ b/homeassistant/components/mitsubishi_comfort/manifest.json
@@ -3,7 +3,7 @@
   "name": "Mitsubishi Comfort",
   "codeowners": ["@nikolairahimi"],
   "config_flow": true,
-  "dhcp": [{ "macaddress": "24CD8D*" }, { "macaddress": "7087A7*" }],
+  "dhcp": [{ "registered_devices": true }],
   "documentation": "https://www.home-assistant.io/integrations/mitsubishi_comfort",
   "integration_type": "hub",
   "iot_class": "local_polling",

--- a/homeassistant/components/mitsubishi_comfort/manifest.json
+++ b/homeassistant/components/mitsubishi_comfort/manifest.json
@@ -3,9 +3,10 @@
   "name": "Mitsubishi Comfort",
   "codeowners": ["@nikolairahimi"],
   "config_flow": true,
+  "dhcp": [{ "macaddress": "24CD8D*" }, { "macaddress": "7087A7*" }],
   "documentation": "https://www.home-assistant.io/integrations/mitsubishi_comfort",
   "integration_type": "hub",
-  "iot_class": "cloud_polling",
+  "iot_class": "local_polling",
   "quality_scale": "bronze",
   "requirements": ["mitsubishi-comfort==0.3.0"]
 }

--- a/homeassistant/components/mitsubishi_comfort/quality_scale.yaml
+++ b/homeassistant/components/mitsubishi_comfort/quality_scale.yaml
@@ -56,7 +56,7 @@ rules:
   icon-translations: todo
   reconfiguration-flow: todo
   dynamic-devices: todo
-  discovery-update-info: todo
+  discovery-update-info: done
   repair-issues: todo
   docs-use-cases: done
   docs-supported-devices: done

--- a/homeassistant/components/mitsubishi_comfort/strings.json
+++ b/homeassistant/components/mitsubishi_comfort/strings.json
@@ -29,9 +29,6 @@
     "no_devices": {
       "message": "No devices were found in your Mitsubishi Comfort account"
     },
-    "no_devices_reachable": {
-      "message": "No devices have a known local address yet. They will be set up automatically once discovered on the network."
-    },
     "update_failed": {
       "message": "{device_name} returned no data"
     }

--- a/homeassistant/components/mitsubishi_comfort/strings.json
+++ b/homeassistant/components/mitsubishi_comfort/strings.json
@@ -29,6 +29,9 @@
     "no_devices": {
       "message": "No devices were found in your Mitsubishi Comfort account"
     },
+    "no_devices_reachable": {
+      "message": "No devices have a known local address yet. They will be set up automatically once discovered on the network."
+    },
     "update_failed": {
       "message": "{device_name} returned no data"
     }

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -444,6 +444,14 @@ DHCP: Final[list[dict[str, str | bool]]] = [
         "macaddress": "00D02D*",
     },
     {
+        "domain": "mitsubishi_comfort",
+        "macaddress": "24CD8D*",
+    },
+    {
+        "domain": "mitsubishi_comfort",
+        "macaddress": "7087A7*",
+    },
+    {
         "domain": "motion_blinds",
         "registered_devices": True,
     },

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -445,11 +445,7 @@ DHCP: Final[list[dict[str, str | bool]]] = [
     },
     {
         "domain": "mitsubishi_comfort",
-        "macaddress": "24CD8D*",
-    },
-    {
-        "domain": "mitsubishi_comfort",
-        "macaddress": "7087A7*",
+        "registered_devices": True,
     },
     {
         "domain": "motion_blinds",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -4369,7 +4369,7 @@
         "mitsubishi_comfort": {
           "integration_type": "hub",
           "config_flow": true,
-          "iot_class": "cloud_polling",
+          "iot_class": "local_polling",
           "name": "Mitsubishi Comfort"
         }
       }

--- a/tests/components/mitsubishi_comfort/conftest.py
+++ b/tests/components/mitsubishi_comfort/conftest.py
@@ -14,13 +14,17 @@ from mitsubishi_comfort import (
 )
 import pytest
 
-from homeassistant.components.mitsubishi_comfort.const import DOMAIN
+from homeassistant.components.mitsubishi_comfort.const import CONF_ADDRESSES, DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers.device_registry import format_mac
 
 from tests.common import MockConfigEntry
 
 MOCK_USERNAME = "test@test.com"
 MOCK_PASSWORD = "testpass"
+MOCK_SERIAL = "SERIAL001"
+MOCK_MAC = "AA:BB:CC:DD:EE:FF"
+MOCK_ADDRESS = "192.168.1.100"
 
 
 def _make_device_status(
@@ -63,12 +67,13 @@ def _make_device_status(
 
 @pytest.fixture
 def mock_config_entry() -> MockConfigEntry:
-    """Return a mock config entry."""
+    """Return a mock config entry with a previously resolved device address."""
     return MockConfigEntry(
         domain=DOMAIN,
         data={
             CONF_USERNAME: MOCK_USERNAME,
             CONF_PASSWORD: MOCK_PASSWORD,
+            CONF_ADDRESSES: {format_mac(MOCK_MAC): MOCK_ADDRESS},
         },
         unique_id="user-12345",
     )
@@ -76,12 +81,12 @@ def mock_config_entry() -> MockConfigEntry:
 
 @pytest.fixture
 def mock_device_info() -> DeviceInfo:
-    """Return a mock DeviceInfo."""
+    """Return a mock DeviceInfo as returned by the cloud (no LAN address)."""
     return DeviceInfo(
-        serial="SERIAL001",
+        serial=MOCK_SERIAL,
         label="Living Room",
-        address="192.168.1.100",
-        mac="AA:BB:CC:DD:EE:FF",
+        address="",
+        mac=MOCK_MAC,
         unit_type="ductless",
         password="dGVzdHBhc3M=",
         crypto_serial="0102030405060708090a",

--- a/tests/components/mitsubishi_comfort/test_config_flow.py
+++ b/tests/components/mitsubishi_comfort/test_config_flow.py
@@ -7,10 +7,14 @@ from mitsubishi_comfort.exceptions import AuthenticationError, DeviceConnectionE
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.mitsubishi_comfort.const import DOMAIN
+from homeassistant.components.mitsubishi_comfort.const import CONF_ADDRESSES, DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+
+from .conftest import MOCK_MAC
 
 from tests.common import MockConfigEntry
 
@@ -110,5 +114,91 @@ async def test_user_step_already_configured(
         result["flow_id"],
         {CONF_USERNAME: MOCK_USERNAME, CONF_PASSWORD: MOCK_PASSWORD},
     )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+def _dhcp_info(ip: str, mac: str = MOCK_MAC) -> DhcpServiceInfo:
+    """Build DHCP discovery info (DHCP reports MACs without separators)."""
+    return DhcpServiceInfo(
+        ip=ip, hostname="kumo", macaddress=mac.replace(":", "").lower()
+    )
+
+
+async def test_dhcp_updates_address_and_reloads(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test DHCP discovery records a new IP for a known device and reloads."""
+    mock_config_entry.add_to_hass(hass)
+    formatted_mac = format_mac(MOCK_MAC)
+
+    with patch(
+        "homeassistant.config_entries.ConfigEntries.async_schedule_reload"
+    ) as mock_reload:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=_dhcp_info("192.168.1.250"),
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert mock_config_entry.data[CONF_ADDRESSES][formatted_mac] == "192.168.1.250"
+    mock_reload.assert_called_once_with(mock_config_entry.entry_id)
+
+
+async def test_dhcp_same_address_does_not_reload(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test DHCP discovery of an unchanged IP does not trigger a reload."""
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.config_entries.ConfigEntries.async_schedule_reload"
+    ) as mock_reload:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=_dhcp_info("192.168.1.100"),
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    mock_reload.assert_not_called()
+
+
+async def test_dhcp_unknown_device_ignored(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test DHCP discovery of a MAC not owned by any entry changes nothing."""
+    mock_config_entry.add_to_hass(hass)
+    original = dict(mock_config_entry.data[CONF_ADDRESSES])
+
+    with patch(
+        "homeassistant.config_entries.ConfigEntries.async_schedule_reload"
+    ) as mock_reload:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=_dhcp_info("192.168.1.251", mac="99:99:99:99:99:99"),
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert mock_config_entry.data[CONF_ADDRESSES] == original
+    mock_reload.assert_not_called()
+
+
+async def test_dhcp_no_account_aborts(hass: HomeAssistant) -> None:
+    """Test DHCP discovery with no configured account aborts without a flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_DHCP},
+        data=_dhcp_info("192.168.1.252"),
+    )
+
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"

--- a/tests/components/mitsubishi_comfort/test_config_flow.py
+++ b/tests/components/mitsubishi_comfort/test_config_flow.py
@@ -11,10 +11,10 @@ from homeassistant.components.mitsubishi_comfort.const import CONF_ADDRESSES, DO
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
-from .conftest import MOCK_MAC
+from .conftest import MOCK_MAC, MOCK_SERIAL
 
 from tests.common import MockConfigEntry
 
@@ -125,13 +125,25 @@ def _dhcp_info(ip: str, mac: str = MOCK_MAC) -> DhcpServiceInfo:
     )
 
 
+def _register_device(
+    device_registry: dr.DeviceRegistry, entry: MockConfigEntry, mac: str = MOCK_MAC
+) -> None:
+    """Register a device with a MAC connection, as setup does."""
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, MOCK_SERIAL)},
+        connections={(dr.CONNECTION_NETWORK_MAC, dr.format_mac(mac))},
+    )
+
+
 async def test_dhcp_updates_address_and_reloads(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test DHCP discovery records a new IP for a known device and reloads."""
+    """Test DHCP discovery records a new IP for a registered device and reloads."""
     mock_config_entry.add_to_hass(hass)
-    formatted_mac = format_mac(MOCK_MAC)
+    _register_device(device_registry, mock_config_entry)
 
     with patch(
         "homeassistant.config_entries.ConfigEntries.async_schedule_reload"
@@ -144,16 +156,20 @@ async def test_dhcp_updates_address_and_reloads(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
-    assert mock_config_entry.data[CONF_ADDRESSES][formatted_mac] == "192.168.1.250"
+    assert mock_config_entry.data[CONF_ADDRESSES][dr.format_mac(MOCK_MAC)] == (
+        "192.168.1.250"
+    )
     mock_reload.assert_called_once_with(mock_config_entry.entry_id)
 
 
 async def test_dhcp_same_address_does_not_reload(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test DHCP discovery of an unchanged IP does not trigger a reload."""
     mock_config_entry.add_to_hass(hass)
+    _register_device(device_registry, mock_config_entry)
 
     with patch(
         "homeassistant.config_entries.ConfigEntries.async_schedule_reload"
@@ -169,12 +185,14 @@ async def test_dhcp_same_address_does_not_reload(
     mock_reload.assert_not_called()
 
 
-async def test_dhcp_unknown_device_ignored(
+async def test_dhcp_unregistered_device_ignored(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test DHCP discovery of a MAC not owned by any entry changes nothing."""
+    """Test DHCP discovery of a MAC with no registered device changes nothing."""
     mock_config_entry.add_to_hass(hass)
+    _register_device(device_registry, mock_config_entry)
     original = dict(mock_config_entry.data[CONF_ADDRESSES])
 
     with patch(

--- a/tests/components/mitsubishi_comfort/test_init.py
+++ b/tests/components/mitsubishi_comfort/test_init.py
@@ -10,8 +10,7 @@ from homeassistant.components.mitsubishi_comfort.const import CONF_ADDRESSES, DO
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .conftest import MOCK_ADDRESS, MOCK_MAC, MOCK_PASSWORD, MOCK_USERNAME
 
@@ -73,16 +72,19 @@ async def test_setup_entry_no_devices_raises(
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
-async def test_setup_entry_no_address_raises_retry(
+async def test_setup_entry_no_address_loads_and_registers(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
     mock_cloud_account: AsyncMock,
 ) -> None:
-    """Test setup retries when no device has a known LAN address yet.
+    """Test setup with no known LAN address loads and registers the device.
 
-    The cloud returns each device's credentials but never its LAN IP, so an
-    entry with no resolved addresses cannot reach any device. Setup must raise
-    ConfigEntryNotReady (not load empty) so Home Assistant retries while DHCP
-    discovery resolves the addresses.
+    The cloud returns each device's credentials but never its LAN IP. Without a
+    resolved address the device cannot be polled, so it creates no entity — but
+    it is registered with its MAC so "registered_devices" DHCP discovery can
+    supply the IP and reload the entry. Setup must not retry (which would hammer
+    the cloud API) since retrying can never resolve the address.
     """
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -94,9 +96,11 @@ async def test_setup_entry_no_address_raises_retry(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state is ConfigEntryState.SETUP_RETRY
-    # The device's MAC is registered so a later DHCP discovery can supply its IP.
-    assert format_mac(MOCK_MAC) in entry.data[CONF_ADDRESSES]
+    assert entry.state is ConfigEntryState.LOADED
+    assert not er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+    assert device_registry.async_get_device(
+        connections={(dr.CONNECTION_NETWORK_MAC, dr.format_mac(MOCK_MAC))}
+    )
 
 
 async def test_setup_entry_resolves_address_from_entry(
@@ -115,11 +119,11 @@ async def test_setup_entry_resolves_address_from_entry(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    # The entity only exists because the address resolved; an unresolved address
-    # would have raised ConfigEntryNotReady instead of creating a coordinator.
     assert mock_config_entry.state is ConfigEntryState.LOADED
     assert entity_registry.async_get_entity_id("climate", DOMAIN, "SERIAL001")
-    assert mock_config_entry.data[CONF_ADDRESSES][format_mac(MOCK_MAC)] == MOCK_ADDRESS
+    assert mock_config_entry.data[CONF_ADDRESSES][dr.format_mac(MOCK_MAC)] == (
+        MOCK_ADDRESS
+    )
 
 
 async def test_setup_entry_skips_incomplete_devices(

--- a/tests/components/mitsubishi_comfort/test_init.py
+++ b/tests/components/mitsubishi_comfort/test_init.py
@@ -6,10 +6,14 @@ from mitsubishi_comfort import DeviceInfo
 from mitsubishi_comfort.exceptions import AuthenticationError, DeviceConnectionError
 import pytest
 
-from homeassistant.components.mitsubishi_comfort.const import DOMAIN
+from homeassistant.components.mitsubishi_comfort.const import CONF_ADDRESSES, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.device_registry import format_mac
+
+from .conftest import MOCK_ADDRESS, MOCK_MAC, MOCK_PASSWORD, MOCK_USERNAME
 
 from tests.common import MockConfigEntry
 
@@ -69,25 +73,53 @@ async def test_setup_entry_no_devices_raises(
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
-async def test_setup_entry_incomplete_credentials_loads_empty(
+async def test_setup_entry_no_address_raises_retry(
+    hass: HomeAssistant,
+    mock_cloud_account: AsyncMock,
+) -> None:
+    """Test setup retries when no device has a known LAN address yet.
+
+    The cloud returns each device's credentials but never its LAN IP, so an
+    entry with no resolved addresses cannot reach any device. Setup must raise
+    ConfigEntryNotReady (not load empty) so Home Assistant retries while DHCP
+    discovery resolves the addresses.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: MOCK_USERNAME, CONF_PASSWORD: MOCK_PASSWORD},
+        unique_id="user-12345",
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    # The device's MAC is registered so a later DHCP discovery can supply its IP.
+    assert format_mac(MOCK_MAC) in entry.data[CONF_ADDRESSES]
+
+
+async def test_setup_entry_resolves_address_from_entry(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
-    mock_device_info: DeviceInfo,
-    mock_cloud_account: AsyncMock,
+    mock_setup_integration: tuple[AsyncMock, MagicMock],
 ) -> None:
-    """Test setup loads with no entities when devices have incomplete credentials."""
+    """Test the LAN address is injected from the entry's persisted cache.
+
+    The cloud-discovered device carries no address; the entity is only created
+    because the entry holds a previously resolved address for the device's MAC.
+    """
     mock_config_entry.add_to_hass(hass)
-    mock_device_info.password = ""
-    mock_device_info.address = ""
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
+    # The entity only exists because the address resolved; an unresolved address
+    # would have raised ConfigEntryNotReady instead of creating a coordinator.
     assert mock_config_entry.state is ConfigEntryState.LOADED
-    assert not er.async_entries_for_config_entry(
-        entity_registry, mock_config_entry.entry_id
-    )
+    assert entity_registry.async_get_entity_id("climate", DOMAIN, "SERIAL001")
+    assert mock_config_entry.data[CONF_ADDRESSES][format_mac(MOCK_MAC)] == MOCK_ADDRESS
 
 
 async def test_setup_entry_skips_incomplete_devices(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds **no devices at all**, logging `Device <name> missing credentials, skipping` for every unit and loading with zero entities and no error.

### Root cause

The integration polls and controls each unit locally over HTTP, so it needs the unit's LAN IP address. The Kumo Cloud returns each device's password, crypto serial, and MAC, but not the local IP, and nothing in the integration resolved it, so every device ended up with an empty `address` and was skipped by the `not info.address` guard. The log is misleading; cloud auth and credentials are fine and only the local address is missing.

### Fix

- **Register each device** in the device registry with its MAC as a `CONNECTION_NETWORK_MAC` connection, and set `dhcp: [{"registered_devices": true}]` in the manifest so DHCP discovery fires for our own devices.
- **`async_step_dhcp`** looks the discovered MAC up in the device registry, records the IP (`entry.data`, keyed by MAC), and reloads, setting the device up, or recovering a changed IP.
- **Set up reachable devices immediately.** Devices without a known address yet are still registered (so discovery can find them) and are added automatically once their IP is discovered — no retry loop against the cloud API.

### Note for reviewers


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #172956, fixes #172949
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
