### PR TITLE
Allow inline number ranges for sentence triggers

### DIFF
--- a/homeassistant/components/assist_satellite/__init__.py
+++ b/homeassistant/components/assist_satellite/__init__.py
@@ -3,6 +3,7 @@
 from dataclasses import asdict
 import logging
 from pathlib import Path
+import re
 from typing import Any
 
 from hassil.util import (
@@ -201,6 +202,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 def has_no_punctuation(value: list[str]) -> list[str]:
     """Validate result does not contain punctuation."""
     for sentence in value:
+        # Exclude {list_references} which may contain punctuation characters.
+        sentence = _remove_list_references(sentence)
         if (
             PUNCTUATION_START.search(sentence)
             or PUNCTUATION_END.search(sentence)
@@ -210,6 +213,11 @@ def has_no_punctuation(value: list[str]) -> list[str]:
             raise vol.Invalid("sentence should not contain punctuation")
 
     return value
+
+
+def _remove_list_references(sentence: str) -> str:
+    """Remove {list_references} from a sentence for linting."""
+    return re.sub(r"(?<!\\)\{[^{}]*\}", "", sentence)
 
 
 def has_one_non_empty_item(value: list[str]) -> list[str]:

--- a/homeassistant/components/assist_satellite/__init__.py
+++ b/homeassistant/components/assist_satellite/__init__.py
@@ -231,7 +231,6 @@ def is_valid_sentence(value: list[str]) -> list[str]:
         except ParseError as err:
             raise vol.Invalid(f"invalid sentence: {err}") from err
     return value
-    return value
 
 
 def has_one_non_empty_item(value: list[str]) -> list[str]:

--- a/homeassistant/components/conversation/trigger.py
+++ b/homeassistant/components/conversation/trigger.py
@@ -1,6 +1,7 @@
 """Offer sentence based automation rules."""
 
 from collections.abc import Awaitable, Callable
+import re
 from typing import Any
 
 from hassil.recognize import RecognizeResult
@@ -31,6 +32,8 @@ TRIGGER_CALLBACK_TYPE = Callable[
 def has_no_punctuation(value: list[str]) -> list[str]:
     """Validate result does not contain punctuation."""
     for sentence in value:
+        # Exclude {list_references} which may contain punctuation characters.
+        sentence = _remove_list_references(sentence)
         if (
             PUNCTUATION_START.search(sentence)
             or PUNCTUATION_END.search(sentence)
@@ -40,6 +43,11 @@ def has_no_punctuation(value: list[str]) -> list[str]:
             raise vol.Invalid("sentence should not contain punctuation")
 
     return value
+
+
+def _remove_list_references(sentence: str) -> str:
+    """Remove {list_references} from a sentence for linting."""
+    return re.sub(r"(?<!\\)\{[^{}]*\}", "", sentence)
 
 
 def has_one_non_empty_item(value: list[str]) -> list[str]:

--- a/homeassistant/components/conversation/trigger.py
+++ b/homeassistant/components/conversation/trigger.py
@@ -60,7 +60,6 @@ def is_valid_sentence(value: list[str]) -> list[str]:
         except ParseError as err:
             raise vol.Invalid(f"invalid sentence: {err}") from err
     return value
-    return value
 
 
 def has_one_non_empty_item(value: list[str]) -> list[str]:

--- a/tests/components/assist_satellite/test_entity.py
+++ b/tests/components/assist_satellite/test_entity.py
@@ -883,6 +883,24 @@ async def test_start_conversation_default_preannounce(
             ),
             True,
         ),
+        (
+            {
+                "answers": [
+                    {
+                        "id": "jazz_with_volume",
+                        "sentences": ["jazz at {1..100:volume} percent volume"],
+                    },
+                ],
+                "preannounce": False,
+            },
+            "jazz at 42 percent volume",
+            AssistSatelliteAnswer(
+                id="jazz_with_volume",
+                sentence="jazz at 42 percent volume",
+                slots={"volume": 42},
+            ),
+            False,
+        ),
     ],
 )
 async def test_ask_question(

--- a/tests/components/assist_satellite/test_entity.py
+++ b/tests/components/assist_satellite/test_entity.py
@@ -893,10 +893,10 @@ async def test_start_conversation_default_preannounce(
                 ],
                 "preannounce": False,
             },
-            "jazz at 42 percent volume",
+            "jazz at forty two percent volume",
             AssistSatelliteAnswer(
                 id="jazz_with_volume",
-                sentence="jazz at 42 percent volume",
+                sentence="jazz at forty two percent volume",
                 slots={"volume": 42},
             ),
             False,

--- a/tests/components/conversation/test_trigger.py
+++ b/tests/components/conversation/test_trigger.py
@@ -707,7 +707,7 @@ async def test_inline_range_list(hass: HomeAssistant) -> None:
             "automation": {
                 "trigger": {
                     "platform": "conversation",
-                    "command": ["set brightness to {0..100:brightness}%"],
+                    "command": ["set brightness to {0..100:brightness} percent"],
                 },
                 "action": {
                     "set_conversation_response": "Brightness set to {{trigger.slots.brightness|int}} percent",
@@ -720,7 +720,7 @@ async def test_inline_range_list(hass: HomeAssistant) -> None:
         "conversation",
         "process",
         {
-            "text": "set brightness to 42%",
+            "text": "set brightness to forty two percent",
         },
         blocking=True,
         return_response=True,

--- a/tests/components/conversation/test_trigger.py
+++ b/tests/components/conversation/test_trigger.py
@@ -696,3 +696,36 @@ async def test_trigger_with_device_id(hass: HomeAssistant) -> None:
         result.response.speech["plain"]["speech"]
         == "my_device - assist_satellite.my_satellite"
     )
+
+
+async def test_inline_range_list(hass: HomeAssistant) -> None:
+    """Test sentence trigger and response with an inline number range list."""
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": {
+                "trigger": {
+                    "platform": "conversation",
+                    "command": ["set brightness to {0..100:brightness}%"],
+                },
+                "action": {
+                    "set_conversation_response": "Brightness set to {{trigger.slots.brightness|int}} percent",
+                },
+            }
+        },
+    )
+
+    service_response = await hass.services.async_call(
+        "conversation",
+        "process",
+        {
+            "text": "set brightness to 42%",
+        },
+        blocking=True,
+        return_response=True,
+    )
+    assert (
+        service_response["response"]["speech"]["plain"]["speech"]
+        == "Brightness set to 42 percent"
+    )

--- a/tests/components/conversation/test_trigger.py
+++ b/tests/components/conversation/test_trigger.py
@@ -710,7 +710,9 @@ async def test_inline_range_list(hass: HomeAssistant) -> None:
                     "command": ["set brightness to {0..100:brightness} percent"],
                 },
                 "action": {
-                    "set_conversation_response": "Brightness set to {{trigger.slots.brightness|int}} percent",
+                    "set_conversation_response": "Brightness set to"
+                    " {{trigger.slots.brightness|int}}"
+                    " ({{trigger.details.brightness.text}}) percent",
                 },
             }
         },
@@ -727,5 +729,5 @@ async def test_inline_range_list(hass: HomeAssistant) -> None:
     )
     assert (
         service_response["response"]["speech"]["plain"]["speech"]
-        == "Brightness set to 42 percent"
+        == "Brightness set to 42 (forty two) percent"
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A recent version of [hassil](https://github.com/OHF-Voice/hassil/releases/tag/v3.6.0) added inline number ranges, allowing sentence templates like "set brightness to {0..100:brightness} percent" to be matched. This is especially important for sentence triggers and satellite questions because lists can't be defined elsewhere so only wildcards were previously possible. Matching also extends to number words, so "set brightness to fifty percent" will match and set `brightness` to 50.

This PR modifies the existing checks for punctuation in sentence triggers so that anything inside curly braces is excluded. This allows the `{0..100:brightness}` syntax to pass through while still flagging other punctuation.

Additionally, tests were added to demonstrate inline number ranges for both sentence triggers and satellite questions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45768
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/3134
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
