### PR TITLE
Use DOMAIN constant in MockConfigEntry (a-o)

### DIFF
--- a/tests/components/adax/test_config_flow.py
+++ b/tests/components/adax/test_config_flow.py
@@ -98,7 +98,7 @@ async def test_flow_entry_already_exists(hass: HomeAssistant) -> None:
     """Test user input for config_entry that already exists."""
 
     first_entry = MockConfigEntry(
-        domain="adax",
+        domain=DOMAIN,
         data=TEST_DATA,
         unique_id=str(TEST_DATA[ACCOUNT_ID]),
     )
@@ -192,7 +192,7 @@ async def test_local_flow_entry_already_exists(hass: HomeAssistant) -> None:
     }
 
     first_entry = MockConfigEntry(
-        domain="adax",
+        domain=DOMAIN,
         data=test_data,
         unique_id="8383838",
     )

--- a/tests/components/amberelectric/test_binary_sensor.py
+++ b/tests/components/amberelectric/test_binary_sensor.py
@@ -30,7 +30,7 @@ MOCK_API_TOKEN = "psk_0000000000000000"
 async def setup_no_spike(hass: HomeAssistant) -> AsyncGenerator[Mock]:
     """Set up general channel."""
     MockConfigEntry(
-        domain="amberelectric",
+        domain=DOMAIN,
         data={
             CONF_SITE_NAME: "mock_title",
             CONF_API_TOKEN: MOCK_API_TOKEN,
@@ -53,7 +53,7 @@ async def setup_no_spike(hass: HomeAssistant) -> AsyncGenerator[Mock]:
 async def setup_potential_spike(hass: HomeAssistant) -> AsyncGenerator[Mock]:
     """Set up general channel."""
     MockConfigEntry(
-        domain="amberelectric",
+        domain=DOMAIN,
         data={
             CONF_SITE_NAME: "mock_title",
             CONF_API_TOKEN: MOCK_API_TOKEN,
@@ -82,7 +82,7 @@ async def setup_potential_spike(hass: HomeAssistant) -> AsyncGenerator[Mock]:
 async def setup_spike(hass: HomeAssistant) -> AsyncGenerator[Mock]:
     """Set up general channel."""
     MockConfigEntry(
-        domain="amberelectric",
+        domain=DOMAIN,
         data={
             CONF_SITE_NAME: "mock_title",
             CONF_API_TOKEN: MOCK_API_TOKEN,
@@ -144,7 +144,7 @@ def test_spike_sensor(hass: HomeAssistant) -> None:
 async def setup_inactive_demand_window(hass: HomeAssistant) -> AsyncGenerator[Mock]:
     """Set up general channel."""
     MockConfigEntry(
-        domain="amberelectric",
+        domain=DOMAIN,
         data={
             CONF_SITE_NAME: "mock_title",
             CONF_API_TOKEN: MOCK_API_TOKEN,
@@ -175,7 +175,7 @@ async def setup_inactive_demand_window(hass: HomeAssistant) -> AsyncGenerator[Mo
 async def setup_active_demand_window(hass: HomeAssistant) -> AsyncGenerator[Mock]:
     """Set up general channel."""
     MockConfigEntry(
-        domain="amberelectric",
+        domain=DOMAIN,
         data={
             CONF_SITE_NAME: "mock_title",
             CONF_API_TOKEN: MOCK_API_TOKEN,

--- a/tests/components/amberelectric/test_coordinator.py
+++ b/tests/components/amberelectric/test_coordinator.py
@@ -16,6 +16,7 @@ import pytest
 from homeassistant.components.amberelectric.const import (
     CONF_SITE_ID,
     CONF_SITE_NAME,
+    DOMAIN,
     REQUEST_TIMEOUT,
 )
 from homeassistant.components.amberelectric.coordinator import AmberUpdateCoordinator
@@ -36,7 +37,7 @@ from .helpers import (
 from tests.common import MockConfigEntry
 
 MOCKED_ENTRY = MockConfigEntry(
-    domain="amberelectric",
+    domain=DOMAIN,
     data={
         CONF_SITE_NAME: "mock_title",
         CONF_API_TOKEN: "psk_0000000000000000",

--- a/tests/components/anthropic/conftest.py
+++ b/tests/components/anthropic/conftest.py
@@ -24,6 +24,7 @@ import pytest
 from homeassistant.components.anthropic.const import (
     DEFAULT_AI_TASK_NAME,
     DEFAULT_CONVERSATION_NAME,
+    DOMAIN,
 )
 from homeassistant.const import CONF_LLM_HASS_API
 from homeassistant.core import HomeAssistant
@@ -41,7 +42,7 @@ def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
     """Mock a config entry."""
     entry = MockConfigEntry(
         title="Claude",
-        domain="anthropic",
+        domain=DOMAIN,
         data={
             "api_key": "bla",
         },

--- a/tests/components/apple_tv/test_config_flow.py
+++ b/tests/components/apple_tv/test_config_flow.py
@@ -273,7 +273,7 @@ async def test_user_adds_device_by_ip_uses_unicast_scan(
 @pytest.mark.usefixtures("mrp_device")
 async def test_user_adds_existing_device(hass: HomeAssistant) -> None:
     """Test that it is not possible to add existing device."""
-    MockConfigEntry(domain="apple_tv", unique_id="mrpid").add_to_hass(hass)
+    MockConfigEntry(domain=DOMAIN, unique_id="mrpid").add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -668,10 +668,10 @@ async def test_zeroconf_add_dmap_device(hass: HomeAssistant) -> None:
 async def test_zeroconf_ip_change(hass: HomeAssistant, mock_scan: AsyncMock) -> None:
     """Test that the config entry gets updated when the ip changes and reloads."""
     entry = MockConfigEntry(
-        domain="apple_tv", unique_id="mrpid", data={CONF_ADDRESS: "127.0.0.2"}
+        domain=DOMAIN, unique_id="mrpid", data={CONF_ADDRESS: "127.0.0.2"}
     )
     unrelated_entry = MockConfigEntry(
-        domain="apple_tv", unique_id="unrelated", data={CONF_ADDRESS: "127.0.0.2"}
+        domain=DOMAIN, unique_id="unrelated", data={CONF_ADDRESS: "127.0.0.2"}
     )
     unrelated_entry.add_to_hass(hass)
     entry.add_to_hass(hass)
@@ -703,10 +703,10 @@ async def test_zeroconf_ip_change_after_ip_conflict_with_ignored_entry(
 ) -> None:
     """Test that the config entry gets updated when the ip changes and reloads."""
     entry = MockConfigEntry(
-        domain="apple_tv", unique_id="mrpid", data={CONF_ADDRESS: "127.0.0.2"}
+        domain=DOMAIN, unique_id="mrpid", data={CONF_ADDRESS: "127.0.0.2"}
     )
     ignored_entry = MockConfigEntry(
-        domain="apple_tv",
+        domain=DOMAIN,
         unique_id="unrelated",
         data={CONF_ADDRESS: "127.0.0.2"},
         source=config_entries.SOURCE_IGNORE,
@@ -745,12 +745,12 @@ async def test_zeroconf_ip_change_via_secondary_identifier(
     in the config entry are checked
     """
     entry = MockConfigEntry(
-        domain="apple_tv",
+        domain=DOMAIN,
         unique_id="aa:bb:cc:dd:ee:ff",
         data={CONF_IDENTIFIERS: ["mrpid"], CONF_ADDRESS: "127.0.0.2"},
     )
     unrelated_entry = MockConfigEntry(
-        domain="apple_tv", unique_id="unrelated", data={CONF_ADDRESS: "127.0.0.2"}
+        domain=DOMAIN, unique_id="unrelated", data={CONF_ADDRESS: "127.0.0.2"}
     )
     unrelated_entry.add_to_hass(hass)
     entry.add_to_hass(hass)
@@ -787,13 +787,13 @@ async def test_zeroconf_updates_identifiers_for_ignored_entries(
     in the config entry are checked
     """
     entry = MockConfigEntry(
-        domain="apple_tv",
+        domain=DOMAIN,
         unique_id="aa:bb:cc:dd:ee:ff",
         source=config_entries.SOURCE_IGNORE,
         data={CONF_IDENTIFIERS: ["mrpid"], CONF_ADDRESS: "127.0.0.2"},
     )
     unrelated_entry = MockConfigEntry(
-        domain="apple_tv", unique_id="unrelated", data={CONF_ADDRESS: "127.0.0.2"}
+        domain=DOMAIN, unique_id="unrelated", data={CONF_ADDRESS: "127.0.0.2"}
     )
     unrelated_entry.add_to_hass(hass)
     entry.add_to_hass(hass)
@@ -849,7 +849,7 @@ async def test_zeroconf_add_but_device_not_found(hass: HomeAssistant) -> None:
 @pytest.mark.usefixtures("dmap_device")
 async def test_zeroconf_add_existing_device(hass: HomeAssistant) -> None:
     """Test add already existing device from zeroconf."""
-    MockConfigEntry(domain="apple_tv", unique_id="dmapid").add_to_hass(hass)
+    MockConfigEntry(domain=DOMAIN, unique_id="dmapid").add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_ZEROCONF}, data=DMAP_SERVICE
@@ -1187,7 +1187,7 @@ async def test_reconfigure_update_credentials(
 ) -> None:
     """Test that reconfigure flow updates config entry."""
     config_entry = MockConfigEntry(
-        domain="apple_tv", unique_id="mrpid", data={"identifiers": ["mrpid"]}
+        domain=DOMAIN, unique_id="mrpid", data={"identifiers": ["mrpid"]}
     )
     config_entry.add_to_hass(hass)
 

--- a/tests/components/arcam_fmj/conftest.py
+++ b/tests/components/arcam_fmj/conftest.py
@@ -9,7 +9,7 @@ from arcam.fmj.client import Client, ResponsePacket
 from arcam.fmj.state import State
 import pytest
 
-from homeassistant.components.arcam_fmj.const import DEFAULT_NAME
+from homeassistant.components.arcam_fmj.const import DEFAULT_NAME, DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.setup import async_setup_component
@@ -122,7 +122,7 @@ def state_2_fixture(client: Mock) -> State:
 def mock_config_entry_fixture(hass: HomeAssistant) -> MockConfigEntry:
     """Get a mock config entry."""
     config_entry = MockConfigEntry(
-        domain="arcam_fmj",
+        domain=DOMAIN,
         data=MOCK_CONFIG_ENTRY,
         title=MOCK_NAME,
         unique_id=MOCK_UUID,

--- a/tests/components/assist_pipeline/test_select.py
+++ b/tests/components/assist_pipeline/test_select.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from homeassistant.components.assist_pipeline import Pipeline
+from homeassistant.components.assist_pipeline import DOMAIN, Pipeline
 from homeassistant.components.assist_pipeline.pipeline import (
     AssistDevice,
     PipelineData,
@@ -48,9 +48,7 @@ class SelectPlatform(MockPlatform):
 async def init_select(hass: HomeAssistant, init_components) -> ConfigEntry:
     """Initialize select entity."""
     mock_platform(hass, "assist_pipeline.select", SelectPlatform())
-    config_entry = MockConfigEntry(
-        domain="assist_pipeline", state=ConfigEntryState.LOADED
-    )
+    config_entry = MockConfigEntry(domain=DOMAIN, state=ConfigEntryState.LOADED)
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_forward_entry_setups(
         config_entry, [Platform.SELECT]

--- a/tests/components/backblaze_b2/test_repairs.py
+++ b/tests/components/backblaze_b2/test_repairs.py
@@ -10,6 +10,7 @@ from b2sdk.v2.exception import (
 )
 import pytest
 
+from homeassistant.components.backblaze_b2 import DOMAIN
 from homeassistant.components.backblaze_b2.repairs import (
     async_check_for_repair_issues,
     async_create_fix_flow,
@@ -24,7 +25,7 @@ from tests.common import MockConfigEntry
 @pytest.fixture
 def mock_entry():
     """Create a mock config entry with runtime data."""
-    entry = MockConfigEntry(domain="backblaze_b2", data={"bucket": "test"})
+    entry = MockConfigEntry(domain=DOMAIN, data={"bucket": "test"})
     entry.runtime_data = Mock()
     return entry
 

--- a/tests/components/bluetooth/__init__.py
+++ b/tests/components/bluetooth/__init__.py
@@ -312,7 +312,7 @@ async def _async_setup_with_adapter(
     hass: HomeAssistant, address: str
 ) -> MockConfigEntry:
     """Set up the Bluetooth integration with any adapter."""
-    entry = MockConfigEntry(domain="bluetooth", unique_id=address)
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=address)
     entry.add_to_hass(hass)
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     await hass.async_block_till_done()

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -467,7 +467,7 @@ async def test_discovery_match_by_service_uuid_and_short_local_name(
     mock_bleak_scanner_start: MagicMock,
 ) -> None:
     """Test bluetooth discovery match by service_uuid and short local name."""
-    entry = MockConfigEntry(domain="bluetooth", unique_id="00:00:00:00:00:01")
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="00:00:00:00:00:01")
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
@@ -3543,7 +3543,7 @@ async def test_title_updated_if_mac_address(
 ) -> None:
     """Test the title is updated if it is the mac address."""
     entry = MockConfigEntry(
-        domain="bluetooth", title="00:00:00:00:00:01", unique_id="00:00:00:00:00:01"
+        domain=DOMAIN, title="00:00:00:00:00:01", unique_id="00:00:00:00:00:01"
     )
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/components/bosch_shc/test_config_flow.py
+++ b/tests/components/bosch_shc/test_config_flow.py
@@ -442,7 +442,7 @@ async def test_form_already_configured(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     entry = MockConfigEntry(
-        domain="bosch_shc", unique_id="test-mac", data={"host": "0.0.0.0"}
+        domain=DOMAIN, unique_id="test-mac", data={"host": "0.0.0.0"}
     )
     entry.add_to_hass(hass)
 
@@ -562,7 +562,7 @@ async def test_zeroconf_already_configured(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     entry = MockConfigEntry(
-        domain="bosch_shc", unique_id="test-mac", data={"host": "0.0.0.0"}
+        domain=DOMAIN, unique_id="test-mac", data={"host": "0.0.0.0"}
     )
     entry.add_to_hass(hass)
 

--- a/tests/components/cast/test_config_flow.py
+++ b/tests/components/cast/test_config_flow.py
@@ -7,6 +7,7 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components import cast
+from homeassistant.components.cast import DOMAIN
 from homeassistant.components.cast.home_assistant_cast import CAST_USER_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -61,7 +62,7 @@ async def test_creating_entry_sets_up_media_player(hass: HomeAssistant) -> None:
 )
 async def test_single_instance(hass: HomeAssistant, source) -> None:
     """Test we only allow a single config flow."""
-    MockConfigEntry(domain="cast").add_to_hass(hass)
+    MockConfigEntry(domain=DOMAIN).add_to_hass(hass)
     await hass.async_block_till_done()
 
     result = await hass.config_entries.flow.async_init(
@@ -236,7 +237,7 @@ async def test_option_flow(
     basic_parameters = ["known_hosts"]
     extra_parameters = ["ignore_cec", "uuid"]
 
-    config_entry = MockConfigEntry(domain="cast", data=initial)
+    config_entry = MockConfigEntry(domain=DOMAIN, data=initial)
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/cast/test_home_assistant_cast.py
+++ b/tests/components/cast/test_home_assistant_cast.py
@@ -117,7 +117,7 @@ async def test_remove_entry(hass: HomeAssistant) -> None:
     """Test removing config entry removes user."""
     entry = MockConfigEntry(
         data={},
-        domain="cast",
+        domain=DOMAIN,
         title="Google Cast",
     )
 

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -127,7 +127,7 @@ async def async_setup_cast(
     with patch(
         "homeassistant.helpers.entity_platform.EntityPlatform._async_schedule_add_entities_for_entry"
     ) as add_entities:
-        entry = MockConfigEntry(data=data, domain="cast")
+        entry = MockConfigEntry(data=data, domain=DOMAIN)
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -226,7 +226,7 @@ async def async_setup_media_player_cast(hass: HomeAssistant, info: ChromecastInf
         ),
     ):
         data = {"ignore_cec": [], "known_hosts": [], "uuid": [str(info.uuid)]}
-        entry = MockConfigEntry(data=data, domain="cast")
+        entry = MockConfigEntry(data=data, domain=DOMAIN)
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done(wait_background_tasks=True)
@@ -487,7 +487,7 @@ async def test_stop_discovery_called_on_stop(
 
 async def test_create_cast_device_without_uuid(hass: HomeAssistant) -> None:
     """Test create a cast device with no UUId does not create an entity."""
-    entry = MockConfigEntry(domain="cast")
+    entry = MockConfigEntry(domain=DOMAIN)
     entry.add_to_hass(hass)
     entry.runtime_data = CastRuntimeData()
     info = get_fake_chromecast_info(uuid=None)
@@ -497,7 +497,7 @@ async def test_create_cast_device_without_uuid(hass: HomeAssistant) -> None:
 
 async def test_create_cast_device_with_uuid(hass: HomeAssistant) -> None:
     """Test create cast devices with UUID creates entities."""
-    entry = MockConfigEntry(domain="cast")
+    entry = MockConfigEntry(domain=DOMAIN)
     entry.add_to_hass(hass)
     entry.runtime_data = CastRuntimeData()
     added_casts = entry.runtime_data.added_cast_devices

--- a/tests/components/cloud/test_ai_task.py
+++ b/tests/components/cloud/test_ai_task.py
@@ -16,6 +16,7 @@ import pytest
 import voluptuous as vol
 
 from homeassistant.components import ai_task, conversation
+from homeassistant.components.cloud import DOMAIN
 from homeassistant.components.cloud.ai_task import (
     CloudAITaskEntity,
     async_prepare_image_generation_attachments,
@@ -36,7 +37,7 @@ def mock_cloud_ai_task_entity(hass: HomeAssistant) -> CloudAITaskEntity:
     )
     cloud.is_logged_in = True
     cloud.valid_subscription = True
-    entry = MockConfigEntry(domain="cloud")
+    entry = MockConfigEntry(domain=DOMAIN)
     entry.add_to_hass(hass)
     entity = CloudAITaskEntity(cloud, entry)
     entity.entity_id = "ai_task.cloud_ai_task"

--- a/tests/components/cloud/test_entity.py
+++ b/tests/components/cloud/test_entity.py
@@ -31,7 +31,7 @@ def cloud_entity(hass: HomeAssistant) -> BaseCloudLLMEntity:
     cloud.llm = MagicMock()
     cloud.is_logged_in = True
     cloud.valid_subscription = True
-    entry = MockConfigEntry(domain="cloud")
+    entry = MockConfigEntry(domain=DOMAIN)
     entry.add_to_hass(hass)
     entity = BaseCloudLLMEntity(cloud, entry)
     entity.entity_id = "ai_task.cloud_ai_task"

--- a/tests/components/eafm/test_sensor.py
+++ b/tests/components/eafm/test_sensor.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock
 import aiohttp
 import pytest
 
+from homeassistant.components.eafm import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
@@ -34,7 +35,7 @@ async def async_setup_test_fixture(
 
     entry = MockConfigEntry(
         version=1,
-        domain="eafm",
+        domain=DOMAIN,
         entry_id="VikingRecorder1234",
         data={"station": "L1234"},
         title="Viking Recorder",

--- a/tests/components/emulated_roku/test_config_flow.py
+++ b/tests/components/emulated_roku/test_config_flow.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.emulated_roku import config_flow
+from homeassistant.components.emulated_roku import DOMAIN, config_flow
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -38,7 +38,7 @@ async def test_flow_works(hass: HomeAssistant) -> None:
 async def test_flow_already_registered_entry(hass: HomeAssistant) -> None:
     """Test that config flow doesn't allow existing names."""
     MockConfigEntry(
-        domain="emulated_roku", data={"name": "Emulated Roku Test", "listen_port": 8062}
+        domain=DOMAIN, data={"name": "Emulated Roku Test", "listen_port": 8062}
     ).add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/evil_genius_labs/conftest.py
+++ b/tests/components/evil_genius_labs/conftest.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
+from homeassistant.components.evil_genius_labs.const import DOMAIN
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -40,7 +41,7 @@ def product_fixture() -> dict[str, str]:
 @pytest.fixture
 def config_entry(hass: HomeAssistant) -> MockConfigEntry:
     """Evil genius labs config entry."""
-    entry = MockConfigEntry(domain="evil_genius_labs", data={"host": "192.168.1.113"})
+    entry = MockConfigEntry(domain=DOMAIN, data={"host": "192.168.1.113"})
     entry.add_to_hass(hass)
     return entry
 

--- a/tests/components/fish_audio/test_tts.py
+++ b/tests/components/fish_audio/test_tts.py
@@ -9,7 +9,7 @@ from fishaudio.exceptions import ServerError
 import pytest
 
 from homeassistant.components import tts
-from homeassistant.components.fish_audio.const import CONF_BACKEND
+from homeassistant.components.fish_audio.const import CONF_BACKEND, DOMAIN
 from homeassistant.components.media_player import (
     ATTR_MEDIA_CONTENT_ID,
     DOMAIN as MP_DOMAIN,
@@ -118,7 +118,7 @@ async def test_tts_missing_voice_id(
     """Test TTS service raises ServiceValidationError when voice_id is missing."""
     # Create a config entry with no voice_id
     entry = MockConfigEntry(
-        domain="fish_audio",
+        domain=DOMAIN,
         data={"api_key": "test-key"},
         unique_id="test_user",
         subentries_data=[

--- a/tests/components/generic/test_camera.py
+++ b/tests/components/generic/test_camera.py
@@ -59,7 +59,7 @@ async def help_setup_mock_config_entry(
         CONF_VERIFY_SSL: options.get(CONF_VERIFY_SSL),
     }
     entry = MockConfigEntry(
-        domain="generic",
+        domain=DOMAIN,
         title=options[CONF_NAME],
         options=entry_options,
         unique_id=unique_id,

--- a/tests/components/google_generative_ai_conversation/conftest.py
+++ b/tests/components/google_generative_ai_conversation/conftest.py
@@ -11,6 +11,7 @@ from homeassistant.components.google_generative_ai_conversation.const import (
     DEFAULT_CONVERSATION_NAME,
     DEFAULT_STT_NAME,
     DEFAULT_TTS_NAME,
+    DOMAIN,
     RECOMMENDED_AI_TASK_OPTIONS,
     RECOMMENDED_CONVERSATION_OPTIONS,
     RECOMMENDED_STT_OPTIONS,
@@ -29,7 +30,7 @@ from tests.common import MockConfigEntry
 def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
     """Mock a config entry."""
     entry = MockConfigEntry(
-        domain="google_generative_ai_conversation",
+        domain=DOMAIN,
         title="Google Generative AI Conversation",
         data={
             "api_key": "bla",

--- a/tests/components/homeassistant_yellow/test_switch.py
+++ b/tests/components/homeassistant_yellow/test_switch.py
@@ -6,7 +6,7 @@ from ha_silabs_firmware_client import FirmwareManifest, FirmwareMetadata
 import pytest
 from yarl import URL
 
-from homeassistant.components.homeassistant_yellow.const import RADIO_DEVICE
+from homeassistant.components.homeassistant_yellow.const import DOMAIN, RADIO_DEVICE
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -78,7 +78,7 @@ async def test_switch_turn_on_off(
     # Set up the Yellow integration
     yellow_config_entry = MockConfigEntry(
         title="Home Assistant Yellow",
-        domain="homeassistant_yellow",
+        domain=DOMAIN,
         data={
             "firmware": "ezsp",
             "firmware_version": "7.3.1.0 build 0",

--- a/tests/components/homeassistant_yellow/test_update.py
+++ b/tests/components/homeassistant_yellow/test_update.py
@@ -11,7 +11,7 @@ from homeassistant.components.homeassistant_hardware.util import (
     ApplicationType,
     FirmwareInfo,
 )
-from homeassistant.components.homeassistant_yellow.const import RADIO_DEVICE
+from homeassistant.components.homeassistant_yellow.const import DOMAIN, RADIO_DEVICE
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -27,7 +27,7 @@ async def test_yellow_update_entity(hass: HomeAssistant) -> None:
     # Set up the Yellow integration
     yellow_config_entry = MockConfigEntry(
         title="Home Assistant Yellow",
-        domain="homeassistant_yellow",
+        domain=DOMAIN,
         data={
             "firmware": "ezsp",
             "firmware_version": "7.3.1.0 build 0",
@@ -115,7 +115,7 @@ async def test_yellow_update_entity_state(
     # Set up the Yellow integration
     yellow_config_entry = MockConfigEntry(
         title="Home Assistant Yellow",
-        domain="homeassistant_yellow",
+        domain=DOMAIN,
         data={
             "firmware": firmware,
             "firmware_version": version,

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -237,7 +237,7 @@ async def setup_test_accessories_with_controller(
 
     config_entry = MockConfigEntry(
         version=1,
-        domain="homekit_controller",
+        domain=DOMAIN,
         entry_id="TestData",
         data=data,
         title="test",

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -16,7 +16,7 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.homekit_controller import config_flow
-from homeassistant.components.homekit_controller.const import KNOWN_DEVICES
+from homeassistant.components.homekit_controller.const import DOMAIN, KNOWN_DEVICES
 from homeassistant.components.homekit_controller.storage import async_get_entity_storage
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -427,7 +427,7 @@ async def test_discovery_broken_pairing_flag(hass: HomeAssistant, controller) ->
     await controller.add_paired_device(Accessories(), "00:00:00:00:00:00")
 
     MockConfigEntry(
-        domain="homekit_controller",
+        domain=DOMAIN,
         data={"AccessoryPairingID": "00:00:00:00:00:00"},
         unique_id="00:00:00:00:00:00",
     ).add_to_hass(hass)
@@ -461,7 +461,7 @@ async def test_discovery_invalid_config_entry(hass: HomeAssistant, controller) -
     pairing = await controller.add_paired_device(Accessories(), "00:00:00:00:00:00")
 
     MockConfigEntry(
-        domain="homekit_controller",
+        domain=DOMAIN,
         data={"AccessoryPairingID": "00:00:00:00:00:00"},
         unique_id="00:00:00:00:00:00",
     ).add_to_hass(hass)
@@ -499,7 +499,7 @@ async def test_discovery_ignored_config_entry(hass: HomeAssistant, controller) -
     pairing = await controller.add_paired_device(Accessories(), "00:00:00:00:00:00")
 
     MockConfigEntry(
-        domain="homekit_controller",
+        domain=DOMAIN,
         data={},
         unique_id="00:00:00:00:00:00",
         source=config_entries.SOURCE_IGNORE,
@@ -535,7 +535,7 @@ async def test_discovery_ignored_config_entry(hass: HomeAssistant, controller) -
 async def test_discovery_already_configured(hass: HomeAssistant, controller) -> None:
     """Already configured."""
     entry = MockConfigEntry(
-        domain="homekit_controller",
+        domain=DOMAIN,
         data={
             "AccessoryIP": "4.4.4.4",
             "AccessoryPort": 66,
@@ -568,7 +568,7 @@ async def test_discovery_already_configured_update_csharp(
 ) -> None:
     """Already configured and csharp changes."""
     entry = MockConfigEntry(
-        domain="homekit_controller",
+        domain=DOMAIN,
         data={
             "AccessoryIP": "4.4.4.4",
             "AccessoryPort": 66,
@@ -1196,7 +1196,7 @@ async def test_discovery_updates_ip_when_config_entry_set_up(
 ) -> None:
     """Already configured updates ip when config entry set up."""
     entry = MockConfigEntry(
-        domain="homekit_controller",
+        domain=DOMAIN,
         data={
             "AccessoryIP": "4.4.4.4",
             "AccessoryPort": 66,
@@ -1235,7 +1235,7 @@ async def test_discovery_updates_ip_config_entry_not_set_up(
 ) -> None:
     """Already configured updates ip when the config entry is not set up."""
     entry = MockConfigEntry(
-        domain="homekit_controller",
+        domain=DOMAIN,
         data={
             "AccessoryIP": "4.4.4.4",
             "AccessoryPort": 66,

--- a/tests/components/homekit_controller/test_connection.py
+++ b/tests/components/homekit_controller/test_connection.py
@@ -157,7 +157,7 @@ async def test_migrate_device_id_no_serial(
     await fake_controller.add_paired_device(accessories, "00:00:00:00:00:00")
     config_entry = MockConfigEntry(
         version=1,
-        domain="homekit_controller",
+        domain=DOMAIN,
         entry_id="TestData",
         data={"AccessoryPairingID": "00:00:00:00:00:00"},
         title="test",
@@ -191,7 +191,7 @@ async def test_migrate_ble_unique_id(hass: HomeAssistant) -> None:
     await fake_controller.add_paired_device(accessories, "02:03:EF:02:03:EF")
     config_entry = MockConfigEntry(
         version=1,
-        domain="homekit_controller",
+        domain=DOMAIN,
         entry_id="TestData",
         data={"AccessoryPairingID": "02:03:EF:02:03:EF"},
         title="test",
@@ -215,7 +215,7 @@ async def test_thread_provision_no_creds(hass: HomeAssistant) -> None:
     await fake_controller.add_paired_device(accessories, "02:03:EF:02:03:EF")
     config_entry = MockConfigEntry(
         version=1,
-        domain="homekit_controller",
+        domain=DOMAIN,
         entry_id="TestData",
         data={"AccessoryPairingID": "02:03:EF:02:03:EF"},
         title="test",
@@ -262,7 +262,7 @@ async def test_thread_provision(
     await fake_controller.add_paired_device(accessories, "00:00:00:00:00:00")
     config_entry = MockConfigEntry(
         version=1,
-        domain="homekit_controller",
+        domain=DOMAIN,
         entry_id="TestData",
         data={"AccessoryPairingID": "00:00:00:00:00:00"},
         title="test",
@@ -328,7 +328,7 @@ async def test_thread_provision_migration_failed(hass: HomeAssistant) -> None:
     await fake_controller.add_paired_device(accessories, "00:00:00:00:00:00")
     config_entry = MockConfigEntry(
         version=1,
-        domain="homekit_controller",
+        domain=DOMAIN,
         entry_id="TestData",
         data={"AccessoryPairingID": "00:00:00:00:00:00", "Connection": "BLE"},
         title="test",
@@ -521,7 +521,7 @@ async def test_poll_all_on_startup_refreshes_stale_values(
     await fake_controller.add_paired_device(accessories, "00:00:00:00:00:00")
     config_entry = MockConfigEntry(
         version=1,
-        domain="homekit_controller",
+        domain=DOMAIN,
         entry_id="TestData",
         data={"AccessoryPairingID": "00:00:00:00:00:00"},
         title="test",
@@ -659,7 +659,7 @@ async def test_async_setup_handles_unparsable_response(
 
     config_entry = MockConfigEntry(
         version=1,
-        domain="homekit_controller",
+        domain=DOMAIN,
         entry_id="TestData",
         data={"AccessoryPairingID": "00:00:00:00:00:00"},
         title="test",

--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -9,7 +9,7 @@ import pytest
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.hue import config_flow, const
+from homeassistant.components.hue import DOMAIN, config_flow, const
 from homeassistant.components.hue.errors import CannotConnect
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -104,7 +104,7 @@ async def test_manual_flow_works(hass: HomeAssistant) -> None:
     disc_bridge = get_discovered_bridge(bridge_id="id-1234", host="2.2.2.2")
 
     MockConfigEntry(
-        domain="hue", source=config_entries.SOURCE_IGNORE, unique_id="bla"
+        domain=DOMAIN, source=config_entries.SOURCE_IGNORE, unique_id="bla"
     ).add_to_hass(hass)
 
     with patch(
@@ -155,7 +155,7 @@ async def test_manual_flow_works(hass: HomeAssistant) -> None:
 async def test_manual_flow_bridge_exist(hass: HomeAssistant) -> None:
     """Test config flow aborts on already configured bridges."""
     MockConfigEntry(
-        domain="hue", unique_id="id-1234", data={"host": "2.2.2.2"}
+        domain=DOMAIN, unique_id="id-1234", data={"host": "2.2.2.2"}
     ).add_to_hass(hass)
 
     with patch(
@@ -199,7 +199,7 @@ async def test_flow_all_discovered_bridges_exist(
     create_mock_api_discovery(aioclient_mock, [(mock_host, mock_id)])
 
     MockConfigEntry(
-        domain="hue", unique_id=mock_id, data={"host": mock_host}
+        domain=DOMAIN, unique_id=mock_id, data={"host": mock_host}
     ).add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
@@ -216,7 +216,7 @@ async def test_flow_bridges_discovered(
     """Test config flow discovers two bridges."""
     # Add ignored config entry. Should still show up as option.
     MockConfigEntry(
-        domain="hue", source=config_entries.SOURCE_IGNORE, unique_id="bla"
+        domain=DOMAIN, source=config_entries.SOURCE_IGNORE, unique_id="bla"
     ).add_to_hass(hass)
 
     create_mock_api_discovery(
@@ -243,7 +243,7 @@ async def test_flow_two_bridges_discovered_one_new(
     """Test config flow discovers two bridges."""
     create_mock_api_discovery(aioclient_mock, [("1.2.3.4", "bla"), ("5.6.7.8", "beer")])
     MockConfigEntry(
-        domain="hue", unique_id="bla", data={"host": "1.2.3.4"}
+        domain=DOMAIN, unique_id="bla", data={"host": "1.2.3.4"}
     ).add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
@@ -372,14 +372,14 @@ async def test_creating_entry_removes_entries_for_same_host_or_bridge(
     """
     create_mock_api_discovery(aioclient_mock, [("2.2.2.2", "id-1234")])
     orig_entry = MockConfigEntry(
-        domain="hue",
+        domain=DOMAIN,
         data={"host": "0.0.0.0", "api_key": "123456789"},
         unique_id="id-1234",
     )
     orig_entry.add_to_hass(hass)
 
     MockConfigEntry(
-        domain="hue",
+        domain=DOMAIN,
         data={"host": "1.2.3.4", "api_key": "123456789"},
         unique_id="id-5678",
     ).add_to_hass(hass)
@@ -452,7 +452,7 @@ async def test_bridge_homekit(
 async def test_bridge_import_already_configured(hass: HomeAssistant) -> None:
     """Test if a import flow aborts if host is already configured."""
     MockConfigEntry(
-        domain="hue", unique_id="aabbccddeeff", data={"host": "0.0.0.0"}
+        domain=DOMAIN, unique_id="aabbccddeeff", data={"host": "0.0.0.0"}
     ).add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
@@ -471,7 +471,7 @@ async def test_bridge_homekit_already_configured(
     """Test if a HomeKit discovered bridge has already been configured."""
     create_mock_api_discovery(aioclient_mock, [("0.0.0.0", "aabbccddeeff")])
     MockConfigEntry(
-        domain="hue", unique_id="aabbccddeeff", data={"host": "0.0.0.0"}
+        domain=DOMAIN, unique_id="aabbccddeeff", data={"host": "0.0.0.0"}
     ).add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
@@ -495,7 +495,7 @@ async def test_bridge_homekit_already_configured(
 async def test_options_flow_v1(hass: HomeAssistant) -> None:
     """Test options config flow for a V1 bridge."""
     entry = MockConfigEntry(
-        domain="hue",
+        domain=DOMAIN,
         unique_id="aabbccddeeff",
         data={"host": "0.0.0.0"},
     )
@@ -544,7 +544,7 @@ async def test_options_flow_v2(
 ) -> None:
     """Test options config flow for a V2 bridge."""
     entry = MockConfigEntry(
-        domain="hue",
+        domain=DOMAIN,
         unique_id="aabbccddeeff",
         data={"host": "0.0.0.0", "api_version": 2},
     )
@@ -608,7 +608,7 @@ async def test_bridge_zeroconf_already_exists(
         aioclient_mock, [("0.0.0.0", "ecb5faabcabc"), ("192.168.1.217", "ecb5faabcabc")]
     )
     entry = MockConfigEntry(
-        domain="hue",
+        domain=DOMAIN,
         source=config_entries.SOURCE_HOMEKIT,
         data={"host": "0.0.0.0"},
         unique_id="ecb5faabcabc",

--- a/tests/components/influxdb/test_config_flow.py
+++ b/tests/components/influxdb/test_config_flow.py
@@ -578,7 +578,7 @@ async def test_single_instance(
 ) -> None:
     """Test we cannot setup a second entry for InfluxDB."""
     mock_entry = MockConfigEntry(
-        domain="influxdb",
+        domain=DOMAIN,
         data=config_base,
     )
 
@@ -728,7 +728,7 @@ async def test_single_instance_import(
 ) -> None:
     """Test we cannot setup a second entry for InfluxDB."""
     mock_entry = MockConfigEntry(
-        domain="influxdb",
+        domain=DOMAIN,
         data=config_base,
     )
 

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -311,7 +311,7 @@ async def test_setup_config_ssl(
         patch("os.access", return_value=True),
         patch("os.path.isfile", return_value=True),
     ):
-        mock_entry = MockConfigEntry(domain="influxdb", data=config)
+        mock_entry = MockConfigEntry(domain=DOMAIN, data=config)
 
         mock_entry.add_to_hass(hass)
 
@@ -459,7 +459,7 @@ async def test_setup_no_import_when_config_entry_exist(
     config["influxdb"].update(config_ext)
 
     mock_entry = MockConfigEntry(
-        domain="influxdb",
+        domain=DOMAIN,
         data=config_base,
     )
     mock_entry.add_to_hass(hass)
@@ -481,7 +481,7 @@ async def _setup(
 ) -> None:
     """Prepare client for next test and return event handler method."""
     mock_entry = MockConfigEntry(
-        domain="influxdb",
+        domain=DOMAIN,
         data=config,
     )
 
@@ -1895,7 +1895,7 @@ async def test_connection_failure_on_startup(
     write_api.side_effect = test_exception
 
     mock_entry = MockConfigEntry(
-        domain="influxdb",
+        domain=DOMAIN,
         data=config_base,
     )
 

--- a/tests/components/ipma/test_init.py
+++ b/tests/components/ipma/test_init.py
@@ -41,7 +41,7 @@ async def test_unload_config_entry(hass: HomeAssistant) -> None:
         return_value=MockLocation(),
     ):
         config_entry = MockConfigEntry(
-            domain="ipma",
+            domain=DOMAIN,
             data={CONF_LATITUDE: 0, CONF_LONGITUDE: 0, CONF_MODE: "daily"},
         )
         config_entry.add_to_hass(hass)

--- a/tests/components/ipma/test_sensor.py
+++ b/tests/components/ipma/test_sensor.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import patch
 
+from homeassistant.components.ipma.const import DOMAIN
 from homeassistant.core import HomeAssistant
 
 from . import ENTRY_CONFIG, MockLocation
@@ -13,7 +14,7 @@ async def test_ipma_fire_risk_create_sensors(hass: HomeAssistant) -> None:
     """Test creation of fire risk sensors."""
 
     with patch("pyipma.location.Location.get", return_value=MockLocation()):
-        entry = MockConfigEntry(domain="ipma", data=ENTRY_CONFIG)
+        entry = MockConfigEntry(domain=DOMAIN, data=ENTRY_CONFIG)
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -27,7 +28,7 @@ async def test_ipma_uv_index_create_sensors(hass: HomeAssistant) -> None:
     """Test creation of uv index sensors."""
 
     with patch("pyipma.location.Location.get", return_value=MockLocation()):
-        entry = MockConfigEntry(domain="ipma", data=ENTRY_CONFIG)
+        entry = MockConfigEntry(domain=DOMAIN, data=ENTRY_CONFIG)
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -41,7 +42,7 @@ async def test_ipma_warning_create_sensors(hass: HomeAssistant) -> None:
     """Test creation of warning sensors."""
 
     with patch("pyipma.location.Location.get", return_value=MockLocation()):
-        entry = MockConfigEntry(domain="ipma", data=ENTRY_CONFIG)
+        entry = MockConfigEntry(domain=DOMAIN, data=ENTRY_CONFIG)
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/ipma/test_weather.py
+++ b/tests/components/ipma/test_weather.py
@@ -8,7 +8,7 @@ from pyipma.observation import Observation
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.ipma.const import MIN_TIME_BETWEEN_UPDATES
+from homeassistant.components.ipma.const import DOMAIN, MIN_TIME_BETWEEN_UPDATES
 from homeassistant.components.weather import (
     ATTR_WEATHER_HUMIDITY,
     ATTR_WEATHER_PRESSURE,
@@ -59,7 +59,7 @@ async def test_setup_config_flow(hass: HomeAssistant) -> None:
         "pyipma.location.Location.get",
         return_value=MockLocation(),
     ):
-        entry = MockConfigEntry(domain="ipma", data=TEST_CONFIG)
+        entry = MockConfigEntry(domain=DOMAIN, data=TEST_CONFIG)
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -82,7 +82,7 @@ async def test_failed_get_observation_forecast(hass: HomeAssistant) -> None:
         "pyipma.location.Location.get",
         return_value=MockBadLocation(),
     ):
-        entry = MockConfigEntry(domain="ipma", data=TEST_CONFIG)
+        entry = MockConfigEntry(domain=DOMAIN, data=TEST_CONFIG)
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -114,7 +114,7 @@ async def test_forecast_service(
         "pyipma.location.Location.get",
         return_value=MockLocation(),
     ):
-        entry = MockConfigEntry(domain="ipma", data=TEST_CONFIG)
+        entry = MockConfigEntry(domain=DOMAIN, data=TEST_CONFIG)
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -159,7 +159,7 @@ async def test_forecast_subscription(
         "pyipma.location.Location.get",
         return_value=MockLocation(),
     ):
-        entry = MockConfigEntry(domain="ipma", data=TEST_CONFIG)
+        entry = MockConfigEntry(domain=DOMAIN, data=TEST_CONFIG)
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -1344,7 +1344,7 @@ async def test_reconfigure_flow_secure_manual_to_keyfile(
     """Test reconfigure flow changing secure credential source."""
     mock_config_entry = MockConfigEntry(
         title="KNX",
-        domain="knx",
+        domain=DOMAIN,
         data={
             **DEFAULT_ENTRY_DATA,
             CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING_TCP_SECURE,
@@ -1449,7 +1449,7 @@ async def test_reconfigure_flow_routing(hass: HomeAssistant, knx_setup) -> None:
     """Test reconfigure flow changing routing settings."""
     mock_config_entry = MockConfigEntry(
         title="KNX",
-        domain="knx",
+        domain=DOMAIN,
         data={
             **DEFAULT_ENTRY_DATA,
             CONF_KNX_CONNECTION_TYPE: CONF_KNX_ROUTING,
@@ -1523,7 +1523,7 @@ async def test_reconfigure_update_keyfile(hass: HomeAssistant, knx_setup) -> Non
     }
     mock_config_entry = MockConfigEntry(
         title="KNX",
-        domain="knx",
+        domain=DOMAIN,
         data=start_data,
     )
     mock_config_entry.add_to_hass(hass)
@@ -1571,7 +1571,7 @@ async def test_reconfigure_keyfile_upload(hass: HomeAssistant, knx_setup) -> Non
     }
     mock_config_entry = MockConfigEntry(
         title="KNX",
-        domain="knx",
+        domain=DOMAIN,
         data=start_data,
     )
     mock_config_entry.add_to_hass(hass)

--- a/tests/components/kostal_plenticore/conftest.py
+++ b/tests/components/kostal_plenticore/conftest.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 from pykoplenti import ExtendedApiClient, MeData, SettingsData, VersionData
 import pytest
 
+from homeassistant.components.kostal_plenticore.const import DOMAIN
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -78,7 +79,7 @@ def mock_config_entry() -> MockConfigEntry:
     return MockConfigEntry(
         entry_id="2ab8dd92a62787ddfe213a67e09406bd",
         title="scb",
-        domain="kostal_plenticore",
+        domain=DOMAIN,
         data={"host": "192.168.1.2", "password": "SecretPassword"},
     )
 
@@ -89,7 +90,7 @@ def mock_installer_config_entry() -> MockConfigEntry:
     return MockConfigEntry(
         entry_id="2ab8dd92a62787ddfe213a67e09406bd",
         title="scb",
-        domain="kostal_plenticore",
+        domain=DOMAIN,
         data={
             "host": "192.168.1.2",
             "password": "secret_password",

--- a/tests/components/kostal_plenticore/test_config_flow.py
+++ b/tests/components/kostal_plenticore/test_config_flow.py
@@ -343,7 +343,7 @@ async def test_form_unexpected_error(hass: HomeAssistant) -> None:
 async def test_already_configured(hass: HomeAssistant) -> None:
     """Test we handle already configured error."""
     MockConfigEntry(
-        domain="kostal_plenticore",
+        domain=DOMAIN,
         data={"host": "1.1.1.1", "password": "foobar"},
         unique_id="112233445566",
     ).add_to_hass(hass)
@@ -541,7 +541,7 @@ async def test_reconfigure_already_configured(
     """Test we handle already configured error."""
     mock_config_entry.add_to_hass(hass)
     MockConfigEntry(
-        domain="kostal_plenticore",
+        domain=DOMAIN,
         data={CONF_HOST: "1.1.1.1", CONF_PASSWORD: "foobar"},
         unique_id="112233445566",
     ).add_to_hass(hass)

--- a/tests/components/matter/common.py
+++ b/tests/components/matter/common.py
@@ -10,6 +10,7 @@ from matter_server.common.helpers.util import dataclass_from_dict
 from matter_server.common.models import EventType, MatterNodeData
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.matter import DOMAIN
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -137,7 +138,7 @@ async def _setup_integration_with_nodes(
 
     client.get_node.side_effect = _get_node
     config_entry = MockConfigEntry(
-        domain="matter", data={"url": "http://mock-matter-server-url"}
+        domain=DOMAIN, data={"url": "http://mock-matter-server-url"}
     )
     config_entry.add_to_hass(hass)
 

--- a/tests/components/matter/conftest.py
+++ b/tests/components/matter/conftest.py
@@ -10,6 +10,7 @@ from matter_server.common.const import SCHEMA_VERSION
 from matter_server.common.models import ServerInfoMessage
 import pytest
 
+from homeassistant.components.matter import DOMAIN
 from homeassistant.core import HomeAssistant
 
 from .common import (
@@ -65,7 +66,7 @@ async def integration_fixture(
     hass: HomeAssistant, matter_client: MagicMock
 ) -> MockConfigEntry:
     """Set up the Matter integration."""
-    entry = MockConfigEntry(domain="matter", data={"url": "ws://localhost:5580/ws"})
+    entry = MockConfigEntry(domain=DOMAIN, data={"url": "ws://localhost:5580/ws"})
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -179,7 +179,7 @@ async def test_bad_node_not_crash_integration(
     del bad_node.endpoints[0].node
     matter_client.get_nodes.return_value = [good_node, bad_node]
     config_entry = MockConfigEntry(
-        domain="matter", data={"url": "http://mock-matter-server-url"}
+        domain=DOMAIN, data={"url": "http://mock-matter-server-url"}
     )
     config_entry.add_to_hass(hass)
 

--- a/tests/components/matter/test_init.py
+++ b/tests/components/matter/test_init.py
@@ -111,7 +111,7 @@ async def test_entry_setup_unload(
     node = create_node_from_fixture("mock_onoff_light")
     matter_client.get_nodes.return_value = [node]
     matter_client.get_node.return_value = node
-    entry = MockConfigEntry(domain="matter", data={"url": "ws://localhost:5580/ws"})
+    entry = MockConfigEntry(domain=DOMAIN, data={"url": "ws://localhost:5580/ws"})
     entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -19,7 +19,7 @@ import pytest
 from homeassistant.components.conversation import DOMAIN as CONVERSATION_DOMAIN
 from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
-from homeassistant.components.mcp_server.const import STATELESS_LLM_API
+from homeassistant.components.mcp_server.const import DOMAIN, STATELESS_LLM_API
 from homeassistant.components.mcp_server.http import (
     MESSAGES_API,
     SSE_API,
@@ -219,7 +219,7 @@ async def test_http_sse_multiple_config_entries(
     """
 
     config_entry = MockConfigEntry(
-        domain="mcp_server", data={CONF_LLM_HASS_API: ["llm-api-id"]}
+        domain=DOMAIN, data={CONF_LLM_HASS_API: ["llm-api-id"]}
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/met/test_config_flow.py
+++ b/tests/components/met/test_config_flow.py
@@ -87,7 +87,7 @@ async def test_flow_entry_already_exists(hass: HomeAssistant) -> None:
     in the config gui. Then the form should show with error.
     """
     first_entry = MockConfigEntry(
-        domain="met",
+        domain=DOMAIN,
         data={"name": "home", CONF_LATITUDE: 0, CONF_LONGITUDE: 0, CONF_ELEVATION: 0},
     )
     first_entry.add_to_hass(hass)

--- a/tests/components/mqtt/test_config_flow.py
+++ b/tests/components/mqtt/test_config_flow.py
@@ -17,6 +17,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components import mqtt
 from homeassistant.components.hassio import AddonError
+from homeassistant.components.mqtt import DOMAIN
 from homeassistant.components.mqtt.config_flow import (
     PWD_NOT_CHANGED,
     TRANSLATION_DESCRIPTION_PLACEHOLDERS,
@@ -548,7 +549,7 @@ async def test_manual_config_set(
 async def test_user_single_instance(hass: HomeAssistant) -> None:
     """Test we only allow a single config flow."""
     MockConfigEntry(
-        domain="mqtt",
+        domain=DOMAIN,
         version=mqtt.CONFIG_ENTRY_VERSION,
         minor_version=mqtt.CONFIG_ENTRY_MINOR_VERSION,
     ).add_to_hass(hass)
@@ -563,7 +564,7 @@ async def test_user_single_instance(hass: HomeAssistant) -> None:
 async def test_hassio_already_configured(hass: HomeAssistant) -> None:
     """Test we only allow a single config flow."""
     MockConfigEntry(
-        domain="mqtt",
+        domain=mqtt.DOMAIN,
         version=mqtt.CONFIG_ENTRY_VERSION,
         minor_version=mqtt.CONFIG_ENTRY_MINOR_VERSION,
     ).add_to_hass(hass)

--- a/tests/components/nobo_hub/test_config_flow.py
+++ b/tests/components/nobo_hub/test_config_flow.py
@@ -679,7 +679,7 @@ async def test_options_flow(
 ) -> None:
     """Test the options flow."""
     config_entry = MockConfigEntry(
-        domain="nobo_hub",
+        domain=DOMAIN,
         unique_id="123456789012",
         data={
             CONF_SERIAL: "123456789012",

--- a/tests/components/omnilogic/test_config_flow.py
+++ b/tests/components/omnilogic/test_config_flow.py
@@ -47,7 +47,7 @@ async def test_form(hass: HomeAssistant) -> None:
 
 async def test_already_configured(hass: HomeAssistant) -> None:
     """Test config flow when Omnilogic component is already setup."""
-    MockConfigEntry(domain="omnilogic", data=DATA).add_to_hass(hass)
+    MockConfigEntry(domain=DOMAIN, data=DATA).add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/onvif/test_init.py
+++ b/tests/components/onvif/test_init.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+from homeassistant.components.onvif.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     CONF_HOST,
@@ -29,7 +30,7 @@ from tests.common import MockConfigEntry
 
 async def test_migrate_camera_entities_unique_ids(hass: HomeAssistant) -> None:
     """Test that camera entities unique ids get migrated properly."""
-    config_entry = MockConfigEntry(domain="onvif", unique_id=MAC)
+    config_entry = MockConfigEntry(domain=DOMAIN, unique_id=MAC)
     config_entry.add_to_hass(hass)
 
     entity_registry = er.async_get(hass)
@@ -119,7 +120,7 @@ async def test_migrate_camera_entities_unique_ids(hass: HomeAssistant) -> None:
 async def test_setup_entry(hass: HomeAssistant) -> None:
     """Test setting up the config entry."""
     entry = MockConfigEntry(
-        domain="onvif",
+        domain=DOMAIN,
         title=NAME,
         unique_id=MAC,
         data={

--- a/tests/components/onvif/test_ptz.py
+++ b/tests/components/onvif/test_ptz.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from homeassistant.components.onvif.const import DOMAIN
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
@@ -34,7 +35,7 @@ def _setup_ptz_camera_mocks(mock_onvif_camera_cls: MagicMock) -> MagicMock:
 def _make_entry() -> MockConfigEntry:
     """Build a config entry suitable for the PTZ tests."""
     return MockConfigEntry(
-        domain="onvif",
+        domain=DOMAIN,
         title=NAME,
         unique_id=MAC,
         data={

--- a/tests/components/openai_conversation/conftest.py
+++ b/tests/components/openai_conversation/conftest.py
@@ -27,6 +27,7 @@ from homeassistant.components.openai_conversation.const import (
     DEFAULT_CONVERSATION_NAME,
     DEFAULT_STT_NAME,
     DEFAULT_TTS_NAME,
+    DOMAIN,
     RECOMMENDED_AI_TASK_OPTIONS,
     RECOMMENDED_STT_OPTIONS,
     RECOMMENDED_TTS_OPTIONS,
@@ -53,7 +54,7 @@ def mock_config_entry(
     """Mock a config entry."""
     entry = MockConfigEntry(
         title="OpenAI",
-        domain="openai_conversation",
+        domain=DOMAIN,
         data={
             "api_key": "bla",
         },

--- a/tests/components/opendisplay/test_init.py
+++ b/tests/components/opendisplay/test_init.py
@@ -12,7 +12,7 @@ from opendisplay import (
 )
 import pytest
 
-from homeassistant.components.opendisplay.const import CONF_ENCRYPTION_KEY
+from homeassistant.components.opendisplay.const import CONF_ENCRYPTION_KEY, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -195,7 +195,7 @@ async def test_setup_invalid_encryption_key_format(
 ) -> None:
     """Test that a malformed stored encryption key triggers reauth."""
     entry = MockConfigEntry(
-        domain="opendisplay",
+        domain=DOMAIN,
         unique_id="AA:BB:CC:DD:EE:FF",
         title="OpenDisplay 1234",
         data={CONF_ENCRYPTION_KEY: "not-valid-hex!"},

--- a/tests/components/opengarage/test_config_flow.py
+++ b/tests/components/opengarage/test_config_flow.py
@@ -108,7 +108,7 @@ async def test_form_unknown_error(hass: HomeAssistant) -> None:
 async def test_flow_entry_already_exists(hass: HomeAssistant) -> None:
     """Test user input for config_entry that already exists."""
     first_entry = MockConfigEntry(
-        domain="opengarage",
+        domain=DOMAIN,
         data={
             "host": "http://1.1.1.1",
             "device_key": "AfsasdnfkjDD",

--- a/tests/components/otbr/test_homeassistant_hardware.py
+++ b/tests/components/otbr/test_homeassistant_hardware.py
@@ -16,6 +16,7 @@ from homeassistant.components.homeassistant_hardware.util import (
     OwningAddon,
     OwningIntegration,
 )
+from homeassistant.components.otbr import DOMAIN
 from homeassistant.components.otbr.homeassistant_hardware import async_get_firmware_info
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -37,7 +38,7 @@ async def test_get_firmware_info(hass: HomeAssistant) -> None:
     """Test `async_get_firmware_info`."""
 
     otbr = MockConfigEntry(
-        domain="otbr",
+        domain=DOMAIN,
         unique_id="some_unique_id",
         data={
             "url": "http://core_openthread_border_router:8888",
@@ -89,7 +90,7 @@ async def test_get_firmware_info_ignored(hass: HomeAssistant) -> None:
     """Test `async_get_firmware_info` with ignored entry."""
 
     otbr = MockConfigEntry(
-        domain="otbr",
+        domain=DOMAIN,
         unique_id="some_unique_id",
         data={},
         version=1,
@@ -104,7 +105,7 @@ async def test_get_firmware_info_no_coprocessor_version(hass: HomeAssistant) -> 
     """Test `async_get_firmware_info` with no coprocessor version support."""
 
     otbr = MockConfigEntry(
-        domain="otbr",
+        domain=DOMAIN,
         unique_id="some_unique_id",
         data={
             "url": "http://core_openthread_border_router:8888",
@@ -171,7 +172,7 @@ async def test_hardware_firmware_info_provider_notification(
 ) -> None:
     """Test that the OTBR provides hardware and firmware information."""
     otbr = MockConfigEntry(
-        domain="otbr",
+        domain=DOMAIN,
         unique_id="some_unique_id",
         data={
             "url": "http://core_openthread_border_router:8888",
@@ -229,7 +230,7 @@ async def test_get_firmware_info_remote_otbr(hass: HomeAssistant) -> None:
     """Test `async_get_firmware_info` with no coprocessor version support."""
 
     otbr = MockConfigEntry(
-        domain="otbr",
+        domain=DOMAIN,
         unique_id="some_unique_id",
         data={
             "url": "http://192.168.1.10:8888",

--- a/tests/components/owntracks/test_device_tracker.py
+++ b/tests/components/owntracks/test_device_tracker.py
@@ -19,6 +19,7 @@ from homeassistant.components.owntracks.const import (
     ATTR_TID,
     ATTR_UPDATE_TIMESTAMP,
     ATTR_VELOCITY,
+    DOMAIN,
 )
 from homeassistant.const import STATE_NOT_HOME
 from homeassistant.core import HomeAssistant
@@ -327,7 +328,7 @@ async def setup_owntracks(
 ) -> None:
     """Set up OwnTracks."""
     MockConfigEntry(
-        domain="owntracks", data={"webhook_id": "owntracks_test", "secret": "abcd"}
+        domain=DOMAIN, data={"webhook_id": "owntracks_test", "secret": "abcd"}
     ).add_to_hass(hass)
 
     with patch.object(owntracks, "OwnTracksContext", ctx_cls):
@@ -1609,7 +1610,7 @@ async def test_restore_state(
 ) -> None:
     """Test that we can restore state."""
     entry = MockConfigEntry(
-        domain="owntracks", data={"webhook_id": "owntracks_test", "secret": "abcd"}
+        domain=DOMAIN, data={"webhook_id": "owntracks_test", "secret": "abcd"}
     )
     entry.add_to_hass(hass)
 
@@ -1661,7 +1662,7 @@ async def test_returns_empty_friends(
 ) -> None:
     """Test that an empty list of persons' locations is returned."""
     entry = MockConfigEntry(
-        domain="owntracks", data={"webhook_id": "owntracks_test", "secret": "abcd"}
+        domain=DOMAIN, data={"webhook_id": "owntracks_test", "secret": "abcd"}
     )
     entry.add_to_hass(hass)
 
@@ -1684,7 +1685,7 @@ async def test_returns_array_friends(
 ) -> None:
     """Test that a list of persons' current locations is returned."""
     otracks = MockConfigEntry(
-        domain="owntracks", data={"webhook_id": "owntracks_test", "secret": "abcd"}
+        domain=DOMAIN, data={"webhook_id": "owntracks_test", "secret": "abcd"}
     )
     otracks.add_to_hass(hass)
 

--- a/tests/components/owntracks/test_init.py
+++ b/tests/components/owntracks/test_init.py
@@ -5,6 +5,7 @@ import pytest
 
 from homeassistant.components import owntracks
 from homeassistant.components.device_tracker.legacy import Device
+from homeassistant.components.owntracks import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -52,7 +53,7 @@ async def mock_client(
     mock_component(hass, "device_tracker")
 
     MockConfigEntry(
-        domain="owntracks", data={"webhook_id": "owntracks_test", "secret": "abcd"}
+        domain=DOMAIN, data={"webhook_id": "owntracks_test", "secret": "abcd"}
     ).add_to_hass(hass)
     await async_setup_component(hass, "owntracks", {})
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When `MockConfigEntry` is created with a literal string matching the component name, use the `DOMAIN` constant instead

Linked to #172693

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
