### PR TITLE
Teach legacy zone condition and trigger about in_zones state attribute

### DIFF
--- a/homeassistant/components/zone/condition.py
+++ b/homeassistant/components/zone/condition.py
@@ -80,6 +80,11 @@ def zone(
     ):
         return False
 
+    # Prefer the in_zones attribute reported by the entity (e.g. person,
+    # device_tracker) over recomputing membership from coordinates.
+    if (in_zones := entity.attributes.get(ATTR_IN_ZONES)) is not None:
+        return zone_ent.entity_id in in_zones
+
     latitude = entity.attributes.get(ATTR_LATITUDE)
     longitude = entity.attributes.get(ATTR_LONGITUDE)
 

--- a/homeassistant/components/zone/condition.py
+++ b/homeassistant/components/zone/condition.py
@@ -4,7 +4,11 @@ from typing import Any, Unpack, cast
 
 import voluptuous as vol
 
-from homeassistant.components.device_tracker import ATTR_IN_ZONES
+from homeassistant.components.device_tracker import (
+    ATTR_IN_ZONES,
+    DOMAIN as DEVICE_TRACKER_DOMAIN,
+)
+from homeassistant.components.person import DOMAIN as PERSON_DOMAIN
 from homeassistant.const import (
     ATTR_GPS_ACCURACY,
     ATTR_LATITUDE,
@@ -44,6 +48,8 @@ _OPTIONS_SCHEMA_DICT: dict[vol.Marker, Any] = {
 }
 _CONDITION_SCHEMA = vol.Schema({CONF_OPTIONS: _OPTIONS_SCHEMA_DICT})
 
+_IN_ZONES_DOMAINS = {DEVICE_TRACKER_DOMAIN, PERSON_DOMAIN}
+
 
 def zone(
     hass: HomeAssistant,
@@ -82,7 +88,10 @@ def zone(
 
     # Prefer the in_zones attribute reported by the entity (e.g. person,
     # device_tracker) over recomputing membership from coordinates.
-    if (in_zones := entity.attributes.get(ATTR_IN_ZONES)) is not None:
+    if (
+        entity.domain in _IN_ZONES_DOMAINS
+        and (in_zones := entity.attributes.get(ATTR_IN_ZONES)) is not None
+    ):
         return zone_ent.entity_id in in_zones
 
     latitude = entity.attributes.get(ATTR_LATITUDE)

--- a/homeassistant/components/zone/trigger.py
+++ b/homeassistant/components/zone/trigger.py
@@ -43,6 +43,7 @@ from homeassistant.helpers.trigger import (
 from homeassistant.helpers.typing import ConfigType
 
 from . import condition
+from .condition import _IN_ZONES_DOMAINS
 from .const import DOMAIN
 
 EVENT_ENTER = "enter"
@@ -57,10 +58,13 @@ _EVENT_DESCRIPTION = {EVENT_ENTER: "entering", EVENT_LEAVE: "leaving"}
 def _state_has_zone_info(state: State) -> bool:
     """Return True if the state can be matched against a zone.
 
-    An ``in_zones`` attribute (e.g. from a scanner-based tracker) is sufficient
-    even when the state has no coordinates.
+    For device_tracker and person entities an ``in_zones`` attribute is
+    sufficient even when the state has no coordinates (e.g. a scanner-based
+    tracker); other entities are matched by their coordinates.
     """
-    return ATTR_IN_ZONES in state.attributes or location.has_location(state)
+    return location.has_location(state) or (
+        state.domain in _IN_ZONES_DOMAINS and ATTR_IN_ZONES in state.attributes
+    )
 
 
 _LEGACY_OPTIONS_SCHEMA: dict[vol.Marker, Any] = {

--- a/homeassistant/components/zone/trigger.py
+++ b/homeassistant/components/zone/trigger.py
@@ -53,6 +53,16 @@ _LOGGER = logging.getLogger(__name__)
 
 _EVENT_DESCRIPTION = {EVENT_ENTER: "entering", EVENT_LEAVE: "leaving"}
 
+
+def _state_has_zone_info(state: State) -> bool:
+    """Return True if the state can be matched against a zone.
+
+    An ``in_zones`` attribute (e.g. from a scanner-based tracker) is sufficient
+    even when the state has no coordinates.
+    """
+    return ATTR_IN_ZONES in state.attributes or location.has_location(state)
+
+
 _LEGACY_OPTIONS_SCHEMA: dict[vol.Marker, Any] = {
     vol.Required(CONF_ENTITY_ID): cv.entity_ids_or_uuids,
     vol.Required(CONF_ZONE): cv.entity_id,
@@ -127,8 +137,8 @@ class LegacyZoneTrigger(Trigger):
             from_s = zone_event.data["old_state"]
             to_s = zone_event.data["new_state"]
 
-            if (from_s and not location.has_location(from_s)) or (
-                to_s and not location.has_location(to_s)
+            if (from_s and not _state_has_zone_info(from_s)) or (
+                to_s and not _state_has_zone_info(to_s)
             ):
                 return
 

--- a/tests/components/zone/test_condition.py
+++ b/tests/components/zone/test_condition.py
@@ -225,14 +225,14 @@ async def test_multiple_zones(hass: HomeAssistant) -> None:
     assert not test.async_check()
 
 
+@pytest.mark.parametrize("entity_id", ["device_tracker.cat", "person.bob"])
 async def test_zone_condition_prefers_in_zones_over_coordinates(
-    hass: HomeAssistant,
+    hass: HomeAssistant, entity_id: str
 ) -> None:
     """Test the legacy zone condition prefers in_zones over coordinates.
 
-    When the entity reports an ``in_zones`` attribute it is authoritative;
-    coordinates are only consulted as a fallback for entities that don't
-    report it.
+    For device_tracker and person entities the ``in_zones`` attribute is
+    authoritative; coordinates are only consulted as a fallback.
     """
     hass.states.async_set(
         "zone.home",
@@ -242,27 +242,58 @@ async def test_zone_condition_prefers_in_zones_over_coordinates(
 
     # in_zones lists the zone but the coordinates are far away -> in_zones wins.
     hass.states.async_set(
-        "device_tracker.person",
+        entity_id,
         "home",
         {"latitude": 50.0, "longitude": 50.0, "in_zones": ["zone.home"]},
     )
-    assert zone_condition.zone(hass, "zone.home", "device_tracker.person") is True
+    assert zone_condition.zone(hass, "zone.home", entity_id) is True
 
     # in_zones is empty but the coordinates are inside the zone -> in_zones wins.
     hass.states.async_set(
-        "device_tracker.person",
+        entity_id,
         "not_home",
         {"latitude": 2.1, "longitude": 1.1, "in_zones": []},
     )
-    assert zone_condition.zone(hass, "zone.home", "device_tracker.person") is False
+    assert zone_condition.zone(hass, "zone.home", entity_id) is False
 
     # in_zones lists a different zone -> not in the target zone.
     hass.states.async_set(
-        "device_tracker.person",
+        entity_id,
         "work",
         {"latitude": 2.1, "longitude": 1.1, "in_zones": ["zone.work"]},
     )
-    assert zone_condition.zone(hass, "zone.home", "device_tracker.person") is False
+    assert zone_condition.zone(hass, "zone.home", entity_id) is False
+
+
+async def test_zone_condition_ignores_in_zones_for_other_domains(
+    hass: HomeAssistant,
+) -> None:
+    """Test in_zones is only honored for device_tracker and person entities.
+
+    An entity in another domain that exposes an ``in_zones`` attribute is
+    matched by coordinates instead.
+    """
+    hass.states.async_set(
+        "zone.home",
+        "zoning",
+        {"name": "home", "latitude": 2.1, "longitude": 1.1, "radius": 10},
+    )
+
+    # in_zones claims the zone but the coordinates are far away -> coordinates win.
+    hass.states.async_set(
+        "sensor.tracker",
+        "home",
+        {"latitude": 50.0, "longitude": 50.0, "in_zones": ["zone.home"]},
+    )
+    assert zone_condition.zone(hass, "zone.home", "sensor.tracker") is False
+
+    # in_zones is empty but the coordinates are inside the zone -> coordinates win.
+    hass.states.async_set(
+        "sensor.tracker",
+        "home",
+        {"latitude": 2.1, "longitude": 1.1, "in_zones": []},
+    )
+    assert zone_condition.zone(hass, "zone.home", "sensor.tracker") is True
 
 
 async def test_zone_condition_falls_back_to_coordinates(hass: HomeAssistant) -> None:

--- a/tests/components/zone/test_condition.py
+++ b/tests/components/zone/test_condition.py
@@ -225,6 +225,74 @@ async def test_multiple_zones(hass: HomeAssistant) -> None:
     assert not test.async_check()
 
 
+async def test_zone_condition_prefers_in_zones_over_coordinates(
+    hass: HomeAssistant,
+) -> None:
+    """Test the legacy zone condition prefers in_zones over coordinates.
+
+    When the entity reports an ``in_zones`` attribute it is authoritative;
+    coordinates are only consulted as a fallback for entities that don't
+    report it.
+    """
+    hass.states.async_set(
+        "zone.home",
+        "zoning",
+        {"name": "home", "latitude": 2.1, "longitude": 1.1, "radius": 10},
+    )
+
+    # in_zones lists the zone but the coordinates are far away -> in_zones wins.
+    hass.states.async_set(
+        "device_tracker.person",
+        "home",
+        {"latitude": 50.0, "longitude": 50.0, "in_zones": ["zone.home"]},
+    )
+    assert zone_condition.zone(hass, "zone.home", "device_tracker.person") is True
+
+    # in_zones is empty but the coordinates are inside the zone -> in_zones wins.
+    hass.states.async_set(
+        "device_tracker.person",
+        "not_home",
+        {"latitude": 2.1, "longitude": 1.1, "in_zones": []},
+    )
+    assert zone_condition.zone(hass, "zone.home", "device_tracker.person") is False
+
+    # in_zones lists a different zone -> not in the target zone.
+    hass.states.async_set(
+        "device_tracker.person",
+        "work",
+        {"latitude": 2.1, "longitude": 1.1, "in_zones": ["zone.work"]},
+    )
+    assert zone_condition.zone(hass, "zone.home", "device_tracker.person") is False
+
+
+async def test_zone_condition_falls_back_to_coordinates(hass: HomeAssistant) -> None:
+    """Test the legacy zone condition uses coordinates without an in_zones attr.
+
+    Coordinate-only entities (e.g. geo_location) report no ``in_zones``.
+    """
+    hass.states.async_set(
+        "zone.home",
+        "zoning",
+        {"name": "home", "latitude": 2.1, "longitude": 1.1, "radius": 10},
+    )
+
+    # Inside the zone by coordinates, no in_zones attribute.
+    hass.states.async_set(
+        "geo_location.quake",
+        "1.0",
+        {"latitude": 2.1, "longitude": 1.1},
+    )
+    assert zone_condition.zone(hass, "zone.home", "geo_location.quake") is True
+
+    # Outside the zone by coordinates.
+    hass.states.async_set(
+        "geo_location.quake",
+        "1.0",
+        {"latitude": 50.0, "longitude": 50.0},
+    )
+    assert zone_condition.zone(hass, "zone.home", "geo_location.quake") is False
+
+
 # --- New-style zone condition tests ---
 
 ZONE_HOME = "zone.home"

--- a/tests/components/zone/test_trigger.py
+++ b/tests/components/zone/test_trigger.py
@@ -125,6 +125,55 @@ async def test_if_fires_on_zone_enter(
     assert len(service_calls) == 2
 
 
+@pytest.mark.parametrize(
+    "coords",
+    [
+        # Coordinates stay inside the zone the whole time, so a coordinate-based
+        # trigger would never see an enter transition.
+        pytest.param(
+            {"latitude": 32.880586, "longitude": -117.237564},
+            id="with_coordinates",
+        ),
+        # No coordinates at all; a coordinate-based trigger could not evaluate.
+        pytest.param({}, id="without_coordinates"),
+    ],
+)
+async def test_if_fires_on_zone_enter_via_in_zones(
+    hass: HomeAssistant,
+    service_calls: list[ServiceCall],
+    coords: dict[str, float],
+) -> None:
+    """Test the zone trigger fires based on in_zones, not coordinates.
+
+    Only the entity's in_zones attribute changes (from empty to the zone), and
+    that is what drives the enter event.
+    """
+    hass.states.async_set("test.entity", "hello", {**coords, "in_zones": []})
+    await hass.async_block_till_done()
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "zone",
+                    "entity_id": "test.entity",
+                    "zone": "zone.test",
+                    "event": "enter",
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+
+    # Only in_zones changes; any coordinates are left unchanged.
+    hass.states.async_set("test.entity", "hello", {**coords, "in_zones": ["zone.test"]})
+    await hass.async_block_till_done()
+
+    assert len(service_calls) == 1
+
+
 async def test_if_fires_on_zone_enter_uuid(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,

--- a/tests/components/zone/test_trigger.py
+++ b/tests/components/zone/test_trigger.py
@@ -148,7 +148,7 @@ async def test_if_fires_on_zone_enter_via_in_zones(
     Only the entity's in_zones attribute changes (from empty to the zone), and
     that is what drives the enter event.
     """
-    hass.states.async_set("test.entity", "hello", {**coords, "in_zones": []})
+    hass.states.async_set("device_tracker.entity", "hello", {**coords, "in_zones": []})
     await hass.async_block_till_done()
 
     assert await async_setup_component(
@@ -158,7 +158,7 @@ async def test_if_fires_on_zone_enter_via_in_zones(
             automation.DOMAIN: {
                 "trigger": {
                     "platform": "zone",
-                    "entity_id": "test.entity",
+                    "entity_id": "device_tracker.entity",
                     "zone": "zone.test",
                     "event": "enter",
                 },
@@ -168,10 +168,99 @@ async def test_if_fires_on_zone_enter_via_in_zones(
     )
 
     # Only in_zones changes; any coordinates are left unchanged.
-    hass.states.async_set("test.entity", "hello", {**coords, "in_zones": ["zone.test"]})
+    hass.states.async_set(
+        "device_tracker.entity", "hello", {**coords, "in_zones": ["zone.test"]}
+    )
     await hass.async_block_till_done()
 
     assert len(service_calls) == 1
+
+
+async def test_zone_enter_ignores_in_zones_for_other_domains(
+    hass: HomeAssistant, service_calls: list[ServiceCall]
+) -> None:
+    """Test the zone trigger uses coordinates for non device_tracker/person.
+
+    A sensor entity reports in_zones that always lists the zone, yet only its
+    coordinates crossing into the zone drives the enter event. If in_zones were
+    honored the entity would already count as "in" and never enter.
+    """
+    hass.states.async_set(
+        "sensor.tracker",
+        "hello",
+        {
+            "latitude": 32.881011,
+            "longitude": -117.234758,
+            "in_zones": ["zone.test"],
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "zone",
+                    "entity_id": "sensor.tracker",
+                    "zone": "zone.test",
+                    "event": "enter",
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+
+    # in_zones unchanged (still lists the zone); coordinates move inside.
+    hass.states.async_set(
+        "sensor.tracker",
+        "hello",
+        {
+            "latitude": 32.880586,
+            "longitude": -117.237564,
+            "in_zones": ["zone.test"],
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert len(service_calls) == 1
+
+
+async def test_zone_trigger_skips_coordinateless_non_tracker(
+    hass: HomeAssistant,
+    service_calls: list[ServiceCall],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a coordinate-less non-tracker entity with in_zones is skipped.
+
+    Its in_zones attribute is not honored (wrong domain) and it has no
+    coordinates, so the zone trigger neither fires nor raises.
+    """
+    hass.states.async_set("sensor.tracker", "hello", {"in_zones": []})
+    await hass.async_block_till_done()
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "zone",
+                    "entity_id": "sensor.tracker",
+                    "zone": "zone.test",
+                    "event": "enter",
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+
+    hass.states.async_set("sensor.tracker", "hello", {"in_zones": ["zone.test"]})
+    await hass.async_block_till_done()
+
+    assert len(service_calls) == 0
+    assert "has no 'latitude' attribute" not in caplog.text
 
 
 async def test_if_fires_on_zone_enter_uuid(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Teach legacy zone condition and trigger about `in_zones` state attribute

This means legacy zone condition and trigger will now work also for device trackers which do not report coordinates, for example scanners associated with a zone other than the home zone or a GPS tracker only reporting zones and not exact coordinates.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45766
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
