### PR TITLE
Add pylint checker to improve DOMAIN constant import

### DIFF
--- a/pylint/plugins/pylint_home_assistant/checkers/imports.py
+++ b/pylint/plugins/pylint_home_assistant/checkers/imports.py
@@ -8,6 +8,8 @@ from pylint.checkers import BaseChecker
 from pylint.lint import PyLinter
 
 from pylint_home_assistant.const import Module
+from pylint_home_assistant.helpers.ast_utils import get_name_import_source_module
+from pylint_home_assistant.helpers.module_info import parse_module
 
 
 @dataclass
@@ -210,26 +212,31 @@ class HassImportsFormatChecker(BaseChecker):
             "home-assistant-import-constant-unnecessary-alias",
             "Used when a constant alias is unnecessary",
         ),
+        "C7416": (
+            "`%s.DOMAIN` should be imported from the component and "
+            "replaced by the `DOMAIN` constant",
+            "home-assistant-import-domain-constant",
+            "Used when DOMAIN is accessed via a module attribute instead of "
+            "being imported from the component and used as the DOMAIN constant",
+        ),
     }
     options = ()
 
-    def __init__(self, linter: PyLinter) -> None:
-        """Initialize the HassImportsFormatChecker."""
-        super().__init__(linter)
-        self.current_package: str | None = None
+    current_package: str
+    current_component: str | None
 
     def visit_module(self, node: nodes.Module) -> None:
         """Determine current package."""
-        if node.package:
-            self.current_package = node.name
-        else:
+        self.current_package = node.name
+        if not node.package:
             # Strip name of the current module
             self.current_package = node.name[: node.name.rfind(".")]
 
+        parsed_module = parse_module(node.name, include_test=True)
+        self.current_component = parsed_module.domain if parsed_module else None
+
     def visit_import(self, node: nodes.Import) -> None:
         """Check for improper `import _` invocations."""
-        if self.current_package is None:
-            return
         for module, _alias in node.names:
             if module.startswith(f"{self.current_package}."):
                 self.add_message("home-assistant-relative-import", node=node)
@@ -427,6 +434,26 @@ class HassImportsFormatChecker(BaseChecker):
                             name[0],
                         ),
                     )
+
+    def visit_attribute(self, node: nodes.Attribute) -> None:
+        """Check for `x.DOMAIN` referencing the current component."""
+        if (
+            node.attrname != "DOMAIN"
+            or not isinstance(node.expr, nodes.Name)
+            or not self.current_component
+        ):
+            return
+
+        if (
+            (module := get_name_import_source_module(node.expr))
+            and (parsed := parse_module(module, include_test=True))
+            and parsed.domain == self.current_component
+        ):
+            self.add_message(
+                "home-assistant-import-domain-constant",
+                node=node,
+                args=(node.expr.name,),
+            )
 
 
 def register(linter: PyLinter) -> None:

--- a/pylint/plugins/pylint_home_assistant/helpers/ast_utils.py
+++ b/pylint/plugins/pylint_home_assistant/helpers/ast_utils.py
@@ -13,6 +13,36 @@ def enclosing_function(node: nodes.NodeNG) -> nodes.FunctionDef | None:
     return None
 
 
+def _get_importfrom_base(node: nodes.ImportFrom) -> str:
+    """Resolve the absolute base package/module of an import-from node."""
+    modname = node.modname or ""
+    if not node.level:
+        return modname
+    root = node.root()
+    if root.package:
+        base = root.name.rsplit(".", node.level - 1)[0]
+    else:
+        base = root.name.rsplit(".", node.level)[0]
+    return f"{base}.{modname}" if modname else base
+
+
+def get_name_import_source_module(node: nodes.Name) -> str | None:
+    """Resolve the module path a name refers to, if it is an imported module."""
+    _scope, assignments = node.lookup(node.name)
+    for assignment in assignments:
+        if isinstance(assignment, nodes.Import):
+            # `import a.b.c as alias` binds `alias` to module `a.b.c`
+            for orig, alias in assignment.names:
+                if alias == node.name:
+                    return str(orig)
+        elif isinstance(assignment, nodes.ImportFrom):
+            base = _get_importfrom_base(assignment)
+            for orig, alias in assignment.names:
+                if orig != "*" and (alias or orig) == node.name:
+                    return f"{base}.{orig}" if base else orig
+    return None
+
+
 def get_schema_field_name(node: nodes.Call) -> str | None:
     """Extract the field name from ``vol.Required(...)`` or ``vol.Optional(...)``.
 

--- a/pylint/plugins/pylint_home_assistant/helpers/module_info.py
+++ b/pylint/plugins/pylint_home_assistant/helpers/module_info.py
@@ -5,6 +5,8 @@ import re
 
 _INTEGRATION_ROOT = "homeassistant.components"
 _INTEGRATION_ROOT_DOT = f"{_INTEGRATION_ROOT}."
+_INTEGRATION_TEST_ROOT = "tests.components"
+_INTEGRATION_TEST_ROOT_DOT = f"{_INTEGRATION_TEST_ROOT}."
 _ROOT_SEGMENT_COUNT = _INTEGRATION_ROOT.count(".") + 1
 _MODULE_REGEX: re.Pattern[str] = re.compile(
     rf"^{re.escape(_INTEGRATION_ROOT)}\.\w+(\.\w+)?$"
@@ -26,14 +28,20 @@ class IntegrationModule:
     """
 
 
-def parse_module(module_name: str) -> IntegrationModule | None:
+def parse_module(
+    module_name: str, *, include_test: bool = False
+) -> IntegrationModule | None:
     """Parse a dotted module name into integration parts.
 
     Returns ``None`` if *module_name* is not under the integration root.
     For deep sub-modules (e.g. ``homeassistant.components.hue.light.v2``),
     ``module`` is set to the first segment after the domain (``light``).
     """
-    if not module_name.startswith(_INTEGRATION_ROOT_DOT):
+    if module_name.startswith(_INTEGRATION_ROOT_DOT):
+        root = _INTEGRATION_ROOT
+    elif include_test and module_name.startswith(_INTEGRATION_TEST_ROOT_DOT):
+        root = _INTEGRATION_TEST_ROOT
+    else:
         return None
 
     parts = module_name.split(".")
@@ -42,13 +50,13 @@ def parse_module(module_name: str) -> IntegrationModule | None:
         return None
     if n == _ROOT_SEGMENT_COUNT + 1:
         return IntegrationModule(
-            root=_INTEGRATION_ROOT,
+            root=root,
             domain=parts[_ROOT_SEGMENT_COUNT],
             module=None,
         )
     # n >= _ROOT_SEGMENT_COUNT + 2: domain.module[.submodule...]
     return IntegrationModule(
-        root=_INTEGRATION_ROOT,
+        root=root,
         domain=parts[_ROOT_SEGMENT_COUNT],
         module=parts[_ROOT_SEGMENT_COUNT + 1],
     )

--- a/tests/pylint/test_imports.py
+++ b/tests/pylint/test_imports.py
@@ -369,3 +369,90 @@ def test_domain_alias(
             imports_checker.visit_import(import_node)
         else:
             imports_checker.visit_importfrom(import_node)
+
+
+@pytest.mark.parametrize(
+    ("module_name", "code"),
+    [
+        (
+            "homeassistant.components.pylint_test.sensor",
+            "from . import const\nconst.DOMAIN  #@",
+        ),
+        (
+            "homeassistant.components.pylint_test.sensor",
+            "from homeassistant.components.pylint_test import const\nconst.DOMAIN  #@",
+        ),
+        (
+            "homeassistant.components.pylint_test.sensor",
+            "from homeassistant.components import pylint_test\npylint_test.DOMAIN  #@",
+        ),
+        (
+            "homeassistant.components.pylint_test.sensor",
+            "import homeassistant.components.pylint_test as comp\ncomp.DOMAIN  #@",
+        ),
+        (
+            "homeassistant.components.pylint_test.api.hub",
+            "from .. import const\nconst.DOMAIN  #@",
+        ),
+        (
+            "tests.components.pylint_test.test_sensor",
+            "from homeassistant.components.pylint_test import const\nconst.DOMAIN  #@",
+        ),
+    ],
+)
+def test_bad_domain_attribute(
+    linter: UnittestLinter,
+    imports_checker: BaseChecker,
+    module_name: str,
+    code: str,
+) -> None:
+    """Ensure DOMAIN accessed via a component module attribute is rejected."""
+
+    node = astroid.extract_node(code, module_name)
+    imports_checker.visit_module(node.root())
+
+    with assert_adds_messages(
+        linter,
+        pylint.testutils.MessageTest(
+            msg_id="home-assistant-import-domain-constant",
+            node=node,
+            args=(node.expr.name,),
+            line=2,
+            col_offset=0,
+            end_line=2,
+            end_col_offset=len(node.expr.name) + 7,
+        ),
+    ):
+        imports_checker.visit_attribute(node)
+
+
+@pytest.mark.parametrize(
+    ("module_name", "code"),
+    [
+        (
+            "homeassistant.components.pylint_test.sensor",
+            "from homeassistant.components.other import const\nconst.DOMAIN  #@",
+        ),
+        (
+            "homeassistant.components.pylint_test.sensor",
+            "from . import const\nconst.OTHER  #@",
+        ),
+        (
+            "homeassistant.components.pylint_test.sensor",
+            "value.DOMAIN  #@",
+        ),
+    ],
+)
+def test_good_domain_attribute(
+    linter: UnittestLinter,
+    imports_checker: BaseChecker,
+    module_name: str,
+    code: str,
+) -> None:
+    """Ensure unrelated DOMAIN attribute accesses pass through ok."""
+
+    node = astroid.extract_node(code, module_name)
+    imports_checker.visit_module(node.root())
+
+    with assert_no_messages(linter):
+        imports_checker.visit_attribute(node)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Avoid awkward DOMAIN import patterns, such as:

```python
from homeassistant.components.current_component import config_flow
...
config_flow.DOMAIN
```

prefer

```python
from homeassistant.components.current_component import DOMAIN
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
