### PR TITLE
Use DOMAIN constant in test (async_setup_component h-n)

### DIFF
--- a/tests/components/hassio/test_addon_panel.py
+++ b/tests/components/hassio/test_addon_panel.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 from aiohasupervisor.models import IngressPanel
 import pytest
 
+from homeassistant.components.hassio import DOMAIN
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -38,7 +39,7 @@ async def test_hassio_addon_panel_startup(
         "homeassistant.components.hassio.addon_panel._register_panel",
     ) as mock_panel:
         with patch.dict(os.environ, MOCK_ENVIRON):
-            await async_setup_component(hass, "hassio", {})
+            await async_setup_component(hass, DOMAIN, {})
             await hass.async_block_till_done()
 
         ingress_panels.assert_not_called()
@@ -71,7 +72,7 @@ async def test_hassio_addon_panel_api(
     }
 
     with patch.dict(os.environ, MOCK_ENVIRON):
-        await async_setup_component(hass, "hassio", {})
+        await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
     with patch(
@@ -119,7 +120,7 @@ async def test_hassio_addon_panel_api_non_admin(
     }
 
     with patch.dict(os.environ, MOCK_ENVIRON):
-        await async_setup_component(hass, "hassio", {})
+        await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
     with patch(
@@ -160,7 +161,7 @@ async def test_hassio_addon_panel_registration(
     }
 
     with patch.dict(os.environ, MOCK_ENVIRON):
-        await async_setup_component(hass, "hassio", {})
+        await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
     with patch(
@@ -193,7 +194,7 @@ async def test_hassio_addon_panel_api_delete(
         "test1": IngressPanel(enable=True, title="Test", icon="mdi:test", admin=False),
     }
     with patch.dict(os.environ, MOCK_ENVIRON):
-        await async_setup_component(hass, "hassio", {})
+        await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
     hass_client = await hass_client()
@@ -218,7 +219,7 @@ async def test_hassio_addon_panel_api_delete_non_admin(
         "test1": IngressPanel(enable=True, title="Test", icon="mdi:test", admin=False),
     }
     with patch.dict(os.environ, MOCK_ENVIRON):
-        await async_setup_component(hass, "hassio", {})
+        await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
     hass_admin_user.groups = []

--- a/tests/components/hassio/test_binary_sensor.py
+++ b/tests/components/hassio/test_binary_sensor.py
@@ -109,7 +109,7 @@ async def test_binary_sensor(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -140,7 +140,7 @@ async def test_mount_binary_sensor(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -236,7 +236,7 @@ async def test_mount_refresh_after_issue(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result

--- a/tests/components/hassio/test_config.py
+++ b/tests/components/hassio/test_config.py
@@ -114,7 +114,7 @@ async def test_load_config_store(
     await hass.auth.async_update_user(user, group_ids=[GROUP_ID_ADMIN])
 
     with patch("homeassistant.components.hassio.config.STORE_DELAY_SAVE", 0):
-        assert await async_setup_component(hass, "hassio", {})
+        assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
         await hass.async_block_till_done()
 
@@ -131,7 +131,7 @@ async def test_save_config_store(
 ) -> None:
     """Test saving the config store."""
     with patch("homeassistant.components.hassio.config.STORE_DELAY_SAVE", 0):
-        assert await async_setup_component(hass, "hassio", {})
+        assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
         await hass.async_block_till_done()
 

--- a/tests/components/hassio/test_diagnostics.py
+++ b/tests/components/hassio/test_diagnostics.py
@@ -97,7 +97,7 @@ async def test_diagnostics(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result

--- a/tests/components/hassio/test_discovery.py
+++ b/tests/components/hassio/test_discovery.py
@@ -11,6 +11,7 @@ from aiohttp.test_utils import TestClient
 import pytest
 
 from homeassistant import config_entries
+from homeassistant.components.hassio import DOMAIN
 from homeassistant.components.mqtt import DOMAIN as MQTT_DOMAIN
 from homeassistant.config_entries import ConfigEntries
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STARTED
@@ -124,7 +125,7 @@ async def test_hassio_discovery_startup_done(
 
     supervisor_root_info.side_effect = SupervisorError()
     await hass.async_start()
-    await async_setup_component(hass, "hassio", {})
+    await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     assert get_addon_discovery_info.call_count == 1

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -165,7 +165,7 @@ async def test_setup_api_ping(
 ) -> None:
     """Test setup with API ping."""
     with patch.dict(os.environ, MOCK_ENVIRON):
-        result = await async_setup_component(hass, "hassio", {})
+        result = await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
     assert result
@@ -181,7 +181,7 @@ async def test_setup_api_ping_fails(
     supervisor_client.supervisor.ping.side_effect = SupervisorError
 
     with patch.dict(os.environ, MOCK_ENVIRON):
-        result = await async_setup_component(hass, "hassio", {})
+        result = await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
     # async_setup succeeds (domain registered), but the config entry is in retry
@@ -200,7 +200,7 @@ async def test_setup_onboarding_supervisor_update(
         patch.dict(os.environ, MOCK_ENVIRON),
         patch("homeassistant.components.hassio.async_is_onboarded", return_value=False),
     ):
-        result = await async_setup_component(hass, "hassio", {})
+        result = await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
     assert result
@@ -221,7 +221,7 @@ async def test_setup_onboarding_supervisor_no_update(
         patch.dict(os.environ, MOCK_ENVIRON),
         patch("homeassistant.components.hassio.async_is_onboarded", return_value=False),
     ):
-        result = await async_setup_component(hass, "hassio", {})
+        result = await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
     assert result
@@ -242,7 +242,7 @@ async def test_setup_onboarding_supervisor_update_error(
         patch.dict(os.environ, MOCK_ENVIRON),
         patch("homeassistant.components.hassio.async_is_onboarded", return_value=False),
     ):
-        result = await async_setup_component(hass, "hassio", {})
+        result = await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
     assert result
@@ -255,7 +255,7 @@ async def test_setup_onboarding_supervisor_update_error(
 async def test_setup_app_panel(hass: HomeAssistant) -> None:
     """Test app panel is registered."""
     with patch.dict(os.environ, MOCK_ENVIRON):
-        result = await async_setup_component(hass, "hassio", {})
+        result = await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
         assert result
 
@@ -280,7 +280,7 @@ async def test_setup_api_push_api_data(
     """Test setup with API push."""
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
-            hass, "hassio", {"http": {"server_port": 9999}, "hassio": {}}
+            hass, DOMAIN, {"http": {"server_port": 9999}, "hassio": {}}
         )
         await hass.async_block_till_done()
 
@@ -297,7 +297,7 @@ async def test_setup_api_push_api_data_error(
     """Test setup with error while pushing core config data to API."""
     supervisor_client.homeassistant.set_options.side_effect = SupervisorError("boom")
     with patch.dict(os.environ, MOCK_ENVIRON):
-        result = await async_setup_component(hass, "hassio", {"http": {}, "hassio": {}})
+        result = await async_setup_component(hass, DOMAIN, {"http": {}, "hassio": {}})
         await hass.async_block_till_done()
 
     assert result
@@ -312,7 +312,7 @@ async def test_setup_api_push_api_data_server_host(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         await hass.async_block_till_done()
@@ -332,7 +332,7 @@ async def test_setup_api_push_api_data_default(
         patch.dict(os.environ, MOCK_ENVIRON),
         patch("homeassistant.components.hassio.config.STORE_DELAY_SAVE", 0),
     ):
-        result = await async_setup_component(hass, "hassio", {"http": {}, "hassio": {}})
+        result = await async_setup_component(hass, DOMAIN, {"http": {}, "hassio": {}})
         await hass.async_block_till_done()
 
     assert result
@@ -374,7 +374,7 @@ async def test_setup_adds_admin_group_to_user(
     }
 
     with patch.dict(os.environ, MOCK_ENVIRON):
-        result = await async_setup_component(hass, "hassio", {"http": {}, "hassio": {}})
+        result = await async_setup_component(hass, DOMAIN, {"http": {}, "hassio": {}})
         assert result
 
     assert user.is_admin
@@ -395,7 +395,7 @@ async def test_setup_migrate_user_name(
     }
 
     with patch.dict(os.environ, MOCK_ENVIRON):
-        result = await async_setup_component(hass, "hassio", {"http": {}, "hassio": {}})
+        result = await async_setup_component(hass, DOMAIN, {"http": {}, "hassio": {}})
         assert result
 
     assert user.name == "Supervisor"
@@ -409,7 +409,7 @@ async def test_setup_api_existing_hassio_user(
     token = await hass.auth.async_create_refresh_token(user)
     hass_storage[STORAGE_KEY] = {"version": 1, "data": {"hassio_user": user.id}}
     with patch.dict(os.environ, MOCK_ENVIRON):
-        result = await async_setup_component(hass, "hassio", {"http": {}, "hassio": {}})
+        result = await async_setup_component(hass, DOMAIN, {"http": {}, "hassio": {}})
         await hass.async_block_till_done()
 
     assert result
@@ -426,7 +426,7 @@ async def test_setup_core_push_config(
     hass.config.time_zone = "testzone"
 
     with patch.dict(os.environ, MOCK_ENVIRON):
-        result = await async_setup_component(hass, "hassio", {"hassio": {}})
+        result = await async_setup_component(hass, DOMAIN, {"hassio": {}})
         await hass.async_block_till_done()
 
     assert result
@@ -451,7 +451,7 @@ async def test_setup_core_push_config_error(
     supervisor_client.supervisor.set_options.side_effect = SupervisorError("boom")
 
     with patch.dict(os.environ, MOCK_ENVIRON):
-        result = await async_setup_component(hass, "hassio", {"hassio": {}})
+        result = await async_setup_component(hass, DOMAIN, {"hassio": {}})
         await hass.async_block_till_done()
 
     assert result
@@ -467,7 +467,7 @@ async def test_setup_hassio_no_additional_data(
         patch.dict(os.environ, MOCK_ENVIRON),
         patch.dict(os.environ, {"SUPERVISOR_TOKEN": "123456"}),
     ):
-        result = await async_setup_component(hass, "hassio", {"hassio": {}})
+        result = await async_setup_component(hass, DOMAIN, {"hassio": {}})
         await hass.async_block_till_done()
 
     assert result
@@ -477,7 +477,7 @@ async def test_setup_hassio_no_additional_data(
 async def test_fail_setup_without_environ_var(hass: HomeAssistant) -> None:
     """Fail setup if no environ variable set."""
     with patch.dict(os.environ, {}, clear=True):
-        result = await async_setup_component(hass, "hassio", {})
+        result = await async_setup_component(hass, DOMAIN, {})
         assert not result
 
 
@@ -488,7 +488,7 @@ async def test_warn_when_cannot_connect(
     """Test that a failed ping puts the config entry in retry state."""
     supervisor_is_connected.side_effect = SupervisorError
     with patch.dict(os.environ, MOCK_ENVIRON):
-        result = await async_setup_component(hass, "hassio", {})
+        result = await async_setup_component(hass, DOMAIN, {})
         assert result
 
     assert is_hassio(hass)
@@ -499,7 +499,7 @@ async def test_warn_when_cannot_connect(
 @pytest.mark.usefixtures("hassio_env")
 async def test_service_register(hass: HomeAssistant) -> None:
     """Check if service will be setup."""
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     # New app services
     assert hass.services.has_service("hassio", "app_start")
     assert hass.services.has_service("hassio", "app_stop")
@@ -535,7 +535,7 @@ async def test_service_calls(
     """Call service and check the API calls behind that."""
     supervisor_is_connected.side_effect = SupervisorError
     with patch.dict(os.environ, MOCK_ENVIRON):
-        assert await async_setup_component(hass, "hassio", {})
+        assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
     supervisor_client.reset_mock()
@@ -694,7 +694,7 @@ async def test_service_calls(
 async def test_invalid_service_calls(hass: HomeAssistant, app_or_addon: str) -> None:
     """Call service with invalid input and check that it raises."""
     with patch.dict(os.environ, MOCK_ENVIRON):
-        assert await async_setup_component(hass, "hassio", {})
+        assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
     with pytest.raises(Invalid):
@@ -732,7 +732,7 @@ async def test_service_calls_apps_addons_exclusive(
     """Test that apps and addons parameters are mutually exclusive."""
     supervisor_is_connected.side_effect = SupervisorError
     with patch.dict(os.environ, MOCK_ENVIRON):
-        assert await async_setup_component(hass, "hassio", {})
+        assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
     with pytest.raises(
@@ -775,7 +775,7 @@ async def test_addon_service_call_with_complex_slug(
     ]
     supervisor_is_connected.side_effect = SupervisorError
     with patch.dict(os.environ, MOCK_ENVIRON):
-        assert await async_setup_component(hass, "hassio", {})
+        assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
     await hass.services.async_call(
@@ -790,7 +790,7 @@ async def test_service_calls_core(
     """Call core service and check the API calls behind that."""
     with patch.dict(os.environ, MOCK_ENVIRON):
         assert await async_setup_component(hass, "homeassistant", {})
-        assert await async_setup_component(hass, "hassio", {})
+        assert await async_setup_component(hass, DOMAIN, {})
 
     await hass.services.async_call("homeassistant", "stop")
     await hass.async_block_till_done()
@@ -819,7 +819,7 @@ async def test_invalid_service_calls_app_duplicates(
     hass: HomeAssistant, app_or_addon: str
 ) -> None:
     """Test invalid backup/restore service calls due to duplicates in apps list."""
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     with pytest.raises(Invalid, match="contains duplicate items"):
         await hass.services.async_call(
@@ -835,7 +835,7 @@ async def test_invalid_service_calls_app_duplicates(
 @pytest.mark.usefixtures("hassio_env", "supervisor_client")
 async def test_invalid_service_calls_folder_duplicates(hass: HomeAssistant) -> None:
     """Test invalid backup/restore service calls due to duplicates in folder list."""
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     with pytest.raises(Invalid, match="contains duplicate items"):
         await hass.services.async_call(
@@ -853,7 +853,7 @@ async def test_partial_backup_legacy_homeassistant_folder(
     hass: HomeAssistant, supervisor_client: AsyncMock
 ) -> None:
     """Test legacy "homeassistant" folder is translated to homeassistant=True."""
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     supervisor_client.backups.partial_backup.return_value = NewBackup(
         job_id=uuid4(), slug="partial"
     )
@@ -883,7 +883,7 @@ async def test_partial_restore_legacy_homeassistant_folder(
     hass: HomeAssistant, supervisor_client: AsyncMock
 ) -> None:
     """Test that the legacy "homeassistant" folder is translated for restore too."""
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     await hass.services.async_call(
         DOMAIN,
@@ -903,7 +903,7 @@ async def test_partial_restore_legacy_homeassistant_folder(
 @pytest.mark.usefixtures("hassio_env", "supervisor_client")
 async def test_partial_backup_invalid_folder(hass: HomeAssistant) -> None:
     """Test that an unknown folder name is rejected."""
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     with pytest.raises(Invalid, match="not a valid value"):
         await hass.services.async_call(DOMAIN, "backup_partial", {"folders": ["bogus"]})
@@ -914,7 +914,7 @@ async def test_partial_backup_legacy_homeassistant_folder_conflict(
     hass: HomeAssistant,
 ) -> None:
     """Reject combining homeassistant=False with the legacy "homeassistant" folder."""
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     with pytest.raises(ServiceValidationError, match="conflicts"):
         await hass.services.async_call(
@@ -1198,7 +1198,7 @@ async def test_setup_hardware_integration(
             return_value=None,
         ),
     ):
-        result = await async_setup_component(hass, "hassio", {"hassio": {}})
+        result = await async_setup_component(hass, DOMAIN, {"hassio": {}})
         await hass.async_block_till_done(wait_background_tasks=True)
 
     assert result
@@ -1895,7 +1895,7 @@ async def test_stop_handler_restored_on_unload(
     """Test that the default stop handler is restored when the hassio entry unloads."""
     assert await async_setup_component(hass, "homeassistant", {})
     with patch.dict(os.environ, MOCK_ENVIRON):
-        assert await async_setup_component(hass, "hassio", {})
+        assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
     entry = hass.config_entries.async_entries("hassio")[0]
@@ -1922,7 +1922,7 @@ async def test_supervisor_issues_not_set_on_coordinator_failure(
     """
     supervisor_root_info.side_effect = SupervisorError()
     with patch.dict(os.environ, MOCK_ENVIRON):
-        result = await async_setup_component(hass, "hassio", {})
+        result = await async_setup_component(hass, DOMAIN, {})
         assert result
 
     entry = hass.config_entries.async_entries("hassio")[0]

--- a/tests/components/hassio/test_issues.py
+++ b/tests/components/hassio/test_issues.py
@@ -150,7 +150,7 @@ async def test_unhealthy_issues(
         supervisor_client, unhealthy=[UnhealthyReason.DOCKER, UnhealthyReason.SETUP]
     )
 
-    result = await async_setup_component(hass, "hassio", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     client = await hass_ws_client(hass)
@@ -174,7 +174,7 @@ async def test_unhealthy_reasons(
     """Test all unhealthy reasons in client library are made into repairs."""
     mock_resolution_info(supervisor_client, unhealthy=[unhealthy_reason])
 
-    result = await async_setup_component(hass, "hassio", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     client = await hass_ws_client(hass)
@@ -200,7 +200,7 @@ async def test_unsupported_issues(
         unsupported=[UnsupportedReason.CONNECTIVITY_CHECK, UnsupportedReason.OS],
     )
 
-    result = await async_setup_component(hass, "hassio", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     client = await hass_ws_client(hass)
@@ -229,7 +229,7 @@ async def test_unsupported_reasons(
     """Test all unsupported reasons in client library are made into repairs."""
     mock_resolution_info(supervisor_client, unsupported=[unsupported_reason])
 
-    result = await async_setup_component(hass, "hassio", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     client = await hass_ws_client(hass)
@@ -252,7 +252,7 @@ async def test_unhealthy_issues_add_remove(
     """Test unhealthy issues added and removed from dispatches."""
     mock_resolution_info(supervisor_client)
 
-    result = await async_setup_component(hass, "hassio", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     client = await hass_supervisor_ws_client()
@@ -309,7 +309,7 @@ async def test_unsupported_issues_add_remove(
     """Test unsupported issues added and removed from dispatches."""
     mock_resolution_info(supervisor_client)
 
-    result = await async_setup_component(hass, "hassio", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     client = await hass_supervisor_ws_client()
@@ -389,7 +389,7 @@ async def test_reset_issues_supervisor_restart(
         },
     )
 
-    result = await async_setup_component(hass, "hassio", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     client = await hass_supervisor_ws_client()
@@ -443,7 +443,7 @@ async def test_no_reset_issues_supervisor_update_found(
         unsupported=[UnsupportedReason.OS],
     )
 
-    result = await async_setup_component(hass, "hassio", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     client = await hass_supervisor_ws_client()
@@ -488,7 +488,7 @@ async def test_reasons_added_and_removed(
         unhealthy=[UnhealthyReason.DOCKER],
     )
 
-    result = await async_setup_component(hass, "hassio", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     client = await hass_supervisor_ws_client()
@@ -543,7 +543,7 @@ async def test_ignored_unsupported_skipped(
         unhealthy=[UnhealthyReason.PRIVILEGED],
     )
 
-    result = await async_setup_component(hass, "hassio", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     client = await hass_ws_client(hass)
@@ -568,7 +568,7 @@ async def test_new_unsupported_unhealthy_reason(
         unhealthy=["fake_unhealthy"],
     )
 
-    result = await async_setup_component(hass, "hassio", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     client = await hass_ws_client(hass)
@@ -649,7 +649,7 @@ async def test_supervisor_issues(
         },
     )
 
-    result = await async_setup_component(hass, "hassio", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     client = await hass_ws_client(hass)
@@ -716,7 +716,7 @@ async def test_supervisor_issues_initial_failure(
     ]
 
     with patch("homeassistant.components.hassio.issues.REQUEST_REFRESH_DELAY", new=0.1):
-        result = await async_setup_component(hass, "hassio", {})
+        result = await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
         assert result
 
@@ -744,7 +744,7 @@ async def test_supervisor_issues_add_remove(
     """Test supervisor issues added and removed from dispatches."""
     mock_resolution_info(supervisor_client)
 
-    result = await async_setup_component(hass, "hassio", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     client = await hass_supervisor_ws_client()
@@ -835,7 +835,7 @@ async def test_supervisor_issues_suggestions_fail(
     )
     resolution_suggestions_for_issue.side_effect = SupervisorTimeoutError
 
-    result = await async_setup_component(hass, "hassio", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     client = await hass_ws_client(hass)
@@ -855,7 +855,7 @@ async def test_supervisor_remove_missing_issue_without_error(
     """Test HA skips message to remove issue that it didn't know about (sync issue)."""
     mock_resolution_info(supervisor_client)
 
-    result = await async_setup_component(hass, "hassio", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     client = await hass_supervisor_ws_client()
@@ -891,7 +891,7 @@ async def test_system_is_not_ready(
         "System is not ready with state: setup"
     )
 
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     assert "Failed to update supervisor issues" in caplog.text
 
 
@@ -907,7 +907,7 @@ async def test_supervisor_issues_detached_addon_missing(
     """Test supervisor issue for detached addon due to missing repository."""
     mock_resolution_info(supervisor_client)
 
-    result = await async_setup_component(hass, "hassio", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     client = await hass_supervisor_ws_client()
@@ -958,7 +958,7 @@ async def test_supervisor_issues_ntp_sync_failed(
     """Test supervisor issue for NTP sync failed."""
     mock_resolution_info(supervisor_client)
 
-    result = await async_setup_component(hass, "hassio", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     client = await hass_supervisor_ws_client()
@@ -1013,7 +1013,7 @@ async def test_supervisor_issues_disk_lifetime(
     """Test supervisor issue for disk lifetime nearly exceeded."""
     mock_resolution_info(supervisor_client)
 
-    result = await async_setup_component(hass, "hassio", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     client = await hass_supervisor_ws_client()
@@ -1060,7 +1060,7 @@ async def test_supervisor_issues_free_space(
     """Test supervisor issue for too little free space remaining."""
     mock_resolution_info(supervisor_client)
 
-    result = await async_setup_component(hass, "hassio", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     client = await hass_supervisor_ws_client()
@@ -1114,7 +1114,7 @@ async def test_supervisor_issues_addon_pwned(
     """Test supervisor issue for pwned secret in an addon."""
     mock_resolution_info(supervisor_client)
 
-    result = await async_setup_component(hass, "hassio", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     client = await hass_supervisor_ws_client()
@@ -1170,7 +1170,7 @@ async def test_supervisor_issues_unload_disconnects_listener(
     the listener — preventing listener accumulation on config-entry reload.
     """
     mock_resolution_info(supervisor_client)
-    result = await async_setup_component(hass, "hassio", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     # Get config entry

--- a/tests/components/hassio/test_jobs.py
+++ b/tests/components/hassio/test_jobs.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 from aiohasupervisor.models import Job, JobsInfo
 import pytest
 
-from homeassistant.components.hassio.const import MAIN_COORDINATOR
+from homeassistant.components.hassio.const import DOMAIN, MAIN_COORDINATOR
 from homeassistant.components.hassio.coordinator import HassioMainDataUpdateCoordinator
 from homeassistant.components.hassio.jobs import JobSubscription
 from homeassistant.core import HomeAssistant, callback
@@ -61,7 +61,7 @@ async def test_job_manager_setup(hass: HomeAssistant, jobs_info: AsyncMock) -> N
         ],
     )
 
-    result = await async_setup_component(hass, "hassio", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
     jobs_info.assert_called_once()
 
@@ -76,7 +76,7 @@ async def test_disconnect_on_config_entry_reload(
     hass: HomeAssistant, jobs_info: AsyncMock
 ) -> None:
     """Test dispatcher subscription disconnects on config entry reload."""
-    result = await async_setup_component(hass, "hassio", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
     jobs_info.assert_called_once()
 
@@ -94,7 +94,7 @@ async def test_job_manager_ws_updates(
     hass_supervisor_ws_client: WebSocketGenerator,
 ) -> None:
     """Test job updates sync from Supervisor WS messages."""
-    result = await async_setup_component(hass, "hassio", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
     jobs_info.assert_called_once()
 
@@ -302,7 +302,7 @@ async def test_job_manager_reload_on_supervisor_restart(
         ],
     )
 
-    result = await async_setup_component(hass, "hassio", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
     jobs_info.assert_called_once()
 

--- a/tests/components/hassio/test_repairs.py
+++ b/tests/components/hassio/test_repairs.py
@@ -16,6 +16,7 @@ from aiohasupervisor.models import (
 )
 import pytest
 
+from homeassistant.components.hassio import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.setup import async_setup_component
@@ -64,7 +65,7 @@ async def test_supervisor_issue_repair_flow(
         },
     )
 
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     repair_issue = issue_registry.async_get_issue(
         domain="hassio", issue_id=issue_uuid.hex
@@ -150,7 +151,7 @@ async def test_supervisor_issue_repair_flow_with_multiple_suggestions(
         },
     )
 
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     repair_issue = issue_registry.async_get_issue(
         domain="hassio", issue_id=issue_uuid.hex
@@ -249,7 +250,7 @@ async def test_supervisor_issue_repair_flow_with_multiple_suggestions_and_confir
         },
     )
 
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     repair_issue = issue_registry.async_get_issue(
         domain="hassio", issue_id=issue_uuid.hex
@@ -357,7 +358,7 @@ async def test_supervisor_issue_repair_flow_skip_confirmation(
         },
     )
 
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     repair_issue = issue_registry.async_get_issue(
         domain="hassio", issue_id=issue_uuid.hex
@@ -436,7 +437,7 @@ async def test_supervisor_issue_ntp_sync_failed_repair_flow(
         },
     )
 
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     repair_issue = issue_registry.async_get_issue(
         domain="hassio", issue_id=issue_uuid.hex
@@ -516,7 +517,7 @@ async def test_supervisor_issue_ntp_sync_failed_repair_flow_error(
         suggestion_result=SupervisorError("boom"),
     )
 
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     repair_issue = issue_registry.async_get_issue(
         domain="hassio", issue_id=issue_uuid.hex
@@ -590,7 +591,7 @@ async def test_mount_failed_repair_flow_error(
         suggestion_result=SupervisorError("boom"),
     )
 
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     repair_issue = issue_registry.async_get_issue(
         domain="hassio", issue_id=issue_uuid.hex
@@ -666,7 +667,7 @@ async def test_mount_failed_repair_flow(
         },
     )
 
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     repair_issue = issue_registry.async_get_issue(
         domain="hassio", issue_id=issue_uuid.hex
@@ -792,7 +793,7 @@ async def test_supervisor_issue_docker_config_repair_flow(
         },
     )
 
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     repair_issue = issue_registry.async_get_issue(
         domain="hassio", issue_id=issue1_uuid.hex
@@ -878,7 +879,7 @@ async def test_supervisor_issue_repair_flow_multiple_data_disks(
         },
     )
 
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     repair_issue = issue_registry.async_get_issue(
         domain="hassio", issue_id=issue_uuid.hex
@@ -989,7 +990,7 @@ async def test_supervisor_issue_detached_addon_removed(
         },
     )
 
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     repair_issue = issue_registry.async_get_issue(
         domain="hassio", issue_id=issue_uuid.hex
@@ -1083,7 +1084,7 @@ async def test_supervisor_issue_addon_boot_fail(
         },
     )
 
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     repair_issue = issue_registry.async_get_issue(
         domain="hassio", issue_id=issue_uuid.hex
@@ -1183,7 +1184,7 @@ async def test_supervisor_issue_deprecated_addon(
         },
     )
 
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     repair_issue = issue_registry.async_get_issue(
         domain="hassio", issue_id=issue_uuid.hex
@@ -1272,7 +1273,7 @@ async def test_supervisor_issue_deprecated_arch_addon(
         },
     )
 
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     repair_issue = issue_registry.async_get_issue(
         domain="hassio", issue_id=issue_uuid.hex

--- a/tests/components/hassio/test_sensor.py
+++ b/tests/components/hassio/test_sensor.py
@@ -119,7 +119,7 @@ async def test_sensor(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -170,7 +170,7 @@ async def test_stats_addon_sensor(
 
     assert await async_setup_component(
         hass,
-        "hassio",
+        DOMAIN,
         {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
     )
     await hass.async_block_till_done()

--- a/tests/components/hassio/test_switch.py
+++ b/tests/components/hassio/test_switch.py
@@ -33,7 +33,7 @@ async def setup_integration(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result

--- a/tests/components/hassio/test_update.py
+++ b/tests/components/hassio/test_update.py
@@ -134,7 +134,7 @@ async def test_update_entities(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -156,7 +156,7 @@ async def test_update_addon(hass: HomeAssistant, update_addon: AsyncMock) -> Non
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -185,7 +185,7 @@ async def test_update_addon_progress(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -288,7 +288,7 @@ async def test_addon_update_progress_startup(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -385,7 +385,7 @@ async def test_update_addon_with_backup(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -479,7 +479,7 @@ async def test_update_addon_with_backup_removes_old_backups(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -531,7 +531,7 @@ async def test_update_os(hass: HomeAssistant, supervisor_client: AsyncMock) -> N
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -627,7 +627,7 @@ async def test_update_os_with_backup(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -665,7 +665,7 @@ async def test_update_core(hass: HomeAssistant, supervisor_client: AsyncMock) ->
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -697,7 +697,7 @@ async def test_update_core_progress(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -847,7 +847,7 @@ async def test_core_update_progress_startup(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -943,7 +943,7 @@ async def test_update_core_with_backup(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -982,7 +982,7 @@ async def test_update_core_sets_progress_immediately(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -1026,7 +1026,7 @@ async def test_update_core_resets_progress_on_error(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -1065,7 +1065,7 @@ async def test_update_addon_sets_progress_immediately(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -1112,7 +1112,7 @@ async def test_update_addon_resets_progress_on_error(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -1239,7 +1239,7 @@ async def test_update_addon_stays_in_progress_until_refresh(
     with patch.dict(os.environ, MOCK_ENVIRON):
         assert await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
     await hass.async_block_till_done()
@@ -1314,7 +1314,7 @@ async def test_update_addon_completes_on_any_version_change(
     with patch.dict(os.environ, MOCK_ENVIRON):
         assert await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
     await hass.async_block_till_done()
@@ -1345,7 +1345,7 @@ async def test_update_supervisor(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -1379,7 +1379,7 @@ async def test_update_supervisor_progress(
     with patch.dict(os.environ, MOCK_ENVIRON):
         assert await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
     await hass.async_block_till_done()
@@ -1481,7 +1481,7 @@ async def test_update_supervisor_stays_in_progress_until_restart(
     with patch.dict(os.environ, MOCK_ENVIRON):
         assert await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
     await hass.async_block_till_done()
@@ -1547,7 +1547,7 @@ async def test_update_supervisor_completes_on_any_version_change(
     with patch.dict(os.environ, MOCK_ENVIRON):
         assert await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
     await hass.async_block_till_done()
@@ -1601,7 +1601,7 @@ async def test_update_addon_with_error(
     with patch.dict(os.environ, MOCK_ENVIRON):
         assert await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
     await hass.async_block_till_done()
@@ -1637,7 +1637,7 @@ async def test_update_addon_with_backup_and_error(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -1674,7 +1674,7 @@ async def test_update_os_with_error(
     with patch.dict(os.environ, MOCK_ENVIRON):
         assert await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
     await hass.async_block_till_done()
@@ -1702,7 +1702,7 @@ async def test_update_os_with_backup_and_error(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -1738,7 +1738,7 @@ async def test_update_supervisor_with_error(
     with patch.dict(os.environ, MOCK_ENVIRON):
         assert await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
     await hass.async_block_till_done()
@@ -1765,7 +1765,7 @@ async def test_update_core_with_error(
     with patch.dict(os.environ, MOCK_ENVIRON):
         assert await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
     await hass.async_block_till_done()
@@ -1793,7 +1793,7 @@ async def test_update_core_with_backup_and_error(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -1830,7 +1830,7 @@ async def test_release_notes_between_versions(
     ):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -1866,7 +1866,7 @@ async def test_release_notes_full(
     ):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -1912,7 +1912,7 @@ async def test_not_release_notes(
     ):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -1942,7 +1942,7 @@ async def test_no_os_entity(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -1966,7 +1966,7 @@ async def test_setting_up_core_update_when_addon_fails(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         await hass.async_block_till_done()

--- a/tests/components/hassio/test_websocket_api.py
+++ b/tests/components/hassio/test_websocket_api.py
@@ -98,7 +98,7 @@ async def test_ws_subscription(
     hass: HomeAssistant, hass_supervisor_ws_client: WebSocketGenerator
 ) -> None:
     """Test websocket subscription."""
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     client = await hass_supervisor_ws_client()
     await client.send_json({WS_ID: 5, WS_TYPE: WS_TYPE_SUBSCRIBE})
     response = await client.receive_json()
@@ -137,7 +137,7 @@ async def test_admin_non_supervisor_publish_supervisor_event_failure(
 ) -> None:
     """Test non admin user cannot publish supervisor event."""
     hass_admin_user.groups = []
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     client = await hass_ws_client(hass)
 
     await client.send_json(
@@ -159,7 +159,7 @@ async def test_websocket_supervisor_api(
     aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test Supervisor websocket api."""
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     websocket_client = await hass_ws_client(hass)
     aioclient_mock.post(
         "http://127.0.0.1/backups/new/partial",
@@ -203,7 +203,7 @@ async def test_websocket_supervisor_api_with_params(
     aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test Supervisor websocket api with query params."""
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     websocket_client = await hass_ws_client(hass)
     aioclient_mock.get(
         "http://127.0.0.1/backups/backup_id/info",
@@ -234,7 +234,7 @@ async def test_websocket_supervisor_api_error(
     aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test Supervisor websocket api error."""
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     websocket_client = await hass_ws_client(hass)
     aioclient_mock.get(
         "http://127.0.0.1/ping",
@@ -263,7 +263,7 @@ async def test_websocket_supervisor_api_error_without_msg(
     aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test Supervisor websocket api error."""
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     websocket_client = await hass_ws_client(hass)
     aioclient_mock.get(
         "http://127.0.0.1/ping",
@@ -294,7 +294,7 @@ async def test_websocket_non_admin_user(
 ) -> None:
     """Test Supervisor websocket api error."""
     hass_admin_user.groups = []
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     websocket_client = await hass_ws_client(hass)
     aioclient_mock.get(
         "http://127.0.0.1/addons/test_addon/info",
@@ -388,7 +388,7 @@ async def test_update_addon(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -491,7 +491,7 @@ async def test_update_addon_with_backup(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -634,7 +634,7 @@ async def test_update_addon_with_backup_removes_old_backups(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -697,7 +697,7 @@ async def test_update_core(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -792,7 +792,7 @@ async def test_update_core_with_backup(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -831,7 +831,7 @@ async def test_update_addon_with_error(
     with patch.dict(os.environ, MOCK_ENVIRON):
         assert await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
     await hass.async_block_till_done()
@@ -871,7 +871,7 @@ async def test_update_addon_with_backup_and_error(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -910,7 +910,7 @@ async def test_update_core_with_error(
     with patch.dict(os.environ, MOCK_ENVIRON):
         assert await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
     await hass.async_block_till_done()
@@ -938,7 +938,7 @@ async def test_update_core_with_backup_and_error(
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
-            "hassio",
+            DOMAIN,
             {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
         )
         assert result
@@ -969,7 +969,7 @@ async def test_read_update_config(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test read and update config."""
-    assert await async_setup_component(hass, "hassio", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     websocket_client = await hass_ws_client(hass)
 
     await websocket_client.send_json_auto_id({"type": "hassio/update/config/info"})

--- a/tests/components/history/test_init.py
+++ b/tests/components/history/test_init.py
@@ -9,6 +9,7 @@ from freezegun import freeze_time
 import pytest
 
 from homeassistant.components import history
+from homeassistant.components.history import DOMAIN
 from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.components.recorder.models import process_timestamp
 from homeassistant.const import EVENT_HOMEASSISTANT_FINAL_WRITE
@@ -382,7 +383,7 @@ async def test_fetch_period_api(
     hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> None:
     """Test the fetch period view for history."""
-    await async_setup_component(hass, "history", {})
+    await async_setup_component(hass, DOMAIN, {})
     client = await hass_client()
     response = await client.get(
         f"/api/history/period/{dt_util.utcnow().isoformat()}?filter_entity_id=sensor.power"
@@ -398,7 +399,7 @@ async def test_fetch_period_api_with_use_include_order(
 ) -> None:
     """Test the fetch period view for history with include order."""
     await async_setup_component(
-        hass, "history", {history.DOMAIN: {history.CONF_ORDER: True}}
+        hass, DOMAIN, {history.DOMAIN: {history.CONF_ORDER: True}}
     )
     client = await hass_client()
     response = await client.get(
@@ -415,7 +416,7 @@ async def test_fetch_period_api_with_minimal_response(
 ) -> None:
     """Test the fetch period view for history with minimal_response."""
     now = dt_util.utcnow()
-    await async_setup_component(hass, "history", {})
+    await async_setup_component(hass, DOMAIN, {})
 
     hass.states.async_set("sensor.power", 0, {"attr": "any"})
     await async_wait_recording_done(hass)
@@ -457,7 +458,7 @@ async def test_fetch_period_api_with_no_timestamp(
     hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> None:
     """Test the fetch period view for history with no timestamp."""
-    await async_setup_component(hass, "history", {})
+    await async_setup_component(hass, DOMAIN, {})
     client = await hass_client()
     response = await client.get("/api/history/period?filter_entity_id=sensor.power")
     assert response.status == HTTPStatus.OK
@@ -472,7 +473,7 @@ async def test_fetch_period_api_with_include_order(
     """Test the fetch period view for history."""
     await async_setup_component(
         hass,
-        "history",
+        DOMAIN,
         {
             "history": {
                 "use_include_order": True,
@@ -498,7 +499,7 @@ async def test_entity_ids_limit_via_api(
     """Test limiting history to entity_ids."""
     await async_setup_component(
         hass,
-        "history",
+        DOMAIN,
         {"history": {}},
     )
     hass.states.async_set("light.kitchen", "on")
@@ -525,7 +526,7 @@ async def test_entity_ids_limit_via_api_with_skip_initial_state(
     """Test limiting history to entity_ids with skip_initial_state."""
     await async_setup_component(
         hass,
-        "history",
+        DOMAIN,
         {"history": {}},
     )
     hass.states.async_set("light.kitchen", "on")
@@ -560,7 +561,7 @@ async def test_fetch_period_api_before_history_started(
     """Test the fetch period view for history for the far past."""
     await async_setup_component(
         hass,
-        "history",
+        DOMAIN,
         {},
     )
     await async_wait_recording_done(hass)
@@ -582,7 +583,7 @@ async def test_fetch_period_api_far_future(
     """Test the fetch period view for history for the far future."""
     await async_setup_component(
         hass,
-        "history",
+        DOMAIN,
         {},
     )
     await async_wait_recording_done(hass)
@@ -604,7 +605,7 @@ async def test_fetch_period_api_with_invalid_datetime(
     """Test the fetch period view for history with an invalid date time."""
     await async_setup_component(
         hass,
-        "history",
+        DOMAIN,
         {},
     )
     await async_wait_recording_done(hass)
@@ -624,7 +625,7 @@ async def test_fetch_period_api_invalid_end_time(
     """Test the fetch period view for history with an invalid end time."""
     await async_setup_component(
         hass,
-        "history",
+        DOMAIN,
         {},
     )
     await async_wait_recording_done(hass)
@@ -647,7 +648,7 @@ async def test_entity_ids_limit_via_api_with_end_time(
     """Test limiting history to entity_ids with end_time."""
     await async_setup_component(
         hass,
-        "history",
+        DOMAIN,
         {"history": {}},
     )
     start = dt_util.utcnow()
@@ -692,7 +693,7 @@ async def test_fetch_period_api_with_no_entity_ids(
     hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> None:
     """Test the fetch period view for history with minimal_response."""
-    await async_setup_component(hass, "history", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_wait_recording_done(hass)
 
     yesterday = dt_util.utcnow() - timedelta(days=1)
@@ -753,7 +754,7 @@ async def test_history_with_invalid_entity_ids(
     """Test sending valid and invalid entity_ids to the API."""
     await async_setup_component(
         hass,
-        "history",
+        DOMAIN,
         {"history": {}},
     )
     hass.states.async_set("light.kitchen", "on")
@@ -785,7 +786,7 @@ async def test_fetch_period_api_filters_unauthorized_entities(
     hass_read_only_user.mock_policy(
         {"entities": {"entity_ids": {"light.kitchen": True}}}
     )
-    await async_setup_component(hass, "history", {})
+    await async_setup_component(hass, DOMAIN, {})
 
     hass.states.async_set("light.kitchen", "on")
     hass.states.async_set("light.cow", "on")

--- a/tests/components/history/test_websocket_api.py
+++ b/tests/components/history/test_websocket_api.py
@@ -11,7 +11,7 @@ from freezegun import freeze_time
 import pytest
 
 from homeassistant.components import history
-from homeassistant.components.history import websocket_api
+from homeassistant.components.history import DOMAIN, websocket_api
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_FINAL_WRITE,
     EVENT_STATE_CHANGED,
@@ -77,7 +77,7 @@ async def test_history_during_period(
     """Test history_during_period."""
     now = dt_util.utcnow()
 
-    await async_setup_component(hass, "history", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_setup_component(hass, "sensor", {})
     await async_recorder_block_till_done(hass)
     hass.states.async_set("sensor.test", "on", attributes={"any": "attr"})
@@ -210,7 +210,7 @@ async def test_history_during_period_impossible_conditions(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test history_during_period returns when condition cannot be true."""
-    await async_setup_component(hass, "history", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_setup_component(hass, "sensor", {})
     await async_recorder_block_till_done(hass)
     hass.states.async_set("sensor.test", "on", attributes={"any": "attr"})
@@ -278,7 +278,7 @@ async def test_history_during_period_significant_domain(
     await hass.config.async_set_time_zone(time_zone)
     now = dt_util.utcnow()
 
-    await async_setup_component(hass, "history", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_setup_component(hass, "sensor", {})
     await async_recorder_block_till_done(hass)
     hass.states.async_set("climate.test", "on", attributes={"temperature": "1"})
@@ -443,7 +443,7 @@ async def test_history_during_period_bad_start_time(
     """Test history_during_period bad state time."""
     await async_setup_component(
         hass,
-        "history",
+        DOMAIN,
         {"history": {}},
     )
 
@@ -470,7 +470,7 @@ async def test_history_during_period_bad_end_time(
 
     await async_setup_component(
         hass,
-        "history",
+        DOMAIN,
         {"history": {}},
     )
 
@@ -497,7 +497,7 @@ async def test_history_stream_historical_only(
     now = dt_util.utcnow()
     await async_setup_component(
         hass,
-        "history",
+        DOMAIN,
         {},
     )
     await async_setup_component(hass, "sensor", {})
@@ -586,7 +586,7 @@ async def test_history_stream_significant_domain_historical_only(
     """Test the stream with climate domain with historical states only."""
     now = dt_util.utcnow()
 
-    await async_setup_component(hass, "history", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_setup_component(hass, "sensor", {})
     await async_recorder_block_till_done(hass)
     hass.states.async_set("climate.test", "on", attributes={"temperature": "1"})
@@ -788,7 +788,7 @@ async def test_history_stream_bad_start_time(
     """Test history stream bad state time."""
     await async_setup_component(
         hass,
-        "history",
+        DOMAIN,
         {"history": {}},
     )
 
@@ -816,7 +816,7 @@ async def test_history_stream_end_time_before_start_time(
 
     await async_setup_component(
         hass,
-        "history",
+        DOMAIN,
         {"history": {}},
     )
 
@@ -844,7 +844,7 @@ async def test_history_stream_bad_end_time(
 
     await async_setup_component(
         hass,
-        "history",
+        DOMAIN,
         {"history": {}},
     )
 
@@ -871,7 +871,7 @@ async def test_history_stream_live_no_attributes_minimal_response(
     now = dt_util.utcnow()
     await async_setup_component(
         hass,
-        "history",
+        DOMAIN,
         {},
     )
     await async_setup_component(hass, "sensor", {})
@@ -965,7 +965,7 @@ async def test_history_stream_live(
     now = dt_util.utcnow()
     await async_setup_component(
         hass,
-        "history",
+        DOMAIN,
         {},
     )
     await async_setup_component(hass, "sensor", {})
@@ -1079,7 +1079,7 @@ async def test_history_stream_live_minimal_response(
     now = dt_util.utcnow()
     await async_setup_component(
         hass,
-        "history",
+        DOMAIN,
         {},
     )
     await async_setup_component(hass, "sensor", {})
@@ -1185,7 +1185,7 @@ async def test_history_stream_live_no_attributes(
     now = dt_util.utcnow()
     await async_setup_component(
         hass,
-        "history",
+        DOMAIN,
         {},
     )
     await async_setup_component(hass, "sensor", {})
@@ -1291,7 +1291,7 @@ async def test_history_stream_live_no_attributes_minimal_response_specific_entit
     wanted_entities = ["sensor.two", "sensor.four", "sensor.one"]
     await async_setup_component(
         hass,
-        "history",
+        DOMAIN,
         {history.DOMAIN: {}},
     )
     await async_setup_component(hass, "sensor", {})
@@ -1386,7 +1386,7 @@ async def test_history_stream_live_with_future_end_time(
     wanted_entities = ["sensor.two", "sensor.four", "sensor.one"]
     await async_setup_component(
         hass,
-        "history",
+        DOMAIN,
         {history.DOMAIN: {}},
     )
     await async_setup_component(hass, "sensor", {})
@@ -1496,7 +1496,7 @@ async def test_history_stream_before_history_starts(
     """Test history stream before we have history."""
     await async_setup_component(
         hass,
-        "history",
+        DOMAIN,
         {},
     )
     await async_setup_component(hass, "sensor", {})
@@ -1548,7 +1548,7 @@ async def test_history_stream_for_entity_with_no_possible_changes(
     """
     await async_setup_component(
         hass,
-        "history",
+        DOMAIN,
         {},
     )
     await async_setup_component(hass, "sensor", {})
@@ -1624,7 +1624,7 @@ async def test_overflow_queue(
     ):
         await async_setup_component(
             hass,
-            "history",
+            DOMAIN,
             {history.DOMAIN: {}},
         )
         await async_setup_component(hass, "sensor", {})
@@ -1711,7 +1711,7 @@ async def test_history_during_period_for_invalid_entity_ids(
     """Test history_during_period for valid and invalid entity ids."""
     now = dt_util.utcnow()
 
-    await async_setup_component(hass, "history", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_setup_component(hass, "sensor", {})
     await async_recorder_block_till_done(hass)
     hass.states.async_set("sensor.one", "on", attributes={"any": "attr"})
@@ -1873,7 +1873,7 @@ async def test_history_stream_for_invalid_entity_ids(
     now = dt_util.utcnow()
     await async_setup_component(
         hass,
-        "history",
+        DOMAIN,
         {history.DOMAIN: {}},
     )
 
@@ -2050,7 +2050,7 @@ async def test_history_stream_historical_only_with_start_time_state_past(
     """Test history stream."""
     await async_setup_component(
         hass,
-        "history",
+        DOMAIN,
         {},
     )
     await async_setup_component(hass, "sensor", {})
@@ -2161,7 +2161,7 @@ async def test_history_stream_live_chained_events(
 ) -> None:
     """Test history stream with history with a chained event."""
     now = dt_util.utcnow()
-    await async_setup_component(hass, "history", {})
+    await async_setup_component(hass, DOMAIN, {})
 
     hass.states.async_set("binary_sensor.is_light", STATE_OFF)
     await async_wait_recording_done(hass)
@@ -2251,7 +2251,7 @@ async def test_history_during_period_filters_unauthorized_entities(
     )
     now = dt_util.utcnow()
 
-    await async_setup_component(hass, "history", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
     hass.states.async_set("sensor.allowed", "on")
     hass.states.async_set("sensor.forbidden", "on")
@@ -2303,7 +2303,7 @@ async def test_history_stream_filters_unauthorized_entities(
     )
     now = dt_util.utcnow()
 
-    await async_setup_component(hass, "history", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
     hass.states.async_set("sensor.allowed", "on")
     hass.states.async_set("sensor.forbidden", "on")

--- a/tests/components/homeassistant/test_exposed_entities.py
+++ b/tests/components/homeassistant/test_exposed_entities.py
@@ -3,6 +3,7 @@
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.homeassistant import DOMAIN
 from homeassistant.components.homeassistant.exposed_entities import (
     DATA_EXPOSED_ENTITIES,
     ExposedEntities,
@@ -101,7 +102,7 @@ def entities_no_unique_id(hass: HomeAssistant) -> dict[str, str]:
 
 async def test_load_preferences(hass: HomeAssistant) -> None:
     """Make sure that we can load/save data correctly."""
-    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     exposed_entities = hass.data[DATA_EXPOSED_ENTITIES]
     assert exposed_entities._assistants == {}
@@ -134,7 +135,7 @@ async def test_expose_entity(
 ) -> None:
     """Test expose entity."""
     ws_client = await hass_ws_client(hass)
-    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     entry1 = entity_registry.async_get_or_create("test", "test", "unique1")
@@ -194,7 +195,7 @@ async def test_expose_entity_unknown(
 ) -> None:
     """Test behavior when exposing an unknown entity."""
     ws_client = await hass_ws_client(hass)
-    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     exposed_entities = hass.data[DATA_EXPOSED_ENTITIES]
@@ -257,7 +258,7 @@ async def test_expose_new_entities(
 ) -> None:
     """Test expose entity."""
     ws_client = await hass_ws_client(hass)
-    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     entry1 = entity_registry.async_get_or_create("climate", "test", "unique1")
@@ -313,7 +314,7 @@ async def test_listen_updates(
     def listener():
         calls.append(None)
 
-    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     async_listen_entity_updates(hass, "cloud.alexa", listener)
@@ -343,7 +344,7 @@ async def test_get_assistant_settings(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test get assistant settings."""
-    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     entry = entity_registry.async_get_or_create("climate", "test", "unique1")
@@ -370,7 +371,7 @@ async def test_should_expose(
 ) -> None:
     """Test expose entity."""
     ws_client = await hass_ws_client(hass)
-    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     # Expose new entities to Alexa
@@ -433,7 +434,7 @@ async def test_should_expose_hidden_categorized(
 ) -> None:
     """Test expose entity."""
     ws_client = await hass_ws_client(hass)
-    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     # Expose new entities to Alexa
@@ -466,7 +467,7 @@ async def test_list_exposed_entities(
 ) -> None:
     """Test list exposed entities."""
     ws_client = await hass_ws_client(hass)
-    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     entry1 = entity_registry.async_get_or_create("test", "test", "unique1")
@@ -535,7 +536,7 @@ async def test_listeners(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Make sure we call entity listeners."""
-    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     exposed_entities = hass.data[DATA_EXPOSED_ENTITIES]
 

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -201,7 +201,7 @@ async def test_turn_on_skips_domains_without_service(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test if turn_on is blocking domain with no service."""
-    await async_setup_component(hass, "homeassistant", {})
+    await async_setup_component(hass, DOMAIN, {})
     async_mock_service(hass, "light", SERVICE_TURN_ON)
     hass.states.async_set("light.Bowl", STATE_ON)
     hass.states.async_set("light.Ceiling", STATE_OFF)
@@ -241,7 +241,7 @@ async def test_turn_on_skips_domains_without_service(
 
 async def test_entity_update(hass: HomeAssistant) -> None:
     """Test being able to call entity update."""
-    await async_setup_component(hass, "homeassistant", {})
+    await async_setup_component(hass, DOMAIN, {})
 
     with patch(
         "homeassistant.components.homeassistant.async_update_entity",
@@ -260,7 +260,7 @@ async def test_entity_update(hass: HomeAssistant) -> None:
 
 async def test_setting_location(hass: HomeAssistant) -> None:
     """Test setting the location."""
-    await async_setup_component(hass, "homeassistant", {})
+    await async_setup_component(hass, DOMAIN, {})
     events = async_capture_events(hass, EVENT_CORE_CONFIG_UPDATE)
     # Just to make sure that we are updating values.
     assert hass.config.latitude != 30
@@ -303,7 +303,7 @@ async def test_require_admin(
     hass: HomeAssistant, hass_read_only_user: MockUser
 ) -> None:
     """Test services requiring admin."""
-    await async_setup_component(hass, "homeassistant", {})
+    await async_setup_component(hass, DOMAIN, {})
 
     for service in (
         SERVICE_HOMEASSISTANT_RESTART,
@@ -334,7 +334,7 @@ async def test_turn_on_off_toggle_schema(
     hass: HomeAssistant, hass_read_only_user: MockUser
 ) -> None:
     """Test the schemas for the turn on/off/toggle services."""
-    await async_setup_component(hass, "homeassistant", {})
+    await async_setup_component(hass, DOMAIN, {})
 
     for service in SERVICE_TURN_ON, SERVICE_TURN_OFF, SERVICE_TOGGLE:
         for invalid in None, "nothing", ENTITY_MATCH_ALL, ENTITY_MATCH_NONE:
@@ -352,7 +352,7 @@ async def test_not_allowing_recursion(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test we do not allow recursion."""
-    await async_setup_component(hass, "homeassistant", {})
+    await async_setup_component(hass, DOMAIN, {})
 
     for service in SERVICE_TURN_ON, SERVICE_TURN_OFF, SERVICE_TOGGLE:
         await hass.services.async_call(
@@ -371,7 +371,7 @@ async def test_reload_config_entry_by_entity_id(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test being able to reload a config entry by entity_id."""
-    await async_setup_component(hass, "homeassistant", {})
+    await async_setup_component(hass, DOMAIN, {})
     entry1 = MockConfigEntry(domain="mockdomain")
     entry1.add_to_hass(hass)
     entry2 = MockConfigEntry(domain="mockdomain")
@@ -410,7 +410,7 @@ async def test_reload_config_entry_by_entity_id(
 
 async def test_reload_config_entry_by_entry_id(hass: HomeAssistant) -> None:
     """Test being able to reload a config entry by config entry id."""
-    await async_setup_component(hass, "homeassistant", {})
+    await async_setup_component(hass, DOMAIN, {})
 
     with patch(
         "homeassistant.config_entries.ConfigEntries.async_reload",
@@ -434,7 +434,7 @@ async def test_raises_when_db_upgrade_in_progress(
     hass: HomeAssistant, service, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test an exception is raised when the database migration is in progress."""
-    await async_setup_component(hass, "homeassistant", {})
+    await async_setup_component(hass, DOMAIN, {})
 
     with (
         pytest.raises(HomeAssistantError),
@@ -476,7 +476,7 @@ async def test_raises_when_config_is_invalid(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test an exception is raised when the configuration is invalid."""
-    await async_setup_component(hass, "homeassistant", {})
+    await async_setup_component(hass, DOMAIN, {})
 
     with (
         pytest.raises(HomeAssistantError),
@@ -526,7 +526,7 @@ async def test_restart_homeassistant(
     hass: HomeAssistant, service_data: dict, safe_mode_enabled: bool
 ) -> None:
     """Test we can restart when there is no configuration error."""
-    await async_setup_component(hass, "homeassistant", {})
+    await async_setup_component(hass, DOMAIN, {})
     with (
         patch(
             "homeassistant.config.async_check_ha_config_file", return_value=None
@@ -550,7 +550,7 @@ async def test_restart_homeassistant(
 
 async def test_stop_homeassistant(hass: HomeAssistant) -> None:
     """Test we can stop when there is a configuration error."""
-    await async_setup_component(hass, "homeassistant", {})
+    await async_setup_component(hass, DOMAIN, {})
     with (
         patch(
             "homeassistant.config.async_check_ha_config_file", return_value=None
@@ -571,7 +571,7 @@ async def test_stop_homeassistant(hass: HomeAssistant) -> None:
 
 async def test_save_persistent_states(hass: HomeAssistant) -> None:
     """Test we can call save_persistent_states."""
-    await async_setup_component(hass, "homeassistant", {})
+    await async_setup_component(hass, DOMAIN, {})
     with patch(
         "homeassistant.helpers.restore_state.RestoreStateData.async_save_persistent_states",
         return_value=None,
@@ -586,7 +586,7 @@ async def test_save_persistent_states(hass: HomeAssistant) -> None:
 
 async def test_reload_custom_templates(hass: HomeAssistant) -> None:
     """Test we can call reload_custom_templates."""
-    await async_setup_component(hass, "homeassistant", {})
+    await async_setup_component(hass, DOMAIN, {})
     with patch(
         "homeassistant.components.homeassistant.async_load_custom_templates",
         return_value=None,
@@ -603,7 +603,7 @@ async def test_reload_all(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test reload_all service."""
-    await async_setup_component(hass, "homeassistant", {})
+    await async_setup_component(hass, DOMAIN, {})
     test1 = async_mock_service(hass, "test1", "reload")
     test2 = async_mock_service(hass, "test2", "reload")
     no_reload = async_mock_service(hass, "test3", "not_reload")

--- a/tests/components/homeassistant_sky_connect/test_init.py
+++ b/tests/components/homeassistant_sky_connect/test_init.py
@@ -531,7 +531,7 @@ async def test_bad_config_entry_fixing(hass: HomeAssistant) -> None:
             )
         ],
     ):
-        await async_setup_component(hass, "homeassistant_sky_connect", {})
+        await async_setup_component(hass, DOMAIN, {})
 
     assert hass.config_entries.async_get_entry(new_entry.entry_id) is not None
     assert hass.config_entries.async_get_entry(old_entry.entry_id) is not None

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -393,10 +393,10 @@ async def test_options_flow_devices(
     with patch("homeassistant.components.homekit.HomeKit") as mock_homekit:
         mock_homekit.return_value = homekit = Mock()
         type(homekit).async_start = AsyncMock()
-        assert await async_setup_component(hass, "homekit", {"homekit": {}})
+        assert await async_setup_component(hass, DOMAIN, {"homekit": {}})
         assert await async_setup_component(hass, "homeassistant", {})
         assert await async_setup_component(hass, "demo", {"demo": {}})
-        assert await async_setup_component(hass, "homekit", {"homekit": {}})
+        assert await async_setup_component(hass, DOMAIN, {"homekit": {}})
 
         hass.states.async_set("climate.old", "off")
         await hass.async_block_till_done()

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -1721,7 +1721,7 @@ async def test_yaml_updates_update_config_entry_for_name(hass: HomeAssistant) ->
         mock_homekit.return_value = homekit = Mock()
         type(homekit).async_start = AsyncMock()
         assert await async_setup_component(
-            hass, "homekit", {"homekit": {CONF_NAME: BRIDGE_NAME, CONF_PORT: 12345}}
+            hass, DOMAIN, {"homekit": {CONF_NAME: BRIDGE_NAME, CONF_PORT: 12345}}
         )
         await hass.async_block_till_done()
 
@@ -1770,7 +1770,7 @@ async def test_yaml_can_link_with_default_name(hass: HomeAssistant) -> None:
         type(homekit).async_start = AsyncMock()
         assert await async_setup_component(
             hass,
-            "homekit",
+            DOMAIN,
             {"homekit": {"entity_config": {"camera.back_camera": {"stream_count": 3}}}},
         )
         await hass.async_block_till_done()
@@ -1816,7 +1816,7 @@ async def test_yaml_can_link_with_port(hass: HomeAssistant) -> None:
         type(homekit).async_start = AsyncMock()
         assert await async_setup_component(
             hass,
-            "homekit",
+            DOMAIN,
             {
                 "homekit": {
                     "port": 12345,
@@ -2304,7 +2304,7 @@ async def test_reload(mock_port_available: MagicMock, hass: HomeAssistant) -> No
         mock_homekit.return_value = homekit = Mock()
         type(homekit).async_start = AsyncMock()
         assert await async_setup_component(
-            hass, "homekit", {"homekit": {CONF_NAME: "reloadable", CONF_PORT: 12345}}
+            hass, DOMAIN, {"homekit": {CONF_NAME: "reloadable", CONF_PORT: 12345}}
         )
         await hass.async_block_till_done()
 

--- a/tests/components/homekit/test_init.py
+++ b/tests/components/homekit/test_init.py
@@ -32,7 +32,7 @@ async def test_humanify_homekit_changed_event(hass: HomeAssistant, hk_driver) ->
     with patch("homeassistant.components.homekit.HomeKit") as mock_homekit:
         mock_homekit.return_value = homekit = Mock()
         type(homekit).async_start = AsyncMock()
-        assert await async_setup_component(hass, "homekit", {"homekit": {}})
+        assert await async_setup_component(hass, DOMAIN, {"homekit": {}})
     assert await async_setup_component(hass, "logbook", {})
     await hass.async_block_till_done()
 

--- a/tests/components/homematic/test_notify.py
+++ b/tests/components/homematic/test_notify.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+from homeassistant.components.homematic import DOMAIN
 from homeassistant.components.notify import DOMAIN as NOTIFY_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -17,7 +18,7 @@ async def test_setup_full(hass: HomeAssistant) -> None:
     ):
         await async_setup_component(
             hass,
-            "homematic",
+            DOMAIN,
             {"homematic": {"hosts": {"ccu2": {"host": "127.0.0.1"}}}},
         )
     with assert_setup_component(1, domain="notify") as handle_config:
@@ -47,7 +48,7 @@ async def test_setup_without_optional(hass: HomeAssistant) -> None:
     ):
         await async_setup_component(
             hass,
-            "homematic",
+            DOMAIN,
             {"homematic": {"hosts": {"ccu2": {"host": "127.0.0.1"}}}},
         )
     with assert_setup_component(1, domain="notify") as handle_config:

--- a/tests/components/http/test_auth.py
+++ b/tests/components/http/test_auth.py
@@ -18,6 +18,7 @@ from homeassistant.auth.models import User
 from homeassistant.auth.providers import trusted_networks
 from homeassistant.auth.providers.homeassistant import HassAuthProvider
 from homeassistant.components import websocket_api
+from homeassistant.components.http import DOMAIN
 from homeassistant.components.http.auth import (
     CONTENT_USER_NAME,
     DATA_SIGN_SECRET,
@@ -111,7 +112,7 @@ def trusted_networks_auth(
 async def test_auth_middleware_loaded_by_default(hass: HomeAssistant) -> None:
     """Test accessing to server from banned IP when feature is off."""
     with patch("homeassistant.components.http.async_setup_auth") as mock_setup:
-        await async_setup_component(hass, "http", {"http": {}})
+        await async_setup_component(hass, DOMAIN, {"http": {}})
 
     assert len(mock_setup.mock_calls) == 1
 

--- a/tests/components/http/test_ban.py
+++ b/tests/components/http/test_ban.py
@@ -12,6 +12,7 @@ from aiohttp.web_middlewares import middleware
 import pytest
 
 from homeassistant.components import http
+from homeassistant.components.http import DOMAIN
 from homeassistant.components.http.ban import (
     IP_BANS_FILE,
     KEY_BAN_MANAGER,
@@ -311,7 +312,7 @@ async def test_ban_middleware_not_loaded_by_config(hass: HomeAssistant) -> None:
     """Test accessing to server from banned IP when feature is off."""
     with patch("homeassistant.components.http.setup_bans") as mock_setup:
         await async_setup_component(
-            hass, "http", {"http": {http.CONF_IP_BAN_ENABLED: False}}
+            hass, DOMAIN, {"http": {http.CONF_IP_BAN_ENABLED: False}}
         )
 
     assert len(mock_setup.mock_calls) == 0
@@ -320,7 +321,7 @@ async def test_ban_middleware_not_loaded_by_config(hass: HomeAssistant) -> None:
 async def test_ban_middleware_loaded_by_default(hass: HomeAssistant) -> None:
     """Test accessing to server from banned IP when feature is off."""
     with patch("homeassistant.components.http.setup_bans") as mock_setup:
-        await async_setup_component(hass, "http", {"http": {}})
+        await async_setup_component(hass, DOMAIN, {"http": {}})
 
     assert len(mock_setup.mock_calls) == 1
 

--- a/tests/components/http/test_cors.py
+++ b/tests/components/http/test_cors.py
@@ -16,7 +16,7 @@ from aiohttp.hdrs import (
 from aiohttp.test_utils import TestClient
 import pytest
 
-from homeassistant.components.http import StaticPathConfig
+from homeassistant.components.http import DOMAIN, StaticPathConfig
 from homeassistant.components.http.cors import setup_cors
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.http import KEY_ALLOW_CONFIGURED_CORS, HomeAssistantView
@@ -32,7 +32,7 @@ TRUSTED_ORIGIN = "https://home-assistant.io"
 async def test_cors_middleware_loaded_by_default(hass: HomeAssistant) -> None:
     """Test accessing to server from banned IP when feature is off."""
     with patch("homeassistant.components.http.setup_cors") as mock_setup:
-        await async_setup_component(hass, "http", {"http": {}})
+        await async_setup_component(hass, DOMAIN, {"http": {}})
 
     assert len(mock_setup.mock_calls) == 1
 
@@ -42,7 +42,7 @@ async def test_cors_middleware_loaded_from_config(hass: HomeAssistant) -> None:
     with patch("homeassistant.components.http.setup_cors") as mock_setup:
         await async_setup_component(
             hass,
-            "http",
+            DOMAIN,
             {"http": {"cors_allowed_origins": ["http://home-assistant.io"]}},
         )
 
@@ -126,7 +126,7 @@ async def test_cors_middleware_with_cors_allowed_view(hass: HomeAssistant) -> No
             return "test"
 
     assert await async_setup_component(
-        hass, "http", {"http": {"cors_allowed_origins": ["http://home-assistant.io"]}}
+        hass, DOMAIN, {"http": {"cors_allowed_origins": ["http://home-assistant.io"]}}
     )
 
     hass.http.register_view(MyView("/api/test", "api:test"))

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -15,6 +15,7 @@ import pytest
 from homeassistant.auth.providers.homeassistant import HassAuthProvider
 from homeassistant.components import cloud, http
 from homeassistant.components.cloud import CloudNotAvailable
+from homeassistant.components.http import DOMAIN
 from homeassistant.const import HASSIO_USER_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
@@ -148,7 +149,7 @@ async def test_proxy_config(hass: HomeAssistant) -> None:
     assert (
         await async_setup_component(
             hass,
-            "http",
+            DOMAIN,
             {
                 "http": {
                     http.CONF_USE_X_FORWARDED_FOR: True,
@@ -164,7 +165,7 @@ async def test_proxy_config_only_use_xff(hass: HomeAssistant) -> None:
     """Test use_x_forwarded_for must config together with trusted_proxies."""
     assert (
         await async_setup_component(
-            hass, "http", {"http": {http.CONF_USE_X_FORWARDED_FOR: True}}
+            hass, DOMAIN, {"http": {http.CONF_USE_X_FORWARDED_FOR: True}}
         )
         is not True
     )
@@ -174,7 +175,7 @@ async def test_proxy_config_only_trust_proxies(hass: HomeAssistant) -> None:
     """Test use_x_forwarded_for must config together with trusted_proxies."""
     assert (
         await async_setup_component(
-            hass, "http", {"http": {http.CONF_TRUSTED_PROXIES: ["127.0.0.1"]}}
+            hass, DOMAIN, {"http": {http.CONF_TRUSTED_PROXIES: ["127.0.0.1"]}}
         )
         is not True
     )
@@ -197,7 +198,7 @@ async def test_ssl_profile_defaults_modern(hass: HomeAssistant, tmp_path: Path) 
         assert (
             await async_setup_component(
                 hass,
-                "http",
+                DOMAIN,
                 {"http": {"ssl_certificate": cert_path, "ssl_key": key_path}},
             )
             is True
@@ -227,7 +228,7 @@ async def test_ssl_profile_change_intermediate(
         assert (
             await async_setup_component(
                 hass,
-                "http",
+                DOMAIN,
                 {
                     "http": {
                         "ssl_profile": "intermediate",
@@ -261,7 +262,7 @@ async def test_ssl_profile_change_modern(hass: HomeAssistant, tmp_path: Path) ->
         assert (
             await async_setup_component(
                 hass,
-                "http",
+                DOMAIN,
                 {
                     "http": {
                         "ssl_profile": "modern",
@@ -295,7 +296,7 @@ async def test_peer_cert(hass: HomeAssistant, tmp_path: Path) -> None:
         assert (
             await async_setup_component(
                 hass,
-                "http",
+                DOMAIN,
                 {
                     "http": {
                         "ssl_peer_certificate": peer_cert_path,
@@ -327,7 +328,7 @@ async def test_emergency_ssl_certificate_when_invalid(
     assert (
         await async_setup_component(
             hass,
-            "http",
+            DOMAIN,
             {
                 "http": {"ssl_certificate": cert_path, "ssl_key": key_path},
             },
@@ -357,7 +358,7 @@ async def test_emergency_ssl_certificate_not_used_when_not_recovery_mode(
 
     assert (
         await async_setup_component(
-            hass, "http", {"http": {"ssl_certificate": cert_path, "ssl_key": key_path}}
+            hass, DOMAIN, {"http": {"ssl_certificate": cert_path, "ssl_key": key_path}}
         )
         is False
     )
@@ -381,7 +382,7 @@ async def test_emergency_ssl_certificate_when_invalid_get_url_fails(
         assert (
             await async_setup_component(
                 hass,
-                "http",
+                DOMAIN,
                 {
                     "http": {"ssl_certificate": cert_path, "ssl_key": key_path},
                 },
@@ -417,7 +418,7 @@ async def test_invalid_ssl_and_cannot_create_emergency_cert(
         assert (
             await async_setup_component(
                 hass,
-                "http",
+                DOMAIN,
                 {
                     "http": {"ssl_certificate": cert_path, "ssl_key": key_path},
                 },
@@ -454,7 +455,7 @@ async def test_invalid_ssl_and_cannot_create_emergency_cert_with_ssl_peer_cert(
         assert (
             await async_setup_component(
                 hass,
-                "http",
+                DOMAIN,
                 {
                     "http": {
                         "ssl_certificate": cert_path,
@@ -474,7 +475,7 @@ async def test_invalid_ssl_and_cannot_create_emergency_cert_with_ssl_peer_cert(
 async def test_cors_defaults(hass: HomeAssistant) -> None:
     """Test the CORS default settings."""
     with patch("homeassistant.components.http.setup_cors") as mock_setup:
-        assert await async_setup_component(hass, "http", {})
+        assert await async_setup_component(hass, DOMAIN, {})
 
     assert len(mock_setup.mock_calls) == 1
     assert mock_setup.mock_calls[0][1][1] == ["https://cast.home-assistant.io"]
@@ -558,7 +559,7 @@ async def test_ssl_issue_if_no_urls_configured(
     ):
         assert await async_setup_component(
             hass,
-            "http",
+            DOMAIN,
             {"http": {"ssl_certificate": cert_path, "ssl_key": key_path}},
         )
         await hass.async_start()
@@ -590,7 +591,7 @@ async def test_ssl_issue_if_using_cloud(
     ):
         assert await async_setup_component(
             hass,
-            "http",
+            DOMAIN,
             {"http": {"ssl_certificate": cert_path, "ssl_key": key_path}},
         )
         await hass.async_start()
@@ -628,7 +629,7 @@ async def test_ssl_issue_if_not_connected_to_cloud(
     ):
         assert await async_setup_component(
             hass,
-            "http",
+            DOMAIN,
             {"http": {"ssl_certificate": cert_path, "ssl_key": key_path}},
         )
         await hass.async_start()
@@ -670,7 +671,7 @@ async def test_ssl_issue_urls_configured(
     ):
         assert await async_setup_component(
             hass,
-            "http",
+            DOMAIN,
             {"http": {"ssl_certificate": cert_path, "ssl_key": key_path}},
         )
         await hass.async_start()
@@ -722,7 +723,7 @@ async def test_server_host(
     ):
         assert await async_setup_component(
             hass,
-            "http",
+            DOMAIN,
             {"http": http_config},
         )
         await hass.async_start()
@@ -766,7 +767,7 @@ async def test_unix_socket_started_with_supervisor(
             loop, "create_unix_server", return_value=Mock()
         ) as mock_create_unix,
     ):
-        assert await async_setup_component(hass, "http", {"http": {}})
+        assert await async_setup_component(hass, DOMAIN, {"http": {}})
         await hass.async_start()
         await hass.async_block_till_done()
 
@@ -784,7 +785,7 @@ async def test_unix_socket_not_started_without_supervisor(
         patch("asyncio.BaseEventLoop.create_server", return_value=Mock()),
     ):
         os.environ.pop("SUPERVISOR_CORE_API_SOCKET", None)
-        assert await async_setup_component(hass, "http", {"http": {}})
+        assert await async_setup_component(hass, DOMAIN, {"http": {}})
         await hass.async_start()
         await hass.async_block_till_done()
 
@@ -804,7 +805,7 @@ async def test_unix_socket_rejected_relative_path(
         ),
         patch("asyncio.BaseEventLoop.create_server", return_value=Mock()),
     ):
-        assert await async_setup_component(hass, "http", {"http": {}})
+        assert await async_setup_component(hass, DOMAIN, {"http": {}})
         await hass.async_start()
         await hass.async_block_till_done()
 

--- a/tests/components/http/test_static.py
+++ b/tests/components/http/test_static.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from aiohttp.test_utils import TestClient
 import pytest
 
-from homeassistant.components.http import StaticPathConfig
+from homeassistant.components.http import DOMAIN, StaticPathConfig
 from homeassistant.components.http.static import CachingStaticResource
 from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.core import HomeAssistant
@@ -19,7 +19,7 @@ from tests.typing import ClientSessionGenerator
 @pytest.fixture(autouse=True)
 async def http(hass: HomeAssistant) -> None:
     """Ensure http is set up."""
-    assert await async_setup_component(hass, "http", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
 

--- a/tests/components/hue/test_init.py
+++ b/tests/components/hue/test_init.py
@@ -7,6 +7,7 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components import hue
+from homeassistant.components.hue import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -162,7 +163,7 @@ async def test_security_vuln_check(hass: HomeAssistant) -> None:
             ),
         ),
     ):
-        assert await async_setup_component(hass, "hue", {})
+        assert await async_setup_component(hass, DOMAIN, {})
 
     await hass.async_block_till_done()
 

--- a/tests/components/image_upload/test_init.py
+++ b/tests/components/image_upload/test_init.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 from aiohttp import ClientSession, ClientWebSocketResponse
 from freezegun.api import FrozenDateTimeFactory
 
+from homeassistant.components.image_upload import DOMAIN
 from homeassistant.components.websocket_api import TYPE_RESULT
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -31,7 +32,7 @@ async def test_upload_image(
         tempfile.TemporaryDirectory() as tempdir,
         patch.object(hass.config, "path", return_value=tempdir),
     ):
-        assert await async_setup_component(hass, "image_upload", {})
+        assert await async_setup_component(hass, DOMAIN, {})
         ws_client: ClientWebSocketResponse = await hass_ws_client()
         client: ClientSession = await hass_client()
 

--- a/tests/components/image_upload/test_media_source.py
+++ b/tests/components/image_upload/test_media_source.py
@@ -8,6 +8,7 @@ from aiohttp import ClientSession
 import pytest
 
 from homeassistant.components import media_source
+from homeassistant.components.image_upload import DOMAIN
 from homeassistant.components.media_player import BrowseError
 from homeassistant.components.media_source import Unresolvable
 from homeassistant.core import HomeAssistant
@@ -32,7 +33,7 @@ async def __upload_test_image(
         tempfile.TemporaryDirectory() as tempdir,
         patch.object(hass.config, "path", return_value=tempdir),
     ):
-        assert await async_setup_component(hass, "image_upload", {})
+        assert await async_setup_component(hass, DOMAIN, {})
         client: ClientSession = await hass_client()
 
         file = await hass.async_add_executor_job(TEST_IMAGE.open, "rb")

--- a/tests/components/input_boolean/test_init.py
+++ b/tests/components/input_boolean/test_init.py
@@ -179,7 +179,7 @@ async def test_input_boolean_context(
 ) -> None:
     """Test that input_boolean context works."""
     assert await async_setup_component(
-        hass, "input_boolean", {"input_boolean": {"ac": {CONF_INITIAL: True}}}
+        hass, DOMAIN, {"input_boolean": {"ac": {CONF_INITIAL: True}}}
     )
 
     state = hass.states.get("input_boolean.ac")

--- a/tests/components/input_boolean/test_reproduce_state.py
+++ b/tests/components/input_boolean/test_reproduce_state.py
@@ -1,5 +1,6 @@
 """Test reproduce state for input boolean."""
 
+from homeassistant.components.input_boolean import DOMAIN
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 from homeassistant.setup import async_setup_component
@@ -9,7 +10,7 @@ async def test_reproducing_states(hass: HomeAssistant) -> None:
     """Test reproducing input_boolean states."""
     assert await async_setup_component(
         hass,
-        "input_boolean",
+        DOMAIN,
         {
             "input_boolean": {
                 "initial_on": {"initial": True},

--- a/tests/components/input_datetime/test_init.py
+++ b/tests/components/input_datetime/test_init.py
@@ -443,7 +443,7 @@ async def test_input_datetime_context(
 ) -> None:
     """Test that input_datetime context works."""
     assert await async_setup_component(
-        hass, "input_datetime", {"input_datetime": {"only_date": {"has_date": True}}}
+        hass, DOMAIN, {"input_datetime": {"only_date": {"has_date": True}}}
     )
 
     state = hass.states.get("input_datetime.only_date")

--- a/tests/components/input_number/test_init.py
+++ b/tests/components/input_number/test_init.py
@@ -327,7 +327,7 @@ async def test_input_number_context(
 ) -> None:
     """Test that input_number context works."""
     assert await async_setup_component(
-        hass, "input_number", {"input_number": {"b1": {"min": 0, "max": 100}}}
+        hass, DOMAIN, {"input_number": {"b1": {"min": 0, "max": 100}}}
     )
 
     state = hass.states.get("input_number.b1")

--- a/tests/components/input_number/test_reproduce_state.py
+++ b/tests/components/input_number/test_reproduce_state.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from homeassistant.components.input_number import DOMAIN
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 from homeassistant.setup import async_setup_component
@@ -17,7 +18,7 @@ async def test_reproducing_states(
 
     assert await async_setup_component(
         hass,
-        "input_number",
+        DOMAIN,
         {
             "input_number": {
                 "test_number": {"min": "5", "max": "100", "initial": VALID_NUMBER1}

--- a/tests/components/input_select/test_init.py
+++ b/tests/components/input_select/test_init.py
@@ -424,7 +424,7 @@ async def test_input_select_context(
     """Test that input_select context works."""
     assert await async_setup_component(
         hass,
-        "input_select",
+        DOMAIN,
         {
             "input_select": {
                 "s1": {"options": ["first option", "middle option", "last option"]}

--- a/tests/components/input_select/test_reproduce_state.py
+++ b/tests/components/input_select/test_reproduce_state.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from homeassistant.components.input_select import DOMAIN
 from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.state import async_reproduce_state
@@ -27,7 +28,7 @@ async def test_reproducing_states(
     # Setup entity
     assert await async_setup_component(
         hass,
-        "input_select",
+        DOMAIN,
         {
             "input_select": {
                 "test_select": {"options": VALID_OPTION_SET1, "initial": VALID_OPTION1}

--- a/tests/components/input_text/test_init.py
+++ b/tests/components/input_text/test_init.py
@@ -232,7 +232,7 @@ async def test_input_text_context(
 ) -> None:
     """Test that input_text context works."""
     assert await async_setup_component(
-        hass, "input_text", {"input_text": {"t1": {"initial": "bla"}}}
+        hass, DOMAIN, {"input_text": {"t1": {"initial": "bla"}}}
     )
 
     state = hass.states.get("input_text.t1")

--- a/tests/components/input_text/test_reproduce_state.py
+++ b/tests/components/input_text/test_reproduce_state.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from homeassistant.components.input_text import DOMAIN
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 from homeassistant.setup import async_setup_component
@@ -20,7 +21,7 @@ async def test_reproducing_states(
     # Setup entity for testing
     assert await async_setup_component(
         hass,
-        "input_text",
+        DOMAIN,
         {
             "input_text": {
                 "test_text": {"min": "6", "max": "10", "initial": VALID_TEXT1}

--- a/tests/components/intent/test_init.py
+++ b/tests/components/intent/test_init.py
@@ -14,6 +14,7 @@ from homeassistant.components.cover import (
     CoverState,
 )
 from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
+from homeassistant.components.intent import DOMAIN
 from homeassistant.components.lock import SERVICE_LOCK, SERVICE_UNLOCK
 from homeassistant.components.valve import (
     DOMAIN as VALVE_DOMAIN,
@@ -62,7 +63,7 @@ async def test_http_handle_intent(
 
     intent.async_register(hass, TestIntentHandler())
 
-    result = await async_setup_component(hass, "intent", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     client = await hass_client()
@@ -117,7 +118,7 @@ async def test_http_language_device_satellite_id(
 
     intent.async_register(hass, TestIntentHandler())
 
-    result = await async_setup_component(hass, "intent", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     client = await hass_client()
@@ -158,7 +159,7 @@ async def test_http_handle_intent_match_failure(
 ) -> None:
     """Test handle intent match failure via HTTP API."""
 
-    assert await async_setup_component(hass, "intent", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     hass.states.async_set(
         "cover.garage_door_1", "closed", {ATTR_FRIENDLY_NAME: "Garage Door"}
@@ -185,7 +186,7 @@ async def test_http_assistant(
     """Test handle intent only targets exposed entities with 'assistant' set."""
 
     assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "intent", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     hass.states.async_set(
         "cover.garage_door_1", "closed", {ATTR_FRIENDLY_NAME: "Garage Door 1"}
@@ -235,7 +236,7 @@ async def test_http_assistant(
 
 async def test_cover_intents_loading(hass: HomeAssistant) -> None:
     """Test Cover Intents Loading."""
-    assert await async_setup_component(hass, "intent", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     with pytest.raises(intent.UnknownIntent):
         await intent.async_handle(
@@ -263,7 +264,7 @@ async def test_cover_intents_loading(hass: HomeAssistant) -> None:
 async def test_turn_on_intent(hass: HomeAssistant) -> None:
     """Test HassTurnOn intent."""
     result = await async_setup_component(hass, "homeassistant", {})
-    result = await async_setup_component(hass, "intent", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
     assert result
 
@@ -287,7 +288,7 @@ async def test_turn_on_intent_button(
     hass: HomeAssistant, entity_registry: er.EntityRegistry, domain
 ) -> None:
     """Test HassTurnOn intent on button domains."""
-    assert await async_setup_component(hass, "intent", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     button = entity_registry.async_get_or_create(domain, "test", "button_uid")
 
@@ -314,7 +315,7 @@ async def test_turn_on_off_intent_valve(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test HassTurnOn/Off intent on valve domains."""
-    assert await async_setup_component(hass, "intent", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     valve = entity_registry.async_get_or_create("valve", "test", "valve_uid")
 
@@ -347,7 +348,7 @@ async def test_turn_on_off_intent_cover(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test HassTurnOn/Off intent on cover domains."""
-    assert await async_setup_component(hass, "intent", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     cover = entity_registry.async_get_or_create("cover", "test", "cover_uid")
 
@@ -380,7 +381,7 @@ async def test_turn_on_off_intent_lock(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test HassTurnOn/Off intent on lock domains."""
-    assert await async_setup_component(hass, "intent", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     lock = entity_registry.async_get_or_create("lock", "test", "lock_uid")
 
@@ -412,7 +413,7 @@ async def test_turn_on_off_intent_lock(
 async def test_turn_off_intent(hass: HomeAssistant) -> None:
     """Test HassTurnOff intent."""
     result = await async_setup_component(hass, "homeassistant", {})
-    result = await async_setup_component(hass, "intent", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     hass.states.async_set("light.test_light", "on")
@@ -433,7 +434,7 @@ async def test_turn_off_intent(hass: HomeAssistant) -> None:
 async def test_toggle_intent(hass: HomeAssistant) -> None:
     """Test HassToggle intent."""
     result = await async_setup_component(hass, "homeassistant", {})
-    result = await async_setup_component(hass, "intent", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     hass.states.async_set("light.test_light", "off")
@@ -457,7 +458,7 @@ async def test_turn_on_multiple_intent(hass: HomeAssistant) -> None:
     This tests that matching finds the proper entity among similar names.
     """
     result = await async_setup_component(hass, "homeassistant", {})
-    result = await async_setup_component(hass, "intent", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     hass.states.async_set("light.test_light", "off")
@@ -480,7 +481,7 @@ async def test_turn_on_multiple_intent(hass: HomeAssistant) -> None:
 async def test_turn_on_all(hass: HomeAssistant) -> None:
     """Test HassTurnOn intent with "all" name."""
     result = await async_setup_component(hass, "homeassistant", {})
-    result = await async_setup_component(hass, "intent", {})
+    result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
     hass.states.async_set("light.test_light", "off")
@@ -516,7 +517,7 @@ async def test_get_state_intent(
     This tests name, area, domain, device class, and state constraints.
     """
     assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "intent", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     bedroom = area_registry.async_get_or_create("bedroom")
     kitchen = area_registry.async_get_or_create("kitchen")
@@ -705,7 +706,7 @@ async def test_get_state_intent(
 async def test_set_position_intent_unsupported_domain(hass: HomeAssistant) -> None:
     """Test that HassSetPosition intent fails with unsupported domain."""
     assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "intent", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     # Can't set position of lights
     hass.states.async_set("light.test_light", "off")
@@ -722,7 +723,7 @@ async def test_set_position_intent_unsupported_domain(hass: HomeAssistant) -> No
 async def test_intents_with_no_responses(hass: HomeAssistant) -> None:
     """Test intents that should not return a response during handling."""
     assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "intent", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     # The "respond" intent gets its response text from home-assistant-intents
     for intent_name in (intent.INTENT_NEVERMIND, intent.INTENT_RESPOND):
@@ -733,7 +734,7 @@ async def test_intents_with_no_responses(hass: HomeAssistant) -> None:
 async def test_intents_respond_intent(hass: HomeAssistant) -> None:
     """Test HassRespond intent with a response slot value."""
     assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "intent", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     response = await intent.async_handle(
         hass, "test", intent.INTENT_RESPOND, {"response": {"value": "Hello World"}}
@@ -743,7 +744,7 @@ async def test_intents_respond_intent(hass: HomeAssistant) -> None:
 
 async def test_stop_moving_valve(hass: HomeAssistant) -> None:
     """Test HassStopMoving intent for valves."""
-    assert await async_setup_component(hass, "intent", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     entity_id = f"{VALVE_DOMAIN}.test_valve"
     hass.states.async_set(entity_id, ValveState.OPEN)
@@ -771,7 +772,7 @@ async def test_stop_moving_valve(hass: HomeAssistant) -> None:
 )
 async def test_stop_moving_cover(hass: HomeAssistant, slots: dict[str, Any]) -> None:
     """Test HassStopMoving intent for covers."""
-    assert await async_setup_component(hass, "intent", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     entity_id = f"{COVER_DOMAIN}.test_cover"
     hass.states.async_set(
@@ -793,7 +794,7 @@ async def test_stop_moving_cover(hass: HomeAssistant, slots: dict[str, Any]) -> 
 async def test_stop_moving_intent_unsupported_domain(hass: HomeAssistant) -> None:
     """Test that HassStopMoving intent fails with unsupported domain."""
     assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "intent", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     # Can't stop lights
     hass.states.async_set("light.test_light", "on")

--- a/tests/components/intent/test_temperature.py
+++ b/tests/components/intent/test_temperature.py
@@ -14,6 +14,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
+from homeassistant.components.intent import DOMAIN
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.const import ATTR_DEVICE_CLASS, Platform, UnitOfTemperature
@@ -141,7 +142,7 @@ async def test_get_temperature(
 ) -> None:
     """Test HassClimateGetTemperature intent."""
     assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "intent", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     climate_1 = MockClimateEntity()
     climate_1._attr_name = "Climate 1"
@@ -421,7 +422,7 @@ async def test_get_temperature_no_entities(
 ) -> None:
     """Test HassClimateGetTemperature intent with no climate entities."""
     assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "intent", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     await create_mock_platform(hass, [])
 
@@ -443,7 +444,7 @@ async def test_not_exposed(
 ) -> None:
     """Test HassClimateGetTemperature intent when entities aren't exposed."""
     assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "intent", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     climate_1 = MockClimateEntity()
     climate_1._attr_name = "Climate 1"

--- a/tests/components/intent/test_timers.py
+++ b/tests/components/intent/test_timers.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from homeassistant.components import conversation
+from homeassistant.components.intent import DOMAIN
 from homeassistant.components.intent.timers import (
     TIMER_DATA,
     MultipleTimersMatchedError,
@@ -37,7 +38,7 @@ async def init_components(hass: HomeAssistant) -> None:
     """Initialize required components for tests."""
     assert await async_setup_component(hass, "homeassistant", {})
     assert await async_setup_component(hass, "conversation", {})
-    assert await async_setup_component(hass, "intent", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
 
 async def test_start_finish_timer(hass: HomeAssistant, init_components) -> None:
@@ -1682,7 +1683,7 @@ async def test_async_device_supports_timers(hass: HomeAssistant) -> None:
     assert not async_device_supports_timers(hass, device_id)
 
     # After intent initialization
-    assert await async_setup_component(hass, "intent", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     assert not async_device_supports_timers(hass, device_id)
 
     @callback

--- a/tests/components/intent_script/test_init.py
+++ b/tests/components/intent_script/test_init.py
@@ -26,7 +26,7 @@ async def test_intent_script(hass: HomeAssistant) -> None:
 
     await async_setup_component(
         hass,
-        "intent_script",
+        DOMAIN,
         {
             "intent_script": {
                 "HelloWorld": {
@@ -78,7 +78,7 @@ async def test_intent_script_wait_response(hass: HomeAssistant) -> None:
 
     await async_setup_component(
         hass,
-        "intent_script",
+        DOMAIN,
         {
             "intent_script": {
                 "HelloWorldWaitResponse": {
@@ -135,7 +135,7 @@ async def test_intent_script_service_response(hass: HomeAssistant) -> None:
 
     await async_setup_component(
         hass,
-        "intent_script",
+        DOMAIN,
         {
             "intent_script": {
                 "HelloWorldServiceResponse": {
@@ -165,7 +165,7 @@ async def test_intent_script_falsy_reprompt(hass: HomeAssistant) -> None:
 
     await async_setup_component(
         hass,
-        "intent_script",
+        DOMAIN,
         {
             "intent_script": {
                 "HelloWorld": {
@@ -220,7 +220,7 @@ async def test_intent_script_targets(
 
     await async_setup_component(
         hass,
-        "intent_script",
+        DOMAIN,
         {
             "intent_script": {
                 "Targets": {
@@ -333,7 +333,7 @@ async def test_intent_script_action_validation(
 
     await async_setup_component(
         hass,
-        "intent_script",
+        DOMAIN,
         {
             "intent_script": {
                 "ChooseWithRegistryIdIntent": {
@@ -430,7 +430,7 @@ async def test_reload(hass: HomeAssistant) -> None:
 
     config = {"intent_script": {"NewIntent1": {"speech": {"text": "HelloWorld123"}}}}
 
-    await async_setup_component(hass, "intent_script", config)
+    await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
 
     intents = hass.data.get(intent.DATA_KEY)
@@ -475,7 +475,7 @@ async def test_reload_unloads_scripts(hass: HomeAssistant) -> None:
     """Test that reloading intent scripts unloads the action scripts."""
     await async_setup_component(
         hass,
-        "intent_script",
+        DOMAIN,
         {
             "intent_script": {
                 "TestIntent": {

--- a/tests/components/iotawatt/test_init.py
+++ b/tests/components/iotawatt/test_init.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import httpx
 
+from homeassistant.components.iotawatt.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -18,7 +19,7 @@ async def test_setup_unload(
 ) -> None:
     """Test we can setup and unload an entry."""
     mock_iotawatt.getSensors.return_value["sensors"]["my_sensor_key"] = INPUT_SENSOR
-    assert await async_setup_component(hass, "iotawatt", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
     assert await hass.config_entries.async_unload(entry.entry_id)
 
@@ -28,7 +29,7 @@ async def test_setup_connection_failed(
 ) -> None:
     """Test connection error during startup."""
     mock_iotawatt.connect.side_effect = httpx.ConnectError("")
-    assert await async_setup_component(hass, "iotawatt", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
     assert entry.state is ConfigEntryState.SETUP_RETRY
 
@@ -38,6 +39,6 @@ async def test_setup_auth_failed(
 ) -> None:
     """Test auth error during startup."""
     mock_iotawatt.connect.return_value = False
-    assert await async_setup_component(hass, "iotawatt", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
     assert entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/iotawatt/test_sensor.py
+++ b/tests/components/iotawatt/test_sensor.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
 
+from homeassistant.components.iotawatt.const import DOMAIN
 from homeassistant.components.sensor import (
     ATTR_STATE_CLASS,
     SensorDeviceClass,
@@ -29,7 +30,7 @@ async def test_sensor_type_input(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory, mock_iotawatt: MagicMock
 ) -> None:
     """Test input sensors work."""
-    assert await async_setup_component(hass, "iotawatt", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids()) == 0
@@ -67,7 +68,7 @@ async def test_sensor_type_output(
     mock_iotawatt.getSensors.return_value["sensors"]["my_watthour_sensor_key"] = (
         OUTPUT_SENSOR
     )
-    assert await async_setup_component(hass, "iotawatt", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids()) == 1

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -8,6 +8,7 @@ import voluptuous as vol
 
 from homeassistant import core
 from homeassistant.components import light
+from homeassistant.components.light import DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_PLATFORM,
@@ -843,7 +844,7 @@ async def test_light_context(
     """Test that light context works."""
     setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
-    assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"light": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get("light.ceiling")
@@ -871,7 +872,7 @@ async def test_light_turn_on_auth(
     """Test that light context works."""
     setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
-    assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"light": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get("light.ceiling")
@@ -906,7 +907,7 @@ async def test_light_brightness_step(hass: HomeAssistant) -> None:
     entity1.supported_color_modes = {light.ColorMode.BRIGHTNESS}
     entity1.color_mode = light.ColorMode.BRIGHTNESS
     entity1.brightness = 50
-    assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"light": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
@@ -950,7 +951,7 @@ async def test_light_brightness_step_pct(hass: HomeAssistant) -> None:
     entity.supported_color_modes = {light.ColorMode.BRIGHTNESS}
     entity.color_mode = light.ColorMode.BRIGHTNESS
     entity.brightness = 255
-    assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"light": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity.entity_id)
@@ -993,7 +994,7 @@ async def test_light_brightness_pct_conversion(
     entity.supported_color_modes = {light.ColorMode.BRIGHTNESS}
     entity.color_mode = light.ColorMode.BRIGHTNESS
     entity.brightness = 100
-    assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"light": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity.entity_id)
@@ -1148,7 +1149,7 @@ async def test_light_service_call_rgbw(hass: HomeAssistant) -> None:
 
     setup_test_component_platform(hass, light.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"light": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
@@ -1188,7 +1189,7 @@ async def test_light_state_off(hass: HomeAssistant) -> None:
     entity3 = entities[3]
     entity3.supported_color_modes = {light.ColorMode.RGBW}
 
-    assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"light": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
@@ -1251,7 +1252,7 @@ async def test_light_state_rgbw(hass: HomeAssistant) -> None:
     entity0.rgbww_color = "Invalid"  # Should be ignored
     entity0.xy_color = "Invalid"  # Should be ignored
 
-    assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"light": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
@@ -1282,7 +1283,7 @@ async def test_light_state_rgbww(hass: HomeAssistant) -> None:
     entity0.xy_color = "Invalid"  # Should be ignored
     entity0.brightness = 255
 
-    assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"light": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
@@ -1344,7 +1345,7 @@ async def test_light_service_call_color_conversion(hass: HomeAssistant) -> None:
     entity6.supported_color_modes = {light.ColorMode.COLOR_TEMP}
     entity6.color_mode = light.ColorMode.COLOR_TEMP
 
-    assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"light": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
@@ -1753,7 +1754,7 @@ async def test_light_turn_on_rgb_color_is_plain_tuple(
     ]
     setup_test_component_platform(hass, light.DOMAIN, entities)
 
-    assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"light": {"platform": "test"}})
     await hass.async_block_till_done()
 
     await hass.services.async_call(
@@ -1803,7 +1804,7 @@ async def test_light_service_call_color_temp_emulation(hass: HomeAssistant) -> N
     entity2.supported_color_modes = {light.ColorMode.HS, light.ColorMode.WHITE}
     entity2.color_mode = light.ColorMode.HS
 
-    assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"light": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
@@ -1864,7 +1865,7 @@ async def test_light_service_call_color_temp_conversion(hass: HomeAssistant) -> 
     assert entity1.min_color_temp_kelvin == 2000
     assert entity1.max_color_temp_kelvin == 6535
 
-    assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"light": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
@@ -1982,7 +1983,7 @@ async def test_light_service_call_white_mode(hass: HomeAssistant) -> None:
     entity0.color_mode = light.ColorMode.HS
     setup_test_component_platform(hass, light.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"light": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
@@ -2105,7 +2106,7 @@ async def test_light_state_color_conversion(hass: HomeAssistant) -> None:
     entity2.rgb_color = "Invalid"  # Should be ignored
     entity2.xy_color = (0.1, 0.8)
 
-    assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"light": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -16,6 +16,7 @@ from homeassistant.components import logbook, recorder
 # pylint: disable-next=home-assistant-component-root-import
 from homeassistant.components.alexa.smart_home import EVENT_ALEXA_SMART_HOME
 from homeassistant.components.automation import EVENT_AUTOMATION_TRIGGERED
+from homeassistant.components.logbook import DOMAIN
 from homeassistant.components.logbook.models import EventAsRow, LazyEventPartialState
 from homeassistant.components.logbook.processor import EventProcessor
 from homeassistant.components.logbook.queries.common import PSEUDO_EVENT_STATE_CHANGED
@@ -137,7 +138,7 @@ async def test_service_call_create_logbook_entry_invalid_entity_id(
     hass: HomeAssistant,
 ) -> None:
     """Test if service call create log book entry with an invalid entity id."""
-    await async_setup_component(hass, "logbook", {})
+    await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
     hass.bus.async_fire(
         logbook.EVENT_LOGBOOK_ENTRY,
@@ -356,7 +357,7 @@ async def test_logbook_view(
     hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> None:
     """Test the logbook view."""
-    await async_setup_component(hass, "logbook", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
     client = await hass_client()
     response = await client.get(f"/api/logbook/{dt_util.utcnow().isoformat()}")
@@ -368,7 +369,7 @@ async def test_logbook_view_invalid_start_date_time(
     hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> None:
     """Test the logbook view with an invalid date time."""
-    await async_setup_component(hass, "logbook", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
     client = await hass_client()
     response = await client.get("/api/logbook/INVALID")
@@ -380,7 +381,7 @@ async def test_logbook_view_invalid_end_date_time(
     hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> None:
     """Test the logbook view."""
-    await async_setup_component(hass, "logbook", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
     client = await hass_client()
     response = await client.get(
@@ -395,7 +396,7 @@ async def test_logbook_view_period_entity(
     hass_client: ClientSessionGenerator,
 ) -> None:
     """Test the logbook view with period and entity."""
-    await async_setup_component(hass, "logbook", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
 
     entity_id_test = "switch.test"
@@ -499,7 +500,7 @@ async def test_logbook_describe_event(
         ),
     )
 
-    assert await async_setup_component(hass, "logbook", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     with freeze_time(dt_util.utcnow() - timedelta(seconds=5)):
         hass.bus.async_fire("some_event")
         await async_wait_recording_done(hass)
@@ -605,7 +606,7 @@ async def test_logbook_view_end_time_entity(
     hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> None:
     """Test the logbook view with end_time and entity."""
-    await async_setup_component(hass, "logbook", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
 
     entity_id_test = "switch.test"
@@ -753,7 +754,7 @@ async def test_logbook_entity_no_longer_in_state_machine(
     hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> None:
     """Test logbook view with entity removed from state machine."""
-    await async_setup_component(hass, "logbook", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_setup_component(hass, "automation", {})
     await async_setup_component(hass, "script", {})
 
@@ -794,7 +795,7 @@ async def test_filter_continuous_sensor_values(
     hass_client: ClientSessionGenerator,
 ) -> None:
     """Test remove continuous sensor events from logbook."""
-    await async_setup_component(hass, "logbook", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
 
     entity_id_test = "switch.test"
@@ -1488,7 +1489,7 @@ async def test_logbook_(
     hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> None:
     """Test the logbook view with a single entity and ."""
-    await async_setup_component(hass, "logbook", {})
+    await async_setup_component(hass, DOMAIN, {})
     assert await async_setup_component(
         hass,
         "template",
@@ -1558,7 +1559,7 @@ async def test_logbook_many_entities_multiple_calls(
     hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> None:
     """Test the logbook view with a many entities called multiple times."""
-    await async_setup_component(hass, "logbook", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_setup_component(hass, "automation", {})
 
     await async_recorder_block_till_done(hass)
@@ -1631,7 +1632,7 @@ async def test_custom_log_entry_discoverable_via_(
     hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> None:
     """Test if a custom log entry is later discoverable via ."""
-    await async_setup_component(hass, "logbook", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
 
     logbook.async_log_entry(
@@ -1669,7 +1670,7 @@ async def test_logbook_multiple_entities(
     hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> None:
     """Test the logbook view with a multiple entities."""
-    await async_setup_component(hass, "logbook", {})
+    await async_setup_component(hass, DOMAIN, {})
     assert await async_setup_component(
         hass,
         "template",
@@ -1794,7 +1795,7 @@ async def test_logbook_invalid_entity(
     hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> None:
     """Test the logbook view with requesting an invalid entity."""
-    await async_setup_component(hass, "logbook", {})
+    await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
     client = await hass_client()
 
@@ -1861,7 +1862,7 @@ async def test_fire_logbook_entries(
     hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> None:
     """Test many logbook entry calls."""
-    await async_setup_component(hass, "logbook", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
 
     for _ in range(10):
@@ -1910,7 +1911,7 @@ async def test_exclude_events_domain(
             logbook.DOMAIN: {CONF_EXCLUDE: {CONF_DOMAINS: ["switch", "alexa"]}},
         }
     )
-    await async_setup_component(hass, "logbook", config)
+    await async_setup_component(hass, DOMAIN, config)
     await async_recorder_block_till_done(hass)
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1954,7 +1955,7 @@ async def test_exclude_events_domain_glob(
     )
     await asyncio.gather(
         async_setup_component(hass, "homeassistant", {}),
-        async_setup_component(hass, "logbook", config),
+        async_setup_component(hass, DOMAIN, config),
     )
     await async_recorder_block_till_done(hass)
 
@@ -1999,7 +2000,7 @@ async def test_include_events_entity(
     )
     await asyncio.gather(
         async_setup_component(hass, "homeassistant", {}),
-        async_setup_component(hass, "logbook", config),
+        async_setup_component(hass, DOMAIN, config),
     )
     await async_recorder_block_till_done(hass)
 
@@ -2037,7 +2038,7 @@ async def test_exclude_events_entity(
     )
     await asyncio.gather(
         async_setup_component(hass, "homeassistant", {}),
-        async_setup_component(hass, "logbook", config),
+        async_setup_component(hass, DOMAIN, config),
     )
     await async_recorder_block_till_done(hass)
 
@@ -2076,7 +2077,7 @@ async def test_include_events_domain(
     )
     await asyncio.gather(
         async_setup_component(hass, "homeassistant", {}),
-        async_setup_component(hass, "logbook", config),
+        async_setup_component(hass, DOMAIN, config),
     )
     await async_recorder_block_till_done(hass)
 
@@ -2125,7 +2126,7 @@ async def test_include_events_domain_glob(
     )
     await asyncio.gather(
         async_setup_component(hass, "homeassistant", {}),
-        async_setup_component(hass, "logbook", config),
+        async_setup_component(hass, DOMAIN, config),
     )
     await async_recorder_block_till_done(hass)
 
@@ -2190,7 +2191,7 @@ async def test_include_exclude_events_no_globs(
     )
     await asyncio.gather(
         async_setup_component(hass, "homeassistant", {}),
-        async_setup_component(hass, "logbook", config),
+        async_setup_component(hass, DOMAIN, config),
     )
     await async_recorder_block_till_done(hass)
 
@@ -2252,7 +2253,7 @@ async def test_include_exclude_events_with_glob_filters(
     )
     await asyncio.gather(
         async_setup_component(hass, "homeassistant", {}),
-        async_setup_component(hass, "logbook", config),
+        async_setup_component(hass, DOMAIN, config),
     )
     await async_recorder_block_till_done(hass)
 
@@ -2304,7 +2305,7 @@ async def test_empty_config(
     )
     await asyncio.gather(
         async_setup_component(hass, "homeassistant", {}),
-        async_setup_component(hass, "logbook", config),
+        async_setup_component(hass, DOMAIN, config),
     )
     await async_recorder_block_till_done(hass)
 
@@ -2329,7 +2330,7 @@ async def test_context_filter(
     hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> None:
     """Test we can filter by context."""
-    assert await async_setup_component(hass, "logbook", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
 
     entity_id = "switch.blu"
@@ -2528,7 +2529,7 @@ async def test_get_events_future_start_time(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test get_events with a future start time."""
-    await async_setup_component(hass, "logbook", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
     future = dt_util.utcnow() + timedelta(hours=10)
 
@@ -2554,7 +2555,7 @@ async def test_get_events_bad_start_time(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test get_events bad start time."""
-    await async_setup_component(hass, "logbook", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
 
     client = await hass_ws_client()
@@ -2576,7 +2577,7 @@ async def test_get_events_bad_end_time(
 ) -> None:
     """Test get_events bad end time."""
     now = dt_util.utcnow()
-    await async_setup_component(hass, "logbook", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
 
     client = await hass_ws_client()
@@ -2598,7 +2599,7 @@ async def test_get_events_invalid_filters(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test get_events invalid filters."""
-    await async_setup_component(hass, "logbook", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
 
     client = await hass_ws_client()

--- a/tests/components/logbook/test_websocket_api.py
+++ b/tests/components/logbook/test_websocket_api.py
@@ -12,7 +12,7 @@ import pytest
 from homeassistant import core
 from homeassistant.components import logbook, recorder
 from homeassistant.components.automation import ATTR_SOURCE, EVENT_AUTOMATION_TRIGGERED
-from homeassistant.components.logbook import websocket_api
+from homeassistant.components.logbook import DOMAIN, websocket_api
 from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.util import get_instance
 from homeassistant.components.script import EVENT_SCRIPT_STARTED
@@ -372,7 +372,7 @@ async def test_get_events_future_start_time(
     recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test get_events with a future start time."""
-    await async_setup_component(hass, "logbook", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
     future = dt_util.utcnow() + timedelta(hours=10)
 
@@ -397,7 +397,7 @@ async def test_get_events_bad_start_time(
     recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test get_events bad start time."""
-    await async_setup_component(hass, "logbook", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
 
     client = await hass_ws_client()
@@ -418,7 +418,7 @@ async def test_get_events_bad_end_time(
 ) -> None:
     """Test get_events bad end time."""
     now = dt_util.utcnow()
-    await async_setup_component(hass, "logbook", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
 
     client = await hass_ws_client()
@@ -439,7 +439,7 @@ async def test_get_events_invalid_filters(
     recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test get_events invalid filters."""
-    await async_setup_component(hass, "logbook", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
 
     client = await hass_ws_client()
@@ -1968,7 +1968,7 @@ async def test_event_stream_bad_start_time(
     recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test event_stream bad start time."""
-    await async_setup_component(hass, "logbook", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
 
     client = await hass_ws_client()
@@ -2205,7 +2205,7 @@ async def test_event_stream_bad_end_time(
     recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test event_stream bad end time."""
-    await async_setup_component(hass, "logbook", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
     utc_now = dt_util.utcnow()
 

--- a/tests/components/logger/test_init.py
+++ b/tests/components/logger/test_init.py
@@ -35,7 +35,7 @@ async def test_log_filtering(
 
     assert await async_setup_component(
         hass,
-        "logger",
+        DOMAIN,
         {
             "logger": {
                 "default": "warning",
@@ -104,7 +104,7 @@ async def test_setting_level(hass: HomeAssistant) -> None:
     with patch("logging.getLogger", mocks.__getitem__):
         assert await async_setup_component(
             hass,
-            "logger",
+            DOMAIN,
             {
                 "logger": {
                     "default": "warning",
@@ -169,7 +169,7 @@ async def test_can_set_level_from_yaml(hass: HomeAssistant) -> None:
 
     assert await async_setup_component(
         hass,
-        "logger",
+        DOMAIN,
         {
             "logger": {
                 "logs": {
@@ -223,7 +223,7 @@ async def test_can_set_level_from_store(
         "key": "core.logger",
         "version": 1,
     }
-    assert await async_setup_component(hass, "logger", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await _assert_log_levels(hass)
     _reset_logging()
 
@@ -336,7 +336,7 @@ async def test_can_set_integration_level_from_store(
         "key": "core.logger",
         "version": 1,
     }
-    assert await async_setup_component(hass, "logger", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     assert logging.getLogger(INTEGRATION_NS).isEnabledFor(logging.DEBUG) is False
     assert logging.getLogger(INTEGRATION_NS).isEnabledFor(logging.WARNING) is True
@@ -363,7 +363,7 @@ async def test_chattier_log_level_wins_1(
     }
     assert await async_setup_component(
         hass,
-        "logger",
+        DOMAIN,
         {
             "logger": {
                 "logs": {
@@ -397,7 +397,7 @@ async def test_chattier_log_level_wins_2(
         "version": 1,
     }
     assert await async_setup_component(
-        hass, "logger", {"logger": {"logs": {INTEGRATION_NS: "debug"}}}
+        hass, DOMAIN, {"logger": {"logs": {INTEGRATION_NS: "debug"}}}
     )
 
     assert logging.getLogger(INTEGRATION_NS).isEnabledFor(logging.DEBUG) is True
@@ -421,7 +421,7 @@ async def test_log_once_removed_from_store(
     }
     hass_storage["core.logger"] = store_contents
 
-    assert await async_setup_component(hass, "logger", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     assert hass_storage["core.logger"]["data"] == store_contents["data"]
 
@@ -438,7 +438,7 @@ async def test_services_require_admin(
     hass: HomeAssistant, hass_read_only_user: MockUser, service: str
 ) -> None:
     """Test logger services require admin."""
-    assert await async_setup_component(hass, "logger", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     with pytest.raises(Unauthorized):
         await hass.services.async_call(

--- a/tests/components/logger/test_websocket_api.py
+++ b/tests/components/logger/test_websocket_api.py
@@ -4,6 +4,7 @@ import logging
 from unittest.mock import patch
 
 from homeassistant import config_entries, loader
+from homeassistant.components.logger import DOMAIN
 from homeassistant.components.logger.helpers import DATA_LOGGER
 from homeassistant.components.websocket_api import TYPE_RESULT
 from homeassistant.core import HomeAssistant
@@ -24,7 +25,7 @@ async def test_integration_log_info(
 ) -> None:
     """Test fetching integration log info."""
 
-    assert await async_setup_component(hass, "logger", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     logging.getLogger("homeassistant.components.http").setLevel(logging.DEBUG)
     logging.getLogger("homeassistant.components.websocket_api").setLevel(logging.DEBUG)
@@ -43,7 +44,7 @@ async def test_integration_log_info_discovered_flows(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_admin_user: MockUser
 ) -> None:
     """Test that log info includes discovered flows."""
-    assert await async_setup_component(hass, "logger", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     # Set up a discovery flow (zeroconf)
     mock_integration(hass, MockModule("discovered_integration"))
@@ -108,7 +109,7 @@ async def test_integration_log_info_with_settings(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_admin_user: MockUser
 ) -> None:
     """Test that log info includes integrations with custom log settings."""
-    assert await async_setup_component(hass, "logger", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     # Set up a mock integration that is not loaded
     mock_integration(hass, MockModule("unloaded_integration"))
@@ -164,7 +165,7 @@ async def test_integration_log_level(
 ) -> None:
     """Test setting integration log level."""
     websocket_client = await hass_ws_client()
-    assert await async_setup_component(hass, "logger", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     await websocket_client.send_json(
         {
@@ -191,7 +192,7 @@ async def test_custom_integration_log_level(
 ) -> None:
     """Test setting integration log level."""
     websocket_client = await hass_ws_client()
-    assert await async_setup_component(hass, "logger", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     integration = loader.Integration(
         hass,
@@ -243,7 +244,7 @@ async def test_integration_log_level_unknown_integration(
 ) -> None:
     """Test setting integration log level for an unknown integration."""
     websocket_client = await hass_ws_client()
-    assert await async_setup_component(hass, "logger", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     await websocket_client.send_json(
         {
@@ -268,7 +269,7 @@ async def test_module_log_level(
     websocket_client = await hass_ws_client()
     assert await async_setup_component(
         hass,
-        "logger",
+        DOMAIN,
         {"logger": {"logs": {"homeassistant.components.other_component": "warning"}}},
     )
 
@@ -300,7 +301,7 @@ async def test_module_log_level_override(
     websocket_client = await hass_ws_client()
     assert await async_setup_component(
         hass,
-        "logger",
+        DOMAIN,
         {"logger": {"logs": {"homeassistant.components.websocket_api": "warning"}}},
     )
 
@@ -372,7 +373,7 @@ async def test_integration_log_level_requires_admin(
     hass_read_only_access_token: str,
 ) -> None:
     """Test setting integration log level requires admin."""
-    assert await async_setup_component(hass, "logger", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     websocket_client = await hass_ws_client(hass, hass_read_only_access_token)
     await websocket_client.send_json(
@@ -396,7 +397,7 @@ async def test_module_log_level_requires_admin(
     hass_read_only_access_token: str,
 ) -> None:
     """Test setting module log level requires admin."""
-    assert await async_setup_component(hass, "logger", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     websocket_client = await hass_ws_client(hass, hass_read_only_access_token)
     await websocket_client.send_json(

--- a/tests/components/lovelace/test_cast.py
+++ b/tests/components/lovelace/test_cast.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from homeassistant.components.lovelace import cast as lovelace_cast
+from homeassistant.components.lovelace import DOMAIN, cast as lovelace_cast
 from homeassistant.components.media_player import MediaClass
 from homeassistant.core import HomeAssistant
 from homeassistant.core_config import async_process_ha_core_config
@@ -44,7 +44,7 @@ async def mock_yaml_dashboard(hass: HomeAssistant) -> AsyncGenerator[None]:
     # Set up a YAML dashboard with 2 views.
     assert await async_setup_component(
         hass,
-        "lovelace",
+        DOMAIN,
         {
             "lovelace": {
                 "dashboards": {
@@ -101,7 +101,7 @@ async def test_root_object(hass: HomeAssistant) -> None:
 
 async def test_browse_media_error(hass: HomeAssistant) -> None:
     """Test browse media checks valid URL."""
-    assert await async_setup_component(hass, "lovelace", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     with pytest.raises(HomeAssistantError):
         await lovelace_cast.async_browse_media(

--- a/tests/components/lovelace/test_dashboard.py
+++ b/tests/components/lovelace/test_dashboard.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from homeassistant.components import frontend
-from homeassistant.components.lovelace import const, dashboard
+from homeassistant.components.lovelace import DOMAIN, const, dashboard
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.setup import async_setup_component
@@ -36,7 +36,7 @@ async def test_lovelace_from_storage_new_installation(
     hass_storage: dict[str, Any],
 ) -> None:
     """Test new installation has default lovelace panel but no dashboard entry."""
-    assert await async_setup_component(hass, "lovelace", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     # Default lovelace panel is registered for backward compatibility
     assert "lovelace" in hass.data[frontend.DATA_PANELS]
@@ -63,7 +63,7 @@ async def test_lovelace_from_storage_migration(
         "data": {"config": {"views": [{"title": "Home"}]}},
     }
 
-    assert await async_setup_component(hass, "lovelace", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     # After migration, lovelace panel should be registered as a dashboard
     assert "lovelace" in hass.data[frontend.DATA_PANELS]
@@ -151,7 +151,7 @@ async def test_lovelace_dashboard_deleted_re_registers_panel(
         "data": {"config": {"views": [{"title": "Home"}]}},
     }
 
-    assert await async_setup_component(hass, "lovelace", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     # After migration, lovelace panel should be registered as a dashboard
     assert "lovelace" in hass.data[frontend.DATA_PANELS]
@@ -201,7 +201,7 @@ async def test_lovelace_migration_completes_when_both_files_exist(
     }
 
     with patch("homeassistant.components.lovelace.os.rename") as mock_rename:
-        assert await async_setup_component(hass, "lovelace", {})
+        assert await async_setup_component(hass, DOMAIN, {})
 
     # Old file should be renamed as backup
     old_path = hass.config.path(".storage", dashboard.CONFIG_STORAGE_KEY_DEFAULT)
@@ -258,7 +258,7 @@ async def test_lovelace_migration_skipped_when_already_migrated(
         "data": {"config": {"views": [{"title": "Old"}]}},
     }
 
-    assert await async_setup_component(hass, "lovelace", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     client = await hass_ws_client(hass)
     await client.send_json({"id": 5, "type": "lovelace/dashboards/list"})
@@ -276,7 +276,7 @@ async def test_lovelace_from_yaml(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test we load lovelace config from yaml."""
-    assert await async_setup_component(hass, "lovelace", {"lovelace": {"mode": "YAML"}})
+    assert await async_setup_component(hass, DOMAIN, {"lovelace": {"mode": "YAML"}})
     assert hass.data[frontend.DATA_PANELS]["lovelace"].config == {"mode": "yaml"}
 
     client = await hass_ws_client(hass)
@@ -366,7 +366,7 @@ async def test_lovelace_from_yaml_creates_repair_issue(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test YAML mode creates a repair issue."""
-    assert await async_setup_component(hass, "lovelace", {"lovelace": {"mode": "YAML"}})
+    assert await async_setup_component(hass, DOMAIN, {"lovelace": {"mode": "YAML"}})
 
     # Panel should be registered as a YAML dashboard
     assert hass.data[frontend.DATA_PANELS]["lovelace"].config == {"mode": "yaml"}
@@ -387,7 +387,7 @@ async def test_dashboard_from_yaml(
     """Test we load lovelace dashboard config from yaml."""
     assert await async_setup_component(
         hass,
-        "lovelace",
+        DOMAIN,
         {
             "lovelace": {
                 "dashboards": {
@@ -493,7 +493,7 @@ async def test_wrong_key_dashboard_from_yaml(hass: HomeAssistant) -> None:
     with assert_setup_component(0, "lovelace"):
         assert not await async_setup_component(
             hass,
-            "lovelace",
+            DOMAIN,
             {
                 "lovelace": {
                     "dashboards": {
@@ -517,7 +517,7 @@ async def test_storage_dashboards(
     hass_storage: dict[str, Any],
 ) -> None:
     """Test we load lovelace config from storage."""
-    assert await async_setup_component(hass, "lovelace", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     # Default lovelace panel is registered for backward compatibility
     assert "lovelace" in hass.data[frontend.DATA_PANELS]
@@ -684,7 +684,7 @@ async def test_websocket_list_dashboards(
     """Test listing dashboards both storage + YAML."""
     assert await async_setup_component(
         hass,
-        "lovelace",
+        DOMAIN,
         {
             "lovelace": {
                 "dashboards": {
@@ -744,7 +744,7 @@ async def test_lovelace_migration_sets_default_panel(
 
     # Need to setup frontend to register the websocket commands
     assert await async_setup_component(hass, "frontend", {})
-    assert await async_setup_component(hass, "lovelace", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     # Verify default_panel was set in frontend system storage via websocket
     client = await hass_ws_client(hass)
@@ -776,7 +776,7 @@ async def test_lovelace_migration_preserves_existing_default_panel(
 
     # Need to setup frontend to register the websocket commands
     assert await async_setup_component(hass, "frontend", {})
-    assert await async_setup_component(hass, "lovelace", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     # Verify default_panel was NOT overwritten via websocket
     client = await hass_ws_client(hass)
@@ -795,7 +795,7 @@ async def test_lovelace_no_migration_no_default_panel_set(
     # Need to setup frontend to register the websocket commands
     assert await async_setup_component(hass, "frontend", {})
     # No pre-existing lovelace storage = no migration
-    assert await async_setup_component(hass, "lovelace", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     # Verify default_panel was NOT set via websocket
     client = await hass_ws_client(hass)
@@ -809,7 +809,7 @@ async def test_lovelace_info_default(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test lovelace/info returns default resource_mode."""
-    assert await async_setup_component(hass, "lovelace", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     client = await hass_ws_client(hass)
 
@@ -824,7 +824,7 @@ async def test_lovelace_info_yaml_resource_mode(
 ) -> None:
     """Test lovelace/info returns yaml resource_mode."""
     assert await async_setup_component(
-        hass, "lovelace", {"lovelace": {"resource_mode": "yaml"}}
+        hass, DOMAIN, {"lovelace": {"resource_mode": "yaml"}}
     )
 
     client = await hass_ws_client(hass)
@@ -839,7 +839,7 @@ async def test_lovelace_info_yaml_mode_fallback(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test lovelace/info returns yaml resource_mode when mode is yaml."""
-    assert await async_setup_component(hass, "lovelace", {"lovelace": {"mode": "yaml"}})
+    assert await async_setup_component(hass, DOMAIN, {"lovelace": {"mode": "yaml"}})
 
     client = await hass_ws_client(hass)
 

--- a/tests/components/lovelace/test_init.py
+++ b/tests/components/lovelace/test_init.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import voluptuous as vol
 
-from homeassistant.components.lovelace import _validate_url_slug
+from homeassistant.components.lovelace import DOMAIN, _validate_url_slug
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -52,7 +52,7 @@ async def test_create_dashboards_when_onboarded(
     """Test we don't create dashboards when onboarded."""
     client = await hass_ws_client(hass)
 
-    assert await async_setup_component(hass, "lovelace", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     # List dashboards
     await client.send_json_auto_id({"type": "lovelace/dashboards/list"})
@@ -71,7 +71,7 @@ async def test_create_dashboards_when_not_onboarded(
     """Test we automatically create dashboards when not onboarded."""
     client = await hass_ws_client(hass)
 
-    assert await async_setup_component(hass, "lovelace", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     # Call onboarding listener
     mock_add_onboarding_listener.mock_calls[0][1][1]()

--- a/tests/components/lovelace/test_resources.py
+++ b/tests/components/lovelace/test_resources.py
@@ -8,7 +8,7 @@ import uuid
 import pytest
 
 from homeassistant.components.lovelace import dashboard, resources
-from homeassistant.components.lovelace.const import LOVELACE_DATA
+from homeassistant.components.lovelace.const import DOMAIN, LOVELACE_DATA
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -26,7 +26,7 @@ async def test_yaml_resources(
 ) -> None:
     """Test defining resources in configuration.yaml."""
     assert await async_setup_component(
-        hass, "lovelace", {"lovelace": {"mode": "yaml", "resources": RESOURCE_EXAMPLES}}
+        hass, DOMAIN, {"lovelace": {"mode": "yaml", "resources": RESOURCE_EXAMPLES}}
     )
 
     client = await hass_ws_client(hass)
@@ -47,9 +47,7 @@ async def test_yaml_resources_backwards(
         "homeassistant.components.lovelace.dashboard.load_yaml_dict",
         return_value={"resources": RESOURCE_EXAMPLES},
     ):
-        assert await async_setup_component(
-            hass, "lovelace", {"lovelace": {"mode": "yaml"}}
-        )
+        assert await async_setup_component(hass, DOMAIN, {"lovelace": {"mode": "yaml"}})
 
     client = await hass_ws_client(hass)
 
@@ -74,7 +72,7 @@ async def test_storage_resources(
         "version": 1,
         "data": {"items": resource_config},
     }
-    assert await async_setup_component(hass, "lovelace", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     client = await hass_ws_client(hass)
 
@@ -93,7 +91,7 @@ async def test_storage_resources_import(
     list_cmd: str,
 ) -> None:
     """Test importing resources from storage config."""
-    assert await async_setup_component(hass, "lovelace", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     hass_storage[dashboard.CONFIG_STORAGE_KEY_DEFAULT] = {
         "key": "lovelace",
         "version": 1,
@@ -259,7 +257,7 @@ async def test_storage_resources_import_invalid(
     list_cmd: str,
 ) -> None:
     """Test importing resources from storage config."""
-    assert await async_setup_component(hass, "lovelace", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     hass_storage[dashboard.CONFIG_STORAGE_KEY_DEFAULT] = {
         "key": "lovelace",
         "version": 1,
@@ -296,7 +294,7 @@ async def test_storage_resources_create_preserves_existing(
         "version": 1,
         "data": {"items": resource_config},
     }
-    assert await async_setup_component(hass, "lovelace", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     resource_collection = hass.data[LOVELACE_DATA].resources
 
@@ -329,7 +327,7 @@ async def test_storage_resources_safe_mode(
         "version": 1,
         "data": {"items": resource_config},
     }
-    assert await async_setup_component(hass, "lovelace", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     client = await hass_ws_client(hass)
     hass.config.safe_mode = True

--- a/tests/components/lovelace/test_system_health.py
+++ b/tests/components/lovelace/test_system_health.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from homeassistant.components.lovelace import dashboard
+from homeassistant.components.lovelace import DOMAIN, dashboard
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -28,7 +28,7 @@ def mock_onboarding_done() -> Generator[MagicMock]:
 
 async def test_system_health_info_autogen(hass: HomeAssistant) -> None:
     """Test system health info endpoint."""
-    assert await async_setup_component(hass, "lovelace", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     assert await async_setup_component(hass, "system_health", {})
     info = await get_system_health_info(hass, "lovelace")
     assert info == {"dashboards": 1, "mode": "auto-gen", "resources": 0}
@@ -45,7 +45,7 @@ async def test_system_health_info_storage_migration(
         "version": 1,
         "data": {"config": {"resources": [], "views": []}},
     }
-    assert await async_setup_component(hass, "lovelace", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
     info = await get_system_health_info(hass, "lovelace")
     # After migration: default dashboard (auto-gen) + migrated
@@ -56,7 +56,7 @@ async def test_system_health_info_storage_migration(
 async def test_system_health_info_yaml(hass: HomeAssistant) -> None:
     """Test system health info endpoint."""
     assert await async_setup_component(hass, "system_health", {})
-    assert await async_setup_component(hass, "lovelace", {"lovelace": {"mode": "YAML"}})
+    assert await async_setup_component(hass, DOMAIN, {"lovelace": {"mode": "YAML"}})
     await hass.async_block_till_done()
     with patch(
         "homeassistant.components.lovelace.dashboard.load_yaml_dict",
@@ -70,7 +70,7 @@ async def test_system_health_info_yaml(hass: HomeAssistant) -> None:
 async def test_system_health_info_yaml_not_found(hass: HomeAssistant) -> None:
     """Test system health info endpoint."""
     assert await async_setup_component(hass, "system_health", {})
-    assert await async_setup_component(hass, "lovelace", {"lovelace": {"mode": "YAML"}})
+    assert await async_setup_component(hass, DOMAIN, {"lovelace": {"mode": "YAML"}})
     await hass.async_block_till_done()
     info = await get_system_health_info(hass, "lovelace")
     # 2 dashboards: default storage (None) + yaml "lovelace" dashboard

--- a/tests/components/lutron/test_init.py
+++ b/tests/components/lutron/test_init.py
@@ -21,7 +21,7 @@ async def test_setup_entry(
     """Test setting up the integration."""
     mock_config_entry.add_to_hass(hass)
 
-    assert await async_setup_component(hass, "lutron", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     assert mock_config_entry.runtime_data.client is mock_lutron
@@ -42,7 +42,7 @@ async def test_unload_entry(
     """Test unloading the integration."""
     mock_config_entry.add_to_hass(hass)
 
-    assert await async_setup_component(hass, "lutron", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
@@ -111,7 +111,7 @@ async def test_unique_id_migration(
     # Trigger the integration setup.
     # The async_setup_entry logic will detect the legacy IDs in the registry
     # and update them to the new UUIDs provided by the mock_lutron fixture.
-    assert await async_setup_component(hass, "lutron", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     # Verify that the entity's unique ID has been updated to the new format.

--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -12,6 +12,7 @@ from homeassistant.components.media_player import (
     ATTR_MEDIA_CONTENT_TYPE,
     ATTR_MEDIA_FILTER_CLASSES,
     ATTR_MEDIA_SEARCH_QUERY,
+    DOMAIN,
     BrowseMedia,
     MediaClass,
     MediaPlayerEnqueue,
@@ -93,9 +94,7 @@ async def test_get_image_http(
     hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
 ) -> None:
     """Test get image via http command."""
-    await async_setup_component(
-        hass, "media_player", {"media_player": {"platform": "demo"}}
-    )
+    await async_setup_component(hass, DOMAIN, {"media_player": {"platform": "demo"}})
     await hass.async_block_till_done()
 
     state = hass.states.get("media_player.bedroom")
@@ -123,7 +122,7 @@ async def test_get_image_http_remote(
         return_value=True,
     ):
         await async_setup_component(
-            hass, "media_player", {"media_player": {"platform": "demo"}}
+            hass, DOMAIN, {"media_player": {"platform": "demo"}}
         )
         await hass.async_block_till_done()
 
@@ -156,7 +155,7 @@ async def test_get_image_http_log_credentials_redacted(
         url,
     ):
         await async_setup_component(
-            hass, "media_player", {"media_player": {"platform": "demo"}}
+            hass, DOMAIN, {"media_player": {"platform": "demo"}}
         )
         await hass.async_block_till_done()
 
@@ -183,9 +182,7 @@ async def test_get_async_get_browse_image(
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test get browse image."""
-    await async_setup_component(
-        hass, "media_player", {"media_player": {"platform": "demo"}}
-    )
+    await async_setup_component(hass, DOMAIN, {"media_player": {"platform": "demo"}})
     await hass.async_block_till_done()
 
     entity_comp = hass.data.get("entity_components", {}).get("media_player")
@@ -212,9 +209,7 @@ async def test_media_browse(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test browsing media."""
-    await async_setup_component(
-        hass, "media_player", {"media_player": {"platform": "demo"}}
-    )
+    await async_setup_component(hass, DOMAIN, {"media_player": {"platform": "demo"}})
     await hass.async_block_till_done()
 
     client = await hass_ws_client(hass)
@@ -282,9 +277,7 @@ async def test_media_browse(
 
 async def test_media_browse_service(hass: HomeAssistant) -> None:
     """Test browsing media using service call."""
-    await async_setup_component(
-        hass, "media_player", {"media_player": {"platform": "demo"}}
-    )
+    await async_setup_component(hass, DOMAIN, {"media_player": {"platform": "demo"}})
     await hass.async_block_till_done()
 
     with patch(
@@ -353,9 +346,7 @@ async def test_media_search(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test browsing media."""
-    await async_setup_component(
-        hass, "media_player", {"media_player": {"platform": "demo"}}
-    )
+    await async_setup_component(hass, DOMAIN, {"media_player": {"platform": "demo"}})
     await hass.async_block_till_done()
 
     client = await hass_ws_client(hass)
@@ -417,9 +408,7 @@ async def test_media_search(
 
 async def test_media_search_service(hass: HomeAssistant) -> None:
     """Test browsing media."""
-    await async_setup_component(
-        hass, "media_player", {"media_player": {"platform": "demo"}}
-    )
+    await async_setup_component(hass, DOMAIN, {"media_player": {"platform": "demo"}})
     await hass.async_block_till_done()
     expected = [
         BrowseMedia(
@@ -464,9 +453,7 @@ async def test_media_search_service(hass: HomeAssistant) -> None:
 
 async def test_group_members_available_when_off(hass: HomeAssistant) -> None:
     """Test that group_members are still available when media_player is off."""
-    await async_setup_component(
-        hass, "media_player", {"media_player": {"platform": "demo"}}
-    )
+    await async_setup_component(hass, DOMAIN, {"media_player": {"platform": "demo"}})
     await hass.async_block_till_done()
 
     await hass.services.async_call(
@@ -495,9 +482,7 @@ async def test_group_members_available_when_off(hass: HomeAssistant) -> None:
 )
 async def test_enqueue_rewrite(hass: HomeAssistant, input, expected) -> None:
     """Test that group_members are still available when media_player is off."""
-    await async_setup_component(
-        hass, "media_player", {"media_player": {"platform": "demo"}}
-    )
+    await async_setup_component(hass, DOMAIN, {"media_player": {"platform": "demo"}})
     await hass.async_block_till_done()
 
     # Fake group support for DemoYoutubePlayer
@@ -522,9 +507,7 @@ async def test_enqueue_rewrite(hass: HomeAssistant, input, expected) -> None:
 
 async def test_enqueue_alert_exclusive(hass: HomeAssistant) -> None:
     """Test that alert and enqueue cannot be used together."""
-    await async_setup_component(
-        hass, "media_player", {"media_player": {"platform": "demo"}}
-    )
+    await async_setup_component(hass, DOMAIN, {"media_player": {"platform": "demo"}})
     await hass.async_block_till_done()
 
     with pytest.raises(vol.Invalid):
@@ -562,9 +545,7 @@ async def test_get_async_get_browse_image_quoting(
     async_get_browse_image() should get called with the same string that is
     passed into get_browse_image_url().
     """
-    await async_setup_component(
-        hass, "media_player", {"media_player": {"platform": "demo"}}
-    )
+    await async_setup_component(hass, DOMAIN, {"media_player": {"platform": "demo"}})
     await hass.async_block_till_done()
 
     entity_comp = hass.data.get("entity_components", {}).get("media_player")
@@ -586,9 +567,7 @@ async def test_get_async_get_browse_image_quoting(
 
 async def test_play_media_via_selector(hass: HomeAssistant) -> None:
     """Test play_media data under 'media' is remapped for backward compat."""
-    await async_setup_component(
-        hass, "media_player", {"media_player": {"platform": "demo"}}
-    )
+    await async_setup_component(hass, DOMAIN, {"media_player": {"platform": "demo"}})
     await hass.async_block_till_done()
 
     # Fake group support for DemoYoutubePlayer

--- a/tests/components/melissa/__init__.py
+++ b/tests/components/melissa/__init__.py
@@ -1,5 +1,6 @@
 """Tests for the melissa component."""
 
+from homeassistant.components.melissa import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -8,5 +9,5 @@ VALID_CONFIG = {"melissa": {"username": "********", "password": "********"}}
 
 async def setup_integration(hass: HomeAssistant) -> None:
     """Set up the melissa integration in Home Assistant."""
-    assert await async_setup_component(hass, "melissa", VALID_CONFIG)
+    assert await async_setup_component(hass, DOMAIN, VALID_CONFIG)
     await hass.async_block_till_done()

--- a/tests/components/mill/test_init.py
+++ b/tests/components/mill/test_init.py
@@ -4,6 +4,7 @@ import asyncio
 from unittest.mock import patch
 
 from homeassistant.components import mill
+from homeassistant.components.mill import DOMAIN
 from homeassistant.components.mill.coordinator import MillDataUpdateCoordinator
 from homeassistant.components.recorder import Recorder
 from homeassistant.config_entries import ConfigEntryState
@@ -30,7 +31,7 @@ async def test_setup_with_cloud_config(
         patch("mill.Mill.fetch_heater_and_sensor_data", return_value={}) as mock_fetch,
         patch("mill.Mill.connect", return_value=True) as mock_connect,
     ):
-        assert await async_setup_component(hass, "mill", {})
+        assert await async_setup_component(hass, DOMAIN, {})
     assert len(mock_fetch.mock_calls) == 1
     assert len(mock_connect.mock_calls) == 1
 
@@ -49,7 +50,7 @@ async def test_setup_with_cloud_config_fails(
     )
     entry.add_to_hass(hass)
     with patch("mill.Mill.connect", return_value=False):
-        assert await async_setup_component(hass, "mill", {})
+        assert await async_setup_component(hass, DOMAIN, {})
     assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
@@ -87,7 +88,7 @@ async def test_setup_with_old_cloud_config(
         patch("mill.Mill.fetch_heater_and_sensor_data", return_value={}),
         patch("mill.Mill.connect", return_value=True) as mock_connect,
     ):
-        assert await async_setup_component(hass, "mill", {})
+        assert await async_setup_component(hass, DOMAIN, {})
 
     assert len(mock_connect.mock_calls) == 1
 
@@ -125,7 +126,7 @@ async def test_setup_with_local_config(
             },
         ) as mock_connect,
     ):
-        assert await async_setup_component(hass, "mill", {})
+        assert await async_setup_component(hass, DOMAIN, {})
 
     assert len(mock_fetch.mock_calls) == 1
     assert len(mock_connect.mock_calls) == 1
@@ -155,7 +156,7 @@ async def test_unload_entry(recorder_mock: Recorder, hass: HomeAssistant) -> Non
             return_value=True,
         ),
     ):
-        assert await async_setup_component(hass, "mill", {})
+        assert await async_setup_component(hass, DOMAIN, {})
 
         assert isinstance(entry.runtime_data, MillDataUpdateCoordinator)
 

--- a/tests/components/my/test_init.py
+++ b/tests/components/my/test_init.py
@@ -2,7 +2,7 @@
 
 from unittest import mock
 
-from homeassistant.components.my import URL_PATH
+from homeassistant.components.my import DOMAIN, URL_PATH
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -12,7 +12,7 @@ async def test_setup(hass: HomeAssistant) -> None:
     with mock.patch(
         "homeassistant.components.frontend.async_register_built_in_panel"
     ) as mock_register_panel:
-        assert await async_setup_component(hass, "my", {"foo": "bar"})
+        assert await async_setup_component(hass, DOMAIN, {"foo": "bar"})
         assert mock_register_panel.call_args == mock.call(
             hass, "my", frontend_url_path=URL_PATH
         )

--- a/tests/components/netatmo/test_diagnostics.py
+++ b/tests/components/netatmo/test_diagnostics.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 from syrupy.assertion import SnapshotAssertion
 from syrupy.filters import paths
 
+from homeassistant.components.netatmo import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -39,7 +40,7 @@ async def test_entry_diagnostics(
         )
         mock_auth.return_value.async_addwebhook.side_effect = AsyncMock()
         mock_auth.return_value.async_dropwebhook.side_effect = AsyncMock()
-        assert await async_setup_component(hass, "netatmo", {})
+        assert await async_setup_component(hass, DOMAIN, {})
 
     await hass.async_block_till_done()
 

--- a/tests/components/netatmo/test_init.py
+++ b/tests/components/netatmo/test_init.py
@@ -78,7 +78,7 @@ async def test_setup_component(
         )
         mock_auth.return_value.async_addwebhook.side_effect = AsyncMock()
         mock_auth.return_value.async_dropwebhook.side_effect = AsyncMock()
-        assert await async_setup_component(hass, "netatmo", {})
+        assert await async_setup_component(hass, DOMAIN, {})
 
     await hass.async_block_till_done()
 
@@ -125,7 +125,7 @@ async def test_setup_component_with_config(
         mock_auth.return_value.async_dropwebhook.side_effect = AsyncMock()
 
         assert await async_setup_component(
-            hass, "netatmo", {"netatmo": {"client_id": "123", "client_secret": "abc"}}
+            hass, DOMAIN, {"netatmo": {"client_id": "123", "client_secret": "abc"}}
         )
 
         await hass.async_block_till_done()
@@ -196,7 +196,7 @@ async def test_setup_without_https(
         )
         mock_async_generate_url.return_value = "http://example.com"
         assert await async_setup_component(
-            hass, "netatmo", {"netatmo": {"client_id": "123", "client_secret": "abc"}}
+            hass, DOMAIN, {"netatmo": {"client_id": "123", "client_secret": "abc"}}
         )
 
         await hass.async_block_till_done()
@@ -239,7 +239,7 @@ async def test_setup_with_cloud(
             fake_post_request, hass
         )
         assert await async_setup_component(
-            hass, "netatmo", {"netatmo": {"client_id": "123", "client_secret": "abc"}}
+            hass, DOMAIN, {"netatmo": {"client_id": "123", "client_secret": "abc"}}
         )
         assert cloud.async_active_subscription(hass) is True
         assert cloud.async_is_connected(hass) is True
@@ -310,7 +310,7 @@ async def test_setup_with_cloudhook(hass: HomeAssistant) -> None:
         )
         mock_auth.return_value.async_addwebhook.side_effect = AsyncMock()
         mock_auth.return_value.async_dropwebhook.side_effect = AsyncMock()
-        assert await async_setup_component(hass, "netatmo", {})
+        assert await async_setup_component(hass, DOMAIN, {})
         assert cloud.async_active_subscription(hass) is True
 
         assert (
@@ -354,7 +354,7 @@ async def test_setup_component_with_delay(
         patch("homeassistant.components.netatmo.data_handler.PLATFORMS", ["light"]),
     ):
         assert await async_setup_component(
-            hass, "netatmo", {"netatmo": {"client_id": "123", "client_secret": "abc"}}
+            hass, DOMAIN, {"netatmo": {"client_id": "123", "client_secret": "abc"}}
         )
 
         await hass.async_block_till_done()
@@ -423,7 +423,7 @@ async def test_setup_component_invalid_token_scope(hass: HomeAssistant) -> None:
         )
         mock_auth.return_value.async_addwebhook.side_effect = AsyncMock()
         mock_auth.return_value.async_dropwebhook.side_effect = AsyncMock()
-        assert await async_setup_component(hass, "netatmo", {})
+        assert await async_setup_component(hass, DOMAIN, {})
 
     await hass.async_block_till_done()
 
@@ -477,7 +477,7 @@ async def test_setup_component_invalid_token(
         mock_session.return_value.async_ensure_token_valid.side_effect = (
             fake_ensure_valid_token
         )
-        assert await async_setup_component(hass, "netatmo", {})
+        assert await async_setup_component(hass, DOMAIN, {})
 
     await hass.async_block_till_done()
 

--- a/tests/components/network/test_init.py
+++ b/tests/components/network/test_init.py
@@ -770,7 +770,7 @@ async def test_websocket_network_url(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test the network/url websocket command."""
-    assert await async_setup_component(hass, "network", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     client = await hass_ws_client(hass)
 
@@ -812,7 +812,7 @@ async def test_repair_docker_host_network_not_docker(
 ) -> None:
     """Test repair is not created when not in Docker."""
     with patch("homeassistant.util.package.is_docker_env", return_value=False):
-        assert await async_setup_component(hass, "network", {})
+        assert await async_setup_component(hass, DOMAIN, {})
 
     assert not issue_registry.async_get_issue(DOMAIN, "docker_host_network")
 
@@ -827,7 +827,7 @@ async def test_repair_docker_host_network_with_host_networking(
         patch("homeassistant.util.package.is_docker_env", return_value=True),
         patch("homeassistant.components.network.Path.exists", return_value=True),
     ):
-        assert await async_setup_component(hass, "network", {})
+        assert await async_setup_component(hass, DOMAIN, {})
 
     assert not issue_registry.async_get_issue(DOMAIN, "docker_host_network")
 
@@ -844,7 +844,7 @@ async def test_repair_docker_host_network_without_host_networking(
         patch("homeassistant.util.package.is_docker_env", return_value=True),
         patch("homeassistant.components.network.Path.exists", return_value=False),
     ):
-        assert await async_setup_component(hass, "network", {})
+        assert await async_setup_component(hass, DOMAIN, {})
 
     assert (issue := issue_registry.async_get_issue(DOMAIN, "docker_host_network"))
     assert issue == snapshot

--- a/tests/components/notify/test_legacy.py
+++ b/tests/components/notify/test_legacy.py
@@ -114,7 +114,7 @@ async def help_setup_notify(
     # Mock platform with service
     mock_notify_platform(hass, tmp_path, "test", async_get_service=async_get_service)
     # Setup the platform
-    await async_setup_component(hass, "notify", {"notify": [{"platform": "test"}]})
+    await async_setup_component(hass, DOMAIN, {"notify": [{"platform": "test"}]})
     await hass.async_block_till_done()
 
     # Return mock for assertion service calls
@@ -193,9 +193,7 @@ async def test_invalid_platform(
     """Test service setup with an invalid platform."""
     mock_notify_platform(hass, tmp_path, "testnotify1")
     # Setup the platform
-    await async_setup_component(
-        hass, "notify", {"notify": [{"platform": "testnotify1"}]}
-    )
+    await async_setup_component(hass, DOMAIN, {"notify": [{"platform": "testnotify1"}]})
     await hass.async_block_till_done()
     assert "Invalid notify platform" in caplog.text
     caplog.clear()
@@ -303,9 +301,7 @@ async def test_reload_with_notify_builtin_platform_reload(
     await notify.async_reload(hass, "testnotify")
 
     # Setup the platform
-    await async_setup_component(
-        hass, "notify", {"notify": [{"platform": "testnotify"}]}
-    )
+    await async_setup_component(hass, DOMAIN, {"notify": [{"platform": "testnotify"}]})
     await hass.async_block_till_done()
     assert hass.services.has_service(notify.DOMAIN, "testnotify_a")
     assert hass.services.has_service(notify.DOMAIN, "testnotify_b")
@@ -360,9 +356,7 @@ async def test_setup_platform_and_reload(hass: HomeAssistant, tmp_path: Path) ->
     )
 
     # Setup the testnotify platform
-    await async_setup_component(
-        hass, "notify", {"notify": [{"platform": "testnotify"}]}
-    )
+    await async_setup_component(hass, DOMAIN, {"notify": [{"platform": "testnotify"}]})
     await hass.async_block_till_done()
     assert hass.services.has_service("testnotify", SERVICE_RELOAD)
     assert hass.services.has_service(notify.DOMAIN, "testnotify_a")
@@ -474,7 +468,7 @@ async def test_setup_platform_before_notify_setup(
     )
 
     # Setup the testnotify platform
-    setup_coro = async_setup_component(hass, "notify", hass_config)
+    setup_coro = async_setup_component(hass, DOMAIN, hass_config)
 
     load_task = asyncio.create_task(load_coro)
     setup_task = asyncio.create_task(setup_coro)
@@ -541,7 +535,7 @@ async def test_setup_platform_after_notify_setup(
     )
 
     # Setup the testnotify platform
-    setup_coro = async_setup_component(hass, "notify", hass_config)
+    setup_coro = async_setup_component(hass, DOMAIN, hass_config)
 
     setup_task = asyncio.create_task(setup_coro)
     load_task = asyncio.create_task(load_coro)

--- a/tests/components/numato/test_binary_sensor.py
+++ b/tests/components/numato/test_binary_sensor.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
+from homeassistant.components.numato import DOMAIN
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import discovery
@@ -25,7 +26,7 @@ async def test_failing_setups_no_entities(
 ) -> None:
     """When port setup fails, no entity shall be created."""
     monkeypatch.setattr(numato_fixture.NumatoDeviceMock, "setup", mockup_raise)
-    assert await async_setup_component(hass, "numato", NUMATO_CFG)
+    assert await async_setup_component(hass, DOMAIN, NUMATO_CFG)
     await hass.async_block_till_done()
     for entity_id in MOCKUP_ENTITY_IDS:
         assert entity_id not in hass.states.async_entity_ids()
@@ -38,7 +39,7 @@ async def test_setup_callbacks(hass: HomeAssistant, numato_fixture) -> None:
         NumatoModuleMock.NumatoDeviceMock, "add_event_detect"
     ) as mock_add_event_detect:
         numato_fixture.discover()
-        assert await async_setup_component(hass, "numato", NUMATO_CFG)
+        assert await async_setup_component(hass, DOMAIN, NUMATO_CFG)
         await hass.async_block_till_done()  # wait until services are registered
 
     mock_add_event_detect.assert_called()
@@ -56,7 +57,7 @@ async def test_hass_binary_sensor_notification(
     hass: HomeAssistant, numato_fixture
 ) -> None:
     """Test regular operations from within Home Assistant."""
-    assert await async_setup_component(hass, "numato", NUMATO_CFG)
+    assert await async_setup_component(hass, DOMAIN, NUMATO_CFG)
     await hass.async_block_till_done()  # wait until services are registered
     assert (
         hass.states.get("binary_sensor.numato_binary_sensor_mock_port2").state == "on"
@@ -100,7 +101,7 @@ async def test_binary_sensor_setup_no_notify(
         raise_notification_error,
     ):
         numato_fixture.discover()
-        assert await async_setup_component(hass, "numato", NUMATO_CFG)
+        assert await async_setup_component(hass, DOMAIN, NUMATO_CFG)
         await hass.async_block_till_done()  # wait until services are registered
 
     assert all(

--- a/tests/components/numato/test_init.py
+++ b/tests/components/numato/test_init.py
@@ -4,6 +4,7 @@ from numato_gpio import NumatoGpioError
 import pytest
 
 from homeassistant.components import numato
+from homeassistant.components.numato import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -19,7 +20,7 @@ async def test_setup_no_devices(
     without raising.
     """
     monkeypatch.setattr(numato_fixture, "discover", mockup_return)
-    assert await async_setup_component(hass, "numato", NUMATO_CFG)
+    assert await async_setup_component(hass, DOMAIN, NUMATO_CFG)
     assert len(numato_fixture.devices) == 0
 
 
@@ -31,7 +32,7 @@ async def test_fail_setup_raising_discovery(
     Setup shall return False.
     """
     monkeypatch.setattr(numato_fixture, "discover", mockup_raise)
-    assert not await async_setup_component(hass, "numato", NUMATO_CFG)
+    assert not await async_setup_component(hass, DOMAIN, NUMATO_CFG)
     await hass.async_block_till_done()
 
 
@@ -82,7 +83,7 @@ async def test_invalid_port_number(hass: HomeAssistant, numato_fixture, config) 
     port1_config = sensorports_cfg["1"]
     sensorports_cfg["one"] = port1_config
     del sensorports_cfg["1"]
-    assert not await async_setup_component(hass, "numato", config)
+    assert not await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
     assert not numato_fixture.devices
 
@@ -97,7 +98,7 @@ async def test_too_low_adc_port_number(
 
     sensorports_cfg = config["numato"]["devices"][0]["sensors"]["ports"]
     sensorports_cfg.update({0: {"name": "toolow"}})
-    assert not await async_setup_component(hass, "numato", config)
+    assert not await async_setup_component(hass, DOMAIN, config)
     assert not numato_fixture.devices
 
 
@@ -110,7 +111,7 @@ async def test_too_high_adc_port_number(
     """
     sensorports_cfg = config["numato"]["devices"][0]["sensors"]["ports"]
     sensorports_cfg.update({8: {"name": "toohigh"}})
-    assert not await async_setup_component(hass, "numato", config)
+    assert not await async_setup_component(hass, DOMAIN, config)
     assert not numato_fixture.devices
 
 
@@ -123,7 +124,7 @@ async def test_invalid_adc_range_value_type(
     """
     sensorports_cfg = config["numato"]["devices"][0]["sensors"]["ports"]
     sensorports_cfg["1"]["source_range"][0] = "zero"
-    assert not await async_setup_component(hass, "numato", config)
+    assert not await async_setup_component(hass, DOMAIN, config)
     assert not numato_fixture.devices
 
 
@@ -136,7 +137,7 @@ async def test_invalid_adc_source_range_length(
     """
     sensorports_cfg = config["numato"]["devices"][0]["sensors"]["ports"]
     sensorports_cfg["1"]["source_range"].append(42)
-    assert not await async_setup_component(hass, "numato", config)
+    assert not await async_setup_component(hass, DOMAIN, config)
     assert not numato_fixture.devices
 
 
@@ -149,7 +150,7 @@ async def test_invalid_adc_source_range_order(
     """
     sensorports_cfg = config["numato"]["devices"][0]["sensors"]["ports"]
     sensorports_cfg["1"]["source_range"] = [2, 1]
-    assert not await async_setup_component(hass, "numato", config)
+    assert not await async_setup_component(hass, DOMAIN, config)
     assert not numato_fixture.devices
 
 
@@ -162,7 +163,7 @@ async def test_invalid_adc_destination_range_value_type(
     """
     sensorports_cfg = config["numato"]["devices"][0]["sensors"]["ports"]
     sensorports_cfg["1"]["destination_range"][0] = "zero"
-    assert not await async_setup_component(hass, "numato", config)
+    assert not await async_setup_component(hass, DOMAIN, config)
     assert not numato_fixture.devices
 
 
@@ -175,7 +176,7 @@ async def test_invalid_adc_destination_range_length(
     """
     sensorports_cfg = config["numato"]["devices"][0]["sensors"]["ports"]
     sensorports_cfg["1"]["destination_range"].append(42)
-    assert not await async_setup_component(hass, "numato", config)
+    assert not await async_setup_component(hass, DOMAIN, config)
     assert not numato_fixture.devices
 
 
@@ -188,5 +189,5 @@ async def test_invalid_adc_destination_range_order(
     """
     sensorports_cfg = config["numato"]["devices"][0]["sensors"]["ports"]
     sensorports_cfg["1"]["destination_range"] = [2, 1]
-    assert not await async_setup_component(hass, "numato", config)
+    assert not await async_setup_component(hass, DOMAIN, config)
     assert not numato_fixture.devices

--- a/tests/components/numato/test_sensor.py
+++ b/tests/components/numato/test_sensor.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from homeassistant.components.numato import DOMAIN
 from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import discovery
@@ -19,7 +20,7 @@ async def test_failing_setups_no_entities(
 ) -> None:
     """When port setup fails, no entity shall be created."""
     monkeypatch.setattr(numato_fixture.NumatoDeviceMock, "setup", mockup_raise)
-    assert await async_setup_component(hass, "numato", NUMATO_CFG)
+    assert await async_setup_component(hass, DOMAIN, NUMATO_CFG)
     await hass.async_block_till_done()
     for entity_id in MOCKUP_ENTITY_IDS:
         assert entity_id not in hass.states.async_entity_ids()
@@ -30,7 +31,7 @@ async def test_failing_sensor_update(
 ) -> None:
     """Test condition when a sensor update fails."""
     monkeypatch.setattr(numato_fixture.NumatoDeviceMock, "adc_read", mockup_raise)
-    assert await async_setup_component(hass, "numato", NUMATO_CFG)
+    assert await async_setup_component(hass, DOMAIN, NUMATO_CFG)
     await hass.async_block_till_done()
     assert hass.states.get("sensor.numato_adc_mock_port1").state is STATE_UNKNOWN
 

--- a/tests/components/numato/test_switch.py
+++ b/tests/components/numato/test_switch.py
@@ -3,6 +3,7 @@
 import pytest
 
 from homeassistant.components import switch
+from homeassistant.components.numato import DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_TURN_OFF,
@@ -26,7 +27,7 @@ async def test_failing_setups_no_entities(
 ) -> None:
     """When port setup fails, no entity shall be created."""
     monkeypatch.setattr(numato_fixture.NumatoDeviceMock, "setup", mockup_raise)
-    assert await async_setup_component(hass, "numato", NUMATO_CFG)
+    assert await async_setup_component(hass, DOMAIN, NUMATO_CFG)
     await hass.async_block_till_done()
     for entity_id in MOCKUP_ENTITY_IDS:
         assert entity_id not in hass.states.async_entity_ids()
@@ -34,7 +35,7 @@ async def test_failing_setups_no_entities(
 
 async def test_regular_hass_operations(hass: HomeAssistant, numato_fixture) -> None:
     """Test regular operations from within Home Assistant."""
-    assert await async_setup_component(hass, "numato", NUMATO_CFG)
+    assert await async_setup_component(hass, DOMAIN, NUMATO_CFG)
     await hass.async_block_till_done()  # wait until services are registered
     await hass.services.async_call(
         switch.DOMAIN,
@@ -82,7 +83,7 @@ async def test_failing_hass_operations(
     Switches remain in their initial 'off' state when the device can't
     be written to.
     """
-    assert await async_setup_component(hass, "numato", NUMATO_CFG)
+    assert await async_setup_component(hass, DOMAIN, NUMATO_CFG)
 
     await hass.async_block_till_done()  # wait until services are registered
     monkeypatch.setattr(numato_fixture.devices[0], "write", mockup_raise)

--- a/tests/components/number/test_init.py
+++ b/tests/components/number/test_init.py
@@ -586,7 +586,7 @@ async def test_restore_number_save_state(
     )
     setup_test_component_platform(hass, DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "number", {"number": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"number": {"platform": "test"}})
     await hass.async_block_till_done()
 
     # Trigger saving state
@@ -659,7 +659,7 @@ async def test_restore_number_restore_state(
     )
     setup_test_component_platform(hass, DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "number", {"number": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"number": {"platform": "test"}})
     await hass.async_block_till_done()
 
     assert hass.states.get(entity0.entity_id)
@@ -751,7 +751,7 @@ async def test_custom_unit(
     )
     setup_test_component_platform(hass, DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "number", {"number": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"number": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
@@ -821,7 +821,7 @@ async def test_custom_unit_change(
     )
     setup_test_component_platform(hass, DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "number", {"number": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"number": {"platform": "test"}})
     await hass.async_block_till_done()
 
     # Default unit conversion according to unit system
@@ -882,7 +882,7 @@ async def test_translated_unit(
         setup_test_component_platform(hass, DOMAIN, [entity0])
 
         assert await async_setup_component(
-            hass, "number", {"number": {"platform": "test"}}
+            hass, DOMAIN, {"number": {"platform": "test"}}
         )
         await hass.async_block_till_done()
 
@@ -916,7 +916,7 @@ async def test_translated_unit_with_native_unit_raises(
         setup_test_component_platform(hass, DOMAIN, [entity0])
 
         assert await async_setup_component(
-            hass, "number", {"number": {"platform": "test"}}
+            hass, DOMAIN, {"number": {"platform": "test"}}
         )
         await hass.async_block_till_done()
         # Setup fails so entity_id is None
@@ -941,7 +941,7 @@ async def test_ambiguous_unit_of_measurement_compat(
     )
     setup_test_component_platform(hass, DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "number", {"number": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"number": {"platform": "test"}})
     await hass.async_block_till_done()
 
     # Check compatible unit is applied


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When `async_setup_component` is called with a literal string matching the component name, use the `DOMAIN` constant instead.

Linked to #173004

Please note that I purposefully did not touch the configuration dictionnary.
The top-level key is often the component domain, but I felt changing that was out of scope.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
