### PR TITLE
Fix Duco mode end time sensor name

### DIFF
--- a/homeassistant/components/duco/strings.json
+++ b/homeassistant/components/duco/strings.json
@@ -59,7 +59,7 @@
         "name": "Target flow level"
       },
       "time_state_end": {
-        "name": "Mode end time"
+        "name": "State end time"
       },
       "ventilation_state": {
         "name": "Ventilation state",

--- a/tests/components/duco/snapshots/test_sensor.ambr
+++ b/tests/components/duco/snapshots/test_sensor.ambr
@@ -435,7 +435,7 @@
     'state': '90',
   })
 # ---
-# name: test_sensor_entities_state[sensor.living_mode_end_time-entry]
+# name: test_sensor_entities_state[sensor.living_state_end_time-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -449,7 +449,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.living_mode_end_time',
+    'entity_id': 'sensor.living_state_end_time',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -457,12 +457,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Mode end time',
+    'object_id_base': 'State end time',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
     'original_icon': None,
-    'original_name': 'Mode end time',
+    'original_name': 'State end time',
     'platform': 'duco',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -472,14 +472,14 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_entities_state[sensor.living_mode_end_time-state]
+# name: test_sensor_entities_state[sensor.living_state_end_time-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'timestamp',
-      'friendly_name': 'Living Mode end time',
+      'friendly_name': 'Living State end time',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.living_mode_end_time',
+    'entity_id': 'sensor.living_state_end_time',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,


### PR DESCRIPTION
> [!NOTE]
> If appropriate, could this follow-up Duco bugfix be included in milestone 2026.6.1? When the ventilation state sensor naming was updated, this related `time_state_end` sensor rename should have been included as well, but was missed.

## Proposed change
This PR fixes the remaining Duco timestamp sensor name so it stays consistent with the renamed ventilation state sensor.

The `time_state_end` entity currently still uses **Mode end time**, while the related enum sensor uses **Ventilation state**. This follow-up renames the timestamp sensor to **State end time** so both entities reflect the same state model.

This should ideally be considered for the first milestone as a small bugfix follow-up. When the ventilation state sensor naming was adjusted, this companion timestamp sensor should have been renamed in the same change but was missed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: follow-up to PR #172314
- Link to documentation pull request: current: https://github.com/home-assistant/home-assistant.io/pull/45754, next: https://github.com/home-assistant/home-assistant.io/pull/45757
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr