### PR TITLE
Return enum values as strings in config_entry_attr template function

### DIFF
--- a/homeassistant/helpers/template/extensions/config_entries.py
+++ b/homeassistant/helpers/template/extensions/config_entries.py
@@ -1,6 +1,7 @@
 """Config entry functions for Home Assistant templates."""
 
 from collections.abc import Iterable
+from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.exceptions import TemplateError
@@ -104,4 +105,7 @@ class ConfigEntryExtension(BaseTemplateExtension):
         if config_entry is None:
             return None
 
-        return getattr(config_entry, attr_name)
+        value = getattr(config_entry, attr_name)
+        if isinstance(value, Enum):
+            return value.value
+        return value

--- a/tests/helpers/template/extensions/test_config_entries.py
+++ b/tests/helpers/template/extensions/test_config_entries.py
@@ -120,7 +120,7 @@ async def test_config_entry_attr(hass: HomeAssistant) -> None:
     config_entry = MockConfigEntry(**info)
     config_entry.add_to_hass(hass)
 
-    info["state"] = config_entries.ConfigEntryState.NOT_LOADED
+    info["state"] = "not_loaded"
 
     for key, value in info.items():
         assert render(


### PR DESCRIPTION
## Breaking change

`config_entry_attr('...', 'state')` previously returned `ConfigEntryState.NOT_LOADED`, now returns `not_loaded`. Same for `disabled_by` which now returns the enum value string instead of the enum repr.

## Proposed change

The `config_entry_attr` template function returns raw Python enum objects for `state` and `disabled_by` attributes, rendering as `ConfigEntryState.LOADED` in templates instead of the expected `loaded`.

Return the enum's `.value` for enum attributes so templates get usable string values.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #172970
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr