### PR TITLE
Add network MAC connection to AirVisual Pro devices

### DIFF
--- a/homeassistant/components/airvisual_pro/entity.py
+++ b/homeassistant/components/airvisual_pro/entity.py
@@ -1,6 +1,10 @@
 """The AirVisual Pro integration."""
 
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import (
+    CONNECTION_NETWORK_MAC,
+    DeviceInfo,
+    format_mac,
+)
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -25,6 +29,12 @@ class AirVisualProEntity(CoordinatorEntity[AirVisualProCoordinator]):
         """Return device registry information for this entity."""
         return DeviceInfo(
             identifiers={(DOMAIN, self.coordinator.data["serial_number"])},
+            connections={
+                (
+                    CONNECTION_NETWORK_MAC,
+                    format_mac(self.coordinator.data["status"]["mac_address"]),
+                )
+            },
             manufacturer="AirVisual",
             model=self.coordinator.data["status"]["model"],
             name=self.coordinator.data["settings"]["node_name"],

--- a/tests/components/airvisual_pro/snapshots/test_init.ambr
+++ b/tests/components/airvisual_pro/snapshots/test_init.ambr
@@ -1,0 +1,36 @@
+# serializer version: 1
+# name: test_device_registry
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        '12:34:56:78:90:ab',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': 'KBG63F84',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'airvisual_pro',
+        'XXXXXXX',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'AirVisual',
+    'model': '20',
+    'model_id': None,
+    'name': 'Office',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'sw_version': '1.1826',
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/airvisual_pro/test_init.py
+++ b/tests/components/airvisual_pro/test_init.py
@@ -2,29 +2,26 @@
 
 from unittest.mock import Mock, patch
 
-from homeassistant.config_entries import ConfigEntryState
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.airvisual_pro.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry
 
 
-async def test_device_registry_connection(
+async def test_device_registry(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     pro: Mock,
+    device_registry: dr.DeviceRegistry,
+    snapshot: SnapshotAssertion,
 ) -> None:
-    """Test the device is registered with its MAC address as a network connection."""
+    """Test the device registry entry, including the network MAC connection."""
     with patch("homeassistant.components.airvisual_pro.NodeSamba", return_value=pro):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state is ConfigEntryState.LOADED
-
-    device_registry = dr.async_get(hass)
-    devices = dr.async_entries_for_config_entry(device_registry, config_entry.entry_id)
-    assert len(devices) == 1
-    assert (
-        dr.CONNECTION_NETWORK_MAC,
-        "12:34:56:78:90:ab",
-    ) in devices[0].connections
+    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "XXXXXXX")})
+    assert device_entry == snapshot

--- a/tests/components/airvisual_pro/test_init.py
+++ b/tests/components/airvisual_pro/test_init.py
@@ -1,0 +1,30 @@
+"""Test AirVisual Pro setup."""
+
+from unittest.mock import Mock, patch
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from tests.common import MockConfigEntry
+
+
+async def test_device_registry_connection(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    pro: Mock,
+) -> None:
+    """Test the device is registered with its MAC address as a network connection."""
+    with patch("homeassistant.components.airvisual_pro.NodeSamba", return_value=pro):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    device_registry = dr.async_get(hass)
+    devices = dr.async_entries_for_config_entry(device_registry, config_entry.entry_id)
+    assert len(devices) == 1
+    assert (
+        dr.CONNECTION_NETWORK_MAC,
+        "12:34:56:78:90:ab",
+    ) in devices[0].connections


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Register the AirVisual Pro device with its network MAC address as a connection so
the address is shown on the device page and other integrations can attach to the
same device.

The AirVisual Pro reports its MAC address (`status.mac_address`), but the
integration registered the device without any `connections`, so Home Assistant
did not display the device's MAC address, and integrations that key off the
network MAC ended up creating a separate device for the same physical unit.
Adding the `CONNECTION_NETWORK_MAC` connection fixes both: the address now shows
on the device page, and integrations referencing the same network device link to
it instead of producing a duplicate.

Please re-classify it as a Bugfix if deemed appropriate (one could argue a
network device should always carry its network MAC connection).

Tested on real hardware with four AirVisual Pro units. The MAC address is now
shown in Device info, and the UniFi Network integration's client device attaches
to the same device via the new connection instead of remaining a separate entry.
The added unit test verifies the connection is registered.

Before:
<img width="326" height="303" alt="Before" src="https://github.com/user-attachments/assets/fb41b98a-305b-4d7f-8f9f-96bdb1f05782" />

After:
<img width="322" height="385" alt="After" src="https://github.com/user-attachments/assets/cc052d17-b5a8-452f-888c-e66cc24affaa" />

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
