### PR TITLE
Add reauthentication flow to Aquacell

### DIFF
--- a/homeassistant/components/aquacell/config_flow.py
+++ b/homeassistant/components/aquacell/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow for Aquacell integration."""
 
+from collections.abc import Mapping
 from datetime import datetime
 import logging
 from typing import Any
@@ -27,6 +28,12 @@ DATA_SCHEMA = vol.Schema(
             {key: brand.name for key, brand in SUPPORTED_BRANDS.items()}
         ),
         vol.Required(CONF_EMAIL): str,
+        vol.Required(CONF_PASSWORD): str,
+    }
+)
+
+STEP_REAUTH_SCHEMA = vol.Schema(
+    {
         vol.Required(CONF_PASSWORD): str,
     }
 )
@@ -75,5 +82,50 @@ class AquaCellConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user",
             data_schema=DATA_SCHEMA,
+            errors=errors,
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Perform reauth upon an API authentication error."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm reauth dialog."""
+        errors: dict[str, str] = {}
+        reauth_entry = self._get_reauth_entry()
+        if user_input is not None:
+            session = async_get_clientsession(self.hass)
+            api = AquacellApi(
+                session, reauth_entry.data.get(CONF_BRAND, Brand.AQUACELL)
+            )
+            try:
+                refresh_token = await api.authenticate(
+                    reauth_entry.data[CONF_EMAIL], user_input[CONF_PASSWORD]
+                )
+            except ApiException, TimeoutError:
+                errors["base"] = "cannot_connect"
+            except AuthenticationFailed:
+                errors["base"] = "invalid_auth"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                return self.async_update_reload_and_abort(
+                    reauth_entry,
+                    data_updates={
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                        CONF_REFRESH_TOKEN: refresh_token,
+                        CONF_REFRESH_TOKEN_CREATION_TIME: datetime.now().timestamp(),
+                    },
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=STEP_REAUTH_SCHEMA,
+            description_placeholders={"email": reauth_entry.data[CONF_EMAIL]},
             errors=errors,
         )

--- a/homeassistant/components/aquacell/coordinator.py
+++ b/homeassistant/components/aquacell/coordinator.py
@@ -14,7 +14,7 @@ from aioaquacell import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryError
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -79,7 +79,7 @@ class AquacellCoordinator(DataUpdateCoordinator[dict[str, Softener]]):
 
                 softeners = await self.aquacell_api.get_all_softeners()
             except AuthenticationFailed as err:
-                raise ConfigEntryError from err
+                raise ConfigEntryAuthFailed from err
             except (AquacellApiException, TimeoutError) as err:
                 raise UpdateFailed(f"Error communicating with API: {err}") from err
 

--- a/homeassistant/components/aquacell/strings.json
+++ b/homeassistant/components/aquacell/strings.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
@@ -9,6 +10,13 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
+      "reauth_confirm": {
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "description": "The password for {email} is no longer valid. Enter your current softener mobile app password to reconnect.",
+        "title": "[%key:common::config_flow::title::reauth%]"
+      },
       "user": {
         "data": {
           "brand": "Brand",

--- a/tests/components/aquacell/test_config_flow.py
+++ b/tests/components/aquacell/test_config_flow.py
@@ -1,13 +1,16 @@
 """Test the Aquacell config flow."""
 
+from datetime import datetime
 from unittest.mock import AsyncMock
 
 from aioaquacell import ApiException, AuthenticationFailed
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.aquacell.const import (
     CONF_BRAND,
     CONF_REFRESH_TOKEN,
+    CONF_REFRESH_TOKEN_CREATION_TIME,
     DOMAIN,
 )
 from homeassistant.config_entries import SOURCE_USER
@@ -123,11 +126,13 @@ async def test_form_exceptions(
 
 async def test_reauth_flow(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
     mock_setup_entry: AsyncMock,
     mock_aquacell_api: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the reauthentication flow."""
+    freezer.move_to("2024-01-01 00:00:00+00:00")
     mock_config_entry.add_to_hass(hass)
 
     result = await mock_config_entry.start_reauth_flow(hass)
@@ -146,6 +151,10 @@ async def test_reauth_flow(
 
     assert mock_config_entry.data[CONF_PASSWORD] == "new-password"
     assert mock_config_entry.data[CONF_REFRESH_TOKEN] == "refresh-token"
+    assert (
+        mock_config_entry.data[CONF_REFRESH_TOKEN_CREATION_TIME]
+        == datetime.now().timestamp()
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/components/aquacell/test_config_flow.py
+++ b/tests/components/aquacell/test_config_flow.py
@@ -119,3 +119,75 @@ async def test_form_exceptions(
     assert result3["data"][CONF_REFRESH_TOKEN] == TEST_CONFIG_ENTRY[CONF_REFRESH_TOKEN]
     assert result3["data"][CONF_BRAND] == TEST_CONFIG_ENTRY[CONF_BRAND]
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_reauth_flow(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_aquacell_api: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the reauthentication flow."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reauth_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_PASSWORD: "new-password"},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+
+    assert mock_config_entry.data[CONF_PASSWORD] == "new-password"
+    assert mock_config_entry.data[CONF_REFRESH_TOKEN] == "refresh-token"
+
+
+@pytest.mark.parametrize(
+    ("exception", "error"),
+    [
+        (ApiException, "cannot_connect"),
+        (TimeoutError, "cannot_connect"),
+        (AuthenticationFailed, "invalid_auth"),
+        (Exception, "unknown"),
+    ],
+)
+async def test_reauth_exceptions(
+    hass: HomeAssistant,
+    exception: Exception,
+    error: str,
+    mock_setup_entry: AsyncMock,
+    mock_aquacell_api: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test we handle exceptions in the reauth flow and can recover."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reauth_flow(hass)
+
+    mock_aquacell_api.authenticate.side_effect = exception
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_PASSWORD: "new-password"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"] == {"base": error}
+
+    mock_aquacell_api.authenticate.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_PASSWORD: "new-password"},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert mock_config_entry.data[CONF_PASSWORD] == "new-password"


### PR DESCRIPTION
## Proposed change

The Aquacell integration authenticates against AWS Cognito and stores a refresh token that is valid for 30 days. When it expires the coordinator re-authenticates with the stored email/password. If the stored password is no longer valid, `_async_update_data` raised `ConfigEntryError`, which left the entry in a setup-error state with no UI affordance to fix the credentials - the only recovery was to delete and re-add the integration.

This change:
- Raises `ConfigEntryAuthFailed` (instead of `ConfigEntryError`) when authentication fails, so Home Assistant starts a reauthentication flow.
- Adds `async_step_reauth` / `async_step_reauth_confirm` to the config flow, asking the user only for the password (the email and brand are taken from the existing entry) and updating the entry on success.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.
