### PR TITLE
Add Bluetooth connection to Aranet devices

### DIFF
--- a/homeassistant/components/aranet/sensor.py
+++ b/homeassistant/components/aranet/sensor.py
@@ -31,7 +31,7 @@ from homeassistant.const import (
     UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -144,7 +144,11 @@ def _sensor_device_info_to_hass(
     adv: Aranet4Advertisement,
 ) -> DeviceInfo:
     """Convert a sensor device info to hass device info."""
-    hass_device_info = DeviceInfo({})
+    # Tie the device to its Bluetooth address so the address shows on the device
+    # page and other integrations referencing the same device attach to it.
+    hass_device_info = DeviceInfo(
+        connections={(CONNECTION_BLUETOOTH, adv.device.address)}
+    )
     if adv.readings and adv.readings.name:
         hass_device_info[ATTR_NAME] = adv.readings.name
         hass_device_info[ATTR_MANUFACTURER] = ARANET_MANUFACTURER_NAME

--- a/homeassistant/components/aranet/sensor.py
+++ b/homeassistant/components/aranet/sensor.py
@@ -144,8 +144,6 @@ def _sensor_device_info_to_hass(
     adv: Aranet4Advertisement,
 ) -> DeviceInfo:
     """Convert a sensor device info to hass device info."""
-    # Tie the device to its Bluetooth address so the address shows on the device
-    # page and other integrations referencing the same device attach to it.
     hass_device_info = DeviceInfo(
         connections={(CONNECTION_BLUETOOTH, adv.device.address)}
     )

--- a/tests/components/aranet/test_sensor.py
+++ b/tests/components/aranet/test_sensor.py
@@ -85,6 +85,7 @@ async def test_sensors_aranet_radiation(
     assert device.model == "Aranet Radiation"
     assert device.sw_version == "v1.4.38"
     assert device.manufacturer == "SAF Tehnika"
+    assert device.connections == {(dr.CONNECTION_BLUETOOTH, "aa:bb:cc:dd:ee:ff")}
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
@@ -146,6 +147,7 @@ async def test_sensors_aranet2(
     assert device.model == "Aranet2"
     assert device.sw_version == "v1.4.4"
     assert device.manufacturer == "SAF Tehnika"
+    assert device.connections == {(dr.CONNECTION_BLUETOOTH, "aa:bb:cc:dd:ee:ff")}
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
@@ -227,6 +229,7 @@ async def test_sensors_aranet4(
     assert device.model == "Aranet4"
     assert device.sw_version == "v1.2.0"
     assert device.manufacturer == "SAF Tehnika"
+    assert device.connections == {(dr.CONNECTION_BLUETOOTH, "aa:bb:cc:dd:ee:ff")}
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
@@ -310,6 +313,7 @@ async def test_sensors_aranetrn(
     assert device.model == "Aranet Radon"
     assert device.sw_version == "v1.6.4"
     assert device.manufacturer == "SAF Tehnika"
+    assert device.connections == {(dr.CONNECTION_BLUETOOTH, "aa:bb:cc:dd:ee:ff")}
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Register the device with its Bluetooth address as a connection so the address is
shown on the device page and other integrations can attach to the same device.

Aranet devices were registered without any device `connections`, so Home
Assistant did not display the device's Bluetooth address, and other integrations
that key off the Bluetooth connection could not attach to the same device entry, so
they ended up creating a separate device for the same physical sensor. Adding the
`CONNECTION_BLUETOOTH` connection fixes both: the address now shows on the device
page, and integrations referencing the same Bluetooth device link to it instead
of producing a duplicate.

Please re-classify it as a Bugfix if deemed appropriate (as one could argue that Bluetooth devices should always have a Bluetooth connection).

Tested on real hardware with every supported Aranet device type except Aranet2:
Aranet4, Aranet Radon, and Aranet Radiation. The added unit tests cover all four
types, including Aranet2.

Below, Aranet4, Aranet Radon, and Aranet Radiation device pages with the change applied. The Bluetooth address is now shown in Device info, and a second integration (Bermuda BLE Trilateration, third-party) attaches to the same device via the new connection instead of creating a duplicate.

<img width="660" height="392" alt="Aranet4" src="https://github.com/user-attachments/assets/3cc597b0-1a28-4520-90ca-e65c98cf73ee" />

<img width="660" height="400" alt="Aranet Radiation" src="https://github.com/user-attachments/assets/c4a4c8ed-7420-41da-b6ec-640dd3fa3565" />

<img width="666" height="391" alt="Aranet Radon" src="https://github.com/user-attachments/assets/10bc4272-2d58-45f7-aafc-c47abddbabfa" />

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
