### PR TITLE
Add off operation_mode to SYSTEM_BOILER in LG ThinQ

### DIFF
--- a/homeassistant/components/lg_thinq/water_heater.py
+++ b/homeassistant/components/lg_thinq/water_heater.py
@@ -40,7 +40,6 @@ DEVICE_OP_MODE_TO_HA = {
     "auto": STATE_ECO,
     "heat_pump": STATE_HEAT_PUMP,
     "turbo": STATE_PERFORMANCE,
-    "vacation": STATE_OFF,
 }
 HA_STATE_TO_DEVICE_OP_MODE = {v: k for k, v in DEVICE_OP_MODE_TO_HA.items()}
 
@@ -96,8 +95,6 @@ class ThinQWaterHeaterEntity(ThinQEntity, WaterHeaterEntity):
             self._attr_operation_list = [
                 DEVICE_OP_MODE_TO_HA.get(mode, mode) for mode in modes
             ]
-        else:
-            self._attr_operation_list = [STATE_HEAT_PUMP]
 
     def _update_status(self) -> None:
         """Update status itself."""
@@ -183,6 +180,8 @@ class ThinQWaterBoilerEntity(ThinQWaterHeaterEntity):
         """Initialize a water_heater entity."""
         super().__init__(coordinator, entity_description, property_id)
         self._attr_supported_features |= WaterHeaterEntityFeature.ON_OFF
+        # For SYSTEM_BOILER, we only support heat pump mode and off mode.
+        self._attr_operation_list = [STATE_HEAT_PUMP, STATE_OFF]
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
@@ -197,3 +196,16 @@ class ThinQWaterBoilerEntity(ThinQWaterHeaterEntity):
             "[%s:%s] async_turn_off", self.coordinator.device_name, self.property_id
         )
         await self.async_call_api(self.coordinator.api.async_turn_off(self.property_id))
+
+    async def async_set_operation_mode(self, operation_mode: str) -> None:
+        """Set new operation mode."""
+        _LOGGER.debug(
+            "[%s:%s] async_set_operation_mode: %s",
+            self.coordinator.device_name,
+            self.property_id,
+            operation_mode,
+        )
+        if operation_mode == STATE_OFF:
+            await self.async_turn_off()
+        else:
+            await self.async_turn_on()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
"Add an 'Off' function to power down the device without the switch."


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #169535
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
