### PR TITLE
Bump tesla-powerwall to 0.5.3

### DIFF
--- a/homeassistant/components/powerwall/manifest.json
+++ b/homeassistant/components/powerwall/manifest.json
@@ -15,5 +15,5 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["tesla_powerwall"],
-  "requirements": ["tesla-powerwall==0.5.2"]
+  "requirements": ["tesla-powerwall==0.5.3"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3150,7 +3150,7 @@ temperusb==1.6.1
 tesla-fleet-api==1.4.7
 
 # homeassistant.components.powerwall
-tesla-powerwall==0.5.2
+tesla-powerwall==0.5.3
 
 # homeassistant.components.tesla_wall_connector
 tesla-wall-connector==1.1.0


### PR DESCRIPTION
## Proposed change

Bumps `tesla-powerwall` from 0.5.2 to 0.5.3.

0.5.3 adds `get_instantaneous_max_charge_power()` / `get_instantaneous_max_discharge_power()` ([jrester/tesla_powerwall#72](https://github.com/jrester/tesla_powerwall/pull/72)), which expose the instantaneous (BMS-derated) charge/discharge power limits from the `system_status` endpoint. Split out of #172971 (which adds the corresponding sensors) per review feedback.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #172971
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

Changelog / diff for the dependency: [`v0.5.2...v0.5.3`](https://github.com/jrester/tesla_powerwall/compare/v0.5.2...v0.5.3) · [release notes](https://github.com/jrester/tesla_powerwall/releases/tag/v0.5.3)

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
