### PR TITLE
Use parse_module helper in pylint import checker (visit_import)

### DIFF
--- a/pylint/plugins/pylint_home_assistant/checkers/imports.py
+++ b/pylint/plugins/pylint_home_assistant/checkers/imports.py
@@ -8,6 +8,7 @@ from pylint.checkers import BaseChecker
 from pylint.lint import PyLinter
 
 from pylint_home_assistant.const import Module
+from pylint_home_assistant.helpers.module_info import parse_module
 
 
 @dataclass
@@ -230,17 +231,16 @@ class HassImportsFormatChecker(BaseChecker):
         """Check for improper `import _` invocations."""
         if self.current_package is None:
             return
-        for module, _alias in node.names:
-            if module.startswith(f"{self.current_package}."):
+        for other_module, _alias in node.names:
+            if other_module.startswith(f"{self.current_package}."):
                 self.add_message("home-assistant-relative-import", node=node)
                 continue
             if (
-                module.startswith("homeassistant.components.")
-                and len(module.split(".")) > 3
-            ):
+                other_parsed := parse_module(other_module)
+            ) and other_parsed.module is not None:
                 if (
                     self.current_package.startswith("tests.components.")
-                    and self.current_package.split(".")[2] == module.split(".")[2]
+                    and self.current_package.split(".")[2] == other_parsed.domain
                 ):
                     # Ignore check if the component being tested matches
                     # the component being imported from
@@ -314,18 +314,18 @@ class HassImportsFormatChecker(BaseChecker):
         self,
         node: nodes.ImportFrom,
         current_component: str | None,
-        imported_parts: list[str],
-        imported_component: str,
+        other_component: str,
+        other_module: str | None,
     ) -> bool:
         """Check for hass-component-root-import."""
         if (
-            current_component == imported_component
-            or imported_component in _IGNORE_ROOT_IMPORT
+            current_component == other_component
+            or other_component in _IGNORE_ROOT_IMPORT
         ):
             return True
 
         # Check for `from homeassistant.components.other.module import something`
-        if len(imported_parts) > 3:
+        if other_module:
             self.add_message("home-assistant-component-root-import", node=node)
             return False
 
@@ -385,19 +385,16 @@ class HassImportsFormatChecker(BaseChecker):
         ):
             return
 
-        if node.modname.startswith("homeassistant.components."):
-            imported_parts = node.modname.split(".")
-            imported_component = imported_parts[2]
-
+        if other_parsed := parse_module(node.modname):
             # Checks for hass-component-root-import
             if not self._check_for_component_root_import(
-                node, current_component, imported_parts, imported_component
+                node, current_component, other_parsed.domain, other_parsed.module
             ):
                 return
 
             # Checks for hass-import-constant-alias
             if not self._check_for_constant_alias(
-                node, current_component, imported_component
+                node, current_component, other_parsed.domain
             ):
                 return
 

--- a/pylint/plugins/pylint_home_assistant/checkers/imports.py
+++ b/pylint/plugins/pylint_home_assistant/checkers/imports.py
@@ -314,18 +314,18 @@ class HassImportsFormatChecker(BaseChecker):
         self,
         node: nodes.ImportFrom,
         current_component: str | None,
-        other_component: str,
-        other_module: str | None,
+        imported_parts: list[str],
+        imported_component: str,
     ) -> bool:
         """Check for hass-component-root-import."""
         if (
-            current_component == other_component
-            or other_component in _IGNORE_ROOT_IMPORT
+            current_component == imported_component
+            or imported_component in _IGNORE_ROOT_IMPORT
         ):
             return True
 
         # Check for `from homeassistant.components.other.module import something`
-        if other_module:
+        if len(imported_parts) > 3:
             self.add_message("home-assistant-component-root-import", node=node)
             return False
 
@@ -385,16 +385,19 @@ class HassImportsFormatChecker(BaseChecker):
         ):
             return
 
-        if other_parsed := parse_module(node.modname):
+        if node.modname.startswith("homeassistant.components."):
+            imported_parts = node.modname.split(".")
+            imported_component = imported_parts[2]
+
             # Checks for hass-component-root-import
             if not self._check_for_component_root_import(
-                node, current_component, other_parsed.domain, other_parsed.module
+                node, current_component, imported_parts, imported_component
             ):
                 return
 
             # Checks for hass-import-constant-alias
             if not self._check_for_constant_alias(
-                node, current_component, other_parsed.domain
+                node, current_component, imported_component
             ):
                 return
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
No functionnal changes

This just avoids re-uses existing logic in `parse_module` to extract the component domain and module from a full path.

This focus on the parsing of the "other component" in `visit_import`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
