### PR TITLE
Add operation mode sensor to Powerwall

### DIFF
--- a/homeassistant/components/powerwall/__init__.py
+++ b/homeassistant/components/powerwall/__init__.py
@@ -8,6 +8,7 @@ from tesla_powerwall import (
     AccessDeniedError,
     ApiError,
     MissingAttributeError,
+    OperationMode,
     Powerwall,
     PowerwallUnreachableError,
 )
@@ -301,6 +302,14 @@ async def get_backup_reserve_percentage(power_wall: Powerwall) -> float | None:
         return None
 
 
+async def get_operation_mode(power_wall: Powerwall) -> OperationMode | None:
+    """Return the operation mode."""
+    try:
+        return await power_wall.get_operation_mode()
+    except MissingAttributeError:
+        return None
+
+
 async def _fetch_powerwall_data(power_wall: Powerwall) -> PowerwallData:
     """Process and update powerwall data."""
     # We await each call individually since the powerwall
@@ -308,6 +317,7 @@ async def _fetch_powerwall_data(power_wall: Powerwall) -> PowerwallData:
     # as its faster than establishing a new connection when
     # run concurrently.
     backup_reserve = await get_backup_reserve_percentage(power_wall)
+    operation_mode = await get_operation_mode(power_wall)
     charge = await power_wall.get_charge()
     site_master = await power_wall.get_sitemaster()
     meters = await power_wall.get_meters()
@@ -321,6 +331,7 @@ async def _fetch_powerwall_data(power_wall: Powerwall) -> PowerwallData:
         grid_services_active=grid_services_active,
         grid_status=grid_status,
         backup_reserve=backup_reserve,
+        operation_mode=operation_mode,
         batteries={battery.serial_number: battery for battery in batteries},
     )
 

--- a/homeassistant/components/powerwall/coordinator.py
+++ b/homeassistant/components/powerwall/coordinator.py
@@ -10,6 +10,7 @@ from tesla_powerwall import (
     DeviceType,
     GridStatus,
     MetersAggregatesResponse,
+    OperationMode,
     Powerwall,
     PowerwallStatusResponse,
     SiteInfoResponse,
@@ -53,6 +54,7 @@ class PowerwallData:
     grid_services_active: bool
     grid_status: GridStatus
     backup_reserve: float | None
+    operation_mode: OperationMode | None
     batteries: dict[str, BatteryResponse]
 
 

--- a/homeassistant/components/powerwall/sensor.py
+++ b/homeassistant/components/powerwall/sensor.py
@@ -5,7 +5,13 @@ from dataclasses import dataclass
 from operator import attrgetter, methodcaller
 from typing import TYPE_CHECKING
 
-from tesla_powerwall import BatteryResponse, GridState, MeterResponse, MeterType
+from tesla_powerwall import (
+    BatteryResponse,
+    GridState,
+    MeterResponse,
+    MeterType,
+    OperationMode,
+)
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -225,6 +231,9 @@ async def async_setup_entry(
     if data.backup_reserve is not None:
         entities.append(PowerWallBackupReserveSensor(powerwall_data))
 
+    if data.operation_mode is not None:
+        entities.append(PowerWallOperationModeSensor(powerwall_data))
+
     for meter in data.meters.meters:
         entities.append(PowerWallExportSensor(powerwall_data, meter))
         entities.append(PowerWallImportSensor(powerwall_data, meter))
@@ -307,6 +316,26 @@ class PowerWallBackupReserveSensor(PowerWallEntity, SensorEntity):
         if self.data.backup_reserve is None:
             return None
         return round(self.data.backup_reserve)
+
+
+class PowerWallOperationModeSensor(PowerWallEntity, SensorEntity):
+    """Representation of the Powerwall operation mode."""
+
+    _attr_translation_key = "operation_mode"
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = [mode.value for mode in OperationMode]
+
+    @property
+    def unique_id(self) -> str:
+        """Device Uniqueid."""
+        return f"{self.base_unique_id}_operation_mode"
+
+    @property
+    def native_value(self) -> str | None:
+        """Get the current operation mode."""
+        if self.data.operation_mode is None:
+            return None
+        return self.data.operation_mode.value
 
 
 class PowerWallEnergyDirectionSensor(PowerWallEntity, SensorEntity):

--- a/homeassistant/components/powerwall/strings.json
+++ b/homeassistant/components/powerwall/strings.json
@@ -142,6 +142,14 @@
       "load_instant_voltage": {
         "name": "Load voltage"
       },
+      "operation_mode": {
+        "name": "Operation mode",
+        "state": {
+          "autonomous": "Autonomous",
+          "backup": "Backup",
+          "self_consumption": "Self-consumption"
+        }
+      },
       "site_export": {
         "name": "Site export"
       },

--- a/tests/components/powerwall/mocks.py
+++ b/tests/components/powerwall/mocks.py
@@ -10,6 +10,7 @@ from tesla_powerwall import (
     DeviceType,
     GridStatus,
     MetersAggregatesResponse,
+    OperationMode,
     Powerwall,
     PowerwallStatusResponse,
     SiteInfoResponse,
@@ -48,6 +49,7 @@ async def _mock_powerwall_with_fixtures(
         device_type=DeviceType(device_type.result()["device_type"]),
         serial_numbers=["TG0123456789AB", "TG9876543210BA"],
         backup_reserve_percentage=15.0,
+        operation_mode=OperationMode.SELF_CONSUMPTION,
         batteries=[
             BatteryResponse.from_dict(battery) for battery in batteries.result()
         ],
@@ -65,6 +67,7 @@ async def _mock_powerwall_return_value(
     device_type=None,
     serial_numbers=None,
     backup_reserve_percentage=None,
+    operation_mode=None,
     batteries=None,
 ):
     powerwall_mock = MagicMock(Powerwall)
@@ -81,6 +84,7 @@ async def _mock_powerwall_return_value(
     powerwall_mock.get_backup_reserve_percentage.return_value = (
         backup_reserve_percentage
     )
+    powerwall_mock.get_operation_mode.return_value = operation_mode
     powerwall_mock.is_grid_services_active.return_value = grid_services_active
     powerwall_mock.get_gateway_din.return_value = MOCK_GATEWAY_DIN
     powerwall_mock.get_batteries.return_value = batteries

--- a/tests/components/powerwall/test_sensor.py
+++ b/tests/components/powerwall/test_sensor.py
@@ -124,8 +124,14 @@ async def test_sensors(hass: HomeAssistant, device_registry: dr.DeviceRegistry) 
     for key, value in expected_attributes.items():
         assert state.attributes[key] == value
 
+    state = hass.states.get("sensor.mysite_operation_mode")
+    assert state.state == "self_consumption"
+    assert state.attributes[ATTR_DEVICE_CLASS] == "enum"
+    assert state.attributes[ATTR_FRIENDLY_NAME] == "MySite Operation mode"
+
     mock_powerwall.get_meters.return_value = MetersAggregatesResponse.from_dict({})
     mock_powerwall.get_backup_reserve_percentage.return_value = None
+    mock_powerwall.get_operation_mode.return_value = None
 
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=60))
     await hass.async_block_till_done()
@@ -133,6 +139,7 @@ async def test_sensors(hass: HomeAssistant, device_registry: dr.DeviceRegistry) 
     assert hass.states.get("sensor.mysite_load_power").state == STATE_UNKNOWN
     assert hass.states.get("sensor.mysite_load_frequency").state == STATE_UNKNOWN
     assert hass.states.get("sensor.mysite_backup_reserve").state == STATE_UNKNOWN
+    assert hass.states.get("sensor.mysite_operation_mode").state == STATE_UNKNOWN
 
     assert (
         float(hass.states.get("sensor.mysite_tg0123456789ab_battery_capacity").state)
@@ -217,6 +224,32 @@ async def test_sensor_backup_reserve_unavailable(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     state = hass.states.get("sensor.powerwall_backup_reserve")
+    assert state is None
+
+
+async def test_sensor_operation_mode_unavailable(hass: HomeAssistant) -> None:
+    """Confirm operation mode sensor is not added if unavailable."""
+
+    mock_powerwall = await _mock_powerwall_with_fixtures(hass)
+    mock_powerwall.get_operation_mode.side_effect = MissingAttributeError(
+        Mock(), "real_mode", "operation"
+    )
+
+    config_entry = MockConfigEntry(domain=DOMAIN, data={CONF_IP_ADDRESS: "1.2.3.4"})
+    config_entry.add_to_hass(hass)
+    with (
+        patch(
+            "homeassistant.components.powerwall.config_flow.Powerwall",
+            return_value=mock_powerwall,
+        ),
+        patch(
+            "homeassistant.components.powerwall.Powerwall", return_value=mock_powerwall
+        ),
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.mysite_operation_mode")
     assert state is None
 
 


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a read-only **Operation mode** sensor to the Tesla Powerwall integration, exposing the gateway's current operation mode (`self_consumption` / `autonomous` / `backup`) as an enum sensor.

The value is already retrieved from the gateway — the `tesla_powerwall` library exposes it via `get_operation_mode()` (it reads `real_mode` from the same `/api/operation` payload the existing **Backup reserve** sensor already uses). This PR just surfaces it as an entity; no new dependency and no extra round-trip pattern beyond the existing per-call fetch.

The implementation mirrors the existing `backup_reserve` sensor: a `None`-safe wrapper (`get_operation_mode`) returning `None` on `MissingAttributeError`, with the sensor only created when the gateway reports the value. The enum options come from the library's `OperationMode` enum.

Why: the operation mode is otherwise only readable via the cloud-based Tesla integrations (whose state reflects the last command sent, not the gateway's actual mode), so there's no native read-back of what the Powerwall is actually doing. This adds a reliable local one.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
