### PR TITLE
Tado refactor to utilize get_zone_states

### DIFF
--- a/homeassistant/components/tado/coordinator.py
+++ b/homeassistant/components/tado/coordinator.py
@@ -6,6 +6,7 @@ from typing import Any
 from zoneinfo import ZoneInfo
 
 from PyTado.interface import Tado
+from PyTado.zone import TadoZone
 from requests import RequestException
 
 from homeassistant.components.climate import PRESET_AWAY, PRESET_HOME
@@ -248,7 +249,7 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         return mapped_devices
 
-    async def _async_update_zones(self) -> dict[int, dict]:
+    async def _async_update_zones(self) -> dict[int, TadoZone]:
         """Update the zone data from Tado."""
 
         try:
@@ -260,16 +261,31 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             _LOGGER.error("Error updating Tado zones: %s", err)
             raise UpdateFailed(f"Error updating Tado zones: {err}") from err
 
-        mapped_zones: dict[int, dict] = {}
-        for zone in zone_states:
-            mapped_zones[int(zone)] = await self._update_zone(int(zone))
+        mapped_zones: dict[int, TadoZone] = {}
+        for zone_id_str, raw_state in zone_states.items():
+            zone_id = int(zone_id_str)
+            mapped_zones[zone_id] = await self._build_zone(zone_id, raw_state)
 
         return mapped_zones
 
-    async def _update_zone(self, zone_id: int) -> dict[str, str]:
-        """Update the internal data of a zone."""
-
+    async def _build_zone(self, zone_id: int, raw_state: dict[str, Any]) -> TadoZone:
+        """Fetch defaultOverlay for a zone and construct a TadoZone."""
         _LOGGER.debug("Updating zone %s", zone_id)
+        try:
+            overlay_default = await self.hass.async_add_executor_job(
+                self._tado.get_zone_overlay_default, zone_id
+            )
+        except RequestException as err:
+            _LOGGER.error("Error updating Tado zone %s: %s", zone_id, err)
+            raise UpdateFailed(f"Error updating Tado zone {zone_id}: {err}") from err
+
+        data = TadoZone.from_data(zone_id, {**raw_state, **overlay_default})
+        _LOGGER.debug("Zone %s updated, with data: %s", zone_id, data)
+        return data
+
+    async def _update_zone(self, zone_id: int) -> TadoZone:
+        """Fetch the latest state for a single zone (used after overlay changes)."""
+        _LOGGER.debug("Refreshing zone %s after overlay change", zone_id)
         try:
             data = await self.hass.async_add_executor_job(
                 self._tado.get_zone_state, zone_id

--- a/tests/components/tado/fixtures/zone_states.json
+++ b/tests/components/tado/fixtures/zone_states.json
@@ -295,14 +295,29 @@
       "preparation": null,
       "setting": {
         "type": "AIR_CONDITIONING",
-        "power": "OFF"
+        "power": "ON",
+        "mode": "HEAT",
+        "temperature": {
+          "celsius": 25.0,
+          "fahrenheit": 77.0
+        },
+        "fanLevel": "LEVEL3",
+        "verticalSwing": "ON",
+        "horizontalSwing": "ON"
       },
       "overlayType": "MANUAL",
       "overlay": {
         "type": "MANUAL",
         "setting": {
           "type": "AIR_CONDITIONING",
-          "power": "OFF"
+          "power": "ON",
+          "mode": "HEAT",
+          "temperature": {
+            "celsius": 25.0,
+            "fahrenheit": 77.0
+          },
+          "fanLevel": "LEVEL3",
+          "verticalSwing": "ON"
         },
         "termination": {
           "type": "MANUAL",
@@ -337,14 +352,14 @@
         "acPower": {
           "timestamp": "2022-07-13T18: 06: 58.183Z",
           "type": "POWER",
-          "value": "OFF"
+          "value": "ON"
         }
       },
       "sensorDataPoints": {
         "insideTemperature": {
-          "celsius": 24.21,
-          "fahrenheit": 75.58,
-          "timestamp": "2024-06-28T21: 43: 51.067Z",
+          "celsius": 24.3,
+          "fahrenheit": 75.74,
+          "timestamp": "2024-06-28T22: 23: 15.679Z",
           "type": "TEMPERATURE",
           "precision": {
             "celsius": 0.1,
@@ -353,8 +368,8 @@
         },
         "humidity": {
           "type": "PERCENTAGE",
-          "percentage": 71.4,
-          "timestamp": "2024-06-28T21: 43: 51.067Z"
+          "percentage": 70.9,
+          "timestamp": "2024-06-28T22: 23: 15.679Z"
         }
       },
       "terminationCondition": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
get_zone_states() already fetches all zone state data in one call, but never truly used. Instead it was fetched per zone, wasting calls on getting  data already known. This PR reuses the bulk payload.
For instance, if a house has 6 zones, it now no longer wastes 6 API calls per refresh cycle.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
