### PR TITLE
Bump uiprotect to 11.3.0

### DIFF
--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "loggers": ["uiprotect"],
   "quality_scale": "platinum",
-  "requirements": ["uiprotect==10.5.0"]
+  "requirements": ["uiprotect==11.3.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3243,7 +3243,7 @@ uasiren==0.0.1
 uhooapi==1.2.8
 
 # homeassistant.components.unifiprotect
-uiprotect==10.5.0
+uiprotect==11.3.0
 
 # homeassistant.components.landisgyr_heat_meter
 ultraheat-api==0.6.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

Bump `uiprotect` from `10.5.0` to `11.3.0`.

Notable changes since 10.5.0:

**New public API endpoints**
- **10.6.0** – Fobs (list / get / update)
- **10.7.0** – Speakers (list / get / update / test-sound)
- **10.8.0** – Liveviews (full CRUD)
- **10.9.0** – Link-stations and alarm-hubs
- **10.10.0** – Bridges and viewers
- **10.11.0** – Users, ULP-users, files, disable-mic
- **10.18.0** – Public API convenience setters on `Light`

**Type improvements / enums**
- **10.12.0** – `UlpUserStatus` enum for `PublicUlpUser.status`
- **10.13.0** – Relay public-API field types tightened to spec enums
- **10.14.0** – `AssetFileType` enum for `PublicFile.type`
- **10.15.0** – `ChannelQuality` enum for RTSPS helpers
- **10.16.0** – Typed alarm hub accessors on `LinkStation`
- **10.17.0** – Alarm hub status fields typed as enums
- **11.0.0** – `Siren.state` typed as `DeviceState`; new `SirenConnectionType` enum
- **11.1.0** – Unknown `VideoMode`/`OsdOverlayLocation` values tolerated (firmware forward-compat); alarm hub battery/cover fields made optional; `subscribe_events` single-source `ProtectEvent`
- **11.2.0** – `typer` made optional CLI extra
- **11.3.0** – `rich`, `dateparser`, `pillow` made optional CLI extras (resolves transitive conflicts with `surepy` and others)

**Bug fixes & security**
- **10.10.1** – Fix stripping of all `-e` instances in thumbnail/heatmap generation
- **10.10.2** – Prevent retry past TLS failures; fix `list_from_unifi_list` annotation
- **10.18.1** – Sanitize camera names in backup paths (path traversal)
- **11.0.1** – Tolerate unknown `OsdOverlayLocation` values from newer firmware
- **11.0.2** – Relax `pyjwt` and `av` dependency floors (unblocks HA library bumps)

https://github.com/uilibs/uiprotect/compare/v10.5.0...v11.3.0
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
