### PR TITLE
Fix value template in MQTT Fan and Siren subentry setup

### DIFF
--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -3395,7 +3395,7 @@ PLATFORM_MQTT_FIELDS: dict[Platform, dict[str, PlatformField]] = {
             validator=valid_subscribe_topic,
             error="invalid_subscribe_topic",
         ),
-        CONF_VALUE_TEMPLATE: PlatformField(
+        CONF_STATE_VALUE_TEMPLATE: PlatformField(
             selector=TEMPLATE_SELECTOR,
             required=False,
             validator=validate(cv.template),

--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -2451,7 +2451,7 @@ PLATFORM_MQTT_FIELDS: dict[Platform, dict[str, PlatformField]] = {
             validator=valid_subscribe_topic,
             error="invalid_subscribe_topic",
         ),
-        CONF_VALUE_TEMPLATE: PlatformField(
+        CONF_STATE_VALUE_TEMPLATE: PlatformField(
             selector=TEMPLATE_SELECTOR,
             required=False,
             validator=validate(cv.template),

--- a/tests/components/mqtt/common.py
+++ b/tests/components/mqtt/common.py
@@ -354,7 +354,7 @@ MOCK_SUBENTRY_FAN_COMPONENT = {
         "entity_category": None,
         "state_topic": "test-topic",
         "command_template": "{{ value }}",
-        "value_template": "{{ value_json.value }}",
+        "state_value_template": "{{ value_json.value }}",
         "percentage_command_topic": "test-topic/pct",
         "percentage_state_topic": "test-topic/pct",
         "percentage_command_template": "{{ value }}",
@@ -637,7 +637,7 @@ MOCK_SUBENTRY_SIREN_COMPONENT = {
         "state_topic": "test-topic",
         "command_template": "{{ value }}",
         "command_off_template": "{{ value }}",
-        "value_template": "{{ value_json.value }}",
+        "state_value_template": "{{ value_json.value }}",
         "payload_off": "OFF",
         "payload_on": "ON",
         "available_tones": ["Happy hour", "Cooling alarm"],
@@ -957,11 +957,13 @@ MOCK_SUBENTRY_DATA_SET_MIX = {
             },
         }
     },
-    "components": MOCK_SUBENTRY_NOTIFY_COMPONENT1
+    "components": MOCK_SUBENTRY_FAN_COMPONENT
+    | MOCK_SUBENTRY_NOTIFY_COMPONENT1
     | MOCK_SUBENTRY_NOTIFY_COMPONENT2
     | MOCK_SUBENTRY_LIGHT_BASIC_KELVIN_COMPONENT
     | MOCK_SUBENTRY_SWITCH_COMPONENT
-    | MOCK_SUBENTRY_SENSOR_COMPONENT_UOM_NULL,
+    | MOCK_SUBENTRY_SENSOR_COMPONENT_UOM_NULL
+    | MOCK_SUBENTRY_SIREN_COMPONENT,
 } | MOCK_SUBENTRY_AVAILABILITY_DATA
 _SENTINEL = object()
 

--- a/tests/components/mqtt/test_config_flow.py
+++ b/tests/components/mqtt/test_config_flow.py
@@ -3242,7 +3242,7 @@ async def test_migrate_of_incompatible_config_entry(
                 "command_topic": "test-topic",
                 "command_template": "{{ value }}",
                 "state_topic": "test-topic",
-                "value_template": "{{ value_json.value }}",
+                "state_value_template": "{{ value_json.value }}",
                 "fan_speed_settings": {
                     "percentage_command_template": "{{ value }}",
                     "percentage_command_topic": "test-topic/pct",
@@ -3801,7 +3801,7 @@ async def test_migrate_of_incompatible_config_entry(
                 "command_topic": "test-topic",
                 "command_template": "{{ value }}",
                 "state_topic": "test-topic",
-                "value_template": "{{ value_json.value }}",
+                "state_value_template": "{{ value_json.value }}",
                 "optimistic": True,
                 "available_tones": ["Happy hour", "Cooling alarm"],
                 "support_duration": True,

--- a/tests/components/mqtt/test_mixins.py
+++ b/tests/components/mqtt/test_mixins.py
@@ -676,7 +676,7 @@ async def test_loading_subentries(
         entity_id = f"{platform}.{slugify(device.name)}_{slugify(component['name'])}"
         state = hass.states.get(entity_id)
         assert state is not None
-        assert state.state == "unknown"
+        assert state.state in ("off", "unknown")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix value template in MQTT Fan and Siren subentry setup. The current setup causes a config validation on the `value_template`. Some platfoms use `state_value_template` instead.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #172922
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
