### PR TITLE
Switch to active scanner for gardena

### DIFF
--- a/homeassistant/components/gardena_bluetooth/__init__.py
+++ b/homeassistant/components/gardena_bluetooth/__init__.py
@@ -11,7 +11,7 @@ from habluetooth import BluetoothServiceInfoBleak
 
 from homeassistant.components import bluetooth
 from homeassistant.const import CONF_ADDRESS, Platform
-from homeassistant.core import _LOGGER, HomeAssistant
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
 from .coordinator import (
@@ -42,7 +42,7 @@ async def async_get_product_type(hass: HomeAssistant, address: str) -> ProductTy
     data = ManufacturerData()
 
     def _data_callback(info: BluetoothServiceInfoBleak) -> bool:
-        _LOGGER.debug("Processing advertisement from %s: %s", info.address, info)
+        LOGGER.debug("Processing advertisement from %s: %s", info.address, info)
         if info.device.address != address:
             return False
 
@@ -65,7 +65,7 @@ async def async_get_products(hass: HomeAssistant) -> dict[str, ManufacturerData]
     products: dict[str, ManufacturerData] = {}
 
     def _data_callback(info: BluetoothServiceInfoBleak) -> bool:
-        _LOGGER.debug("Processing advertisement from %s: %s", info.address, info)
+        LOGGER.debug("Processing advertisement from %s: %s", info.address, info)
         if ScanService not in info.service_uuids:
             return False
 

--- a/homeassistant/components/gardena_bluetooth/__init__.py
+++ b/homeassistant/components/gardena_bluetooth/__init__.py
@@ -1,15 +1,17 @@
 """The Gardena Bluetooth integration."""
 
+from contextlib import suppress
 import logging
 
 from bleak.backends.device import BLEDevice
 from gardena_bluetooth.client import CachedConnection, Client
-from gardena_bluetooth.const import ProductType
-from gardena_bluetooth.scan import async_get_manufacturer_data
+from gardena_bluetooth.const import ScanService
+from gardena_bluetooth.parse import ManufacturerData, ProductType
+from habluetooth import BluetoothServiceInfoBleak
 
 from homeassistant.components import bluetooth
 from homeassistant.const import CONF_ADDRESS, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import _LOGGER, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
 from .coordinator import (
@@ -30,6 +32,60 @@ PLATFORMS: list[Platform] = [
 ]
 LOGGER = logging.getLogger(__name__)
 DISCONNECT_DELAY = 5
+PRODUCTS_SCAN_TIMEOUT = 10
+PRODUCT_TYPE_TIMEOUT = 30
+
+
+async def async_get_product_type(hass: HomeAssistant, address: str) -> ProductType:
+    """Get a product type for the given address."""
+
+    data = ManufacturerData()
+
+    def _data_callback(info: BluetoothServiceInfoBleak) -> bool:
+        _LOGGER.debug("Processing advertisement from %s: %s", info.address, info)
+        if info.device.address != address:
+            return False
+
+        data.update(info.manufacturer_data.get(ManufacturerData.company, b""))
+        return data.product_type is not ProductType.UNKNOWN
+
+    with suppress(TimeoutError):
+        await bluetooth.async_process_advertisements(
+            hass,
+            _data_callback,
+            {"address": address},
+            mode=bluetooth.BluetoothScanningMode.ACTIVE,
+            timeout=PRODUCT_TYPE_TIMEOUT,
+        )
+    return data.product_type
+
+
+async def async_get_products(hass: HomeAssistant) -> dict[str, ManufacturerData]:
+    """Get all products that are currently advertising."""
+    products: dict[str, ManufacturerData] = {}
+
+    def _data_callback(info: BluetoothServiceInfoBleak) -> bool:
+        _LOGGER.debug("Processing advertisement from %s: %s", info.address, info)
+        if ScanService not in info.service_uuids:
+            return False
+
+        raw = info.manufacturer_data.get(ManufacturerData.company, b"")
+        if (data := products.get(info.device.address)) is None:
+            data = ManufacturerData()
+            products[info.device.address] = data
+
+        data.update(raw)
+        return False
+
+    with suppress(TimeoutError):
+        await bluetooth.async_process_advertisements(
+            hass,
+            _data_callback,
+            {"manufacturer_id": ManufacturerData.company},
+            mode=bluetooth.BluetoothScanningMode.ACTIVE,
+            timeout=PRODUCTS_SCAN_TIMEOUT,
+        )
+    return products
 
 
 def get_connection(hass: HomeAssistant, address: str) -> CachedConnection:
@@ -53,12 +109,7 @@ async def async_setup_entry(
 
     address = entry.data[CONF_ADDRESS]
 
-    try:
-        mfg_data = await async_get_manufacturer_data({address})
-    except TimeoutError as exc:
-        raise ConfigEntryNotReady("Unable to find product type") from exc
-
-    product_type = mfg_data[address].product_type
+    product_type = await async_get_product_type(hass, address)
     if product_type is ProductType.UNKNOWN:
         raise ConfigEntryNotReady("Unable to find product type")
 

--- a/homeassistant/components/gardena_bluetooth/__init__.py
+++ b/homeassistant/components/gardena_bluetooth/__init__.py
@@ -53,7 +53,9 @@ async def async_get_product_type(hass: HomeAssistant, address: str) -> ProductTy
         await bluetooth.async_process_advertisements(
             hass,
             _data_callback,
-            {"address": address},
+            bluetooth.BluetoothCallbackMatcher(
+                address=address, manufacturer_id=ManufacturerData.company
+            ),
             mode=bluetooth.BluetoothScanningMode.ACTIVE,
             timeout=PRODUCT_TYPE_TIMEOUT,
         )
@@ -81,7 +83,9 @@ async def async_get_products(hass: HomeAssistant) -> dict[str, ManufacturerData]
         await bluetooth.async_process_advertisements(
             hass,
             _data_callback,
-            {"manufacturer_id": ManufacturerData.company},
+            bluetooth.BluetoothCallbackMatcher(
+                manufacturer_id=ManufacturerData.company
+            ),
             mode=bluetooth.BluetoothScanningMode.ACTIVE,
             timeout=PRODUCTS_SCAN_TIMEOUT,
         )

--- a/homeassistant/components/gardena_bluetooth/config_flow.py
+++ b/homeassistant/components/gardena_bluetooth/config_flow.py
@@ -4,21 +4,17 @@ import logging
 from typing import Any
 
 from gardena_bluetooth.client import Client
-from gardena_bluetooth.const import PRODUCT_NAMES, DeviceInformation, ScanService
+from gardena_bluetooth.const import PRODUCT_NAMES, DeviceInformation
 from gardena_bluetooth.exceptions import CharacteristicNotFound, CommunicationFailure
-from gardena_bluetooth.parse import ManufacturerData, ProductType
-from gardena_bluetooth.scan import async_get_manufacturer_data
+from gardena_bluetooth.parse import ProductType
 import voluptuous as vol
 
-from homeassistant.components.bluetooth import (
-    BluetoothServiceInfo,
-    async_discovered_service_info,
-)
+from homeassistant.components.bluetooth import BluetoothServiceInfo
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_ADDRESS
 from homeassistant.data_entry_flow import AbortFlow
 
-from . import get_connection
+from . import async_get_product_type, async_get_products, get_connection
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,17 +27,6 @@ _SUPPORTED_PRODUCT_TYPES = {
     ProductType.PRESSURE_TANKS,
     ProductType.AQUA_CONTOURS,
 }
-
-
-def _is_supported(discovery_info: BluetoothServiceInfo):
-    """Check if device is supported."""
-    if ScanService not in discovery_info.service_uuids:
-        return False
-
-    if discovery_info.manufacturer_data.get(ManufacturerData.company) is None:
-        _LOGGER.debug("Missing manufacturer data: %s", discovery_info)
-        return False
-    return True
 
 
 class GardenaBluetoothConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -75,8 +60,7 @@ class GardenaBluetoothConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle the bluetooth discovery step."""
         _LOGGER.debug("Discovered device: %s", discovery_info)
-        data = await async_get_manufacturer_data({discovery_info.address})
-        product_type = data[discovery_info.address].product_type
+        product_type = await async_get_product_type(self.hass, discovery_info.address)
         if product_type not in _SUPPORTED_PRODUCT_TYPES:
             return self.async_abort(reason="no_devices_found")
 
@@ -117,22 +101,16 @@ class GardenaBluetoothConfigFlow(ConfigFlow, domain=DOMAIN):
             self._abort_if_unique_id_configured()
             return await self.async_step_confirm()
 
-        current_addresses = self._async_current_ids(include_ignore=False)
-        candidates = set()
-        for discovery_info in async_discovered_service_info(self.hass):
-            address = discovery_info.address
-            if address in current_addresses or not _is_supported(discovery_info):
-                continue
-            candidates.add(address)
-
-        data = await async_get_manufacturer_data(candidates)
-        for address, mfg_data in data.items():
-            if mfg_data.product_type not in _SUPPORTED_PRODUCT_TYPES:
-                continue
-            self.devices[address] = PRODUCT_NAMES[mfg_data.product_type]
+        current = self._async_current_ids(include_ignore=False)
+        devices = await async_get_products(self.hass)
 
         # Keep selection sorted by address to ensure stable tests
-        self.devices = dict(sorted(self.devices.items(), key=lambda x: x[0]))
+        self.devices = {
+            address: PRODUCT_NAMES[data.product_type]
+            for address in sorted(devices)
+            if address not in current
+            and (data := devices[address]).product_type in _SUPPORTED_PRODUCT_TYPES
+        }
 
         if not self.devices:
             return self.async_abort(reason="no_devices_found")

--- a/tests/components/gardena_bluetooth/__init__.py
+++ b/tests/components/gardena_bluetooth/__init__.py
@@ -1,7 +1,10 @@
 """Tests for the Gardena Bluetooth integration."""
 
+from collections.abc import Generator
+from contextlib import contextmanager
 from unittest.mock import patch
 
+from homeassistant.components import bluetooth
 from homeassistant.components.gardena_bluetooth.const import DOMAIN
 from homeassistant.const import CONF_ADDRESS, Platform
 from homeassistant.core import HomeAssistant
@@ -120,3 +123,29 @@ async def setup_entry(
         await hass.async_block_till_done()
 
     return mock_entry
+
+
+@contextmanager
+def constant_advertisements() -> Generator[None]:
+    """Run time will executing co-routine."""
+
+    async def _advertisements(
+        hass: HomeAssistant,
+        callback: bluetooth.models.ProcessAdvertisementCallback,
+        match_dict: bluetooth.match.BluetoothCallbackMatcher,
+        mode: bluetooth.BluetoothScanningMode,
+        timeout: int,
+    ) -> bluetooth.BluetoothServiceInfoBleak:
+
+        last = None
+        for advertisement in bluetooth.async_discovered_service_info(hass):
+            callback(advertisement)
+            last = advertisement
+        if not last:
+            raise TimeoutError
+        return last
+
+    with (
+        patch.object(bluetooth, "async_process_advertisements", new=_advertisements),
+    ):
+        yield

--- a/tests/components/gardena_bluetooth/__init__.py
+++ b/tests/components/gardena_bluetooth/__init__.py
@@ -1,10 +1,7 @@
 """Tests for the Gardena Bluetooth integration."""
 
-from collections.abc import Generator
-from contextlib import contextmanager
 from unittest.mock import patch
 
-from homeassistant.components import bluetooth
 from homeassistant.components.gardena_bluetooth.const import DOMAIN
 from homeassistant.const import CONF_ADDRESS, Platform
 from homeassistant.core import HomeAssistant
@@ -123,29 +120,3 @@ async def setup_entry(
         await hass.async_block_till_done()
 
     return mock_entry
-
-
-@contextmanager
-def constant_advertisements() -> Generator[None]:
-    """Run time will executing co-routine."""
-
-    async def _advertisements(
-        hass: HomeAssistant,
-        callback: bluetooth.models.ProcessAdvertisementCallback,
-        match_dict: bluetooth.match.BluetoothCallbackMatcher,
-        mode: bluetooth.BluetoothScanningMode,
-        timeout: int,
-    ) -> bluetooth.BluetoothServiceInfoBleak:
-
-        last = None
-        for advertisement in bluetooth.async_discovered_service_info(hass):
-            callback(advertisement)
-            last = advertisement
-        if not last:
-            raise TimeoutError
-        return last
-
-    with (
-        patch.object(bluetooth, "async_process_advertisements", new=_advertisements),
-    ):
-        yield

--- a/tests/components/gardena_bluetooth/conftest.py
+++ b/tests/components/gardena_bluetooth/conftest.py
@@ -203,13 +203,6 @@ def get_product_type_event() -> Generator[asyncio.Event]:
 def constant_advertisements(request: pytest.FixtureRequest) -> Generator[None]:
     """Ensure async_process_advertisements only return a constant list."""
 
-    constant_advertisements = (
-        request.node.get_closest_marker("constant_advertisements") is not None
-    )
-    if constant_advertisements:
-        yield
-        return
-
     async def _advertisements(
         hass: HomeAssistant,
         callback: bluetooth.models.ProcessAdvertisementCallback,

--- a/tests/components/gardena_bluetooth/conftest.py
+++ b/tests/components/gardena_bluetooth/conftest.py
@@ -200,7 +200,7 @@ def get_product_type_event() -> Generator[asyncio.Event]:
 
 
 @pytest.fixture
-def constant_advertisements(request: pytest.FixtureRequest) -> Generator[None]:
+def constant_advertisements() -> Generator[None]:
     """Ensure async_process_advertisements only return a constant list."""
 
     async def _advertisements(

--- a/tests/components/gardena_bluetooth/conftest.py
+++ b/tests/components/gardena_bluetooth/conftest.py
@@ -178,7 +178,7 @@ def enable_all_entities(entity_registry_enabled_by_default: None) -> None:
 
 @pytest.fixture
 def get_product_type_event() -> Generator[asyncio.Event]:
-    """Track manufacturer data requests with an event."""
+    """Track product type data requests with an event."""
 
     event = asyncio.Event()
 

--- a/tests/components/gardena_bluetooth/conftest.py
+++ b/tests/components/gardena_bluetooth/conftest.py
@@ -11,11 +11,10 @@ from gardena_bluetooth.client import Client
 from gardena_bluetooth.const import DeviceInformation
 from gardena_bluetooth.exceptions import CharacteristicNotFound
 from gardena_bluetooth.parse import Characteristic, Service
-from gardena_bluetooth.scan import (
-    async_get_manufacturer_data as _async_get_manufacturer_data,
-)
 import pytest
 
+from homeassistant.components import bluetooth
+from homeassistant.components.gardena_bluetooth import async_get_product_type
 from homeassistant.components.gardena_bluetooth.const import DOMAIN
 from homeassistant.components.gardena_bluetooth.coordinator import SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
@@ -178,23 +177,56 @@ def enable_all_entities(entity_registry_enabled_by_default: None) -> None:
 
 
 @pytest.fixture
-def manufacturer_request_event() -> Generator[asyncio.Event]:
+def get_product_type_event() -> Generator[asyncio.Event]:
     """Track manufacturer data requests with an event."""
 
     event = asyncio.Event()
 
     async def _get(*args, **kwargs):
         event.set()
-        return await _async_get_manufacturer_data(*args, **kwargs)
+        return await async_get_product_type(*args, **kwargs)
 
     with (
         patch(
-            "homeassistant.components.gardena_bluetooth.async_get_manufacturer_data",
+            "homeassistant.components.gardena_bluetooth.async_get_product_type",
             wraps=_get,
         ),
         patch(
-            "homeassistant.components.gardena_bluetooth.config_flow.async_get_manufacturer_data",
+            "homeassistant.components.gardena_bluetooth.config_flow.async_get_product_type",
             wraps=_get,
         ),
     ):
         yield event
+
+
+@pytest.fixture
+def constant_advertisements(request: pytest.FixtureRequest) -> Generator[None]:
+    """Ensure async_process_advertisements only return a constant list."""
+
+    constant_advertisements = (
+        request.node.get_closest_marker("constant_advertisements") is not None
+    )
+    if constant_advertisements:
+        yield
+        return
+
+    async def _advertisements(
+        hass: HomeAssistant,
+        callback: bluetooth.models.ProcessAdvertisementCallback,
+        match_dict: bluetooth.match.BluetoothCallbackMatcher,
+        mode: bluetooth.BluetoothScanningMode,
+        timeout: int,
+    ) -> bluetooth.BluetoothServiceInfoBleak:
+
+        last = None
+        for advertisement in bluetooth.async_discovered_service_info(hass):
+            callback(advertisement)
+            last = advertisement
+        if not last:
+            raise TimeoutError
+        return last
+
+    with (
+        patch.object(bluetooth, "async_process_advertisements", new=_advertisements),
+    ):
+        yield

--- a/tests/components/gardena_bluetooth/test_config_flow.py
+++ b/tests/components/gardena_bluetooth/test_config_flow.py
@@ -1,7 +1,5 @@
 """Test the Gardena Bluetooth config flow."""
 
-import asyncio
-from collections.abc import Awaitable, Callable
 from unittest.mock import Mock
 
 from gardena_bluetooth.exceptions import CharacteristicNotFound
@@ -26,13 +24,10 @@ from . import (
 from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
 
-pytestmark = pytest.mark.usefixtures("mock_setup_entry")
+pytestmark = pytest.mark.usefixtures("mock_setup_entry", "constant_advertisements")
 
 
-async def test_user_selection(
-    hass: HomeAssistant,
-    snapshot: SnapshotAssertion,
-) -> None:
+async def test_user_selection(hass: HomeAssistant, snapshot: SnapshotAssertion) -> None:
     """Test we can select a device."""
 
     inject_bluetooth_service_info(hass, WATER_TIMER_SERVICE_INFO)
@@ -138,9 +133,6 @@ async def test_no_valid_devices(
 
 async def test_timeout_manufacturer_data(
     hass: HomeAssistant,
-    snapshot: SnapshotAssertion,
-    scan_step: Callable[[], Awaitable[None]],
-    manufacturer_request_event: asyncio.Event,
 ) -> None:
     """Test the flow aborts with no_devices_found.
 
@@ -149,24 +141,9 @@ async def test_timeout_manufacturer_data(
     """
 
     inject_bluetooth_service_info(hass, MISSING_PRODUCT_SERVICE_INFO)
-
-    # The injected advertisement starts a bluetooth discovery flow which also
-    # calls async_get_manufacturer_data. Drain it first so it doesn't race
-    # with the user flow's own request.
-    await manufacturer_request_event.wait()
-    await scan_step()
-    await hass.async_block_till_done(wait_background_tasks=True)
-    manufacturer_request_event.clear()
-
-    async with asyncio.TaskGroup() as tg:
-        task = tg.create_task(
-            hass.config_entries.flow.async_init(
-                DOMAIN, context={"source": config_entries.SOURCE_USER}
-            )
-        )
-        await manufacturer_request_event.wait()
-        await scan_step()
-        result = await task
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
 
     assert result.get("type") == "abort"
     assert result.get("reason") == "no_devices_found"

--- a/tests/components/gardena_bluetooth/test_init.py
+++ b/tests/components/gardena_bluetooth/test_init.py
@@ -72,6 +72,7 @@ from tests.components.bluetooth import inject_bluetooth_service_info
         ),
     ],
 )
+@pytest.mark.usefixtures("constant_advertisements")
 async def test_setup(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
@@ -99,7 +100,7 @@ async def test_setup_delayed_product(
     device_registry: dr.DeviceRegistry,
     mock_entry: MockConfigEntry,
     mock_read_char_raw: dict[str, bytes],
-    manufacturer_request_event: asyncio.Event,
+    get_product_type_event: asyncio.Event,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test setup creates expected devices."""
@@ -107,15 +108,16 @@ async def test_setup_delayed_product(
     mock_read_char_raw[Battery.battery_level.uuid] = Battery.battery_level.encode(100)
 
     mock_entry.add_to_hass(hass)
+    await hass.async_block_till_done()
 
-    manufacturer_request_event.clear()
+    get_product_type_event.clear()
 
     async with asyncio.TaskGroup() as tg:
         setup_task = tg.create_task(
             hass.config_entries.async_setup(mock_entry.entry_id)
         )
 
-        await manufacturer_request_event.wait()
+        await get_product_type_event.wait()
         assert mock_entry.state is ConfigEntryState.SETUP_IN_PROGRESS
         inject_bluetooth_service_info(hass, MISSING_MANUFACTURER_DATA_SERVICE_INFO)
         inject_bluetooth_service_info(hass, WATER_TIMER_SERVICE_INFO)
@@ -123,6 +125,7 @@ async def test_setup_delayed_product(
         assert await setup_task is True
 
 
+@pytest.mark.usefixtures("constant_advertisements")
 async def test_setup_retry(
     hass: HomeAssistant, mock_entry: MockConfigEntry, mock_client: Mock
 ) -> None:

--- a/tests/components/gardena_bluetooth/test_number.py
+++ b/tests/components/gardena_bluetooth/test_number.py
@@ -26,6 +26,8 @@ from . import AQUA_CONTOUR_SERVICE_INFO, WATER_TIMER_SERVICE_INFO, setup_entry
 
 from tests.common import MockConfigEntry
 
+pytestmark = pytest.mark.usefixtures("constant_advertisements")
+
 
 @pytest.mark.parametrize(
     ("service_info", "uuid", "raw", "entity_id"),

--- a/tests/components/gardena_bluetooth/test_select.py
+++ b/tests/components/gardena_bluetooth/test_select.py
@@ -25,6 +25,8 @@ from . import AQUA_CONTOUR_SERVICE_INFO, setup_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
+pytestmark = pytest.mark.usefixtures("constant_advertisements")
+
 
 @pytest.fixture
 def mock_chars(mock_read_char_raw):

--- a/tests/components/gardena_bluetooth/test_sensor.py
+++ b/tests/components/gardena_bluetooth/test_sensor.py
@@ -27,6 +27,8 @@ from . import AQUA_CONTOUR_SERVICE_INFO, WATER_TIMER_SERVICE_INFO, setup_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
+pytestmark = pytest.mark.usefixtures("constant_advertisements")
+
 
 @pytest.mark.parametrize(
     ("service_info", "uuid", "raw", "entity_id"),

--- a/tests/components/gardena_bluetooth/test_switch.py
+++ b/tests/components/gardena_bluetooth/test_switch.py
@@ -20,6 +20,8 @@ from . import setup_entry
 
 from tests.common import MockConfigEntry
 
+pytestmark = pytest.mark.usefixtures("constant_advertisements")
+
 
 @pytest.fixture
 def mock_switch_chars(mock_read_char_raw):

--- a/tests/components/gardena_bluetooth/test_text.py
+++ b/tests/components/gardena_bluetooth/test_text.py
@@ -20,6 +20,8 @@ from . import AQUA_CONTOUR_SERVICE_INFO, setup_entry
 
 from tests.common import snapshot_platform
 
+pytestmark = pytest.mark.usefixtures("constant_advertisements")
+
 
 @pytest.mark.parametrize(
     ("service_info", "raw"),

--- a/tests/components/gardena_bluetooth/test_valve.py
+++ b/tests/components/gardena_bluetooth/test_valve.py
@@ -20,6 +20,8 @@ from . import setup_entry
 
 from tests.common import MockConfigEntry
 
+pytestmark = pytest.mark.usefixtures("constant_advertisements")
+
 
 @pytest.fixture
 def mock_switch_chars(mock_read_char_raw):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Switch to HA scanner to ensure we get an active scanner when scanning gardena devices. After the recent bluetooth changes to reduce ACTIVE scan usage. The integration could not find the product type of devices on startup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes  #173209
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
