### PR TITLE
Add sub-devices for Reolink dual lens cameras with per-lens sensors

### DIFF
--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -7,7 +7,7 @@ from random import uniform
 from time import time
 from typing import Any
 
-from reolink_aio.api import RETRY_ATTEMPTS
+from reolink_aio.api import DUAL_LENS_DUAL_MOTION_MODELS, RETRY_ATTEMPTS
 from reolink_aio.exceptions import CredentialsInvalidError, ReolinkError
 
 from homeassistant.const import CONF_PORT, EVENT_HOMEASSISTANT_STOP, Platform
@@ -209,6 +209,19 @@ async def async_setup_entry(
         identifiers={(DOMAIN, host.unique_id)},
         connections={(dr.CONNECTION_NETWORK_MAC, host.api.mac_address)},
     )
+
+    if host.api.is_nvr and host.api.model in DUAL_LENS_DUAL_MOTION_MODELS:
+        # ensure the camera device is setup before
+        # the lens sub-devices that use via_device
+        if host.api.supported(0, "UID"):
+            camera_dev_id = f"{host.unique_id}_{host.api.camera_uid(0)}"
+        else:
+            camera_dev_id = f"{host.unique_id}_ch0"
+        device_registry.async_get_or_create(
+            config_entry_id=config_entry.entry_id,
+            identifiers={(DOMAIN, camera_dev_id)},
+            via_device=(DOMAIN, host.unique_id),
+        )
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
@@ -423,8 +436,8 @@ def migrate_entity_ids(
             device_reg.async_update_device(device.id, new_identifiers=new_identifiers)
             break
 
-        if ch is None or is_chime:
-            continue  # Do not consider the NVR itself or chimes
+        if ch is None or is_chime or device_uid[1].startswith("lens"):
+            continue  # Do not consider the NVR itself, chimes or lens sub-devices
 
         # Check for wrongfully added MAC of the NVR/Hub to the camera
         # Can be removed in HA 2025.12

--- a/homeassistant/components/reolink/binary_sensor.py
+++ b/homeassistant/components/reolink/binary_sensor.py
@@ -4,7 +4,6 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from reolink_aio.api import (
-    DUAL_LENS_DUAL_MOTION_MODELS,
     FACE_DETECTION_TYPE,
     PACKAGE_DETECTION_TYPE,
     PERSON_DETECTION_TYPE,
@@ -344,6 +343,7 @@ class ReolinkBinarySensorEntity(ReolinkChannelCoordinatorEntity, BinarySensorEnt
     """Base binary-sensor class for Reolink IP camera."""
 
     entity_description: ReolinkBinarySensorEntityDescription
+    _lens_entity = True
 
     def __init__(
         self,
@@ -354,13 +354,6 @@ class ReolinkBinarySensorEntity(ReolinkChannelCoordinatorEntity, BinarySensorEnt
         """Initialize Reolink binary sensor."""
         self.entity_description = entity_description
         super().__init__(reolink_data, channel)
-
-        if self._host.api.model in DUAL_LENS_DUAL_MOTION_MODELS:
-            if entity_description.translation_key is not None:
-                key = entity_description.translation_key
-            else:
-                key = entity_description.key
-            self._attr_translation_key = f"{key}_lens_{self._channel}"
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/reolink/binary_sensor.py
+++ b/homeassistant/components/reolink/binary_sensor.py
@@ -70,6 +70,7 @@ BINARY_PUSH_SENSORS = (
         key="motion",
         cmd_id=33,
         device_class=BinarySensorDeviceClass.MOTION,
+        lens_entity=True,
         value=lambda api, ch: api.motion_detected(ch),
         supported=lambda api, ch: api.supported(ch, "motion_detection"),
     ),
@@ -77,6 +78,7 @@ BINARY_PUSH_SENSORS = (
         key=FACE_DETECTION_TYPE,
         cmd_id=33,
         translation_key="face",
+        lens_entity=True,
         value=lambda api, ch: api.ai_detected(ch, FACE_DETECTION_TYPE),
         supported=lambda api, ch: api.ai_supported(ch, FACE_DETECTION_TYPE),
     ),
@@ -84,6 +86,7 @@ BINARY_PUSH_SENSORS = (
         key=PERSON_DETECTION_TYPE,
         cmd_id=[33, 600, 696],
         translation_key="person",
+        lens_entity=True,
         value=lambda api, ch: api.ai_detected(ch, PERSON_DETECTION_TYPE),
         supported=lambda api, ch: api.ai_supported(ch, PERSON_DETECTION_TYPE),
     ),
@@ -91,6 +94,7 @@ BINARY_PUSH_SENSORS = (
         key=VEHICLE_DETECTION_TYPE,
         cmd_id=[33, 600, 696],
         translation_key="vehicle",
+        lens_entity=True,
         value=lambda api, ch: api.ai_detected(ch, VEHICLE_DETECTION_TYPE),
         supported=lambda api, ch: api.ai_supported(ch, VEHICLE_DETECTION_TYPE),
     ),
@@ -98,6 +102,7 @@ BINARY_PUSH_SENSORS = (
         key="non-motor_vehicle",
         cmd_id=[600, 696],
         translation_key="non-motor_vehicle",
+        lens_entity=True,
         value=lambda api, ch: api.ai_detected(ch, "non-motor vehicle"),
         supported=lambda api, ch: api.supported(ch, "ai_non-motor vehicle"),
     ),
@@ -105,6 +110,7 @@ BINARY_PUSH_SENSORS = (
         key=PET_DETECTION_TYPE,
         cmd_id=[33, 600, 696],
         translation_key="pet",
+        lens_entity=True,
         value=lambda api, ch: api.ai_detected(ch, PET_DETECTION_TYPE),
         supported=lambda api, ch: (
             api.ai_supported(ch, PET_DETECTION_TYPE)
@@ -115,6 +121,7 @@ BINARY_PUSH_SENSORS = (
         key=PET_DETECTION_TYPE,
         cmd_id=[33, 600, 696],
         translation_key="animal",
+        lens_entity=True,
         value=lambda api, ch: api.ai_detected(ch, PET_DETECTION_TYPE),
         supported=lambda api, ch: api.supported(ch, "ai_animal"),
     ),
@@ -122,6 +129,7 @@ BINARY_PUSH_SENSORS = (
         key=PACKAGE_DETECTION_TYPE,
         cmd_id=[33, 600, 696],
         translation_key="package",
+        lens_entity=True,
         value=lambda api, ch: api.ai_detected(ch, PACKAGE_DETECTION_TYPE),
         supported=lambda api, ch: api.ai_supported(ch, PACKAGE_DETECTION_TYPE),
     ),
@@ -343,7 +351,6 @@ class ReolinkBinarySensorEntity(ReolinkChannelCoordinatorEntity, BinarySensorEnt
     """Base binary-sensor class for Reolink IP camera."""
 
     entity_description: ReolinkBinarySensorEntityDescription
-    _lens_entity = True
 
     def __init__(
         self,

--- a/homeassistant/components/reolink/camera.py
+++ b/homeassistant/components/reolink/camera.py
@@ -28,6 +28,8 @@ class ReolinkCameraEntityDescription(
     """A class that describes camera entities for a camera channel."""
 
     stream: str
+    # a camera stream always comes from a single lens
+    lens_entity: bool = True
 
 
 CAMERA_ENTITIES = (
@@ -123,7 +125,6 @@ class ReolinkCamera(ReolinkChannelCoordinatorEntity, Camera):
     """An implementation of a Reolink IP camera."""
 
     entity_description: ReolinkCameraEntityDescription
-    _lens_entity = True
 
     def __init__(
         self,

--- a/homeassistant/components/reolink/camera.py
+++ b/homeassistant/components/reolink/camera.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 import logging
 
-from reolink_aio.api import DUAL_LENS_MODELS
+from reolink_aio.api import DUAL_LENS_SINGLE_MOTION_MODELS
 
 from homeassistant.components.camera import (
     Camera,
@@ -123,6 +123,7 @@ class ReolinkCamera(ReolinkChannelCoordinatorEntity, Camera):
     """An implementation of a Reolink IP camera."""
 
     entity_description: ReolinkCameraEntityDescription
+    _lens_entity = True
 
     def __init__(
         self,
@@ -138,7 +139,7 @@ class ReolinkCamera(ReolinkChannelCoordinatorEntity, Camera):
         if "snapshots" not in entity_description.stream:
             self._attr_supported_features = CameraEntityFeature.STREAM
 
-        if self._host.api.model in DUAL_LENS_MODELS:
+        if self._host.api.model in DUAL_LENS_SINGLE_MOTION_MODELS:
             self._attr_translation_key = (
                 f"{entity_description.translation_key}_lens_{self._channel}"
             )

--- a/homeassistant/components/reolink/entity.py
+++ b/homeassistant/components/reolink/entity.py
@@ -22,6 +22,9 @@ class ReolinkEntityDescription(EntityDescription):
     cmd_key: str | None = None
     cmd_id: int | list[int] | None = None
     always_available: bool = False
+    # Whether the entity measures a property of a single lens
+    # of a dual lens camera, instead of the camera as a whole
+    lens_entity: bool = False
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -161,9 +164,6 @@ class ReolinkHostCoordinatorEntity(CoordinatorEntity[ReolinkCoordinator]):
 class ReolinkChannelCoordinatorEntity(ReolinkHostCoordinatorEntity):
     """Parent class for Reolink camera entities connected to a NVR channel."""
 
-    # Whether the entity belongs to a single lens of a dual lens camera
-    _lens_entity = False
-
     def __init__(
         self,
         reolink_data: ReolinkData,
@@ -220,7 +220,10 @@ class ReolinkChannelCoordinatorEntity(ReolinkHostCoordinatorEntity):
                 configuration_url=conf_url,
             )
 
-        if self._lens_entity and self._host.api.model in DUAL_LENS_DUAL_MOTION_MODELS:
+        if (
+            self.entity_description.lens_entity
+            and self._host.api.model in DUAL_LENS_DUAL_MOTION_MODELS
+        ):
             # Dual lens cameras with separate sensors per lens
             # use a sub-device per lens
             parent_dev_id = self._dev_id

--- a/homeassistant/components/reolink/entity.py
+++ b/homeassistant/components/reolink/entity.py
@@ -228,7 +228,7 @@ class ReolinkChannelCoordinatorEntity(ReolinkHostCoordinatorEntity):
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, self._dev_id)},
                 via_device=(DOMAIN, parent_dev_id),
-                name=f"{self._host.api.camera_name(channel)} lens {channel}",
+                name=f"{self._host.api.camera_name(dev_ch)} lens {channel}",
                 model=self._host.api.camera_model(channel),
                 manufacturer=self._host.api.manufacturer,
                 configuration_url=self._conf_url,

--- a/homeassistant/components/reolink/entity.py
+++ b/homeassistant/components/reolink/entity.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from reolink_aio.api import DUAL_LENS_MODELS, Chime, Host
+from reolink_aio.api import DUAL_LENS_DUAL_MOTION_MODELS, DUAL_LENS_MODELS, Chime, Host
 
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
@@ -161,6 +161,9 @@ class ReolinkHostCoordinatorEntity(CoordinatorEntity[ReolinkCoordinator]):
 class ReolinkChannelCoordinatorEntity(ReolinkHostCoordinatorEntity):
     """Parent class for Reolink camera entities connected to a NVR channel."""
 
+    # Whether the entity belongs to a single lens of a dual lens camera
+    _lens_entity = False
+
     def __init__(
         self,
         reolink_data: ReolinkData,
@@ -215,6 +218,20 @@ class ReolinkChannelCoordinatorEntity(ReolinkHostCoordinatorEntity):
                 sw_version=self._host.api.camera_sw_version(dev_ch),
                 serial_number=self._host.api.camera_uid(dev_ch),
                 configuration_url=conf_url,
+            )
+
+        if self._lens_entity and self._host.api.model in DUAL_LENS_DUAL_MOTION_MODELS:
+            # Dual lens cameras with separate sensors per lens
+            # use a sub-device per lens
+            parent_dev_id = self._dev_id
+            self._dev_id = f"{self._host.unique_id}_lens{channel}"
+            self._attr_device_info = DeviceInfo(
+                identifiers={(DOMAIN, self._dev_id)},
+                via_device=(DOMAIN, parent_dev_id),
+                name=f"{self._host.api.camera_name(channel)} lens {channel}",
+                model=self._host.api.camera_model(channel),
+                manufacturer=self._host.api.manufacturer,
+                configuration_url=self._conf_url,
             )
 
     @property

--- a/homeassistant/components/reolink/strings.json
+++ b/homeassistant/components/reolink/strings.json
@@ -52,20 +52,6 @@
           "on": "[%key:component::binary_sensor::entity_component::gas::state::on%]"
         }
       },
-      "animal_lens_0": {
-        "name": "Animal lens 0",
-        "state": {
-          "off": "[%key:component::binary_sensor::entity_component::gas::state::off%]",
-          "on": "[%key:component::binary_sensor::entity_component::gas::state::on%]"
-        }
-      },
-      "animal_lens_1": {
-        "name": "Animal lens 1",
-        "state": {
-          "off": "[%key:component::binary_sensor::entity_component::gas::state::off%]",
-          "on": "[%key:component::binary_sensor::entity_component::gas::state::on%]"
-        }
-      },
       "crossline_dog_cat": {
         "name": "Crossline {zone_name} animal",
         "state": {
@@ -96,20 +82,6 @@
       },
       "face": {
         "name": "Face",
-        "state": {
-          "off": "[%key:component::binary_sensor::entity_component::gas::state::off%]",
-          "on": "[%key:component::binary_sensor::entity_component::gas::state::on%]"
-        }
-      },
-      "face_lens_0": {
-        "name": "Face lens 0",
-        "state": {
-          "off": "[%key:component::binary_sensor::entity_component::gas::state::off%]",
-          "on": "[%key:component::binary_sensor::entity_component::gas::state::on%]"
-        }
-      },
-      "face_lens_1": {
-        "name": "Face lens 1",
         "state": {
           "off": "[%key:component::binary_sensor::entity_component::gas::state::off%]",
           "on": "[%key:component::binary_sensor::entity_component::gas::state::on%]"
@@ -171,20 +143,6 @@
           "on": "[%key:component::binary_sensor::entity_component::gas::state::on%]"
         }
       },
-      "motion_lens_0": {
-        "name": "Motion lens 0",
-        "state": {
-          "off": "[%key:component::binary_sensor::entity_component::gas::state::off%]",
-          "on": "[%key:component::binary_sensor::entity_component::gas::state::on%]"
-        }
-      },
-      "motion_lens_1": {
-        "name": "Motion lens 1",
-        "state": {
-          "off": "[%key:component::binary_sensor::entity_component::gas::state::off%]",
-          "on": "[%key:component::binary_sensor::entity_component::gas::state::on%]"
-        }
-      },
       "non-motor_vehicle": {
         "name": "Bicycle",
         "state": {
@@ -199,20 +157,6 @@
           "on": "[%key:component::binary_sensor::entity_component::gas::state::on%]"
         }
       },
-      "package_lens_0": {
-        "name": "Package lens 0",
-        "state": {
-          "off": "[%key:component::binary_sensor::entity_component::gas::state::off%]",
-          "on": "[%key:component::binary_sensor::entity_component::gas::state::on%]"
-        }
-      },
-      "package_lens_1": {
-        "name": "Package lens 1",
-        "state": {
-          "off": "[%key:component::binary_sensor::entity_component::gas::state::off%]",
-          "on": "[%key:component::binary_sensor::entity_component::gas::state::on%]"
-        }
-      },
       "person": {
         "name": "Person",
         "state": {
@@ -220,36 +164,8 @@
           "on": "[%key:component::binary_sensor::entity_component::gas::state::on%]"
         }
       },
-      "person_lens_0": {
-        "name": "Person lens 0",
-        "state": {
-          "off": "[%key:component::binary_sensor::entity_component::gas::state::off%]",
-          "on": "[%key:component::binary_sensor::entity_component::gas::state::on%]"
-        }
-      },
-      "person_lens_1": {
-        "name": "Person lens 1",
-        "state": {
-          "off": "[%key:component::binary_sensor::entity_component::gas::state::off%]",
-          "on": "[%key:component::binary_sensor::entity_component::gas::state::on%]"
-        }
-      },
       "pet": {
         "name": "Pet",
-        "state": {
-          "off": "[%key:component::binary_sensor::entity_component::gas::state::off%]",
-          "on": "[%key:component::binary_sensor::entity_component::gas::state::on%]"
-        }
-      },
-      "pet_lens_0": {
-        "name": "Pet lens 0",
-        "state": {
-          "off": "[%key:component::binary_sensor::entity_component::gas::state::off%]",
-          "on": "[%key:component::binary_sensor::entity_component::gas::state::on%]"
-        }
-      },
-      "pet_lens_1": {
-        "name": "Pet lens 1",
         "state": {
           "off": "[%key:component::binary_sensor::entity_component::gas::state::off%]",
           "on": "[%key:component::binary_sensor::entity_component::gas::state::on%]"
@@ -276,28 +192,8 @@
           "on": "[%key:component::binary_sensor::entity_component::gas::state::on%]"
         }
       },
-      "vehicle_lens_0": {
-        "name": "Vehicle lens 0",
-        "state": {
-          "off": "[%key:component::binary_sensor::entity_component::gas::state::off%]",
-          "on": "[%key:component::binary_sensor::entity_component::gas::state::on%]"
-        }
-      },
-      "vehicle_lens_1": {
-        "name": "Vehicle lens 1",
-        "state": {
-          "off": "[%key:component::binary_sensor::entity_component::gas::state::off%]",
-          "on": "[%key:component::binary_sensor::entity_component::gas::state::on%]"
-        }
-      },
       "visitor": {
         "name": "Visitor"
-      },
-      "visitor_lens_0": {
-        "name": "Visitor lens 0"
-      },
-      "visitor_lens_1": {
-        "name": "Visitor lens 1"
       }
     },
     "button": {

--- a/homeassistant/components/reolink/util.py
+++ b/homeassistant/components/reolink/util.py
@@ -100,6 +100,8 @@ def get_device_uid_and_ch(
     elif device_uid[1].startswith("chime"):
         ch = int(device_uid[1][5:])
         is_chime = True
+    elif device_uid[1].startswith("lens"):
+        ch = int(device_uid[1][4:])
     else:
         device_uid_part = "_".join(device_uid[1:])
         ch = host.api.channel_for_uid(device_uid_part)

--- a/tests/components/reolink/test_binary_sensor.py
+++ b/tests/components/reolink/test_binary_sensor.py
@@ -72,6 +72,11 @@ async def test_dual_lens_sub_devices(
     reolink_host.is_nvr = False
     reolink_host.channels = [0, 1]
     reolink_host.stream_channels = [0, 1]
+    # a Reolink Duo reports a junk name like "2" for the second channel,
+    # the lens sub-device names should be based on the channel 0 name
+    reolink_host.camera_name.side_effect = lambda ch: (
+        TEST_CAM_NAME if ch == 0 else str(ch + 1)
+    )
 
     # an entity of a previous version attached to the host device
     # should be moved to the lens sub-device, keeping its entity_id

--- a/tests/components/reolink/test_binary_sensor.py
+++ b/tests/components/reolink/test_binary_sensor.py
@@ -4,13 +4,22 @@ from collections.abc import Callable
 from unittest.mock import MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
+import pytest
 
+from homeassistant.components.reolink.const import DOMAIN
 from homeassistant.components.reolink.coordinator import DEVICE_UPDATE_INTERVAL_MIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_OFF, STATE_ON, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from .conftest import TEST_CAM_NAME, TEST_DUO_MODEL, TEST_HOST_MODEL
+from .conftest import (
+    TEST_CAM_NAME,
+    TEST_DUO_MODEL,
+    TEST_HOST_MODEL,
+    TEST_UID,
+    TEST_UID_CAM,
+)
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.typing import ClientSessionGenerator
@@ -31,7 +40,7 @@ async def test_motion_sensor(
     await hass.async_block_till_done()
     assert config_entry.state is ConfigEntryState.LOADED
 
-    entity_id = f"{Platform.BINARY_SENSOR}.{TEST_CAM_NAME}_motion_lens_0"
+    entity_id = f"{Platform.BINARY_SENSOR}.{TEST_CAM_NAME}_lens_0_motion"
     assert hass.states.get(entity_id).state == STATE_ON
 
     reolink_host.motion_detected.return_value = False
@@ -49,6 +58,109 @@ async def test_motion_sensor(
     await client.post(f"/api/webhook/{webhook_id}", data="test_data")
 
     assert hass.states.get(entity_id).state == STATE_ON
+
+
+async def test_dual_lens_sub_devices(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_host: MagicMock,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test dual lens camera with separate sensors per lens uses lens sub-devices."""
+    reolink_host.model = TEST_DUO_MODEL
+    reolink_host.is_nvr = False
+    reolink_host.channels = [0, 1]
+    reolink_host.stream_channels = [0, 1]
+
+    # an entity of a previous version attached to the host device
+    # should be moved to the lens sub-device, keeping its entity_id
+    host_device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, TEST_UID)},
+    )
+    # a lens sub-device of a previous run should be left untouched by migration
+    old_lens_device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, f"{TEST_UID}_lens0")},
+    )
+    old_entity = entity_registry.async_get_or_create(
+        Platform.BINARY_SENSOR,
+        DOMAIN,
+        f"{TEST_UID}_0_motion",
+        suggested_object_id=f"{TEST_CAM_NAME}_motion_lens_0",
+        config_entry=config_entry,
+        device_id=host_device.id,
+    )
+
+    with patch("homeassistant.components.reolink.PLATFORMS", [Platform.BINARY_SENSOR]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    for channel in (0, 1):
+        lens_device = device_registry.async_get_device(
+            identifiers={(DOMAIN, f"{TEST_UID}_lens{channel}")}
+        )
+        assert lens_device is not None
+        assert lens_device.name == f"{TEST_CAM_NAME} lens {channel}"
+        assert lens_device.via_device_id == host_device.id
+
+        entity_id = f"{Platform.BINARY_SENSOR}.{TEST_CAM_NAME}_lens_{channel}_person"
+        entity = entity_registry.async_get(entity_id)
+        assert entity is not None
+        assert entity.device_id == lens_device.id
+
+    # the pre-existing lens sub-device and entity should have been reused
+    lens_0_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{TEST_UID}_lens0")}
+    )
+    assert lens_0_device is not None
+    assert lens_0_device.id == old_lens_device.id
+    entity = entity_registry.async_get(old_entity.entity_id)
+    assert entity is not None
+    assert entity.device_id == lens_0_device.id
+
+
+@pytest.mark.parametrize(
+    ("supported", "parent_dev_id"),
+    [
+        pytest.param(
+            lambda ch, cap: True,
+            f"{TEST_UID}_{TEST_UID_CAM}",
+            id="uid",
+        ),
+        pytest.param(
+            lambda ch, cap: not (cap == "UID" and ch is not None),
+            f"{TEST_UID}_ch0",
+            id="no_uid",
+        ),
+    ],
+)
+async def test_dual_lens_sub_devices_nvr(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_host: MagicMock,
+    device_registry: dr.DeviceRegistry,
+    supported: Callable[[int | None, str], bool],
+    parent_dev_id: str,
+) -> None:
+    """Test lens sub-devices are connected to the camera device of a NVR-type host."""
+    reolink_host.model = TEST_DUO_MODEL
+    reolink_host.supported.side_effect = supported
+
+    with patch("homeassistant.components.reolink.PLATFORMS", [Platform.BINARY_SENSOR]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    parent_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, parent_dev_id)}
+    )
+    assert parent_device is not None
+    lens_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{TEST_UID}_lens0")}
+    )
+    assert lens_device is not None
+    assert lens_device.via_device_id == parent_device.id
 
 
 async def test_smart_ai_sensor(

--- a/tests/components/reolink/test_binary_sensor.py
+++ b/tests/components/reolink/test_binary_sensor.py
@@ -17,6 +17,7 @@ from .conftest import (
     TEST_CAM_NAME,
     TEST_DUO_MODEL,
     TEST_HOST_MODEL,
+    TEST_NVR_NAME,
     TEST_UID,
     TEST_UID_CAM,
 )
@@ -114,6 +115,13 @@ async def test_dual_lens_sub_devices(
         entity = entity_registry.async_get(entity_id)
         assert entity is not None
         assert entity.device_id == lens_device.id
+
+    # sensors that are not lens-specific should stay on the main device
+    entity = entity_registry.async_get(
+        f"{Platform.BINARY_SENSOR}.{TEST_NVR_NAME}_sleep_status"
+    )
+    assert entity is not None
+    assert entity.device_id == host_device.id
 
     # the pre-existing lens sub-device and entity should have been reused
     lens_0_device = device_registry.async_get_device(

--- a/tests/components/reolink/test_camera.py
+++ b/tests/components/reolink/test_camera.py
@@ -63,5 +63,5 @@ async def test_camera_no_stream_source(
     await hass.async_block_till_done()
     assert config_entry.state is ConfigEntryState.LOADED
 
-    entity_id = f"{Platform.CAMERA}.{TEST_CAM_NAME}_snapshots_fluent_lens_0"
+    entity_id = f"{Platform.CAMERA}.{TEST_CAM_NAME}_lens_0_snapshots_fluent"
     assert hass.states.get(entity_id).state == CameraState.IDLE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The Reolink Duo PoE and Duo WiFi dual lens cameras now have a sub-device per lens. The camera and motion/AI sensor entities that previously used "lens 0"/"lens 1" suffixes in their names are moved to the new "lens 0" and "lens 1" sub-devices and lose the suffix from their name. Entity IDs and custom names are not changed, so most automations keep working. Automations, scripts or dashboards that target these entities through the camera **device** need to be updated to use the new lens sub-devices.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Reolink dual lens cameras with separate sensors per lens (`DUAL_LENS_DUAL_MOTION_MODELS`: Duo PoE, Duo WiFi) currently put all entities of both lenses on a single device and disambiguate them with numeric suffixes in the entity names ("Motion lens 0", "Fluent lens 1"). This is the entity naming anti-pattern identified in the sub-device discovery task (#168901). This PR gives each lens its own sub-device:

- Entity classes whose state is lens-specific (cameras, motion/AI binary sensors) are marked with a `_lens_entity` flag. On dual-motion models they attach to a `lens 0`/`lens 1` sub-device (`via_device` pointing to the host device, or to the camera device when behind an NVR-type host) and use plain entity names ("Motion", "Fluent"). Device-wide settings entities stay on the main device.
- Entity unique IDs are unchanged, so existing entities move to the lens sub-devices automatically while keeping their entity IDs; no migration routine is needed.
- `get_device_uid_and_ch` learns to parse the new `lens{N}` device identifier and `migrate_entity_ids` skips lens sub-devices in the camera-UID identifier rewrite so it does not corrupt them.
- The now unused binary sensor `*_lens_0/1` translation keys are removed. The camera lens suffix keys remain for `DUAL_LENS_SINGLE_MOTION_MODELS` (TrackMix, RLC-81MA), which share sensors between lenses and are intentionally not migrated, per the issue scope.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #172453
- This PR is related to issue: #168901
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
