### PR TITLE
Use DOMAIN constant in test (async_setup_component o-z)

### DIFF
--- a/tests/components/onboarding/test_init.py
+++ b/tests/components/onboarding/test_init.py
@@ -4,6 +4,7 @@ from typing import Any
 from unittest.mock import Mock, patch
 
 from homeassistant.components import onboarding
+from homeassistant.components.onboarding import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -21,7 +22,7 @@ async def test_not_setup_views_if_onboarded(
     mock_storage(hass_storage, {"done": onboarding.STEPS})
 
     with patch("homeassistant.components.onboarding.views.async_setup") as mock_setup:
-        assert await async_setup_component(hass, "onboarding", {})
+        assert await async_setup_component(hass, DOMAIN, {})
 
     assert len(mock_setup.mock_calls) == 0
     assert onboarding.DOMAIN not in hass.data
@@ -33,7 +34,7 @@ async def test_setup_views_if_not_onboarded(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.components.onboarding.views.async_setup",
     ) as mock_setup:
-        assert await async_setup_component(hass, "onboarding", {})
+        assert await async_setup_component(hass, DOMAIN, {})
 
     assert len(mock_setup.mock_calls) == 1
     assert onboarding.DOMAIN in hass.data
@@ -84,7 +85,7 @@ async def test_having_owner_finishes_user_step(
         patch("homeassistant.components.onboarding.views.async_setup") as mock_setup,
         patch.object(onboarding, "STEPS", [onboarding.STEP_USER]),
     ):
-        assert await async_setup_component(hass, "onboarding", {})
+        assert await async_setup_component(hass, DOMAIN, {})
 
     assert len(mock_setup.mock_calls) == 0
     assert onboarding.DOMAIN not in hass.data
@@ -97,5 +98,5 @@ async def test_having_owner_finishes_user_step(
 async def test_migration(hass: HomeAssistant, hass_storage: dict[str, Any]) -> None:
     """Test migrating onboarding to new version."""
     hass_storage[onboarding.STORAGE_KEY] = {"version": 1, "data": {"done": ["user"]}}
-    assert await async_setup_component(hass, "onboarding", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     assert onboarding.async_is_onboarded(hass)

--- a/tests/components/onboarding/test_views.py
+++ b/tests/components/onboarding/test_views.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from homeassistant.components import onboarding
-from homeassistant.components.onboarding import const, views
+from homeassistant.components.onboarding import DOMAIN, const, views
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import area_registry as ar
 from homeassistant.setup import async_set_domains_to_be_loaded, async_setup_component
@@ -110,7 +110,7 @@ async def test_onboarding_progress(
     """Test fetching progress."""
     mock_storage(hass_storage, {"done": ["hello"]})
 
-    assert await async_setup_component(hass, "onboarding", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client_no_auth()
@@ -134,7 +134,7 @@ async def test_onboarding_user_already_done(
     mock_storage(hass_storage, {"done": [views.STEP_USER]})
 
     with patch.object(onboarding, "STEPS", ["hello", "world"]):
-        assert await async_setup_component(hass, "onboarding", {})
+        assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
     client = await hass_client_no_auth()
@@ -165,7 +165,7 @@ async def test_onboarding_user(
     area_registry.async_create("Living Room")
 
     assert await async_setup_component(hass, "person", {})
-    assert await async_setup_component(hass, "onboarding", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     cur_users = len(await hass.auth.async_get_users())
@@ -228,7 +228,7 @@ async def test_onboarding_user_invalid_name(
     """Test not providing name."""
     mock_storage(hass_storage, {"done": []})
 
-    assert await async_setup_component(hass, "onboarding", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client_no_auth()
@@ -254,7 +254,7 @@ async def test_onboarding_user_race(
     """Test race condition on creating new user."""
     mock_storage(hass_storage, {"done": ["hello"]})
 
-    assert await async_setup_component(hass, "onboarding", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client_no_auth()
@@ -294,7 +294,7 @@ async def test_onboarding_integration(
     """Test finishing integration step."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
 
-    assert await async_setup_component(hass, "onboarding", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client()
@@ -338,7 +338,7 @@ async def test_onboarding_integration_missing_credential(
     """Test that we fail integration step if user is missing credentials."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
 
-    assert await async_setup_component(hass, "onboarding", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     refresh_token = hass.auth.async_validate_access_token(hass_access_token)
@@ -362,7 +362,7 @@ async def test_onboarding_integration_invalid_redirect_uri(
     """Test finishing integration step."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
 
-    assert await async_setup_component(hass, "onboarding", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client()
@@ -396,7 +396,7 @@ async def test_onboarding_integration_requires_auth(
     """Test finishing integration step."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
 
-    assert await async_setup_component(hass, "onboarding", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client_no_auth()
@@ -417,7 +417,7 @@ async def test_onboarding_core_sets_up_met(
     """Test finishing the core step."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
 
-    assert await async_setup_component(hass, "onboarding", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client()
@@ -438,7 +438,7 @@ async def test_onboarding_core_sets_up_shopping_list(
     """Test finishing the core step set up the shopping list."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
 
-    assert await async_setup_component(hass, "onboarding", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client()
@@ -459,7 +459,7 @@ async def test_onboarding_core_sets_up_google_translate(
     """Test finishing the core step sets up google translate."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
 
-    assert await async_setup_component(hass, "onboarding", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client()
@@ -480,7 +480,7 @@ async def test_onboarding_core_sets_up_radio_browser(
     """Test finishing the core step set up the radio browser."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
 
-    assert await async_setup_component(hass, "onboarding", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client()
@@ -502,7 +502,7 @@ async def test_onboarding_core_no_rpi_power(
     """Test that the core step do not set up rpi_power on non RPi."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
 
-    assert await async_setup_component(hass, "onboarding", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client()
@@ -527,7 +527,7 @@ async def test_onboarding_core_ensures_analytics_loaded(
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
     assert "analytics" not in hass.config.components
 
-    assert await async_setup_component(hass, "onboarding", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client()
@@ -548,7 +548,7 @@ async def test_onboarding_analytics(
     """Test finishing analytics step."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
 
-    assert await async_setup_component(hass, "onboarding", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client()
@@ -571,7 +571,7 @@ async def test_onboarding_installation_type(
     """Test returning installation type during onboarding."""
     mock_storage(hass_storage, {"done": []})
 
-    assert await async_setup_component(hass, "onboarding", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client()
@@ -605,7 +605,7 @@ async def test_onboarding_view_after_done(
     """Test raising after onboarding."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
 
-    assert await async_setup_component(hass, "onboarding", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client()
@@ -623,7 +623,7 @@ async def test_complete_onboarding(
     onboarding.async_add_listener(hass, listener_1)
     listener_1.assert_not_called()
 
-    assert await async_setup_component(hass, "onboarding", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     listener_2 = Mock()
@@ -693,7 +693,7 @@ async def test_wait_integration(
     """Test we can get wait for an integration to load."""
     mock_storage(hass_storage, {"done": []})
 
-    assert await async_setup_component(hass, "onboarding", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client()
@@ -712,7 +712,7 @@ async def test_wait_integration_startup(
     """Test we can get wait for an integration to load during startup."""
     mock_storage(hass_storage, {"done": []})
 
-    assert await async_setup_component(hass, "onboarding", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
     client = await hass_client()
 
@@ -767,7 +767,7 @@ async def test_not_setup_platform_if_onboarded(
     assert await async_setup_component(hass, "test", {})
     await hass.async_block_till_done()
 
-    assert await async_setup_component(hass, "onboarding", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     assert len(platform_mock.async_setup_views.mock_calls) == 0
@@ -782,7 +782,7 @@ async def test_setup_platform_if_not_onboarded(
     assert await async_setup_component(hass, "test", {})
     await hass.async_block_till_done()
 
-    assert await async_setup_component(hass, "onboarding", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     platform_mock.async_setup_views.assert_awaited_once_with(hass, {"done": []})
@@ -805,7 +805,7 @@ async def test_bad_platform(
     assert await async_setup_component(hass, "test", {})
     await hass.async_block_till_done()
 
-    assert await async_setup_component(hass, "onboarding", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     assert platform_mock.mock_calls == []

--- a/tests/components/openai_conversation/conftest.py
+++ b/tests/components/openai_conversation/conftest.py
@@ -125,7 +125,7 @@ async def mock_init_component(
     with patch(
         "openai.resources.models.AsyncModels.list",
     ):
-        assert await async_setup_component(hass, "openai_conversation", {})
+        assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
 

--- a/tests/components/openai_conversation/test_init.py
+++ b/tests/components/openai_conversation/test_init.py
@@ -284,7 +284,7 @@ async def test_init_error(
         "openai.resources.models.AsyncModels.list",
         side_effect=side_effect,
     ):
-        assert await async_setup_component(hass, "openai_conversation", {})
+        assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
         assert error in caplog.text
         assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
@@ -305,7 +305,7 @@ async def test_init_auth_error(
             message="",
         ),
     ):
-        assert await async_setup_component(hass, "openai_conversation", {})
+        assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
         assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 

--- a/tests/components/otbr/test_websocket_api.py
+++ b/tests/components/otbr/test_websocket_api.py
@@ -6,6 +6,7 @@ import pytest
 import python_otbr_api
 
 from homeassistant.components import otbr, thread
+from homeassistant.components.otbr import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -85,7 +86,7 @@ async def test_get_info_no_entry(
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test async_get_info."""
-    await async_setup_component(hass, "otbr", {})
+    await async_setup_component(hass, DOMAIN, {})
     websocket_client = await hass_ws_client(hass)
     await websocket_client.send_json_auto_id({"type": "otbr/info"})
 
@@ -175,7 +176,7 @@ async def test_create_network_no_entry(
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test create network."""
-    await async_setup_component(hass, "otbr", {})
+    await async_setup_component(hass, DOMAIN, {})
     websocket_client = await hass_ws_client(hass)
     await websocket_client.send_json_auto_id(
         {"type": "otbr/create_network", "extended_address": "blah"}
@@ -470,7 +471,7 @@ async def test_set_network_no_entry(
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test set network."""
-    await async_setup_component(hass, "otbr", {})
+    await async_setup_component(hass, DOMAIN, {})
     websocket_client = await hass_ws_client(hass)
     await websocket_client.send_json_auto_id(
         {
@@ -761,7 +762,7 @@ async def test_set_channel_no_entry(
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test set channel."""
-    await async_setup_component(hass, "otbr", {})
+    await async_setup_component(hass, DOMAIN, {})
     websocket_client = await hass_ws_client(hass)
     await websocket_client.send_json_auto_id(
         {

--- a/tests/components/owntracks/test_device_tracker.py
+++ b/tests/components/owntracks/test_device_tracker.py
@@ -332,7 +332,7 @@ async def setup_owntracks(
     ).add_to_hass(hass)
 
     with patch.object(owntracks, "OwnTracksContext", ctx_cls):
-        assert await async_setup_component(hass, "owntracks", {"owntracks": config})
+        assert await async_setup_component(hass, DOMAIN, {"owntracks": config})
         await hass.async_block_till_done()
 
 

--- a/tests/components/owntracks/test_init.py
+++ b/tests/components/owntracks/test_init.py
@@ -55,7 +55,7 @@ async def mock_client(
     MockConfigEntry(
         domain=DOMAIN, data={"webhook_id": "owntracks_test", "secret": "abcd"}
     ).add_to_hass(hass)
-    await async_setup_component(hass, "owntracks", {})
+    await async_setup_component(hass, DOMAIN, {})
 
     return await hass_client_no_auth()
 

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -1238,7 +1238,7 @@ async def test_persons_with_entity(hass: HomeAssistant) -> None:
     """Test finding persons with an entity."""
     assert await async_setup_component(
         hass,
-        "person",
+        DOMAIN,
         {
             "person": [
                 {
@@ -1269,7 +1269,7 @@ async def test_entities_in_person(hass: HomeAssistant) -> None:
     """Test finding entities tracked by person."""
     assert await async_setup_component(
         hass,
-        "person",
+        DOMAIN,
         {
             "person": [
                 {

--- a/tests/components/prusalink/test_binary_sensor.py
+++ b/tests/components/prusalink/test_binary_sensor.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
+from homeassistant.components.prusalink import DOMAIN
 from homeassistant.const import STATE_OFF, STATE_ON, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -26,7 +27,7 @@ async def test_binary_sensors_no_job(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_api: None
 ) -> None:
     """Test sensors while no job active."""
-    assert await async_setup_component(hass, "prusalink", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     state = hass.states.get("binary_sensor.workshop_mock_title_mmu")
     assert state is not None
@@ -37,7 +38,7 @@ async def test_status_connect_enabled_by_default(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_api: None
 ) -> None:
     """Connect binary sensor is enabled by default and reflects status_connect.ok."""
-    assert await async_setup_component(hass, "prusalink", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     state = hass.states.get("binary_sensor.workshop_mock_title_connectivity")
     assert state is not None
@@ -52,7 +53,7 @@ async def test_status_connect_not_created_when_absent(
 ) -> None:
     """Connect sensor is not created when status_connect is not in the response."""
     del mock_get_status_idle["printer"]["status_connect"]
-    assert await async_setup_component(hass, "prusalink", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     assert hass.states.get("binary_sensor.workshop_mock_title_connectivity") is None
 
@@ -62,7 +63,7 @@ async def test_sd_ready(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_api: None
 ) -> None:
     """SD card sensor reflects sd_ready from info endpoint."""
-    assert await async_setup_component(hass, "prusalink", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     state = hass.states.get("binary_sensor.workshop_mock_title_sd_card")
     assert state is not None
@@ -74,7 +75,7 @@ async def test_farm_mode(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_api: None
 ) -> None:
     """Farm mode sensor reflects farm_mode from info endpoint."""
-    assert await async_setup_component(hass, "prusalink", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     state = hass.states.get("binary_sensor.workshop_mock_title_farm_mode")
     assert state is not None
@@ -90,6 +91,6 @@ async def test_farm_mode_not_created_when_absent(
 ) -> None:
     """Farm mode sensor is not created when farm_mode field is absent from info."""
     del mock_info_api["farm_mode"]
-    assert await async_setup_component(hass, "prusalink", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     assert hass.states.get("binary_sensor.workshop_mock_title_farm_mode") is None

--- a/tests/components/prusalink/test_button.py
+++ b/tests/components/prusalink/test_button.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from pyprusalink.types import Conflict
 import pytest
 
+from homeassistant.components.prusalink import DOMAIN
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -76,7 +77,7 @@ async def test_button_pause_cancel(
     method: str,
 ) -> None:
     """Test cancel and pause buttons in PRINTING state."""
-    assert await async_setup_component(hass, "prusalink", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await press_button_and_verify(f"button.{object_id}", method)
 
 
@@ -97,7 +98,7 @@ async def test_button_resume_cancel(
     method: str,
 ) -> None:
     """Test cancel and resume buttons in PAUSED state."""
-    assert await async_setup_component(hass, "prusalink", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await press_button_and_verify(f"button.{object_id}", method)
 
 
@@ -109,7 +110,7 @@ async def test_button_continue(
     press_button_and_verify,
 ) -> None:
     """Test continue button is enabled in ATTENTION state and calls continue_job."""
-    assert await async_setup_component(hass, "prusalink", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await press_button_and_verify(
         "button.workshop_mock_title_continue_job", "continue_job"
     )
@@ -123,7 +124,7 @@ async def test_button_continue_unavailable_when_printing(
     mock_get_status_printing,
 ) -> None:
     """Continue button is unavailable when printer is not in ATTENTION state."""
-    assert await async_setup_component(hass, "prusalink", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     state = hass.states.get("button.workshop_mock_title_continue_job")
     assert state is not None
     assert state.state == "unavailable"

--- a/tests/components/prusalink/test_camera.py
+++ b/tests/components/prusalink/test_camera.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
+from homeassistant.components.prusalink import DOMAIN
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -25,7 +26,7 @@ async def test_camera_no_job(
     hass_client: ClientSessionGenerator,
 ) -> None:
     """Test camera while no job active."""
-    assert await async_setup_component(hass, "prusalink", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     state = hass.states.get("camera.workshop_mock_title_preview")
     assert state is not None
     assert state.state == "unavailable"
@@ -43,7 +44,7 @@ async def test_camera_idle_job_mk3(
     hass_client: ClientSessionGenerator,
 ) -> None:
     """Test camera while job state is idle (MK3)."""
-    assert await async_setup_component(hass, "prusalink", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     state = hass.states.get("camera.workshop_mock_title_preview")
     assert state is not None
     assert state.state == "unavailable"
@@ -61,7 +62,7 @@ async def test_camera_active_job(
     hass_client: ClientSessionGenerator,
 ) -> None:
     """Test camera while job active."""
-    assert await async_setup_component(hass, "prusalink", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     state = hass.states.get("camera.workshop_mock_title_preview")
     assert state is not None
     assert state.state == "idle"

--- a/tests/components/prusalink/test_sensor.py
+++ b/tests/components/prusalink/test_sensor.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
+from homeassistant.components.prusalink import DOMAIN
 from homeassistant.components.sensor import (
     ATTR_OPTIONS,
     ATTR_STATE_CLASS,
@@ -37,7 +38,7 @@ def setup_sensor_platform_only():
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensors_no_job(hass: HomeAssistant, mock_config_entry, mock_api) -> None:
     """Test sensors while no job active."""
-    assert await async_setup_component(hass, "prusalink", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     state = hass.states.get("sensor.workshop_mock_title")
     assert state is not None
@@ -146,7 +147,7 @@ async def test_sensors_idle_job_mk3(
     mock_job_api_idle_mk3,
 ) -> None:
     """Test sensors while job state is idle (MK3)."""
-    assert await async_setup_component(hass, "prusalink", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     state = hass.states.get("sensor.workshop_mock_title")
     assert state is not None
@@ -260,7 +261,7 @@ async def test_sensors_active_job(
         "homeassistant.components.prusalink.sensor.utcnow",
         return_value=datetime(2022, 8, 27, 14, 0, 0, tzinfo=UTC),
     ):
-        assert await async_setup_component(hass, "prusalink", {})
+        assert await async_setup_component(hass, DOMAIN, {})
 
     state = hass.states.get("sensor.workshop_mock_title")
     assert state is not None
@@ -301,7 +302,7 @@ async def test_axis_x_y_sensors(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_api: None
 ) -> None:
     """Test X and Y axis position sensors."""
-    assert await async_setup_component(hass, "prusalink", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     state = hass.states.get("sensor.workshop_mock_title_x_position")
     assert state is not None
@@ -328,7 +329,7 @@ async def test_axis_x_y_not_created_when_absent(
     """X and Y sensors are not created when axis fields are absent from the response."""
     del mock_get_status_idle["printer"]["axis_x"]
     del mock_get_status_idle["printer"]["axis_y"]
-    assert await async_setup_component(hass, "prusalink", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     assert hass.states.get("sensor.workshop_mock_title_x_position") is None
     assert hass.states.get("sensor.workshop_mock_title_y_position") is None
@@ -339,7 +340,7 @@ async def test_min_extrusion_temp_sensor(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_api: None
 ) -> None:
     """Test minimum extrusion temperature sensor from info endpoint."""
-    assert await async_setup_component(hass, "prusalink", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     state = hass.states.get("sensor.workshop_mock_title_minimum_extrusion_temperature")
     assert state is not None
@@ -358,7 +359,7 @@ async def test_min_extrusion_temp_not_created_when_absent(
 ) -> None:
     """Min extrusion temp sensor is not created when the info field is absent."""
     del mock_info_api["min_extrusion_temp"]
-    assert await async_setup_component(hass, "prusalink", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     assert (
         hass.states.get("sensor.workshop_mock_title_minimum_extrusion_temperature")

--- a/tests/components/python_script/test_init.py
+++ b/tests/components/python_script/test_init.py
@@ -28,7 +28,7 @@ async def test_setup(hass: HomeAssistant) -> None:
             "homeassistant.components.python_script.glob.iglob", return_value=scripts
         ),
     ):
-        res = await async_setup_component(hass, "python_script", {})
+        res = await async_setup_component(hass, DOMAIN, {})
 
     assert res
     assert hass.services.has_service("python_script", "hello")
@@ -60,7 +60,7 @@ async def test_setup_fails_on_no_dir(
     with patch(
         "homeassistant.components.python_script.os.path.isdir", return_value=False
     ):
-        res = await async_setup_component(hass, "python_script", {})
+        res = await async_setup_component(hass, DOMAIN, {})
 
     assert not res
     assert "Folder python_scripts not found in configuration folder" in caplog.text
@@ -371,7 +371,7 @@ async def test_reload(hass: HomeAssistant) -> None:
             "homeassistant.components.python_script.glob.iglob", return_value=scripts
         ),
     ):
-        res = await async_setup_component(hass, "python_script", {})
+        res = await async_setup_component(hass, DOMAIN, {})
 
     assert res
     assert hass.services.has_service("python_script", "hello")
@@ -537,7 +537,7 @@ async def test_execute_with_output(
             "homeassistant.components.python_script.glob.iglob", return_value=scripts
         ),
     ):
-        await async_setup_component(hass, "python_script", {})
+        await async_setup_component(hass, DOMAIN, {})
 
     source = """
 output = {"result": f"hello {data.get('name', 'World')}"}
@@ -581,7 +581,7 @@ async def test_execute_no_output(
             "homeassistant.components.python_script.glob.iglob", return_value=scripts
         ),
     ):
-        await async_setup_component(hass, "python_script", {})
+        await async_setup_component(hass, DOMAIN, {})
 
     source = """
 no_output = {"result": f"hello {data.get('name', 'World')}"}
@@ -620,7 +620,7 @@ async def test_execute_wrong_output_type(hass: HomeAssistant) -> None:
             "homeassistant.components.python_script.glob.iglob", return_value=scripts
         ),
     ):
-        await async_setup_component(hass, "python_script", {})
+        await async_setup_component(hass, DOMAIN, {})
 
     source = """
 output = f"hello {data.get('name', 'World')}"

--- a/tests/components/recovery_mode/test_init.py
+++ b/tests/components/recovery_mode/test_init.py
@@ -1,5 +1,6 @@
 """Tests for the Recovery Mode integration."""
 
+from homeassistant.components.recovery_mode import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -8,7 +9,7 @@ from tests.common import async_get_persistent_notifications
 
 async def test_works(hass: HomeAssistant) -> None:
     """Test Recovery Mode works."""
-    assert await async_setup_component(hass, "recovery_mode", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
     notifications = async_get_persistent_notifications(hass)
     assert len(notifications) == 1

--- a/tests/components/repairs/__init__.py
+++ b/tests/components/repairs/__init__.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from aiohttp.test_utils import TestClient
 
+from homeassistant.components.repairs import DOMAIN
 from homeassistant.components.repairs.issue_handler import (  # noqa: F401
     async_process_repairs_platforms,
 )
@@ -23,7 +24,7 @@ async def get_repairs(
     hass_ws_client: WebSocketGenerator,
 ):
     """Return the repairs list of issues."""
-    assert await async_setup_component(hass, "repairs", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     client = await hass_ws_client(hass)
     await hass.async_block_till_done()

--- a/tests/components/rflink/test_init.py
+++ b/tests/components/rflink/test_init.py
@@ -72,7 +72,7 @@ async def mock_rflink(
         "homeassistant.components.rflink.create_rflink_connection", mock_create
     )
 
-    await async_setup_component(hass, "rflink", config)
+    await async_setup_component(hass, DOMAIN, config)
 
     if old_yaml:
         await async_setup_component(hass, domain, config)

--- a/tests/components/rss_feed_template/test_init.py
+++ b/tests/components/rss_feed_template/test_init.py
@@ -6,6 +6,7 @@ from aiohttp.test_utils import TestClient
 from defusedxml import ElementTree
 import pytest
 
+from homeassistant.components.rss_feed_template import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -32,7 +33,7 @@ async def mock_http_client(
         }
     }
 
-    await async_setup_component(hass, "rss_feed_template", config)
+    await async_setup_component(hass, DOMAIN, config)
     return await hass_client()
 
 

--- a/tests/components/scene/test_init.py
+++ b/tests/components/scene/test_init.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components import light, scene
+from homeassistant.components.scene import DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ENTITY_MATCH_ALL,
@@ -234,7 +235,7 @@ async def activate(hass: HomeAssistant, entity_id: str = ENTITY_MATCH_ALL) -> No
 
 async def test_services_registered(hass: HomeAssistant) -> None:
     """Test we register services with empty config."""
-    assert await async_setup_component(hass, "scene", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
     assert hass.services.has_service("scene", "reload")
     assert hass.services.has_service("scene", "turn_on")

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -79,7 +79,7 @@ async def test_passing_variables(hass: HomeAssistant) -> None:
 
     assert await async_setup_component(
         hass,
-        "script",
+        DOMAIN,
         {
             "script": {
                 "test": {
@@ -148,7 +148,7 @@ async def test_turn_on_off_toggle(
         }
     assert await async_setup_component(
         hass,
-        "script",
+        DOMAIN,
         {
             "script": {
                 "test": {
@@ -203,7 +203,7 @@ async def test_setup_with_invalid_configs(
     hass: HomeAssistant, config, nbr_script_entities
 ) -> None:
     """Test setup with invalid configs."""
-    assert await async_setup_component(hass, "script", {"script": config})
+    assert await async_setup_component(hass, DOMAIN, {"script": config})
 
     assert len(hass.states.async_entity_ids("script")) == nbr_script_entities
 
@@ -385,7 +385,7 @@ async def test_reload_service(hass: HomeAssistant, running) -> None:
 
     assert await async_setup_component(
         hass,
-        "script",
+        DOMAIN,
         {
             "script": {
                 "test": {
@@ -561,7 +561,7 @@ async def test_service_descriptions(hass: HomeAssistant) -> None:
     # Test 1: has "description" but no "fields"
     assert await async_setup_component(
         hass,
-        "script",
+        DOMAIN,
         {
             "script": {
                 "test": {
@@ -640,7 +640,7 @@ async def test_shared_context(hass: HomeAssistant) -> None:
     hass.bus.async_listen(EVENT_SCRIPT_STARTED, run_mock)
 
     assert await async_setup_component(
-        hass, "script", {"script": {"test": {"sequence": [{"event": event}]}}}
+        hass, DOMAIN, {"script": {"test": {"sequence": [{"event": event}]}}}
     )
 
     await hass.services.async_call(
@@ -673,7 +673,7 @@ async def test_logging_script_error(
     """Test logging script error."""
     assert await async_setup_component(
         hass,
-        "script",
+        DOMAIN,
         {"script": {"hello": {"sequence": [{"action": "non.existing"}]}}},
     )
     with pytest.raises(ServiceNotFound) as err:
@@ -686,7 +686,7 @@ async def test_logging_script_error(
 
 async def test_turning_no_scripts_off(hass: HomeAssistant) -> None:
     """Test it is possible to turn two scripts off."""
-    assert await async_setup_component(hass, "script", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     # Testing it doesn't raise
     await hass.services.async_call(
@@ -948,7 +948,7 @@ async def test_config_basic(
     """Test passing info in config."""
     assert await async_setup_component(
         hass,
-        "script",
+        DOMAIN,
         {
             "script": {
                 "test_script": {
@@ -973,7 +973,7 @@ async def test_config_multiple_domains(hass: HomeAssistant) -> None:
     """Test splitting configuration over multiple domains."""
     assert await async_setup_component(
         hass,
-        "script",
+        DOMAIN,
         {
             "script": {
                 "first_script": {
@@ -1043,7 +1043,7 @@ async def test_concurrent_script(hass: HomeAssistant, concurrently) -> None:
         call_script_2 = {"action": "script.script2"}
     assert await async_setup_component(
         hass,
-        "script",
+        DOMAIN,
         {
             "script": {
                 "script1": {
@@ -1127,7 +1127,7 @@ async def test_script_variables(
     """Test defining scripts."""
     assert await async_setup_component(
         hass,
-        "script",
+        DOMAIN,
         {
             "script": {
                 "script1": {
@@ -1229,7 +1229,7 @@ async def test_script_this_var_always(
 
     assert await async_setup_component(
         hass,
-        "script",
+        DOMAIN,
         {
             "script": {
                 "script1": {
@@ -1269,7 +1269,7 @@ async def test_script_restore_last_triggered(hass: HomeAssistant) -> None:
 
     assert await async_setup_component(
         hass,
-        "script",
+        DOMAIN,
         {
             "script": {
                 "no_last_triggered": {
@@ -1314,7 +1314,7 @@ async def test_recursive_script(
 
     assert await async_setup_component(
         hass,
-        "script",
+        DOMAIN,
         {
             "script": {
                 "script1": {
@@ -1364,7 +1364,7 @@ async def test_recursive_script_indirect(
 
     assert await async_setup_component(
         hass,
-        "script",
+        DOMAIN,
         {
             "script": {
                 "script1": {
@@ -1503,7 +1503,7 @@ async def test_setup_with_duplicate_scripts(
     """Test setup with duplicate configs."""
     assert await async_setup_component(
         hass,
-        "script",
+        DOMAIN,
         {
             "script one": {
                 "duplicate": {
@@ -1531,7 +1531,7 @@ async def test_websocket_config(
     }
     assert await async_setup_component(
         hass,
-        "script",
+        DOMAIN,
         {
             "script": {
                 "hello": config,
@@ -1586,7 +1586,7 @@ async def test_script_service_changed_entity_id(
     # Make sure the service of a script with overridden entity_id works
     assert await async_setup_component(
         hass,
-        "script",
+        DOMAIN,
         {
             "script": {
                 "test": {
@@ -1769,7 +1769,7 @@ async def test_responses(hass: HomeAssistant, response: Any) -> None:
     mock_restore_cache(hass, ())
     assert await async_setup_component(
         hass,
-        "script",
+        DOMAIN,
         {
             "script": {
                 "test": {
@@ -1804,7 +1804,7 @@ async def test_responses_no_response(hass: HomeAssistant) -> None:
     mock_restore_cache(hass, ())
     assert await async_setup_component(
         hass,
-        "script",
+        DOMAIN,
         {
             "script": {
                 "test": {
@@ -1890,7 +1890,7 @@ async def test_reload_when_labs_flag_changes(
 
     assert await async_setup_component(
         hass,
-        "script",
+        DOMAIN,
         {
             "script": {
                 "test": {

--- a/tests/components/script/test_recorder.py
+++ b/tests/components/script/test_recorder.py
@@ -11,6 +11,7 @@ from homeassistant.components.script import (
     ATTR_LAST_TRIGGERED,
     ATTR_MAX,
     ATTR_MODE,
+    DOMAIN,
 )
 from homeassistant.const import ATTR_FRIENDLY_NAME
 from homeassistant.core import Context, HomeAssistant, ServiceCall, callback
@@ -45,7 +46,7 @@ async def test_exclude_attributes(
 
     assert await async_setup_component(
         hass,
-        "script",
+        DOMAIN,
         {
             "script": {
                 "test": {

--- a/tests/components/search/test_init.py
+++ b/tests/components/search/test_init.py
@@ -2,7 +2,7 @@
 
 from pytest_unordered import unordered
 
-from homeassistant.components.search import ItemType, Searcher
+from homeassistant.components.search import DOMAIN, ItemType, Searcher
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import (
     area_registry as ar,
@@ -28,7 +28,7 @@ async def test_search(
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test search."""
-    assert await async_setup_component(hass, "search", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     # Labels
     label_energy = label_registry.async_create("Energy")

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -141,7 +141,7 @@ async def test_temperature_conversion(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
@@ -162,7 +162,7 @@ async def test_temperature_conversion_wrong_device_class(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     # Check compatible unit is applied
@@ -189,7 +189,7 @@ async def test_ambiguous_unit_of_measurement_compat(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     # Check temperature is not converted
@@ -218,7 +218,7 @@ async def test_deprecated_last_reset(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     assert (
@@ -263,7 +263,7 @@ async def test_datetime_conversion(
     ]
     setup_test_component_platform(hass, sensor.DOMAIN, entities)
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entities[0].entity_id)
@@ -296,7 +296,7 @@ async def test_uptime_device_class_auto_normalizes_drift(
     entity._attr_uptime_drift_tolerance = drift_tolerance
     setup_test_component_platform(hass, sensor.DOMAIN, [entity])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     assert (state := hass.states.get(entity.entity_id))
@@ -350,7 +350,7 @@ async def test_a_sensor_with_a_non_numeric_device_class(
     ]
     setup_test_component_platform(hass, sensor.DOMAIN, entities)
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entities[0].entity_id)
@@ -380,7 +380,7 @@ async def test_deprecated_datetime_str(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     assert (
@@ -402,7 +402,7 @@ async def test_reject_timezoneless_datetime_str(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     assert (
@@ -500,7 +500,7 @@ async def test_restore_sensor_save_state(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     # Trigger saving state
@@ -528,7 +528,7 @@ async def test_restore_sensor_save_state_frozen_time_datetime(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     # Trigger saving state
@@ -556,7 +556,7 @@ async def test_restore_sensor_save_state_frozen_time_date(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     # Trigger saving state
@@ -622,7 +622,7 @@ async def test_restore_sensor_restore_state(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     assert hass.states.get(entity0.entity_id)
@@ -656,7 +656,7 @@ async def test_translated_unit(
         setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
         assert await async_setup_component(
-            hass, "sensor", {"sensor": {"platform": "test"}}
+            hass, DOMAIN, {"sensor": {"platform": "test"}}
         )
         await hass.async_block_till_done()
 
@@ -690,7 +690,7 @@ async def test_translated_unit_with_native_unit_raises(
         setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
         assert await async_setup_component(
-            hass, "sensor", {"sensor": {"platform": "test"}}
+            hass, DOMAIN, {"sensor": {"platform": "test"}}
         )
         await hass.async_block_till_done()
         # Setup fails so entity_id is None
@@ -728,7 +728,7 @@ async def test_unit_translation_key_without_platform_raises(
         setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
         assert await async_setup_component(
-            hass, "sensor", {"sensor": {"platform": "test"}}
+            hass, DOMAIN, {"sensor": {"platform": "test"}}
         )
         await hass.async_block_till_done()
 
@@ -961,7 +961,7 @@ async def test_custom_unit(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     entity_id = entity0.entity_id
@@ -1256,7 +1256,7 @@ async def test_custom_unit_change(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
@@ -1392,7 +1392,7 @@ async def test_unit_conversion_priority(
         ],
     )
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     # Registered entity -> Follow automatic unit conversion
@@ -1554,7 +1554,7 @@ async def test_unit_conversion_priority_precision(
         ],
     )
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     # Registered entity -> Follow automatic unit conversion
@@ -1716,7 +1716,7 @@ async def test_unit_conversion_priority_suggested_unit_change(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0, entity1])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     # Registered entity -> Follow automatic unit conversion the first
@@ -1814,7 +1814,7 @@ async def test_unit_conversion_priority_suggested_unit_change_2(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0, entity1])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     # Registered entity -> Follow unit in entity registry
@@ -1915,7 +1915,7 @@ async def test_default_precision(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     entry = entity_registry.async_get(entity0.entity_id)
@@ -1980,7 +1980,7 @@ async def test_suggested_precision_option(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     # Assert the suggested precision is stored in the registry
@@ -2073,7 +2073,7 @@ async def test_suggested_precision_option_update(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     # Assert the suggested precision is stored in the registry
@@ -2145,7 +2145,7 @@ async def test_unit_conversion_priority_legacy_conversion_removed(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
@@ -2184,7 +2184,7 @@ async def test_value_unknown_in_enumeration(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     assert (
@@ -2206,7 +2206,7 @@ async def test_invalid_enumeration_entity_with_device_class(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     assert (
@@ -2227,7 +2227,7 @@ async def test_invalid_enumeration_entity_without_device_class(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     assert (
@@ -2260,7 +2260,7 @@ async def test_non_numeric_device_class_with_unit_of_measurement(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     assert (
@@ -2340,7 +2340,7 @@ async def test_device_classes_with_invalid_unit_of_measurement(
         str(unit) if unit else "no unit of measurement"
         for unit in DEVICE_CLASS_UNITS.get(device_class, set())
     ]
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     assert (
@@ -2371,7 +2371,7 @@ async def test_state_classes_with_invalid_unit_of_measurement(
         str(unit) if unit else "no unit of measurement"
         for unit in STATE_CLASS_UNITS.get(state_class, set())
     }
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     assert (
@@ -2424,7 +2424,7 @@ async def test_non_numeric_validation_error(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
@@ -2469,7 +2469,7 @@ async def test_non_numeric_validation_raise(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
@@ -2516,7 +2516,7 @@ async def test_numeric_validation(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
@@ -2541,7 +2541,7 @@ async def test_numeric_validation_ignores_custom_device_class(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
@@ -2571,7 +2571,7 @@ async def test_device_classes_with_invalid_state_class(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     classes = DEVICE_CLASS_STATE_CLASSES.get(device_class, set())
@@ -2625,7 +2625,7 @@ async def test_numeric_state_expected_helper(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
@@ -3015,7 +3015,7 @@ async def test_entity_category_config_raises_error(
     entity0 = MockSensor(name="Test", entity_category=EntityCategory.CONFIG)
     setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     assert (
@@ -3057,7 +3057,7 @@ async def test_suggested_unit_guard_invalid_unit(
         unique_id="invalid",
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity])
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     assert not hass.states.get("sensor.invalid")
@@ -3119,7 +3119,7 @@ async def test_suggested_unit_guard_valid_unit(
     )
     setup_test_component_platform(hass, sensor.DOMAIN, [entity])
 
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     # Unit of measurement should set to the suggested unit of measurement

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -313,7 +313,7 @@ async def test_compile_hourly_statistics(
 ) -> None:
     """Test compiling hourly statistics."""
     zero = get_start_time(dt_util.utcnow())
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     attributes = {
@@ -371,7 +371,7 @@ async def test_compile_hourly_statistics_angle(
 ) -> None:
     """Test compiling hourly statistics for measurement_angle."""
     zero = get_start_time(dt_util.utcnow())
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     with freeze_time(zero) as freezer:
@@ -456,7 +456,7 @@ async def test_compile_hourly_statistics_with_some_same_last_updated(
     If the last updated value is the same we will have a zero duration.
     """
     zero = get_start_time(dt_util.utcnow())
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     entity_id = "sensor.test1"
@@ -547,7 +547,7 @@ async def test_compile_hourly_statistics_with_some_same_last_updated_angle(
     If the last updated value is the same we will have a zero duration.
     """
     zero = get_start_time(dt_util.utcnow())
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     entity_id = "sensor.test1"
@@ -705,7 +705,7 @@ async def test_compile_hourly_statistics_with_all_same_last_updated(
     If the last updated value is the same we will have a zero duration.
     """
     zero = get_start_time(dt_util.utcnow())
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     entity_id = "sensor.test1"
@@ -846,7 +846,7 @@ async def test_compile_hourly_statistics_only_state_is_at_end_of_period(
 ) -> None:
     """Test compiling hourly statistics when the only states are at end of period."""
     zero = get_start_time(dt_util.utcnow())
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     entity_id = "sensor.test1"
@@ -938,7 +938,7 @@ async def test_compile_hourly_statistics_purged_state_changes(
     This tests statistics falls back to the state machine when states are purged.
     """
     zero = get_start_time(dt_util.utcnow())
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     attributes = {
@@ -1036,7 +1036,7 @@ async def test_compile_hourly_statistics_ignore_future_state(
     """
     zero = get_start_time(dt_util.utcnow() + timedelta(minutes=5))
     previous_period = zero - timedelta(minutes=5)
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     attributes = {
@@ -1098,7 +1098,7 @@ async def test_compile_hourly_statistics_wrong_unit(
 ) -> None:
     """Test stats for sensor with unit not matching device class."""
     zero = get_start_time(dt_util.utcnow())
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     with freeze_time(zero) as freezer:
@@ -1335,7 +1335,7 @@ async def test_compile_hourly_sum_statistics_amount(
     period1_end = period2 = period0 + timedelta(minutes=10)
     period2_end = period0 + timedelta(minutes=15)
     hass.config.units = units
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     attributes = {
@@ -1516,7 +1516,7 @@ async def test_compile_hourly_sum_statistics_amount_reset_every_state_change(
 ) -> None:
     """Test compiling hourly statistics."""
     zero = get_start_time(dt_util.utcnow())
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     attributes = {
@@ -1640,7 +1640,7 @@ async def test_compile_hourly_sum_statistics_amount_invalid_last_reset(
 ) -> None:
     """Test compiling hourly statistics."""
     zero = get_start_time(dt_util.utcnow())
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     attributes = {
@@ -1741,7 +1741,7 @@ async def test_compile_hourly_sum_statistics_nan_inf_state(
 ) -> None:
     """Test compiling hourly statistics with nan and inf states."""
     zero = get_start_time(dt_util.utcnow())
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     attributes = {
@@ -1886,7 +1886,7 @@ async def test_compile_hourly_sum_statistics_negative_state(
     await async_setup_component(hass, "homeassistant", {})
     with freeze_time(zero) as freezer:
         await async_setup_component(
-            hass, "sensor", {"sensor": [{"platform": "demo"}, {"platform": "test"}]}
+            hass, DOMAIN, {"sensor": [{"platform": "demo"}, {"platform": "test"}]}
         )
         await hass.async_block_till_done()
     attributes = {
@@ -1995,7 +1995,7 @@ async def test_compile_hourly_sum_statistics_total_no_reset(
     period0_end = period1 = period0 + timedelta(minutes=5)
     period1_end = period2 = period0 + timedelta(minutes=10)
     period2_end = period0 + timedelta(minutes=15)
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     attributes = {
@@ -2109,7 +2109,7 @@ async def test_compile_hourly_sum_statistics_total_increasing(
     period0_end = period1 = period0 + timedelta(minutes=5)
     period1_end = period2 = period0 + timedelta(minutes=10)
     period2_end = period0 + timedelta(minutes=15)
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     attributes = {
@@ -2223,7 +2223,7 @@ async def test_compile_hourly_sum_statistics_total_increasing_small_dip(
     period0_end = period1 = period0 + timedelta(minutes=5)
     period1_end = period2 = period0 + timedelta(minutes=10)
     period2_end = period0 + timedelta(minutes=15)
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     attributes = {
@@ -2327,7 +2327,7 @@ async def test_compile_hourly_energy_statistics_unsupported(
     period0_end = period1 = period0 + timedelta(minutes=5)
     period1_end = period2 = period0 + timedelta(minutes=10)
     period2_end = period0 + timedelta(minutes=15)
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     sns1_attr = {
@@ -2432,7 +2432,7 @@ async def test_compile_hourly_energy_statistics_multiple(
     period0_end = period1 = period0 + timedelta(minutes=5)
     period1_end = period2 = period0 + timedelta(minutes=10)
     period2_end = period0 + timedelta(minutes=15)
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     sns1_attr = {**ENERGY_SENSOR_ATTRIBUTES, "last_reset": None}
@@ -2649,7 +2649,7 @@ async def test_compile_hourly_statistics_unchanged(
 ) -> None:
     """Test compiling hourly statistics, with no changes during the hour."""
     zero = get_start_time(dt_util.utcnow())
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     attributes = {
@@ -2693,7 +2693,7 @@ async def test_compile_hourly_statistics_unchanged_angle(
 ) -> None:
     """Test compiling hourly stats, no changes for measurement_angle."""
     zero = get_start_time(dt_util.utcnow())
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     with freeze_time(zero) as freezer:
@@ -2748,7 +2748,7 @@ async def test_compile_hourly_statistics_partially_unavailable(
 ) -> None:
     """Test compiling hourly statistics, with the sensor being partially unavailable."""
     zero = get_start_time(dt_util.utcnow())
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     four, states = await async_record_states_partially_unavailable(
@@ -2820,7 +2820,7 @@ async def test_compile_hourly_statistics_unavailable(
     sensor.test2 should have statistics generated
     """
     zero = get_start_time(dt_util.utcnow())
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     attributes = {
@@ -2872,7 +2872,7 @@ async def test_compile_hourly_statistics_unavailable_angle(
     sensor.test2 should have statistics generated
     """
     zero = get_start_time(dt_util.utcnow())
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     four, states = await async_record_states_partially_unavailable(
@@ -2919,7 +2919,7 @@ async def test_compile_hourly_statistics_fails(
 ) -> None:
     """Test compiling hourly statistics throws."""
     zero = get_start_time(dt_util.utcnow())
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     with patch(
@@ -3232,7 +3232,7 @@ async def test_list_statistic_ids(
     statistic_type: str | StatisticMeanType,
 ) -> None:
     """Test listing future statistic ids."""
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     attributes = {
@@ -3294,7 +3294,7 @@ async def test_list_statistic_ids_unsupported(
     energy_attributes: dict[str, Any],
 ) -> None:
     """Test listing future statistic ids for unsupported sensor."""
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     attributes = dict(energy_attributes)
@@ -3345,7 +3345,7 @@ async def test_compile_hourly_statistics_changing_units_1(
     This tests the case where the recorder cannot convert between the units.
     """
     zero = get_start_time(dt_util.utcnow())
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     attributes = {
@@ -3476,7 +3476,7 @@ async def test_compile_hourly_statistics_changing_units_2(
     converter.
     """
     zero = get_start_time(dt_util.utcnow()) - timedelta(seconds=30 * 5)
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     attributes = {
@@ -3556,7 +3556,7 @@ async def test_compile_hourly_statistics_changing_units_3(
     converter.
     """
     zero = get_start_time(dt_util.utcnow())
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     attributes = {
@@ -3712,7 +3712,7 @@ async def test_compile_hourly_statistics_convert_units_1(
     This tests the case where the recorder can convert between the units.
     """
     zero = get_start_time(dt_util.utcnow())
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     attributes = {
@@ -3926,7 +3926,7 @@ async def test_compile_hourly_statistics_equivalent_units_1(
 ) -> None:
     """Test compiling hourly statistics where units change from one hour to the next."""
     zero = get_start_time(dt_util.utcnow())
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     attributes = {
@@ -4074,7 +4074,7 @@ async def test_compile_hourly_statistics_equivalent_units_2(
 ) -> None:
     """Test compiling hourly statistics where units change during an hour."""
     zero = get_start_time(dt_util.utcnow())
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     attributes = {
@@ -4159,7 +4159,7 @@ async def test_compile_hourly_statistics_custom_equivalent_units(
 ) -> None:
     """Test stats where units change with custom equivalent units."""
     zero = get_start_time(dt_util.utcnow())
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
 
@@ -4369,7 +4369,7 @@ async def test_compile_hourly_statistics_changing_device_class_1(
     Changing device class may influence the unit class.
     """
     zero = get_start_time(dt_util.utcnow())
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
 
@@ -4587,7 +4587,7 @@ async def test_compile_hourly_statistics_changing_device_class_2(
     class, then set to None.
     """
     zero = get_start_time(dt_util.utcnow())
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
 
@@ -4725,7 +4725,7 @@ async def test_compile_hourly_statistics_changing_state_class(
     period0 = get_start_time(dt_util.utcnow())
     period0_end = period1 = period0 + timedelta(minutes=5)
     period1_end = period0 + timedelta(minutes=10)
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     attributes_1 = {
@@ -4862,7 +4862,7 @@ async def test_compile_statistics_hourly_daily_monthly_summary(
 
     zero = dt_util.utcnow()
     instance = get_instance(hass)
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     # Wait for the sensor recorder platform to be added
     await async_recorder_block_till_done(hass)
     attributes = {
@@ -5341,7 +5341,7 @@ async def test_validate_unit_change_convertible(
     now = get_start_time(dt_util.utcnow())
 
     hass.config.units = units
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
     client = await hass_ws_client()
 
@@ -5477,7 +5477,7 @@ async def test_validate_statistics_unit_ignore_device_class(
     now = get_start_time(dt_util.utcnow())
 
     hass.config.units = units
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
     client = await hass_ws_client()
 
@@ -5588,7 +5588,7 @@ async def test_validate_statistics_unit_change_no_device_class(
     now = get_start_time(dt_util.utcnow())
 
     hass.config.units = units
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
     client = await hass_ws_client()
 
@@ -5722,7 +5722,7 @@ async def test_validate_statistics_state_class_removed(
     now = get_start_time(dt_util.utcnow())
 
     hass.config.units = units
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
     client = await hass_ws_client()
 
@@ -5790,7 +5790,7 @@ async def test_validate_statistics_state_class_removed_issue_cleaned_up(
     now = get_start_time(dt_util.utcnow())
 
     hass.config.units = units
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
     client = await hass_ws_client()
 
@@ -5849,7 +5849,7 @@ async def test_validate_statistics_sensor_no_longer_recorded(
     now = get_start_time(dt_util.utcnow())
 
     hass.config.units = units
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
     client = await hass_ws_client()
 
@@ -5903,7 +5903,7 @@ async def test_validate_statistics_sensor_not_recorded(
     now = get_start_time(dt_util.utcnow())
 
     hass.config.units = units
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
     client = await hass_ws_client()
 
@@ -5954,7 +5954,7 @@ async def test_validate_statistics_sensor_removed(
     now = get_start_time(dt_util.utcnow())
 
     hass.config.units = units
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
     client = await hass_ws_client()
 
@@ -6003,7 +6003,7 @@ async def test_validate_statistics_unit_change_no_conversion(
     """Test validate_statistics."""
     now = get_start_time(dt_util.utcnow())
 
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
     client = await hass_ws_client()
 
@@ -6161,7 +6161,7 @@ async def test_validate_statistics_unit_change_equivalent_units(
     """
     now = get_start_time(dt_util.utcnow())
 
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
     client = await hass_ws_client()
 
@@ -6265,7 +6265,7 @@ async def test_validate_statistics_unit_change_equivalent_units_2(
     """
     now = get_start_time(dt_util.utcnow())
 
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
     client = await hass_ws_client()
 
@@ -6344,7 +6344,7 @@ async def test_validate_statistics_unit_change_custom_equivalent_units(
     """
     now = get_start_time(dt_util.utcnow())
 
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
 
     # Add a recorder platform that provides custom equivalent units
@@ -6409,7 +6409,7 @@ async def test_validate_statistics_other_domain(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test sensor does not raise issues for statistics for other domains."""
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
     client = await hass_ws_client()
 
@@ -6463,7 +6463,7 @@ async def test_update_statistics_issues(
     now = get_start_time(dt_util.utcnow())
 
     hass.config.units = units
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
 
     # No statistics, no state - no issues
@@ -6514,7 +6514,7 @@ async def test_update_statistics_issues_with_custom_equivalent_units(
     """Test update_statistics_issues when custom equivalent units are provided."""
     now = get_start_time(dt_util.utcnow())
 
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
 
     # Add a recorder platform that provides custom equivalent units
@@ -6701,7 +6701,7 @@ async def test_exclude_attributes(hass: HomeAssistant) -> None:
         options=["option1", "option2"],
     )
     setup_test_component_platform(hass, DOMAIN, [entity0])
-    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
 
@@ -6742,7 +6742,7 @@ async def test_clean_up_repairs(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test cleaning up repairs."""
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     issue_registry = ir.async_get(hass)
     client = await hass_ws_client()
 
@@ -6799,7 +6799,7 @@ async def test_validate_statistics_mean_type_changed(
     """
     now = get_start_time(dt_util.utcnow())
 
-    await async_setup_component(hass, "sensor", {})
+    await async_setup_component(hass, DOMAIN, {})
     await async_recorder_block_till_done(hass)
     client = await hass_ws_client()
 

--- a/tests/components/sensor/test_recorder_missing_stats.py
+++ b/tests/components/sensor/test_recorder_missing_stats.py
@@ -14,6 +14,7 @@ from homeassistant.components.recorder.statistics import (
     statistics_during_period,
 )
 from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.sensor import DOMAIN
 from homeassistant.core import CoreState
 from homeassistant.helpers import recorder as recorder_helper
 from homeassistant.setup import async_setup_component
@@ -58,7 +59,7 @@ async def test_compile_missing_statistics(
         async_test_recorder(hass, wait_recorder=False),
     ):
         recorder_helper.async_initialize_recorder(hass)
-        await async_setup_component(hass, "sensor", {})
+        await async_setup_component(hass, DOMAIN, {})
         get_instance(hass).recorder_and_worker_thread_ids.add(threading.get_ident())
         await hass.async_start()
         await async_wait_recording_done(hass)
@@ -102,7 +103,7 @@ async def test_compile_missing_statistics(
         async_test_recorder(hass, wait_recorder=False),
     ):
         recorder_helper.async_initialize_recorder(hass)
-        await async_setup_component(hass, "sensor", {})
+        await async_setup_component(hass, DOMAIN, {})
         hass.states.async_set("sensor.test1", "0", POWER_SENSOR_ATTRIBUTES)
         get_instance(hass).recorder_and_worker_thread_ids.add(threading.get_ident())
         await hass.async_start()

--- a/tests/components/spaceapi/test_init.py
+++ b/tests/components/spaceapi/test_init.py
@@ -97,7 +97,7 @@ async def mock_client(
     hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> TestClient:
     """Start the Home Assistant HTTP component."""
-    await async_setup_component(hass, "spaceapi", CONFIG)
+    await async_setup_component(hass, DOMAIN, CONFIG)
 
     hass.states.async_set(
         "test.temp1",
@@ -199,7 +199,7 @@ async def test_spaceapi_no_auth_required(
     hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
 ) -> None:
     """Test SpaceAPI is accessible without authentication."""
-    assert await async_setup_component(hass, "spaceapi", CONFIG)
+    assert await async_setup_component(hass, DOMAIN, CONFIG)
 
     hass.states.async_set("test.test_door", "on")
 
@@ -215,7 +215,7 @@ async def test_spaceapi_cors_headers(
     hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
 ) -> None:
     """Test CORS headers are present on SpaceAPI responses."""
-    assert await async_setup_component(hass, "spaceapi", CONFIG)
+    assert await async_setup_component(hass, DOMAIN, CONFIG)
 
     hass.states.async_set("test.test_door", "on")
 

--- a/tests/components/spc/test_alarm_control_panel.py
+++ b/tests/components/spc/test_alarm_control_panel.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 from pyspcwebgw.const import AreaMode
 
 from homeassistant.components.alarm_control_panel import AlarmControlPanelState
+from homeassistant.components.spc import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -13,7 +14,7 @@ async def test_update_alarm_device(hass: HomeAssistant, mock_client: AsyncMock) 
     """Test that alarm panel state changes on incoming websocket data."""
 
     config = {"spc": {"api_url": "http://localhost/", "ws_url": "ws://localhost/"}}
-    assert await async_setup_component(hass, "spc", config) is True
+    assert await async_setup_component(hass, DOMAIN, config) is True
 
     await hass.async_block_till_done()
 

--- a/tests/components/spc/test_init.py
+++ b/tests/components/spc/test_init.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock
 
+from homeassistant.components.spc import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -10,7 +11,7 @@ async def test_valid_device_config(hass: HomeAssistant, mock_client: AsyncMock) 
     """Test valid device config."""
     config = {"spc": {"api_url": "http://localhost/", "ws_url": "ws://localhost/"}}
 
-    assert await async_setup_component(hass, "spc", config) is True
+    assert await async_setup_component(hass, DOMAIN, config) is True
 
 
 async def test_invalid_device_config(
@@ -19,4 +20,4 @@ async def test_invalid_device_config(
     """Test valid device config."""
     config = {"spc": {"api_url": "http://localhost/"}}
 
-    assert await async_setup_component(hass, "spc", config) is False
+    assert await async_setup_component(hass, DOMAIN, config) is False

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -10,6 +10,7 @@ import pytest
 
 from homeassistant.components.stream import Stream, create_stream
 from homeassistant.components.stream.const import (
+    DOMAIN,
     EXT_X_START_LL_HLS,
     EXT_X_START_NON_LL_HLS,
     HLS_PROVIDER,
@@ -48,7 +49,7 @@ HLS_CONFIG = {
 @pytest.fixture
 async def setup_component(hass: HomeAssistant) -> None:
     """Test fixture to setup the stream component."""
-    await async_setup_component(hass, "stream", HLS_CONFIG)
+    await async_setup_component(hass, DOMAIN, HLS_CONFIG)
 
 
 class HlsClient:

--- a/tests/components/stream/test_init.py
+++ b/tests/components/stream/test_init.py
@@ -15,7 +15,7 @@ from homeassistant.components.stream import (
     async_check_stream_client_error,
     create_stream,
 )
-from homeassistant.components.stream.const import ATTR_PREFER_TCP
+from homeassistant.components.stream.const import ATTR_PREFER_TCP, DOMAIN
 from homeassistant.const import EVENT_LOGGING_CHANGED
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -42,7 +42,7 @@ async def test_log_levels(
 ) -> None:
     """Test that the worker logs the url without username and password."""
 
-    await async_setup_component(hass, "stream", {"stream": {}})
+    await async_setup_component(hass, DOMAIN, {"stream": {}})
 
     # These namespaces should only pass log messages when the stream logger
     # is at logging.DEBUG or below
@@ -83,7 +83,7 @@ async def test_log_levels(
 
 async def test_check_open_stream_params(hass: HomeAssistant) -> None:
     """Test check open stream params."""
-    await async_setup_component(hass, "stream", {"stream": {}})
+    await async_setup_component(hass, DOMAIN, {"stream": {}})
 
     container_mock = MagicMock()
     source = "rtsp://foobar"
@@ -134,7 +134,7 @@ async def test_try_open_stream_error(
     hass: HomeAssistant, error: av.HTTPClientError, enum_result: StreamClientError
 ) -> None:
     """Test trying to open a stream."""
-    await async_setup_component(hass, "stream", {"stream": {}})
+    await async_setup_component(hass, DOMAIN, {"stream": {}})
 
     with (
         patch("av.open", side_effect=error),
@@ -175,7 +175,7 @@ async def test_convert_stream_options(
     expected_pyav_options: dict[str, Any],
 ) -> None:
     """Test stream options."""
-    await async_setup_component(hass, "stream", {"stream": {}})
+    await async_setup_component(hass, DOMAIN, {"stream": {}})
 
     container_mock = MagicMock()
     source = "rtsp://foobar"

--- a/tests/components/stream/test_ll_hls.py
+++ b/tests/components/stream/test_ll_hls.py
@@ -128,7 +128,7 @@ async def test_ll_hls_stream(
     """
     await async_setup_component(
         hass,
-        "stream",
+        DOMAIN,
         {
             "stream": {
                 CONF_LL_HLS: True,
@@ -261,7 +261,7 @@ async def test_ll_hls_playlist_view(
     """Test rendering the hls playlist with 1 and 2 output segments."""
     await async_setup_component(
         hass,
-        "stream",
+        DOMAIN,
         {
             "stream": {
                 CONF_LL_HLS: True,
@@ -332,7 +332,7 @@ async def test_ll_hls_msn(
     """Test that requests using _HLS_msn get held and returned or rejected."""
     await async_setup_component(
         hass,
-        "stream",
+        DOMAIN,
         {
             "stream": {
                 CONF_LL_HLS: True,
@@ -402,7 +402,7 @@ async def test_ll_hls_playlist_bad_msn_part(
 
     await async_setup_component(
         hass,
-        "stream",
+        DOMAIN,
         {
             "stream": {
                 CONF_LL_HLS: True,
@@ -480,7 +480,7 @@ async def test_ll_hls_playlist_rollover_part(
 
     await async_setup_component(
         hass,
-        "stream",
+        DOMAIN,
         {
             "stream": {
                 CONF_LL_HLS: True,
@@ -561,7 +561,7 @@ async def test_ll_hls_playlist_msn_part(
 
     await async_setup_component(
         hass,
-        "stream",
+        DOMAIN,
         {
             "stream": {
                 CONF_LL_HLS: True,
@@ -629,7 +629,7 @@ async def test_get_part_segments(
     """Test requests for part segments and hinted parts."""
     await async_setup_component(
         hass,
-        "stream",
+        DOMAIN,
         {
             "stream": {
                 CONF_LL_HLS: True,

--- a/tests/components/stream/test_recorder.py
+++ b/tests/components/stream/test_recorder.py
@@ -12,6 +12,7 @@ import pytest
 
 from homeassistant.components.stream import Stream, create_stream
 from homeassistant.components.stream.const import (
+    DOMAIN,
     HLS_PROVIDER,
     OUTPUT_IDLE_TIMEOUT,
     RECORDER_PROVIDER,
@@ -37,7 +38,7 @@ from tests.common import async_fire_time_changed
 @pytest.fixture(autouse=True)
 async def stream_component(hass: HomeAssistant) -> None:
     """Set up the component before each test."""
-    await async_setup_component(hass, "stream", {"stream": {}})
+    await async_setup_component(hass, DOMAIN, {"stream": {}})
 
 
 @pytest.fixture

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -837,7 +837,7 @@ async def test_durations(hass: HomeAssistant, worker_finished_stream) -> None:
     target_part_duration = TEST_PART_DURATION - 0.01
     await async_setup_component(
         hass,
-        "stream",
+        DOMAIN,
         {
             "stream": {
                 CONF_LL_HLS: True,
@@ -917,7 +917,7 @@ async def test_has_keyframe(
     """Test that the has_keyframe metadata matches the media."""
     await async_setup_component(
         hass,
-        "stream",
+        DOMAIN,
         {
             "stream": {
                 CONF_LL_HLS: True,
@@ -962,7 +962,7 @@ async def test_h265_video_is_hvc1(hass: HomeAssistant, worker_finished_stream) -
     """Test that a h265 video gets muxed as hvc1."""
     await async_setup_component(
         hass,
-        "stream",
+        DOMAIN,
         {
             "stream": {
                 CONF_LL_HLS: True,
@@ -1007,7 +1007,7 @@ async def test_h265_video_is_hvc1(hass: HomeAssistant, worker_finished_stream) -
 
 async def test_get_image(hass: HomeAssistant, h264_video, filename) -> None:
     """Test getting an image from the stream."""
-    await async_setup_component(hass, "stream", {"stream": {}})
+    await async_setup_component(hass, DOMAIN, {"stream": {}})
 
     # Since libjpeg-turbo is not installed on the CI runner, we use a mock
     with patch(
@@ -1070,7 +1070,7 @@ async def test_worker_disable_ll_hls(hass: HomeAssistant) -> None:
 
 async def test_get_image_rotated(hass: HomeAssistant, h264_video, filename) -> None:
     """Test getting a rotated image."""
-    await async_setup_component(hass, "stream", {"stream": {}})
+    await async_setup_component(hass, DOMAIN, {"stream": {}})
 
     # Since libjpeg-turbo is not installed on the CI runner, we use a mock
     with patch(

--- a/tests/components/stt/test_init.py
+++ b/tests/components/stt/test_init.py
@@ -113,7 +113,7 @@ async def mock_setup(
         TEST_DOMAIN,
         async_get_engine=AsyncMock(return_value=mock_provider),
     )
-    assert await async_setup_component(hass, "stt", {"stt": {"platform": TEST_DOMAIN}})
+    assert await async_setup_component(hass, DOMAIN, {"stt": {"platform": TEST_DOMAIN}})
     await hass.async_block_till_done()
 
 
@@ -460,7 +460,7 @@ async def test_ws_list_engines(
 
 async def test_default_engine_none(hass: HomeAssistant, tmp_path: Path) -> None:
     """Test async_default_engine."""
-    assert await async_setup_component(hass, "stt", {"stt": {}})
+    assert await async_setup_component(hass, DOMAIN, {"stt": {}})
     await hass.async_block_till_done()
 
     assert async_default_engine(hass) is None
@@ -478,7 +478,7 @@ async def test_default_engine(
         TEST_DOMAIN,
         async_get_engine=AsyncMock(return_value=mock_provider),
     )
-    assert await async_setup_component(hass, "stt", {"stt": {"platform": TEST_DOMAIN}})
+    assert await async_setup_component(hass, DOMAIN, {"stt": {"platform": TEST_DOMAIN}})
     await hass.async_block_till_done()
 
     assert async_default_engine(hass) == TEST_DOMAIN
@@ -583,7 +583,7 @@ async def test_get_engine_legacy(
         async_get_engine=AsyncMock(return_value=mock_provider),
     )
     assert await async_setup_component(
-        hass, "stt", {"stt": [{"platform": TEST_DOMAIN}, {"platform": "cloud"}]}
+        hass, DOMAIN, {"stt": [{"platform": TEST_DOMAIN}, {"platform": "cloud"}]}
     )
     await hass.async_block_till_done()
 

--- a/tests/components/switch/test_init.py
+++ b/tests/components/switch/test_init.py
@@ -4,6 +4,7 @@ import pytest
 
 from homeassistant import core
 from homeassistant.components import switch
+from homeassistant.components.switch import DOMAIN
 from homeassistant.const import CONF_PLATFORM
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -63,7 +64,7 @@ async def test_switch_context(
     hass_admin_user: MockUser,
 ) -> None:
     """Test that switch context works."""
-    assert await async_setup_component(hass, "switch", {"switch": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"switch": {"platform": "test"}})
 
     await hass.async_block_till_done()
 

--- a/tests/components/switch/test_light.py
+++ b/tests/components/switch/test_light.py
@@ -7,6 +7,7 @@ from homeassistant.components.light import (
     ATTR_SUPPORTED_COLOR_MODES,
     ColorMode,
 )
+from homeassistant.components.switch import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -51,7 +52,7 @@ async def test_default_state(hass: HomeAssistant) -> None:
 
 async def test_light_service_calls(hass: HomeAssistant) -> None:
     """Test service calls to light."""
-    await async_setup_component(hass, "switch", {"switch": [{"platform": "demo"}]})
+    await async_setup_component(hass, DOMAIN, {"switch": [{"platform": "demo"}]})
     await async_setup_component(
         hass,
         "light",
@@ -86,7 +87,7 @@ async def test_light_service_calls(hass: HomeAssistant) -> None:
 
 async def test_switch_service_calls(hass: HomeAssistant) -> None:
     """Test service calls to switch."""
-    await async_setup_component(hass, "switch", {"switch": [{"platform": "demo"}]})
+    await async_setup_component(hass, DOMAIN, {"switch": [{"platform": "demo"}]})
     await async_setup_component(
         hass,
         "light",

--- a/tests/components/system_health/test_init.py
+++ b/tests/components/system_health/test_init.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, Mock, patch
 from aiohttp.client_exceptions import ClientError
 
 from homeassistant.components import system_health
-from homeassistant.components.system_health import async_register_info
+from homeassistant.components.system_health import DOMAIN, async_register_info
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -61,7 +61,7 @@ async def test_info_endpoint_return_info(
         "homeassistant.components.homeassistant.system_health.system_health_info",
         return_value={"hello": True},
     ):
-        assert await async_setup_component(hass, "system_health", {})
+        assert await async_setup_component(hass, DOMAIN, {})
 
     data = await gather_system_health_info(hass, hass_ws_client)
 
@@ -79,7 +79,7 @@ async def test_info_endpoint_register_callback(
         return {"storage": "YAML"}
 
     async_register_info(hass, "lovelace", mock_info)
-    assert await async_setup_component(hass, "system_health", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     data = await gather_system_health_info(hass, hass_ws_client)
 
     assert len(data) == 1
@@ -99,7 +99,7 @@ async def test_info_endpoint_register_callback_timeout(
         raise TimeoutError
 
     async_register_info(hass, "lovelace", mock_info)
-    assert await async_setup_component(hass, "system_health", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     data = await gather_system_health_info(hass, hass_ws_client)
 
     assert len(data) == 1
@@ -116,7 +116,7 @@ async def test_info_endpoint_register_callback_exc(
         raise Exception("TEST ERROR")  # noqa: TRY002
 
     async_register_info(hass, "lovelace", mock_info)
-    assert await async_setup_component(hass, "system_health", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     data = await gather_system_health_info(hass, hass_ws_client)
 
     assert len(data) == 1
@@ -165,7 +165,7 @@ async def test_platform_loading(
         ),
     )
 
-    assert await async_setup_component(hass, "system_health", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     data = await gather_system_health_info(hass, hass_ws_client)
 
     assert data["fake_integration"] == {

--- a/tests/components/template/test_blueprint.py
+++ b/tests/components/template/test_blueprint.py
@@ -109,7 +109,7 @@ async def test_inverted_binary_sensor(
     ):
         assert await async_setup_component(
             hass,
-            "template",
+            DOMAIN,
             {
                 "template": [
                     {
@@ -324,7 +324,7 @@ async def test_trigger_event_sensor(
     """Test event sensor blueprint."""
     assert await async_setup_component(
         hass,
-        "template",
+        DOMAIN,
         {
             "template": [
                 {
@@ -403,7 +403,7 @@ async def test_blueprint_template_override(
     """Test blueprint template where the template config overrides the blueprint."""
     assert await async_setup_component(
         hass,
-        "template",
+        DOMAIN,
         {
             "template": [
                 {
@@ -503,7 +503,7 @@ async def test_invalid_blueprint(
     with patch_invalid_blueprint():
         assert await async_setup_component(
             hass,
-            "template",
+            DOMAIN,
             {
                 "template": [
                     {
@@ -529,7 +529,7 @@ async def test_no_blueprint(hass: HomeAssistant) -> None:
     ):
         assert await async_setup_component(
             hass,
-            "template",
+            DOMAIN,
             {
                 "template": [
                     {"binary_sensor": {"name": "test entity", "state": "off"}},
@@ -589,7 +589,7 @@ async def test_variables_for_entity(
 
     assert await async_setup_component(
         hass,
-        "template",
+        DOMAIN,
         {
             "template": [
                 {

--- a/tests/components/template/test_config.py
+++ b/tests/components/template/test_config.py
@@ -276,7 +276,7 @@ async def test_invalid_binary_sensor_schema_with_auto_off(
 ) -> None:
     """Test invalid config schemas create issue and log warning."""
 
-    await async_setup_component(hass, "template", {"template": [config]})
+    await async_setup_component(hass, DOMAIN, {"template": [config]})
 
     assert (
         expected_error is None and "ERROR" not in caplog.text
@@ -536,7 +536,7 @@ async def test_invalid_schema_raises_issue(
 ) -> None:
     """Test invalid config schemas create issue and log warning."""
 
-    await async_setup_component(hass, "template", {"template": [config]})
+    await async_setup_component(hass, DOMAIN, {"template": [config]})
 
     assert expected_warning in caplog.text
 
@@ -553,7 +553,7 @@ async def test_multiple_configuration_keys(
     """Test multiple configurations keys create entities."""
     await async_setup_component(
         hass,
-        "template",
+        DOMAIN,
         {
             "template": [{"binary_sensor": [{"name": "Foo", "state": "{{ True }}"}]}],
             "template mytemplates": [

--- a/tests/components/template/test_entity.py
+++ b/tests/components/template/test_entity.py
@@ -55,7 +55,7 @@ async def test_reload_stops_entity_action_scripts(
     hass: HomeAssistant, config: dict
 ) -> None:
     """Test that reloading stops template entity action scripts."""
-    assert await async_setup_component(hass, "template", config)
+    assert await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()

--- a/tests/components/template/test_image.py
+++ b/tests/components/template/test_image.py
@@ -151,7 +151,7 @@ async def test_missing_optional_config(
     with assert_setup_component(1, "template"):
         assert await setup.async_setup_component(
             hass,
-            "template",
+            DOMAIN,
             {
                 "template": {
                     "image": {
@@ -193,7 +193,7 @@ async def test_multiple_configs(
     with assert_setup_component(1, "template"):
         assert await setup.async_setup_component(
             hass,
-            "template",
+            DOMAIN,
             {
                 "template": {
                     "image": [
@@ -229,7 +229,7 @@ async def test_missing_required_keys(hass: HomeAssistant) -> None:
     with assert_setup_component(0, "template"):
         assert await setup.async_setup_component(
             hass,
-            "template",
+            DOMAIN,
             {
                 "template": {
                     "image": {
@@ -253,7 +253,7 @@ async def test_unique_id(
     with assert_setup_component(1, "template"):
         assert await setup.async_setup_component(
             hass,
-            "template",
+            DOMAIN,
             {
                 "template": {
                     "unique_id": "b",
@@ -287,7 +287,7 @@ async def test_custom_entity_picture(
     with assert_setup_component(1, "template"):
         assert await setup.async_setup_component(
             hass,
-            "template",
+            DOMAIN,
             {
                 "template": {
                     "image": {
@@ -322,7 +322,7 @@ async def test_template_error(
     with assert_setup_component(1, "template"):
         assert await setup.async_setup_component(
             hass,
-            "template",
+            DOMAIN,
             {
                 "template": {
                     "image": {
@@ -379,7 +379,7 @@ async def test_templates_with_entities(
     with assert_setup_component(1, "template"):
         assert await setup.async_setup_component(
             hass,
-            "template",
+            DOMAIN,
             {
                 "template": {
                     "image": {
@@ -435,7 +435,7 @@ async def test_trigger_image(
 
     assert await setup.async_setup_component(
         hass,
-        "template",
+        DOMAIN,
         {
             "template": [
                 {
@@ -497,7 +497,7 @@ async def test_trigger_image_custom_entity_picture(
 
     assert await setup.async_setup_component(
         hass,
-        "template",
+        DOMAIN,
         {
             "template": [
                 {

--- a/tests/components/template/test_select.py
+++ b/tests/components/template/test_select.py
@@ -123,7 +123,7 @@ async def test_multiple_configs(hass: HomeAssistant) -> None:
     with assert_setup_component(1, "template"):
         assert await setup.async_setup_component(
             hass,
-            "template",
+            DOMAIN,
             {
                 "template": {
                     "select": [

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -9,6 +9,7 @@ from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.bootstrap import async_from_config_dict
 from homeassistant.components import sensor, template
+from homeassistant.components.template import DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_PICTURE,
     ATTR_FRIENDLY_NAME,
@@ -1226,7 +1227,7 @@ async def test_numeric_trigger_entity_set_unknown(
     """Test trigger entity state parsing with numeric sensors."""
     assert await async_setup_component(
         hass,
-        "template",
+        DOMAIN,
         {
             "template": [
                 {
@@ -1264,7 +1265,7 @@ async def test_trigger_attribute_order(
     """Test trigger entity attributes order."""
     assert await async_setup_component(
         hass,
-        "template",
+        DOMAIN,
         {
             "template": [
                 {
@@ -1347,7 +1348,7 @@ async def test_entity_last_reset_total_increasing(
     with patch("homeassistant.util.dt.now", return_value=now):
         assert await async_setup_component(
             hass,
-            "template",
+            DOMAIN,
             {
                 "template": [
                     {

--- a/tests/components/template/test_trigger_entity.py
+++ b/tests/components/template/test_trigger_entity.py
@@ -267,7 +267,7 @@ async def test_shutdown_stops_script_and_keeps_triggers_subscribed(
     """Test HA shutdown stops coordinator scripts without unsubscribing."""
     assert await async_setup_component(
         hass,
-        "template",
+        DOMAIN,
         {
             "template": {
                 "trigger": {"platform": "event", "event_type": "test_event"},
@@ -320,7 +320,7 @@ async def test_reload_stops_script_and_unsubscribes_triggers(
     """Test that reloading stops coordinator scripts and unsubscribes old triggers."""
     assert await async_setup_component(
         hass,
-        "template",
+        DOMAIN,
         {
             "template": {
                 "trigger": {"platform": "event", "event_type": "test_event"},

--- a/tests/components/template/test_weather.py
+++ b/tests/components/template/test_weather.py
@@ -6,7 +6,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components import template
-from homeassistant.components.template.const import CONF_PICTURE
+from homeassistant.components.template.const import CONF_PICTURE, DOMAIN
 from homeassistant.components.weather import (
     ATTR_WEATHER_APPARENT_TEMPERATURE,
     ATTR_WEATHER_CLOUD_COVERAGE,
@@ -803,7 +803,7 @@ async def test_restore_weather_save_state(
     """Test Restore saved state for Weather trigger template."""
     assert await async_setup_component(
         hass,
-        "template",
+        DOMAIN,
         {
             "template": {
                 "trigger": {"platform": "event", "event_type": "test_event"},
@@ -898,7 +898,7 @@ async def test_trigger_entity_restore_state_fail(
     mock_restore_cache_with_extra_data(hass, ((saved_state, saved_extra_data),))
     assert await async_setup_component(
         hass,
-        "template",
+        DOMAIN,
         {
             "template": {
                 "trigger": {"platform": "event", "event_type": "test_event"},

--- a/tests/components/text/test_init.py
+++ b/tests/components/text/test_init.py
@@ -119,7 +119,7 @@ async def test_restore_number_save_state(
     )
     setup_test_component_platform(hass, DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "text", {"text": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"text": {"platform": "test"}})
     await hass.async_block_till_done()
 
     # Trigger saving state
@@ -163,7 +163,7 @@ async def test_restore_number_restore_state(
     )
     setup_test_component_platform(hass, DOMAIN, [entity0])
 
-    assert await async_setup_component(hass, "text", {"text": {"platform": "test"}})
+    assert await async_setup_component(hass, DOMAIN, {"text": {"platform": "test"}})
     await hass.async_block_till_done()
 
     assert hass.states.get(entity0.entity_id)

--- a/tests/components/timer/test_init.py
+++ b/tests/components/timer/test_init.py
@@ -118,7 +118,7 @@ async def test_config_options(hass: HomeAssistant) -> None:
         }
     }
 
-    assert await async_setup_component(hass, "timer", config)
+    assert await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
 
     assert count_start + 3 == len(hass.states.async_entity_ids())
@@ -682,7 +682,7 @@ async def test_config_reload(
         }
     }
 
-    assert await async_setup_component(hass, "timer", config)
+    assert await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
 
     assert count_start + 2 == len(hass.states.async_entity_ids())

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -21,6 +21,7 @@ from homeassistant.components.media_player import (
     SERVICE_PLAY_MEDIA,
     MediaType,
 )
+from homeassistant.components.tts import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
@@ -1701,7 +1702,7 @@ async def test_ws_list_engines_deprecated(
     mock_integration(hass, MockModule(domain="test_2"))
     mock_platform(hass, "test_2.tts", MockTTS(mock_provider_2))
     await async_setup_component(
-        hass, "tts", {"tts": [{"platform": "test"}, {"platform": "test_2"}]}
+        hass, DOMAIN, {"tts": [{"platform": "test"}, {"platform": "test_2"}]}
     )
     await mock_config_entry_setup(hass, mock_tts_entity)
 

--- a/tests/components/usage_prediction/test_init.py
+++ b/tests/components/usage_prediction/test_init.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.usage_prediction import get_cached_common_control
+from homeassistant.components.usage_prediction import DOMAIN, get_cached_common_control
 from homeassistant.components.usage_prediction.models import EntityUsagePredictions
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -15,7 +15,7 @@ from homeassistant.setup import async_setup_component
 async def test_usage_prediction_caching(hass: HomeAssistant) -> None:
     """Test that usage prediction results are cached for 24 hours."""
 
-    assert await async_setup_component(hass, "usage_prediction", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     finish_event = asyncio.Event()
 

--- a/tests/components/usage_prediction/test_websocket.py
+++ b/tests/components/usage_prediction/test_websocket.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, patch
 from freezegun import freeze_time
 import pytest
 
+from homeassistant.components.usage_prediction import DOMAIN
 from homeassistant.components.usage_prediction.models import EntityUsagePredictions
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -42,7 +43,7 @@ async def test_common_control(
     mock_predict_common_control: Mock,
 ) -> None:
     """Test usage_prediction common control WebSocket command."""
-    assert await async_setup_component(hass, "usage_prediction", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     client = await hass_ws_client(hass)
 
@@ -69,7 +70,7 @@ async def test_caching_behavior(
     mock_predict_common_control: Mock,
 ) -> None:
     """Test that results are cached for 24 hours."""
-    assert await async_setup_component(hass, "usage_prediction", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     client = await hass_ws_client(hass)
 

--- a/tests/components/voip/test_voip.py
+++ b/tests/components/voip/test_voip.py
@@ -16,7 +16,7 @@ from homeassistant.components.assist_satellite import AssistSatelliteEntity
 
 # pylint: disable-next=home-assistant-component-root-import
 from homeassistant.components.assist_satellite.entity import AssistSatelliteState
-from homeassistant.components.voip import HassVoipDatagramProtocol
+from homeassistant.components.voip import DOMAIN, HassVoipDatagramProtocol
 from homeassistant.components.voip.assist_satellite import Tones, VoipAssistSatellite
 from homeassistant.components.voip.devices import VoIPDevice, VoIPDevices
 from homeassistant.components.voip.voip import PreRecordMessageProtocol, make_protocol
@@ -76,7 +76,7 @@ async def test_is_valid_call(
     call_info: CallInfo,
 ) -> None:
     """Test that a call is now allowed from an unknown device."""
-    assert await async_setup_component(hass, "voip", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     protocol = HassVoipDatagramProtocol(hass, voip_devices)
     assert not protocol.is_valid_call(call_info)
 
@@ -102,7 +102,7 @@ async def test_calls_not_allowed(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test that a pre-recorded message is played when calls aren't allowed."""
-    assert await async_setup_component(hass, "voip", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     protocol: PreRecordMessageProtocol = make_protocol(hass, voip_devices, call_info)
     assert isinstance(protocol, PreRecordMessageProtocol)
     assert protocol.file_name == "problem.pcm"
@@ -139,7 +139,7 @@ async def test_pipeline_not_found(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test that a pre-recorded message is played when a pipeline isn't found."""
-    assert await async_setup_component(hass, "voip", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     with patch(
         "homeassistant.components.voip.voip.async_get_pipeline", return_value=None
@@ -160,7 +160,7 @@ async def test_satellite_prepared(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test that satellite is prepared for a call."""
-    assert await async_setup_component(hass, "voip", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     pipeline = assist_pipeline.Pipeline(
         conversation_engine="test",
@@ -196,7 +196,7 @@ async def test_pipeline(
     call_info: CallInfo,
 ) -> None:
     """Test that pipeline function is called from RTP protocol."""
-    assert await async_setup_component(hass, "voip", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
     assert isinstance(satellite, VoipAssistSatellite)
@@ -371,7 +371,7 @@ async def test_stt_stream_timeout(
     hass: HomeAssistant, voip_devices: VoIPDevices, voip_device: VoIPDevice
 ) -> None:
     """Test timeout in STT stream during pipeline run."""
-    assert await async_setup_component(hass, "voip", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
     assert isinstance(satellite, VoipAssistSatellite)
@@ -410,7 +410,7 @@ async def test_tts_timeout(
     voip_device: VoIPDevice,
 ) -> None:
     """Test that TTS will time out based on its length."""
-    assert await async_setup_component(hass, "voip", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
     assert isinstance(satellite, VoipAssistSatellite)
@@ -509,7 +509,7 @@ async def test_tts_wrong_extension(
     voip_device: VoIPDevice,
 ) -> None:
     """Test that TTS will only stream WAV audio."""
-    assert await async_setup_component(hass, "voip", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
     satellite.addr = ("192.168.1.1", 12345)
@@ -602,7 +602,7 @@ async def test_tts_wrong_wav_format(
     voip_device: VoIPDevice,
 ) -> None:
     """Test that TTS will only stream WAV audio with a specific format."""
-    assert await async_setup_component(hass, "voip", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
     satellite.addr = ("192.168.1.1", 12345)
@@ -695,7 +695,7 @@ async def test_empty_tts_output(
     voip_device: VoIPDevice,
 ) -> None:
     """Test that TTS will not stream when output is empty."""
-    assert await async_setup_component(hass, "voip", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
     satellite.addr = ("192.168.1.1", 12345)
@@ -781,7 +781,7 @@ async def test_pipeline_error(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test that a pipeline error causes the error tone to be played."""
-    assert await async_setup_component(hass, "voip", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
     assert isinstance(satellite, VoipAssistSatellite)
@@ -834,7 +834,7 @@ async def test_announce(
     voip_device: VoIPDevice,
 ) -> None:
     """Test announcement."""
-    assert await async_setup_component(hass, "voip", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
     assert isinstance(satellite, VoipAssistSatellite)
@@ -903,7 +903,7 @@ async def test_voip_id_is_ip_address(
     voip_device: VoIPDevice,
 ) -> None:
     """Test announcement when VoIP is an IP address instead of a SIP header."""
-    assert await async_setup_component(hass, "voip", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
     assert isinstance(satellite, VoipAssistSatellite)
@@ -964,7 +964,7 @@ async def test_announce_timeout(
     voip_device: VoIPDevice,
 ) -> None:
     """Test announcement when user does not pick up the phone in time."""
-    assert await async_setup_component(hass, "voip", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
     assert isinstance(satellite, VoipAssistSatellite)
@@ -1007,7 +1007,7 @@ async def test_start_conversation(
     voip_device: VoIPDevice,
 ) -> None:
     """Test start conversation."""
-    assert await async_setup_component(hass, "voip", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
     assert isinstance(satellite, VoipAssistSatellite)
@@ -1116,7 +1116,7 @@ async def test_start_conversation_user_doesnt_pick_up(
     voip_device: VoIPDevice,
 ) -> None:
     """Test start conversation when the user doesn't pick up."""
-    assert await async_setup_component(hass, "voip", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
     satellite.addr = ("192.168.1.1", 12345)

--- a/tests/components/weather/test_intent.py
+++ b/tests/components/weather/test_intent.py
@@ -17,7 +17,7 @@ from homeassistant.setup import async_setup_component
 async def test_get_weather(hass: HomeAssistant) -> None:
     """Test get weather for first entity and by name."""
     assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "weather", {"weather": {}})
+    assert await async_setup_component(hass, DOMAIN, {"weather": {}})
 
     entity1 = WeatherEntity()
     entity1._attr_name = "Weather 1"
@@ -73,7 +73,7 @@ async def test_get_weather(hass: HomeAssistant) -> None:
 async def test_get_weather_wrong_name(hass: HomeAssistant) -> None:
     """Test get weather with the wrong name."""
     assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "weather", {"weather": {}})
+    assert await async_setup_component(hass, DOMAIN, {"weather": {}})
 
     entity1 = WeatherEntity()
     entity1._attr_name = "Weather 1"
@@ -109,7 +109,7 @@ async def test_get_weather_wrong_name(hass: HomeAssistant) -> None:
 async def test_get_weather_no_entities(hass: HomeAssistant) -> None:
     """Test get weather with no weather entities."""
     assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "weather", {"weather": {}})
+    assert await async_setup_component(hass, DOMAIN, {"weather": {}})
     await weather_intent.async_setup_intents(hass)
 
     # No weather entities

--- a/tests/components/web_rtc/test_init.py
+++ b/tests/components/web_rtc/test_init.py
@@ -3,6 +3,7 @@
 from webrtc_models import RTCIceServer
 
 from homeassistant.components.web_rtc import (
+    DOMAIN,
     async_get_ice_servers,
     async_register_ice_servers,
 )
@@ -15,7 +16,7 @@ from tests.typing import WebSocketGenerator
 
 async def test_async_setup(hass: HomeAssistant) -> None:
     """Test setting up the web_rtc integration."""
-    assert await async_setup_component(hass, "web_rtc", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     # Verify default ICE servers are registered
@@ -34,7 +35,7 @@ async def test_async_setup_custom_ice_servers_core(hass: HomeAssistant) -> None:
         {"webrtc": {"ice_servers": [{"url": "stun:custom_stun_server:3478"}]}},
     )
 
-    assert await async_setup_component(hass, "web_rtc", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     ice_servers = async_get_ice_servers(hass)
@@ -46,7 +47,7 @@ async def test_async_setup_custom_ice_servers_integration(hass: HomeAssistant) -
     """Test setting up web_rtc with custom ICE servers in config."""
     assert await async_setup_component(
         hass,
-        "web_rtc",
+        DOMAIN,
         {
             "web_rtc": {
                 "ice_servers": [
@@ -102,7 +103,7 @@ async def test_async_setup_custom_ice_servers_core_and_integration(
 
     assert await async_setup_component(
         hass,
-        "web_rtc",
+        DOMAIN,
         {
             "web_rtc": {
                 "ice_servers": [{"url": "stun:custom_stun_server_integration:3478"}]
@@ -124,7 +125,7 @@ async def test_async_setup_custom_ice_servers_core_and_integration(
 
 async def test_async_register_ice_servers(hass: HomeAssistant) -> None:
     """Test registering ICE servers."""
-    assert await async_setup_component(hass, "web_rtc", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
     default_servers = async_get_ice_servers(hass)
 
@@ -159,7 +160,7 @@ async def test_async_register_ice_servers(hass: HomeAssistant) -> None:
 
 async def test_multiple_ice_server_registrations(hass: HomeAssistant) -> None:
     """Test registering multiple ICE server providers."""
-    assert await async_setup_component(hass, "web_rtc", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
     default_servers = async_get_ice_servers(hass)
 
@@ -213,7 +214,7 @@ async def test_ws_ice_servers_with_registered_servers(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test WebSocket ICE servers endpoint with registered servers."""
-    assert await async_setup_component(hass, "web_rtc", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     @callback

--- a/tests/components/webhook/test_init.py
+++ b/tests/components/webhook/test_init.py
@@ -9,6 +9,7 @@ from aiohttp.test_utils import TestClient
 import pytest
 
 from homeassistant.components import webhook
+from homeassistant.components.webhook import DOMAIN
 from homeassistant.components.websocket_api import auth, http
 from homeassistant.core import HomeAssistant
 from homeassistant.core_config import async_process_ha_core_config
@@ -24,7 +25,7 @@ async def mock_client(
     hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> TestClient:
     """Create http client for webhooks."""
-    await async_setup_component(hass, "webhook", {})
+    await async_setup_component(hass, DOMAIN, {})
     return await hass_client()
 
 
@@ -283,7 +284,7 @@ async def test_webhook_local_only_mock_request(
     hass: HomeAssistant, remote: str | None, expected_calls: int
 ) -> None:
     """Test local_only webhooks for MockRequests with various remote values."""
-    await async_setup_component(hass, "webhook", {})
+    await async_setup_component(hass, DOMAIN, {})
 
     hooks = []
     webhook_id = webhook.async_generate_id()
@@ -316,7 +317,7 @@ async def test_listing_webhook(
     hass_access_token: str,
 ) -> None:
     """Test unregistering a webhook."""
-    assert await async_setup_component(hass, "webhook", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     client = await hass_ws_client(hass, hass_access_token)
 
     webhook.async_register(hass, "test", "Test hook", "my-id", None)
@@ -360,7 +361,7 @@ async def test_listing_webhook_requires_admin(
     hass_read_only_access_token: str,
 ) -> None:
     """Test listing webhooks requires an admin user."""
-    assert await async_setup_component(hass, "webhook", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     client = await hass_ws_client(hass, hass_read_only_access_token)
 
     await client.send_json({"id": 5, "type": "webhook/list"})
@@ -377,7 +378,7 @@ async def test_ws_webhook(
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test sending webhook msg via WS API."""
-    assert await async_setup_component(hass, "webhook", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     received = []
 
@@ -462,7 +463,7 @@ async def test_ws_webhook_local_only(
     expected_calls: int,
 ) -> None:
     """Test a local_only webhook over the websocket connection."""
-    assert await async_setup_component(hass, "webhook", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     assert await async_setup_component(hass, "websocket_api", {})
     await hass.async_block_till_done()
 

--- a/tests/components/webhook/test_trigger.py
+++ b/tests/components/webhook/test_trigger.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from homeassistant.components.webhook import DOMAIN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.setup import async_setup_component
 
@@ -16,7 +17,7 @@ from tests.typing import ClientSessionGenerator
 async def setup_http(hass: HomeAssistant) -> None:
     """Set up http."""
     assert await async_setup_component(hass, "http", {})
-    assert await async_setup_component(hass, "webhook", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
 

--- a/tests/components/websocket_api/conftest.py
+++ b/tests/components/websocket_api/conftest.py
@@ -3,6 +3,7 @@
 from aiohttp.test_utils import TestClient
 import pytest
 
+from homeassistant.components.websocket_api import DOMAIN
 from homeassistant.components.websocket_api.auth import TYPE_AUTH_REQUIRED
 from homeassistant.components.websocket_api.http import URL
 from homeassistant.core import HomeAssistant
@@ -28,7 +29,7 @@ async def no_auth_websocket_client(
     hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
 ) -> TestClient:
     """Websocket connection that requires authentication."""
-    assert await async_setup_component(hass, "websocket_api", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client_no_auth()

--- a/tests/components/websocket_api/test_auth.py
+++ b/tests/components/websocket_api/test_auth.py
@@ -7,6 +7,7 @@ from aiohttp import WSMsgType, web
 import pytest
 
 from homeassistant.auth.providers.homeassistant import HassAuthProvider
+from homeassistant.components.websocket_api import DOMAIN
 from homeassistant.components.websocket_api.auth import (
     TYPE_AUTH,
     TYPE_AUTH_INVALID,
@@ -137,7 +138,7 @@ async def test_auth_active_user_inactive(
     """Test authenticating with a token."""
     refresh_token = hass.auth.async_validate_access_token(hass_access_token)
     refresh_token.user.is_active = False
-    assert await async_setup_component(hass, "websocket_api", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client_no_auth()
@@ -161,7 +162,7 @@ async def test_auth_local_only_user_rejected_remote(
     refresh_token = hass.auth.async_validate_access_token(hass_access_token)
     refresh_token.user.local_only = True
 
-    assert await async_setup_component(hass, "websocket_api", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     set_mock_ip = mock_real_ip(hass.http.app)
@@ -194,7 +195,7 @@ async def test_auth_local_only_user_allowed_local(
     refresh_token = hass.auth.async_validate_access_token(hass_access_token)
     refresh_token.user.local_only = True
 
-    assert await async_setup_component(hass, "websocket_api", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     set_mock_ip = mock_real_ip(hass.http.app)
@@ -216,7 +217,7 @@ async def test_auth_active_with_password_not_allow(
     hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
 ) -> None:
     """Test authenticating with a token."""
-    assert await async_setup_component(hass, "websocket_api", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client_no_auth()
@@ -237,7 +238,7 @@ async def test_auth_legacy_support_with_password(
     local_auth: HassAuthProvider,
 ) -> None:
     """Test authenticating with a token."""
-    assert await async_setup_component(hass, "websocket_api", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client_no_auth()
@@ -256,7 +257,7 @@ async def test_auth_with_invalid_token(
     hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
 ) -> None:
     """Test authenticating with a token."""
-    assert await async_setup_component(hass, "websocket_api", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client_no_auth()
@@ -289,7 +290,7 @@ async def test_auth_sending_invalid_json_disconnects(
     hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
 ) -> None:
     """Test sending invalid json during auth."""
-    assert await async_setup_component(hass, "websocket_api", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client_no_auth()
@@ -308,7 +309,7 @@ async def test_auth_sending_binary_disconnects(
     hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
 ) -> None:
     """Test sending bytes during auth."""
-    assert await async_setup_component(hass, "websocket_api", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client_no_auth()
@@ -327,7 +328,7 @@ async def test_auth_close_disconnects(
     hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
 ) -> None:
     """Test closing during auth."""
-    assert await async_setup_component(hass, "websocket_api", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client_no_auth()
@@ -348,7 +349,7 @@ async def test_auth_error_disconnects(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test error during auth."""
-    assert await async_setup_component(hass, "websocket_api", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client_no_auth()
@@ -379,7 +380,7 @@ async def test_auth_sending_unknown_type_disconnects(
     hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
 ) -> None:
     """Test sending unknown type during auth."""
-    assert await async_setup_component(hass, "websocket_api", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client_no_auth()
@@ -400,7 +401,7 @@ async def test_error_right_after_auth_disconnects(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test error right after auth."""
-    assert await async_setup_component(hass, "websocket_api", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client_no_auth()
@@ -440,7 +441,7 @@ async def test_unix_socket_auth_bypass(
         HASSIO_USER_NAME, group_ids=["system-admin"]
     )
 
-    assert await async_setup_component(hass, "websocket_api", {})
+    assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
     client = await hass_client_no_auth()

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -18,7 +18,7 @@ from homeassistant.components.device_automation import toggle_entity
 from homeassistant.components.group import DOMAIN as GROUP_DOMAIN
 from homeassistant.components.light import LightEntityFeature
 from homeassistant.components.logger import DOMAIN as LOGGER_DOMAIN
-from homeassistant.components.websocket_api import const
+from homeassistant.components.websocket_api import DOMAIN, const
 from homeassistant.components.websocket_api.auth import (
     TYPE_AUTH,
     TYPE_AUTH_OK,
@@ -1238,7 +1238,7 @@ async def test_call_service_context_with_user(
     hass_access_token: str,
 ) -> None:
     """Test that the user is set in the service call context."""
-    assert await async_setup_component(hass, "websocket_api", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     calls = async_mock_service(hass, "domain_test", "test_service")
     client = await hass_client_no_auth()

--- a/tests/components/websocket_api/test_http.py
+++ b/tests/components/websocket_api/test_http.py
@@ -10,6 +10,7 @@ from aiohttp import ServerDisconnectedError, WSMsgType, web
 import pytest
 
 from homeassistant.components.websocket_api import (
+    DOMAIN,
     async_register_command,
     const,
     http,
@@ -412,7 +413,7 @@ async def test_auth_timeout_logs_at_debug(
 ) -> None:
     """Test auth timeout is logged at debug level not warning."""
     # Setup websocket API
-    assert await async_setup_component(hass, "websocket_api", {})
+    assert await async_setup_component(hass, DOMAIN, {})
 
     client = await hass_client()
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When `async_setup_component` is called with a literal string matching the component name, use the `DOMAIN` constant instead.

Linked to #173004

Please note that I purposefully did not touch the configuration dictionnary.
The top-level key is often the component domain, but I felt changing that was out of scope.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
