### PR TITLE
Power off Denon RS-232 receiver when the last zone is turned off

### DIFF
--- a/homeassistant/components/denon_rs232/media_player.py
+++ b/homeassistant/components/denon_rs232/media_player.py
@@ -161,12 +161,16 @@ class DenonRS232MediaPlayer(MediaPlayerEntity):
     @callback
     def _async_update_from_player(self) -> None:
         """Update entity attributes from the shared player object."""
-        if self._player.power is None:
+        # The main entity represents the receiver as a whole, so its power
+        # tracks the chassis (PW). The main zone (ZM), Zone 2 (Z2) and the
+        # chassis are independent scopes: turning on a zone wakes the chassis
+        # while ZM stays off, so only the chassis power reflects "is the
+        # receiver on".
+        power = self._receiver.power if self._is_main else self._player.power
+        if power is None:
             self._attr_state = None
         else:
-            self._attr_state = (
-                MediaPlayerState.ON if self._player.power else MediaPlayerState.OFF
-            )
+            self._attr_state = MediaPlayerState.ON if power else MediaPlayerState.OFF
 
         source = self._player.input_source
         self._attr_source = INPUT_SOURCE_DENON_TO_HA.get(source) if source else None
@@ -190,11 +194,22 @@ class DenonRS232MediaPlayer(MediaPlayerEntity):
 
     async def async_turn_on(self) -> None:
         """Turn the receiver on."""
-        await self._player.power_on()
+        # For the main entity, power the chassis (PWON) rather than just the
+        # main zone (ZMON) so the receiver wakes regardless of zone state.
+        if self._is_main:
+            await self._receiver.power_on()
+        else:
+            await self._player.power_on()
 
     async def async_turn_off(self) -> None:
         """Turn the receiver off."""
-        await self._player.power_standby()
+        # For the main entity, send a full chassis standby (PWSTANDBY). A bare
+        # ZMOFF is a no-op when another zone is keeping the chassis awake, which
+        # leaves the receiver stuck on.
+        if self._is_main:
+            await self._receiver.power_standby()
+        else:
+            await self._player.power_standby()
 
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""

--- a/homeassistant/components/denon_rs232/media_player.py
+++ b/homeassistant/components/denon_rs232/media_player.py
@@ -208,7 +208,7 @@ class DenonRS232MediaPlayer(MediaPlayerEntity):
         """Turn the receiver off."""
         await self._player.power_standby()
         # ensure device powers off when no zones are on
-        if self._receiver.power and not self._other_zones_on():
+        if not self._other_zones_on():
             await self._receiver.power_standby()
 
     async def async_set_volume_level(self, volume: float) -> None:

--- a/homeassistant/components/denon_rs232/media_player.py
+++ b/homeassistant/components/denon_rs232/media_player.py
@@ -202,12 +202,6 @@ class DenonRS232MediaPlayer(MediaPlayerEntity):
 
     async def async_turn_on(self) -> None:
         """Turn the receiver on."""
-        # Wake the chassis first if it is in standby, then switch this zone on.
-        # A zone-on does not wake the chassis on every model, and the chassis
-        # (PW) is independent of the main zone (ZM), so this does not force the
-        # main zone on.
-        if not self._receiver.power:
-            await self._receiver.power_on()
         await self._player.power_on()
 
     async def async_turn_off(self) -> None:

--- a/homeassistant/components/denon_rs232/media_player.py
+++ b/homeassistant/components/denon_rs232/media_player.py
@@ -161,16 +161,12 @@ class DenonRS232MediaPlayer(MediaPlayerEntity):
     @callback
     def _async_update_from_player(self) -> None:
         """Update entity attributes from the shared player object."""
-        # The main entity represents the receiver as a whole, so its power
-        # tracks the chassis (PW). The main zone (ZM), Zone 2 (Z2) and the
-        # chassis are independent scopes: turning on a zone wakes the chassis
-        # while ZM stays off, so only the chassis power reflects "is the
-        # receiver on".
-        power = self._receiver.power if self._is_main else self._player.power
-        if power is None:
+        if self._player.power is None:
             self._attr_state = None
         else:
-            self._attr_state = MediaPlayerState.ON if power else MediaPlayerState.OFF
+            self._attr_state = (
+                MediaPlayerState.ON if self._player.power else MediaPlayerState.OFF
+            )
 
         source = self._player.input_source
         self._attr_source = INPUT_SOURCE_DENON_TO_HA.get(source) if source else None
@@ -192,24 +188,32 @@ class DenonRS232MediaPlayer(MediaPlayerEntity):
         if self._is_main:
             self._attr_is_volume_muted = cast(MainPlayer, self._player).mute
 
+    def _other_zones_on(self) -> bool:
+        """Return whether any zone other than this one is powered on."""
+        return any(
+            player.power
+            for player in (
+                self._receiver.main,
+                self._receiver.zone_2,
+                self._receiver.zone_3,
+            )
+            if player is not self._player
+        )
+
     async def async_turn_on(self) -> None:
         """Turn the receiver on."""
-        # For the main entity, power the chassis (PWON) rather than just the
-        # main zone (ZMON) so the receiver wakes regardless of zone state.
-        if self._is_main:
-            await self._receiver.power_on()
-        else:
-            await self._player.power_on()
+        await self._player.power_on()
 
     async def async_turn_off(self) -> None:
         """Turn the receiver off."""
-        # For the main entity, send a full chassis standby (PWSTANDBY). A bare
-        # ZMOFF is a no-op when another zone is keeping the chassis awake, which
-        # leaves the receiver stuck on.
-        if self._is_main:
-            await self._receiver.power_standby()
-        else:
+        # Power scopes are independent: the chassis (PW) stays awake as long as
+        # any zone is on, and a bare zone-off (e.g. ZMOFF/Z2OFF) only sleeps
+        # that zone. When this is the last powered zone, put the whole receiver
+        # in standby (PWSTANDBY) so the chassis actually powers down.
+        if self._other_zones_on():
             await self._player.power_standby()
+        else:
+            await self._receiver.power_standby()
 
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""

--- a/homeassistant/components/denon_rs232/media_player.py
+++ b/homeassistant/components/denon_rs232/media_player.py
@@ -206,15 +206,11 @@ class DenonRS232MediaPlayer(MediaPlayerEntity):
 
     async def async_turn_off(self) -> None:
         """Turn the receiver off."""
-        # Decide before awaiting: a state push can land while we await the
-        # write below, but switching this zone off never changes the others.
-        last_zone = not self._other_zones_on()
-        # Switch this zone off first (ZMOFF/Z2OFF/Z3OFF) so the receiver does
-        # not restore it the next time the chassis powers on.
+        # A zone-off leaves the chassis on, so stand it by ourselves when this
+        # is the last zone. Decided before the await, which can yield.
+        standby = bool(self._receiver.power) and not self._other_zones_on()
         await self._player.power_standby()
-        # A zone-off leaves the chassis (PW) awake. Once no zone is left on,
-        # send PWSTANDBY so the receiver actually powers down.
-        if last_zone:
+        if standby:
             await self._receiver.power_standby()
 
     async def async_set_volume_level(self, volume: float) -> None:

--- a/homeassistant/components/denon_rs232/media_player.py
+++ b/homeassistant/components/denon_rs232/media_player.py
@@ -202,16 +202,25 @@ class DenonRS232MediaPlayer(MediaPlayerEntity):
 
     async def async_turn_on(self) -> None:
         """Turn the receiver on."""
+        # Wake the chassis first if it is in standby, then switch this zone on.
+        # A zone-on does not wake the chassis on every model, and the chassis
+        # (PW) is independent of the main zone (ZM), so this does not force the
+        # main zone on.
+        if not self._receiver.power:
+            await self._receiver.power_on()
         await self._player.power_on()
 
     async def async_turn_off(self) -> None:
         """Turn the receiver off."""
+        # Decide before awaiting: a state push can land while we await the
+        # write below, but switching this zone off never changes the others.
+        last_zone = not self._other_zones_on()
         # Switch this zone off first (ZMOFF/Z2OFF/Z3OFF) so the receiver does
         # not restore it the next time the chassis powers on.
         await self._player.power_standby()
         # A zone-off leaves the chassis (PW) awake. Once no zone is left on,
         # send PWSTANDBY so the receiver actually powers down.
-        if not self._other_zones_on():
+        if last_zone:
             await self._receiver.power_standby()
 
     async def async_set_volume_level(self, volume: float) -> None:

--- a/homeassistant/components/denon_rs232/media_player.py
+++ b/homeassistant/components/denon_rs232/media_player.py
@@ -206,13 +206,12 @@ class DenonRS232MediaPlayer(MediaPlayerEntity):
 
     async def async_turn_off(self) -> None:
         """Turn the receiver off."""
-        # Power scopes are independent: the chassis (PW) stays awake as long as
-        # any zone is on, and a bare zone-off (e.g. ZMOFF/Z2OFF) only sleeps
-        # that zone. When this is the last powered zone, put the whole receiver
-        # in standby (PWSTANDBY) so the chassis actually powers down.
-        if self._other_zones_on():
-            await self._player.power_standby()
-        else:
+        # Switch this zone off first (ZMOFF/Z2OFF/Z3OFF) so the receiver does
+        # not restore it the next time the chassis powers on.
+        await self._player.power_standby()
+        # A zone-off leaves the chassis (PW) awake. Once no zone is left on,
+        # send PWSTANDBY so the receiver actually powers down.
+        if not self._other_zones_on():
             await self._receiver.power_standby()
 
     async def async_set_volume_level(self, volume: float) -> None:

--- a/homeassistant/components/denon_rs232/media_player.py
+++ b/homeassistant/components/denon_rs232/media_player.py
@@ -206,11 +206,9 @@ class DenonRS232MediaPlayer(MediaPlayerEntity):
 
     async def async_turn_off(self) -> None:
         """Turn the receiver off."""
-        # A zone-off leaves the chassis on, so stand it by ourselves when this
-        # is the last zone. Decided before the await, which can yield.
-        standby = bool(self._receiver.power) and not self._other_zones_on()
         await self._player.power_standby()
-        if standby:
+        # ensure device powers off when no zones are on
+        if self._receiver.power and not self._other_zones_on():
             await self._receiver.power_standby()
 
     async def async_set_volume_level(self, volume: float) -> None:

--- a/tests/components/denon_rs232/test_media_player.py
+++ b/tests/components/denon_rs232/test_media_player.py
@@ -106,47 +106,28 @@ async def test_zone_state_updates(
 
 
 @pytest.mark.parametrize(
-    ("entity_id", "chassis_on", "expected_commands"),
+    ("zone", "entity_id", "power_on_command"),
     [
-        # Chassis already awake, so only this zone is switched on.
-        pytest.param(MAIN_ENTITY_ID, True, [("ZM", "ON")], id="main_chassis_on"),
-        pytest.param(ZONE_2_ENTITY_ID, True, [("Z2", "ON")], id="zone_2_chassis_on"),
-        # Chassis in standby: wake it first, then switch this zone on.
-        pytest.param(
-            MAIN_ENTITY_ID, False, [("PW", "ON"), ("ZM", "ON")], id="main_chassis_off"
-        ),
-        pytest.param(
-            ZONE_2_ENTITY_ID,
-            False,
-            [("PW", "ON"), ("Z2", "ON")],
-            id="zone_2_chassis_off",
-        ),
+        ("main", MAIN_ENTITY_ID, ("ZM", "ON")),
+        ("zone_2", ZONE_2_ENTITY_ID, ("Z2", "ON")),
+        ("zone_3", ZONE_3_ENTITY_ID, ("Z1", "ON")),
     ],
 )
 async def test_turn_on(
     hass: HomeAssistant,
     mock_receiver: MockReceiver,
+    zone: ZoneName,
     entity_id: str,
-    chassis_on: bool,
-    expected_commands: list[tuple[str, str]],
+    power_on_command: tuple[str, str],
 ) -> None:
-    """Test turning a zone on wakes the chassis first when it is in standby."""
-    # Only the chassis power gates the wake command; zone power is irrelevant.
-    state = _default_state()
-    state.power = chassis_on
-    mock_receiver.mock_state(state)
-    await hass.async_block_till_done()
-
-    mock_receiver._send_command.reset_mock()
+    """Test turning a zone on sends that zone's power-on command."""
     await hass.services.async_call(
         MP_DOMAIN,
         SERVICE_TURN_ON,
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    assert mock_receiver._send_command.await_args_list == [
-        call(*command) for command in expected_commands
-    ]
+    assert mock_receiver._send_command.await_args == call(*power_on_command)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/denon_rs232/test_media_player.py
+++ b/tests/components/denon_rs232/test_media_player.py
@@ -77,7 +77,6 @@ async def test_only_active_zones_are_created(
 @pytest.mark.parametrize(
     ("zone", "entity_id", "initial_entity_state"),
     [
-        ("main", MAIN_ENTITY_ID, STATE_ON),
         ("zone_2", ZONE_2_ENTITY_ID, STATE_ON),
         ("zone_3", ZONE_3_ENTITY_ID, STATE_OFF),
     ],
@@ -105,10 +104,44 @@ async def test_zone_state_updates(
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
 
+async def test_main_tracks_chassis_power(
+    hass: HomeAssistant,
+    mock_receiver: MockReceiver,
+) -> None:
+    """Test the main entity tracks chassis power, independent of the main zone.
+
+    Turning on a zone wakes the chassis while the main zone (ZM) stays off, so
+    the main entity must follow the chassis (PW) power state.
+    """
+    assert hass.states.get(MAIN_ENTITY_ID).state == STATE_ON
+
+    # Main zone off but chassis still on (e.g. a zone is keeping it awake):
+    # the main entity stays on.
+    state = _default_state()
+    state.main_zone.power = False
+    mock_receiver.mock_state(state)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(MAIN_ENTITY_ID).state == STATE_ON
+
+    # Chassis in standby: the main entity turns off.
+    state = _default_state()
+    state.power = False
+    mock_receiver.mock_state(state)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(MAIN_ENTITY_ID).state == STATE_OFF
+
+    mock_receiver.mock_state(None)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(MAIN_ENTITY_ID).state == STATE_UNAVAILABLE
+
+
 @pytest.mark.parametrize(
     ("zone", "entity_id", "power_on_command", "power_off_command"),
     [
-        ("main", MAIN_ENTITY_ID, ("ZM", "ON"), ("ZM", "OFF")),
+        ("main", MAIN_ENTITY_ID, ("PW", "ON"), ("PW", "STANDBY")),
         ("zone_2", ZONE_2_ENTITY_ID, ("Z2", "ON"), ("Z2", "OFF")),
         ("zone_3", ZONE_3_ENTITY_ID, ("Z1", "ON"), ("Z1", "OFF")),
     ],

--- a/tests/components/denon_rs232/test_media_player.py
+++ b/tests/components/denon_rs232/test_media_player.py
@@ -106,28 +106,47 @@ async def test_zone_state_updates(
 
 
 @pytest.mark.parametrize(
-    ("zone", "entity_id", "power_on_command"),
+    ("entity_id", "chassis_on", "expected_commands"),
     [
-        ("main", MAIN_ENTITY_ID, ("ZM", "ON")),
-        ("zone_2", ZONE_2_ENTITY_ID, ("Z2", "ON")),
-        ("zone_3", ZONE_3_ENTITY_ID, ("Z1", "ON")),
+        # Chassis already awake, so only this zone is switched on.
+        pytest.param(MAIN_ENTITY_ID, True, [("ZM", "ON")], id="main_chassis_on"),
+        pytest.param(ZONE_2_ENTITY_ID, True, [("Z2", "ON")], id="zone_2_chassis_on"),
+        # Chassis in standby: wake it first, then switch this zone on.
+        pytest.param(
+            MAIN_ENTITY_ID, False, [("PW", "ON"), ("ZM", "ON")], id="main_chassis_off"
+        ),
+        pytest.param(
+            ZONE_2_ENTITY_ID,
+            False,
+            [("PW", "ON"), ("Z2", "ON")],
+            id="zone_2_chassis_off",
+        ),
     ],
 )
 async def test_turn_on(
     hass: HomeAssistant,
     mock_receiver: MockReceiver,
-    zone: ZoneName,
     entity_id: str,
-    power_on_command: tuple[str, str],
+    chassis_on: bool,
+    expected_commands: list[tuple[str, str]],
 ) -> None:
-    """Test turning a zone on sends that zone's power-on command."""
+    """Test turning a zone on wakes the chassis first when it is in standby."""
+    # Only the chassis power gates the wake command; zone power is irrelevant.
+    state = _default_state()
+    state.power = chassis_on
+    mock_receiver.mock_state(state)
+    await hass.async_block_till_done()
+
+    mock_receiver._send_command.reset_mock()
     await hass.services.async_call(
         MP_DOMAIN,
         SERVICE_TURN_ON,
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    assert mock_receiver._send_command.await_args == call(*power_on_command)
+    assert mock_receiver._send_command.await_args_list == [
+        call(*command) for command in expected_commands
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/components/denon_rs232/test_media_player.py
+++ b/tests/components/denon_rs232/test_media_player.py
@@ -131,22 +131,34 @@ async def test_turn_on(
 
 
 @pytest.mark.parametrize(
-    ("entity_id", "active_zones", "power_off_command"),
+    ("entity_id", "active_zones", "expected_commands"),
     [
         # Another zone stays on, so only this zone is switched off.
         pytest.param(
-            MAIN_ENTITY_ID, ("main", "zone_2"), ("ZM", "OFF"), id="main_with_zone_2_on"
+            MAIN_ENTITY_ID,
+            ("main", "zone_2"),
+            [("ZM", "OFF")],
+            id="main_with_zone_2_on",
         ),
         pytest.param(
             ZONE_2_ENTITY_ID,
             ("main", "zone_2"),
-            ("Z2", "OFF"),
+            [("Z2", "OFF")],
             id="zone_2_with_main_on",
         ),
-        # This is the last powered zone, so the whole receiver goes to standby.
-        pytest.param(MAIN_ENTITY_ID, ("main",), ("PW", "STANDBY"), id="main_last_zone"),
+        # This is the last powered zone: switch the zone off, then standby the
+        # chassis so the receiver does not restore the zone on next power-on.
         pytest.param(
-            ZONE_2_ENTITY_ID, ("zone_2",), ("PW", "STANDBY"), id="zone_2_last_zone"
+            MAIN_ENTITY_ID,
+            ("main",),
+            [("ZM", "OFF"), ("PW", "STANDBY")],
+            id="main_last_zone",
+        ),
+        pytest.param(
+            ZONE_2_ENTITY_ID,
+            ("zone_2",),
+            [("Z2", "OFF"), ("PW", "STANDBY")],
+            id="zone_2_last_zone",
         ),
     ],
 )
@@ -155,22 +167,25 @@ async def test_turn_off(
     mock_receiver: MockReceiver,
     entity_id: str,
     active_zones: tuple[ZoneName, ...],
-    power_off_command: tuple[str, str],
+    expected_commands: list[tuple[str, str]],
 ) -> None:
-    """Test turning off the last active zone standbys the whole receiver."""
+    """Test turning off a zone standbys the receiver once no zone is left on."""
     state = _default_state()
     for zone in ("main", "zone_2", "zone_3"):
         state.get_zone(zone).power = zone in active_zones
     mock_receiver.mock_state(state)
     await hass.async_block_till_done()
 
+    mock_receiver._send_command.reset_mock()
     await hass.services.async_call(
         MP_DOMAIN,
         SERVICE_TURN_OFF,
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    assert mock_receiver._send_command.await_args == call(*power_off_command)
+    assert mock_receiver._send_command.await_args_list == [
+        call(*command) for command in expected_commands
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/components/denon_rs232/test_media_player.py
+++ b/tests/components/denon_rs232/test_media_player.py
@@ -160,6 +160,8 @@ async def test_turn_on(
             [("Z2", "OFF"), ("PW", "STANDBY")],
             id="zone_2_last_zone",
         ),
+        # Chassis already in standby: do not send a redundant PWSTANDBY.
+        pytest.param(MAIN_ENTITY_ID, (), [("ZM", "OFF")], id="chassis_already_off"),
     ],
 )
 async def test_turn_off(
@@ -169,8 +171,9 @@ async def test_turn_off(
     active_zones: tuple[ZoneName, ...],
     expected_commands: list[tuple[str, str]],
 ) -> None:
-    """Test turning off a zone standbys the receiver once no zone is left on."""
+    """Test turning off a zone standbys the receiver only when needed."""
     state = _default_state()
+    state.power = bool(active_zones)
     for zone in ("main", "zone_2", "zone_3"):
         state.get_zone(zone).power = zone in active_zones
     mock_receiver.mock_state(state)

--- a/tests/components/denon_rs232/test_media_player.py
+++ b/tests/components/denon_rs232/test_media_player.py
@@ -77,6 +77,7 @@ async def test_only_active_zones_are_created(
 @pytest.mark.parametrize(
     ("zone", "entity_id", "initial_entity_state"),
     [
+        ("main", MAIN_ENTITY_ID, STATE_ON),
         ("zone_2", ZONE_2_ENTITY_ID, STATE_ON),
         ("zone_3", ZONE_3_ENTITY_ID, STATE_OFF),
     ],
@@ -104,58 +105,22 @@ async def test_zone_state_updates(
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
 
-async def test_main_tracks_chassis_power(
-    hass: HomeAssistant,
-    mock_receiver: MockReceiver,
-) -> None:
-    """Test the main entity tracks chassis power, independent of the main zone.
-
-    Turning on a zone wakes the chassis while the main zone (ZM) stays off, so
-    the main entity must follow the chassis (PW) power state.
-    """
-    assert hass.states.get(MAIN_ENTITY_ID).state == STATE_ON
-
-    # Main zone off but chassis still on (e.g. a zone is keeping it awake):
-    # the main entity stays on.
-    state = _default_state()
-    state.main_zone.power = False
-    mock_receiver.mock_state(state)
-    await hass.async_block_till_done()
-
-    assert hass.states.get(MAIN_ENTITY_ID).state == STATE_ON
-
-    # Chassis in standby: the main entity turns off.
-    state = _default_state()
-    state.power = False
-    mock_receiver.mock_state(state)
-    await hass.async_block_till_done()
-
-    assert hass.states.get(MAIN_ENTITY_ID).state == STATE_OFF
-
-    mock_receiver.mock_state(None)
-    await hass.async_block_till_done()
-
-    assert hass.states.get(MAIN_ENTITY_ID).state == STATE_UNAVAILABLE
-
-
 @pytest.mark.parametrize(
-    ("zone", "entity_id", "power_on_command", "power_off_command"),
+    ("zone", "entity_id", "power_on_command"),
     [
-        ("main", MAIN_ENTITY_ID, ("PW", "ON"), ("PW", "STANDBY")),
-        ("zone_2", ZONE_2_ENTITY_ID, ("Z2", "ON"), ("Z2", "OFF")),
-        ("zone_3", ZONE_3_ENTITY_ID, ("Z1", "ON"), ("Z1", "OFF")),
+        ("main", MAIN_ENTITY_ID, ("ZM", "ON")),
+        ("zone_2", ZONE_2_ENTITY_ID, ("Z2", "ON")),
+        ("zone_3", ZONE_3_ENTITY_ID, ("Z1", "ON")),
     ],
 )
-async def test_power_controls(
+async def test_turn_on(
     hass: HomeAssistant,
     mock_receiver: MockReceiver,
     zone: ZoneName,
     entity_id: str,
     power_on_command: tuple[str, str],
-    power_off_command: tuple[str, str],
 ) -> None:
-    """Test power services send the right commands for each zone."""
-
+    """Test turning a zone on sends that zone's power-on command."""
     await hass.services.async_call(
         MP_DOMAIN,
         SERVICE_TURN_ON,
@@ -163,6 +128,41 @@ async def test_power_controls(
         blocking=True,
     )
     assert mock_receiver._send_command.await_args == call(*power_on_command)
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "active_zones", "power_off_command"),
+    [
+        # Another zone stays on, so only this zone is switched off.
+        pytest.param(
+            MAIN_ENTITY_ID, ("main", "zone_2"), ("ZM", "OFF"), id="main_with_zone_2_on"
+        ),
+        pytest.param(
+            ZONE_2_ENTITY_ID,
+            ("main", "zone_2"),
+            ("Z2", "OFF"),
+            id="zone_2_with_main_on",
+        ),
+        # This is the last powered zone, so the whole receiver goes to standby.
+        pytest.param(MAIN_ENTITY_ID, ("main",), ("PW", "STANDBY"), id="main_last_zone"),
+        pytest.param(
+            ZONE_2_ENTITY_ID, ("zone_2",), ("PW", "STANDBY"), id="zone_2_last_zone"
+        ),
+    ],
+)
+async def test_turn_off(
+    hass: HomeAssistant,
+    mock_receiver: MockReceiver,
+    entity_id: str,
+    active_zones: tuple[ZoneName, ...],
+    power_off_command: tuple[str, str],
+) -> None:
+    """Test turning off the last active zone standbys the whole receiver."""
+    state = _default_state()
+    for zone in ("main", "zone_2", "zone_3"):
+        state.get_zone(zone).power = zone in active_zones
+    mock_receiver.mock_state(state)
+    await hass.async_block_till_done()
 
     await hass.services.async_call(
         MP_DOMAIN,

--- a/tests/components/denon_rs232/test_media_player.py
+++ b/tests/components/denon_rs232/test_media_player.py
@@ -160,8 +160,6 @@ async def test_turn_on(
             [("Z2", "OFF"), ("PW", "STANDBY")],
             id="zone_2_last_zone",
         ),
-        # Chassis already in standby: do not send a redundant PWSTANDBY.
-        pytest.param(MAIN_ENTITY_ID, (), [("ZM", "OFF")], id="chassis_already_off"),
     ],
 )
 async def test_turn_off(
@@ -171,9 +169,8 @@ async def test_turn_off(
     active_zones: tuple[ZoneName, ...],
     expected_commands: list[tuple[str, str]],
 ) -> None:
-    """Test turning off a zone standbys the receiver only when needed."""
+    """Test turning off a zone standbys the receiver once no zone is left on."""
     state = _default_state()
-    state.power = bool(active_zones)
     for zone in ("main", "zone_2", "zone_3"):
         state.get_zone(zone).power = zone in active_zones
     mock_receiver.mock_state(state)


### PR DESCRIPTION
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Denon RS-232 receivers have three independent power scopes: the chassis (`PW`), the main zone (`ZM`) and zone 2/3 (`Z2`/`Z1`/`Z3`). Turning a zone on wakes the chassis, but a zone-off (`ZMOFF`/`Z2OFF`/`Z3OFF`) only sleeps that zone and leaves the chassis awake. Because each entity only ever sent its own scoped off command, once a zone had woken the receiver there was no way to actually power it down — matching the report where turning the unit on via Zone 2 left it stuck on.

`async_turn_off` now switches the zone off first, and then, when no other zone is left on, sends `PWSTANDBY` so the chassis actually powers down. Switching the zone off before standby also keeps the receiver from restoring that zone the next time it powers on. When another zone is still on, only the zone-off is sent, so independent zone control is preserved.

A `PWSTANDBY` to an already-off receiver is a harmless no-op, so it is always sent on the last zone rather than gating on a possibly-stale pushed power state.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #172692
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: `https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure`

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---
_Generated by [Claude Code](https://claude.ai/code/session_01GvpYtGANLEng45wz1B8nMo)_