### PR TITLE
Use DOMAIN constant in test (hass.states.async_entity_ids)

### DIFF
--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -1777,7 +1777,7 @@ async def test_automation_bad_config_validation(
     assert issues[0]["translation_placeholders"]["error"].startswith(details)
 
     # Make sure both automations are setup
-    assert set(hass.states.async_entity_ids("automation")) == {
+    assert set(hass.states.async_entity_ids(DOMAIN)) == {
         "automation.bad_automation",
         "automation.good_automation",
     }

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -769,7 +769,7 @@ async def test_duplicate_ids(hass: HomeAssistant, hass_admin_user: MockUser) -> 
     }
     assert await async_setup_component(hass, DOMAIN, config)
 
-    assert len(hass.states.async_entity_ids("person")) == 1
+    assert len(hass.states.async_entity_ids(DOMAIN)) == 1
     assert hass.states.get("person.test_user_1") is not None
     assert hass.states.get("person.test_user_2") is None
 
@@ -847,7 +847,7 @@ async def test_load_person_storage_two_nonlinked(
     }
     await async_setup_component(hass, DOMAIN, {})
 
-    assert len(hass.states.async_entity_ids("person")) == 2
+    assert len(hass.states.async_entity_ids(DOMAIN)) == 2
     assert hass.states.get("person.tracked_person_1") is not None
     assert hass.states.get("person.tracked_person_2") is not None
 
@@ -1028,7 +1028,7 @@ async def test_ws_delete(
     assert len(persons) == 0
 
     assert resp["success"]
-    assert len(hass.states.async_entity_ids("person")) == 0
+    assert len(hass.states.async_entity_ids(DOMAIN)) == 0
     assert not entity_registry.async_is_registered("person.tracked_person")
 
 

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -205,7 +205,7 @@ async def test_setup_with_invalid_configs(
     """Test setup with invalid configs."""
     assert await async_setup_component(hass, "script", {"script": config})
 
-    assert len(hass.states.async_entity_ids("script")) == nbr_script_entities
+    assert len(hass.states.async_entity_ids(DOMAIN)) == nbr_script_entities
 
 
 @pytest.mark.parametrize(
@@ -261,7 +261,7 @@ async def test_bad_config_validation_critical(
     )
 
     # Make sure one bad script does not prevent other scripts from setting up
-    assert hass.states.async_entity_ids("script") == ["script.good_script"]
+    assert hass.states.async_entity_ids(DOMAIN) == ["script.good_script"]
 
 
 @pytest.mark.parametrize(
@@ -337,7 +337,7 @@ async def test_bad_config_validation(
     assert issues[0]["translation_placeholders"]["error"].startswith(details)
 
     # Make sure both scripts are setup
-    assert set(hass.states.async_entity_ids("script")) == {
+    assert set(hass.states.async_entity_ids(DOMAIN)) == {
         "script.bad_script",
         "script.good_script",
     }
@@ -1518,7 +1518,7 @@ async def test_setup_with_duplicate_scripts(
         },
     )
     assert "Duplicate script detected with name: 'duplicate'" in caplog.text
-    assert len(hass.states.async_entity_ids("script")) == 1
+    assert len(hass.states.async_entity_ids(DOMAIN)) == 1
 
 
 async def test_websocket_config(

--- a/tests/components/zone/test_init.py
+++ b/tests/components/zone/test_init.py
@@ -65,7 +65,7 @@ def storage_setup(hass: HomeAssistant, hass_storage: dict[str, Any]):
 async def test_setup_no_zones_still_adds_home_zone(hass: HomeAssistant) -> None:
     """Test if no config is passed in we still get the home zone."""
     assert await setup.async_setup_component(hass, zone.DOMAIN, {"zone": None})
-    assert len(hass.states.async_entity_ids("zone")) == 1
+    assert len(hass.states.async_entity_ids(DOMAIN)) == 1
     state = hass.states.get("zone.home")
     assert hass.config.location_name == state.name
     assert hass.config.latitude == state.attributes["latitude"]
@@ -84,7 +84,7 @@ async def test_setup(hass: HomeAssistant) -> None:
     }
     assert await setup.async_setup_component(hass, zone.DOMAIN, {"zone": info})
 
-    assert len(hass.states.async_entity_ids("zone")) == 2
+    assert len(hass.states.async_entity_ids(DOMAIN)) == 2
     state = hass.states.get("zone.test_zone")
     assert info["name"] == state.name
     assert info["latitude"] == state.attributes["latitude"]
@@ -98,7 +98,7 @@ async def test_setup_zone_skips_home_zone(hass: HomeAssistant) -> None:
     info = {"name": "Home", "latitude": 1.1, "longitude": -2.2}
     assert await setup.async_setup_component(hass, zone.DOMAIN, {"zone": info})
 
-    assert len(hass.states.async_entity_ids("zone")) == 1
+    assert len(hass.states.async_entity_ids(DOMAIN)) == 1
     state = hass.states.get("zone.home")
     assert info["name"] == state.name
 
@@ -107,7 +107,7 @@ async def test_setup_name_can_be_same_on_multiple_zones(hass: HomeAssistant) -> 
     """Test that zone named Home should override hass home zone."""
     info = {"name": "Test Zone", "latitude": 1.1, "longitude": -2.2}
     assert await setup.async_setup_component(hass, zone.DOMAIN, {"zone": [info, info]})
-    assert len(hass.states.async_entity_ids("zone")) == 3
+    assert len(hass.states.async_entity_ids(DOMAIN)) == 3
 
 
 async def test_active_zone_skips_passive_zones(hass: HomeAssistant) -> None:
@@ -811,7 +811,7 @@ async def test_state(hass: HomeAssistant) -> None:
     }
     assert await setup.async_setup_component(hass, zone.DOMAIN, {"zone": info})
 
-    assert len(hass.states.async_entity_ids("zone")) == 2
+    assert len(hass.states.async_entity_ids(DOMAIN)) == 2
     state = hass.states.get("zone.test_zone")
     assert state.state == "0"
     assert state.attributes[ATTR_PERSONS] == []


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When `hass.states.async_entity_ids` is called with a literal string matching the component name, use the `DOMAIN` constant instead

Linked to #173004

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
