### PR TITLE
Use DOMAIN constant in tests (async_mock_service)

### DIFF
--- a/tests/components/alarm_control_panel/test_reproduce_state.py
+++ b/tests/components/alarm_control_panel/test_reproduce_state.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from homeassistant.components.alarm_control_panel import AlarmControlPanelState
+from homeassistant.components.alarm_control_panel import DOMAIN, AlarmControlPanelState
 from homeassistant.const import (
     SERVICE_ALARM_ARM_AWAY,
     SERVICE_ALARM_ARM_CUSTOM_BYPASS,
@@ -56,25 +56,15 @@ async def test_reproducing_states(
         {},
     )
 
-    arm_away_calls = async_mock_service(
-        hass, "alarm_control_panel", SERVICE_ALARM_ARM_AWAY
-    )
+    arm_away_calls = async_mock_service(hass, DOMAIN, SERVICE_ALARM_ARM_AWAY)
     arm_custom_bypass_calls = async_mock_service(
-        hass, "alarm_control_panel", SERVICE_ALARM_ARM_CUSTOM_BYPASS
+        hass, DOMAIN, SERVICE_ALARM_ARM_CUSTOM_BYPASS
     )
-    arm_home_calls = async_mock_service(
-        hass, "alarm_control_panel", SERVICE_ALARM_ARM_HOME
-    )
-    arm_night_calls = async_mock_service(
-        hass, "alarm_control_panel", SERVICE_ALARM_ARM_NIGHT
-    )
-    arm_vacation_calls = async_mock_service(
-        hass, "alarm_control_panel", SERVICE_ALARM_ARM_VACATION
-    )
-    disarm_calls = async_mock_service(hass, "alarm_control_panel", SERVICE_ALARM_DISARM)
-    trigger_calls = async_mock_service(
-        hass, "alarm_control_panel", SERVICE_ALARM_TRIGGER
-    )
+    arm_home_calls = async_mock_service(hass, DOMAIN, SERVICE_ALARM_ARM_HOME)
+    arm_night_calls = async_mock_service(hass, DOMAIN, SERVICE_ALARM_ARM_NIGHT)
+    arm_vacation_calls = async_mock_service(hass, DOMAIN, SERVICE_ALARM_ARM_VACATION)
+    disarm_calls = async_mock_service(hass, DOMAIN, SERVICE_ALARM_DISARM)
+    trigger_calls = async_mock_service(hass, DOMAIN, SERVICE_ALARM_TRIGGER)
 
     # These calls should do nothing as entities already in desired state
     await async_reproduce_state(

--- a/tests/components/alert/test_reproduce_state.py
+++ b/tests/components/alert/test_reproduce_state.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from homeassistant.components.alert import DOMAIN
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 
@@ -15,8 +16,8 @@ async def test_reproducing_states(
     hass.states.async_set("alert.entity_off", "off", {})
     hass.states.async_set("alert.entity_on", "on", {})
 
-    turn_on_calls = async_mock_service(hass, "alert", "turn_on")
-    turn_off_calls = async_mock_service(hass, "alert", "turn_off")
+    turn_on_calls = async_mock_service(hass, DOMAIN, "turn_on")
+    turn_off_calls = async_mock_service(hass, DOMAIN, "turn_off")
 
     # These calls should do nothing as entities already in desired state
     await async_reproduce_state(

--- a/tests/components/automation/test_reproduce_state.py
+++ b/tests/components/automation/test_reproduce_state.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from homeassistant.components.automation import DOMAIN
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 
@@ -15,8 +16,8 @@ async def test_reproducing_states(
     hass.states.async_set("automation.entity_off", "off", {})
     hass.states.async_set("automation.entity_on", "on", {})
 
-    turn_on_calls = async_mock_service(hass, "automation", "turn_on")
-    turn_off_calls = async_mock_service(hass, "automation", "turn_off")
+    turn_on_calls = async_mock_service(hass, DOMAIN, "turn_on")
+    turn_off_calls = async_mock_service(hass, DOMAIN, "turn_off")
 
     # These calls should do nothing as entities already in desired state
     await async_reproduce_state(

--- a/tests/components/climate/test_device_action.py
+++ b/tests/components/climate/test_device_action.py
@@ -199,8 +199,8 @@ async def test_action(
         },
     )
 
-    set_hvac_mode_calls = async_mock_service(hass, "climate", "set_hvac_mode")
-    set_preset_mode_calls = async_mock_service(hass, "climate", "set_preset_mode")
+    set_hvac_mode_calls = async_mock_service(hass, DOMAIN, "set_hvac_mode")
+    set_preset_mode_calls = async_mock_service(hass, DOMAIN, "set_preset_mode")
 
     hass.bus.async_fire("test_event_set_hvac_mode")
     await hass.async_block_till_done()
@@ -273,7 +273,7 @@ async def test_action_legacy(
         },
     )
 
-    set_hvac_mode_calls = async_mock_service(hass, "climate", "set_hvac_mode")
+    set_hvac_mode_calls = async_mock_service(hass, DOMAIN, "set_hvac_mode")
 
     hass.bus.async_fire("test_event_set_hvac_mode")
     await hass.async_block_till_done()

--- a/tests/components/counter/test_reproduce_state.py
+++ b/tests/components/counter/test_reproduce_state.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from homeassistant.components.counter import DOMAIN
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 
@@ -19,7 +20,7 @@ async def test_reproducing_states(
         {"minimum": 5, "maximum": 15, "step": 3},
     )
 
-    configure_calls = async_mock_service(hass, "counter", "set_value")
+    configure_calls = async_mock_service(hass, DOMAIN, "set_value")
 
     # These calls should do nothing as entities already in desired state
     await async_reproduce_state(

--- a/tests/components/cover/test_device_action.py
+++ b/tests/components/cover/test_device_action.py
@@ -390,9 +390,9 @@ async def test_action(
     )
     await hass.async_block_till_done()
 
-    open_calls = async_mock_service(hass, "cover", "open_cover")
-    close_calls = async_mock_service(hass, "cover", "close_cover")
-    stop_calls = async_mock_service(hass, "cover", "stop_cover")
+    open_calls = async_mock_service(hass, DOMAIN, "open_cover")
+    close_calls = async_mock_service(hass, DOMAIN, "close_cover")
+    stop_calls = async_mock_service(hass, DOMAIN, "stop_cover")
 
     hass.bus.async_fire("test_event_open")
     await hass.async_block_till_done()
@@ -459,7 +459,7 @@ async def test_action_legacy(
     )
     await hass.async_block_till_done()
 
-    open_calls = async_mock_service(hass, "cover", "open_cover")
+    open_calls = async_mock_service(hass, DOMAIN, "open_cover")
 
     hass.bus.async_fire("test_event_open")
     await hass.async_block_till_done()
@@ -515,8 +515,8 @@ async def test_action_tilt(
     )
     await hass.async_block_till_done()
 
-    open_calls = async_mock_service(hass, "cover", "open_cover_tilt")
-    close_calls = async_mock_service(hass, "cover", "close_cover_tilt")
+    open_calls = async_mock_service(hass, DOMAIN, "open_cover_tilt")
+    close_calls = async_mock_service(hass, DOMAIN, "close_cover_tilt")
 
     hass.bus.async_fire("test_event_open")
     await hass.async_block_till_done()
@@ -594,8 +594,8 @@ async def test_action_set_position(
     )
     await hass.async_block_till_done()
 
-    cover_pos_calls = async_mock_service(hass, "cover", "set_cover_position")
-    tilt_pos_calls = async_mock_service(hass, "cover", "set_cover_tilt_position")
+    cover_pos_calls = async_mock_service(hass, DOMAIN, "set_cover_position")
+    tilt_pos_calls = async_mock_service(hass, DOMAIN, "set_cover_tilt_position")
 
     hass.bus.async_fire("test_event_set_pos")
     await hass.async_block_till_done()

--- a/tests/components/cover/test_reproduce_state.py
+++ b/tests/components/cover/test_reproduce_state.py
@@ -7,6 +7,7 @@ from homeassistant.components.cover import (
     ATTR_CURRENT_TILT_POSITION,
     ATTR_POSITION,
     ATTR_TILT_POSITION,
+    DOMAIN,
     CoverEntityFeature,
     CoverState,
 )
@@ -252,13 +253,13 @@ async def test_reproducing_states(
             ATTR_SUPPORTED_FEATURES: CoverEntityFeature.SET_TILT_POSITION,
         },
     )
-    close_calls = async_mock_service(hass, "cover", SERVICE_CLOSE_COVER)
-    open_calls = async_mock_service(hass, "cover", SERVICE_OPEN_COVER)
-    close_tilt_calls = async_mock_service(hass, "cover", SERVICE_CLOSE_COVER_TILT)
-    open_tilt_calls = async_mock_service(hass, "cover", SERVICE_OPEN_COVER_TILT)
-    position_calls = async_mock_service(hass, "cover", SERVICE_SET_COVER_POSITION)
+    close_calls = async_mock_service(hass, DOMAIN, SERVICE_CLOSE_COVER)
+    open_calls = async_mock_service(hass, DOMAIN, SERVICE_OPEN_COVER)
+    close_tilt_calls = async_mock_service(hass, DOMAIN, SERVICE_CLOSE_COVER_TILT)
+    open_tilt_calls = async_mock_service(hass, DOMAIN, SERVICE_OPEN_COVER_TILT)
+    position_calls = async_mock_service(hass, DOMAIN, SERVICE_SET_COVER_POSITION)
     position_tilt_calls = async_mock_service(
-        hass, "cover", SERVICE_SET_COVER_TILT_POSITION
+        hass, DOMAIN, SERVICE_SET_COVER_TILT_POSITION
     )
 
     # These calls should do nothing as entities already in desired state

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -157,7 +157,7 @@ async def test_esphome_device_service_calls_not_allowed(
         device_info={"esphome_version": "2023.3.0"},
     )
     await hass.async_block_till_done()
-    mock_esphome_test = async_mock_service(hass, "esphome", "test")
+    mock_esphome_test = async_mock_service(hass, DOMAIN, "test")
     device.mock_service_call(
         HomeassistantServiceCall(
             service="esphome.test",

--- a/tests/components/fan/test_device_action.py
+++ b/tests/components/fan/test_device_action.py
@@ -160,9 +160,9 @@ async def test_action(
         },
     )
 
-    turn_off_calls = async_mock_service(hass, "fan", "turn_off")
-    turn_on_calls = async_mock_service(hass, "fan", "turn_on")
-    toggle_calls = async_mock_service(hass, "fan", "toggle")
+    turn_off_calls = async_mock_service(hass, DOMAIN, "turn_off")
+    turn_on_calls = async_mock_service(hass, DOMAIN, "turn_on")
+    toggle_calls = async_mock_service(hass, DOMAIN, "toggle")
 
     hass.bus.async_fire("test_event_turn_off")
     await hass.async_block_till_done()
@@ -223,7 +223,7 @@ async def test_action_legacy(
         },
     )
 
-    turn_off_calls = async_mock_service(hass, "fan", "turn_off")
+    turn_off_calls = async_mock_service(hass, DOMAIN, "turn_off")
 
     hass.bus.async_fire("test_event_turn_off")
     await hass.async_block_till_done()

--- a/tests/components/fan/test_reproduce_state.py
+++ b/tests/components/fan/test_reproduce_state.py
@@ -10,6 +10,7 @@ from homeassistant.components.fan import (
     ATTR_PRESET_MODES,
     DIRECTION_FORWARD,
     DIRECTION_REVERSE,
+    DOMAIN,
 )
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
@@ -27,11 +28,11 @@ async def test_reproducing_states(
     hass.states.async_set("fan.entity_oscillating", "on", {"oscillating": True})
     hass.states.async_set("fan.entity_direction", "on", {"direction": "forward"})
 
-    turn_on_calls = async_mock_service(hass, "fan", "turn_on")
-    turn_off_calls = async_mock_service(hass, "fan", "turn_off")
-    set_direction_calls = async_mock_service(hass, "fan", "set_direction")
-    oscillate_calls = async_mock_service(hass, "fan", "oscillate")
-    set_percentage_calls = async_mock_service(hass, "fan", "set_percentage")
+    turn_on_calls = async_mock_service(hass, DOMAIN, "turn_on")
+    turn_off_calls = async_mock_service(hass, DOMAIN, "turn_off")
+    set_direction_calls = async_mock_service(hass, DOMAIN, "set_direction")
+    oscillate_calls = async_mock_service(hass, DOMAIN, "oscillate")
+    set_percentage_calls = async_mock_service(hass, DOMAIN, "set_percentage")
 
     # These calls should do nothing as entities already in desired state
     await async_reproduce_state(
@@ -177,12 +178,12 @@ async def test_modern_turn_on_invalid(hass: HomeAssistant, start_state) -> None:
     """Test modern fan state reproduction, turning on with invalid state."""
     hass.states.async_set(MODERN_FAN_ENTITY, "off", start_state)
 
-    turn_on_calls = async_mock_service(hass, "fan", "turn_on")
-    turn_off_calls = async_mock_service(hass, "fan", "turn_off")
-    set_direction_calls = async_mock_service(hass, "fan", "set_direction")
-    oscillate_calls = async_mock_service(hass, "fan", "oscillate")
-    set_percentage_mode = async_mock_service(hass, "fan", "set_percentage")
-    set_preset_mode = async_mock_service(hass, "fan", "set_preset_mode")
+    turn_on_calls = async_mock_service(hass, DOMAIN, "turn_on")
+    turn_off_calls = async_mock_service(hass, DOMAIN, "turn_off")
+    set_direction_calls = async_mock_service(hass, DOMAIN, "set_direction")
+    oscillate_calls = async_mock_service(hass, DOMAIN, "oscillate")
+    set_percentage_mode = async_mock_service(hass, DOMAIN, "set_percentage")
+    set_preset_mode = async_mock_service(hass, DOMAIN, "set_preset_mode")
 
     # Turn on with an invalid config (speed, percentage, preset_modes all None)
     await async_reproduce_state(
@@ -227,12 +228,12 @@ async def test_modern_turn_on_percentage_from_different_speed(
     """
     hass.states.async_set(MODERN_FAN_ENTITY, "off", start_state)
 
-    turn_on_calls = async_mock_service(hass, "fan", "turn_on")
-    turn_off_calls = async_mock_service(hass, "fan", "turn_off")
-    set_direction_calls = async_mock_service(hass, "fan", "set_direction")
-    oscillate_calls = async_mock_service(hass, "fan", "oscillate")
-    set_percentage_mode = async_mock_service(hass, "fan", "set_percentage")
-    set_preset_mode = async_mock_service(hass, "fan", "set_preset_mode")
+    turn_on_calls = async_mock_service(hass, DOMAIN, "turn_on")
+    turn_off_calls = async_mock_service(hass, DOMAIN, "turn_off")
+    set_direction_calls = async_mock_service(hass, DOMAIN, "set_direction")
+    oscillate_calls = async_mock_service(hass, DOMAIN, "oscillate")
+    set_percentage_mode = async_mock_service(hass, DOMAIN, "set_percentage")
+    set_preset_mode = async_mock_service(hass, DOMAIN, "set_preset_mode")
 
     await async_reproduce_state(
         hass, [State(MODERN_FAN_ENTITY, "on", MODERN_FAN_ON_PERCENTAGE15_STATE)]
@@ -259,12 +260,12 @@ async def test_modern_turn_on_percentage_from_same_speed(hass: HomeAssistant) ->
     """
     hass.states.async_set(MODERN_FAN_ENTITY, "off", MODERN_FAN_OFF_PERCENTAGE15_STATE)
 
-    turn_on_calls = async_mock_service(hass, "fan", "turn_on")
-    turn_off_calls = async_mock_service(hass, "fan", "turn_off")
-    set_direction_calls = async_mock_service(hass, "fan", "set_direction")
-    oscillate_calls = async_mock_service(hass, "fan", "oscillate")
-    set_percentage_mode = async_mock_service(hass, "fan", "set_percentage")
-    set_preset_mode = async_mock_service(hass, "fan", "set_preset_mode")
+    turn_on_calls = async_mock_service(hass, DOMAIN, "turn_on")
+    turn_off_calls = async_mock_service(hass, DOMAIN, "turn_off")
+    set_direction_calls = async_mock_service(hass, DOMAIN, "set_direction")
+    oscillate_calls = async_mock_service(hass, DOMAIN, "oscillate")
+    set_percentage_mode = async_mock_service(hass, DOMAIN, "set_percentage")
+    set_preset_mode = async_mock_service(hass, DOMAIN, "set_preset_mode")
 
     await async_reproduce_state(
         hass, [State(MODERN_FAN_ENTITY, "on", MODERN_FAN_ON_PERCENTAGE15_STATE)]
@@ -301,12 +302,12 @@ async def test_modern_turn_on_preset_mode_from_different_speed(
     """
     hass.states.async_set(MODERN_FAN_ENTITY, "off", start_state)
 
-    turn_on_calls = async_mock_service(hass, "fan", "turn_on")
-    turn_off_calls = async_mock_service(hass, "fan", "turn_off")
-    set_direction_calls = async_mock_service(hass, "fan", "set_direction")
-    oscillate_calls = async_mock_service(hass, "fan", "oscillate")
-    set_percentage_mode = async_mock_service(hass, "fan", "set_percentage")
-    set_preset_mode = async_mock_service(hass, "fan", "set_preset_mode")
+    turn_on_calls = async_mock_service(hass, DOMAIN, "turn_on")
+    turn_off_calls = async_mock_service(hass, DOMAIN, "turn_off")
+    set_direction_calls = async_mock_service(hass, DOMAIN, "set_direction")
+    oscillate_calls = async_mock_service(hass, DOMAIN, "oscillate")
+    set_percentage_mode = async_mock_service(hass, DOMAIN, "set_percentage")
+    set_preset_mode = async_mock_service(hass, DOMAIN, "set_preset_mode")
 
     await async_reproduce_state(
         hass, [State(MODERN_FAN_ENTITY, "on", MODERN_FAN_ON_PRESET_MODE_AUTO_STATE)]
@@ -335,12 +336,12 @@ async def test_modern_turn_on_preset_mode_from_same_speed(hass: HomeAssistant) -
         MODERN_FAN_ENTITY, "off", MODERN_FAN_OFF_PPRESET_MODE_AUTO_STATE
     )
 
-    turn_on_calls = async_mock_service(hass, "fan", "turn_on")
-    turn_off_calls = async_mock_service(hass, "fan", "turn_off")
-    set_direction_calls = async_mock_service(hass, "fan", "set_direction")
-    oscillate_calls = async_mock_service(hass, "fan", "oscillate")
-    set_percentage_mode = async_mock_service(hass, "fan", "set_percentage")
-    set_preset_mode = async_mock_service(hass, "fan", "set_preset_mode")
+    turn_on_calls = async_mock_service(hass, DOMAIN, "turn_on")
+    turn_off_calls = async_mock_service(hass, DOMAIN, "turn_off")
+    set_direction_calls = async_mock_service(hass, DOMAIN, "set_direction")
+    oscillate_calls = async_mock_service(hass, DOMAIN, "oscillate")
+    set_percentage_mode = async_mock_service(hass, DOMAIN, "set_percentage")
+    set_preset_mode = async_mock_service(hass, DOMAIN, "set_preset_mode")
 
     await async_reproduce_state(
         hass, [State(MODERN_FAN_ENTITY, "on", MODERN_FAN_ON_PRESET_MODE_AUTO_STATE)]
@@ -377,12 +378,12 @@ async def test_modern_turn_on_preset_mode_reverse(
     """
     hass.states.async_set(MODERN_FAN_ENTITY, "off", start_state)
 
-    turn_on_calls = async_mock_service(hass, "fan", "turn_on")
-    turn_off_calls = async_mock_service(hass, "fan", "turn_off")
-    set_direction_calls = async_mock_service(hass, "fan", "set_direction")
-    oscillate_calls = async_mock_service(hass, "fan", "oscillate")
-    set_percentage_mode = async_mock_service(hass, "fan", "set_percentage")
-    set_preset_mode = async_mock_service(hass, "fan", "set_preset_mode")
+    turn_on_calls = async_mock_service(hass, DOMAIN, "turn_on")
+    turn_off_calls = async_mock_service(hass, DOMAIN, "turn_off")
+    set_direction_calls = async_mock_service(hass, DOMAIN, "set_direction")
+    oscillate_calls = async_mock_service(hass, DOMAIN, "oscillate")
+    set_percentage_mode = async_mock_service(hass, DOMAIN, "set_percentage")
+    set_preset_mode = async_mock_service(hass, DOMAIN, "set_preset_mode")
 
     await async_reproduce_state(
         hass,
@@ -420,12 +421,12 @@ async def test_modern_to_preset(hass: HomeAssistant, start_state) -> None:
     """Test modern fan state reproduction, switching to preset mode "Auto"."""
     hass.states.async_set(MODERN_FAN_ENTITY, "on", start_state)
 
-    turn_on_calls = async_mock_service(hass, "fan", "turn_on")
-    turn_off_calls = async_mock_service(hass, "fan", "turn_off")
-    set_direction_calls = async_mock_service(hass, "fan", "set_direction")
-    oscillate_calls = async_mock_service(hass, "fan", "oscillate")
-    set_percentage_mode = async_mock_service(hass, "fan", "set_percentage")
-    set_preset_mode = async_mock_service(hass, "fan", "set_preset_mode")
+    turn_on_calls = async_mock_service(hass, DOMAIN, "turn_on")
+    turn_off_calls = async_mock_service(hass, DOMAIN, "turn_off")
+    set_direction_calls = async_mock_service(hass, DOMAIN, "set_direction")
+    oscillate_calls = async_mock_service(hass, DOMAIN, "oscillate")
+    set_percentage_mode = async_mock_service(hass, DOMAIN, "set_percentage")
+    set_preset_mode = async_mock_service(hass, DOMAIN, "set_preset_mode")
 
     await async_reproduce_state(
         hass, [State(MODERN_FAN_ENTITY, "on", MODERN_FAN_ON_PRESET_MODE_AUTO_STATE)]
@@ -456,12 +457,12 @@ async def test_modern_to_percentage(hass: HomeAssistant, start_state) -> None:
     """Test modern fan state reproduction, switching to 15% speed."""
     hass.states.async_set(MODERN_FAN_ENTITY, "on", start_state)
 
-    turn_on_calls = async_mock_service(hass, "fan", "turn_on")
-    turn_off_calls = async_mock_service(hass, "fan", "turn_off")
-    set_direction_calls = async_mock_service(hass, "fan", "set_direction")
-    oscillate_calls = async_mock_service(hass, "fan", "oscillate")
-    set_percentage_mode = async_mock_service(hass, "fan", "set_percentage")
-    set_preset_mode = async_mock_service(hass, "fan", "set_preset_mode")
+    turn_on_calls = async_mock_service(hass, DOMAIN, "turn_on")
+    turn_off_calls = async_mock_service(hass, DOMAIN, "turn_off")
+    set_direction_calls = async_mock_service(hass, DOMAIN, "set_direction")
+    oscillate_calls = async_mock_service(hass, DOMAIN, "oscillate")
+    set_percentage_mode = async_mock_service(hass, DOMAIN, "set_percentage")
+    set_preset_mode = async_mock_service(hass, DOMAIN, "set_preset_mode")
 
     await async_reproduce_state(
         hass, [State(MODERN_FAN_ENTITY, "on", MODERN_FAN_ON_PERCENTAGE15_STATE)]
@@ -484,12 +485,12 @@ async def test_modern_direction(hass: HomeAssistant) -> None:
     """Test modern fan state reproduction, switching only direction state."""
     hass.states.async_set(MODERN_FAN_ENTITY, "on", MODERN_FAN_ON_PRESET_MODE_AUTO_STATE)
 
-    turn_on_calls = async_mock_service(hass, "fan", "turn_on")
-    turn_off_calls = async_mock_service(hass, "fan", "turn_off")
-    set_direction_calls = async_mock_service(hass, "fan", "set_direction")
-    oscillate_calls = async_mock_service(hass, "fan", "oscillate")
-    set_percentage_mode = async_mock_service(hass, "fan", "set_percentage")
-    set_preset_mode = async_mock_service(hass, "fan", "set_preset_mode")
+    turn_on_calls = async_mock_service(hass, DOMAIN, "turn_on")
+    turn_off_calls = async_mock_service(hass, DOMAIN, "turn_off")
+    set_direction_calls = async_mock_service(hass, DOMAIN, "set_direction")
+    oscillate_calls = async_mock_service(hass, DOMAIN, "oscillate")
+    set_percentage_mode = async_mock_service(hass, DOMAIN, "set_percentage")
+    set_preset_mode = async_mock_service(hass, DOMAIN, "set_preset_mode")
 
     await async_reproduce_state(
         hass,

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -608,9 +608,9 @@ async def test_reload_all(
     test2 = async_mock_service(hass, "test2", "reload")
     no_reload = async_mock_service(hass, "test3", "not_reload")
     notify = async_mock_service(hass, "notify", "reload")
-    core_config = async_mock_service(hass, "homeassistant", "reload_core_config")
+    core_config = async_mock_service(hass, DOMAIN, "reload_core_config")
     themes = async_mock_service(hass, "frontend", "reload_themes")
-    jinja = async_mock_service(hass, "homeassistant", "reload_custom_templates")
+    jinja = async_mock_service(hass, DOMAIN, "reload_custom_templates")
 
     with patch(
         "homeassistant.config.async_check_ha_config_file",

--- a/tests/components/humidifier/test_device_action.py
+++ b/tests/components/humidifier/test_device_action.py
@@ -228,11 +228,11 @@ async def test_action(
         },
     )
 
-    set_humidity_calls = async_mock_service(hass, "humidifier", "set_humidity")
-    set_mode_calls = async_mock_service(hass, "humidifier", "set_mode")
-    turn_on_calls = async_mock_service(hass, "humidifier", "turn_on")
-    turn_off_calls = async_mock_service(hass, "humidifier", "turn_off")
-    toggle_calls = async_mock_service(hass, "humidifier", "toggle")
+    set_humidity_calls = async_mock_service(hass, DOMAIN, "set_humidity")
+    set_mode_calls = async_mock_service(hass, DOMAIN, "set_mode")
+    turn_on_calls = async_mock_service(hass, DOMAIN, "turn_on")
+    turn_off_calls = async_mock_service(hass, DOMAIN, "turn_off")
+    toggle_calls = async_mock_service(hass, DOMAIN, "toggle")
 
     assert len(set_humidity_calls) == 0
     assert len(set_mode_calls) == 0
@@ -341,7 +341,7 @@ async def test_action_legacy(
         },
     )
 
-    set_mode_calls = async_mock_service(hass, "humidifier", "set_mode")
+    set_mode_calls = async_mock_service(hass, DOMAIN, "set_mode")
 
     hass.bus.async_fire("test_event_set_mode")
     await hass.async_block_till_done()

--- a/tests/components/input_datetime/test_reproduce_state.py
+++ b/tests/components/input_datetime/test_reproduce_state.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from homeassistant.components.input_datetime import DOMAIN
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 
@@ -31,7 +32,7 @@ async def test_reproducing_states(
         {"has_date": False, "has_time": False},
     )
 
-    datetime_calls = async_mock_service(hass, "input_datetime", "set_datetime")
+    datetime_calls = async_mock_service(hass, DOMAIN, "set_datetime")
 
     # These calls should do nothing as entities already in desired state
     await async_reproduce_state(

--- a/tests/components/light/test_reproduce_state.py
+++ b/tests/components/light/test_reproduce_state.py
@@ -3,6 +3,7 @@
 import pytest
 
 from homeassistant.components import light
+from homeassistant.components.light import DOMAIN
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 
@@ -39,8 +40,8 @@ async def test_reproducing_states(
     hass.states.async_set("light.entity_rgb", "on", VALID_RGB_COLOR)
     hass.states.async_set("light.entity_xy", "on", VALID_XY_COLOR)
 
-    turn_on_calls = async_mock_service(hass, "light", "turn_on")
-    turn_off_calls = async_mock_service(hass, "light", "turn_off")
+    turn_on_calls = async_mock_service(hass, DOMAIN, "turn_on")
+    turn_off_calls = async_mock_service(hass, DOMAIN, "turn_off")
 
     # These calls should do nothing as entities already in desired state
     await async_reproduce_state(
@@ -155,7 +156,7 @@ async def test_filter_color_modes(
         **VALID_BRIGHTNESS,
     }
 
-    turn_on_calls = async_mock_service(hass, "light", "turn_on")
+    turn_on_calls = async_mock_service(hass, DOMAIN, "turn_on")
 
     await async_reproduce_state(
         hass, [State("light.entity", "on", {**all_colors, "color_mode": color_mode})]
@@ -205,7 +206,7 @@ async def test_filter_color_modes_missing_attributes(
     )
     expected_fallback_log = "using color_temp (mireds) as fallback"
 
-    turn_on_calls = async_mock_service(hass, "light", "turn_on")
+    turn_on_calls = async_mock_service(hass, DOMAIN, "turn_on")
 
     all_colors = {
         **VALID_COLOR_TEMP_KELVIN,
@@ -261,7 +262,7 @@ async def test_filter_none(hass: HomeAssistant, saved_state) -> None:
     """Test filtering of parameters which are None."""
     hass.states.async_set("light.entity", "off", {})
 
-    turn_on_calls = async_mock_service(hass, "light", "turn_on")
+    turn_on_calls = async_mock_service(hass, DOMAIN, "turn_on")
 
     await async_reproduce_state(hass, [State("light.entity", "on", saved_state)])
 

--- a/tests/components/lock/test_device_action.py
+++ b/tests/components/lock/test_device_action.py
@@ -185,9 +185,9 @@ async def test_action(
     )
     await hass.async_block_till_done()
 
-    lock_calls = async_mock_service(hass, "lock", "lock")
-    unlock_calls = async_mock_service(hass, "lock", "unlock")
-    open_calls = async_mock_service(hass, "lock", "open")
+    lock_calls = async_mock_service(hass, DOMAIN, "lock")
+    unlock_calls = async_mock_service(hass, DOMAIN, "unlock")
+    open_calls = async_mock_service(hass, DOMAIN, "open")
 
     hass.bus.async_fire("test_event_lock")
     await hass.async_block_till_done()
@@ -253,7 +253,7 @@ async def test_action_legacy(
     )
     await hass.async_block_till_done()
 
-    lock_calls = async_mock_service(hass, "lock", "lock")
+    lock_calls = async_mock_service(hass, DOMAIN, "lock")
 
     hass.bus.async_fire("test_event_lock")
     await hass.async_block_till_done()

--- a/tests/components/lock/test_reproduce_state.py
+++ b/tests/components/lock/test_reproduce_state.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from homeassistant.components.lock import DOMAIN
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 
@@ -16,9 +17,9 @@ async def test_reproducing_states(
     hass.states.async_set("lock.entity_unlocked", "unlocked", {})
     hass.states.async_set("lock.entity_opened", "open", {})
 
-    lock_calls = async_mock_service(hass, "lock", "lock")
-    unlock_calls = async_mock_service(hass, "lock", "unlock")
-    open_calls = async_mock_service(hass, "lock", "open")
+    lock_calls = async_mock_service(hass, DOMAIN, "lock")
+    unlock_calls = async_mock_service(hass, DOMAIN, "unlock")
+    open_calls = async_mock_service(hass, DOMAIN, "open")
 
     # These calls should do nothing as entities already in desired state
     await async_reproduce_state(

--- a/tests/components/remote/test_reproduce_state.py
+++ b/tests/components/remote/test_reproduce_state.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from homeassistant.components.remote import DOMAIN
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 
@@ -15,8 +16,8 @@ async def test_reproducing_states(
     hass.states.async_set("remote.entity_off", "off", {})
     hass.states.async_set("remote.entity_on", "on", {})
 
-    turn_on_calls = async_mock_service(hass, "remote", "turn_on")
-    turn_off_calls = async_mock_service(hass, "remote", "turn_off")
+    turn_on_calls = async_mock_service(hass, DOMAIN, "turn_on")
+    turn_off_calls = async_mock_service(hass, DOMAIN, "turn_off")
 
     # These calls should do nothing as entities already in desired state
     await async_reproduce_state(

--- a/tests/components/switch/test_reproduce_state.py
+++ b/tests/components/switch/test_reproduce_state.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from homeassistant.components.switch import DOMAIN
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 
@@ -15,8 +16,8 @@ async def test_reproducing_states(
     hass.states.async_set("switch.entity_off", "off", {})
     hass.states.async_set("switch.entity_on", "on", {})
 
-    turn_on_calls = async_mock_service(hass, "switch", "turn_on")
-    turn_off_calls = async_mock_service(hass, "switch", "turn_off")
+    turn_on_calls = async_mock_service(hass, DOMAIN, "turn_on")
+    turn_off_calls = async_mock_service(hass, DOMAIN, "turn_off")
 
     # These calls should do nothing as entities already in desired state
     await async_reproduce_state(

--- a/tests/components/timer/test_reproduce_state.py
+++ b/tests/components/timer/test_reproduce_state.py
@@ -4,6 +4,7 @@ import pytest
 
 from homeassistant.components.timer import (
     ATTR_DURATION,
+    DOMAIN,
     SERVICE_CANCEL,
     SERVICE_PAUSE,
     SERVICE_START,
@@ -28,9 +29,9 @@ async def test_reproducing_states(
         "timer.entity_active_attr", STATUS_ACTIVE, {ATTR_DURATION: "00:01:00"}
     )
 
-    start_calls = async_mock_service(hass, "timer", SERVICE_START)
-    pause_calls = async_mock_service(hass, "timer", SERVICE_PAUSE)
-    cancel_calls = async_mock_service(hass, "timer", SERVICE_CANCEL)
+    start_calls = async_mock_service(hass, DOMAIN, SERVICE_START)
+    pause_calls = async_mock_service(hass, DOMAIN, SERVICE_PAUSE)
+    cancel_calls = async_mock_service(hass, DOMAIN, SERVICE_CANCEL)
 
     # These calls should do nothing as entities already in desired state
     await async_reproduce_state(

--- a/tests/components/vacuum/test_device_action.py
+++ b/tests/components/vacuum/test_device_action.py
@@ -141,8 +141,8 @@ async def test_action(
         },
     )
 
-    dock_calls = async_mock_service(hass, "vacuum", "return_to_base")
-    clean_calls = async_mock_service(hass, "vacuum", "start")
+    dock_calls = async_mock_service(hass, DOMAIN, "return_to_base")
+    clean_calls = async_mock_service(hass, DOMAIN, "start")
 
     hass.bus.async_fire("test_event_dock")
     await hass.async_block_till_done()
@@ -192,7 +192,7 @@ async def test_action_legacy(
         },
     )
 
-    dock_calls = async_mock_service(hass, "vacuum", "return_to_base")
+    dock_calls = async_mock_service(hass, DOMAIN, "return_to_base")
 
     hass.bus.async_fire("test_event_dock")
     await hass.async_block_till_done()

--- a/tests/components/vacuum/test_reproduce_state.py
+++ b/tests/components/vacuum/test_reproduce_state.py
@@ -4,6 +4,7 @@ import pytest
 
 from homeassistant.components.vacuum import (
     ATTR_FAN_SPEED,
+    DOMAIN,
     SERVICE_PAUSE,
     SERVICE_RETURN_TO_BASE,
     SERVICE_SET_FAN_SPEED,
@@ -36,13 +37,13 @@ async def test_reproducing_states(
     hass.states.async_set("vacuum.entity_returning", VacuumActivity.RETURNING, {})
     hass.states.async_set("vacuum.entity_paused", VacuumActivity.PAUSED, {})
 
-    turn_on_calls = async_mock_service(hass, "vacuum", SERVICE_TURN_ON)
-    turn_off_calls = async_mock_service(hass, "vacuum", SERVICE_TURN_OFF)
-    start_calls = async_mock_service(hass, "vacuum", SERVICE_START)
-    pause_calls = async_mock_service(hass, "vacuum", SERVICE_PAUSE)
-    stop_calls = async_mock_service(hass, "vacuum", SERVICE_STOP)
-    return_calls = async_mock_service(hass, "vacuum", SERVICE_RETURN_TO_BASE)
-    fan_speed_calls = async_mock_service(hass, "vacuum", SERVICE_SET_FAN_SPEED)
+    turn_on_calls = async_mock_service(hass, DOMAIN, SERVICE_TURN_ON)
+    turn_off_calls = async_mock_service(hass, DOMAIN, SERVICE_TURN_OFF)
+    start_calls = async_mock_service(hass, DOMAIN, SERVICE_START)
+    pause_calls = async_mock_service(hass, DOMAIN, SERVICE_PAUSE)
+    stop_calls = async_mock_service(hass, DOMAIN, SERVICE_STOP)
+    return_calls = async_mock_service(hass, DOMAIN, SERVICE_RETURN_TO_BASE)
+    fan_speed_calls = async_mock_service(hass, DOMAIN, SERVICE_SET_FAN_SPEED)
 
     # These calls should do nothing as entities already in desired state
     await async_reproduce_state(

--- a/tests/components/water_heater/test_device_action.py
+++ b/tests/components/water_heater/test_device_action.py
@@ -147,8 +147,8 @@ async def test_action(
         },
     )
 
-    turn_off_calls = async_mock_service(hass, "water_heater", "turn_off")
-    turn_on_calls = async_mock_service(hass, "water_heater", "turn_on")
+    turn_off_calls = async_mock_service(hass, DOMAIN, "turn_off")
+    turn_on_calls = async_mock_service(hass, DOMAIN, "turn_on")
 
     hass.bus.async_fire("test_event_turn_off")
     await hass.async_block_till_done()
@@ -201,7 +201,7 @@ async def test_action_legacy(
         },
     )
 
-    turn_off_calls = async_mock_service(hass, "water_heater", "turn_off")
+    turn_off_calls = async_mock_service(hass, DOMAIN, "turn_off")
 
     hass.bus.async_fire("test_event_turn_off")
     await hass.async_block_till_done()

--- a/tests/components/water_heater/test_reproduce_state.py
+++ b/tests/components/water_heater/test_reproduce_state.py
@@ -6,6 +6,7 @@ from homeassistant.components.water_heater import (
     ATTR_AWAY_MODE,
     ATTR_OPERATION_MODE,
     ATTR_TEMPERATURE,
+    DOMAIN,
     SERVICE_SET_AWAY_MODE,
     SERVICE_SET_OPERATION_MODE,
     SERVICE_SET_TEMPERATURE,
@@ -33,11 +34,11 @@ async def test_reproducing_states(
         {ATTR_AWAY_MODE: True, ATTR_TEMPERATURE: 45},
     )
 
-    turn_on_calls = async_mock_service(hass, "water_heater", SERVICE_TURN_ON)
-    turn_off_calls = async_mock_service(hass, "water_heater", SERVICE_TURN_OFF)
-    set_op_calls = async_mock_service(hass, "water_heater", SERVICE_SET_OPERATION_MODE)
-    set_temp_calls = async_mock_service(hass, "water_heater", SERVICE_SET_TEMPERATURE)
-    set_away_calls = async_mock_service(hass, "water_heater", SERVICE_SET_AWAY_MODE)
+    turn_on_calls = async_mock_service(hass, DOMAIN, SERVICE_TURN_ON)
+    turn_off_calls = async_mock_service(hass, DOMAIN, SERVICE_TURN_OFF)
+    set_op_calls = async_mock_service(hass, DOMAIN, SERVICE_SET_OPERATION_MODE)
+    set_temp_calls = async_mock_service(hass, DOMAIN, SERVICE_SET_TEMPERATURE)
+    set_away_calls = async_mock_service(hass, DOMAIN, SERVICE_SET_AWAY_MODE)
 
     # These calls should do nothing as entities already in desired state
     await async_reproduce_state(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When `async_mock_service` is called with a literal string matching the component name, use the `DOMAIN` constant instead

Linked to #172693

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
