### PR TITLE
Use DOMAIN constant in test (async_setup_component a-g)

### DIFF
--- a/tests/components/air_quality/test_air_quality.py
+++ b/tests/components/air_quality/test_air_quality.py
@@ -2,7 +2,12 @@
 
 import pytest
 
-from homeassistant.components.air_quality import ATTR_N2O, ATTR_OZONE, ATTR_PM_10
+from homeassistant.components.air_quality import (
+    ATTR_N2O,
+    ATTR_OZONE,
+    ATTR_PM_10,
+    DOMAIN,
+)
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
     ATTR_UNIT_OF_MEASUREMENT,
@@ -22,7 +27,7 @@ async def test_state(hass: HomeAssistant) -> None:
     """Test Air Quality state."""
     config = {"air_quality": {"platform": "demo"}}
 
-    assert await async_setup_component(hass, "air_quality", config)
+    assert await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
 
     state = hass.states.get("air_quality.demo_air_quality_home")
@@ -35,7 +40,7 @@ async def test_attributes(hass: HomeAssistant) -> None:
     """Test Air Quality attributes."""
     config = {"air_quality": {"platform": "demo"}}
 
-    assert await async_setup_component(hass, "air_quality", config)
+    assert await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
 
     state = hass.states.get("air_quality.demo_air_quality_office")

--- a/tests/components/alexa/test_init.py
+++ b/tests/components/alexa/test_init.py
@@ -1,6 +1,6 @@
 """Tests for alexa."""
 
-from homeassistant.components.alexa.const import EVENT_ALEXA_SMART_HOME
+from homeassistant.components.alexa.const import DOMAIN, EVENT_ALEXA_SMART_HOME
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -10,7 +10,7 @@ from tests.components.logbook.common import MockRow, mock_humanify
 async def test_humanify_alexa_event(hass: HomeAssistant) -> None:
     """Test humanifying Alexa event."""
     hass.config.components.add("recorder")
-    await async_setup_component(hass, "alexa", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_setup_component(hass, "logbook", {})
     await hass.async_block_till_done()
     hass.states.async_set("light.kitchen", "on", {"friendly_name": "Kitchen Light"})

--- a/tests/components/analytics/test_analytics.py
+++ b/tests/components/analytics/test_analytics.py
@@ -28,6 +28,7 @@ from homeassistant.components.analytics.const import (
     ATTR_USAGE,
     BASIC_ENDPOINT_URL,
     BASIC_ENDPOINT_URL_DEV,
+    DOMAIN,
     SNAPSHOT_DEFAULT_URL,
     SNAPSHOT_URL_PATH,
 )
@@ -1033,7 +1034,7 @@ async def test_devices_payload_no_entities(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test devices payload with no entities."""
-    assert await async_setup_component(hass, "analytics", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     assert await async_devices_payload(hass) == {
         "version": "home-assistant:1",
         "home_assistant": MOCK_VERSION,
@@ -1176,7 +1177,7 @@ async def test_devices_payload_with_entities(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test devices payload with entities."""
-    assert await async_setup_component(hass, "analytics", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     mock_config_entry = MockConfigEntry(domain="hue")
     mock_config_entry.add_to_hass(hass)
@@ -1370,7 +1371,7 @@ async def test_analytics_platforms(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test analytics platforms."""
-    assert await async_setup_component(hass, "analytics", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     mock_config_entry = MockConfigEntry(domain="test")
     mock_config_entry.add_to_hass(hass)

--- a/tests/components/anthropic/conftest.py
+++ b/tests/components/anthropic/conftest.py
@@ -89,7 +89,7 @@ async def mock_init_component(
         new_callable=AsyncMock,
         return_value=AsyncPage(data=model_list),
     ):
-        assert await async_setup_component(hass, "anthropic", {})
+        assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
         yield
 

--- a/tests/components/anthropic/test_init.py
+++ b/tests/components/anthropic/test_init.py
@@ -70,7 +70,7 @@ async def test_init_error(
         "anthropic.resources.models.AsyncModels.list",
         side_effect=side_effect,
     ):
-        assert await async_setup_component(hass, "anthropic", {})
+        assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
         assert error in caplog.text
 
@@ -90,7 +90,7 @@ async def test_init_auth_error(
             message="",
         ),
     ):
-        assert await async_setup_component(hass, "anthropic", {})
+        assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
         assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 

--- a/tests/components/api/test_init.py
+++ b/tests/components/api/test_init.py
@@ -15,6 +15,7 @@ import voluptuous as vol
 from homeassistant import const, core as ha
 from homeassistant.auth.models import Credentials
 from homeassistant.bootstrap import DATA_LOGGING
+from homeassistant.components.api import DOMAIN
 from homeassistant.components.group import DOMAIN as GROUP_DOMAIN
 from homeassistant.components.logger import DOMAIN as LOGGER_DOMAIN
 from homeassistant.components.system_health import DOMAIN as SYSTEM_HEALTH_DOMAIN
@@ -32,7 +33,7 @@ async def mock_api_client(
     hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> TestClient:
     """Start the Home Assistant HTTP component and return admin API client."""
-    await async_setup_component(hass, "api", {})
+    await async_setup_component(hass, DOMAIN, {})
     return await hass_client()
 
 
@@ -705,7 +706,7 @@ async def test_api_error_log(
 ) -> None:
     """Test if we can fetch the error log."""
     hass.data[DATA_LOGGING] = "/some/path"
-    await async_setup_component(hass, "api", {})
+    await async_setup_component(hass, DOMAIN, {})
     client = await hass_client_no_auth()
 
     resp = await client.get(const.URL_API_ERROR_LOG)
@@ -824,7 +825,7 @@ async def test_states_view_filters(
     """Test filtering only visible states."""
     assert not hass_read_only_user.is_admin
     hass_read_only_user.mock_policy({"entities": {"entity_ids": {"test.entity": True}}})
-    await async_setup_component(hass, "api", {})
+    await async_setup_component(hass, DOMAIN, {})
     read_only_user_credential = Credentials(
         id="mock-read-only-credential-id",
         auth_provider_type="homeassistant",

--- a/tests/components/assist_pipeline/conftest.py
+++ b/tests/components/assist_pipeline/conftest.py
@@ -309,7 +309,7 @@ async def init_supporting_components(
 async def init_components(hass: HomeAssistant, init_supporting_components):
     """Initialize relevant components with empty configs."""
 
-    assert await async_setup_component(hass, "assist_pipeline", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
 
 @pytest.fixture

--- a/tests/components/assist_pipeline/test_pipeline.py
+++ b/tests/components/assist_pipeline/test_pipeline.py
@@ -231,7 +231,7 @@ async def test_loading_pipelines_from_storage(
         },
     }
 
-    assert await async_setup_component(hass, "assist_pipeline", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     pipeline_data: PipelineData = hass.data[DOMAIN]
     store = pipeline_data.pipeline_store
@@ -291,7 +291,7 @@ async def test_migrate_pipeline_store(
         },
     }
 
-    assert await async_setup_component(hass, "assist_pipeline", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     pipeline_data: PipelineData = hass.data[DOMAIN]
     store = pipeline_data.pipeline_store
@@ -303,7 +303,7 @@ async def test_migrate_pipeline_store(
 @pytest.mark.usefixtures("disable_tts_entity")
 async def test_create_default_pipeline(hass: HomeAssistant) -> None:
     """Test async_create_default_pipeline."""
-    assert await async_setup_component(hass, "assist_pipeline", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     pipeline_data: PipelineData = hass.data[DOMAIN]
     store = pipeline_data.pipeline_store
@@ -341,7 +341,7 @@ async def test_create_default_pipeline(hass: HomeAssistant) -> None:
 
 async def test_get_pipeline(hass: HomeAssistant) -> None:
     """Test async_get_pipeline."""
-    assert await async_setup_component(hass, "assist_pipeline", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     pipeline_data: PipelineData = hass.data[DOMAIN]
     store = pipeline_data.pipeline_store
@@ -357,7 +357,7 @@ async def test_get_pipeline(hass: HomeAssistant) -> None:
 
 async def test_get_pipelines(hass: HomeAssistant) -> None:
     """Test async_get_pipelines."""
-    assert await async_setup_component(hass, "assist_pipeline", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     pipeline_data: PipelineData = hass.data[DOMAIN]
     store = pipeline_data.pipeline_store
@@ -404,7 +404,7 @@ async def test_default_pipeline_no_stt_tts(
     """Test async_get_pipeline."""
     hass.config.country = ha_country
     hass.config.language = ha_language
-    assert await async_setup_component(hass, "assist_pipeline", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     pipeline_data: PipelineData = hass.data[DOMAIN]
     store = pipeline_data.pipeline_store
@@ -468,7 +468,7 @@ async def test_default_pipeline(
         patch.object(mock_stt_provider_entity, "_supported_languages", MANY_LANGUAGES),
         patch.object(mock_tts_provider, "_supported_languages", MANY_LANGUAGES),
     ):
-        assert await async_setup_component(hass, "assist_pipeline", {})
+        assert await async_setup_component(hass, DOMAIN, {})
 
     pipeline_data: PipelineData = hass.data[DOMAIN]
     store = pipeline_data.pipeline_store
@@ -499,7 +499,7 @@ async def test_default_pipeline_unsupported_stt_language(
 ) -> None:
     """Test async_get_pipeline."""
     with patch.object(mock_stt_provider_entity, "_supported_languages", ["smurfish"]):
-        assert await async_setup_component(hass, "assist_pipeline", {})
+        assert await async_setup_component(hass, DOMAIN, {})
 
     pipeline_data: PipelineData = hass.data[DOMAIN]
     store = pipeline_data.pipeline_store
@@ -530,7 +530,7 @@ async def test_default_pipeline_unsupported_tts_language(
 ) -> None:
     """Test async_get_pipeline."""
     with patch.object(mock_tts_provider, "_supported_languages", ["smurfish"]):
-        assert await async_setup_component(hass, "assist_pipeline", {})
+        assert await async_setup_component(hass, DOMAIN, {})
 
     pipeline_data: PipelineData = hass.data[DOMAIN]
     store = pipeline_data.pipeline_store
@@ -558,7 +558,7 @@ async def test_update_pipeline(
     hass: HomeAssistant, hass_storage: dict[str, Any]
 ) -> None:
     """Test async_update_pipeline."""
-    assert await async_setup_component(hass, "assist_pipeline", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     pipelines = async_get_pipelines(hass)
     pipelines = list(pipelines)

--- a/tests/components/auth/__init__.py
+++ b/tests/components/auth/__init__.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from homeassistant import auth
+from homeassistant.components.auth import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import UNDEFINED, UndefinedType
 from homeassistant.setup import async_setup_component
@@ -39,7 +40,7 @@ async def async_setup_auth(
         EMPTY_CONFIG if module_configs is UNDEFINED else module_configs,
     )
     ensure_auth_manager_loaded(hass.auth)
-    await async_setup_component(hass, "auth", {})
+    await async_setup_component(hass, DOMAIN, {})
     if setup_api:
         await async_setup_component(hass, "api", {})
     if custom_ip:

--- a/tests/components/auth/test_init.py
+++ b/tests/components/auth/test_init.py
@@ -16,6 +16,7 @@ from homeassistant.auth.models import (
     RefreshToken,
 )
 from homeassistant.components import auth
+from homeassistant.components.auth import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
@@ -205,7 +206,7 @@ async def test_ws_current_user(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_access_token: str
 ) -> None:
     """Test the current user command with Home Assistant creds."""
-    assert await async_setup_component(hass, "auth", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     refresh_token = hass.auth.async_validate_access_token(hass_access_token)
     user = refresh_token.user
@@ -430,7 +431,7 @@ async def test_ws_long_lived_access_token(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_access_token: str
 ) -> None:
     """Test generate long-lived access token."""
-    assert await async_setup_component(hass, "auth", {"http": {}})
+    assert await async_setup_component(hass, DOMAIN, {"http": {}})
 
     ws_client = await hass_ws_client(hass, hass_access_token)
 
@@ -460,7 +461,7 @@ async def test_ws_refresh_tokens(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_access_token: str
 ) -> None:
     """Test fetching refresh token metadata."""
-    assert await async_setup_component(hass, "auth", {"http": {}})
+    assert await async_setup_component(hass, DOMAIN, {"http": {}})
 
     ws_client = await hass_ws_client(hass, hass_access_token)
 
@@ -491,7 +492,7 @@ async def test_ws_delete_refresh_token(
     hass_access_token: str,
 ) -> None:
     """Test deleting a refresh token."""
-    assert await async_setup_component(hass, "auth", {"http": {}})
+    assert await async_setup_component(hass, DOMAIN, {"http": {}})
 
     refresh_token = await hass.auth.async_create_refresh_token(
         hass_admin_user, CLIENT_ID, credential=hass_admin_credential
@@ -523,7 +524,7 @@ async def test_ws_delete_all_refresh_tokens_error(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test deleting all refresh tokens, where a revoke callback raises an error."""
-    assert await async_setup_component(hass, "auth", {"http": {}})
+    assert await async_setup_component(hass, DOMAIN, {"http": {}})
 
     # one token already exists
     await hass.auth.async_create_refresh_token(
@@ -605,7 +606,7 @@ async def test_ws_delete_all_refresh_tokens(
     expected_remaining_long_lived_tokens: int,
 ) -> None:
     """Test deleting all or some refresh tokens."""
-    assert await async_setup_component(hass, "auth", {"http": {}})
+    assert await async_setup_component(hass, DOMAIN, {"http": {}})
 
     # one token already exists
     await hass.auth.async_create_refresh_token(
@@ -669,7 +670,7 @@ async def test_ws_sign_path(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_access_token: str
 ) -> None:
     """Test signing a path."""
-    assert await async_setup_component(hass, "auth", {"http": {}})
+    assert await async_setup_component(hass, DOMAIN, {"http": {}})
     ws_client = await hass_ws_client(hass, hass_access_token)
 
     with patch(
@@ -701,7 +702,7 @@ async def test_ws_refresh_token_set_expiry(
     hass_access_token: str,
 ) -> None:
     """Test setting expiry of a refresh token."""
-    assert await async_setup_component(hass, "auth", {"http": {}})
+    assert await async_setup_component(hass, DOMAIN, {"http": {}})
 
     refresh_token = await hass.auth.async_create_refresh_token(
         hass_admin_user, CLIENT_ID, credential=hass_admin_credential
@@ -742,7 +743,7 @@ async def test_ws_refresh_token_set_expiry_error(
     hass_access_token: str,
 ) -> None:
     """Test setting expiry of a invalid refresh token returns error."""
-    assert await async_setup_component(hass, "auth", {"http": {}})
+    assert await async_setup_component(hass, DOMAIN, {"http": {}})
 
     ws_client = await hass_ws_client(hass, hass_access_token)
 

--- a/tests/components/auth/test_mfa_setup_flow.py
+++ b/tests/components/auth/test_mfa_setup_flow.py
@@ -1,6 +1,7 @@
 """Tests for the mfa setup flow."""
 
 from homeassistant.auth import auth_manager_from_config
+from homeassistant.components.auth import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.setup import async_setup_component
@@ -36,7 +37,7 @@ async def test_ws_setup_depose_mfa(
         ],
     )
     ensure_auth_manager_loaded(hass.auth)
-    await async_setup_component(hass, "auth", {"http": {}})
+    await async_setup_component(hass, DOMAIN, {"http": {}})
 
     user = MockUser(id="mock-user").add_to_hass(hass)
     cred = await hass.auth.auth_providers[0].async_get_or_create_credentials(

--- a/tests/components/automation/test_blueprint.py
+++ b/tests/components/automation/test_blueprint.py
@@ -82,7 +82,7 @@ async def test_notify_leaving_zone(
     ):
         assert await async_setup_component(
             hass,
-            "automation",
+            DOMAIN,
             {
                 "automation": {
                     "use_blueprint": {
@@ -160,7 +160,7 @@ async def test_motion_light(hass: HomeAssistant) -> None:
     ):
         assert await async_setup_component(
             hass,
-            "automation",
+            DOMAIN,
             {
                 "automation": {
                     "use_blueprint": {

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -2926,7 +2926,7 @@ async def test_blueprint_automation(
     """Test blueprint automation."""
     assert await async_setup_component(
         hass,
-        "automation",
+        DOMAIN,
         {
             "automation": {
                 "use_blueprint": {
@@ -2961,7 +2961,7 @@ async def test_blueprint_automation_legacy_schema(
     """Test blueprint automation where the blueprint is using legacy schema."""
     assert await async_setup_component(
         hass,
-        "automation",
+        DOMAIN,
         {
             "automation": {
                 "use_blueprint": {
@@ -3021,7 +3021,7 @@ async def test_blueprint_automation_override(
     """Test blueprint automation where the automation config overrides the blueprint."""
     assert await async_setup_component(
         hass,
-        "automation",
+        DOMAIN,
         {
             "automation": {
                 "use_blueprint": {
@@ -3097,7 +3097,7 @@ async def test_blueprint_automation_bad_config(
     """Test blueprint automation with bad inputs."""
     assert await async_setup_component(
         hass,
-        "automation",
+        DOMAIN,
         {
             "automation": {
                 "use_blueprint": {
@@ -3136,7 +3136,7 @@ async def test_blueprint_automation_fails_substitution(
     ):
         assert await async_setup_component(
             hass,
-            "automation",
+            DOMAIN,
             {
                 "automation": {
                     "use_blueprint": {

--- a/tests/components/automation/test_logbook.py
+++ b/tests/components/automation/test_logbook.py
@@ -1,6 +1,7 @@
 """Test automation logbook."""
 
 from homeassistant.components import automation
+from homeassistant.components.automation import DOMAIN
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -10,7 +11,7 @@ from tests.components.logbook.common import MockRow, mock_humanify
 async def test_humanify_automation_trigger_event(hass: HomeAssistant) -> None:
     """Test humanifying Shelly click event."""
     hass.config.components.add("recorder")
-    assert await async_setup_component(hass, "automation", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     assert await async_setup_component(hass, "logbook", {})
     await hass.async_block_till_done()
     context = Context()

--- a/tests/components/aws/test_init.py
+++ b/tests/components/aws/test_init.py
@@ -4,6 +4,7 @@ import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, call, patch as async_patch
 
+from homeassistant.components.aws import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -45,7 +46,7 @@ async def test_empty_config(hass: HomeAssistant) -> None:
     with async_patch(
         "homeassistant.components.aws.AioSession", return_value=mock_session
     ):
-        await async_setup_component(hass, "aws", {"aws": {}})
+        await async_setup_component(hass, DOMAIN, {"aws": {}})
         await hass.async_block_till_done()
 
     # we don't validate auto-created default profile
@@ -60,7 +61,7 @@ async def test_empty_credential(hass: HomeAssistant) -> None:
     ):
         await async_setup_component(
             hass,
-            "aws",
+            DOMAIN,
             {
                 "aws": {
                     "notify": [
@@ -90,7 +91,7 @@ async def test_profile_credential(hass: HomeAssistant) -> None:
     ):
         await async_setup_component(
             hass,
-            "aws",
+            DOMAIN,
             {
                 "aws": {
                     "credentials": {"name": "test", "profile_name": "test-profile"},
@@ -125,7 +126,7 @@ async def test_access_key_credential(hass: HomeAssistant) -> None:
     ):
         await async_setup_component(
             hass,
-            "aws",
+            DOMAIN,
             {
                 "aws": {
                     "credentials": [
@@ -172,7 +173,7 @@ async def test_notify_credential(hass: HomeAssistant) -> None:
     ):
         await async_setup_component(
             hass,
-            "aws",
+            DOMAIN,
             {
                 "aws": {
                     "notify": [
@@ -209,7 +210,7 @@ async def test_notify_credential_profile(hass: HomeAssistant) -> None:
     ):
         await async_setup_component(
             hass,
-            "aws",
+            DOMAIN,
             {
                 "aws": {
                     "notify": [
@@ -239,7 +240,7 @@ async def test_credential_skip_validate(hass: HomeAssistant) -> None:
     ):
         await async_setup_component(
             hass,
-            "aws",
+            DOMAIN,
             {
                 "aws": {
                     "credentials": [
@@ -266,7 +267,7 @@ async def test_service_call_extra_data(hass: HomeAssistant) -> None:
     ):
         await async_setup_component(
             hass,
-            "aws",
+            DOMAIN,
             {
                 "aws": {
                     "notify": [
@@ -310,7 +311,7 @@ async def test_events_service_call(hass: HomeAssistant) -> None:
     ):
         await async_setup_component(
             hass,
-            "aws",
+            DOMAIN,
             {
                 "aws": {
                     "notify": [
@@ -363,7 +364,7 @@ async def test_events_service_call_10_targets(hass: HomeAssistant) -> None:
     ):
         await async_setup_component(
             hass,
-            "aws",
+            DOMAIN,
             {
                 "aws": {
                     "notify": [

--- a/tests/components/backup/test_onboarding.py
+++ b/tests/components/backup/test_onboarding.py
@@ -8,6 +8,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components import backup, onboarding
+from homeassistant.components.backup import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
@@ -56,7 +57,7 @@ async def test_onboarding_view_after_done(
     mock_onboarding_storage(hass_storage, {"done": [onboarding.const.STEP_USER]})
 
     assert await async_setup_component(hass, "onboarding", {})
-    assert await async_setup_component(hass, "backup", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client()
@@ -109,7 +110,7 @@ async def test_onboarding_backup_info(
     mock_onboarding_storage(hass_storage, {"done": []})
 
     assert await async_setup_component(hass, "onboarding", {})
-    assert await async_setup_component(hass, "backup", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client()
@@ -229,7 +230,7 @@ async def test_onboarding_backup_restore(
     mock_onboarding_storage(hass_storage, {"done": []})
 
     assert await async_setup_component(hass, "onboarding", {})
-    assert await async_setup_component(hass, "backup", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client()
@@ -340,7 +341,7 @@ async def test_onboarding_backup_restore_error(
     mock_onboarding_storage(hass_storage, {"done": []})
 
     assert await async_setup_component(hass, "onboarding", {})
-    assert await async_setup_component(hass, "backup", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client()
@@ -383,7 +384,7 @@ async def test_onboarding_backup_restore_unexpected_error(
     mock_onboarding_storage(hass_storage, {"done": []})
 
     assert await async_setup_component(hass, "onboarding", {})
-    assert await async_setup_component(hass, "backup", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client()
@@ -408,7 +409,7 @@ async def test_onboarding_backup_upload(
     mock_onboarding_storage(hass_storage, {"done": []})
 
     assert await async_setup_component(hass, "onboarding", {})
-    assert await async_setup_component(hass, "backup", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client()

--- a/tests/components/blebox/test_config_flow.py
+++ b/tests/components/blebox/test_config_flow.py
@@ -178,7 +178,7 @@ async def test_flow_with_auth_failure(hass: HomeAssistant, product_class_mock) -
 
 async def test_async_setup(hass: HomeAssistant) -> None:
     """Test async_setup (for coverage)."""
-    assert await async_setup_component(hass, "blebox", {"host": "172.2.3.4"})
+    assert await async_setup_component(hass, DOMAIN, {"host": "172.2.3.4"})
     await hass.async_block_till_done()
 
 

--- a/tests/components/blueprint/test_websocket_api.py
+++ b/tests/components/blueprint/test_websocket_api.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch
 import pytest
 import yaml
 
+from homeassistant.components.blueprint import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util.yaml import UndefinedSubstitution, parse_yaml
@@ -35,7 +36,7 @@ async def setup_bp(
     script_config: dict[str, Any],
 ) -> None:
     """Fixture to set up the blueprint component."""
-    assert await async_setup_component(hass, "blueprint", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     # Trigger registration of automation and script blueprints
     await async_setup_component(hass, "automation", automation_config)

--- a/tests/components/camera/conftest.py
+++ b/tests/components/camera/conftest.py
@@ -7,7 +7,7 @@ import pytest
 from webrtc_models import RTCIceCandidateInit
 
 from homeassistant.components import camera
-from homeassistant.components.camera.const import StreamType
+from homeassistant.components.camera.const import DOMAIN, StreamType
 from homeassistant.components.camera.webrtc import WebRTCAnswer, WebRTCSendMessage
 from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.const import Platform
@@ -47,7 +47,7 @@ def camera_only() -> Generator[None]:
 async def mock_camera_fixture(hass: HomeAssistant) -> AsyncGenerator[None]:
     """Initialize a demo camera platform."""
     assert await async_setup_component(
-        hass, "camera", {camera.DOMAIN: {"platform": "demo"}}
+        hass, DOMAIN, {camera.DOMAIN: {"platform": "demo"}}
     )
     await hass.async_block_till_done()
 
@@ -260,7 +260,7 @@ async def register_test_provider(
     hass: HomeAssistant,
 ) -> AsyncGenerator[SomeTestProvider]:
     """Add WebRTC test provider."""
-    await async_setup_component(hass, "camera", {})
+    await async_setup_component(hass, DOMAIN, {})
 
     provider = SomeTestProvider()
     unsub = camera.async_register_webrtc_provider(hass, provider)

--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -329,7 +329,7 @@ async def test_websocket_stream_no_source(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test camera/stream websocket command with camera with no source."""
-    await async_setup_component(hass, "camera", {})
+    await async_setup_component(hass, DOMAIN, {})
 
     # Request playlist through WebSocket
     client = await hass_ws_client(hass)
@@ -349,7 +349,7 @@ async def test_websocket_camera_stream(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, mock_create_stream: Mock
 ) -> None:
     """Test camera/stream websocket command."""
-    await async_setup_component(hass, "camera", {})
+    await async_setup_component(hass, DOMAIN, {})
 
     with patch(
         "homeassistant.components.demo.camera.DemoCamera.stream_source",
@@ -375,7 +375,7 @@ async def test_websocket_get_prefs(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test get camera preferences websocket command."""
-    await async_setup_component(hass, "camera", {})
+    await async_setup_component(hass, DOMAIN, {})
 
     # Request preferences through websocket
     client = await hass_ws_client(hass)
@@ -563,7 +563,7 @@ async def test_no_preload_stream(hass: HomeAssistant, mock_create_stream: Mock) 
         ) as mock_stream_source,
     ):
         mock_stream_source.return_value = io.BytesIO()
-        await async_setup_component(hass, "camera", {DOMAIN: {"platform": "demo"}})
+        await async_setup_component(hass, DOMAIN, {DOMAIN: {"platform": "demo"}})
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
         assert not mock_create_stream.endpoint_url.called
@@ -583,9 +583,7 @@ async def test_preload_stream(hass: HomeAssistant, mock_create_stream: Mock) -> 
             return_value="http://example.com",
         ),
     ):
-        assert await async_setup_component(
-            hass, "camera", {DOMAIN: {"platform": "demo"}}
-        )
+        assert await async_setup_component(hass, DOMAIN, {DOMAIN: {"platform": "demo"}})
         await hass.async_block_till_done()
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
@@ -706,7 +704,7 @@ async def test_stream_unavailable(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, mock_create_stream: Mock
 ) -> None:
     """Camera state."""
-    await async_setup_component(hass, "camera", {})
+    await async_setup_component(hass, DOMAIN, {})
 
     with patch(
         "homeassistant.components.demo.camera.DemoCamera.stream_source",
@@ -799,7 +797,7 @@ async def test_use_stream_for_stills(
 @pytest.mark.usefixtures("mock_camera")
 async def test_entity_picture_url_changes_on_token_update(hass: HomeAssistant) -> None:
     """Test the token is rotated and entity entity picture cache is cleared."""
-    await async_setup_component(hass, "camera", {})
+    await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     camera_state = hass.states.get("camera.demo_camera")
@@ -858,7 +856,7 @@ async def _test_capabilities(
     expected_stream_types_with_webrtc_provider: set[StreamType],
 ) -> None:
     """Test camera capabilities."""
-    await async_setup_component(hass, "camera", {})
+    await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     async def test(expected_types: set[StreamType]) -> None:
@@ -976,7 +974,7 @@ async def test_snapshot_service_webrtc_provider(
     hass: HomeAssistant,
 ) -> None:
     """Test snapshot service with the webrtc provider."""
-    await async_setup_component(hass, "camera", {})
+    await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
     unsub = await _register_test_webrtc_provider(hass)
     camera_obj = get_camera_from_entity_id(hass, "camera.demo_camera")

--- a/tests/components/camera/test_webrtc.py
+++ b/tests/components/camera/test_webrtc.py
@@ -8,6 +8,7 @@ import pytest
 from webrtc_models import RTCIceCandidate, RTCIceCandidateInit, RTCIceServer
 
 from homeassistant.components.camera import (
+    DOMAIN,
     Camera,
     CameraWebRTCProvider,
     StreamType,
@@ -105,7 +106,7 @@ async def test_ws_get_client_config(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test get WebRTC client config."""
-    await async_setup_component(hass, "camera", {})
+    await async_setup_component(hass, DOMAIN, {})
 
     client = await hass_ws_client(hass)
     await client.send_json_auto_id(
@@ -178,7 +179,7 @@ async def test_ws_get_client_config_custom_config(
         {"webrtc": {"ice_servers": [{"url": "stun:custom_stun_server:3478"}]}},
     )
 
-    await async_setup_component(hass, "camera", {})
+    await async_setup_component(hass, DOMAIN, {})
 
     client = await hass_ws_client(hass)
     await client.send_json_auto_id(
@@ -199,7 +200,7 @@ async def test_ws_get_client_config_no_rtc_camera(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test get WebRTC client config."""
-    await async_setup_component(hass, "camera", {})
+    await async_setup_component(hass, DOMAIN, {})
 
     client = await hass_ws_client(hass)
     await client.send_json_auto_id(
@@ -389,7 +390,7 @@ async def test_websocket_webrtc_offer_invalid_entity(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test WebRTC with a camera entity that does not exist."""
-    await async_setup_component(hass, "camera", {})
+    await async_setup_component(hass, DOMAIN, {})
     client = await hass_ws_client(hass)
     await client.send_json_auto_id(
         {
@@ -619,7 +620,7 @@ async def test_ws_webrtc_candidate_invalid_entity(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test ws WebRTC candidate command with a camera entity that does not exist."""
-    await async_setup_component(hass, "camera", {})
+    await async_setup_component(hass, DOMAIN, {})
     client = await hass_ws_client(hass)
     await client.send_json_auto_id(
         {

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -2108,7 +2108,7 @@ async def test_disconnect_on_stop(hass: HomeAssistant) -> None:
 
 async def test_entry_setup_no_config(hass: HomeAssistant) -> None:
     """Test deprecated empty yaml config.."""
-    await async_setup_component(hass, "cast", {})
+    await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     assert not hass.config_entries.async_entries("cast")

--- a/tests/components/cloud/test_binary_sensor.py
+++ b/tests/components/cloud/test_binary_sensor.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 from hass_nabucasa.const import DISPATCH_REMOTE_CONNECT, DISPATCH_REMOTE_DISCONNECT
 import pytest
 
+from homeassistant.components.cloud import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.setup import async_setup_component
@@ -27,7 +28,7 @@ async def test_remote_connection_sensor(
     entity_id = "binary_sensor.remote_ui"
     cloud.remote.certificate = None
 
-    assert await async_setup_component(hass, "cloud", {"cloud": {}})
+    assert await async_setup_component(hass, DOMAIN, {"cloud": {}})
     await hass.async_block_till_done()
 
     assert hass.states.get(entity_id) is None

--- a/tests/components/cloud/test_client.py
+++ b/tests/components/cloud/test_client.py
@@ -167,7 +167,7 @@ async def test_handler_google_actions_disabled(
     mock_cloud_fixture._prefs[PREF_ENABLE_GOOGLE] = False
 
     with patch("hass_nabucasa.Cloud.initialize"):
-        assert await async_setup_component(hass, "cloud", {})
+        assert await async_setup_component(hass, DOMAIN, {})
 
     reqid = "5711642932632160983"
     data = {"requestId": reqid, "inputs": [{"intent": intent}]}
@@ -189,7 +189,7 @@ async def test_handler_ice_servers(
     set_cloud_prefs: Callable[[dict[str, Any]], Coroutine[Any, Any, None]],
 ) -> None:
     """Test handler ICE servers."""
-    assert await async_setup_component(hass, "cloud", {"cloud": {}})
+    assert await async_setup_component(hass, DOMAIN, {"cloud": {}})
     await hass.async_block_till_done()
     # make sure that preferences will not be reset
     await cloud.client.prefs.async_set_username(cloud.username)
@@ -213,7 +213,7 @@ async def test_handler_ice_servers_disabled(
     set_cloud_prefs: Callable[[dict[str, Any]], Coroutine[Any, Any, None]],
 ) -> None:
     """Test handler ICE servers when user has disabled it."""
-    assert await async_setup_component(hass, "cloud", {"cloud": {}})
+    assert await async_setup_component(hass, DOMAIN, {"cloud": {}})
     await hass.async_block_till_done()
     # make sure that preferences will not be reset
     await cloud.client.prefs.async_set_username(cloud.username)
@@ -241,7 +241,7 @@ async def test_webhook_msg(
 ) -> None:
     """Test webhook msg."""
     with patch("hass_nabucasa.Cloud.initialize"):
-        setup = await async_setup_component(hass, "cloud", {"cloud": {}})
+        setup = await async_setup_component(hass, DOMAIN, {"cloud": {}})
         assert setup
     cloud = hass.data[DATA_CLOUD]
 
@@ -318,7 +318,7 @@ async def test_webhook_msg(
 async def test_webhook_msg_local_only(hass: HomeAssistant) -> None:
     """Test a cloudhook for a local_only webhook does not fire the handler."""
     with patch("hass_nabucasa.Cloud.initialize"):
-        setup = await async_setup_component(hass, "cloud", {"cloud": {}})
+        setup = await async_setup_component(hass, DOMAIN, {"cloud": {}})
         assert setup
     cloud = hass.data[DATA_CLOUD]
 
@@ -453,7 +453,7 @@ async def test_login_recovers_bad_internet(
 async def test_system_msg(hass: HomeAssistant) -> None:
     """Test system msg."""
     with patch("hass_nabucasa.Cloud.initialize"):
-        setup = await async_setup_component(hass, "cloud", {"cloud": {}})
+        setup = await async_setup_component(hass, DOMAIN, {"cloud": {}})
         assert setup
     cloud = hass.data[DATA_CLOUD]
 
@@ -476,7 +476,7 @@ async def test_cloud_connection_info(hass: HomeAssistant) -> None:
         patch("uuid.UUID.hex", new_callable=PropertyMock) as hexmock,
     ):
         hexmock.return_value = "12345678901234567890"
-        setup = await async_setup_component(hass, "cloud", {"cloud": {}})
+        setup = await async_setup_component(hass, DOMAIN, {"cloud": {}})
         assert setup
     cloud = hass.data[DATA_CLOUD]
 
@@ -598,7 +598,7 @@ async def test_logged_out(
 ) -> None:
     """Test cleanup when logged out from the cloud."""
 
-    assert await async_setup_component(hass, "cloud", {"cloud": {}})
+    assert await async_setup_component(hass, DOMAIN, {"cloud": {}})
     await hass.async_block_till_done()
     await cloud.login("test-user", "test-pass")
 

--- a/tests/components/cloud/test_init.py
+++ b/tests/components/cloud/test_init.py
@@ -35,7 +35,7 @@ async def test_constructor_loads_info_from_config(hass: HomeAssistant) -> None:
     with patch("hass_nabucasa.Cloud.initialize"):
         result = await async_setup_component(
             hass,
-            "cloud",
+            DOMAIN,
             {
                 "http": {},
                 "cloud": {
@@ -138,7 +138,7 @@ async def test_setup_existing_cloud_user(
     with patch("hass_nabucasa.Cloud.initialize"):
         result = await async_setup_component(
             hass,
-            "cloud",
+            DOMAIN,
             {
                 "http": {},
                 "cloud": {
@@ -248,7 +248,7 @@ async def test_async_get_or_create_cloudhook(
     set_cloud_prefs: Callable[[dict[str, Any]], Coroutine[Any, Any, None]],
 ) -> None:
     """Test async_get_or_create_cloudhook."""
-    assert await async_setup_component(hass, "cloud", {"cloud": {}})
+    assert await async_setup_component(hass, DOMAIN, {"cloud": {}})
     await hass.async_block_till_done()
     await cloud.login("test-user", "test-pass")
 
@@ -318,7 +318,7 @@ async def test_async_listen_cloudhook_change(
     set_cloud_prefs: Callable[[dict[str, Any]], Coroutine[Any, Any, None]],
 ) -> None:
     """Test async_listen_cloudhook_change."""
-    assert await async_setup_component(hass, "cloud", {"cloud": {}})
+    assert await async_setup_component(hass, DOMAIN, {"cloud": {}})
     await hass.async_block_till_done()
     await cloud.login("test-user", "test-pass")
 
@@ -430,7 +430,7 @@ async def test_async_listen_cloudhook_change_cloud_setup_later(
     assert len(changes) == 0
 
     # Now set up cloud
-    assert await async_setup_component(hass, "cloud", {"cloud": {}})
+    assert await async_setup_component(hass, DOMAIN, {"cloud": {}})
     await hass.async_block_till_done()
     await cloud.login("test-user", "test-pass")
 

--- a/tests/components/config/test_automation.py
+++ b/tests/components/config/test_automation.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components import config
-from homeassistant.components.config import automation
+from homeassistant.components.config import DOMAIN, automation
 from homeassistant.const import STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -38,7 +38,7 @@ async def test_get_automation_config(
 ) -> None:
     """Test getting automation config."""
     with patch.object(config, "SECTIONS", [automation]):
-        await async_setup_component(hass, "config", {})
+        await async_setup_component(hass, DOMAIN, {})
 
     client = await hass_client()
 
@@ -61,7 +61,7 @@ async def test_update_automation_config(
 ) -> None:
     """Test updating automation config."""
     with patch.object(config, "SECTIONS", [automation]):
-        await async_setup_component(hass, "config", {})
+        await async_setup_component(hass, DOMAIN, {})
 
     assert sorted(hass.states.async_entity_ids("automation")) == []
 
@@ -153,7 +153,7 @@ async def test_update_automation_config_with_error(
 ) -> None:
     """Test updating automation config with errors."""
     with patch.object(config, "SECTIONS", [automation]):
-        await async_setup_component(hass, "config", {})
+        await async_setup_component(hass, DOMAIN, {})
 
     assert sorted(hass.states.async_entity_ids("automation")) == []
 
@@ -206,7 +206,7 @@ async def test_update_automation_config_with_blueprint_substitution_error(
 ) -> None:
     """Test updating automation config with errors."""
     with patch.object(config, "SECTIONS", [automation]):
-        await async_setup_component(hass, "config", {})
+        await async_setup_component(hass, DOMAIN, {})
 
     assert sorted(hass.states.async_entity_ids("automation")) == []
 
@@ -242,7 +242,7 @@ async def test_update_remove_key_automation_config(
 ) -> None:
     """Test updating automation config while removing a key."""
     with patch.object(config, "SECTIONS", [automation]):
-        await async_setup_component(hass, "config", {})
+        await async_setup_component(hass, DOMAIN, {})
 
     assert sorted(hass.states.async_entity_ids("automation")) == []
 
@@ -284,7 +284,7 @@ async def test_bad_formatted_automations(
 ) -> None:
     """Test that we handle automations without ID."""
     with patch.object(config, "SECTIONS", [automation]):
-        await async_setup_component(hass, "config", {})
+        await async_setup_component(hass, DOMAIN, {})
 
     assert sorted(hass.states.async_entity_ids("automation")) == []
 
@@ -353,7 +353,7 @@ async def test_delete_automation(
     assert len(entity_registry.entities) == 2
 
     with patch.object(config, "SECTIONS", [automation]):
-        assert await async_setup_component(hass, "config", {})
+        assert await async_setup_component(hass, DOMAIN, {})
 
     assert sorted(hass.states.async_entity_ids("automation")) == [
         "automation.automation_0",
@@ -391,7 +391,7 @@ async def test_api_calls_require_admin(
 ) -> None:
     """Test cloud APIs endpoints do not work as a normal user."""
     with patch.object(config, "SECTIONS", [automation]):
-        await async_setup_component(hass, "config", {})
+        await async_setup_component(hass, DOMAIN, {})
 
     hass_config_store["automations.yaml"] = [{"id": "sun"}, {"id": "moon"}]
 

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -12,7 +12,7 @@ from pytest_unordered import unordered
 import voluptuous as vol
 
 from homeassistant import config_entries as core_ce, data_entry_flow, loader
-from homeassistant.components.config import config_entries
+from homeassistant.components.config import DOMAIN, config_entries
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_RADIUS
 from homeassistant.core import HomeAssistant, callback
@@ -735,7 +735,7 @@ async def test_get_progress_index(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test querying for the flows that are in progress."""
-    assert await async_setup_component(hass, "config", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     mock_platform(hass, "test.config_flow", None)
     ws_client = await hass_ws_client(hass)
 
@@ -806,7 +806,7 @@ async def test_get_progress_index_unauth(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_admin_user: MockUser
 ) -> None:
     """Test we can't get flows that are in progress."""
-    assert await async_setup_component(hass, "config", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     hass_admin_user.groups = []
     ws_client = await hass_ws_client(hass)
 
@@ -890,7 +890,7 @@ async def test_get_progress_subscribe(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test querying for the flows that are in progress."""
-    assert await async_setup_component(hass, "config", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     mock_platform(hass, "test.config_flow", None)
     ws_client = await hass_ws_client(hass)
 
@@ -1003,7 +1003,7 @@ async def test_get_progress_subscribe(
 
 async def test_get_progress_subscribe_create_entry(hass: HomeAssistant) -> None:
     """Test flows creating entry immediately don't trigger subscription notification."""
-    assert await async_setup_component(hass, "config", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     mock_platform(hass, "test.config_flow", None)
 
     mock_integration(
@@ -1035,7 +1035,7 @@ async def test_get_progress_subscribe_in_progress(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test querying for the flows that are in progress."""
-    assert await async_setup_component(hass, "config", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     mock_platform(hass, "test.config_flow", None)
     ws_client = await hass_ws_client(hass)
 
@@ -1157,7 +1157,7 @@ async def test_get_progress_subscribe_in_progress_bad_flow(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test querying for the flows that are in progress."""
-    assert await async_setup_component(hass, "config", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     mock_platform(hass, "test.config_flow", None)
     mock_platform(hass, "test2.config_flow", None)
     ws_client = await hass_ws_client(hass)
@@ -1283,7 +1283,7 @@ async def test_get_progress_subscribe_unauth(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_admin_user: MockUser
 ) -> None:
     """Test we can't subscribe to flows."""
-    assert await async_setup_component(hass, "config", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     hass_admin_user.groups = []
     ws_client = await hass_ws_client(hass)
 
@@ -2023,7 +2023,7 @@ async def test_get_single(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test that we can get a config entry."""
-    assert await async_setup_component(hass, "config", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     ws_client = await hass_ws_client(hass)
 
     entry = MockConfigEntry(domain="test", state=core_ce.ConfigEntryState.LOADED)
@@ -2082,7 +2082,7 @@ async def test_update_prefrences(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test that we can update system options."""
-    assert await async_setup_component(hass, "config", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     ws_client = await hass_ws_client(hass)
 
     entry = MockConfigEntry(domain="test", state=core_ce.ConfigEntryState.LOADED)
@@ -2134,7 +2134,7 @@ async def test_update_entry(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test that we can update entry."""
-    assert await async_setup_component(hass, "config", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     ws_client = await hass_ws_client(hass)
 
     entry = MockConfigEntry(domain="demo", title="Initial Title")
@@ -2159,7 +2159,7 @@ async def test_update_entry_nonexisting(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test that we can update entry."""
-    assert await async_setup_component(hass, "config", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     ws_client = await hass_ws_client(hass)
 
     await ws_client.send_json(
@@ -2180,7 +2180,7 @@ async def test_disable_entry(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test that we can disable entry."""
-    assert await async_setup_component(hass, "config", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     ws_client = await hass_ws_client(hass)
 
     entry = MockConfigEntry(domain="test", state=core_ce.ConfigEntryState.LOADED)
@@ -2241,7 +2241,7 @@ async def test_disable_entry_nonexisting(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test that we can disable entry."""
-    assert await async_setup_component(hass, "config", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     ws_client = await hass_ws_client(hass)
 
     await ws_client.send_json(
@@ -2281,7 +2281,7 @@ async def test_ignore_flow(
     entry_discovery_keys: dict[str, tuple[DiscoveryKey, ...]],
 ) -> None:
     """Test we can ignore a flow."""
-    assert await async_setup_component(hass, "config", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     mock_integration(
         hass, MockModule("test", async_setup_entry=AsyncMock(return_value=True))
     )
@@ -2331,7 +2331,7 @@ async def test_ignore_flow_nonexisting(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test we can ignore a flow."""
-    assert await async_setup_component(hass, "config", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     ws_client = await hass_ws_client(hass)
 
     await ws_client.send_json(
@@ -2353,7 +2353,7 @@ async def test_get_matching_entries_ws(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test get entries with the websocket api."""
-    assert await async_setup_component(hass, "config", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     mock_integration(hass, MockModule("comp1"))
     mock_integration(
         hass, MockModule("comp2", partial_manifest={"integration_type": "helper"})
@@ -2806,7 +2806,7 @@ async def test_subscribe_entries_ws(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test subscribe entries with the websocket api."""
-    assert await async_setup_component(hass, "config", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     mock_integration(hass, MockModule("comp1"))
     mock_integration(
         hass, MockModule("comp2", partial_manifest={"integration_type": "helper"})
@@ -3025,7 +3025,7 @@ async def test_subscribe_entries_ws_filtered(
 ) -> None:
     """Test subscribe entries with the websocket api with a type filter."""
     created = utcnow().timestamp()
-    assert await async_setup_component(hass, "config", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     mock_integration(hass, MockModule("comp1"))
     mock_integration(
         hass, MockModule("comp2", partial_manifest={"integration_type": "helper"})
@@ -3453,7 +3453,7 @@ async def test_list_subentries(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test that we can list subentries."""
-    assert await async_setup_component(hass, "config", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     ws_client = await hass_ws_client(hass)
 
     entry = MockConfigEntry(
@@ -3512,7 +3512,7 @@ async def test_update_subentry(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test that we can update a subentry."""
-    assert await async_setup_component(hass, "config", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     ws_client = await hass_ws_client(hass)
 
     entry = MockConfigEntry(
@@ -3588,7 +3588,7 @@ async def test_delete_subentry(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test that we can delete a subentry."""
-    assert await async_setup_component(hass, "config", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     ws_client = await hass_ws_client(hass)
 
     entry = MockConfigEntry(

--- a/tests/components/config/test_core.py
+++ b/tests/components/config/test_core.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from homeassistant.components import config
-from homeassistant.components.config import core
+from homeassistant.components.config import DOMAIN, core
 from homeassistant.components.websocket_api import TYPE_RESULT
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -27,7 +27,7 @@ async def client(
 ) -> MockHAClientWebSocket:
     """Fixture that can interact with the config manager API."""
     with patch.object(config, "SECTIONS", [core]):
-        assert await async_setup_component(hass, "config", {})
+        assert await async_setup_component(hass, DOMAIN, {})
     return await hass_ws_client(hass)
 
 
@@ -36,7 +36,7 @@ async def test_validate_config_ok(
 ) -> None:
     """Test checking config."""
     with patch.object(config, "SECTIONS", [core]):
-        await async_setup_component(hass, "config", {})
+        await async_setup_component(hass, DOMAIN, {})
 
     client = await hass_client()
 
@@ -99,7 +99,7 @@ async def test_validate_config_requires_admin(
 ) -> None:
     """Test checking configuration does not work as a normal user."""
     with patch.object(config, "SECTIONS", [core]):
-        await async_setup_component(hass, "config", {})
+        await async_setup_component(hass, DOMAIN, {})
 
     client = await hass_client(hass_read_only_access_token)
     resp = await client.post("/api/config/core/check_config")
@@ -195,7 +195,7 @@ async def test_websocket_core_update_not_admin(
     """Test core config fails for non admin."""
     hass_admin_user.groups = []
     with patch.object(config, "SECTIONS", [core]):
-        await async_setup_component(hass, "config", {})
+        await async_setup_component(hass, DOMAIN, {})
 
     client = await hass_ws_client(hass)
     await client.send_json({"id": 6, "type": "config/core/update", "latitude": 23})

--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -6,7 +6,7 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from pytest_unordered import unordered
 
-from homeassistant.components.config import device_registry
+from homeassistant.components.config import DOMAIN, device_registry
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -268,7 +268,7 @@ async def test_remove_config_entry_from_device(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test removing config entry from device."""
-    assert await async_setup_component(hass, "config", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     ws_client = await hass_ws_client(hass)
 
     can_remove = False
@@ -354,7 +354,7 @@ async def test_remove_config_entry_from_device_fails(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test removing config entry from device failing cases."""
-    assert await async_setup_component(hass, "config", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     ws_client = await hass_ws_client(hass)
 
     async def async_remove_config_entry_device(
@@ -474,7 +474,7 @@ async def test_remove_config_entry_from_device_if_integration_remove(
 
     Should not error when the integration removes the entry.
     """
-    assert await async_setup_component(hass, "config", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     ws_client = await hass_ws_client(hass)
 
     can_remove = False

--- a/tests/components/config/test_init.py
+++ b/tests/components/config/test_init.py
@@ -1,10 +1,11 @@
 """Test config init."""
 
+from homeassistant.components.config import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
 async def test_config_setup(hass: HomeAssistant) -> None:
     """Test it sets up hassbian."""
-    await async_setup_component(hass, "config", {})
+    await async_setup_component(hass, DOMAIN, {})
     assert "config" in hass.config.components

--- a/tests/components/config/test_scene.py
+++ b/tests/components/config/test_scene.py
@@ -8,7 +8,7 @@ from unittest.mock import ANY, patch
 import pytest
 
 from homeassistant.components import config
-from homeassistant.components.config import scene
+from homeassistant.components.config import DOMAIN, scene
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -32,7 +32,7 @@ async def test_create_scene(
 ) -> None:
     """Test creating a scene."""
     with patch.object(config, "SECTIONS", [scene]):
-        await async_setup_component(hass, "config", {})
+        await async_setup_component(hass, DOMAIN, {})
 
     assert sorted(hass.states.async_entity_ids("scene")) == []
 
@@ -79,7 +79,7 @@ async def test_update_scene(
 ) -> None:
     """Test updating a scene."""
     with patch.object(config, "SECTIONS", [scene]):
-        await async_setup_component(hass, "config", {})
+        await async_setup_component(hass, DOMAIN, {})
 
     assert sorted(hass.states.async_entity_ids("scene")) == []
 
@@ -127,7 +127,7 @@ async def test_bad_formatted_scene(
 ) -> None:
     """Test that we handle scene without ID."""
     with patch.object(config, "SECTIONS", [scene]):
-        await async_setup_component(hass, "config", {})
+        await async_setup_component(hass, DOMAIN, {})
 
     assert sorted(hass.states.async_entity_ids("scene")) == []
 
@@ -197,7 +197,7 @@ async def test_delete_scene(
     assert len(entity_registry.entities) == 2
 
     with patch.object(config, "SECTIONS", [scene]):
-        assert await async_setup_component(hass, "config", {})
+        assert await async_setup_component(hass, DOMAIN, {})
 
     assert sorted(hass.states.async_entity_ids("scene")) == [
         "scene.light_off",
@@ -237,7 +237,7 @@ async def test_api_calls_require_admin(
 ) -> None:
     """Test scene APIs endpoints do not work as a normal user."""
     with patch.object(config, "SECTIONS", [scene]):
-        await async_setup_component(hass, "config", {})
+        await async_setup_component(hass, DOMAIN, {})
 
     hass_config_store["scenes.yaml"] = [
         {

--- a/tests/components/config/test_script.py
+++ b/tests/components/config/test_script.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components import config
-from homeassistant.components.config import script
+from homeassistant.components.config import DOMAIN, script
 from homeassistant.const import STATE_OFF, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -32,7 +32,7 @@ async def test_get_script_config(
 ) -> None:
     """Test getting script config."""
     with patch.object(config, "SECTIONS", [script]):
-        await async_setup_component(hass, "config", {})
+        await async_setup_component(hass, DOMAIN, {})
 
     client = await hass_client()
 
@@ -57,7 +57,7 @@ async def test_update_script_config(
 ) -> None:
     """Test updating script config."""
     with patch.object(config, "SECTIONS", [script]):
-        await async_setup_component(hass, "config", {})
+        await async_setup_component(hass, DOMAIN, {})
 
     assert sorted(hass.states.async_entity_ids("script")) == []
 
@@ -95,7 +95,7 @@ async def test_invalid_object_id(
 ) -> None:
     """Test creating a script with an invalid object_id."""
     with patch.object(config, "SECTIONS", [script]):
-        await async_setup_component(hass, "config", {})
+        await async_setup_component(hass, DOMAIN, {})
 
     assert sorted(hass.states.async_entity_ids("script")) == []
 
@@ -160,7 +160,7 @@ async def test_update_script_config_with_error(
 ) -> None:
     """Test updating script config with errors."""
     with patch.object(config, "SECTIONS", [script]):
-        await async_setup_component(hass, "config", {})
+        await async_setup_component(hass, DOMAIN, {})
 
     assert sorted(hass.states.async_entity_ids("script")) == []
 
@@ -210,7 +210,7 @@ async def test_update_script_config_with_blueprint_substitution_error(
 ) -> None:
     """Test updating script config with errors."""
     with patch.object(config, "SECTIONS", [script]):
-        await async_setup_component(hass, "config", {})
+        await async_setup_component(hass, DOMAIN, {})
 
     assert sorted(hass.states.async_entity_ids("script")) == []
 
@@ -245,7 +245,7 @@ async def test_update_remove_key_script_config(
 ) -> None:
     """Test updating script config while removing a key."""
     with patch.object(config, "SECTIONS", [script]):
-        await async_setup_component(hass, "config", {})
+        await async_setup_component(hass, DOMAIN, {})
 
     assert sorted(hass.states.async_entity_ids("script")) == []
 
@@ -292,7 +292,7 @@ async def test_delete_script(
 ) -> None:
     """Test deleting a script."""
     with patch.object(config, "SECTIONS", [script]):
-        await async_setup_component(hass, "config", {})
+        await async_setup_component(hass, DOMAIN, {})
 
     assert sorted(hass.states.async_entity_ids("script")) == [
         "script.one",
@@ -331,7 +331,7 @@ async def test_api_calls_require_admin(
 ) -> None:
     """Test script APIs endpoints do not work as a normal user."""
     with patch.object(config, "SECTIONS", [script]):
-        await async_setup_component(hass, "config", {})
+        await async_setup_component(hass, DOMAIN, {})
 
     hass_config_store["scripts.yaml"] = {
         "moon": {"alias": "Moon"},

--- a/tests/components/conversation/conftest.py
+++ b/tests/components/conversation/conftest.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from homeassistant.components import conversation
-from homeassistant.components.conversation import async_get_agent, default_agent
+from homeassistant.components.conversation import DOMAIN, async_get_agent, default_agent
 from homeassistant.components.shopping_list import intent as sl_intent
 from homeassistant.const import MATCH_ALL
 from homeassistant.core import Context, HomeAssistant
@@ -75,7 +75,7 @@ async def sl_setup(hass: HomeAssistant):
 async def init_components(hass: HomeAssistant):
     """Initialize relevant components with empty configs."""
     assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "conversation", {conversation.DOMAIN: {}})
+    assert await async_setup_component(hass, DOMAIN, {conversation.DOMAIN: {}})
 
     # Disable fuzzy matching by default for tests
     agent = async_get_agent(hass)

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -13,6 +13,7 @@ import yaml
 
 from homeassistant.components import conversation, cover, media_player, weather
 from homeassistant.components.conversation import (
+    DOMAIN,
     async_get_agent,
     default_agent,
     get_agent_manager,
@@ -87,7 +88,7 @@ class OrderBeerIntentHandler(intent.IntentHandler):
 async def init_components(hass: HomeAssistant) -> None:
     """Initialize relevant components with empty configs."""
     assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "conversation", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     assert await async_setup_component(hass, "intent", {})
 
 
@@ -266,7 +267,7 @@ async def test_expose_flag_automatically_set(
 
     assert async_get_assistant_settings(hass, conversation.DOMAIN) == {}
 
-    assert await async_setup_component(hass, "conversation", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
     with patch("homeassistant.components.http.start_http_server_and_save_config"):
         await hass.async_start()
@@ -2486,7 +2487,7 @@ async def test_custom_sentences_config(
     assert await async_setup_component(hass, "homeassistant", {})
     assert await async_setup_component(
         hass,
-        "conversation",
+        DOMAIN,
         {"conversation": {"intents": {"StealthMode": ["engage stealth mode"]}}},
     )
     assert await async_setup_component(hass, "intent", {})
@@ -2723,7 +2724,7 @@ async def test_custom_sentences_priority(
         custom_sentences_file.seek(0)
 
         assert await async_setup_component(hass, "homeassistant", {})
-        assert await async_setup_component(hass, "conversation", {})
+        assert await async_setup_component(hass, DOMAIN, {})
         assert await async_setup_component(hass, "light", {})
         assert await async_setup_component(hass, "intent", {})
         assert await async_setup_component(
@@ -2768,7 +2769,7 @@ async def test_config_sentences_priority(
     assert await async_setup_component(hass, "intent", {})
     assert await async_setup_component(
         hass,
-        "conversation",
+        DOMAIN,
         {
             "conversation": {
                 "intents": {

--- a/tests/components/conversation/test_default_agent_intents.py
+++ b/tests/components/conversation/test_default_agent_intents.py
@@ -14,6 +14,7 @@ from homeassistant.components import (
     vacuum,
     valve,
 )
+from homeassistant.components.conversation import DOMAIN
 from homeassistant.components.cover import intent as cover_intent
 from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
 from homeassistant.components.media_player import (
@@ -65,7 +66,7 @@ class MockTodoListEntity(todo.TodoListEntity):
 async def init_components(hass: HomeAssistant):
     """Initialize relevant components with empty configs."""
     assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "conversation", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     assert await async_setup_component(hass, "intent", {})
 
 

--- a/tests/components/conversation/test_entity.py
+++ b/tests/components/conversation/test_entity.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 from homeassistant.components import conversation
+from homeassistant.components.conversation import DOMAIN
 from homeassistant.core import Context, HomeAssistant, State
 from homeassistant.helpers import intent
 from homeassistant.setup import async_setup_component
@@ -18,7 +19,7 @@ async def test_state_set_and_restore(hass: HomeAssistant) -> None:
     mock_restore_cache(hass, (State(entity_id, timestamp),))
 
     await async_setup_component(hass, "homeassistant", {})
-    await async_setup_component(hass, "conversation", {})
+    await async_setup_component(hass, DOMAIN, {})
 
     state = hass.states.get(entity_id)
     assert state

--- a/tests/components/conversation/test_init.py
+++ b/tests/components/conversation/test_init.py
@@ -9,6 +9,7 @@ import voluptuous as vol
 
 from homeassistant.components import conversation
 from homeassistant.components.conversation import (
+    DOMAIN,
     ConversationInput,
     async_get_agent,
     async_get_chat_log,
@@ -269,7 +270,7 @@ async def test_async_handle_sentence_triggers(
 ) -> None:
     """Test handling sentence triggers with async_handle_sentence_triggers."""
     assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "conversation", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     assert await async_setup_component(
         hass,
@@ -311,7 +312,7 @@ async def test_async_handle_sentence_triggers(
 async def test_async_handle_intents(hass: HomeAssistant) -> None:
     """Test handling registered intents with async_handle_intents."""
     assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "conversation", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     # Reuse custom sentences in test config to trigger default agent.
     class OrderBeerIntentHandler(intent.IntentHandler):

--- a/tests/components/conversation/test_trace.py
+++ b/tests/components/conversation/test_trace.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components import conversation
-from homeassistant.components.conversation import trace
+from homeassistant.components.conversation import DOMAIN, trace
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
@@ -15,7 +15,7 @@ from homeassistant.setup import async_setup_component
 async def init_components(hass: HomeAssistant):
     """Initialize relevant components with empty configs."""
     assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "conversation", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     assert await async_setup_component(hass, "intent", {})
 
 

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -10,6 +10,7 @@ import voluptuous as vol
 from homeassistant import loader
 from homeassistant.components import automation, device_automation
 from homeassistant.components.device_automation import (
+    DOMAIN,
     InvalidDeviceAutomationConfig,
     toggle_entity,
 )
@@ -107,7 +108,7 @@ async def test_websocket_get_actions(
     fake_integration,
 ) -> None:
     """Test we get the expected actions through websocket."""
-    await async_setup_component(hass, "device_automation", {})
+    await async_setup_component(hass, DOMAIN, {})
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
     device_entry = device_registry.async_get_or_create(
@@ -162,7 +163,7 @@ async def test_websocket_get_conditions(
     fake_integration,
 ) -> None:
     """Test we get the expected conditions through websocket."""
-    await async_setup_component(hass, "device_automation", {})
+    await async_setup_component(hass, DOMAIN, {})
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
     device_entry = device_registry.async_get_or_create(
@@ -216,7 +217,7 @@ async def test_websocket_get_triggers(
     fake_integration,
 ) -> None:
     """Test we get the expected triggers through websocket."""
-    await async_setup_component(hass, "device_automation", {})
+    await async_setup_component(hass, DOMAIN, {})
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
     device_entry = device_registry.async_get_or_create(
@@ -278,7 +279,7 @@ async def test_websocket_get_action_capabilities(
     fake_integration,
 ) -> None:
     """Test we get the expected action capabilities through websocket."""
-    await async_setup_component(hass, "device_automation", {})
+    await async_setup_component(hass, DOMAIN, {})
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
     device_entry = device_registry.async_get_or_create(
@@ -347,7 +348,7 @@ async def test_websocket_get_action_capabilities_unknown_domain(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test we get no action capabilities for a non existing domain."""
-    await async_setup_component(hass, "device_automation", {})
+    await async_setup_component(hass, DOMAIN, {})
     expected_capabilities = {}
 
     client = await hass_ws_client(hass)
@@ -378,7 +379,7 @@ async def test_websocket_get_action_capabilities_no_capabilities(
     The tests tests a domain which has a device action platform, but no
     async_get_action_capabilities.
     """
-    await async_setup_component(hass, "device_automation", {})
+    await async_setup_component(hass, DOMAIN, {})
     expected_capabilities = {}
 
     client = await hass_ws_client(hass)
@@ -405,7 +406,7 @@ async def test_websocket_get_action_capabilities_bad_action(
     fake_integration,
 ) -> None:
     """Test we get no action capabilities when there is an error."""
-    await async_setup_component(hass, "device_automation", {})
+    await async_setup_component(hass, DOMAIN, {})
     expected_capabilities = {}
 
     module_cache = hass.data[loader.DATA_COMPONENTS]
@@ -439,7 +440,7 @@ async def test_websocket_get_condition_capabilities(
     fake_integration,
 ) -> None:
     """Test we get the expected condition capabilities through websocket."""
-    await async_setup_component(hass, "device_automation", {})
+    await async_setup_component(hass, DOMAIN, {})
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
     device_entry = device_registry.async_get_or_create(
@@ -511,7 +512,7 @@ async def test_websocket_get_condition_capabilities_unknown_domain(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test we get no condition capabilities for a non existing domain."""
-    await async_setup_component(hass, "device_automation", {})
+    await async_setup_component(hass, DOMAIN, {})
     expected_capabilities = {}
 
     client = await hass_ws_client(hass)
@@ -542,7 +543,7 @@ async def test_websocket_get_condition_capabilities_no_capabilities(
     The tests tests a domain which has a device condition platform, but no
     async_get_condition_capabilities.
     """
-    await async_setup_component(hass, "device_automation", {})
+    await async_setup_component(hass, DOMAIN, {})
     expected_capabilities = {}
 
     client = await hass_ws_client(hass)
@@ -573,7 +574,7 @@ async def test_websocket_get_condition_capabilities_bad_condition(
     fake_integration,
 ) -> None:
     """Test we get no condition capabilities when there is an error."""
-    await async_setup_component(hass, "device_automation", {})
+    await async_setup_component(hass, DOMAIN, {})
     expected_capabilities = {}
 
     module_cache = hass.data[loader.DATA_COMPONENTS]
@@ -609,7 +610,7 @@ async def test_async_get_device_automations_single_device_trigger(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test we get can fetch the triggers for a device id."""
-    await async_setup_component(hass, "device_automation", {})
+    await async_setup_component(hass, DOMAIN, {})
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
     device_entry = device_registry.async_get_or_create(
@@ -632,7 +633,7 @@ async def test_async_get_device_automations_all_devices_trigger(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test we get can fetch all the triggers when no device id is passed."""
-    await async_setup_component(hass, "device_automation", {})
+    await async_setup_component(hass, DOMAIN, {})
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
     device_entry = device_registry.async_get_or_create(
@@ -655,7 +656,7 @@ async def test_async_get_device_automations_all_devices_condition(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test we get can fetch all the conditions when no device id is passed."""
-    await async_setup_component(hass, "device_automation", {})
+    await async_setup_component(hass, DOMAIN, {})
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
     device_entry = device_registry.async_get_or_create(
@@ -678,7 +679,7 @@ async def test_async_get_device_automations_all_devices_action(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test we get can fetch all the actions when no device id is passed."""
-    await async_setup_component(hass, "device_automation", {})
+    await async_setup_component(hass, DOMAIN, {})
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
     device_entry = device_registry.async_get_or_create(
@@ -702,7 +703,7 @@ async def test_async_get_device_automations_all_devices_action_exception_throw(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test we can fetch all actions with no device id and handle exceptions."""
-    await async_setup_component(hass, "device_automation", {})
+    await async_setup_component(hass, DOMAIN, {})
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
     device_entry = device_registry.async_get_or_create(
@@ -737,7 +738,7 @@ async def test_websocket_get_trigger_capabilities(
     trigger_key: str,
 ) -> None:
     """Test we get the expected trigger capabilities through websocket."""
-    await async_setup_component(hass, "device_automation", {})
+    await async_setup_component(hass, DOMAIN, {})
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
     device_entry = device_registry.async_get_or_create(
@@ -810,7 +811,7 @@ async def test_websocket_get_trigger_capabilities_unknown_domain(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test we get no trigger capabilities for a non existing domain."""
-    await async_setup_component(hass, "device_automation", {})
+    await async_setup_component(hass, DOMAIN, {})
     expected_capabilities = {}
 
     client = await hass_ws_client(hass)
@@ -841,7 +842,7 @@ async def test_websocket_get_trigger_capabilities_no_capabilities(
     The tests tests a domain which has a device trigger platform, but no
     async_get_trigger_capabilities.
     """
-    await async_setup_component(hass, "device_automation", {})
+    await async_setup_component(hass, DOMAIN, {})
     expected_capabilities = {}
 
     client = await hass_ws_client(hass)
@@ -872,7 +873,7 @@ async def test_websocket_get_trigger_capabilities_bad_trigger(
     fake_integration,
 ) -> None:
     """Test we get no trigger capabilities when there is an error."""
-    await async_setup_component(hass, "device_automation", {})
+    await async_setup_component(hass, DOMAIN, {})
     expected_capabilities = {}
 
     module_cache = hass.data[loader.DATA_COMPONENTS]
@@ -1597,7 +1598,7 @@ async def test_websocket_device_not_found(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test calling command with unknown device."""
-    await async_setup_component(hass, "device_automation", {})
+    await async_setup_component(hass, DOMAIN, {})
     client = await hass_ws_client(hass)
     await client.send_json(
         {"id": 1, "type": "device_automation/action/list", "device_id": "non-existing"}
@@ -1733,7 +1734,7 @@ async def test_async_get_device_automations_platform_reraises_exceptions(
     hass: HomeAssistant, exc: Exception
 ) -> None:
     """Test InvalidDeviceAutomationConfig is raised when get_integration fails."""
-    await async_setup_component(hass, "device_automation", {})
+    await async_setup_component(hass, DOMAIN, {})
     with (
         patch(
             "homeassistant.components.device_automation.async_get_integration_with_requirements",

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -9,6 +9,7 @@ import pytest
 
 from homeassistant.components import device_tracker, zone
 from homeassistant.components.device_tracker import (
+    DOMAIN,
     SourceType,
     TrackerEntity,
     const,
@@ -794,7 +795,7 @@ async def test_modern_platform_setup(hass: HomeAssistant) -> None:
     )
 
     await async_setup_component(hass, "homeassistant", {})
-    await async_setup_component(hass, "device_tracker", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_setup_component(hass, test_domain, {})
     await hass.async_block_till_done()
 

--- a/tests/components/eafm/test_sensor.py
+++ b/tests/components/eafm/test_sensor.py
@@ -42,7 +42,7 @@ async def async_setup_test_fixture(
     )
     entry.add_to_hass(hass)
 
-    assert await async_setup_component(hass, "eafm", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     assert entry.state is ConfigEntryState.LOADED
     await hass.async_block_till_done()
 

--- a/tests/components/emoncms_history/test_init.py
+++ b/tests/components/emoncms_history/test_init.py
@@ -8,6 +8,7 @@ import aiohttp
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
+from homeassistant.components.emoncms_history import DOMAIN
 from homeassistant.const import CONF_API_KEY, CONF_URL, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -27,14 +28,14 @@ async def test_setup_valid_config(hass: HomeAssistant) -> None:
     hass.states.async_set("sensor.temp", "23.4", {"unit_of_measurement": "°C"})
     await hass.async_block_till_done()
 
-    assert await async_setup_component(hass, "emoncms_history", config)
+    assert await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
 
 
 async def test_setup_missing_config(hass: HomeAssistant) -> None:
     """Test setting up the emoncms_history component with missing configuration."""
     config = {"emoncms_history": {"api_key": "dummy"}}
-    success = await async_setup_component(hass, "emoncms_history", config)
+    success = await async_setup_component(hass, DOMAIN, config)
     assert not success
 
 
@@ -66,7 +67,7 @@ async def test_emoncms_send_data(
         }
     }
 
-    assert await async_setup_component(hass, "emoncms_history", config)
+    assert await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
 
     for state in None, "", STATE_UNAVAILABLE, STATE_UNKNOWN:

--- a/tests/components/emulated_hue/test_init.py
+++ b/tests/components/emulated_hue/test_init.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 from aiohttp import web
 
+from homeassistant.components.emulated_hue import DOMAIN
 from homeassistant.components.emulated_hue.config import (
     DATA_KEY,
     DATA_VERSION,
@@ -147,7 +148,7 @@ async def test_setup_works(hass: HomeAssistant) -> None:
         mock_create_upnp_datagram_endpoint.return_value = AsyncMock(
             spec=UPNPResponderProtocol
         )
-        assert await async_setup_component(hass, "emulated_hue", {})
+        assert await async_setup_component(hass, DOMAIN, {})
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 

--- a/tests/components/energy/conftest.py
+++ b/tests/components/energy/conftest.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.energy import async_get_manager
+from homeassistant.components.energy import DOMAIN, async_get_manager
 from homeassistant.components.energy.data import EnergyManager
 from homeassistant.components.recorder import Recorder
 from homeassistant.core import HomeAssistant
@@ -50,7 +50,7 @@ async def mock_energy_manager(
     recorder_mock: Recorder, hass: HomeAssistant
 ) -> EnergyManager:
     """Set up energy."""
-    assert await async_setup_component(hass, "energy", {"energy": {}})
+    assert await async_setup_component(hass, DOMAIN, {"energy": {}})
     manager = await async_get_manager(hass)
     manager.data = manager.default_preferences()
     return manager

--- a/tests/components/energy/test_sensor.py
+++ b/tests/components/energy/test_sensor.py
@@ -8,7 +8,7 @@ from typing import Any
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
-from homeassistant.components.energy import async_get_manager, data
+from homeassistant.components.energy import DOMAIN, async_get_manager, data
 from homeassistant.components.energy.sensor import (
     EnergyCostSensor,
     EnergyPowerSensor,
@@ -55,7 +55,7 @@ async def setup_integration(
     """Set up the integration."""
 
     async def setup_integration(hass: HomeAssistant) -> None:
-        assert await async_setup_component(hass, "energy", {})
+        assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
     return setup_integration
@@ -1394,7 +1394,7 @@ async def test_power_sensor_manager_creation(
     recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
     """Test SensorManager creates power sensors correctly."""
-    assert await async_setup_component(hass, "energy", {"energy": {}})
+    assert await async_setup_component(hass, DOMAIN, {"energy": {}})
     manager = await async_get_manager(hass)
     manager.data = manager.default_preferences()
 
@@ -1434,7 +1434,7 @@ async def test_power_sensor_inverted_propagates_unit(
     recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
     """Test inverted power sensor copies unit from the source state."""
-    assert await async_setup_component(hass, "energy", {"energy": {}})
+    assert await async_setup_component(hass, DOMAIN, {"energy": {}})
     manager = await async_get_manager(hass)
     manager.data = manager.default_preferences()
 
@@ -1486,7 +1486,7 @@ async def test_power_sensor_inverted_source_without_unit(
     recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
     """Test inverted sensor reports no unit when source has none."""
-    assert await async_setup_component(hass, "energy", {"energy": {}})
+    assert await async_setup_component(hass, DOMAIN, {"energy": {}})
     manager = await async_get_manager(hass)
     manager.data = manager.default_preferences()
 
@@ -1519,7 +1519,7 @@ async def test_power_sensor_manager_cleanup(
     recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
     """Test SensorManager removes power sensors when config changes."""
-    assert await async_setup_component(hass, "energy", {"energy": {}})
+    assert await async_setup_component(hass, DOMAIN, {"energy": {}})
     manager = await async_get_manager(hass)
     manager.data = manager.default_preferences()
 
@@ -1574,7 +1574,7 @@ async def test_power_sensor_grid_combined(
     recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
     """Test power sensor for grid with combined config."""
-    assert await async_setup_component(hass, "energy", {"energy": {}})
+    assert await async_setup_component(hass, DOMAIN, {"energy": {}})
     manager = await async_get_manager(hass)
     manager.data = manager.default_preferences()
 
@@ -1625,7 +1625,7 @@ async def test_power_sensor_device_assignment(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test power sensor is assigned to same device as source sensor."""
-    assert await async_setup_component(hass, "energy", {"energy": {}})
+    assert await async_setup_component(hass, DOMAIN, {"energy": {}})
     manager = await async_get_manager(hass)
     manager.data = manager.default_preferences()
 
@@ -1687,7 +1687,7 @@ async def test_power_sensor_device_assignment_combined_second_sensor(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test power sensor checks second sensor if first has no device."""
-    assert await async_setup_component(hass, "energy", {"energy": {}})
+    assert await async_setup_component(hass, DOMAIN, {"energy": {}})
     manager = await async_get_manager(hass)
     manager.data = manager.default_preferences()
 
@@ -1762,7 +1762,7 @@ async def test_power_sensor_inverted_availability(
     recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
     """Test inverted power sensor availability follows source sensor."""
-    assert await async_setup_component(hass, "energy", {"energy": {}})
+    assert await async_setup_component(hass, DOMAIN, {"energy": {}})
     manager = await async_get_manager(hass)
     manager.data = manager.default_preferences()
 
@@ -1815,7 +1815,7 @@ async def test_power_sensor_combined_availability(
     recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
     """Test combined power sensor availability requires both sources available."""
-    assert await async_setup_component(hass, "energy", {"energy": {}})
+    assert await async_setup_component(hass, DOMAIN, {"energy": {}})
     manager = await async_get_manager(hass)
     manager.data = manager.default_preferences()
 
@@ -1887,7 +1887,7 @@ async def test_power_sensor_battery_combined(
     recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
     """Test power sensor for battery with combined config."""
-    assert await async_setup_component(hass, "energy", {"energy": {}})
+    assert await async_setup_component(hass, DOMAIN, {"energy": {}})
     manager = await async_get_manager(hass)
     manager.data = manager.default_preferences()
 
@@ -1947,7 +1947,7 @@ async def test_power_sensor_combined_unit_conversion(
     recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
     """Test power sensor combined mode with different units."""
-    assert await async_setup_component(hass, "energy", {"energy": {}})
+    assert await async_setup_component(hass, DOMAIN, {"energy": {}})
     manager = await async_get_manager(hass)
     manager.data = manager.default_preferences()
 
@@ -1996,7 +1996,7 @@ async def test_power_sensor_inverted_negative_values(
     recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
     """Test inverted power sensor with negative source values."""
-    assert await async_setup_component(hass, "energy", {"energy": {}})
+    assert await async_setup_component(hass, DOMAIN, {"energy": {}})
     manager = await async_get_manager(hass)
     manager.data = manager.default_preferences()
 
@@ -2074,7 +2074,7 @@ async def test_energy_data_removal(
         },
     )
 
-    assert await async_setup_component(hass, "energy", {"energy": {}})
+    assert await async_setup_component(hass, DOMAIN, {"energy": {}})
     await hass.async_block_till_done()
 
     # Verify cost sensor was created
@@ -2331,7 +2331,7 @@ async def test_power_sensor_inverted_invalid_value(
     recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
     """Test inverted power sensor with invalid source value."""
-    assert await async_setup_component(hass, "energy", {"energy": {}})
+    assert await async_setup_component(hass, DOMAIN, {"energy": {}})
     manager = await async_get_manager(hass)
     manager.data = manager.default_preferences()
 
@@ -2375,7 +2375,7 @@ async def test_power_sensor_combined_invalid_value(
     recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
     """Test combined power sensor with invalid source value."""
-    assert await async_setup_component(hass, "energy", {"energy": {}})
+    assert await async_setup_component(hass, DOMAIN, {"energy": {}})
     manager = await async_get_manager(hass)
     manager.data = manager.default_preferences()
 
@@ -2447,7 +2447,7 @@ async def test_power_sensor_naming_fallback(
     recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
     """Test power sensor naming when source not in registry."""
-    assert await async_setup_component(hass, "energy", {"energy": {}})
+    assert await async_setup_component(hass, DOMAIN, {"energy": {}})
     manager = await async_get_manager(hass)
     manager.data = manager.default_preferences()
 
@@ -2485,7 +2485,7 @@ async def test_power_sensor_no_device_assignment(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test power sensor when source sensors have no device."""
-    assert await async_setup_component(hass, "energy", {"energy": {}})
+    assert await async_setup_component(hass, DOMAIN, {"energy": {}})
     manager = await async_get_manager(hass)
     manager.data = manager.default_preferences()
 
@@ -2528,7 +2528,7 @@ async def test_power_sensor_keeps_existing_on_update(
     recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
     """Test that existing power sensor is kept when config doesn't change."""
-    assert await async_setup_component(hass, "energy", {"energy": {}})
+    assert await async_setup_component(hass, DOMAIN, {"energy": {}})
     manager = await async_get_manager(hass)
     manager.data = manager.default_preferences()
 
@@ -2638,7 +2638,7 @@ async def test_power_sensor_naming_with_registry_name(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test power sensor naming uses registry name when available."""
-    assert await async_setup_component(hass, "energy", {"energy": {}})
+    assert await async_setup_component(hass, DOMAIN, {"energy": {}})
     manager = await async_get_manager(hass)
     manager.data = manager.default_preferences()
 

--- a/tests/components/energy/test_websocket_api.py
+++ b/tests/components/energy/test_websocket_api.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from homeassistant.components.energy import data, is_configured
+from homeassistant.components.energy import DOMAIN, data, is_configured
 from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.models import StatisticMeanType
 from homeassistant.components.recorder.statistics import async_add_external_statistics
@@ -24,7 +24,7 @@ from tests.typing import WebSocketGenerator
 @pytest.fixture(autouse=True)
 async def setup_integration(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Set up the integration."""
-    assert await async_setup_component(hass, "energy", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
 
 @pytest.fixture

--- a/tests/components/esphome/test_ffmpeg_proxy.py
+++ b/tests/components/esphome/test_ffmpeg_proxy.py
@@ -16,6 +16,7 @@ import mutagen
 import pytest
 
 from homeassistant.components import esphome
+from homeassistant.components.esphome import DOMAIN
 from homeassistant.components.esphome.ffmpeg_proxy import (
     _MAX_STDERR_LINES,
     async_create_proxy_url,
@@ -53,7 +54,7 @@ def _write_silence(filename: str, length: int) -> None:
 
 async def test_async_create_proxy_url(hass: HomeAssistant) -> None:
     """Test that async_create_proxy_url returns the correct format."""
-    assert await async_setup_component(hass, "esphome", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     device_id = "test-device"
     convert_id = "test-id"

--- a/tests/components/evil_genius_labs/conftest.py
+++ b/tests/components/evil_genius_labs/conftest.py
@@ -74,6 +74,6 @@ async def setup_evil_genius_labs(
             platforms,
         ),
     ):
-        assert await async_setup_component(hass, "evil_genius_labs", {})
+        assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
         yield

--- a/tests/components/fan/test_init.py
+++ b/tests/components/fan/test_init.py
@@ -115,7 +115,7 @@ async def test_preset_mode_validation(
     )
     setup_test_component_platform(hass, "fan", [test_fan])
 
-    assert await async_setup_component(hass, "fan", {"fan": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"fan": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get("fan.support_fan_with_preset_mode_support")

--- a/tests/components/file_upload/test_init.py
+++ b/tests/components/file_upload/test_init.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components import file_upload
+from homeassistant.components.file_upload import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -21,7 +22,7 @@ async def uploaded_file_dir(
     hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> Path:
     """Test uploading and using a file."""
-    assert await async_setup_component(hass, "file_upload", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     client = await hass_client()
 
     with (
@@ -83,7 +84,7 @@ async def test_upload_large_file(
     hass: HomeAssistant, hass_client: ClientSessionGenerator, large_file_io
 ) -> None:
     """Test uploading large file."""
-    assert await async_setup_component(hass, "file_upload", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     client = await hass_client()
 
     with (
@@ -117,7 +118,7 @@ async def test_upload_with_wrong_key_fails(
     hass: HomeAssistant, hass_client: ClientSessionGenerator, large_file_io
 ) -> None:
     """Test uploading fails."""
-    assert await async_setup_component(hass, "file_upload", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     client = await hass_client()
 
     with patch(
@@ -134,7 +135,7 @@ async def test_upload_large_file_fails(
     hass: HomeAssistant, hass_client: ClientSessionGenerator, large_file_io
 ) -> None:
     """Test uploading large file."""
-    assert await async_setup_component(hass, "file_upload", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     client = await hass_client()
 
     @contextmanager

--- a/tests/components/forecast_solar/test_init.py
+++ b/tests/components/forecast_solar/test_init.py
@@ -30,7 +30,7 @@ async def test_load_unload_config_entry(
 ) -> None:
     """Test the Forecast.Solar configuration entry loading/unloading."""
     mock_config_entry.add_to_hass(hass)
-    await async_setup_component(hass, "forecast_solar", {})
+    await async_setup_component(hass, DOMAIN, {})
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
 

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -85,7 +85,7 @@ async def frontend(hass: HomeAssistant, ignore_frontend_deps: None) -> None:
     """Frontend setup with themes."""
     assert await async_setup_component(
         hass,
-        "frontend",
+        DOMAIN,
         {},
     )
 
@@ -95,7 +95,7 @@ async def frontend_themes(hass: HomeAssistant) -> None:
     """Frontend setup with themes."""
     assert await async_setup_component(
         hass,
-        "frontend",
+        DOMAIN,
         CONFIG_THEMES,
     )
 
@@ -142,7 +142,7 @@ async def mock_http_client_with_extra_js(
     """Start the Home Assistant HTTP component."""
     assert await async_setup_component(
         hass,
-        "frontend",
+        DOMAIN,
         {
             DOMAIN: {
                 CONF_EXTRA_MODULE_URL: ["/local/my_module.js"],
@@ -247,7 +247,7 @@ async def test_themes_persist(
         },
     }
 
-    assert await async_setup_component(hass, "frontend", CONFIG_THEMES)
+    assert await async_setup_component(hass, DOMAIN, CONFIG_THEMES)
     themes_ws_client = await hass_ws_client(hass)
 
     await themes_ws_client.send_json({"id": 5, "type": "frontend/get_themes"})
@@ -1117,7 +1117,7 @@ async def test_www_local_dir(
 
     await hass.async_add_executor_job(_create_www_and_x_txt)
 
-    assert await async_setup_component(hass, "frontend", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     client = await hass_client()
     resp = await client.get("/local/x.txt")
     assert resp.status == HTTPStatus.OK
@@ -1338,7 +1338,7 @@ async def test_update_panel_persists(
         },
     }
 
-    assert await async_setup_component(hass, "frontend", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     client = await hass_ws_client(hass)
 
     await client.send_json({"id": 1, "type": "get_panels"})
@@ -1452,7 +1452,7 @@ async def test_panels_config_invalid_storage(
         "data": "not_a_dict",
     }
 
-    assert await async_setup_component(hass, "frontend", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     assert "Ignoring invalid panel storage data" in caplog.text
 
     client = await hass_ws_client(hass)

--- a/tests/components/frontend/test_storage.py
+++ b/tests/components/frontend/test_storage.py
@@ -19,7 +19,7 @@ from tests.typing import WebSocketGenerator
 @pytest.fixture(autouse=True)
 async def setup_frontend(hass: HomeAssistant) -> None:
     """Fixture to setup the frontend."""
-    await async_setup_component(hass, "frontend", {})
+    await async_setup_component(hass, DOMAIN, {})
 
 
 async def test_get_user_data_empty(

--- a/tests/components/google_assistant/test_google_assistant.py
+++ b/tests/components/google_assistant/test_google_assistant.py
@@ -15,6 +15,7 @@ from homeassistant.components import (
     light,
     media_player,
 )
+from homeassistant.components.google_assistant import DOMAIN
 from homeassistant.const import EntityCategory, Platform
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
@@ -44,7 +45,7 @@ async def assistant_client(
     """Create web client for the Google Assistant API."""
     await setup.async_setup_component(
         hass,
-        "google_assistant",
+        DOMAIN,
         {
             "google_assistant": {
                 "project_id": PROJECT_ID,

--- a/tests/components/google_assistant/test_init.py
+++ b/tests/components/google_assistant/test_init.py
@@ -3,6 +3,7 @@
 from http import HTTPStatus
 
 from homeassistant.components import google_assistant as ga
+from homeassistant.components.google_assistant import DOMAIN
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -60,7 +61,7 @@ async def test_request_sync_service(
 
     await async_setup_component(
         hass,
-        "google_assistant",
+        DOMAIN,
         {"google_assistant": DUMMY_CONFIG},
     )
 

--- a/tests/components/google_generative_ai_conversation/conftest.py
+++ b/tests/components/google_generative_ai_conversation/conftest.py
@@ -112,9 +112,7 @@ async def mock_init_component(
 ) -> AsyncGenerator[None]:
     """Initialize integration."""
     with patch("google.genai.models.AsyncModels.get"):
-        assert await async_setup_component(
-            hass, "google_generative_ai_conversation", {}
-        )
+        assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
         yield
 

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components import group
+from homeassistant.components.group import DOMAIN
 from homeassistant.components.group.registry import GroupIntegrationRegistry
 from homeassistant.components.lock import LockState
 from homeassistant.const import (
@@ -79,7 +80,7 @@ async def help_test_mixed_entity_platforms_on_off_state_test(
     if grouped_groups:
         assert await async_setup_component(
             hass,
-            "group",
+            DOMAIN,
             {
                 "group": {
                     "test1": {
@@ -103,7 +104,7 @@ async def help_test_mixed_entity_platforms_on_off_state_test(
     else:
         assert await async_setup_component(
             hass,
-            "group",
+            DOMAIN,
             {
                 "group": {
                     "test": {
@@ -147,7 +148,7 @@ async def test_setup_group_with_mixed_groupable_states(hass: HomeAssistant) -> N
     hass.states.async_set("light.Bowl", STATE_ON)
     hass.states.async_set("device_tracker.Paulus", STATE_HOME)
 
-    assert await async_setup_component(hass, "group", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     await group.Group.async_create_group(
         hass,
@@ -169,7 +170,7 @@ async def test_setup_group_with_a_non_existing_state(hass: HomeAssistant) -> Non
     """Try to set up a group with a non existing state."""
     hass.states.async_set("light.Bowl", STATE_ON)
 
-    assert await async_setup_component(hass, "group", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     grp = await group.Group.async_create_group(
         hass,
@@ -190,7 +191,7 @@ async def test_setup_group_with_non_groupable_states(hass: HomeAssistant) -> Non
     hass.states.async_set("cast.living_room", "Plex")
     hass.states.async_set("cast.bedroom", "Netflix")
 
-    assert await async_setup_component(hass, "group", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     grp = await group.Group.async_create_group(
         hass,
@@ -227,7 +228,7 @@ async def test_monitor_group(hass: HomeAssistant) -> None:
     hass.states.async_set("light.Bowl", STATE_ON)
     hass.states.async_set("light.Ceiling", STATE_OFF)
 
-    assert await async_setup_component(hass, "group", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     test_group = await group.Group.async_create_group(
         hass,
@@ -253,7 +254,7 @@ async def test_group_turns_off_if_all_off(hass: HomeAssistant) -> None:
     hass.states.async_set("light.Bowl", STATE_OFF)
     hass.states.async_set("light.Ceiling", STATE_OFF)
 
-    assert await async_setup_component(hass, "group", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     test_group = await group.Group.async_create_group(
         hass,
@@ -279,7 +280,7 @@ async def test_group_turns_on_if_all_are_off_and_one_turns_on(
     hass.states.async_set("light.Bowl", STATE_OFF)
     hass.states.async_set("light.Ceiling", STATE_OFF)
 
-    assert await async_setup_component(hass, "group", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     test_group = await group.Group.async_create_group(
         hass,
@@ -307,7 +308,7 @@ async def test_allgroup_stays_off_if_all_are_off_and_one_turns_on(
     hass.states.async_set("light.Bowl", STATE_OFF)
     hass.states.async_set("light.Ceiling", STATE_OFF)
 
-    assert await async_setup_component(hass, "group", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     test_group = await group.Group.async_create_group(
         hass,
@@ -333,7 +334,7 @@ async def test_allgroup_turn_on_if_last_turns_on(hass: HomeAssistant) -> None:
     hass.states.async_set("light.Bowl", STATE_ON)
     hass.states.async_set("light.Ceiling", STATE_OFF)
 
-    assert await async_setup_component(hass, "group", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     test_group = await group.Group.async_create_group(
         hass,
@@ -359,7 +360,7 @@ async def test_expand_entity_ids(hass: HomeAssistant) -> None:
     hass.states.async_set("light.Bowl", STATE_ON)
     hass.states.async_set("light.Ceiling", STATE_OFF)
 
-    assert await async_setup_component(hass, "group", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     test_group = await group.Group.async_create_group(
         hass,
@@ -384,7 +385,7 @@ async def test_expand_entity_ids_does_not_return_duplicates(
     hass.states.async_set("light.Bowl", STATE_ON)
     hass.states.async_set("light.Ceiling", STATE_OFF)
 
-    assert await async_setup_component(hass, "group", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     test_group = await group.Group.async_create_group(
         hass,
@@ -411,7 +412,7 @@ async def test_expand_entity_ids_recursive(hass: HomeAssistant) -> None:
     hass.states.async_set("light.Bowl", STATE_ON)
     hass.states.async_set("light.Ceiling", STATE_OFF)
 
-    assert await async_setup_component(hass, "group", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     test_group = await group.Group.async_create_group(
         hass,
@@ -439,7 +440,7 @@ async def test_get_entity_ids(hass: HomeAssistant) -> None:
     hass.states.async_set("light.Bowl", STATE_ON)
     hass.states.async_set("light.Ceiling", STATE_OFF)
 
-    assert await async_setup_component(hass, "group", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     test_group = await group.Group.async_create_group(
         hass,
@@ -462,7 +463,7 @@ async def test_get_entity_ids_with_domain_filter(hass: HomeAssistant) -> None:
     """Test if get_entity_ids works with a domain_filter."""
     hass.states.async_set("switch.AC", STATE_OFF)
 
-    assert await async_setup_component(hass, "group", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     mixed_group = await group.Group.async_create_group(
         hass,
@@ -499,7 +500,7 @@ async def test_group_being_init_before_first_tracked_state_is_set_to_on(
     as ON.
     """
 
-    assert await async_setup_component(hass, "group", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     test_group = await group.Group.async_create_group(
         hass,
@@ -528,7 +529,7 @@ async def test_group_being_init_before_first_tracked_state_is_set_to_off(
     If no states existed and now a state it is tracking is being added
     as OFF.
     """
-    assert await async_setup_component(hass, "group", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     test_group = await group.Group.async_create_group(
         hass,
         "test group",
@@ -551,7 +552,7 @@ async def test_group_being_init_before_first_tracked_state_is_set_to_off(
 async def test_groups_get_unique_names(hass: HomeAssistant) -> None:
     """Two groups with same name should both have a unique entity id."""
 
-    assert await async_setup_component(hass, "group", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     grp1 = await group.Group.async_create_group(
         hass,
@@ -580,7 +581,7 @@ async def test_groups_get_unique_names(hass: HomeAssistant) -> None:
 async def test_expand_entity_ids_expands_nested_groups(hass: HomeAssistant) -> None:
     """Test if entity ids epands to nested groups."""
 
-    assert await async_setup_component(hass, "group", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     await group.Group.async_create_group(
         hass,
@@ -626,7 +627,7 @@ async def test_set_assumed_state_based_on_tracked(hass: HomeAssistant) -> None:
     hass.states.async_set("light.Bowl", STATE_ON)
     hass.states.async_set("light.Ceiling", STATE_OFF)
 
-    assert await async_setup_component(hass, "group", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     test_group = await group.Group.async_create_group(
         hass,
@@ -663,7 +664,7 @@ async def test_group_updated_after_device_tracker_zone_change(
     hass.states.async_set("device_tracker.Eve", STATE_NOT_HOME)
     await hass.async_block_till_done()
 
-    assert await async_setup_component(hass, "group", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     assert await async_setup_component(hass, "device_tracker", {})
     await hass.async_block_till_done()
 
@@ -690,7 +691,7 @@ async def test_is_on(hass: HomeAssistant) -> None:
 
     assert group.is_on(hass, "group.none") is False
     assert await async_setup_component(hass, "light", {})
-    assert await async_setup_component(hass, "group", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     test_group = await group.Group.async_create_group(
@@ -827,7 +828,7 @@ async def test_is_on_and_state_mixed_domains(
     await asyncio.gather(
         *[async_setup_component(hass, domain, {}) for domain in set(domains)]
     )
-    assert await async_setup_component(hass, "group", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     test_group = await group.Group.async_create_group(
@@ -862,7 +863,7 @@ async def test_reloading_groups(hass: HomeAssistant) -> None:
     """Test reloading the group config."""
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "second_group": {"entities": "light.Bowl", "icon": "mdi:work"},
@@ -919,7 +920,7 @@ async def test_modify_group(hass: HomeAssistant) -> None:
         "entities": None,
     }
 
-    assert await async_setup_component(hass, "group", {"group": group_conf})
+    assert await async_setup_component(hass, DOMAIN, {"group": group_conf})
     await hass.async_block_till_done()
     assert hass.states.get(f"{group.DOMAIN}.modify_group")
 
@@ -947,7 +948,7 @@ async def test_setup(hass: HomeAssistant) -> None:
     assert await async_setup_component(hass, "light", {})
     await hass.async_block_till_done()
 
-    assert await async_setup_component(hass, "group", {"group": group_conf})
+    assert await async_setup_component(hass, DOMAIN, {"group": group_conf})
     await hass.async_block_till_done()
 
     test_group = await group.Group.async_create_group(
@@ -992,7 +993,7 @@ async def test_setup(hass: HomeAssistant) -> None:
 async def test_service_group_services(hass: HomeAssistant) -> None:
     """Check if service are available."""
     with assert_setup_component(0, "group"):
-        await async_setup_component(hass, "group", {"group": {}})
+        await async_setup_component(hass, DOMAIN, {"group": {}})
 
     assert hass.services.has_service("group", group.SERVICE_SET)
     assert hass.services.has_service("group", group.SERVICE_REMOVE)
@@ -1007,7 +1008,7 @@ async def test_service_group_services_add_remove_entities(hass: HomeAssistant) -
 
     assert await async_setup_component(hass, "person", {})
     with assert_setup_component(0, "group"):
-        await async_setup_component(hass, "group", {"group": {}})
+        await async_setup_component(hass, DOMAIN, {"group": {}})
     await hass.async_block_till_done()
 
     assert hass.services.has_service("group", group.SERVICE_SET)
@@ -1058,7 +1059,7 @@ async def test_service_group_services_add_remove_entities(hass: HomeAssistant) -
 async def test_service_group_set_group_remove_group(hass: HomeAssistant) -> None:
     """Check if service are available."""
     with assert_setup_component(0, "group"):
-        await async_setup_component(hass, "group", {"group": {}})
+        await async_setup_component(hass, DOMAIN, {"group": {}})
 
     common.async_set_group(hass, "user_test_group", name="Test")
     await hass.async_block_till_done()
@@ -1109,7 +1110,7 @@ async def test_group_order(hass: HomeAssistant) -> None:
     assert await async_setup_component(hass, "light", {})
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "group_zero": {"entities": "light.Bowl", "icon": "mdi:work"},
@@ -1132,7 +1133,7 @@ async def test_group_order_with_dynamic_creation(hass: HomeAssistant) -> None:
     assert await async_setup_component(hass, "light", {})
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "group_zero": {"entities": "light.Bowl", "icon": "mdi:work"},
@@ -1186,7 +1187,7 @@ async def test_group_persons(hass: HomeAssistant) -> None:
     assert await async_setup_component(hass, "person", {})
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "group_zero": {"entities": "person.one, person.two, person.three"},
@@ -1209,7 +1210,7 @@ async def test_group_persons_and_device_trackers(hass: HomeAssistant) -> None:
     assert await async_setup_component(hass, "device_tracker", {})
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "group_zero": {
@@ -1235,7 +1236,7 @@ async def test_group_mixed_domains_on(hass: HomeAssistant) -> None:
         assert await async_setup_component(hass, domain, {})
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "group_zero": {
@@ -1265,7 +1266,7 @@ async def test_group_mixed_domains_off(hass: HomeAssistant) -> None:
         assert await async_setup_component(hass, domain, {})
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "group_zero": {
@@ -1303,7 +1304,7 @@ async def test_group_locks(hass: HomeAssistant, states, group_state) -> None:
     assert await async_setup_component(hass, "lock", {})
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "group_zero": {"entities": "lock.one, lock.two, lock.three"},
@@ -1324,7 +1325,7 @@ async def test_group_sensors(hass: HomeAssistant) -> None:
     assert await async_setup_component(hass, "sensor", {})
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "group_zero": {"entities": "sensor.one, sensor.two, sensor.three"},
@@ -1345,7 +1346,7 @@ async def test_group_climate_mixed(hass: HomeAssistant) -> None:
     assert await async_setup_component(hass, "climate", {})
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "group_zero": {"entities": "climate.one, climate.two, climate.three"},
@@ -1366,7 +1367,7 @@ async def test_group_climate_all_cool(hass: HomeAssistant) -> None:
     assert await async_setup_component(hass, "climate", {})
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "group_zero": {"entities": "climate.one, climate.two, climate.three"},
@@ -1387,7 +1388,7 @@ async def test_group_climate_all_off(hass: HomeAssistant) -> None:
     assert await async_setup_component(hass, "climate", {})
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "group_zero": {"entities": "climate.one, climate.two, climate.three"},
@@ -1408,7 +1409,7 @@ async def test_group_alarm(hass: HomeAssistant) -> None:
 
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "group_zero": {
@@ -1437,7 +1438,7 @@ async def test_group_alarm_disarmed(hass: HomeAssistant) -> None:
     assert await async_setup_component(hass, "alarm_control_panel", {})
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "group_zero": {
@@ -1464,7 +1465,7 @@ async def test_group_vacuum_off(hass: HomeAssistant) -> None:
 
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "group_zero": {"entities": "vacuum.one, vacuum.two, vacuum.three"},
@@ -1488,7 +1489,7 @@ async def test_group_vacuum_on(hass: HomeAssistant) -> None:
     assert await async_setup_component(hass, "vacuum", {})
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "group_zero": {"entities": "vacuum.one, vacuum.two, vacuum.three"},
@@ -1551,7 +1552,7 @@ async def test_device_tracker_or_person_not_home(
 
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "group_zero": {"entities": ", ".join(entity_state_list)},
@@ -1571,7 +1572,7 @@ async def test_light_removed(hass: HomeAssistant) -> None:
 
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "group_zero": {"entities": "light.one, light.two, light.three"},
@@ -1597,7 +1598,7 @@ async def test_switch_removed(hass: HomeAssistant) -> None:
     hass.set_state(CoreState.stopped)
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "group_zero": {"entities": "switch.one, switch.two, switch.three"},
@@ -1634,7 +1635,7 @@ async def test_lights_added_after_group(hass: HomeAssistant) -> None:
 
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "living_room_downlights": {"entities": entity_ids},
@@ -1670,7 +1671,7 @@ async def test_lights_added_before_group(hass: HomeAssistant) -> None:
 
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "living_room_downlights": {"entities": entity_ids},
@@ -1693,7 +1694,7 @@ async def test_cover_added_after_group(hass: HomeAssistant) -> None:
     assert await async_setup_component(hass, "cover", {})
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "shades": {"entities": entity_ids},
@@ -1731,7 +1732,7 @@ async def test_group_that_references_a_group_of_lights(hass: HomeAssistant) -> N
 
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "living_room_downlights": {"entities": entity_ids},
@@ -1766,7 +1767,7 @@ async def test_group_that_references_a_group_of_covers(hass: HomeAssistant) -> N
 
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "living_room_downcover": {"entities": entity_ids},
@@ -1803,7 +1804,7 @@ async def test_group_that_references_two_groups_of_covers(hass: HomeAssistant) -
     assert await async_setup_component(hass, "cover", {})
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "living_room_downcover": {"entities": entity_ids},
@@ -1850,7 +1851,7 @@ async def test_group_that_references_two_types_of_groups(hass: HomeAssistant) ->
     assert await async_setup_component(hass, "device_tracker", {})
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "covers": {"entities": group_1_entity_ids},
@@ -1905,7 +1906,7 @@ async def test_plant_group(hass: HomeAssistant) -> None:
     )
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "plants": {"entities": entity_ids},

--- a/tests/components/group/test_light.py
+++ b/tests/components/group/test_light.py
@@ -1565,7 +1565,7 @@ async def test_reload_with_platform_not_setup(hass: HomeAssistant) -> None:
     )
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "group_zero": {"entities": "light.Bowl", "icon": "mdi:work"},
@@ -1595,7 +1595,7 @@ async def test_reload_with_base_integration_platform_not_setup(
     """Test the ability to reload lights."""
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "group_zero": {"entities": "light.Bowl", "icon": "mdi:work"},

--- a/tests/components/group/test_lock.py
+++ b/tests/components/group/test_lock.py
@@ -331,7 +331,7 @@ async def test_reload_with_platform_not_setup(hass: HomeAssistant) -> None:
     )
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "group_zero": {"entities": "lock.something", "icon": "mdi:work"},
@@ -361,7 +361,7 @@ async def test_reload_with_base_integration_platform_not_setup(
     """Test the ability to reload locks."""
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "group_zero": {"entities": "lock.something", "icon": "mdi:work"},

--- a/tests/components/group/test_notify.py
+++ b/tests/components/group/test_notify.py
@@ -111,7 +111,7 @@ async def test_send_message_with_data(hass: HomeAssistant, tmp_path: Path) -> No
     """Test sending a message with to a notify group."""
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {},
     )
     await hass.async_block_till_done()
@@ -211,7 +211,7 @@ async def test_invalid_configuration(
     """Test failing to set up group with an invalid configuration."""
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {},
     )
     await hass.async_block_till_done()
@@ -244,7 +244,7 @@ async def test_reload_notify(hass: HomeAssistant, tmp_path: Path) -> None:
     """Verify we can reload the notify service."""
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {},
     )
     await hass.async_block_till_done()

--- a/tests/components/group/test_switch.py
+++ b/tests/components/group/test_switch.py
@@ -349,7 +349,7 @@ async def test_reload_with_platform_not_setup(hass: HomeAssistant) -> None:
     )
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "group_zero": {"entities": "switch.something", "icon": "mdi:work"},
@@ -379,7 +379,7 @@ async def test_reload_with_base_integration_platform_not_setup(
     """Test the ability to reload switches."""
     assert await async_setup_component(
         hass,
-        "group",
+        DOMAIN,
         {
             "group": {
                 "group_zero": {"entities": "switch.something", "icon": "mdi:work"},


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When `async_setup_component` is called with a literal string matching the component name, use the `DOMAIN` constant instead.

Linked to #173004

Please note that I purposefully did not touch the configuration dictionnary.
The top-level key is often the component domain, but I felt changing that was out of scope.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
