### PR TITLE
Add Rabbit Air air quality sensor

### DIFF
--- a/homeassistant/components/rabbitair/__init__.py
+++ b/homeassistant/components/rabbitair/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 
 from .coordinator import RabbitAirConfigEntry, RabbitAirDataUpdateCoordinator
 
-PLATFORMS: list[Platform] = [Platform.FAN]
+PLATFORMS: list[Platform] = [Platform.FAN, Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: RabbitAirConfigEntry) -> bool:

--- a/homeassistant/components/rabbitair/entity.py
+++ b/homeassistant/components/rabbitair/entity.py
@@ -32,7 +32,6 @@ class RabbitAirBaseEntity(CoordinatorEntity[RabbitAirDataUpdateCoordinator]):
     ) -> None:
         """Initialize the entity."""
         super().__init__(coordinator)
-        self._attr_name = entry.title
         self._attr_unique_id = entry.unique_id
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry.data[CONF_MAC])},

--- a/homeassistant/components/rabbitair/entity.py
+++ b/homeassistant/components/rabbitair/entity.py
@@ -25,6 +25,8 @@ MODELS = {
 class RabbitAirBaseEntity(CoordinatorEntity[RabbitAirDataUpdateCoordinator]):
     """Base class for Rabbit Air entity."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: RabbitAirDataUpdateCoordinator,

--- a/homeassistant/components/rabbitair/fan.py
+++ b/homeassistant/components/rabbitair/fan.py
@@ -46,6 +46,7 @@ async def async_setup_entry(
 class RabbitAirFanEntity(RabbitAirBaseEntity, FanEntity):
     """Fan control functions of the Rabbit Air air purifier."""
 
+    _attr_name = None
     _attr_translation_key = "rabbitair"
     _attr_supported_features = (
         FanEntityFeature.PRESET_MODE
@@ -61,7 +62,6 @@ class RabbitAirFanEntity(RabbitAirBaseEntity, FanEntity):
     ) -> None:
         """Initialize the entity."""
         super().__init__(coordinator, entry)
-        self._attr_name = entry.title
 
         if self._is_model(Model.MinusA2):
             self._attr_preset_modes = list(PRESET_MODES)

--- a/homeassistant/components/rabbitair/fan.py
+++ b/homeassistant/components/rabbitair/fan.py
@@ -61,6 +61,7 @@ class RabbitAirFanEntity(RabbitAirBaseEntity, FanEntity):
     ) -> None:
         """Initialize the entity."""
         super().__init__(coordinator, entry)
+        self._attr_name = entry.title
 
         if self._is_model(Model.MinusA2):
             self._attr_preset_modes = list(PRESET_MODES)

--- a/homeassistant/components/rabbitair/icons.json
+++ b/homeassistant/components/rabbitair/icons.json
@@ -12,6 +12,11 @@
           }
         }
       }
+    },
+    "sensor": {
+      "air_quality": {
+        "default": "mdi:air-filter"
+      }
     }
   }
 }

--- a/homeassistant/components/rabbitair/sensor.py
+++ b/homeassistant/components/rabbitair/sensor.py
@@ -7,7 +7,7 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
@@ -44,7 +44,6 @@ class RabbitAirAirQualitySensor(RabbitAirBaseEntity, SensorEntity):
     """Rabbit Air air quality sensor."""
 
     entity_description = AIR_QUALITY_DESCRIPTION
-    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -54,10 +53,8 @@ class RabbitAirAirQualitySensor(RabbitAirBaseEntity, SensorEntity):
         """Initialize the entity."""
         super().__init__(coordinator, entry)
         self._attr_unique_id = f"{entry.unique_id}_{self.entity_description.key}"
-        self._attr_native_value = _quality_value(coordinator.data.quality)
 
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        self._attr_native_value = _quality_value(self.coordinator.data.quality)
-        super()._handle_coordinator_update()
+    @property
+    def native_value(self) -> StateType:
+        """Return the air quality state."""
+        return _quality_value(self.coordinator.data.quality)

--- a/homeassistant/components/rabbitair/sensor.py
+++ b/homeassistant/components/rabbitair/sensor.py
@@ -1,0 +1,64 @@
+"""Support for Rabbit Air sensors."""
+
+from rabbitair import Quality
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.typing import StateType
+
+from .coordinator import RabbitAirConfigEntry, RabbitAirDataUpdateCoordinator
+from .entity import RabbitAirBaseEntity
+
+
+def _quality_value(quality: Quality | None) -> StateType:
+    """Return the air quality state."""
+    return None if quality is None else quality.name.lower()
+
+
+AIR_QUALITY_OPTIONS = [quality.name.lower() for quality in Quality]
+
+AIR_QUALITY_DESCRIPTION = SensorEntityDescription(
+    key="air_quality",
+    translation_key="air_quality",
+    device_class=SensorDeviceClass.ENUM,
+    options=AIR_QUALITY_OPTIONS,
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: RabbitAirConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Rabbit Air sensors."""
+    if entry.runtime_data.data.quality is not None:
+        async_add_entities([RabbitAirAirQualitySensor(entry.runtime_data, entry)])
+
+
+class RabbitAirAirQualitySensor(RabbitAirBaseEntity, SensorEntity):
+    """Rabbit Air air quality sensor."""
+
+    entity_description = AIR_QUALITY_DESCRIPTION
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: RabbitAirDataUpdateCoordinator,
+        entry: RabbitAirConfigEntry,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator, entry)
+        del self._attr_name
+        self._attr_unique_id = f"{entry.unique_id}_{self.entity_description.key}"
+        self._attr_native_value = _quality_value(coordinator.data.quality)
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._attr_native_value = _quality_value(self.coordinator.data.quality)
+        super()._handle_coordinator_update()

--- a/homeassistant/components/rabbitair/sensor.py
+++ b/homeassistant/components/rabbitair/sensor.py
@@ -53,7 +53,6 @@ class RabbitAirAirQualitySensor(RabbitAirBaseEntity, SensorEntity):
     ) -> None:
         """Initialize the entity."""
         super().__init__(coordinator, entry)
-        del self._attr_name
         self._attr_unique_id = f"{entry.unique_id}_{self.entity_description.key}"
         self._attr_native_value = _quality_value(coordinator.data.quality)
 

--- a/homeassistant/components/rabbitair/strings.json
+++ b/homeassistant/components/rabbitair/strings.json
@@ -32,6 +32,18 @@
           }
         }
       }
+    },
+    "sensor": {
+      "air_quality": {
+        "name": "Air quality",
+        "state": {
+          "high": "[%key:common::state::high%]",
+          "highest": "Highest",
+          "low": "[%key:common::state::low%]",
+          "lowest": "Lowest",
+          "medium": "[%key:common::state::medium%]"
+        }
+      }
     }
   }
 }

--- a/tests/components/rabbitair/test_config_flow.py
+++ b/tests/components/rabbitair/test_config_flow.py
@@ -5,7 +5,7 @@ from ipaddress import ip_address
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from rabbitair import Mode, Model, Speed
+from rabbitair import Mode, Model, Quality, Speed
 
 from homeassistant import config_entries
 from homeassistant.components.rabbitair.const import DOMAIN
@@ -62,6 +62,7 @@ def get_mock_state(
     main_firmware: str | None = TEST_HARDWARE,
     power: bool | None = True,
     mode: Mode | None = Mode.Auto,
+    quality: Quality | None = Quality.High,
     speed: Speed | None = Speed.Low,
     wifi_firmware: str | None = TEST_FIRMWARE,
 ) -> Mock:
@@ -71,6 +72,7 @@ def get_mock_state(
     mock_state.main_firmware = main_firmware
     mock_state.power = power
     mock_state.mode = mode
+    mock_state.quality = quality
     mock_state.speed = speed
     mock_state.wifi_firmware = wifi_firmware
     return mock_state

--- a/tests/components/rabbitair/test_sensor.py
+++ b/tests/components/rabbitair/test_sensor.py
@@ -21,12 +21,12 @@ from .test_config_flow import (
 
 from tests.common import MockConfigEntry
 
+pytestmark = pytest.mark.usefixtures("mock_async_zeroconf")
 
-@pytest.mark.usefixtures("mock_async_zeroconf")
-async def test_air_quality_sensor(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry
-) -> None:
-    """Test the air quality sensor."""
+
+@pytest.fixture
+def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Return a mock config entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -38,12 +38,20 @@ async def test_air_quality_sensor(
         unique_id=TEST_UNIQUE_ID,
     )
     entry.add_to_hass(hass)
+    return entry
 
+
+async def test_air_quality_sensor(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the air quality sensor."""
     with patch(
-        "rabbitair.UdpClient.get_state",
+        "homeassistant.components.rabbitair.coordinator.Client.get_state",
         return_value=get_mock_state(quality=Quality.High),
     ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
     state = hass.states.get("sensor.rabbit_air_air_quality")
@@ -55,26 +63,15 @@ async def test_air_quality_sensor(
     assert registry_entry.unique_id == f"{TEST_UNIQUE_ID}_air_quality"
 
 
-@pytest.mark.usefixtures("mock_async_zeroconf")
-async def test_no_air_quality_sensor_when_quality_is_none(hass: HomeAssistant) -> None:
+async def test_no_air_quality_sensor_when_quality_is_none(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
     """Test the air quality sensor is not created when quality is unavailable."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_HOST: TEST_HOST,
-            CONF_ACCESS_TOKEN: TEST_TOKEN,
-            CONF_MAC: TEST_MAC,
-        },
-        title=TEST_TITLE,
-        unique_id=TEST_UNIQUE_ID,
-    )
-    entry.add_to_hass(hass)
-
     with patch(
-        "rabbitair.UdpClient.get_state",
+        "homeassistant.components.rabbitair.coordinator.Client.get_state",
         return_value=get_mock_state(quality=None),
     ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
     assert hass.states.get("sensor.rabbit_air_air_quality") is None

--- a/tests/components/rabbitair/test_sensor.py
+++ b/tests/components/rabbitair/test_sensor.py
@@ -53,3 +53,28 @@ async def test_air_quality_sensor(
     registry_entry = entity_registry.async_get("sensor.rabbit_air_air_quality")
     assert registry_entry
     assert registry_entry.unique_id == f"{TEST_UNIQUE_ID}_air_quality"
+
+
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_no_air_quality_sensor_when_quality_is_none(hass: HomeAssistant) -> None:
+    """Test the air quality sensor is not created when quality is unavailable."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: TEST_HOST,
+            CONF_ACCESS_TOKEN: TEST_TOKEN,
+            CONF_MAC: TEST_MAC,
+        },
+        title=TEST_TITLE,
+        unique_id=TEST_UNIQUE_ID,
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "rabbitair.UdpClient.get_state",
+        return_value=get_mock_state(quality=None),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.rabbit_air_air_quality") is None

--- a/tests/components/rabbitair/test_sensor.py
+++ b/tests/components/rabbitair/test_sensor.py
@@ -1,0 +1,55 @@
+"""Test the Rabbit Air sensor platform."""
+
+from unittest.mock import patch
+
+import pytest
+from rabbitair import Quality
+
+from homeassistant.components.rabbitair.const import DOMAIN
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_HOST, CONF_MAC
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .test_config_flow import (
+    TEST_HOST,
+    TEST_MAC,
+    TEST_TITLE,
+    TEST_TOKEN,
+    TEST_UNIQUE_ID,
+    get_mock_state,
+)
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_air_quality_sensor(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test the air quality sensor."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: TEST_HOST,
+            CONF_ACCESS_TOKEN: TEST_TOKEN,
+            CONF_MAC: TEST_MAC,
+        },
+        title=TEST_TITLE,
+        unique_id=TEST_UNIQUE_ID,
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "rabbitair.UdpClient.get_state",
+        return_value=get_mock_state(quality=Quality.High),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.rabbit_air_air_quality")
+    assert state
+    assert state.state == "high"
+
+    registry_entry = entity_registry.async_get("sensor.rabbit_air_air_quality")
+    assert registry_entry
+    assert registry_entry.unique_id == f"{TEST_UNIQUE_ID}_air_quality"


### PR DESCRIPTION
## Proposed change

Add an air quality sensor to the Rabbit Air integration.

<img width="367" height="437" alt="image" src="https://github.com/user-attachments/assets/996122f3-e45f-4df0-9209-0156ed1fd26c" />

The sensor uses the existing Rabbit Air coordinator data and exposes the `quality` value from `python-rabbitair` as a Home Assistant enum sensor with the following states:

- `lowest`
- `low`
- `medium`
- `high`
- `highest`

This also adds translations and an icon for the new sensor.

This is the first of many sensors to be added, I'd like to make sure I have the basic approach right before adding more in bulk.

The change was co-authored by OpenAI Codex 5.5.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: [home-assistant/home-assistant.io#45749](https://github.com/home-assistant/home-assistant.io/pull/45749)
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

## Validation

- `uv run ruff check homeassistant/components/rabbitair tests/components/rabbitair`
- `uv run ruff format --check homeassistant/components/rabbitair tests/components/rabbitair`
- `uv run pytest tests/components/rabbitair`
- `uv run --with tqdm python -m script.hassfest --integration-path homeassistant/components/rabbitair`