### PR TITLE
Strip trailing slash from Jellyfin server URL

### DIFF
--- a/homeassistant/components/jellyfin/__init__.py
+++ b/homeassistant/components/jellyfin/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
@@ -61,6 +62,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: JellyfinConfigEntry) -> 
     entry.async_on_unload(client.stop)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: JellyfinConfigEntry) -> bool:
+    """Migrate an old config entry."""
+    if entry.version == 1 and entry.minor_version < 2:
+        new_data = {**entry.data, CONF_URL: entry.data[CONF_URL].rstrip("/")}
+        hass.config_entries.async_update_entry(entry, data=new_data, minor_version=2)
 
     return True
 

--- a/homeassistant/components/jellyfin/client_wrapper.py
+++ b/homeassistant/components/jellyfin/client_wrapper.py
@@ -21,7 +21,10 @@ async def validate_input(
     hass: HomeAssistant, user_input: dict[str, Any], client: JellyfinClient
 ) -> tuple[str, dict[str, Any]]:
     """Validate that the provided url and credentials can be used to connect."""
-    url = user_input[CONF_URL]
+    # Strip any trailing slash; the client joins paths without normalizing, so a
+    # trailing slash produces a double-slashed request path (e.g. //system/info/public)
+    # that some Jellyfin versions reject with a 404.
+    url = user_input[CONF_URL].rstrip("/")
     username = user_input[CONF_USERNAME]
     password = user_input[CONF_PASSWORD]
 

--- a/homeassistant/components/jellyfin/client_wrapper.py
+++ b/homeassistant/components/jellyfin/client_wrapper.py
@@ -21,10 +21,7 @@ async def validate_input(
     hass: HomeAssistant, user_input: dict[str, Any], client: JellyfinClient
 ) -> tuple[str, dict[str, Any]]:
     """Validate that the provided url and credentials can be used to connect."""
-    # Strip any trailing slash; the client joins paths without normalizing, so a
-    # trailing slash produces a double-slashed request path (e.g. //system/info/public)
-    # that some Jellyfin versions reject with a 404.
-    url = user_input[CONF_URL].rstrip("/")
+    url = user_input[CONF_URL]
     username = user_input[CONF_USERNAME]
     password = user_input[CONF_PASSWORD]
 

--- a/homeassistant/components/jellyfin/config_flow.py
+++ b/homeassistant/components/jellyfin/config_flow.py
@@ -58,6 +58,8 @@ class JellyfinConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
+            user_input[CONF_URL] = user_input[CONF_URL].rstrip("/")
+
             if self.client_device_id is None:
                 self.client_device_id = _generate_client_device_id()
 

--- a/homeassistant/components/jellyfin/config_flow.py
+++ b/homeassistant/components/jellyfin/config_flow.py
@@ -46,6 +46,7 @@ class JellyfinConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Jellyfin."""
 
     VERSION = 1
+    MINOR_VERSION = 2
 
     def __init__(self) -> None:
         """Initialize the Jellyfin config flow."""

--- a/tests/components/jellyfin/test_config_flow.py
+++ b/tests/components/jellyfin/test_config_flow.py
@@ -59,6 +59,35 @@ async def test_form(
     assert len(mock_client.jellyfin.get_user_settings.mock_calls) == 1
 
 
+async def test_form_strips_trailing_slash_from_url(
+    hass: HomeAssistant,
+    mock_jellyfin: MagicMock,
+    mock_client: MagicMock,
+    mock_client_device_id: MagicMock,
+    mock_setup_entry: MagicMock,
+) -> None:
+    """Test a trailing slash is stripped from the configured URL.
+
+    A trailing slash would otherwise be joined into a double-slashed request
+    path (e.g. //system/info/public) that some Jellyfin versions reject.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={**USER_INPUT, CONF_URL: f"{TEST_URL}/"},
+    )
+    await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    # The persisted URL has no trailing slash...
+    assert result2["data"][CONF_URL] == TEST_URL
+    # ...and the connection was attempted against the normalized URL.
+    mock_client.auth.connect_to_address.assert_called_once_with(TEST_URL)
+
+
 async def test_form_cannot_connect(
     hass: HomeAssistant,
     mock_jellyfin: MagicMock,

--- a/tests/components/jellyfin/test_init.py
+++ b/tests/components/jellyfin/test_init.py
@@ -4,11 +4,13 @@ from unittest.mock import MagicMock
 
 from homeassistant.components.jellyfin.const import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
+from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
 from . import async_load_json_fixture
+from .const import TEST_PASSWORD, TEST_URL, TEST_USERNAME
 
 from tests.common import MockConfigEntry
 from tests.typing import WebSocketGenerator
@@ -73,6 +75,33 @@ async def test_load_unload_config_entry(
     await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_migrate_strips_trailing_slash_from_url(
+    hass: HomeAssistant,
+    mock_jellyfin: MagicMock,
+    mock_client: MagicMock,
+) -> None:
+    """Test migrating an entry strips a trailing slash from the stored URL."""
+    config_entry = MockConfigEntry(
+        title="Jellyfin",
+        domain=DOMAIN,
+        data={
+            CONF_URL: f"{TEST_URL}/",
+            CONF_USERNAME: TEST_USERNAME,
+            CONF_PASSWORD: TEST_PASSWORD,
+        },
+        unique_id="USER-UUID",
+        version=1,
+        minor_version=1,
+    )
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.minor_version == 2
+    assert config_entry.data[CONF_URL] == TEST_URL
 
 
 async def test_device_remove_devices(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A configured URL with a trailing slash is joined into a double-slashed request path (//system/info/public) that newer Jellyfin returns 404 for, so get_public_info() yields no data and setup fails with CannotConnect. Normalize the URL in the config flow (clean storage for new entries) and in validate_input (so existing entries recover on reload).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
