### PR TITLE
Add Assist command timeout to pipelines

### DIFF
--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -168,7 +168,7 @@ def _async_resolve_default_pipeline_settings(
     stt_engine_id: str | None = None,
     tts_engine_id: str | None = None,
     pipeline_name: str,
-) -> dict[str, str | None]:
+) -> dict[str, str | float | None]:
     """Resolve settings for a default pipeline.
 
     The default pipeline will use the homeassistant conversation agent and the

--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -135,9 +135,7 @@ PIPELINE_FIELDS: VolDictType = {
     vol.Required("wake_word_id"): vol.Any(str, None),
     vol.Optional("prefer_local_intents"): bool,
     vol.Optional("acknowledge_media_id"): str,
-    vol.Optional(
-        "command_timeout_seconds", default=DEFAULT_COMMAND_TIMEOUT_SECONDS
-    ): vol.All(
+    vol.Optional("command_timeout_seconds"): vol.All(
         vol.Coerce(float),
         vol.Range(
             min=MIN_COMMAND_TIMEOUT_SECONDS,

--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -81,7 +81,15 @@ from .error import (
     WakeWordDetectionError,
     WakeWordTimeoutError,
 )
-from .vad import AudioBuffer, VoiceActivityTimeout, VoiceCommandSegmenter, chunk_samples
+from .vad import (
+    DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    MAX_COMMAND_TIMEOUT_SECONDS,
+    MIN_COMMAND_TIMEOUT_SECONDS,
+    AudioBuffer,
+    VoiceActivityTimeout,
+    VoiceCommandSegmenter,
+    chunk_samples,
+)
 
 if TYPE_CHECKING:
     from hassil.recognize import RecognizeResult
@@ -90,7 +98,7 @@ _LOGGER = logging.getLogger(__name__)
 
 STORAGE_KEY = f"{DOMAIN}.pipelines"
 STORAGE_VERSION = 1
-STORAGE_VERSION_MINOR = 2
+STORAGE_VERSION_MINOR = 3
 
 ENGINE_LANGUAGE_PAIRS = (
     ("stt_engine", "stt_language"),
@@ -127,6 +135,15 @@ PIPELINE_FIELDS: VolDictType = {
     vol.Required("wake_word_id"): vol.Any(str, None),
     vol.Optional("prefer_local_intents"): bool,
     vol.Optional("acknowledge_media_id"): str,
+    vol.Optional(
+        "command_timeout_seconds", default=DEFAULT_COMMAND_TIMEOUT_SECONDS
+    ): vol.All(
+        vol.Coerce(float),
+        vol.Range(
+            min=MIN_COMMAND_TIMEOUT_SECONDS,
+            max=MAX_COMMAND_TIMEOUT_SECONDS,
+        ),
+    ),
 }
 
 STORED_PIPELINE_RUNS = 10
@@ -243,6 +260,7 @@ def _async_resolve_default_pipeline_settings(
         "tts_voice": tts_voice,
         "wake_word_entity": wake_word_entity,
         "wake_word_id": wake_word_id,
+        "command_timeout_seconds": DEFAULT_COMMAND_TIMEOUT_SECONDS,
     }
 
 
@@ -350,6 +368,7 @@ async def async_update_pipeline(
     wake_word_entity: str | None | UndefinedType = UNDEFINED,
     wake_word_id: str | None | UndefinedType = UNDEFINED,
     prefer_local_intents: bool | UndefinedType = UNDEFINED,
+    command_timeout_seconds: float | UndefinedType = UNDEFINED,
 ) -> None:
     """Update a pipeline."""
     pipeline_data = hass.data[KEY_ASSIST_PIPELINE]
@@ -374,6 +393,7 @@ async def async_update_pipeline(
                 ("wake_word_entity", wake_word_entity),
                 ("wake_word_id", wake_word_id),
                 ("prefer_local_intents", prefer_local_intents),
+                ("command_timeout_seconds", command_timeout_seconds),
             )
             if val is not UNDEFINED
         }
@@ -429,6 +449,7 @@ class Pipeline:
     wake_word_entity: str | None
     wake_word_id: str | None
     prefer_local_intents: bool = False
+    command_timeout_seconds: float = DEFAULT_COMMAND_TIMEOUT_SECONDS
 
     id: str = field(default_factory=ulid_util.ulid_now)
 
@@ -453,6 +474,9 @@ class Pipeline:
             wake_word_entity=data["wake_word_entity"],
             wake_word_id=data["wake_word_id"],
             prefer_local_intents=data.get("prefer_local_intents", False),
+            command_timeout_seconds=data.get(
+                "command_timeout_seconds", DEFAULT_COMMAND_TIMEOUT_SECONDS
+            ),
         )
 
     def to_json(self) -> dict[str, Any]:
@@ -471,6 +495,7 @@ class Pipeline:
             "wake_word_entity": self.wake_word_entity,
             "wake_word_id": self.wake_word_id,
             "prefer_local_intents": self.prefer_local_intents,
+            "command_timeout_seconds": self.command_timeout_seconds,
         }
 
 
@@ -952,7 +977,8 @@ class PipelineRun:
                 and self.stt_provider.audio_processing.requires_external_vad
             ):
                 stt_vad = VoiceCommandSegmenter(
-                    silence_seconds=self.audio_settings.silence_seconds
+                    silence_seconds=self.audio_settings.silence_seconds,
+                    timeout_seconds=self.pipeline.command_timeout_seconds,
                 )
 
             result = await self.stt_provider.async_process_audio_stream(
@@ -2179,6 +2205,13 @@ class PipelineStore(Store[SerializedPipelineStorageCollection]):
                 # Populate keys which were introduced before version 1.2
                 pipeline.setdefault("wake_word_entity", None)
                 pipeline.setdefault("wake_word_id", None)
+
+        if old_major_version == 1 and old_minor_version < 3:
+            # Version 1.3 adds command timeout configuration
+            for pipeline in old_data["items"]:
+                pipeline.setdefault(
+                    "command_timeout_seconds", DEFAULT_COMMAND_TIMEOUT_SECONDS
+                )
 
         if old_major_version > 1:
             raise NotImplementedError

--- a/homeassistant/components/assist_pipeline/vad.py
+++ b/homeassistant/components/assist_pipeline/vad.py
@@ -4,10 +4,15 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from enum import StrEnum
 import logging
+from typing import Final
 
 from .const import SAMPLE_CHANNELS, SAMPLE_RATE, SAMPLE_WIDTH
 
 _LOGGER = logging.getLogger(__name__)
+
+DEFAULT_COMMAND_TIMEOUT_SECONDS: Final = 15.0
+MIN_COMMAND_TIMEOUT_SECONDS: Final = 5.0
+MAX_COMMAND_TIMEOUT_SECONDS: Final = 300.0
 
 
 class VadSensitivity(StrEnum):
@@ -82,7 +87,7 @@ class VoiceCommandSegmenter:
     silence_seconds: float = 0.7
     """Seconds of silence after voice command has ended."""
 
-    timeout_seconds: float = 15.0
+    timeout_seconds: float = DEFAULT_COMMAND_TIMEOUT_SECONDS
     """Maximum number of seconds before stopping with timeout=True."""
 
     reset_seconds: float = 1.0

--- a/tests/components/assist_pipeline/test_pipeline.py
+++ b/tests/components/assist_pipeline/test_pipeline.py
@@ -297,6 +297,8 @@ async def test_migrate_pipeline_store(
     store = pipeline_data.pipeline_store
     assert len(store.data) == 3
     assert store.async_get_preferred_item() == "01GX8ZWBAQYWNB1XV3EXEZ75DY"
+    for pipeline in store.data.values():
+        assert pipeline.command_timeout_seconds == 15.0
 
 
 @pytest.mark.usefixtures("init_supporting_components")
@@ -594,6 +596,7 @@ async def test_update_pipeline(
         tts_voice="test_voice",
         wake_word_entity="wake_work.test_1",
         wake_word_id="wake_word_id_1",
+        command_timeout_seconds=30.0,
     )
 
     pipelines = async_get_pipelines(hass)
@@ -613,6 +616,7 @@ async def test_update_pipeline(
             tts_voice="test_voice",
             wake_word_entity="wake_work.test_1",
             wake_word_id="wake_word_id_1",
+            command_timeout_seconds=30.0,
         )
     ]
     assert len(hass_storage[STORAGE_KEY]["data"]["items"]) == 1
@@ -630,6 +634,7 @@ async def test_update_pipeline(
         "wake_word_entity": "wake_work.test_1",
         "wake_word_id": "wake_word_id_1",
         "prefer_local_intents": False,
+        "command_timeout_seconds": 30.0,
     }
 
     await async_update_pipeline(
@@ -657,6 +662,7 @@ async def test_update_pipeline(
             tts_voice="test_voice",
             wake_word_entity="wake_work.test_1",
             wake_word_id="wake_word_id_1",
+            command_timeout_seconds=30.0,
         )
     ]
     assert len(hass_storage[STORAGE_KEY]["data"]["items"]) == 1
@@ -674,6 +680,7 @@ async def test_update_pipeline(
         "wake_word_entity": "wake_work.test_1",
         "wake_word_id": "wake_word_id_1",
         "prefer_local_intents": False,
+        "command_timeout_seconds": 30.0,
     }
 
 
@@ -2174,6 +2181,10 @@ async def test_stt_vad_enabled_based_on_audio_processing(
     pipeline_store = pipeline_data.pipeline_store
     pipeline_id = pipeline_store.async_get_preferred_item()
     pipeline = assist_pipeline.pipeline.async_get_pipeline(hass, pipeline_id)
+    await assist_pipeline.pipeline.async_update_pipeline(
+        hass, pipeline, command_timeout_seconds=30.0
+    )
+    pipeline = assist_pipeline.pipeline.async_get_pipeline(hass, pipeline_id)
 
     # Test with requires_external_vad=True (default)
     # VAD should be used
@@ -2223,7 +2234,7 @@ async def test_stt_vad_enabled_based_on_audio_processing(
         await pipeline_input.execute()
 
         # VAD should be created when requires_external_vad is True
-        mock_vad.assert_called_once()
+        mock_vad.assert_called_once_with(silence_seconds=0.7, timeout_seconds=30.0)
         assert mock_vad_instance.process.called
 
     # Test with requires_external_vad=False

--- a/tests/components/assist_pipeline/test_vad.py
+++ b/tests/components/assist_pipeline/test_vad.py
@@ -3,12 +3,20 @@
 import itertools as it
 
 from homeassistant.components.assist_pipeline.vad import (
+    DEFAULT_COMMAND_TIMEOUT_SECONDS,
     AudioBuffer,
     VoiceCommandSegmenter,
     chunk_samples,
 )
 
 _ONE_SECOND = 1.0
+
+
+def test_defaults() -> None:
+    "Test voice command segmenter defaults."
+    segmenter = VoiceCommandSegmenter()
+
+    assert segmenter.timeout_seconds == DEFAULT_COMMAND_TIMEOUT_SECONDS
 
 
 def test_silence() -> None:

--- a/tests/components/assist_pipeline/test_vad.py
+++ b/tests/components/assist_pipeline/test_vad.py
@@ -13,7 +13,7 @@ _ONE_SECOND = 1.0
 
 
 def test_defaults() -> None:
-    "Test voice command segmenter defaults."
+    """Test voice command segmenter defaults."""
     segmenter = VoiceCommandSegmenter()
 
     assert segmenter.timeout_seconds == DEFAULT_COMMAND_TIMEOUT_SECONDS

--- a/tests/components/assist_pipeline/test_websocket.py
+++ b/tests/components/assist_pipeline/test_websocket.py
@@ -1249,6 +1249,7 @@ async def test_get_pipeline(
         "wake_word_entity": "wakeword_entity_1",
         "wake_word_id": "wakeword_id_1",
         "prefer_local_intents": False,
+        "command_timeout_seconds": 15.0,
     }
 
 
@@ -1277,6 +1278,7 @@ async def test_list_pipelines(
                 "wake_word_entity": None,
                 "wake_word_id": None,
                 "prefer_local_intents": False,
+                "command_timeout_seconds": 15.0,
             }
         ],
         "preferred_pipeline": ANY,
@@ -1443,6 +1445,7 @@ async def test_update_pipeline(
         tts_voice=None,
         wake_word_entity=None,
         wake_word_id=None,
+        command_timeout_seconds=45.0,
     )
 
 

--- a/tests/components/assist_pipeline/test_websocket.py
+++ b/tests/components/assist_pipeline/test_websocket.py
@@ -1162,7 +1162,7 @@ async def test_get_pipeline(
         "wake_word_entity": None,
         "wake_word_id": None,
         "prefer_local_intents": False,
-        "command_timeout_seconds": 45.0,
+        "command_timeout_seconds": 15.0,
     }
 
     # Get conversation agent as pipeline
@@ -1189,7 +1189,7 @@ async def test_get_pipeline(
         "wake_word_entity": None,
         "wake_word_id": None,
         "prefer_local_intents": False,
-        "command_timeout_seconds": 45.0,
+        "command_timeout_seconds": 15.0,
     }
 
     await client.send_json_auto_id(

--- a/tests/components/assist_pipeline/test_websocket.py
+++ b/tests/components/assist_pipeline/test_websocket.py
@@ -935,6 +935,7 @@ async def test_add_pipeline(
             "wake_word_entity": "wakeword_entity_1",
             "wake_word_id": "wakeword_id_1",
             "prefer_local_intents": True,
+            "command_timeout_seconds": 30.0,
         }
     )
     msg = await client.receive_json()
@@ -953,6 +954,7 @@ async def test_add_pipeline(
         "wake_word_entity": "wakeword_entity_1",
         "wake_word_id": "wakeword_id_1",
         "prefer_local_intents": True,
+        "command_timeout_seconds": 30.0,
     }
 
     assert len(pipeline_store.data) == 2
@@ -971,6 +973,7 @@ async def test_add_pipeline(
         wake_word_entity="wakeword_entity_1",
         wake_word_id="wakeword_id_1",
         prefer_local_intents=True,
+        command_timeout_seconds=30.0,
     )
 
     await client.send_json_auto_id(
@@ -1159,6 +1162,7 @@ async def test_get_pipeline(
         "wake_word_entity": None,
         "wake_word_id": None,
         "prefer_local_intents": False,
+        "command_timeout_seconds": 45.0,
     }
 
     # Get conversation agent as pipeline
@@ -1185,6 +1189,7 @@ async def test_get_pipeline(
         "wake_word_entity": None,
         "wake_word_id": None,
         "prefer_local_intents": False,
+        "command_timeout_seconds": 45.0,
     }
 
     await client.send_json_auto_id(
@@ -1301,6 +1306,7 @@ async def test_update_pipeline(
             "tts_voice": "new_tts_voice",
             "wake_word_entity": "new_wakeword_entity",
             "wake_word_id": "new_wakeword_id",
+            "command_timeout_seconds": 45.0,
         }
     )
     msg = await client.receive_json()
@@ -1346,6 +1352,7 @@ async def test_update_pipeline(
             "tts_voice": "new_tts_voice",
             "wake_word_entity": "new_wakeword_entity",
             "wake_word_id": "new_wakeword_id",
+            "command_timeout_seconds": 45.0,
         }
     )
     msg = await client.receive_json()
@@ -1364,6 +1371,7 @@ async def test_update_pipeline(
         "wake_word_entity": "new_wakeword_entity",
         "wake_word_id": "new_wakeword_id",
         "prefer_local_intents": False,
+        "command_timeout_seconds": 45.0,
     }
 
     assert len(pipeline_store.data) == 2
@@ -1381,6 +1389,7 @@ async def test_update_pipeline(
         tts_voice="new_tts_voice",
         wake_word_entity="new_wakeword_entity",
         wake_word_id="new_wakeword_id",
+        command_timeout_seconds=45.0,
     )
 
     await client.send_json_auto_id(
@@ -1398,6 +1407,7 @@ async def test_update_pipeline(
             "tts_voice": None,
             "wake_word_entity": None,
             "wake_word_id": None,
+            "command_timeout_seconds": 45.0,
         }
     )
     msg = await client.receive_json()
@@ -1416,6 +1426,7 @@ async def test_update_pipeline(
         "wake_word_entity": None,
         "wake_word_id": None,
         "prefer_local_intents": False,
+        "command_timeout_seconds": 45.0,
     }
 
     pipeline = pipeline_store.data[pipeline_id]

--- a/tests/components/cloud/test_stt.py
+++ b/tests/components/cloud/test_stt.py
@@ -148,5 +148,11 @@ async def test_migrating_pipelines(
     )
     assert hass_storage[STORAGE_KEY]["data"]["items"][0]["wake_word_entity"] is None
     assert hass_storage[STORAGE_KEY]["data"]["items"][0]["wake_word_id"] is None
-    assert hass_storage[STORAGE_KEY]["data"]["items"][1] == PIPELINE_DATA["items"][1]
-    assert hass_storage[STORAGE_KEY]["data"]["items"][2] == PIPELINE_DATA["items"][2]
+    assert hass_storage[STORAGE_KEY]["data"]["items"][1] == {
+        **PIPELINE_DATA["items"][1],
+        "command_timeout_seconds": 15.0,
+    }
+    assert hass_storage[STORAGE_KEY]["data"]["items"][2] == {
+        **PIPELINE_DATA["items"][2],
+        "command_timeout_seconds": 15.0,
+    }

--- a/tests/components/cloud/test_tts.py
+++ b/tests/components/cloud/test_tts.py
@@ -478,8 +478,14 @@ async def test_migrating_pipelines(
     )
     assert hass_storage[STORAGE_KEY]["data"]["items"][0]["wake_word_entity"] is None
     assert hass_storage[STORAGE_KEY]["data"]["items"][0]["wake_word_id"] is None
-    assert hass_storage[STORAGE_KEY]["data"]["items"][1] == PIPELINE_DATA["items"][1]
-    assert hass_storage[STORAGE_KEY]["data"]["items"][2] == PIPELINE_DATA["items"][2]
+    assert hass_storage[STORAGE_KEY]["data"]["items"][1] == {
+        **PIPELINE_DATA["items"][1],
+        "command_timeout_seconds": 15.0,
+    }
+    assert hass_storage[STORAGE_KEY]["data"]["items"][2] == {
+        **PIPELINE_DATA["items"][2],
+        "command_timeout_seconds": 15.0,
+    }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change

Adds command timeout to Assist pipeline config.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #172293
- This PR is related to issue: #172293
- Link to documentation pull request: home-assistant/home-assistant.io#45762
- Link to developer documentation pull request:
- Link to frontend pull request: home-assistant/frontend#52435

@mib1185 could you take a look?

Replaces #172384 based on maintainer feedback.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr