### PR TITLE
Do not use home zone coordinates for person when detected home by scanner

### DIFF
--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -14,7 +14,6 @@ from homeassistant.components.device_tracker import (
     DOMAIN as DEVICE_TRACKER_DOMAIN,
     SourceType,
 )
-from homeassistant.components.zone import ENTITY_ID_HOME
 from homeassistant.const import (
     ATTR_EDITABLE,
     ATTR_GPS_ACCURACY,
@@ -460,7 +459,7 @@ class Person(
         """Register device trackers."""
         await super().async_added_to_hass()
         if state := await self.async_get_last_state():
-            self._parse_source_state(state, state)
+            self._parse_source_state(state)
 
         if self.hass.is_running:
             # Update person now if hass is already running.
@@ -510,7 +509,7 @@ class Person(
     @callback
     def _update_state(self) -> None:
         """Update the state."""
-        latest_non_gps_home = latest_not_home = latest_gps = latest = coordinates = None
+        latest_non_gps_home = latest_not_home = latest_gps = latest = None
         for entity_id in self._config[CONF_DEVICE_TRACKERS]:
             state = self.hass.states.get(entity_id)
 
@@ -526,23 +525,13 @@ class Person(
 
         if latest_non_gps_home:
             latest = latest_non_gps_home
-            if (
-                latest_non_gps_home.attributes.get(ATTR_LATITUDE) is None
-                and latest_non_gps_home.attributes.get(ATTR_LONGITUDE) is None
-                and (home_zone := self.hass.states.get(ENTITY_ID_HOME))
-            ):
-                coordinates = home_zone
-            else:
-                coordinates = latest_non_gps_home
         elif latest_gps:
             latest = latest_gps
-            coordinates = latest_gps
         else:
             latest = latest_not_home
-            coordinates = latest_not_home
 
-        if latest and coordinates:
-            self._parse_source_state(latest, coordinates)
+        if latest:
+            self._parse_source_state(latest)
         else:
             self._attr_state = None
             self._source = None
@@ -555,16 +544,16 @@ class Person(
         self.async_write_ha_state()
 
     @callback
-    def _parse_source_state(self, state: State, coordinates: State) -> None:
+    def _parse_source_state(self, state: State) -> None:
         """Parse source state and set person attributes.
 
         This is a device tracker state or the restored person state.
         """
         self._attr_state = state.state
         self._source = state.entity_id
-        self._latitude = coordinates.attributes.get(ATTR_LATITUDE)
-        self._longitude = coordinates.attributes.get(ATTR_LONGITUDE)
-        self._gps_accuracy = coordinates.attributes.get(ATTR_GPS_ACCURACY)
+        self._latitude = state.attributes.get(ATTR_LATITUDE)
+        self._longitude = state.attributes.get(ATTR_LONGITUDE)
+        self._gps_accuracy = state.attributes.get(ATTR_GPS_ACCURACY)
         self._in_zones = state.attributes.get(ATTR_IN_ZONES, [])
 
     @callback

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -14,6 +14,7 @@ from homeassistant.components.device_tracker import (
     DOMAIN as DEVICE_TRACKER_DOMAIN,
     SourceType,
 )
+from homeassistant.components.zone import ENTITY_ID_HOME
 from homeassistant.const import (
     ATTR_EDITABLE,
     ATTR_GPS_ACCURACY,
@@ -555,6 +556,21 @@ class Person(
         self._longitude = state.attributes.get(ATTR_LONGITUDE)
         self._gps_accuracy = state.attributes.get(ATTR_GPS_ACCURACY)
         self._in_zones = state.attributes.get(ATTR_IN_ZONES, [])
+
+        # A legacy scanner (one that doesn't report in_zones) reports "home"
+        # without coordinates. Use the home zone's coordinates for backwards
+        # compatibility with legacy zone conditions and triggers. Modern
+        # trackers report in_zones and keep their own (possibly absent)
+        # coordinates.
+        if (
+            ATTR_IN_ZONES not in state.attributes
+            and state.state == STATE_HOME
+            and self._latitude is None
+            and self._longitude is None
+            and (home_zone := self.hass.states.get(ENTITY_ID_HOME)) is not None
+        ):
+            self._latitude = home_zone.attributes.get(ATTR_LATITUDE)
+            self._longitude = home_zone.attributes.get(ATTR_LONGITUDE)
 
     @callback
     def _update_extra_state_attributes(self) -> None:

--- a/homeassistant/components/person/manifest.json
+++ b/homeassistant/components/person/manifest.json
@@ -2,7 +2,7 @@
   "domain": "person",
   "name": "Person",
   "codeowners": [],
-  "dependencies": ["image_upload", "http"],
+  "dependencies": ["image_upload", "http", "zone"],
   "documentation": "https://www.home-assistant.io/integrations/person",
   "integration_type": "system",
   "iot_class": "calculated",

--- a/homeassistant/components/person/manifest.json
+++ b/homeassistant/components/person/manifest.json
@@ -2,7 +2,7 @@
   "domain": "person",
   "name": "Person",
   "codeowners": [],
-  "dependencies": ["image_upload", "http", "zone"],
+  "dependencies": ["image_upload", "http"],
   "documentation": "https://www.home-assistant.io/integrations/person",
   "integration_type": "system",
   "iot_class": "calculated",

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -151,9 +151,12 @@ async def test_setup_tracker(hass: HomeAssistant, hass_admin_user: MockUser) -> 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
 
+    # A legacy tracker reporting home (no coordinates) is placed at the home zone.
     state = hass.states.get("person.tracked_person")
     assert state.state == "home"
     assert state.attributes == expected_attributes | {
+        ATTR_LATITUDE: 32.87336,
+        ATTR_LONGITUDE: -117.22743,
         ATTR_SOURCE: DEVICE_TRACKER,
     }
 
@@ -290,9 +293,12 @@ async def test_setup_two_trackers(
     hass.states.async_set(DEVICE_TRACKER_2, "zone2", {ATTR_SOURCE_TYPE: SourceType.GPS})
     await hass.async_block_till_done()
 
+    # Legacy router reporting home (no in_zones) is placed at the home zone.
     state = hass.states.get("person.tracked_person")
     assert state.state == "home"
     assert state.attributes == expected_attributes | {
+        ATTR_LATITUDE: 32.87336,
+        ATTR_LONGITUDE: -117.22743,
         ATTR_SOURCE: DEVICE_TRACKER,
     }
 
@@ -418,14 +424,28 @@ _LEGACY_NOT_HOME: tuple[str, dict[str, Any]] = (
     "not_home",
     {ATTR_SOURCE_TYPE: SourceType.ROUTER},
 )
-# A legacy GPS tracker reports coordinates but no `in_zones`.
-_LEGACY_GPS: tuple[str, dict[str, Any]] = (
+# A legacy tracker in a non-home zone reports the zone name, still no `in_zones`.
+_LEGACY_OFFICE: tuple[str, dict[str, Any]] = (
+    "office",
+    {ATTR_SOURCE_TYPE: SourceType.ROUTER},
+)
+# Legacy GPS trackers report coordinates but no `in_zones`.
+_LEGACY_GPS_NOT_HOME: tuple[str, dict[str, Any]] = (
     "not_home",
     {
         ATTR_SOURCE_TYPE: SourceType.GPS,
         ATTR_LATITUDE: 5.0,
         ATTR_LONGITUDE: 6.0,
         ATTR_GPS_ACCURACY: 8,
+    },
+)
+_LEGACY_GPS_WORK: tuple[str, dict[str, Any]] = (
+    "work",
+    {
+        ATTR_SOURCE_TYPE: SourceType.GPS,
+        ATTR_LATITUDE: 7.0,
+        ATTR_LONGITUDE: 8.0,
+        ATTR_GPS_ACCURACY: 9,
     },
 )
 
@@ -460,12 +480,15 @@ async def _async_setup_person_two_trackers(hass: HomeAssistant, user_id: str) ->
             },
             id="home_beats_gps",
         ),
-        # A legacy "home" tracker (no in_zones) likewise outranks GPS.
+        # A legacy "home" tracker (no in_zones) likewise outranks GPS; it is
+        # placed at the home zone.
         pytest.param(
             _LEGACY_HOME,
             _GPS_NOT_HOME,
             "home",
             {
+                ATTR_LATITUDE: 32.87336,
+                ATTR_LONGITUDE: -117.22743,
                 ATTR_SOURCE: DEVICE_TRACKER,
             },
             id="legacy_home_beats_gps",
@@ -594,12 +617,14 @@ async def test_state_priority_overrides_recency(
             id="home_newer",
         ),
         # A pair of legacy "home" trackers (no in_zones) likewise picks the
-        # most recent.
+        # most recent; it is placed at the home zone.
         pytest.param(
             _LEGACY_HOME,
             _LEGACY_HOME,
             "home",
             {
+                ATTR_LATITUDE: 32.87336,
+                ATTR_LONGITUDE: -117.22743,
                 ATTR_SOURCE: DEVICE_TRACKER_2,
             },
             id="legacy_home_newer",
@@ -684,11 +709,14 @@ async def test_scanner_associated_with_other_zone(
 @pytest.mark.parametrize(
     ("tracker", "expected_state", "expected_extra"),
     [
-        # A legacy "home" tracker has no coordinates of its own.
+        # A legacy "home" tracker has no coordinates of its own, so it is
+        # placed at the home zone.
         pytest.param(
             _LEGACY_HOME,
             "home",
             {
+                ATTR_LATITUDE: 32.87336,
+                ATTR_LONGITUDE: -117.22743,
                 ATTR_SOURCE: DEVICE_TRACKER,
             },
             id="home",
@@ -700,9 +728,16 @@ async def test_scanner_associated_with_other_zone(
             {ATTR_SOURCE: DEVICE_TRACKER},
             id="not_home",
         ),
-        # A legacy GPS tracker contributes its own coordinates but no zones.
+        # A legacy tracker in a non-home zone gets no coordinate fallback.
         pytest.param(
-            _LEGACY_GPS,
+            _LEGACY_OFFICE,
+            "office",
+            {ATTR_SOURCE: DEVICE_TRACKER},
+            id="office",
+        ),
+        # Legacy GPS trackers contribute their own coordinates but no zones.
+        pytest.param(
+            _LEGACY_GPS_NOT_HOME,
             "not_home",
             {
                 ATTR_GPS_ACCURACY: 8,
@@ -710,7 +745,18 @@ async def test_scanner_associated_with_other_zone(
                 ATTR_LONGITUDE: 6.0,
                 ATTR_SOURCE: DEVICE_TRACKER,
             },
-            id="gps",
+            id="gps_not_home",
+        ),
+        pytest.param(
+            _LEGACY_GPS_WORK,
+            "work",
+            {
+                ATTR_GPS_ACCURACY: 9,
+                ATTR_LATITUDE: 7.0,
+                ATTR_LONGITUDE: 8.0,
+                ATTR_SOURCE: DEVICE_TRACKER,
+            },
+            id="gps_work",
         ),
     ],
 )
@@ -910,9 +956,12 @@ async def test_load_person_storage(
     hass.states.async_set(DEVICE_TRACKER, "home")
     await hass.async_block_till_done()
 
+    # A legacy tracker reporting home (no coordinates) is placed at the home zone.
     state = hass.states.get("person.tracked_person")
     assert state.state == "home"
     assert state.attributes == expected_attributes | {
+        ATTR_LATITUDE: 32.87336,
+        ATTR_LONGITUDE: -117.22743,
         ATTR_SOURCE: DEVICE_TRACKER,
     }
 
@@ -1275,7 +1324,7 @@ async def test_reload(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
         },
     )
 
-    assert len(hass.states.async_entity_ids()) == 2  # Person1, Person2
+    assert len(hass.states.async_entity_ids()) == 3  # zone.home, Person1, Person2
 
     state_1 = hass.states.get("person.person_1")
     state_2 = hass.states.get("person.person_2")
@@ -1305,7 +1354,7 @@ async def test_reload(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
         )
         await hass.async_block_till_done()
 
-    assert len(hass.states.async_entity_ids()) == 2  # Person1, Person3
+    assert len(hass.states.async_entity_ids()) == 3  # zone.home, Person1, Person3
 
     state_1 = hass.states.get("person.person_1")
     state_2 = hass.states.get("person.person_2")

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -154,8 +154,6 @@ async def test_setup_tracker(hass: HomeAssistant, hass_admin_user: MockUser) -> 
     state = hass.states.get("person.tracked_person")
     assert state.state == "home"
     assert state.attributes == expected_attributes | {
-        ATTR_LATITUDE: 32.87336,
-        ATTR_LONGITUDE: -117.22743,
         ATTR_SOURCE: DEVICE_TRACKER,
     }
 
@@ -236,18 +234,11 @@ async def test_setup_two_trackers(
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
-    # Router tracker at home — the person entity gets latitude, longitude and
-    # accuracy from the home zone (the coordinates source), not from the router
-    # tracker's own attributes. `in_zones`, however, is propagated from the
-    # source tracker.
-    # Note: a router tracker would not really have gps_accuracy; it is set here
-    # only to assert it is NOT propagated.
     hass.states.async_set(
         DEVICE_TRACKER,
         "home",
         {
             ATTR_SOURCE_TYPE: SourceType.ROUTER,
-            ATTR_GPS_ACCURACY: 99,
             ATTR_IN_ZONES: ["zone.home"],
         },
     )
@@ -257,8 +248,6 @@ async def test_setup_two_trackers(
     assert state.state == "home"
     assert state.attributes == expected_attributes | {
         ATTR_IN_ZONES: ["zone.home"],
-        ATTR_LATITUDE: 32.87336,
-        ATTR_LONGITUDE: -117.22743,
         ATTR_SOURCE: DEVICE_TRACKER,
     }
 
@@ -304,8 +293,6 @@ async def test_setup_two_trackers(
     state = hass.states.get("person.tracked_person")
     assert state.state == "home"
     assert state.attributes == expected_attributes | {
-        ATTR_LATITUDE: 32.87336,
-        ATTR_LONGITUDE: -117.22743,
         ATTR_SOURCE: DEVICE_TRACKER,
     }
 
@@ -463,15 +450,12 @@ async def _async_setup_person_two_trackers(hass: HomeAssistant, user_id: str) ->
     ("high_priority", "low_priority", "expected_state", "expected_extra"),
     [
         # A non-GPS "home" tracker outranks a GPS tracker reporting coordinates.
-        # Its coordinates come from the home zone (it has none of its own).
         pytest.param(
             _ROUTER_HOME,
             _GPS_NOT_HOME,
             "home",
             {
                 ATTR_IN_ZONES: ["zone.home"],
-                ATTR_LATITUDE: 32.87336,
-                ATTR_LONGITUDE: -117.22743,
                 ATTR_SOURCE: DEVICE_TRACKER,
             },
             id="home_beats_gps",
@@ -482,8 +466,6 @@ async def _async_setup_person_two_trackers(hass: HomeAssistant, user_id: str) ->
             _GPS_NOT_HOME,
             "home",
             {
-                ATTR_LATITUDE: 32.87336,
-                ATTR_LONGITUDE: -117.22743,
                 ATTR_SOURCE: DEVICE_TRACKER,
             },
             id="legacy_home_beats_gps",
@@ -495,8 +477,6 @@ async def _async_setup_person_two_trackers(hass: HomeAssistant, user_id: str) ->
             "home",
             {
                 ATTR_IN_ZONES: ["zone.home"],
-                ATTR_LATITUDE: 32.87336,
-                ATTR_LONGITUDE: -117.22743,
                 ATTR_SOURCE: DEVICE_TRACKER,
             },
             id="home_beats_other_zone",
@@ -602,16 +582,13 @@ async def test_state_priority_overrides_recency(
             {ATTR_SOURCE: DEVICE_TRACKER_2},
             id="other_newer_not_home",
         ),
-        # "home" bucket: the most recent "home" tracker becomes the source and
-        # its coordinates come from the home zone.
+        # "home" bucket: the most recent "home" tracker becomes the source.
         pytest.param(
             _ROUTER_HOME,
             _ROUTER_HOME,
             "home",
             {
                 ATTR_IN_ZONES: ["zone.home"],
-                ATTR_LATITUDE: 32.87336,
-                ATTR_LONGITUDE: -117.22743,
                 ATTR_SOURCE: DEVICE_TRACKER_2,
             },
             id="home_newer",
@@ -623,8 +600,6 @@ async def test_state_priority_overrides_recency(
             _LEGACY_HOME,
             "home",
             {
-                ATTR_LATITUDE: 32.87336,
-                ATTR_LONGITUDE: -117.22743,
                 ATTR_SOURCE: DEVICE_TRACKER_2,
             },
             id="legacy_home_newer",
@@ -672,8 +647,8 @@ async def test_scanner_associated_with_other_zone(
     """Test a person tracked by a scanner associated with a non-home zone.
 
     A connected scanner associated with a non-home zone reports the zone name
-    and lists the zone in `in_zones`. As a non-GPS tracker not reporting "home"
-    it lands in the lowest-priority bucket, so it has no coordinate fallback.
+    and lists the zone in `in_zones`. Being a non-GPS tracker, it provides no
+    coordinates of its own.
     """
     hass.set_state(CoreState.not_running)
     user_id = hass_admin_user.id
@@ -692,8 +667,7 @@ async def test_scanner_associated_with_other_zone(
     hass.states.async_set(DEVICE_TRACKER, _SCANNER_OFFICE[0], _SCANNER_OFFICE[1])
     await hass.async_block_till_done()
 
-    # No coordinates: a scanner tracker provides none of its own, and as a
-    # lowest-priority state it gets no coordinate fallback from the home zone.
+    # No coordinates: a scanner tracker provides none of its own.
     state = hass.states.get("person.tracked_person")
     assert state.state == "office"
     assert state.attributes == {
@@ -710,14 +684,11 @@ async def test_scanner_associated_with_other_zone(
 @pytest.mark.parametrize(
     ("tracker", "expected_state", "expected_extra"),
     [
-        # A legacy "home" tracker has no coordinates of its own, so they come
-        # from the home zone. It reports no `in_zones`.
+        # A legacy "home" tracker has no coordinates of its own.
         pytest.param(
             _LEGACY_HOME,
             "home",
             {
-                ATTR_LATITUDE: 32.87336,
-                ATTR_LONGITUDE: -117.22743,
                 ATTR_SOURCE: DEVICE_TRACKER,
             },
             id="home",
@@ -942,8 +913,6 @@ async def test_load_person_storage(
     state = hass.states.get("person.tracked_person")
     assert state.state == "home"
     assert state.attributes == expected_attributes | {
-        ATTR_LATITUDE: 32.87336,
-        ATTR_LONGITUDE: -117.22743,
         ATTR_SOURCE: DEVICE_TRACKER,
     }
 
@@ -1306,7 +1275,7 @@ async def test_reload(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
         },
     )
 
-    assert len(hass.states.async_entity_ids()) == 3  # Person1, Person2, zone.home
+    assert len(hass.states.async_entity_ids()) == 2  # Person1, Person2
 
     state_1 = hass.states.get("person.person_1")
     state_2 = hass.states.get("person.person_2")
@@ -1336,7 +1305,7 @@ async def test_reload(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
         )
         await hass.async_block_till_done()
 
-    assert len(hass.states.async_entity_ids()) == 3  # Person1, Person2, zone.home
+    assert len(hass.states.async_entity_ids()) == 2  # Person1, Person3
 
     state_1 = hass.states.get("person.person_1")
     state_2 = hass.states.get("person.person_2")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The state of person entities no longer have the latitude + longitude of the home zone when the state of the person entity is from a scanner associated with the home zone.

Automations and scripts which test the coordinates of person entities need to be adjusted. To determine if a device tracker is in a certain zone, the state attribute `in_zones` can be used.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Do not use home zone coordinates for person when detected home by scanner

For backwards compatibility reasons, the home zone coordinates will still be used if the scanner is using the deprecated model which doesn't have an `in_zones` state attribute.

Rationale:
Using the home zone coordinates was introduced to benefit frontend, but this is no longer needed because of the recently introduced `in_zones` state attribute of device trackers, which frontend makes use of in https://github.com/home-assistant/frontend/pull/52415

This reverts the functionality added by https://github.com/home-assistant/core/pull/134075

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
