### PR TITLE
Use DOMAIN constant in tests (hass.services.async_call)

### DIFF
--- a/tests/components/ai_task/test_init.py
+++ b/tests/components/ai_task/test_init.py
@@ -10,7 +10,11 @@ import voluptuous as vol
 
 from homeassistant.components import media_source
 from homeassistant.components.ai_task import AITaskPreferences
-from homeassistant.components.ai_task.const import DATA_MEDIA_SOURCE, DATA_PREFERENCES
+from homeassistant.components.ai_task.const import (
+    DATA_MEDIA_SOURCE,
+    DATA_PREFERENCES,
+    DOMAIN,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import selector
@@ -95,7 +99,7 @@ async def test_generate_data_service(
         ),
     ):
         result = await hass.services.async_call(
-            "ai_task",
+            DOMAIN,
             "generate_data",
             {
                 "task_name": "Test Name",
@@ -130,7 +134,7 @@ async def test_generate_data_service_structure_fields(
 ) -> None:
     """Test the entity can generate structured data with a top level object schema."""
     result = await hass.services.async_call(
-        "ai_task",
+        DOMAIN,
         "generate_data",
         {
             "task_name": "Profile Generation",
@@ -280,7 +284,7 @@ async def test_generate_data_service_invalid_structure(
     """Test the entity can generate structured data."""
     with pytest.raises(expected_exception, match=expected_error):
         await hass.services.async_call(
-            "ai_task",
+            DOMAIN,
             "generate_data",
             {
                 "task_name": "Profile Generation",
@@ -322,7 +326,7 @@ async def test_generate_image_service(
         return_value="media-source://ai_task/image/2025-06-14_225900_test_task.png",
     ) as mock_upload_media:
         result = await hass.services.async_call(
-            "ai_task",
+            DOMAIN,
             "generate_image",
             {
                 "task_name": "Test Image",
@@ -361,7 +365,7 @@ async def test_generate_image_service_no_entity(
         match="No entity_id provided and no preferred entity set",
     ):
         await hass.services.async_call(
-            "ai_task",
+            DOMAIN,
             "generate_image",
             {
                 "task_name": "Test Image",

--- a/tests/components/assist_satellite/test_entity.py
+++ b/tests/components/assist_satellite/test_entity.py
@@ -24,7 +24,7 @@ from homeassistant.components.assist_satellite import (
     AssistSatelliteAnswer,
     SatelliteBusyError,
 )
-from homeassistant.components.assist_satellite.const import PREANNOUNCE_URL
+from homeassistant.components.assist_satellite.const import DOMAIN, PREANNOUNCE_URL
 from homeassistant.components.assist_satellite.entity import AssistSatelliteState
 from homeassistant.components.media_source import PlayMedia
 from homeassistant.config_entries import ConfigEntry
@@ -362,7 +362,7 @@ async def test_announce(
         patch.object(entity, "async_announce", new=async_announce),
     ):
         await hass.services.async_call(
-            "assist_satellite",
+            DOMAIN,
             "announce",
             service_data,
             target={"entity_id": "assist_satellite.test_entity"},
@@ -457,7 +457,7 @@ async def test_announce_default_preannounce(
 
     with patch.object(entity, "async_announce", new=async_announce):
         await hass.services.async_call(
-            "assist_satellite",
+            DOMAIN,
             "announce",
             {"media_id": "test-media-id"},
             target={"entity_id": "assist_satellite.test_entity"},
@@ -777,7 +777,7 @@ async def test_start_conversation(
         patch.object(entity, "async_start_conversation", new=async_start_conversation),
     ):
         await hass.services.async_call(
-            "assist_satellite",
+            DOMAIN,
             "start_conversation",
             service_data,
             target={"entity_id": "assist_satellite.test_entity"},
@@ -796,7 +796,7 @@ async def test_start_conversation_reject_builtin_agent(
     """Test starting a conversation on a device."""
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
-            "assist_satellite",
+            DOMAIN,
             "start_conversation",
             {"start_message": "Hey!"},
             target={"entity_id": "assist_satellite.test_entity"},
@@ -822,7 +822,7 @@ async def test_start_conversation_default_preannounce(
         patch.object(entity, "async_start_conversation", new=async_start_conversation),
     ):
         await hass.services.async_call(
-            "assist_satellite",
+            DOMAIN,
             "start_conversation",
             {"start_media_id": "test-media-id"},
             target={"entity_id": "assist_satellite.test_entity"},
@@ -958,7 +958,7 @@ async def test_ask_question(
         patch.object(entity, "async_start_conversation", new=async_start_conversation),
     ):
         response = await hass.services.async_call(
-            "assist_satellite",
+            DOMAIN,
             "ask_question",
             {"entity_id": entity_id, "question": question_text, **service_data},
             blocking=True,
@@ -977,7 +977,7 @@ async def test_ask_question_requires_entity_permission(
     """Test ask_question is denied for users without POLICY_CONTROL on the entity."""
     with pytest.raises(Unauthorized):
         await hass.services.async_call(
-            "assist_satellite",
+            DOMAIN,
             "ask_question",
             {"entity_id": "assist_satellite.test_entity", "question": "Anything?"},
             blocking=True,

--- a/tests/components/automation/test_blueprint.py
+++ b/tests/components/automation/test_blueprint.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components import automation
+from homeassistant.components.automation import DOMAIN
 from homeassistant.components.blueprint import models
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, callback
@@ -141,7 +142,7 @@ async def test_notify_leaving_zone(
 
         # Verify trigger works
         await hass.services.async_call(
-            "automation",
+            DOMAIN,
             "trigger",
             {"entity_id": "automation.automation_0"},
             blocking=True,
@@ -228,7 +229,7 @@ async def test_motion_light(hass: HomeAssistant) -> None:
 
     # Verify trigger works
     await hass.services.async_call(
-        "automation",
+        DOMAIN,
         "trigger",
         {"entity_id": "automation.automation_0"},
     )

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -262,12 +262,12 @@ async def test_trigger_service_ignoring_condition(
     assert caplog.record_tuples[0][1] == logging.WARNING
 
     await hass.services.async_call(
-        "automation", "trigger", {"entity_id": "automation.test"}, blocking=True
+        DOMAIN, "trigger", {"entity_id": "automation.test"}, blocking=True
     )
     assert len(calls) == 1
 
     await hass.services.async_call(
-        "automation",
+        DOMAIN,
         "trigger",
         {"entity_id": "automation.test", "skip_condition": True},
         blocking=True,
@@ -275,7 +275,7 @@ async def test_trigger_service_ignoring_condition(
     assert len(calls) == 2
 
     await hass.services.async_call(
-        "automation",
+        DOMAIN,
         "trigger",
         {"entity_id": "automation.test", "skip_condition": False},
         blocking=True,
@@ -3187,7 +3187,7 @@ async def test_trigger_service(hass: HomeAssistant, calls: list[ServiceCall]) ->
     )
     context = Context()
     await hass.services.async_call(
-        "automation",
+        DOMAIN,
         "trigger",
         {"entity_id": "automation.hello"},
         blocking=True,
@@ -3684,7 +3684,7 @@ async def test_automation_turns_off_other_automation(hass: HomeAssistant) -> Non
     assert len(calls) == 0
 
     await hass.services.async_call(
-        "automation",
+        DOMAIN,
         "turn_on",
         {"entity_id": "automation.automation_1"},
         blocking=True,

--- a/tests/components/cast/test_home_assistant_cast.py
+++ b/tests/components/cast/test_home_assistant_cast.py
@@ -23,7 +23,7 @@ async def test_service_show_view(hass: HomeAssistant) -> None:
     # No valid URL
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
-            "cast",
+            DOMAIN,
             "show_lovelace_view",
             {"entity_id": "media_player.kitchen", "view_path": "mock_path"},
             blocking=True,
@@ -35,7 +35,7 @@ async def test_service_show_view(hass: HomeAssistant) -> None:
         {"external_url": "https://example.com"},
     )
     await hass.services.async_call(
-        "cast",
+        DOMAIN,
         "show_lovelace_view",
         {"entity_id": "media_player.kitchen", "view_path": "mock_path"},
         blocking=True,
@@ -65,7 +65,7 @@ async def test_service_show_view_dashboard(hass: HomeAssistant) -> None:
     calls = async_mock_signal(hass, home_assistant_cast.SIGNAL_HASS_CAST_SHOW_VIEW)
 
     await hass.services.async_call(
-        "cast",
+        DOMAIN,
         "show_lovelace_view",
         {
             "entity_id": "media_player.kitchen",
@@ -101,7 +101,7 @@ async def test_use_cloud_url(hass: HomeAssistant) -> None:
         return_value="https://something.nabu.casa",
     ):
         await hass.services.async_call(
-            "cast",
+            DOMAIN,
             "show_lovelace_view",
             {"entity_id": "media_player.kitchen", "view_path": "mock_path"},
             blocking=True,

--- a/tests/components/group/test_fan.py
+++ b/tests/components/group/test_fan.py
@@ -22,7 +22,7 @@ from homeassistant.components.fan import (
     SERVICE_TURN_ON,
     FanEntityFeature,
 )
-from homeassistant.components.group import SERVICE_RELOAD
+from homeassistant.components.group import DOMAIN, SERVICE_RELOAD
 from homeassistant.components.group.fan import DEFAULT_NAME
 from homeassistant.const import (
     ATTR_ASSUMED_STATE,
@@ -415,7 +415,7 @@ async def test_reload(hass: HomeAssistant) -> None:
     yaml_path = get_fixture_path("fan_configuration.yaml", "group")
     with patch.object(hass_config, "YAML_CONFIG_FILE", yaml_path):
         await hass.services.async_call(
-            "group",
+            DOMAIN,
             SERVICE_RELOAD,
             {},
             blocking=True,

--- a/tests/components/group/test_notify.py
+++ b/tests/components/group/test_notify.py
@@ -270,7 +270,7 @@ async def test_reload_notify(hass: HomeAssistant, tmp_path: Path) -> None:
 
     with patch.object(hass_config, "YAML_CONFIG_FILE", yaml_path):
         await hass.services.async_call(
-            "group",
+            DOMAIN,
             SERVICE_RELOAD,
             {},
             blocking=True,

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -541,19 +541,19 @@ async def test_service_calls(
     supervisor_client.reset_mock()
 
     await hass.services.async_call(
-        "hassio", f"{app_or_addon}_start", {app_or_addon: "test"}
+        DOMAIN, f"{app_or_addon}_start", {app_or_addon: "test"}
     )
     await hass.services.async_call(
-        "hassio", f"{app_or_addon}_stop", {app_or_addon: "test"}
+        DOMAIN, f"{app_or_addon}_stop", {app_or_addon: "test"}
     )
     await hass.services.async_call(
-        "hassio", f"{app_or_addon}_restart", {app_or_addon: "test"}
+        DOMAIN, f"{app_or_addon}_restart", {app_or_addon: "test"}
     )
     await hass.services.async_call(
-        "hassio", f"{app_or_addon}_stdin", {app_or_addon: "test", "input": "test"}
+        DOMAIN, f"{app_or_addon}_stdin", {app_or_addon: "test", "input": "test"}
     )
     await hass.services.async_call(
-        "hassio",
+        DOMAIN,
         f"{app_or_addon}_stdin",
         {app_or_addon: "test", "input": {"hello": "world"}},
     )
@@ -570,8 +570,8 @@ async def test_service_calls(
         in supervisor_client.addons.write_addon_stdin.mock_calls
     )
 
-    await hass.services.async_call("hassio", "host_shutdown", {})
-    await hass.services.async_call("hassio", "host_reboot", {})
+    await hass.services.async_call(DOMAIN, "host_shutdown", {})
+    await hass.services.async_call(DOMAIN, "host_reboot", {})
     await hass.async_block_till_done()
 
     supervisor_client.host.shutdown.assert_called_once_with()
@@ -585,7 +585,7 @@ async def test_service_calls(
     )
 
     full_backup = await hass.services.async_call(
-        "hassio", "backup_full", {}, blocking=True, return_response=True
+        DOMAIN, "backup_full", {}, blocking=True, return_response=True
     )
     supervisor_client.backups.full_backup.assert_called_once_with(
         FullBackupOptions(name="2021-11-13 03:48:00")
@@ -593,7 +593,7 @@ async def test_service_calls(
     assert full_backup == {"backup": "full"}
 
     partial_backup = await hass.services.async_call(
-        "hassio",
+        DOMAIN,
         "backup_partial",
         {
             "homeassistant": True,
@@ -615,9 +615,9 @@ async def test_service_calls(
     )
     assert partial_backup == {"backup": "partial"}
 
-    await hass.services.async_call("hassio", "restore_full", {"slug": "test"})
+    await hass.services.async_call(DOMAIN, "restore_full", {"slug": "test"})
     await hass.services.async_call(
-        "hassio",
+        DOMAIN,
         "restore_partial",
         {
             "slug": "test",
@@ -641,7 +641,7 @@ async def test_service_calls(
     )
 
     await hass.services.async_call(
-        "hassio",
+        DOMAIN,
         "backup_full",
         {
             "name": "backup_name",
@@ -659,7 +659,7 @@ async def test_service_calls(
     )
 
     await hass.services.async_call(
-        "hassio",
+        DOMAIN,
         "backup_full",
         {
             "location": "/backup",
@@ -675,7 +675,7 @@ async def test_service_calls(
     await hass.async_block_till_done()
 
     await hass.services.async_call(
-        "hassio",
+        DOMAIN,
         "backup_full",
         {
             "location": "/backup",
@@ -699,11 +699,11 @@ async def test_invalid_service_calls(hass: HomeAssistant, app_or_addon: str) -> 
 
     with pytest.raises(Invalid):
         await hass.services.async_call(
-            "hassio", f"{app_or_addon}_start", {app_or_addon: "inv@lid"}
+            DOMAIN, f"{app_or_addon}_start", {app_or_addon: "inv@lid"}
         )
     with pytest.raises(Invalid):
         await hass.services.async_call(
-            "hassio",
+            DOMAIN,
             f"{app_or_addon}_stdin",
             {app_or_addon: "inv@lid", "input": "test"},
         )
@@ -738,7 +738,7 @@ async def test_service_calls_apps_addons_exclusive(
     with pytest.raises(
         Invalid, match="two or more values in the same group of exclusion"
     ):
-        await hass.services.async_call("hassio", service, service_data)
+        await hass.services.async_call(DOMAIN, service, service_data)
 
 
 @pytest.mark.parametrize(
@@ -779,7 +779,7 @@ async def test_addon_service_call_with_complex_slug(
         await hass.async_block_till_done()
 
     await hass.services.async_call(
-        "hassio", f"{app_or_addon}_start", {app_or_addon: "test.a_1-2"}
+        DOMAIN, f"{app_or_addon}_start", {app_or_addon: "test.a_1-2"}
     )
 
 
@@ -823,12 +823,12 @@ async def test_invalid_service_calls_app_duplicates(
 
     with pytest.raises(Invalid, match="contains duplicate items"):
         await hass.services.async_call(
-            "hassio", "backup_partial", {app_or_addon: ["test", "test"]}
+            DOMAIN, "backup_partial", {app_or_addon: ["test", "test"]}
         )
 
     with pytest.raises(Invalid, match="contains duplicate items"):
         await hass.services.async_call(
-            "hassio", "restore_partial", {app_or_addon: ["test", "test"]}
+            DOMAIN, "restore_partial", {app_or_addon: ["test", "test"]}
         )
 
 
@@ -839,12 +839,12 @@ async def test_invalid_service_calls_folder_duplicates(hass: HomeAssistant) -> N
 
     with pytest.raises(Invalid, match="contains duplicate items"):
         await hass.services.async_call(
-            "hassio", "backup_partial", {"folders": ["ssl", "ssl"]}
+            DOMAIN, "backup_partial", {"folders": ["ssl", "ssl"]}
         )
 
     with pytest.raises(Invalid, match="contains duplicate items"):
         await hass.services.async_call(
-            "hassio", "restore_partial", {"folders": ["ssl", "ssl"]}
+            DOMAIN, "restore_partial", {"folders": ["ssl", "ssl"]}
         )
 
 
@@ -859,7 +859,7 @@ async def test_partial_backup_legacy_homeassistant_folder(
     )
 
     await hass.services.async_call(
-        "hassio",
+        DOMAIN,
         "backup_partial",
         {"folders": ["homeassistant", "ssl"], "name": "test"},
         blocking=True,
@@ -886,7 +886,7 @@ async def test_partial_restore_legacy_homeassistant_folder(
     assert await async_setup_component(hass, "hassio", {})
 
     await hass.services.async_call(
-        "hassio",
+        DOMAIN,
         "restore_partial",
         {"slug": "test", "folders": ["homeassistant", "ssl"]},
         blocking=True,
@@ -906,9 +906,7 @@ async def test_partial_backup_invalid_folder(hass: HomeAssistant) -> None:
     assert await async_setup_component(hass, "hassio", {})
 
     with pytest.raises(Invalid, match="not a valid value"):
-        await hass.services.async_call(
-            "hassio", "backup_partial", {"folders": ["bogus"]}
-        )
+        await hass.services.async_call(DOMAIN, "backup_partial", {"folders": ["bogus"]})
 
 
 @pytest.mark.usefixtures("hassio_env", "supervisor_client")
@@ -920,7 +918,7 @@ async def test_partial_backup_legacy_homeassistant_folder_conflict(
 
     with pytest.raises(ServiceValidationError, match="conflicts"):
         await hass.services.async_call(
-            "hassio",
+            DOMAIN,
             "backup_partial",
             {"homeassistant": False, "folders": ["homeassistant"]},
             blocking=True,
@@ -1569,7 +1567,7 @@ async def test_mount_reload_action(
     """Test reload_mount service call."""
     device = await mount_reload_test_setup(hass, device_registry, supervisor_client)
     await hass.services.async_call(
-        "hassio", "mount_reload", {"device_id": device.id}, blocking=True
+        DOMAIN, "mount_reload", {"device_id": device.id}, blocking=True
     )
     supervisor_client.mounts.reload_mount.assert_awaited_once_with("NAS")
 
@@ -1586,7 +1584,7 @@ async def test_mount_reload_action_failure(
     )
     with pytest.raises(HomeAssistantError) as exc:
         await hass.services.async_call(
-            "hassio", "mount_reload", {"device_id": device.id}, blocking=True
+            DOMAIN, "mount_reload", {"device_id": device.id}, blocking=True
         )
     assert str(exc.value) == "Failed to reload mount NAS: test failure"
 
@@ -1600,7 +1598,7 @@ async def test_mount_reload_unknown_device_id(
     await mount_reload_test_setup(hass, device_registry, supervisor_client)
     with pytest.raises(ServiceValidationError) as exc:
         await hass.services.async_call(
-            "hassio", "mount_reload", {"device_id": "1234"}, blocking=True
+            DOMAIN, "mount_reload", {"device_id": "1234"}, blocking=True
         )
     assert str(exc.value) == "Device ID not found"
 
@@ -1615,7 +1613,7 @@ async def test_mount_reload_no_name(
     device_registry.async_update_device(device.id, name=None)
     with pytest.raises(ServiceValidationError) as exc:
         await hass.services.async_call(
-            "hassio", "mount_reload", {"device_id": device.id}, blocking=True
+            DOMAIN, "mount_reload", {"device_id": device.id}, blocking=True
         )
     assert str(exc.value) == "Device is not a supervisor mount point"
 
@@ -1630,7 +1628,7 @@ async def test_mount_reload_invalid_model(
     device_registry.async_update_device(device.id, model=None)
     with pytest.raises(ServiceValidationError) as exc:
         await hass.services.async_call(
-            "hassio", "mount_reload", {"device_id": device.id}, blocking=True
+            DOMAIN, "mount_reload", {"device_id": device.id}, blocking=True
         )
     assert str(exc.value) == "Device is not a supervisor mount point"
 
@@ -1652,7 +1650,7 @@ async def test_mount_reload_not_supervisor_device(
     )
     with pytest.raises(ServiceValidationError) as exc:
         await hass.services.async_call(
-            "hassio", "mount_reload", {"device_id": device2.id}, blocking=True
+            DOMAIN, "mount_reload", {"device_id": device2.id}, blocking=True
         )
     assert str(exc.value) == "Device is not a supervisor mount point"
 

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -248,7 +248,7 @@ async def test_entity_update(hass: HomeAssistant) -> None:
         return_value=None,
     ) as mock_update:
         await hass.services.async_call(
-            "homeassistant",
+            DOMAIN,
             "update_entity",
             {"entity_id": ["light.kitchen"]},
             blocking=True,
@@ -268,7 +268,7 @@ async def test_setting_location(hass: HomeAssistant) -> None:
     elevation = hass.config.elevation
     assert elevation != 50
     await hass.services.async_call(
-        "homeassistant",
+        DOMAIN,
         SERVICE_SET_LOCATION,
         {"latitude": 30, "longitude": 40},
         blocking=True,
@@ -279,7 +279,7 @@ async def test_setting_location(hass: HomeAssistant) -> None:
     assert hass.config.elevation == elevation
 
     await hass.services.async_call(
-        "homeassistant",
+        DOMAIN,
         SERVICE_SET_LOCATION,
         {"latitude": 30, "longitude": 40, "elevation": 50},
         blocking=True,
@@ -289,7 +289,7 @@ async def test_setting_location(hass: HomeAssistant) -> None:
     assert hass.config.elevation == 50
 
     await hass.services.async_call(
-        "homeassistant",
+        DOMAIN,
         SERVICE_SET_LOCATION,
         {"latitude": 30, "longitude": 40, "elevation": 0},
         blocking=True,
@@ -387,7 +387,7 @@ async def test_reload_config_entry_by_entity_id(
         return_value=None,
     ) as mock_reload:
         await hass.services.async_call(
-            "homeassistant",
+            DOMAIN,
             "reload_config_entry",
             {"entity_id": f"{reg_entity1.entity_id},{reg_entity2.entity_id}"},
             blocking=True,
@@ -401,7 +401,7 @@ async def test_reload_config_entry_by_entity_id(
 
     with pytest.raises(ValueError):
         await hass.services.async_call(
-            "homeassistant",
+            DOMAIN,
             "reload_config_entry",
             {"entity_id": "unknown.entity_id"},
             blocking=True,
@@ -417,7 +417,7 @@ async def test_reload_config_entry_by_entry_id(hass: HomeAssistant) -> None:
         return_value=None,
     ) as mock_reload:
         await hass.services.async_call(
-            "homeassistant",
+            DOMAIN,
             "reload_config_entry",
             {ATTR_ENTRY_ID: "8955375327824e14ba89e4b29cc3ec9a"},
             blocking=True,
@@ -444,7 +444,7 @@ async def test_raises_when_db_upgrade_in_progress(
         ) as mock_async_migration_in_progress,
     ):
         await hass.services.async_call(
-            "homeassistant",
+            DOMAIN,
             service,
             blocking=True,
         )
@@ -462,7 +462,7 @@ async def test_raises_when_db_upgrade_in_progress(
         patch("homeassistant.config.async_check_ha_config_file", return_value=None),
     ):
         await hass.services.async_call(
-            "homeassistant",
+            DOMAIN,
             service,
             blocking=True,
         )
@@ -489,7 +489,7 @@ async def test_raises_when_config_is_invalid(
         ) as mock_async_check_ha_config_file,
     ):
         await hass.services.async_call(
-            "homeassistant",
+            DOMAIN,
             SERVICE_HOMEASSISTANT_RESTART,
             blocking=True,
         )
@@ -510,7 +510,7 @@ async def test_raises_when_config_is_invalid(
         ) as mock_async_check_ha_config_file,
     ):
         await hass.services.async_call(
-            "homeassistant",
+            DOMAIN,
             SERVICE_HOMEASSISTANT_RESTART,
             blocking=True,
         )
@@ -537,7 +537,7 @@ async def test_restart_homeassistant(
         ) as mock_restart,
     ):
         await hass.services.async_call(
-            "homeassistant",
+            DOMAIN,
             SERVICE_HOMEASSISTANT_RESTART,
             service_data,
             blocking=True,
@@ -560,7 +560,7 @@ async def test_stop_homeassistant(hass: HomeAssistant) -> None:
         ) as mock_restart,
     ):
         await hass.services.async_call(
-            "homeassistant",
+            DOMAIN,
             SERVICE_HOMEASSISTANT_STOP,
             blocking=True,
         )
@@ -577,7 +577,7 @@ async def test_save_persistent_states(hass: HomeAssistant) -> None:
         return_value=None,
     ) as mock_save:
         await hass.services.async_call(
-            "homeassistant",
+            DOMAIN,
             SERVICE_SAVE_PERSISTENT_STATES,
             blocking=True,
         )
@@ -592,7 +592,7 @@ async def test_reload_custom_templates(hass: HomeAssistant) -> None:
         return_value=None,
     ) as mock_load_custom_templates:
         await hass.services.async_call(
-            "homeassistant",
+            DOMAIN,
             SERVICE_RELOAD_CUSTOM_TEMPLATES,
             blocking=True,
         )
@@ -617,7 +617,7 @@ async def test_reload_all(
         return_value=None,
     ) as mock_async_check_ha_config_file:
         await hass.services.async_call(
-            "homeassistant",
+            DOMAIN,
             SERVICE_RELOAD_ALL,
             blocking=True,
         )
@@ -645,7 +645,7 @@ async def test_reload_all(
         ) as mock_async_check_ha_config_file,
     ):
         await hass.services.async_call(
-            "homeassistant",
+            DOMAIN,
             SERVICE_RELOAD_ALL,
             blocking=True,
         )

--- a/tests/components/hue/test_scene.py
+++ b/tests/components/hue/test_scene.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from homeassistant.components.hue import DOMAIN
 from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -125,7 +126,7 @@ async def test_scene_advanced_turn_on_service(
 
     # call the hue.activate_scene service
     await hass.services.async_call(
-        "hue",
+        DOMAIN,
         "activate_scene",
         {"entity_id": test_entity_id},
         blocking=True,
@@ -138,7 +139,7 @@ async def test_scene_advanced_turn_on_service(
 
     # test again with sending speed and dynamic
     await hass.services.async_call(
-        "hue",
+        DOMAIN,
         "activate_scene",
         {"entity_id": test_entity_id, "speed": 80, "dynamic": True},
         blocking=True,

--- a/tests/components/hue/test_services.py
+++ b/tests/components/hue/test_services.py
@@ -3,7 +3,7 @@
 from unittest.mock import Mock, patch
 
 from homeassistant.components import hue
-from homeassistant.components.hue import bridge
+from homeassistant.components.hue import DOMAIN, bridge
 from homeassistant.components.hue.const import (
     CONF_ALLOW_HUE_GROUPS,
     CONF_ALLOW_UNREACHABLE,
@@ -209,7 +209,7 @@ async def test_hue_multi_bridge_activate_scene_all_respond(
         hue.services, "hue_activate_scene_v2", return_value=True
     ) as mock_hue_activate_scene2:
         await hass.services.async_call(
-            "hue",
+            DOMAIN,
             "hue_activate_scene",
             {"group_name": "Group 1", "scene_name": "Cozy dinner"},
             blocking=True,
@@ -246,7 +246,7 @@ async def test_hue_multi_bridge_activate_scene_one_responds(
         hue.services, "hue_activate_scene_v2", return_value=False
     ) as mock_hue_activate_scene2:
         await hass.services.async_call(
-            "hue",
+            DOMAIN,
             "hue_activate_scene",
             {"group_name": "Group 1", "scene_name": "Cozy dinner"},
             blocking=True,
@@ -281,7 +281,7 @@ async def test_hue_multi_bridge_activate_scene_zero_responds(
         hue.services, "hue_activate_scene_v2", return_value=False
     ) as mock_hue_activate_scene2:
         await hass.services.async_call(
-            "hue",
+            DOMAIN,
             "hue_activate_scene",
             {"group_name": "Non existing group", "scene_name": "Non existing Scene"},
             blocking=True,

--- a/tests/components/input_boolean/test_init.py
+++ b/tests/components/input_boolean/test_init.py
@@ -186,7 +186,7 @@ async def test_input_boolean_context(
     assert state is not None
 
     await hass.services.async_call(
-        "input_boolean",
+        DOMAIN,
         "turn_off",
         {"entity_id": state.entity_id},
         True,

--- a/tests/components/input_datetime/test_init.py
+++ b/tests/components/input_datetime/test_init.py
@@ -286,7 +286,7 @@ async def test_set_invalid(hass: HomeAssistant) -> None:
 
     with pytest.raises(vol.Invalid):
         await hass.services.async_call(
-            "input_datetime",
+            DOMAIN,
             "set_datetime",
             {"entity_id": entity_id, "time": time_portion},
             blocking=True,
@@ -316,7 +316,7 @@ async def test_set_invalid_2(hass: HomeAssistant) -> None:
 
     with pytest.raises(vol.Invalid):
         await hass.services.async_call(
-            "input_datetime",
+            DOMAIN,
             "set_datetime",
             {"entity_id": entity_id, "time": time_portion, "datetime": dt_obj},
             blocking=True,
@@ -450,7 +450,7 @@ async def test_input_datetime_context(
     assert state is not None
 
     await hass.services.async_call(
-        "input_datetime",
+        DOMAIN,
         "set_datetime",
         {"entity_id": state.entity_id, "date": "2018-01-02"},
         blocking=True,

--- a/tests/components/input_number/test_init.py
+++ b/tests/components/input_number/test_init.py
@@ -334,7 +334,7 @@ async def test_input_number_context(
     assert state is not None
 
     await hass.services.async_call(
-        "input_number",
+        DOMAIN,
         "increment",
         {"entity_id": state.entity_id},
         True,

--- a/tests/components/knx/test_services.py
+++ b/tests/components/knx/test_services.py
@@ -115,7 +115,7 @@ async def test_send(
     await knx.setup_integration()
 
     await hass.services.async_call(
-        "knx",
+        DOMAIN,
         "send",
         service_payload,
         blocking=True,
@@ -131,12 +131,12 @@ async def test_read(hass: HomeAssistant, knx: KNXTestKit) -> None:
     await knx.setup_integration()
 
     # send read telegram
-    await hass.services.async_call("knx", "read", {"address": "1/1/1"}, blocking=True)
+    await hass.services.async_call(DOMAIN, "read", {"address": "1/1/1"}, blocking=True)
     await knx.assert_read("1/1/1")
 
     # send multiple read telegrams
     await hass.services.async_call(
-        "knx",
+        DOMAIN,
         "read",
         {"address": ["1/1/1", "2/2/2", "3/3/3"]},
         blocking=True,
@@ -159,7 +159,7 @@ async def test_event_register(hass: HomeAssistant, knx: KNXTestKit) -> None:
 
     # register event with `type`
     await hass.services.async_call(
-        "knx",
+        DOMAIN,
         "event_register",
         {"address": test_address, "type": "2byte_unsigned"},
         blocking=True,
@@ -172,7 +172,7 @@ async def test_event_register(hass: HomeAssistant, knx: KNXTestKit) -> None:
 
     # remove event registration - no event added
     await hass.services.async_call(
-        "knx",
+        DOMAIN,
         "event_register",
         {"address": test_address, "remove": True},
         blocking=True,
@@ -182,7 +182,7 @@ async def test_event_register(hass: HomeAssistant, knx: KNXTestKit) -> None:
 
     # register event without `type`
     await hass.services.async_call(
-        "knx", "event_register", {"address": test_address}, blocking=True
+        DOMAIN, "event_register", {"address": test_address}, blocking=True
     )
     await knx.receive_write(test_address, True)
     await knx.receive_write(test_address, False)
@@ -197,7 +197,7 @@ async def test_event_register(hass: HomeAssistant, knx: KNXTestKit) -> None:
     # remove event for non-registered address - raise error
     with pytest.raises(HomeAssistantError) as exc_info:
         await hass.services.async_call(
-            "knx",
+            DOMAIN,
             "event_register",
             {"address": "4/4/4", "remove": True},
             blocking=True,
@@ -222,7 +222,7 @@ async def test_exposure_register(hass: HomeAssistant, knx: KNXTestKit) -> None:
 
     # register exposure
     await hass.services.async_call(
-        "knx",
+        DOMAIN,
         "exposure_register",
         {"address": test_address, "entity_id": test_entity, "type": "binary"},
         blocking=True,
@@ -233,7 +233,7 @@ async def test_exposure_register(hass: HomeAssistant, knx: KNXTestKit) -> None:
 
     # register exposure
     await hass.services.async_call(
-        "knx",
+        DOMAIN,
         "exposure_register",
         {"address": test_address, "remove": True},
         blocking=True,
@@ -244,7 +244,7 @@ async def test_exposure_register(hass: HomeAssistant, knx: KNXTestKit) -> None:
 
     # register exposure for attribute with default
     await hass.services.async_call(
-        "knx",
+        DOMAIN,
         "exposure_register",
         {
             "address": test_address,
@@ -289,7 +289,7 @@ async def test_reload_service(
         patch("homeassistant.components.knx.async_setup_entry") as mock_setup_entry,
     ):
         await hass.services.async_call(
-            "knx",
+            DOMAIN,
             "reload",
             blocking=True,
         )
@@ -304,7 +304,7 @@ async def test_service_setup_failed(hass: HomeAssistant, knx: KNXTestKit) -> Non
 
     with pytest.raises(HomeAssistantError) as exc_info:
         await hass.services.async_call(
-            "knx",
+            DOMAIN,
             "send",
             {"address": "1/2/3", "payload": True, "response": False},
             blocking=True,

--- a/tests/components/knx/test_telegrams.py
+++ b/tests/components/knx/test_telegrams.py
@@ -8,6 +8,7 @@ import pytest
 
 from homeassistant.components.knx.const import (
     CONF_KNX_TELEGRAM_LOG_SIZE,
+    DOMAIN,
     KNX_MODULE_KEY,
 )
 from homeassistant.components.knx.telegrams import TelegramDict
@@ -78,7 +79,7 @@ async def test_store_telegam_history(
 
     await knx.receive_write("1/3/4", True)
     await hass.services.async_call(
-        "knx", "send", {"address": "2/2/2", "payload": [1, 2, 3, 4]}, blocking=True
+        DOMAIN, "send", {"address": "2/2/2", "payload": [1, 2, 3, 4]}, blocking=True
     )
     await knx.assert_write("2/2/2", (1, 2, 3, 4))
 

--- a/tests/components/knx/test_trigger.py
+++ b/tests/components/knx/test_trigger.py
@@ -5,6 +5,7 @@ import logging
 import pytest
 
 from homeassistant.components import automation
+from homeassistant.components.knx import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.setup import async_setup_component
@@ -242,7 +243,7 @@ async def test_telegram_trigger_options(
         assert len(service_calls) == 0
 
     await hass.services.async_call(
-        "knx",
+        DOMAIN,
         "send",
         {"address": "0/0/1", "payload": True},
         blocking=True,

--- a/tests/components/logger/test_init.py
+++ b/tests/components/logger/test_init.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from homeassistant.components import logger
-from homeassistant.components.logger import LOGSEVERITY
+from homeassistant.components.logger import DOMAIN, LOGSEVERITY
 from homeassistant.components.logger.helpers import SAVE_DELAY_LONG
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.exceptions import Unauthorized
@@ -140,7 +140,7 @@ async def test_setting_level(hass: HomeAssistant) -> None:
     # Test set default level
     with patch("logging.getLogger", mocks.__getitem__):
         await hass.services.async_call(
-            "logger", "set_default_level", {"level": "fatal"}, blocking=True
+            DOMAIN, "set_default_level", {"level": "fatal"}, blocking=True
         )
     assert len(mocks[""].orig_setLevel.mock_calls) == 2
     assert mocks[""].orig_setLevel.mock_calls[1][1][0] == LOGSEVERITY["FATAL"]
@@ -148,7 +148,7 @@ async def test_setting_level(hass: HomeAssistant) -> None:
     # Test update other loggers
     with patch("logging.getLogger", mocks.__getitem__):
         await hass.services.async_call(
-            "logger",
+            DOMAIN,
             "set_level",
             {"test.child": "info", "new_logger": "notset"},
             blocking=True,

--- a/tests/components/matter/test_water_heater.py
+++ b/tests/components/matter/test_water_heater.py
@@ -8,6 +8,7 @@ from matter_server.common.helpers.util import create_attribute_path_from_attribu
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.matter import DOMAIN
 from homeassistant.components.matter.services import (
     ATTR_DURATION,
     ATTR_EMERGENCY_BOOST,
@@ -305,7 +306,7 @@ async def test_async_boost_actions(
 
     # Set boost with duration, emergency_boost, and temporary_setpoint
     await hass.services.async_call(
-        "matter",
+        DOMAIN,
         SERVICE_WATER_HEATER_BOOST,
         {
             ATTR_ENTITY_ID: "water_heater.water_heater",

--- a/tests/components/notify/test_legacy.py
+++ b/tests/components/notify/test_legacy.py
@@ -12,6 +12,7 @@ import yaml
 
 from homeassistant import config as hass_config
 from homeassistant.components import notify
+from homeassistant.components.notify import DOMAIN
 from homeassistant.const import SERVICE_RELOAD, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.discovery import async_load_platform
@@ -650,7 +651,7 @@ async def test_messages_to_targets_route(hass: HomeAssistant, tmp_path: Path) ->
     )
 
     await hass.services.async_call(
-        "notify",
+        DOMAIN,
         "test_target_name",
         {"message": "my message", "title": "my title", "data": {"hello": "world"}},
     )

--- a/tests/components/onvif/test_ptz.py
+++ b/tests/components/onvif/test_ptz.py
@@ -51,7 +51,7 @@ def _make_entry() -> MockConfigEntry:
 async def _call_ptz(hass: HomeAssistant, continuous_duration: float) -> None:
     """Call the onvif.ptz service with the given continuous_duration."""
     await hass.services.async_call(
-        "onvif",
+        DOMAIN,
         "ptz",
         {
             "entity_id": "camera.testcamera_mainstream",

--- a/tests/components/openai_conversation/test_init.py
+++ b/tests/components/openai_conversation/test_init.py
@@ -118,7 +118,7 @@ async def test_generate_image_service(
         ),
     ) as mock_create:
         response = await hass.services.async_call(
-            "openai_conversation",
+            DOMAIN,
             "generate_image",
             service_data,
             blocking=True,
@@ -154,7 +154,7 @@ async def test_generate_image_service_error(
         pytest.raises(HomeAssistantError, match="Error generating image: Reason"),
     ):
         await hass.services.async_call(
-            "openai_conversation",
+            DOMAIN,
             "generate_image",
             {
                 "config_entry": mock_config_entry.entry_id,
@@ -182,7 +182,7 @@ async def test_generate_image_service_error(
         pytest.raises(HomeAssistantError, match="No image returned"),
     ):
         await hass.services.async_call(
-            "openai_conversation",
+            DOMAIN,
             "generate_image",
             {
                 "config_entry": mock_config_entry.entry_id,
@@ -212,7 +212,7 @@ async def test_generate_content_service_with_image_not_allowed_path(
         ),
     ):
         await hass.services.async_call(
-            "openai_conversation",
+            DOMAIN,
             "generate_content",
             {
                 "config_entry": mock_config_entry.entry_id,
@@ -245,7 +245,7 @@ async def test_invalid_config_entry(
     }
     with pytest.raises(ServiceValidationError, match=error):
         await hass.services.async_call(
-            "openai_conversation",
+            DOMAIN,
             service_name,
             service_data,
             blocking=True,
@@ -473,7 +473,7 @@ async def test_generate_content_service(
         )
 
         response = await hass.services.async_call(
-            "openai_conversation",
+            DOMAIN,
             "generate_content",
             service_data,
             blocking=True,
@@ -546,7 +546,7 @@ async def test_generate_content_service_invalid(
     ):
         with pytest.raises(HomeAssistantError, match=error):
             await hass.services.async_call(
-                "openai_conversation",
+                DOMAIN,
                 "generate_content",
                 service_data,
                 blocking=True,
@@ -575,7 +575,7 @@ async def test_generate_content_service_error(
         pytest.raises(HomeAssistantError, match="Error generating content: Reason"),
     ):
         await hass.services.async_call(
-            "openai_conversation",
+            DOMAIN,
             "generate_content",
             {
                 "config_entry": mock_config_entry.entry_id,
@@ -615,7 +615,7 @@ async def test_service_auth_error(
         pytest.raises(HomeAssistantError, match="Authentication error"),
     ):
         await hass.services.async_call(
-            "openai_conversation",
+            DOMAIN,
             service_name,
             {
                 "config_entry": mock_config_entry.entry_id,

--- a/tests/components/overkiz/test_cover.py
+++ b/tests/components/overkiz/test_cover.py
@@ -27,6 +27,7 @@ from homeassistant.components.cover import (
     CoverEntityFeature,
     CoverState,
 )
+from homeassistant.components.overkiz import DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     STATE_UNAVAILABLE,
@@ -1253,7 +1254,7 @@ async def test_set_cover_position_and_tilt_executes_single_command(
     await setup_overkiz_integration(fixture=DYNAMIC_EXTERIOR_VENETIAN_BLIND.fixture)
 
     await hass.services.async_call(
-        "overkiz",
+        DOMAIN,
         "set_cover_position_and_tilt",
         {
             ATTR_ENTITY_ID: DYNAMIC_EXTERIOR_VENETIAN_BLIND.entity_id,
@@ -1294,7 +1295,7 @@ async def test_set_cover_position_and_tilt_inverts_boundaries(
     await setup_overkiz_integration(fixture=DYNAMIC_EXTERIOR_VENETIAN_BLIND.fixture)
 
     await hass.services.async_call(
-        "overkiz",
+        DOMAIN,
         "set_cover_position_and_tilt",
         {
             ATTR_ENTITY_ID: DYNAMIC_EXTERIOR_VENETIAN_BLIND.entity_id,
@@ -1334,7 +1335,7 @@ async def test_set_cover_position_and_tilt_unsupported_command_raises(
         pytest.raises(ServiceValidationError),
     ):
         await hass.services.async_call(
-            "overkiz",
+            DOMAIN,
             "set_cover_position_and_tilt",
             {
                 ATTR_ENTITY_ID: DYNAMIC_EXTERIOR_VENETIAN_BLIND.entity_id,

--- a/tests/components/python_script/test_init.py
+++ b/tests/components/python_script/test_init.py
@@ -42,9 +42,7 @@ async def test_setup(hass: HomeAssistant) -> None:
         ),
         patch("homeassistant.components.python_script.execute") as mock_ex,
     ):
-        await hass.services.async_call(
-            "python_script", "hello", {"some": "data"}, blocking=True
-        )
+        await hass.services.async_call(DOMAIN, "hello", {"some": "data"}, blocking=True)
 
     assert len(mock_ex.mock_calls) == 1
     test_hass, script, source, data = mock_ex.mock_calls[0][1]
@@ -392,7 +390,7 @@ async def test_reload(hass: HomeAssistant) -> None:
             "homeassistant.components.python_script.glob.iglob", return_value=scripts
         ),
     ):
-        await hass.services.async_call("python_script", "reload", {}, blocking=True)
+        await hass.services.async_call(DOMAIN, "reload", {}, blocking=True)
 
     assert not hass.services.has_service("python_script", "hello")
     assert hass.services.has_service("python_script", "hello2")
@@ -551,7 +549,7 @@ output = {"result": f"hello {data.get('name', 'World')}"}
         create=True,
     ):
         response = await hass.services.async_call(
-            "python_script",
+            DOMAIN,
             "hello",
             {"name": "paulus"},
             blocking=True,
@@ -595,7 +593,7 @@ no_output = {"result": f"hello {data.get('name', 'World')}"}
         create=True,
     ):
         response = await hass.services.async_call(
-            "python_script",
+            DOMAIN,
             "hello",
             {"name": "paulus"},
             blocking=True,
@@ -637,7 +635,7 @@ output = f"hello {data.get('name', 'World')}"
         pytest.raises(ServiceValidationError),
     ):
         await hass.services.async_call(
-            "python_script",
+            DOMAIN,
             "hello",
             {"name": "paulus"},
             blocking=True,

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -484,7 +484,7 @@ async def test_purge_method(
     await async_wait_purge_done(hass)
 
     # run purge method - no service data, use defaults
-    await hass.services.async_call("recorder", "purge")
+    await hass.services.async_call(DOMAIN, "purge")
     await hass.async_block_till_done()
 
     # Small wait for recorder thread
@@ -503,7 +503,7 @@ async def test_purge_method(
         assert statistics.count() == 4
 
     # run purge method - correct service data
-    await hass.services.async_call("recorder", "purge", service_data=service_data)
+    await hass.services.async_call(DOMAIN, "purge", service_data=service_data)
     await hass.async_block_till_done()
 
     # Small wait for recorder thread
@@ -539,7 +539,7 @@ async def test_purge_method(
 
     # run purge method - correct service data, with repack
     service_data["repack"] = True
-    await hass.services.async_call("recorder", "purge", service_data=service_data)
+    await hass.services.async_call(DOMAIN, "purge", service_data=service_data)
     await hass.async_block_till_done()
     await async_wait_purge_done(hass)
     assert (

--- a/tests/components/recorder/test_purge_v32_schema.py
+++ b/tests/components/recorder/test_purge_v32_schema.py
@@ -432,7 +432,7 @@ async def test_purge_method(
     await async_wait_purge_done(hass)
 
     # run purge method - no service data, use defaults
-    await hass.services.async_call("recorder", "purge")
+    await hass.services.async_call(DOMAIN, "purge")
     await hass.async_block_till_done()
 
     # Small wait for recorder thread
@@ -449,7 +449,7 @@ async def test_purge_method(
         assert statistics.count() == 4
 
     # run purge method - correct service data
-    await hass.services.async_call("recorder", "purge", service_data=service_data)
+    await hass.services.async_call(DOMAIN, "purge", service_data=service_data)
     await hass.async_block_till_done()
 
     # Small wait for recorder thread
@@ -483,7 +483,7 @@ async def test_purge_method(
 
     # run purge method - correct service data, with repack
     service_data["repack"] = True
-    await hass.services.async_call("recorder", "purge", service_data=service_data)
+    await hass.services.async_call(DOMAIN, "purge", service_data=service_data)
     await hass.async_block_till_done()
     await async_wait_purge_done(hass)
     assert (

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 
 from homeassistant import exceptions
 from homeassistant.components import recorder
-from homeassistant.components.recorder import Recorder, history, statistics
+from homeassistant.components.recorder import DOMAIN, Recorder, history, statistics
 from homeassistant.components.recorder.db_schema import StatisticsShortTerm
 from homeassistant.components.recorder.models import (
     StatisticMeanType,
@@ -4471,13 +4471,13 @@ async def test_get_statistics_service(
     await async_recorder_block_till_done(hass)
 
     result = await hass.services.async_call(
-        "recorder", "get_statistics", service_args, return_response=True, blocking=True
+        DOMAIN, "get_statistics", service_args, return_response=True, blocking=True
     )
     assert result == expected_result
 
     with pytest.raises(exceptions.Unauthorized):
         result = await hass.services.async_call(
-            "recorder",
+            DOMAIN,
             "get_statistics",
             service_args,
             return_response=True,
@@ -4538,7 +4538,7 @@ async def test_get_statistics_service_missing_mandatory_keys(
         match=re.escape(f"required key not provided @ data['{missing_key}']"),
     ):
         await hass.services.async_call(
-            "recorder",
+            DOMAIN,
             "get_statistics",
             service_args,
             return_response=True,

--- a/tests/components/rest/test_init.py
+++ b/tests/components/rest/test_init.py
@@ -274,7 +274,7 @@ async def test_reload(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) 
 
     with patch.object(hass_config, "YAML_CONFIG_FILE", yaml_path):
         await hass.services.async_call(
-            "rest",
+            DOMAIN,
             SERVICE_RELOAD,
             {},
             blocking=True,
@@ -324,7 +324,7 @@ async def test_reload_and_remove_all(
 
     with patch.object(hass_config, "YAML_CONFIG_FILE", yaml_path):
         await hass.services.async_call(
-            "rest",
+            DOMAIN,
             SERVICE_RELOAD,
             {},
             blocking=True,
@@ -369,7 +369,7 @@ async def test_reload_fails_to_read_configuration(
     yaml_path = get_fixture_path("configuration_invalid.notyaml", "rest")
     with patch.object(hass_config, "YAML_CONFIG_FILE", yaml_path):
         await hass.services.async_call(
-            "rest",
+            DOMAIN,
             SERVICE_RELOAD,
             {},
             blocking=True,

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -4,7 +4,7 @@ from unittest.mock import ANY, call
 
 import RFXtrx as rfxtrxmod
 
-from homeassistant.components.rfxtrx.const import EVENT_RFXTRX_EVENT
+from homeassistant.components.rfxtrx.const import DOMAIN, EVENT_RFXTRX_EVENT
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
@@ -81,7 +81,7 @@ async def test_send(hass: HomeAssistant, rfxtrx) -> None:
     await setup_rfx_test_cfg(hass, device="/dev/null", devices={})
 
     await hass.services.async_call(
-        "rfxtrx", "send", {"event": "0a520802060101ff0f0269"}, blocking=True
+        DOMAIN, "send", {"event": "0a520802060101ff0f0269"}, blocking=True
     )
 
     assert rfxtrx.transport.send.mock_calls == [

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -103,7 +103,7 @@ async def test_passing_variables(hass: HomeAssistant) -> None:
     assert calls[0].data["hello"] == "world"
 
     await hass.services.async_call(
-        "script", "test", {"greeting": "universe"}, context=context
+        DOMAIN, "test", {"greeting": "universe"}, context=context
     )
 
     await hass.async_block_till_done()
@@ -677,7 +677,7 @@ async def test_logging_script_error(
         {"script": {"hello": {"sequence": [{"action": "non.existing"}]}}},
     )
     with pytest.raises(ServiceNotFound) as err:
-        await hass.services.async_call("script", "hello", blocking=True)
+        await hass.services.async_call(DOMAIN, "hello", blocking=True)
 
     assert err.value.domain == "non"
     assert err.value.service == "existing"
@@ -1086,7 +1086,7 @@ async def test_concurrent_script(hass: HomeAssistant, concurrently) -> None:
     hass.states.async_set("input_boolean.test1", "off")
     hass.states.async_set("input_boolean.test2", "off")
 
-    await hass.services.async_call("script", "script1")
+    await hass.services.async_call(DOMAIN, "script1")
     await asyncio.wait_for(service_called.wait(), 1)
     service_called.clear()
 
@@ -1183,7 +1183,7 @@ async def test_script_variables(
     mock_calls = async_mock_service(hass, "test", "script")
 
     await hass.services.async_call(
-        "script", "script1", {"var_from_service": "hello"}, blocking=True
+        DOMAIN, "script1", {"var_from_service": "hello"}, blocking=True
     )
 
     assert len(mock_calls) == 1
@@ -1195,7 +1195,7 @@ async def test_script_variables(
     assert mock_calls[0].data.get("this_variable") == "script.script1"
 
     await hass.services.async_call(
-        "script", "script1", {"test_var": "from_service"}, blocking=True
+        DOMAIN, "script1", {"test_var": "from_service"}, blocking=True
     )
 
     assert len(mock_calls) == 2
@@ -1204,7 +1204,7 @@ async def test_script_variables(
 
     # Call script with vars but no templates in it
     await hass.services.async_call(
-        "script", "script2", {"test_var": "from_service"}, blocking=True
+        DOMAIN, "script2", {"test_var": "from_service"}, blocking=True
     )
 
     assert len(mock_calls) == 3
@@ -1212,11 +1212,11 @@ async def test_script_variables(
 
     assert "Error rendering variables" not in caplog.text
     with pytest.raises(TemplateError):
-        await hass.services.async_call("script", "script3", blocking=True)
+        await hass.services.async_call(DOMAIN, "script3", blocking=True)
     assert "Error rendering variables" in caplog.text
     assert len(mock_calls) == 3
 
-    await hass.services.async_call("script", "script3", {"break": 0}, blocking=True)
+    await hass.services.async_call(DOMAIN, "script3", {"break": 0}, blocking=True)
 
     assert len(mock_calls) == 4
     assert mock_calls[3].data["value"] == 1
@@ -1247,7 +1247,7 @@ async def test_script_this_var_always(
     )
     mock_calls = async_mock_service(hass, "test", "script")
 
-    await hass.services.async_call("script", "script1", blocking=True)
+    await hass.services.async_call(DOMAIN, "script1", blocking=True)
 
     assert len(mock_calls) == 1
     # Verify this available to all templates
@@ -1335,7 +1335,7 @@ async def test_recursive_script(
 
     hass.services.async_register("test", "script", async_service_handler)
 
-    await hass.services.async_call("script", "script1")
+    await hass.services.async_call(DOMAIN, "script1")
     await asyncio.wait_for(service_called.wait(), 1)
 
     assert warning_msg in caplog.text
@@ -1403,7 +1403,7 @@ async def test_recursive_script_indirect(
 
     hass.services.async_register("test", "script", async_service_handler)
 
-    await hass.services.async_call("script", "script1")
+    await hass.services.async_call(DOMAIN, "script1")
     await asyncio.wait_for(service_called.wait(), 1)
 
     assert warning_msg in caplog.text
@@ -1482,7 +1482,7 @@ async def test_recursive_script_turn_on(
 
         hass.services.async_register("test", "script_done", async_service_handler)
 
-        await hass.services.async_call("script", "script1")
+        await hass.services.async_call(DOMAIN, "script1")
         await asyncio.wait_for(service_called.wait(), 1)
 
         # Trigger 1st stage script shutdown
@@ -1640,7 +1640,7 @@ async def test_blueprint_script(hass: HomeAssistant, calls: list[ServiceCall]) -
         },
     )
     await hass.services.async_call(
-        "script", "test_script", {"var_from_service": "hello"}, blocking=True
+        DOMAIN, "test_script", {"var_from_service": "hello"}, blocking=True
     )
     await hass.async_block_till_done()
     assert len(calls) == 1
@@ -1874,7 +1874,7 @@ async def test_script_queued_mode(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    await hass.services.async_call("script", "test_main", blocking=True)
+    await hass.services.async_call(DOMAIN, "test_main", blocking=True)
     assert calls == 4
 
 

--- a/tests/components/shell_command/test_init.py
+++ b/tests/components/shell_command/test_init.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import pytest
 
 from homeassistant.components import shell_command
+from homeassistant.components.shell_command import DOMAIN
 from homeassistant.const import SERVICE_RELOAD
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, TemplateError
@@ -47,7 +48,7 @@ async def test_executing_service(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        await hass.services.async_call("shell_command", "test_service", blocking=True)
+        await hass.services.async_call(DOMAIN, "test_service", blocking=True)
         await hass.async_block_till_done()
         assert os.path.isfile(path)
 
@@ -82,7 +83,7 @@ async def test_template_render_no_template(mock_call, hass: HomeAssistant) -> No
     )
     await hass.async_block_till_done()
 
-    await hass.services.async_call("shell_command", "test_service", blocking=True)
+    await hass.services.async_call(DOMAIN, "test_service", blocking=True)
     await hass.async_block_till_done()
     cmd = mock_call.mock_calls[0][1][0]
 
@@ -106,7 +107,7 @@ async def test_incorrect_template(mock_call, hass: HomeAssistant) -> None:
 
     with pytest.raises(TemplateError):
         await hass.services.async_call(
-            "shell_command", "test_service", blocking=True, return_response=True
+            DOMAIN, "test_service", blocking=True, return_response=True
         )
 
     await hass.async_block_till_done()
@@ -127,7 +128,7 @@ async def test_template_render(mock_call, hass: HomeAssistant) -> None:
         },
     )
 
-    await hass.services.async_call("shell_command", "test_service", blocking=True)
+    await hass.services.async_call(DOMAIN, "test_service", blocking=True)
 
     await hass.async_block_till_done()
     cmd = mock_call.mock_calls[0][1]
@@ -150,7 +151,7 @@ async def test_subprocess_error(mock_error, mock_call, hass: HomeAssistant) -> N
         )
 
         response = await hass.services.async_call(
-            "shell_command", "test_service", blocking=True, return_response=True
+            DOMAIN, "test_service", blocking=True, return_response=True
         )
         await hass.async_block_till_done()
         assert mock_call.call_count == 1
@@ -170,7 +171,7 @@ async def test_stdout_captured(mock_output, hass: HomeAssistant) -> None:
     )
 
     response = await hass.services.async_call(
-        "shell_command", "test_service", blocking=True, return_response=True
+        DOMAIN, "test_service", blocking=True, return_response=True
     )
 
     await hass.async_block_till_done()
@@ -200,9 +201,7 @@ async def test_non_text_stdout_capture(
     )
 
     # No problem without 'return_response'
-    response = await hass.services.async_call(
-        "shell_command", "output_image", blocking=True
-    )
+    response = await hass.services.async_call(DOMAIN, "output_image", blocking=True)
 
     await hass.async_block_till_done()
     assert not response
@@ -215,7 +214,7 @@ async def test_non_text_stdout_capture(
         ),
     ):
         response = await hass.services.async_call(
-            "shell_command", "output_image", blocking=True, return_response=True
+            DOMAIN, "output_image", blocking=True, return_response=True
         )
 
     await hass.async_block_till_done()
@@ -234,7 +233,7 @@ async def test_stderr_captured(mock_output, hass: HomeAssistant) -> None:
     )
 
     response = await hass.services.async_call(
-        "shell_command", "test_service", blocking=True, return_response=True
+        DOMAIN, "test_service", blocking=True, return_response=True
     )
 
     await hass.async_block_till_done()

--- a/tests/components/template/test_entity.py
+++ b/tests/components/template/test_entity.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.template import entity as abstract_entity
+from homeassistant.components.template import DOMAIN, entity as abstract_entity
 from homeassistant.const import SERVICE_RELOAD
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -78,7 +78,7 @@ async def test_reload_stops_entity_action_scripts(
         autospec=True,
         return_value={"template": []},
     ):
-        await hass.services.async_call("template", SERVICE_RELOAD, blocking=True)
+        await hass.services.async_call(DOMAIN, SERVICE_RELOAD, blocking=True)
         await hass.async_block_till_done()
 
     assert not turn_on_script.is_running

--- a/tests/components/template/test_trigger_entity.py
+++ b/tests/components/template/test_trigger_entity.py
@@ -360,7 +360,7 @@ async def test_reload_stops_script_and_unsubscribes_triggers(
         autospec=True,
         return_value={"template": []},
     ):
-        await hass.services.async_call("template", SERVICE_RELOAD, blocking=True)
+        await hass.services.async_call(DOMAIN, SERVICE_RELOAD, blocking=True)
         await hass.async_block_till_done()
 
     # Script should be stopped and unloaded

--- a/tests/components/waze_travel_time/test_init.py
+++ b/tests/components/waze_travel_time/test_init.py
@@ -57,7 +57,7 @@ async def call_service_get_travel_times(
     if base_coordinates is not None:
         params["base_coordinates"] = base_coordinates
     return await hass.services.async_call(
-        "waze_travel_time",
+        DOMAIN,
         "get_travel_times",
         params,
         blocking=True,
@@ -131,7 +131,7 @@ async def test_service_get_travel_times_empty_response(
     """Test service get_travel_times."""
     mock_update.return_value = []
     response_data = await hass.services.async_call(
-        "waze_travel_time",
+        DOMAIN,
         "get_travel_times",
         {
             "origin": "location1",

--- a/tests/components/zha/test_lock.py
+++ b/tests/components/zha/test_lock.py
@@ -11,6 +11,7 @@ from zigpy.zcl.clusters import closures, general
 import zigpy.zcl.foundation as zcl_f
 
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN, LockState
+from homeassistant.components.zha import DOMAIN
 from homeassistant.components.zha.helpers import (
     ZHADeviceProxy,
     ZHAGatewayProxy,
@@ -143,7 +144,7 @@ async def async_set_user_code(hass: HomeAssistant, cluster: Cluster, entity_id: 
     with patch("zigpy.zcl.Cluster.request", return_value=[zcl_f.Status.SUCCESS]):
         # set lock code via service call
         await hass.services.async_call(
-            "zha",
+            DOMAIN,
             "set_lock_user_code",
             {"entity_id": entity_id, "code_slot": 3, "user_code": "13246579"},
             blocking=True,
@@ -167,7 +168,7 @@ async def async_clear_user_code(hass: HomeAssistant, cluster: Cluster, entity_id
     with patch("zigpy.zcl.Cluster.request", return_value=[zcl_f.Status.SUCCESS]):
         # set lock code via service call
         await hass.services.async_call(
-            "zha",
+            DOMAIN,
             "clear_lock_user_code",
             {
                 "entity_id": entity_id,
@@ -189,7 +190,7 @@ async def async_enable_user_code(hass: HomeAssistant, cluster: Cluster, entity_i
     with patch("zigpy.zcl.Cluster.request", return_value=[zcl_f.Status.SUCCESS]):
         # set lock code via service call
         await hass.services.async_call(
-            "zha",
+            DOMAIN,
             "enable_lock_user_code",
             {
                 "entity_id": entity_id,
@@ -214,7 +215,7 @@ async def async_disable_user_code(
     with patch("zigpy.zcl.Cluster.request", return_value=[zcl_f.Status.SUCCESS]):
         # set lock code via service call
         await hass.services.async_call(
-            "zha",
+            DOMAIN,
             "disable_lock_user_code",
             {
                 "entity_id": entity_id,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When `hass.services.async_call` is called with a literal string matching the component name, use the `DOMAIN` constant instead

Linked to #172693

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
