### PR TITLE
Fix process advertisement for active scans

### DIFF
--- a/homeassistant/components/bluetooth/api.py
+++ b/homeassistant/components/bluetooth/api.py
@@ -6,6 +6,7 @@ These APIs are the only documented way to interact with the bluetooth integratio
 import asyncio
 from asyncio import Future
 from collections.abc import Callable, Iterable
+from contextlib import ExitStack
 from typing import TYPE_CHECKING, cast
 
 from bleak import BleakScanner
@@ -178,15 +179,20 @@ async def async_process_advertisements(
         if not done.done() and callback(service_info):
             done.set_result(service_info)
 
-    unload = _get_manager(hass).async_register_callback(
-        _async_discovered_device, match_dict, mode, scan_duration=timeout
-    )
+    manager = _get_manager(hass)
 
-    try:
+    with ExitStack() as stack:
+        unload = manager.async_register_callback(
+            _async_discovered_device, match_dict, mode, scan_duration=timeout
+        )
+        stack.callback(unload)
+
+        if mode == BluetoothScanningMode.ACTIVE:
+            task = hass.async_create_task(manager.async_request_active_scan(timeout))
+            stack.callback(task.cancel)
+
         async with asyncio.timeout(timeout):
             return await done
-    finally:
-        unload()
 
 
 @hass_callback

--- a/homeassistant/components/bluetooth/api.py
+++ b/homeassistant/components/bluetooth/api.py
@@ -183,7 +183,7 @@ async def async_process_advertisements(
 
     with ExitStack() as stack:
         unload = manager.async_register_callback(
-            _async_discovered_device, match_dict, mode, scan_duration=timeout
+            _async_discovered_device, match_dict, mode
         )
         stack.callback(unload)
 

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -2666,21 +2666,26 @@ async def test_process_advertisements_timeout(
 
 
 @pytest.mark.usefixtures("enable_bluetooth", "mock_bleak_scanner_start")
-async def test_process_advertisements_wires_timeout_as_scan_duration(
+async def test_process_advertisements_triggers_active_scan_of_correct_duration(
     hass: HomeAssistant,
 ) -> None:
-    """async_process_advertisements forwards its timeout as scan_duration."""
+    """async_process_advertisements triggers active scan now."""
 
     def _callback(service_info: BluetoothServiceInfo) -> bool:
         return False
 
+    timeout = 0.001
     mock_cancel = Mock()
+
     with (
         patch.object(
             HomeAssistantBluetoothManager,
             "async_register_active_scan",
             return_value=mock_cancel,
         ) as mock_register,
+        patch.object(
+            HomeAssistantBluetoothManager, "async_request_active_scan"
+        ) as mock_register_active,
         pytest.raises(TimeoutError),
     ):
         await async_process_advertisements(
@@ -2688,9 +2693,10 @@ async def test_process_advertisements_wires_timeout_as_scan_duration(
             _callback,
             {"address": "aa:44:33:11:23:45"},
             BluetoothScanningMode.ACTIVE,
-            0,
+            timeout,
         )
-    mock_register.assert_called_once_with("aa:44:33:11:23:45", None, 0)
+    mock_register.assert_called_once_with("aa:44:33:11:23:45", None, None)
+    mock_register_active.assert_called_once_with(timeout)
     mock_cancel.assert_called_once()
 
 

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -2685,7 +2685,7 @@ async def test_process_advertisements_triggers_active_scan_of_correct_duration(
         ) as mock_register,
         patch.object(
             HomeAssistantBluetoothManager, "async_request_active_scan"
-        ) as mock_register_active,
+        ) as mock_request_active_scan,
         pytest.raises(TimeoutError),
     ):
         await async_process_advertisements(
@@ -2696,7 +2696,7 @@ async def test_process_advertisements_triggers_active_scan_of_correct_duration(
             timeout,
         )
     mock_register.assert_called_once_with("aa:44:33:11:23:45", None, None)
-    mock_register_active.assert_called_once_with(timeout)
+    mock_request_active_scan.assert_called_once_with(timeout)
     mock_cancel.assert_called_once()
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Make sure a call to async_process_advertisements triggers active scanning if requested. After the scanning changes, this function would never hit active scanning to get data.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
