### PR TITLE
Use DOMAIN constant in test (config_entries.flow.async_init)

### DIFF
--- a/tests/components/cast/test_config_flow.py
+++ b/tests/components/cast/test_config_flow.py
@@ -66,7 +66,7 @@ async def test_single_instance(hass: HomeAssistant, source) -> None:
     await hass.async_block_till_done()
 
     result = await hass.config_entries.flow.async_init(
-        "cast", context={"source": source}
+        DOMAIN, context={"source": source}
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
@@ -75,7 +75,7 @@ async def test_single_instance(hass: HomeAssistant, source) -> None:
 async def test_user_setup(hass: HomeAssistant) -> None:
     """Test we can finish a config flow."""
     result = await hass.config_entries.flow.async_init(
-        "cast", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.FORM
 
@@ -95,7 +95,7 @@ async def test_user_setup(hass: HomeAssistant) -> None:
 async def test_user_setup_options(hass: HomeAssistant) -> None:
     """Test we can finish a config flow."""
     result = await hass.config_entries.flow.async_init(
-        "cast", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.FORM
 
@@ -117,7 +117,7 @@ async def test_user_setup_options(hass: HomeAssistant) -> None:
 async def test_zeroconf_setup(hass: HomeAssistant) -> None:
     """Test we can finish a config flow through zeroconf."""
     result = await hass.config_entries.flow.async_init(
-        "cast", context={"source": config_entries.SOURCE_ZEROCONF}
+        DOMAIN, context={"source": config_entries.SOURCE_ZEROCONF}
     )
     assert result["type"] is FlowResultType.FORM
 
@@ -140,7 +140,7 @@ async def test_zeroconf_setup_onboarding(hass: HomeAssistant) -> None:
         "homeassistant.components.onboarding.async_is_onboarded", return_value=False
     ):
         result = await hass.config_entries.flow.async_init(
-            "cast", context={"source": config_entries.SOURCE_ZEROCONF}
+            DOMAIN, context={"source": config_entries.SOURCE_ZEROCONF}
         )
 
     users = await hass.auth.async_get_users()
@@ -271,7 +271,7 @@ async def test_option_flow(
 async def test_known_hosts(hass: HomeAssistant, castbrowser_mock) -> None:
     """Test known hosts is passed to pychromecast."""
     result = await hass.config_entries.flow.async_init(
-        "cast", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"known_hosts": ["192.168.0.1", "192.168.0.2"]}

--- a/tests/components/daikin/test_config_flow.py
+++ b/tests/components/daikin/test_config_flow.py
@@ -8,7 +8,7 @@ from aiohttp import ClientError, web_exceptions
 from pydaikin.exceptions import DaikinException
 import pytest
 
-from homeassistant.components.daikin.const import KEY_MAC
+from homeassistant.components.daikin.const import DOMAIN, KEY_MAC
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
@@ -59,7 +59,7 @@ def mock_daikin_discovery():
 async def test_user(hass: HomeAssistant, mock_daikin) -> None:
     """Test user config."""
     result = await hass.config_entries.flow.async_init(
-        "daikin",
+        DOMAIN,
         context={"source": SOURCE_USER},
     )
 
@@ -67,7 +67,7 @@ async def test_user(hass: HomeAssistant, mock_daikin) -> None:
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_init(
-        "daikin",
+        DOMAIN,
         context={"source": SOURCE_USER},
         data={CONF_HOST: HOST},
     )
@@ -81,7 +81,7 @@ async def test_abort_if_already_setup(hass: HomeAssistant, mock_daikin) -> None:
     """Test we abort if Daikin is already setup."""
     MockConfigEntry(domain="daikin", unique_id=MAC).add_to_hass(hass)
     result = await hass.config_entries.flow.async_init(
-        "daikin",
+        DOMAIN,
         context={"source": SOURCE_USER},
         data={CONF_HOST: HOST, KEY_MAC: MAC},
     )
@@ -105,7 +105,7 @@ async def test_device_abort(hass: HomeAssistant, mock_daikin, s_effect, reason) 
     mock_daikin.side_effect = s_effect
 
     result = await hass.config_entries.flow.async_init(
-        "daikin",
+        DOMAIN,
         context={"source": SOURCE_USER},
         data={CONF_HOST: HOST, KEY_MAC: MAC},
     )
@@ -117,7 +117,7 @@ async def test_device_abort(hass: HomeAssistant, mock_daikin, s_effect, reason) 
 async def test_api_password_abort(hass: HomeAssistant) -> None:
     """Test device abort."""
     result = await hass.config_entries.flow.async_init(
-        "daikin",
+        DOMAIN,
         context={"source": SOURCE_USER},
         data={CONF_HOST: HOST, CONF_API_KEY: "aa", CONF_PASSWORD: "aa"},
     )
@@ -149,7 +149,7 @@ async def test_discovery_zeroconf(
 ) -> None:
     """Test discovery/zeroconf step."""
     result = await hass.config_entries.flow.async_init(
-        "daikin",
+        DOMAIN,
         context={"source": source},
         data=data,
     )
@@ -158,7 +158,7 @@ async def test_discovery_zeroconf(
 
     MockConfigEntry(domain="daikin", unique_id=unique_id).add_to_hass(hass)
     result = await hass.config_entries.flow.async_init(
-        "daikin",
+        DOMAIN,
         context={"source": SOURCE_USER, "unique_id": unique_id},
         data={CONF_HOST: HOST},
     )
@@ -167,7 +167,7 @@ async def test_discovery_zeroconf(
     assert result["reason"] == "already_configured"
 
     result = await hass.config_entries.flow.async_init(
-        "daikin",
+        DOMAIN,
         context={"source": source},
         data=data,
     )

--- a/tests/components/dialogflow/test_init.py
+++ b/tests/components/dialogflow/test_init.py
@@ -8,6 +8,7 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components import dialogflow, intent_script
+from homeassistant.components.dialogflow import DOMAIN
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.core_config import async_process_ha_core_config
 from homeassistant.data_entry_flow import FlowResultType
@@ -89,7 +90,7 @@ async def fixture(hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerat
     )
 
     result = await hass.config_entries.flow.async_init(
-        "dialogflow", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.FORM, result
 

--- a/tests/components/drop_connect/test_config_flow.py
+++ b/tests/components/drop_connect/test_config_flow.py
@@ -1,6 +1,7 @@
 """Test config flow."""
 
 from homeassistant import config_entries
+from homeassistant.components.drop_connect.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.mqtt import MqttServiceInfo
@@ -19,7 +20,7 @@ async def test_mqtt_setup(hass: HomeAssistant, mqtt_mock: MqttMockHAClient) -> N
         timestamp=None,
     )
     result = await hass.config_entries.flow.async_init(
-        "drop_connect",
+        DOMAIN,
         context={"source": config_entries.SOURCE_MQTT},
         data=discovery_info,
     )
@@ -56,7 +57,7 @@ async def test_duplicate(hass: HomeAssistant, mqtt_mock: MqttMockHAClient) -> No
         timestamp=None,
     )
     result = await hass.config_entries.flow.async_init(
-        "drop_connect",
+        DOMAIN,
         context={"source": config_entries.SOURCE_MQTT},
         data=discovery_info,
     )
@@ -73,7 +74,7 @@ async def test_duplicate(hass: HomeAssistant, mqtt_mock: MqttMockHAClient) -> No
 
     # Attempting configuration of the same object should abort
     result = await hass.config_entries.flow.async_init(
-        "drop_connect",
+        DOMAIN,
         context={"source": config_entries.SOURCE_MQTT},
         data=discovery_info,
     )
@@ -95,7 +96,7 @@ async def test_mqtt_setup_incomplete_payload(
         timestamp=None,
     )
     result = await hass.config_entries.flow.async_init(
-        "drop_connect",
+        DOMAIN,
         context={"source": config_entries.SOURCE_MQTT},
         data=discovery_info,
     )
@@ -117,7 +118,7 @@ async def test_mqtt_setup_bad_json(
         timestamp=None,
     )
     result = await hass.config_entries.flow.async_init(
-        "drop_connect",
+        DOMAIN,
         context={"source": config_entries.SOURCE_MQTT},
         data=discovery_info,
     )
@@ -139,7 +140,7 @@ async def test_mqtt_setup_bad_topic(
         timestamp=None,
     )
     result = await hass.config_entries.flow.async_init(
-        "drop_connect",
+        DOMAIN,
         context={"source": config_entries.SOURCE_MQTT},
         data=discovery_info,
     )
@@ -161,7 +162,7 @@ async def test_mqtt_setup_no_payload(
         timestamp=None,
     )
     result = await hass.config_entries.flow.async_init(
-        "drop_connect",
+        DOMAIN,
         context={"source": config_entries.SOURCE_MQTT},
         data=discovery_info,
     )
@@ -173,7 +174,7 @@ async def test_mqtt_setup_no_payload(
 async def test_user_setup(hass: HomeAssistant) -> None:
     """Test user setup."""
     result = await hass.config_entries.flow.async_init(
-        "drop_connect", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "not_supported"

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -1073,7 +1073,7 @@ async def test_connection_aborted_wrong_device(
     new_combined_info = AsyncMock(return_value=(device_info, [], []))
     mock_client.device_info_and_list_entities = new_combined_info
     result = await hass.config_entries.flow.async_init(
-        "esphome", context={"source": config_entries.SOURCE_DHCP}, data=service_info
+        DOMAIN, context={"source": config_entries.SOURCE_DHCP}, data=service_info
     )
 
     assert result["type"] is FlowResultType.ABORT
@@ -1153,7 +1153,7 @@ async def test_connection_aborted_wrong_device_same_name(
     new_combined_info = AsyncMock(return_value=(device_info, [], []))
     mock_client.device_info_and_list_entities = new_combined_info
     result = await hass.config_entries.flow.async_init(
-        "esphome", context={"source": config_entries.SOURCE_DHCP}, data=service_info
+        DOMAIN, context={"source": config_entries.SOURCE_DHCP}, data=service_info
     )
 
     assert result["type"] is FlowResultType.ABORT

--- a/tests/components/gogogate2/test_config_flow.py
+++ b/tests/components/gogogate2/test_config_flow.py
@@ -50,7 +50,7 @@ async def test_auth_fail(
         GogoGate2ApiErrorCode.CREDENTIALS_INCORRECT, "blah"
     )
     result = await hass.config_entries.flow.async_init(
-        "gogogate2", context={"source": SOURCE_USER}
+        DOMAIN, context={"source": SOURCE_USER}
     )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -70,7 +70,7 @@ async def test_auth_fail(
     api.reset_mock()
     api.async_info.side_effect = Exception("Generic connection error.")
     result = await hass.config_entries.flow.async_init(
-        "gogogate2", context={"source": SOURCE_USER}
+        DOMAIN, context={"source": SOURCE_USER}
     )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -88,7 +88,7 @@ async def test_auth_fail(
     api.reset_mock()
     api.async_info.side_effect = ApiError(0, "blah")
     result = await hass.config_entries.flow.async_init(
-        "gogogate2", context={"source": SOURCE_USER}
+        DOMAIN, context={"source": SOURCE_USER}
     )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/google_mail/test_config_flow.py
+++ b/tests/components/google_mail/test_config_flow.py
@@ -24,7 +24,7 @@ async def test_full_flow(
 ) -> None:
     """Check full flow."""
     result = await hass.config_entries.flow.async_init(
-        "google_mail", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -188,7 +188,7 @@ async def test_already_configured(
     config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
-        "google_mail", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,

--- a/tests/components/google_sheets/test_config_flow.py
+++ b/tests/components/google_sheets/test_config_flow.py
@@ -60,7 +60,7 @@ async def test_full_flow(
 ) -> None:
     """Check full flow."""
     result = await hass.config_entries.flow.async_init(
-        "google_sheets", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -127,7 +127,7 @@ async def test_create_sheet_error(
 ) -> None:
     """Test case where creating the spreadsheet fails."""
     result = await hass.config_entries.flow.async_init(
-        "google_sheets", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -341,7 +341,7 @@ async def test_already_configured(
     config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
-        "google_sheets", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,

--- a/tests/components/google_tasks/test_config_flow.py
+++ b/tests/components/google_tasks/test_config_flow.py
@@ -53,7 +53,7 @@ async def test_full_flow(
 ) -> None:
     """Check full flow."""
     result = await hass.config_entries.flow.async_init(
-        "google_tasks", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -108,7 +108,7 @@ async def test_api_not_enabled(
 ) -> None:
     """Check flow aborts if api is not enabled."""
     result = await hass.config_entries.flow.async_init(
-        "google_tasks", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -176,7 +176,7 @@ async def test_general_exception(
 ) -> None:
     """Check flow aborts if exception happens."""
     result = await hass.config_entries.flow.async_init(
-        "google_tasks", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,

--- a/tests/components/home_connect/test_config_flow.py
+++ b/tests/components/home_connect/test_config_flow.py
@@ -104,7 +104,7 @@ async def test_full_flow(
     assert await setup.async_setup_component(hass, "home_connect", {})
 
     result = await hass.config_entries.flow.async_init(
-        "home_connect", context=ConfigFlowContext(source=config_entries.SOURCE_USER)
+        DOMAIN, context=ConfigFlowContext(source=config_entries.SOURCE_USER)
     )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -159,7 +159,7 @@ async def test_prevent_reconfiguring_same_account(
     assert await setup.async_setup_component(hass, "home_connect", {})
 
     result = await hass.config_entries.flow.async_init(
-        "home_connect", context=ConfigFlowContext(source=config_entries.SOURCE_USER)
+        DOMAIN, context=ConfigFlowContext(source=config_entries.SOURCE_USER)
     )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -247,7 +247,7 @@ async def test_discovery_works(
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
-        "homekit_controller",
+        DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=discovery_info,
     )
@@ -280,7 +280,7 @@ async def test_abort_duplicate_flow(hass: HomeAssistant, controller) -> None:
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
-        "homekit_controller",
+        DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=discovery_info,
     )
@@ -288,7 +288,7 @@ async def test_abort_duplicate_flow(hass: HomeAssistant, controller) -> None:
     assert result["step_id"] == "pair"
 
     result = await hass.config_entries.flow.async_init(
-        "homekit_controller",
+        DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=discovery_info,
     )
@@ -304,7 +304,7 @@ async def test_pair_already_paired_1(hass: HomeAssistant, controller) -> None:
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
-        "homekit_controller",
+        DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=discovery_info,
     )
@@ -321,7 +321,7 @@ async def test_unknown_domain_type(hass: HomeAssistant, controller) -> None:
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
-        "homekit_controller",
+        DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=discovery_info,
     )
@@ -339,7 +339,7 @@ async def test_id_missing(hass: HomeAssistant, controller) -> None:
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
-        "homekit_controller",
+        DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=discovery_info,
     )
@@ -356,7 +356,7 @@ async def test_discovery_ignored_model(hass: HomeAssistant, controller) -> None:
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
-        "homekit_controller",
+        DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=discovery_info,
     )
@@ -384,7 +384,7 @@ async def test_discovery_ignored_hk_bridge(
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
-        "homekit_controller",
+        DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=discovery_info,
     )
@@ -412,7 +412,7 @@ async def test_discovery_does_not_ignore_non_homekit(
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
-        "homekit_controller",
+        DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=discovery_info,
     )
@@ -443,7 +443,7 @@ async def test_discovery_broken_pairing_flag(hass: HomeAssistant, controller) ->
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
-        "homekit_controller",
+        DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=discovery_info,
     )
@@ -479,7 +479,7 @@ async def test_discovery_invalid_config_entry(hass: HomeAssistant, controller) -
         side_effect=AuthenticationError("Invalid pairing keys"),
     ):
         result = await hass.config_entries.flow.async_init(
-            "homekit_controller",
+            DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
             data=discovery_info,
         )
@@ -518,7 +518,7 @@ async def test_discovery_ignored_config_entry(hass: HomeAssistant, controller) -
         side_effect=AuthenticationError("Invalid pairing keys"),
     ):
         result = await hass.config_entries.flow.async_init(
-            "homekit_controller",
+            DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
             data=discovery_info,
         )
@@ -553,7 +553,7 @@ async def test_discovery_already_configured(hass: HomeAssistant, controller) -> 
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
-        "homekit_controller",
+        DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=discovery_info,
     )
@@ -591,7 +591,7 @@ async def test_discovery_already_configured_update_csharp(
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
-        "homekit_controller",
+        DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=discovery_info,
     )
@@ -614,7 +614,7 @@ async def test_pair_abort_errors_on_start(
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
-        "homekit_controller",
+        DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=discovery_info,
     )
@@ -638,7 +638,7 @@ async def test_pair_try_later_errors_on_start(
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
-        "homekit_controller",
+        DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=discovery_info,
     )
@@ -678,7 +678,7 @@ async def test_pair_form_errors_on_start(
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
-        "homekit_controller",
+        DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=discovery_info,
     )
@@ -729,7 +729,7 @@ async def test_pair_abort_errors_on_finish(
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
-        "homekit_controller",
+        DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=discovery_info,
     )
@@ -772,7 +772,7 @@ async def test_pair_form_errors_on_finish(
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
-        "homekit_controller",
+        DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=discovery_info,
     )
@@ -819,7 +819,7 @@ async def test_pair_unknown_errors(hass: HomeAssistant, controller) -> None:
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
-        "homekit_controller",
+        DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=discovery_info,
     )
@@ -870,7 +870,7 @@ async def test_user_works(hass: HomeAssistant, controller) -> None:
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
-        "homekit_controller", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     assert result["type"] is FlowResultType.FORM
@@ -907,7 +907,7 @@ async def test_user_pairing_with_insecure_setup_code(
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
-        "homekit_controller", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     assert result["type"] is FlowResultType.FORM
@@ -946,7 +946,7 @@ async def test_user_pairing_with_insecure_setup_code(
 async def test_user_no_devices(hass: HomeAssistant, controller) -> None:
     """Test user initiated pairing where no devices discovered."""
     result = await hass.config_entries.flow.async_init(
-        "homekit_controller", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "no_devices"
@@ -962,7 +962,7 @@ async def test_user_no_unpaired_devices(hass: HomeAssistant, controller) -> None
 
     # Device discovery is requested
     result = await hass.config_entries.flow.async_init(
-        "homekit_controller", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     assert result["type"] is FlowResultType.ABORT
@@ -983,7 +983,7 @@ async def test_discovery_dismiss_existing_flow_on_paired(
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
-        "homekit_controller",
+        DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=discovery_info,
     )
@@ -999,7 +999,7 @@ async def test_discovery_dismiss_existing_flow_on_paired(
     discovery_info.properties["sf"] = 0x00
     # Device is discovered again after pairing to someone else
     result2 = await hass.config_entries.flow.async_init(
-        "homekit_controller",
+        DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=discovery_info,
     )
@@ -1022,7 +1022,7 @@ async def test_mdns_update_to_paired_during_pairing(
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
-        "homekit_controller",
+        DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=discovery_info,
     )
@@ -1072,7 +1072,7 @@ async def test_mdns_update_to_paired_during_pairing(
     # Make sure when the device is discovered as paired via mdns
     # it does not abort pairing if it happens before pairing is finished
     result2 = await hass.config_entries.flow.async_init(
-        "homekit_controller",
+        DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=discovery_info_paired,
     )
@@ -1092,7 +1092,7 @@ async def test_discovery_no_bluetooth_support(hass: HomeAssistant, controller) -
         False,
     ):
         result = await hass.config_entries.flow.async_init(
-            "homekit_controller",
+            DOMAIN,
             context={"source": config_entries.SOURCE_BLUETOOTH},
             data=HK_BLUETOOTH_SERVICE_INFO_NOT_DISCOVERED,
         )
@@ -1107,7 +1107,7 @@ async def test_bluetooth_not_homekit(hass: HomeAssistant, controller) -> None:
         True,
     ):
         result = await hass.config_entries.flow.async_init(
-            "homekit_controller",
+            DOMAIN,
             context={"source": config_entries.SOURCE_BLUETOOTH},
             data=NOT_HK_BLUETOOTH_SERVICE_INFO,
         )
@@ -1124,7 +1124,7 @@ async def test_bluetooth_valid_device_no_discovery(
         True,
     ):
         result = await hass.config_entries.flow.async_init(
-            "homekit_controller",
+            DOMAIN,
             context={"source": config_entries.SOURCE_BLUETOOTH},
             data=HK_BLUETOOTH_SERVICE_INFO_NOT_DISCOVERED,
         )
@@ -1143,7 +1143,7 @@ async def test_bluetooth_valid_device_discovery_paired(
         True,
     ):
         result = await hass.config_entries.flow.async_init(
-            "homekit_controller",
+            DOMAIN,
             context={"source": config_entries.SOURCE_BLUETOOTH},
             data=HK_BLUETOOTH_SERVICE_INFO_DISCOVERED_PAIRED,
         )
@@ -1164,7 +1164,7 @@ async def test_bluetooth_valid_device_discovery_unpaired(
         True,
     ):
         result = await hass.config_entries.flow.async_init(
-            "homekit_controller",
+            DOMAIN,
             context={"source": config_entries.SOURCE_BLUETOOTH},
             data=HK_BLUETOOTH_SERVICE_INFO_DISCOVERED_UNPAIRED,
         )
@@ -1218,7 +1218,7 @@ async def test_discovery_updates_ip_when_config_entry_set_up(
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
-        "homekit_controller",
+        DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=discovery_info,
     )
@@ -1256,7 +1256,7 @@ async def test_discovery_updates_ip_config_entry_not_set_up(
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
-        "homekit_controller",
+        DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=discovery_info,
     )

--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -387,7 +387,7 @@ async def test_creating_entry_removes_entries_for_same_host_or_bridge(
     assert len(hass.config_entries.async_entries("hue")) == 2
 
     result = await hass.config_entries.flow.async_init(
-        "hue",
+        DOMAIN,
         data={"host": "2.2.2.2"},
         context={"source": config_entries.SOURCE_IMPORT},
     )

--- a/tests/components/husqvarna_automower/test_config_flow.py
+++ b/tests/components/husqvarna_automower/test_config_flow.py
@@ -47,7 +47,7 @@ async def test_full_flow(
 ) -> None:
     """Check full flow."""
     result = await hass.config_entries.flow.async_init(
-        "husqvarna_automower", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,

--- a/tests/components/ifttt/test_init.py
+++ b/tests/components/ifttt/test_init.py
@@ -2,6 +2,7 @@
 
 from homeassistant import config_entries
 from homeassistant.components import ifttt
+from homeassistant.components.ifttt import DOMAIN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.core_config import async_process_ha_core_config
 from homeassistant.data_entry_flow import FlowResultType
@@ -19,7 +20,7 @@ async def test_config_flow_registers_webhook(
     )
 
     result = await hass.config_entries.flow.async_init(
-        "ifttt", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.FORM, result
 

--- a/tests/components/insteon/test_config_flow.py
+++ b/tests/components/insteon/test_config_flow.py
@@ -280,7 +280,7 @@ async def test_discovery_via_usb(hass: HomeAssistant) -> None:
         manufacturer="test",
     )
     result = await hass.config_entries.flow.async_init(
-        "insteon", context={"source": config_entries.SOURCE_USB}, data=discovery_info
+        DOMAIN, context={"source": config_entries.SOURCE_USB}, data=discovery_info
     )
     await hass.async_block_till_done()
     assert result["type"] is FlowResultType.FORM
@@ -312,7 +312,7 @@ async def test_discovery_via_usb_already_setup(hass: HomeAssistant) -> None:
         manufacturer="test",
     )
     result = await hass.config_entries.flow.async_init(
-        "insteon", context={"source": config_entries.SOURCE_USB}, data=discovery_info
+        DOMAIN, context={"source": config_entries.SOURCE_USB}, data=discovery_info
     )
     await hass.async_block_till_done()
 

--- a/tests/components/locative/test_init.py
+++ b/tests/components/locative/test_init.py
@@ -45,7 +45,7 @@ async def webhook_id(hass: HomeAssistant, locative_client: TestClient) -> str:
         {"internal_url": "http://example.local:8123"},
     )
     result = await hass.config_entries.flow.async_init(
-        "locative", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.FORM, result
 

--- a/tests/components/mailgun/test_init.py
+++ b/tests/components/mailgun/test_init.py
@@ -8,6 +8,7 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components import mailgun, webhook
+from homeassistant.components.mailgun import DOMAIN
 from homeassistant.const import CONF_API_KEY, CONF_DOMAIN
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.core_config import async_process_ha_core_config
@@ -42,7 +43,7 @@ async def webhook_id_with_api_key(hass: HomeAssistant) -> str:
         {"internal_url": "http://example.local:8123"},
     )
     result = await hass.config_entries.flow.async_init(
-        "mailgun", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.FORM, result
 
@@ -62,7 +63,7 @@ async def webhook_id_without_api_key(hass: HomeAssistant) -> str:
         {"internal_url": "http://example.local:8123"},
     )
     result = await hass.config_entries.flow.async_init(
-        "mailgun", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.FORM, result
 

--- a/tests/components/met/test_weather.py
+++ b/tests/components/met/test_weather.py
@@ -23,7 +23,7 @@ async def test_new_config_entry(
     hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_weather
 ) -> None:
     """Test the expected entities are created."""
-    await hass.config_entries.flow.async_init("met", context={"source": "onboarding"})
+    await hass.config_entries.flow.async_init(DOMAIN, context={"source": "onboarding"})
     await hass.async_block_till_done()
     assert len(hass.states.async_entity_ids("weather")) == 1
 
@@ -40,7 +40,7 @@ async def test_legacy_config_entry(
         DOMAIN,
         "home-hourly",
     )
-    await hass.config_entries.flow.async_init("met", context={"source": "onboarding"})
+    await hass.config_entries.flow.async_init(DOMAIN, context={"source": "onboarding"})
     await hass.async_block_till_done()
     assert len(hass.states.async_entity_ids("weather")) == 1
 
@@ -69,7 +69,7 @@ async def test_weather(hass: HomeAssistant, mock_weather) -> None:
 
 async def test_tracking_home(hass: HomeAssistant, mock_weather) -> None:
     """Test we track home."""
-    await hass.config_entries.flow.async_init("met", context={"source": "onboarding"})
+    await hass.config_entries.flow.async_init(DOMAIN, context={"source": "onboarding"})
     await hass.async_block_till_done()
     assert len(hass.states.async_entity_ids("weather")) == 1
     assert len(mock_weather.mock_calls) == 4
@@ -95,7 +95,7 @@ async def test_not_tracking_home(hass: HomeAssistant, mock_weather) -> None:
     """Test when we not track home."""
 
     await hass.config_entries.flow.async_init(
-        "met",
+        DOMAIN,
         context={"source": config_entries.SOURCE_USER},
         data={"name": "Somewhere", "latitude": 10, "longitude": 20, "elevation": 0},
     )
@@ -133,7 +133,7 @@ async def test_remove_hourly_entity(
     ]
 
     await hass.config_entries.flow.async_init(
-        "met",
+        DOMAIN,
         context={"source": config_entries.SOURCE_USER},
         data={"name": "Somewhere", "latitude": 10, "longitude": 20, "elevation": 0},
     )

--- a/tests/components/mqtt/test_config_flow.py
+++ b/tests/components/mqtt/test_config_flow.py
@@ -376,7 +376,7 @@ async def test_user_connection_works(
     mock_try_connection.return_value = True
 
     result = await hass.config_entries.flow.async_init(
-        "mqtt", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.FORM
 
@@ -409,7 +409,7 @@ async def test_user_connection_works_with_supervisor(
     mock_try_connection.return_value = True
 
     result = await hass.config_entries.flow.async_init(
-        "mqtt", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.MENU
     assert result["menu_options"] == ["addon", "broker"]
@@ -450,7 +450,7 @@ async def test_user_v5_connection_works(
     mock_try_connection.return_value = True
 
     result = await hass.config_entries.flow.async_init(
-        "mqtt",
+        DOMAIN,
         context={"source": config_entries.SOURCE_USER},
     )
     assert result["type"] is FlowResultType.FORM
@@ -488,7 +488,7 @@ async def test_user_connection_fails(
 ) -> None:
     """Test if connection cannot be made."""
     result = await hass.config_entries.flow.async_init(
-        "mqtt", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.FORM
 
@@ -518,7 +518,7 @@ async def test_manual_config_set(
 
     # Start config flow
     result = await hass.config_entries.flow.async_init(
-        "mqtt", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.FORM
 
@@ -555,7 +555,7 @@ async def test_user_single_instance(hass: HomeAssistant) -> None:
     ).add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
-        "mqtt", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
@@ -570,7 +570,7 @@ async def test_hassio_already_configured(hass: HomeAssistant) -> None:
     ).add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
-        "mqtt", context={"source": config_entries.SOURCE_HASSIO}
+        DOMAIN, context={"source": config_entries.SOURCE_HASSIO}
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
@@ -612,7 +612,7 @@ async def test_hassio_confirm(
 ) -> None:
     """Test we can finish a config flow."""
     result = await hass.config_entries.flow.async_init(
-        "mqtt",
+        DOMAIN,
         data=HassioServiceInfo(
             config=ADD_ON_DISCOVERY_INFO.copy(),
             name="Mosquitto Mqtt Broker",
@@ -652,7 +652,7 @@ async def test_hassio_cannot_connect(
 ) -> None:
     """Test a config flow is aborted when a connection was not successful."""
     result = await hass.config_entries.flow.async_init(
-        "mqtt",
+        DOMAIN,
         data=HassioServiceInfo(
             config={
                 "addon": "Mock Addon",
@@ -713,7 +713,7 @@ async def test_addon_flow_with_supervisor_addon_running(
     """
     # show menu
     result = await hass.config_entries.flow.async_init(
-        "mqtt", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.MENU
     assert result["menu_options"] == ["addon", "broker"]
@@ -768,7 +768,7 @@ async def test_addon_flow_with_supervisor_addon_installed(
     """
     # show menu
     result = await hass.config_entries.flow.async_init(
-        "mqtt", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.MENU
     assert result["menu_options"] == ["addon", "broker"]
@@ -835,7 +835,7 @@ async def test_addon_flow_with_supervisor_addon_running_connection_fails(
     """
     # show menu
     result = await hass.config_entries.flow.async_init(
-        "mqtt", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.MENU
     assert result["menu_options"] == ["addon", "broker"]
@@ -868,7 +868,7 @@ async def test_addon_not_running_api_error(
     start_addon.side_effect = SupervisorError()
 
     result = await hass.config_entries.flow.async_init(
-        "mqtt", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.MENU
     assert result["menu_options"] == ["addon", "broker"]
@@ -912,7 +912,7 @@ async def test_addon_discovery_info_error(
     get_addon_discovery_info.side_effect = AddonError
 
     result = await hass.config_entries.flow.async_init(
-        "mqtt", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.MENU
     assert result["menu_options"] == ["addon", "broker"]
@@ -955,7 +955,7 @@ async def test_addon_info_error(
     addon_info.side_effect = SupervisorError()
 
     result = await hass.config_entries.flow.async_init(
-        "mqtt", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.MENU
     assert result["menu_options"] == ["addon", "broker"]
@@ -1002,7 +1002,7 @@ async def test_addon_flow_with_supervisor_addon_not_installed(
     Case: The Mosquitto add-on is not yet installed nor running.
     """
     result = await hass.config_entries.flow.async_init(
-        "mqtt", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.MENU
     assert result["menu_options"] == ["addon", "broker"]
@@ -1067,7 +1067,7 @@ async def test_addon_not_installed_failures(
     install_addon.side_effect = SupervisorError()
 
     result = await hass.config_entries.flow.async_init(
-        "mqtt", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.MENU
     assert result["menu_options"] == ["addon", "broker"]

--- a/tests/components/neato/test_config_flow.py
+++ b/tests/components/neato/test_config_flow.py
@@ -41,7 +41,7 @@ async def test_full_flow(
     )
 
     result = await hass.config_entries.flow.async_init(
-        "neato", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -93,7 +93,7 @@ async def test_abort_if_already_setup(hass: HomeAssistant) -> None:
 
     # Should fail
     result = await hass.config_entries.flow.async_init(
-        "neato", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"

--- a/tests/components/netatmo/test_config_flow.py
+++ b/tests/components/netatmo/test_config_flow.py
@@ -41,13 +41,13 @@ async def test_abort_if_existing_entry(hass: HomeAssistant) -> None:
     flow.hass = hass
 
     result = await hass.config_entries.flow.async_init(
-        "netatmo", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 
     result = await hass.config_entries.flow.async_init(
-        "netatmo",
+        DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=ZeroconfServiceInfo(
             ip_address=ip_address("192.168.1.5"),
@@ -72,7 +72,7 @@ async def test_full_flow(
     """Check full flow."""
 
     result = await hass.config_entries.flow.async_init(
-        "netatmo", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -239,7 +239,7 @@ async def test_reauth(
     """Test initialization of the reauth flow."""
 
     result = await hass.config_entries.flow.async_init(
-        "netatmo", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,

--- a/tests/components/senz/test_config_flow.py
+++ b/tests/components/senz/test_config_flow.py
@@ -42,7 +42,7 @@ async def test_full_flow(
     )
 
     result = await hass.config_entries.flow.async_init(
-        "senz", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,

--- a/tests/components/tasmota/test_config_flow.py
+++ b/tests/components/tasmota/test_config_flow.py
@@ -19,7 +19,7 @@ async def test_mqtt_abort_if_existing_entry(
     MockConfigEntry(domain=DOMAIN).add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
-        "tasmota", context={"source": config_entries.SOURCE_MQTT}
+        DOMAIN, context={"source": config_entries.SOURCE_MQTT}
     )
 
     assert result["type"] is FlowResultType.ABORT
@@ -50,7 +50,7 @@ async def test_mqtt_abort_invalid_topic(
         timestamp=None,
     )
     result = await hass.config_entries.flow.async_init(
-        "tasmota", context={"source": config_entries.SOURCE_MQTT}, data=discovery_info
+        DOMAIN, context={"source": config_entries.SOURCE_MQTT}, data=discovery_info
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "invalid_discovery_info"
@@ -64,7 +64,7 @@ async def test_mqtt_abort_invalid_topic(
         timestamp=None,
     )
     result = await hass.config_entries.flow.async_init(
-        "tasmota", context={"source": config_entries.SOURCE_MQTT}, data=discovery_info
+        DOMAIN, context={"source": config_entries.SOURCE_MQTT}, data=discovery_info
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "invalid_discovery_info"
@@ -89,7 +89,7 @@ async def test_mqtt_abort_invalid_topic(
         timestamp=None,
     )
     result = await hass.config_entries.flow.async_init(
-        "tasmota", context={"source": config_entries.SOURCE_MQTT}, data=discovery_info
+        DOMAIN, context={"source": config_entries.SOURCE_MQTT}, data=discovery_info
     )
     assert result["type"] is FlowResultType.FORM
 
@@ -116,7 +116,7 @@ async def test_mqtt_setup(hass: HomeAssistant, mqtt_mock: MqttMockHAClient) -> N
         timestamp=None,
     )
     result = await hass.config_entries.flow.async_init(
-        "tasmota", context={"source": config_entries.SOURCE_MQTT}, data=discovery_info
+        DOMAIN, context={"source": config_entries.SOURCE_MQTT}, data=discovery_info
     )
     assert result["type"] is FlowResultType.FORM
 
@@ -150,7 +150,7 @@ async def test_user_setup(
 ) -> None:
     """Test we can finish a config flow."""
     result = await hass.config_entries.flow.async_init(
-        "tasmota", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "config"
@@ -168,7 +168,7 @@ async def test_user_setup_invalid_topic_prefix(
 ) -> None:
     """Test abort on invalid discovery topic."""
     result = await hass.config_entries.flow.async_init(
-        "tasmota", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "config"
@@ -188,7 +188,7 @@ async def test_user_single_instance(
     MockConfigEntry(domain=DOMAIN).add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
-        "tasmota", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"

--- a/tests/components/tradfri/test_config_flow.py
+++ b/tests/components/tradfri/test_config_flow.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.tradfri import config_flow
+from homeassistant.components.tradfri import DOMAIN, config_flow
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.zeroconf import (
@@ -36,7 +36,7 @@ async def test_already_paired(hass: HomeAssistant, mock_entry_setup) -> None:
         mock_it.generate_psk.return_value = None
         mock_lib.init.return_value = mock_it
         result = await hass.config_entries.flow.async_init(
-            "tradfri", context={"source": config_entries.SOURCE_USER}
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"host": "123.123.123.123", "security_code": "abcd"}
@@ -53,7 +53,7 @@ async def test_user_connection_successful(
     mock_auth.side_effect = lambda hass, host, code: {"host": host, "gateway_id": "bla"}
 
     flow = await hass.config_entries.flow.async_init(
-        "tradfri", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     result = await hass.config_entries.flow.async_configure(
@@ -76,7 +76,7 @@ async def test_user_connection_timeout(
     mock_auth.side_effect = config_flow.AuthError("timeout")
 
     flow = await hass.config_entries.flow.async_init(
-        "tradfri", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     result = await hass.config_entries.flow.async_configure(
@@ -96,7 +96,7 @@ async def test_user_connection_bad_key(
     mock_auth.side_effect = config_flow.AuthError("invalid_security_code")
 
     flow = await hass.config_entries.flow.async_init(
-        "tradfri", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     result = await hass.config_entries.flow.async_configure(
@@ -116,7 +116,7 @@ async def test_discovery_connection(
     mock_auth.side_effect = lambda hass, host, code: {"host": host, "gateway_id": "bla"}
 
     flow = await hass.config_entries.flow.async_init(
-        "tradfri",
+        DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=ZeroconfServiceInfo(
             ip_address=ip_address("123.123.123.123"),
@@ -151,7 +151,7 @@ async def test_discovery_duplicate_aborted(hass: HomeAssistant) -> None:
     entry.add_to_hass(hass)
 
     flow = await hass.config_entries.flow.async_init(
-        "tradfri",
+        DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=ZeroconfServiceInfo(
             ip_address=ip_address("123.123.123.124"),
@@ -175,7 +175,7 @@ async def test_duplicate_discovery(
 ) -> None:
     """Test a duplicate discovery in progress is ignored."""
     result = await hass.config_entries.flow.async_init(
-        "tradfri",
+        DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=ZeroconfServiceInfo(
             ip_address=ip_address("123.123.123.123"),
@@ -191,7 +191,7 @@ async def test_duplicate_discovery(
     assert result["type"] is FlowResultType.FORM
 
     result2 = await hass.config_entries.flow.async_init(
-        "tradfri",
+        DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=ZeroconfServiceInfo(
             ip_address=ip_address("123.123.123.123"),
@@ -216,7 +216,7 @@ async def test_discovery_updates_unique_id(hass: HomeAssistant) -> None:
     entry.add_to_hass(hass)
 
     flow = await hass.config_entries.flow.async_init(
-        "tradfri",
+        DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=ZeroconfServiceInfo(
             ip_address=ip_address("123.123.123.123"),

--- a/tests/components/twilio/test_init.py
+++ b/tests/components/twilio/test_init.py
@@ -2,6 +2,7 @@
 
 from homeassistant import config_entries
 from homeassistant.components import twilio
+from homeassistant.components.twilio import DOMAIN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.core_config import async_process_ha_core_config
 from homeassistant.data_entry_flow import FlowResultType
@@ -18,7 +19,7 @@ async def test_config_flow_registers_webhook(
         {"internal_url": "http://example.local:8123"},
     )
     result = await hass.config_entries.flow.async_init(
-        "twilio", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.FORM, result
 

--- a/tests/components/twitch/test_config_flow.py
+++ b/tests/components/twitch/test_config_flow.py
@@ -57,7 +57,7 @@ async def test_full_flow(
 ) -> None:
     """Check full flow."""
     result = await hass.config_entries.flow.async_init(
-        "twitch", context={"source": SOURCE_USER}
+        DOMAIN, context={"source": SOURCE_USER}
     )
     await _do_get_token(hass, result, hass_client_no_auth, scopes)
 
@@ -86,7 +86,7 @@ async def test_already_configured(
     """Check flow aborts when account already configured."""
     await setup_integration(hass, config_entry)
     result = await hass.config_entries.flow.async_init(
-        "twitch", context={"source": SOURCE_USER}
+        DOMAIN, context={"source": SOURCE_USER}
     )
     await _do_get_token(hass, result, hass_client_no_auth, scopes)
 

--- a/tests/components/xbox/test_config_flow.py
+++ b/tests/components/xbox/test_config_flow.py
@@ -50,7 +50,7 @@ async def test_full_flow(
     """Check full flow."""
 
     result = await hass.config_entries.flow.async_init(
-        "xbox", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -134,7 +134,7 @@ async def test_discovery(
     """Check DHCP/SSDP discovery."""
 
     result = await hass.config_entries.flow.async_init(
-        "xbox", context={"source": source}, data=service_info
+        DOMAIN, context={"source": source}, data=service_info
     )
 
     assert result["type"] is FlowResultType.FORM

--- a/tests/components/youtube/test_config_flow.py
+++ b/tests/components/youtube/test_config_flow.py
@@ -33,7 +33,7 @@ async def test_full_flow(
 ) -> None:
     """Check full flow."""
     result = await hass.config_entries.flow.async_init(
-        "youtube", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -92,7 +92,7 @@ async def test_flow_abort_without_channel(
 ) -> None:
     """Check abort flow if user has no channel."""
     result = await hass.config_entries.flow.async_init(
-        "youtube", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -133,7 +133,7 @@ async def test_flow_abort_without_subscriptions(
 ) -> None:
     """Check abort flow if user has no subscriptions and no own channel."""
     result = await hass.config_entries.flow.async_init(
-        "youtube", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -178,7 +178,7 @@ async def test_flow_without_subscriptions(
 ) -> None:
     """Check flow continues without subscriptions using own channel."""
     result = await hass.config_entries.flow.async_init(
-        "youtube", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -241,7 +241,7 @@ async def test_flow_http_error(
 ) -> None:
     """Check full flow."""
     result = await hass.config_entries.flow.async_init(
-        "youtube", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -398,7 +398,7 @@ async def test_flow_exception(
 ) -> None:
     """Check full flow."""
     result = await hass.config_entries.flow.async_init(
-        "youtube", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -461,7 +461,7 @@ async def test_own_channel_included(
 ) -> None:
     """Test user's own channel is included in selectable channels."""
     result = await hass.config_entries.flow.async_init(
-        "youtube", context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     state = config_entry_oauth2_flow._encode_jwt(
         hass,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When `hass.config_entries.flow.async_init` is called with a literal string matching the component name, use the `DOMAIN` constant instead

Linked to #173004

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
