### PR TITLE
Drop legacy requires_api_password from discovery announcement

### DIFF
--- a/homeassistant/components/api/__init__.py
+++ b/homeassistant/components/api/__init__.py
@@ -59,7 +59,6 @@ ATTR_EXTERNAL_URL = "external_url"
 ATTR_INTERNAL_URL = "internal_url"
 ATTR_LOCATION_NAME = "location_name"
 ATTR_INSTALLATION_TYPE = "installation_type"
-ATTR_REQUIRES_API_PASSWORD = "requires_api_password"
 ATTR_UUID = "uuid"
 ATTR_VERSION = "version"
 

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -258,8 +258,6 @@ async def _async_get_local_service_info(hass: HomeAssistant) -> AsyncServiceInfo
         "internal_url": "",
         # Old base URL, for backward compatibility
         "base_url": "",
-        # Always needs authentication
-        "requires_api_password": True,
     }
 
     # Get instance URL's

--- a/tests/components/zeroconf/test_repairs.py
+++ b/tests/components/zeroconf/test_repairs.py
@@ -58,7 +58,6 @@ def _get_hass_service_info_mock(
             "external_url": None,
             "internal_url": "http://10.0.0.1:8123",
             "location_name": "Home",
-            "requires_api_password": "True",
             "uuid": instance_id,
             "version": "2025.9.0.dev0",
         },


### PR DESCRIPTION
## Breaking change

The `requires_api_password` property is removed from the zeroconf/mDNS discovery announcement (`_home-assistant._tcp`). This is a legacy field that has been hardcoded to `True` since the `http.api_password` auth mechanism was removed in 2024.7.0, so it no longer carries any information. Third-party discovery clients that still parse it must tolerate its absence. The official companion apps already ignore it (iOS does not read it; Android's copy is unused dead code).

## Proposed change

`requires_api_password` originated in the legacy `http.api_password` era as a discovery hint telling clients whether an instance required a password before they could talk to its API. The corresponding `legacy_api_password` auth provider was deprecated in #104409 and fully removed in #119976 (shipped in 2024.7.0). Since then every instance always requires token-based authentication, so the field has been hardcoded to `True` and conveys nothing.

This PR drops the vestigial field:

- Remove `requires_api_password` from the zeroconf/mDNS announcement in `homeassistant/components/zeroconf`.
- Remove the now-unused `ATTR_REQUIRES_API_PASSWORD` constant in the `api` integration (there is no longer a discovery endpoint emitting it).
- Update the zeroconf repairs test fixture to reflect the new announcement.

Note: `rss_feed_template`'s unrelated `requires_api_password` config option (a per-feed auth toggle) is intentionally left untouched.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
