### PR TITLE
Fix pylint utcnow checker for dt_util.UTC

### DIFF
--- a/pylint/plugins/pylint_home_assistant/checkers/utcnow.py
+++ b/pylint/plugins/pylint_home_assistant/checkers/utcnow.py
@@ -80,14 +80,27 @@ class HassEnforceUtcnowChecker(BaseChecker):
                                 self._utc_paths.add((local,))
                             case "timezone":
                                 self._utc_paths.add((local, "utc"))
+                case nodes.ImportFrom(modname="homeassistant.util", names=names):
+                    # ``homeassistant.util.dt`` re-exports ``UTC`` from
+                    # ``datetime``, so ``dt_util.UTC`` must be flagged too.
+                    for name, alias in names:
+                        if name == "dt":
+                            local = alias or name
+                            self._utc_paths.add((local, "UTC"))
+                case nodes.ImportFrom(modname="homeassistant.util.dt", names=names):
+                    for name, alias in names:
+                        if name == "UTC":
+                            self._utc_paths.add((alias or name,))
                 case nodes.Import(names=names):
                     for name, alias in names:
-                        if name != "datetime":
-                            continue
-                        local = alias or name
-                        self._datetime_class_paths.add((local, "datetime"))
-                        self._utc_paths.add((local, "UTC"))
-                        self._utc_paths.add((local, "timezone", "utc"))
+                        match name:
+                            case "datetime":
+                                local = alias or name
+                                self._datetime_class_paths.add((local, "datetime"))
+                                self._utc_paths.add((local, "UTC"))
+                                self._utc_paths.add((local, "timezone", "utc"))
+                            case "homeassistant.util.dt" if alias:
+                                self._utc_paths.add((alias, "UTC"))
 
     def visit_call(self, node: nodes.Call) -> None:
         """Check for ``datetime.now(UTC)`` calls."""

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -554,7 +554,7 @@ async def test_external_toggle_resets_min_cycle(
     # Set up thermostat with min cycle duration and cooldown
     await _setup_thermostat_with_min_cycle_duration(hass, False, HVACMode.HEAT)
 
-    fake_changed = datetime.datetime.now(dt_util.UTC)
+    fake_changed = dt_util.utcnow()
     # Perform initial actions at the same frozen time so the cycle timer is recent
     freezer.move_to(fake_changed)
     # Start with switch on and record service call registrations
@@ -1098,7 +1098,7 @@ async def test_temp_change_ac_trigger_on_long_enough_3(hass: HomeAssistant) -> N
     _setup_sensor(hass, 30)
     await hass.async_block_till_done()
     await common.async_set_temperature(hass, 25)
-    test_time = datetime.datetime.now(dt_util.UTC)
+    test_time = dt_util.utcnow()
     async_fire_time_changed(hass, test_time)
     await hass.async_block_till_done()
     assert len(calls) == 0
@@ -1122,7 +1122,7 @@ async def test_temp_change_ac_trigger_off_long_enough_3(hass: HomeAssistant) -> 
     _setup_sensor(hass, 20)
     await hass.async_block_till_done()
     await common.async_set_temperature(hass, 25)
-    test_time = datetime.datetime.now(dt_util.UTC)
+    test_time = dt_util.utcnow()
     async_fire_time_changed(hass, test_time)
     await hass.async_block_till_done()
     assert len(calls) == 0
@@ -1173,7 +1173,7 @@ async def test_temp_change_heater_trigger_on_long_enough_2(hass: HomeAssistant) 
     _setup_sensor(hass, 20)
     await hass.async_block_till_done()
     await common.async_set_temperature(hass, 25)
-    test_time = datetime.datetime.now(dt_util.UTC)
+    test_time = dt_util.utcnow()
     async_fire_time_changed(hass, test_time)
     await hass.async_block_till_done()
     assert len(calls) == 0
@@ -1199,7 +1199,7 @@ async def test_temp_change_heater_trigger_off_long_enough_2(
     _setup_sensor(hass, 30)
     await hass.async_block_till_done()
     await common.async_set_temperature(hass, 25)
-    test_time = datetime.datetime.now(dt_util.UTC)
+    test_time = dt_util.utcnow()
     async_fire_time_changed(hass, test_time)
     await hass.async_block_till_done()
     assert len(calls) == 0
@@ -1249,7 +1249,7 @@ async def test_max_cycle_duration_turns_off(hass: HomeAssistant) -> None:
     assert call.service == SERVICE_TURN_ON
 
     # Advance time to trigger max cycle shut-off
-    test_time = datetime.datetime.now(dt_util.UTC)
+    test_time = dt_util.utcnow()
     async_fire_time_changed(hass, test_time)
     await hass.async_block_till_done()
     async_fire_time_changed(hass, test_time + datetime.timedelta(minutes=10))
@@ -1292,7 +1292,7 @@ async def test_external_toggle_resets_max_cycle(
     assert len(calls) == 1
 
     # Simulate an external toggle event shortly after (resets internals)
-    test_time = datetime.datetime.now(dt_util.UTC)
+    test_time = dt_util.utcnow()
     async_fire_time_changed(hass, test_time)
     freezer.move_to(test_time + datetime.timedelta(minutes=1))
     hass.states.async_set(ENT_SWITCH, STATE_ON)
@@ -1359,7 +1359,7 @@ async def test_cycle_cooldown_schedules_restart_after_cooldown(
 ) -> None:
     """Test that cooldown blocks restart and schedules a restart check."""
     hass.config.temperature_unit = UnitOfTemperature.CELSIUS
-    now = datetime.datetime.now(dt_util.UTC)
+    now = dt_util.utcnow()
     freezer.move_to(now)
 
     assert await async_setup_component(

--- a/tests/pylint/test_utcnow.py
+++ b/tests/pylint/test_utcnow.py
@@ -175,6 +175,35 @@ def test_enforce_utcnow_good(
         """,
             id="kwarg_zoneinfo_utc",
         ),
+        pytest.param(
+            """
+        import datetime
+
+        from homeassistant.util import dt as dt_util
+
+        now = datetime.datetime.now(dt_util.UTC)
+        """,
+            id="dt_util_utc",
+        ),
+        pytest.param(
+            """
+        import datetime
+
+        from homeassistant.util import dt as dt_util
+
+        now = datetime.datetime.now(tz=dt_util.UTC)
+        """,
+            id="kwarg_dt_util_utc",
+        ),
+        pytest.param(
+            """
+        from datetime import datetime
+        from homeassistant.util.dt import UTC
+
+        now = datetime.now(UTC)
+        """,
+            id="from_util_dt_import_utc",
+        ),
     ],
 )
 def test_enforce_utcnow_bad(

--- a/tests/pylint/test_utcnow.py
+++ b/tests/pylint/test_utcnow.py
@@ -204,6 +204,16 @@ def test_enforce_utcnow_good(
         """,
             id="from_util_dt_import_utc",
         ),
+        pytest.param(
+            """
+        import datetime
+
+        import homeassistant.util.dt as dt_util
+
+        now = datetime.datetime.now(dt_util.UTC)
+        """,
+            id="import_util_dt_as_dt_util_utc",
+        ),
     ],
 )
 def test_enforce_utcnow_bad(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- We missed this case, in the `utcnow` pylint checker, where the UTC name comes from the `util.dt` module. Include this case.

**Todo**

- [x] Fix new violations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
