### PR TITLE
Move RainMachine service registration to async_setup

### DIFF
--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -1,44 +1,37 @@
 """Support for RainMachine devices."""
 
-from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from datetime import timedelta
-from functools import partial, wraps
-from typing import Any, cast
+from functools import partial
+from typing import Any
 
 from regenmaschine import Client
 from regenmaschine.controller import Controller
 from regenmaschine.errors import RainMachineError, UnknownAPICallError
-import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    CONF_CONDITION,
-    CONF_DEVICE_ID,
     CONF_IP_ADDRESS,
     CONF_PASSWORD,
     CONF_PORT,
     CONF_SSL,
-    CONF_UNIT_OF_MEASUREMENT,
     Platform,
 )
-from homeassistant.core import HomeAssistant, ServiceCall, callback
-from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import (
     aiohttp_client,
     config_validation as cv,
-    device_registry as dr,
     entity_registry as er,
 )
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import UpdateFailed
-from homeassistant.util.dt import as_timestamp, utcnow
 from homeassistant.util.network import is_ip_address
 
 from .config_flow import get_client_controller
 from .const import (
     CONF_ALLOW_INACTIVE_ZONES_TO_RUN,
     CONF_DEFAULT_ZONE_RUN_TIME,
-    CONF_DURATION,
     CONF_USE_APP_RUN_TIMES,
     DATA_API_VERSIONS,
     DATA_MACHINE_FIRMWARE_UPDATE_STATUS,
@@ -52,10 +45,9 @@ from .const import (
     LOGGER,
 )
 from .coordinator import RainMachineDataUpdateCoordinator
+from .services import async_setup_services
 
-API_URL_REFERENCE = (
-    "https://rainmachine.docs.apiary.io/#reference/weather-services/parserdata/post"
-)
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 DEFAULT_SSL = True
 
@@ -67,94 +59,6 @@ PLATFORMS = [
     Platform.SWITCH,
     Platform.UPDATE,
 ]
-
-CONF_DEWPOINT = "dewpoint"
-CONF_ET = "et"
-CONF_MAXRH = "maxrh"
-CONF_MAXTEMP = "maxtemp"
-CONF_MINRH = "minrh"
-CONF_MINTEMP = "mintemp"
-CONF_PRESSURE = "pressure"
-CONF_QPF = "qpf"
-CONF_RAIN = "rain"
-CONF_SECONDS = "seconds"
-CONF_SOLARRAD = "solarrad"
-CONF_TEMPERATURE = "temperature"
-CONF_TIMESTAMP = "timestamp"
-CONF_UNITS = "units"
-CONF_VALUE = "value"
-CONF_WEATHER = "weather"
-CONF_WIND = "wind"
-
-# Config Validator for Flow Meter Data
-CV_FLOW_METER_VALID_UNITS = {
-    "clicks",
-    "gal",
-    "litre",
-    "m3",
-}
-
-# Config Validators for Weather Service Data
-CV_WX_DATA_VALID_PERCENTAGE = vol.All(vol.Coerce(int), vol.Range(min=0, max=100))
-CV_WX_DATA_VALID_TEMP_RANGE = vol.All(vol.Coerce(float), vol.Range(min=-40.0, max=40.0))
-CV_WX_DATA_VALID_RAIN_RANGE = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=1000.0))
-CV_WX_DATA_VALID_WIND_SPEED = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=65.0))
-CV_WX_DATA_VALID_PRESSURE = vol.All(vol.Coerce(float), vol.Range(min=60.0, max=110.0))
-CV_WX_DATA_VALID_SOLARRAD = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=100.0))
-
-SERVICE_NAME_PAUSE_WATERING = "pause_watering"
-SERVICE_NAME_PUSH_FLOW_METER_DATA = "push_flow_meter_data"
-SERVICE_NAME_PUSH_WEATHER_DATA = "push_weather_data"
-SERVICE_NAME_RESTRICT_WATERING = "restrict_watering"
-SERVICE_NAME_STOP_ALL = "stop_all"
-SERVICE_NAME_UNPAUSE_WATERING = "unpause_watering"
-SERVICE_NAME_UNRESTRICT_WATERING = "unrestrict_watering"
-
-SERVICE_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_DEVICE_ID): cv.string,
-    }
-)
-
-SERVICE_PAUSE_WATERING_SCHEMA = SERVICE_SCHEMA.extend(
-    {
-        vol.Required(CONF_SECONDS): cv.positive_int,
-    }
-)
-
-SERVICE_PUSH_FLOW_METER_DATA_SCHEMA = SERVICE_SCHEMA.extend(
-    {
-        vol.Required(CONF_VALUE): cv.positive_float,
-        vol.Optional(CONF_UNIT_OF_MEASUREMENT): vol.All(
-            cv.string, vol.In(CV_FLOW_METER_VALID_UNITS)
-        ),
-    }
-)
-
-SERVICE_PUSH_WEATHER_DATA_SCHEMA = SERVICE_SCHEMA.extend(
-    {
-        vol.Optional(CONF_TIMESTAMP): cv.positive_float,
-        vol.Optional(CONF_MINTEMP): CV_WX_DATA_VALID_TEMP_RANGE,
-        vol.Optional(CONF_MAXTEMP): CV_WX_DATA_VALID_TEMP_RANGE,
-        vol.Optional(CONF_TEMPERATURE): CV_WX_DATA_VALID_TEMP_RANGE,
-        vol.Optional(CONF_WIND): CV_WX_DATA_VALID_WIND_SPEED,
-        vol.Optional(CONF_SOLARRAD): CV_WX_DATA_VALID_SOLARRAD,
-        vol.Optional(CONF_QPF): CV_WX_DATA_VALID_RAIN_RANGE,
-        vol.Optional(CONF_RAIN): CV_WX_DATA_VALID_RAIN_RANGE,
-        vol.Optional(CONF_ET): CV_WX_DATA_VALID_RAIN_RANGE,
-        vol.Optional(CONF_MINRH): CV_WX_DATA_VALID_PERCENTAGE,
-        vol.Optional(CONF_MAXRH): CV_WX_DATA_VALID_PERCENTAGE,
-        vol.Optional(CONF_CONDITION): cv.string,
-        vol.Optional(CONF_PRESSURE): CV_WX_DATA_VALID_PRESSURE,
-        vol.Optional(CONF_DEWPOINT): CV_WX_DATA_VALID_TEMP_RANGE,
-    }
-)
-
-SERVICE_RESTRICT_WATERING_SCHEMA = SERVICE_SCHEMA.extend(
-    {
-        vol.Required(CONF_DURATION): cv.time_period,
-    }
-)
 
 COORDINATOR_UPDATE_INTERVAL_MAP = {
     DATA_API_VERSIONS: timedelta(minutes=1),
@@ -178,44 +82,13 @@ class RainMachineData:
     coordinators: dict[str, RainMachineDataUpdateCoordinator]
 
 
-@callback
-def async_get_entry_for_service_call(
-    hass: HomeAssistant, call: ServiceCall
-) -> RainMachineConfigEntry:
-    """Get the controller related to a service call (by device ID)."""
-    device_id = call.data[CONF_DEVICE_ID]
-    device_registry = dr.async_get(hass)
-
-    if (device_entry := device_registry.async_get(device_id)) is None:
-        raise ValueError(f"Invalid RainMachine device ID: {device_id}")
-
-    for entry_id in device_entry.config_entries:
-        if (entry := hass.config_entries.async_get_entry(entry_id)) is None:
-            continue
-        if entry.domain == DOMAIN:
-            return cast(RainMachineConfigEntry, entry)
-
-    raise ValueError(f"No controller for device ID: {device_id}")
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the RainMachine component."""
+    async_setup_services(hass)
+    return True
 
 
-async def async_update_programs_and_zones(
-    hass: HomeAssistant, entry: RainMachineConfigEntry
-) -> None:
-    """Update program and zone DataUpdateCoordinators.
-
-    Program and zone updates always go together because of how linked they are:
-    programs affect zones and certain combinations of zones affect programs.
-    """
-    data = entry.runtime_data
-    # No gather here to allow http keep-alive to reuse
-    # the connection for each coordinator.
-    await data.coordinators[DATA_PROGRAMS].async_refresh()
-    await data.coordinators[DATA_ZONES].async_refresh()
-
-
-async def async_setup_entry(  # noqa: C901
-    hass: HomeAssistant, entry: RainMachineConfigEntry
-) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: RainMachineConfigEntry) -> bool:
     """Set up RainMachine as config entry."""
     websession = aiohttp_client.async_get_clientsession(hass)
     client = Client(session=websession)
@@ -324,149 +197,6 @@ async def async_setup_entry(  # noqa: C901
 
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
-    def call_with_controller(
-        update_programs_and_zones: bool = True,
-    ) -> Callable[
-        [Callable[[ServiceCall, Controller], Coroutine[Any, Any, None]]],
-        Callable[[ServiceCall], Coroutine[Any, Any, None]],
-    ]:
-        """Hydrate a service call with the appropriate controller."""
-
-        def decorator(
-            func: Callable[[ServiceCall, Controller], Coroutine[Any, Any, None]],
-        ) -> Callable[[ServiceCall], Coroutine[Any, Any, None]]:
-            """Define the decorator."""
-
-            @wraps(func)
-            async def wrapper(call: ServiceCall) -> None:
-                """Wrap the service function."""
-                entry = async_get_entry_for_service_call(hass, call)
-                data = entry.runtime_data
-
-                try:
-                    await func(call, data.controller)
-                except RainMachineError as err:
-                    raise HomeAssistantError(
-                        f"Error while executing {func.__name__}: {err}"
-                    ) from err
-
-                if update_programs_and_zones:
-                    await async_update_programs_and_zones(hass, entry)
-
-            return wrapper
-
-        return decorator
-
-    @call_with_controller()
-    async def async_pause_watering(call: ServiceCall, controller: Controller) -> None:
-        """Pause watering for a set number of seconds."""
-        await controller.watering.pause_all(call.data[CONF_SECONDS])
-
-    @call_with_controller(update_programs_and_zones=False)
-    async def async_push_flow_meter_data(
-        call: ServiceCall, controller: Controller
-    ) -> None:
-        """Push flow meter data to the device."""
-        value = call.data[CONF_VALUE]
-        if units := call.data.get(CONF_UNIT_OF_MEASUREMENT):
-            await controller.watering.post_flowmeter(value=value, units=units)
-        else:
-            await controller.watering.post_flowmeter(value=value)
-
-    @call_with_controller(update_programs_and_zones=False)
-    async def async_push_weather_data(
-        call: ServiceCall, controller: Controller
-    ) -> None:
-        """Push weather data to the device."""
-        await controller.parsers.post_data(
-            {
-                CONF_WEATHER: [
-                    {
-                        key: value
-                        for key, value in call.data.items()
-                        if key != CONF_DEVICE_ID
-                    }
-                ]
-            }
-        )
-
-    @call_with_controller()
-    async def async_restrict_watering(
-        call: ServiceCall, controller: Controller
-    ) -> None:
-        """Restrict watering for a time period."""
-        duration = call.data[CONF_DURATION]
-        await controller.restrictions.set_universal(
-            {
-                "rainDelayStartTime": round(as_timestamp(utcnow())),
-                "rainDelayDuration": duration.total_seconds(),
-            },
-        )
-
-    @call_with_controller()
-    async def async_stop_all(call: ServiceCall, controller: Controller) -> None:
-        """Stop all watering."""
-        await controller.watering.stop_all()
-
-    @call_with_controller()
-    async def async_unpause_watering(call: ServiceCall, controller: Controller) -> None:
-        """Unpause watering."""
-        await controller.watering.unpause_all()
-
-    @call_with_controller()
-    async def async_unrestrict_watering(
-        call: ServiceCall, controller: Controller
-    ) -> None:
-        """Unrestrict watering."""
-        await controller.restrictions.set_universal(
-            {
-                "rainDelayStartTime": round(as_timestamp(utcnow())),
-                "rainDelayDuration": 0,
-            },
-        )
-
-    for service_name, schema, method in (
-        (
-            SERVICE_NAME_PAUSE_WATERING,
-            SERVICE_PAUSE_WATERING_SCHEMA,
-            async_pause_watering,
-        ),
-        (
-            SERVICE_NAME_PUSH_FLOW_METER_DATA,
-            SERVICE_PUSH_FLOW_METER_DATA_SCHEMA,
-            async_push_flow_meter_data,
-        ),
-        (
-            SERVICE_NAME_PUSH_WEATHER_DATA,
-            SERVICE_PUSH_WEATHER_DATA_SCHEMA,
-            async_push_weather_data,
-        ),
-        (
-            SERVICE_NAME_RESTRICT_WATERING,
-            SERVICE_RESTRICT_WATERING_SCHEMA,
-            async_restrict_watering,
-        ),
-        (SERVICE_NAME_STOP_ALL, SERVICE_SCHEMA, async_stop_all),
-        (SERVICE_NAME_UNPAUSE_WATERING, SERVICE_SCHEMA, async_unpause_watering),
-        (
-            SERVICE_NAME_UNRESTRICT_WATERING,
-            SERVICE_SCHEMA,
-            async_unrestrict_watering,
-        ),
-    ):
-        if hass.services.has_service(DOMAIN, service_name):
-            continue
-        # pylint: disable-next=home-assistant-service-registered-in-setup-entry
-        hass.services.async_register(
-            DOMAIN,
-            service_name,
-            method,
-            schema=schema,
-            description_placeholders={
-                "api_url": API_URL_REFERENCE,
-            },
-        )
-
     return True
 
 
@@ -474,22 +204,7 @@ async def async_unload_entry(
     hass: HomeAssistant, entry: RainMachineConfigEntry
 ) -> bool:
     """Unload an RainMachine config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if not hass.config_entries.async_loaded_entries(DOMAIN):
-        # If this is the last loaded instance of RainMachine, deregister any services
-        # defined during integration setup:
-        for service_name in (
-            SERVICE_NAME_PAUSE_WATERING,
-            SERVICE_NAME_PUSH_FLOW_METER_DATA,
-            SERVICE_NAME_PUSH_WEATHER_DATA,
-            SERVICE_NAME_RESTRICT_WATERING,
-            SERVICE_NAME_STOP_ALL,
-            SERVICE_NAME_UNPAUSE_WATERING,
-            SERVICE_NAME_UNRESTRICT_WATERING,
-        ):
-            hass.services.async_remove(DOMAIN, service_name)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 async def async_migrate_entry(

--- a/homeassistant/components/rainmachine/coordinator.py
+++ b/homeassistant/components/rainmachine/coordinator.py
@@ -11,13 +11,26 @@ from homeassistant.helpers.dispatcher import (
 )
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import LOGGER
+from .const import DATA_PROGRAMS, DATA_ZONES, LOGGER
 
 SIGNAL_REBOOT_COMPLETED = "rainmachine_reboot_completed_{0}"
 SIGNAL_REBOOT_REQUESTED = "rainmachine_reboot_requested_{0}"
 
 if TYPE_CHECKING:
     from . import RainMachineConfigEntry
+
+
+async def async_update_programs_and_zones(entry: RainMachineConfigEntry) -> None:
+    """Update program and zone DataUpdateCoordinators.
+
+    Program and zone updates always go together because of how linked they are:
+    programs affect zones and certain combinations of zones affect programs.
+    """
+    data = entry.runtime_data
+    # No gather here to allow http keep-alive to reuse
+    # the connection for each coordinator.
+    await data.coordinators[DATA_PROGRAMS].async_refresh()
+    await data.coordinators[DATA_ZONES].async_refresh()
 
 
 class RainMachineDataUpdateCoordinator(DataUpdateCoordinator[dict]):

--- a/homeassistant/components/rainmachine/services.py
+++ b/homeassistant/components/rainmachine/services.py
@@ -1,0 +1,290 @@
+"""Support for RainMachine services."""
+
+from collections.abc import Callable, Coroutine
+from functools import wraps
+from typing import TYPE_CHECKING, Any, cast
+
+from regenmaschine.controller import Controller
+from regenmaschine.errors import RainMachineError
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_CONDITION, CONF_DEVICE_ID, CONF_UNIT_OF_MEASUREMENT
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.util.dt import as_timestamp, utcnow
+
+from .const import CONF_DURATION, DOMAIN
+from .coordinator import async_update_programs_and_zones
+
+if TYPE_CHECKING:
+    from . import RainMachineConfigEntry
+
+API_URL_REFERENCE = (
+    "https://rainmachine.docs.apiary.io/#reference/weather-services/parserdata/post"
+)
+
+CONF_DEWPOINT = "dewpoint"
+CONF_ET = "et"
+CONF_MAXRH = "maxrh"
+CONF_MAXTEMP = "maxtemp"
+CONF_MINRH = "minrh"
+CONF_MINTEMP = "mintemp"
+CONF_PRESSURE = "pressure"
+CONF_QPF = "qpf"
+CONF_RAIN = "rain"
+CONF_SECONDS = "seconds"
+CONF_SOLARRAD = "solarrad"
+CONF_TEMPERATURE = "temperature"
+CONF_TIMESTAMP = "timestamp"
+CONF_UNITS = "units"
+CONF_VALUE = "value"
+CONF_WEATHER = "weather"
+CONF_WIND = "wind"
+
+# Config Validator for Flow Meter Data
+CV_FLOW_METER_VALID_UNITS = {
+    "clicks",
+    "gal",
+    "litre",
+    "m3",
+}
+
+# Config Validators for Weather Service Data
+CV_WX_DATA_VALID_PERCENTAGE = vol.All(vol.Coerce(int), vol.Range(min=0, max=100))
+CV_WX_DATA_VALID_TEMP_RANGE = vol.All(vol.Coerce(float), vol.Range(min=-40.0, max=40.0))
+CV_WX_DATA_VALID_RAIN_RANGE = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=1000.0))
+CV_WX_DATA_VALID_WIND_SPEED = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=65.0))
+CV_WX_DATA_VALID_PRESSURE = vol.All(vol.Coerce(float), vol.Range(min=60.0, max=110.0))
+CV_WX_DATA_VALID_SOLARRAD = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=100.0))
+
+SERVICE_NAME_PAUSE_WATERING = "pause_watering"
+SERVICE_NAME_PUSH_FLOW_METER_DATA = "push_flow_meter_data"
+SERVICE_NAME_PUSH_WEATHER_DATA = "push_weather_data"
+SERVICE_NAME_RESTRICT_WATERING = "restrict_watering"
+SERVICE_NAME_STOP_ALL = "stop_all"
+SERVICE_NAME_UNPAUSE_WATERING = "unpause_watering"
+SERVICE_NAME_UNRESTRICT_WATERING = "unrestrict_watering"
+
+SERVICE_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_DEVICE_ID): cv.string,
+    }
+)
+
+SERVICE_PAUSE_WATERING_SCHEMA = SERVICE_SCHEMA.extend(
+    {
+        vol.Required(CONF_SECONDS): cv.positive_int,
+    }
+)
+
+SERVICE_PUSH_FLOW_METER_DATA_SCHEMA = SERVICE_SCHEMA.extend(
+    {
+        vol.Required(CONF_VALUE): cv.positive_float,
+        vol.Optional(CONF_UNIT_OF_MEASUREMENT): vol.All(
+            cv.string, vol.In(CV_FLOW_METER_VALID_UNITS)
+        ),
+    }
+)
+
+SERVICE_PUSH_WEATHER_DATA_SCHEMA = SERVICE_SCHEMA.extend(
+    {
+        vol.Optional(CONF_TIMESTAMP): cv.positive_float,
+        vol.Optional(CONF_MINTEMP): CV_WX_DATA_VALID_TEMP_RANGE,
+        vol.Optional(CONF_MAXTEMP): CV_WX_DATA_VALID_TEMP_RANGE,
+        vol.Optional(CONF_TEMPERATURE): CV_WX_DATA_VALID_TEMP_RANGE,
+        vol.Optional(CONF_WIND): CV_WX_DATA_VALID_WIND_SPEED,
+        vol.Optional(CONF_SOLARRAD): CV_WX_DATA_VALID_SOLARRAD,
+        vol.Optional(CONF_QPF): CV_WX_DATA_VALID_RAIN_RANGE,
+        vol.Optional(CONF_RAIN): CV_WX_DATA_VALID_RAIN_RANGE,
+        vol.Optional(CONF_ET): CV_WX_DATA_VALID_RAIN_RANGE,
+        vol.Optional(CONF_MINRH): CV_WX_DATA_VALID_PERCENTAGE,
+        vol.Optional(CONF_MAXRH): CV_WX_DATA_VALID_PERCENTAGE,
+        vol.Optional(CONF_CONDITION): cv.string,
+        vol.Optional(CONF_PRESSURE): CV_WX_DATA_VALID_PRESSURE,
+        vol.Optional(CONF_DEWPOINT): CV_WX_DATA_VALID_TEMP_RANGE,
+    }
+)
+
+SERVICE_RESTRICT_WATERING_SCHEMA = SERVICE_SCHEMA.extend(
+    {
+        vol.Required(CONF_DURATION): cv.time_period,
+    }
+)
+
+
+@callback
+def async_get_entry_for_service_call(call: ServiceCall) -> RainMachineConfigEntry:
+    """Get the controller related to a service call (by device ID)."""
+    device_id = call.data[CONF_DEVICE_ID]
+    device_registry = dr.async_get(call.hass)
+
+    if (device_entry := device_registry.async_get(device_id)) is None:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="invalid_device_id",
+            translation_placeholders={"device_id": device_id},
+        )
+
+    for entry_id in device_entry.config_entries:
+        if (entry := call.hass.config_entries.async_get_entry(entry_id)) is None:
+            continue
+        if entry.domain == DOMAIN:
+            if entry.state is not ConfigEntryState.LOADED:
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="controller_not_ready",
+                    translation_placeholders={"device_id": device_id},
+                )
+            return cast("RainMachineConfigEntry", entry)
+
+    raise ServiceValidationError(
+        translation_domain=DOMAIN,
+        translation_key="no_controller_for_device_id",
+        translation_placeholders={"device_id": device_id},
+    )
+
+
+def call_with_controller(
+    update_programs_and_zones: bool = True,
+) -> Callable[
+    [Callable[[ServiceCall, Controller], Coroutine[Any, Any, None]]],
+    Callable[[ServiceCall], Coroutine[Any, Any, None]],
+]:
+    """Hydrate a service call with the appropriate controller."""
+
+    def decorator(
+        func: Callable[[ServiceCall, Controller], Coroutine[Any, Any, None]],
+    ) -> Callable[[ServiceCall], Coroutine[Any, Any, None]]:
+        """Define the decorator."""
+
+        @wraps(func)
+        async def wrapper(call: ServiceCall) -> None:
+            """Wrap the service function."""
+            entry = async_get_entry_for_service_call(call)
+            data = entry.runtime_data
+
+            try:
+                await func(call, data.controller)
+            except RainMachineError as err:
+                raise HomeAssistantError(
+                    f"Error while executing {func.__name__}: {err}"
+                ) from err
+
+            if update_programs_and_zones:
+                await async_update_programs_and_zones(entry)
+
+        return wrapper
+
+    return decorator
+
+
+@call_with_controller()
+async def async_pause_watering(call: ServiceCall, controller: Controller) -> None:
+    """Pause watering for a set number of seconds."""
+    await controller.watering.pause_all(call.data[CONF_SECONDS])
+
+
+@call_with_controller(update_programs_and_zones=False)
+async def async_push_flow_meter_data(call: ServiceCall, controller: Controller) -> None:
+    """Push flow meter data to the device."""
+    value = call.data[CONF_VALUE]
+    if units := call.data.get(CONF_UNIT_OF_MEASUREMENT):
+        await controller.watering.post_flowmeter(value=value, units=units)
+    else:
+        await controller.watering.post_flowmeter(value=value)
+
+
+@call_with_controller(update_programs_and_zones=False)
+async def async_push_weather_data(call: ServiceCall, controller: Controller) -> None:
+    """Push weather data to the device."""
+    await controller.parsers.post_data(
+        {
+            CONF_WEATHER: [
+                {
+                    key: value
+                    for key, value in call.data.items()
+                    if key != CONF_DEVICE_ID
+                }
+            ]
+        }
+    )
+
+
+@call_with_controller()
+async def async_restrict_watering(call: ServiceCall, controller: Controller) -> None:
+    """Restrict watering for a time period."""
+    duration = call.data[CONF_DURATION]
+    await controller.restrictions.set_universal(
+        {
+            "rainDelayStartTime": round(as_timestamp(utcnow())),
+            "rainDelayDuration": duration.total_seconds(),
+        },
+    )
+
+
+@call_with_controller()
+async def async_stop_all(call: ServiceCall, controller: Controller) -> None:
+    """Stop all watering."""
+    await controller.watering.stop_all()
+
+
+@call_with_controller()
+async def async_unpause_watering(call: ServiceCall, controller: Controller) -> None:
+    """Unpause watering."""
+    await controller.watering.unpause_all()
+
+
+@call_with_controller()
+async def async_unrestrict_watering(call: ServiceCall, controller: Controller) -> None:
+    """Unrestrict watering."""
+    await controller.restrictions.set_universal(
+        {
+            "rainDelayStartTime": round(as_timestamp(utcnow())),
+            "rainDelayDuration": 0,
+        },
+    )
+
+
+@callback
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Register the RainMachine services."""
+    for service_name, schema, method in (
+        (
+            SERVICE_NAME_PAUSE_WATERING,
+            SERVICE_PAUSE_WATERING_SCHEMA,
+            async_pause_watering,
+        ),
+        (
+            SERVICE_NAME_PUSH_FLOW_METER_DATA,
+            SERVICE_PUSH_FLOW_METER_DATA_SCHEMA,
+            async_push_flow_meter_data,
+        ),
+        (
+            SERVICE_NAME_PUSH_WEATHER_DATA,
+            SERVICE_PUSH_WEATHER_DATA_SCHEMA,
+            async_push_weather_data,
+        ),
+        (
+            SERVICE_NAME_RESTRICT_WATERING,
+            SERVICE_RESTRICT_WATERING_SCHEMA,
+            async_restrict_watering,
+        ),
+        (SERVICE_NAME_STOP_ALL, SERVICE_SCHEMA, async_stop_all),
+        (SERVICE_NAME_UNPAUSE_WATERING, SERVICE_SCHEMA, async_unpause_watering),
+        (
+            SERVICE_NAME_UNRESTRICT_WATERING,
+            SERVICE_SCHEMA,
+            async_unrestrict_watering,
+        ),
+    ):
+        hass.services.async_register(
+            DOMAIN,
+            service_name,
+            method,
+            schema=schema,
+            description_placeholders={
+                "api_url": API_URL_REFERENCE,
+            },
+        )

--- a/homeassistant/components/rainmachine/strings.json
+++ b/homeassistant/components/rainmachine/strings.json
@@ -82,6 +82,17 @@
       }
     }
   },
+  "exceptions": {
+    "controller_not_ready": {
+      "message": "The RainMachine controller for device ID {device_id} is not ready."
+    },
+    "invalid_device_id": {
+      "message": "Invalid RainMachine device ID: {device_id}."
+    },
+    "no_controller_for_device_id": {
+      "message": "No RainMachine controller found for device ID: {device_id}."
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -18,7 +18,7 @@ from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import VolDictType
 
-from . import RainMachineConfigEntry, RainMachineData, async_update_programs_and_zones
+from . import RainMachineConfigEntry, RainMachineData
 from .const import (
     CONF_ALLOW_INACTIVE_ZONES_TO_RUN,
     CONF_DEFAULT_ZONE_RUN_TIME,
@@ -30,6 +30,7 @@ from .const import (
     DATA_ZONES,
     DEFAULT_ZONE_RUN,
 )
+from .coordinator import async_update_programs_and_zones
 from .entity import RainMachineEntity, RainMachineEntityDescription
 from .util import RUN_STATE_MAP, key_exists
 
@@ -265,9 +266,7 @@ class RainMachineBaseSwitch(RainMachineEntity, SwitchEntity):
     @callback
     def _update_activities(self) -> None:
         """Update all activity data."""
-        self.hass.async_create_task(
-            async_update_programs_and_zones(self.hass, self._entry)
-        )
+        self.hass.async_create_task(async_update_programs_and_zones(self._entry))
 
     async def async_start_program(self) -> None:
         """Execute the start_program entity service."""

--- a/tests/components/rainmachine/test_services.py
+++ b/tests/components/rainmachine/test_services.py
@@ -1,0 +1,233 @@
+"""Test RainMachine services."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from regenmaschine.errors import RainMachineError
+
+from homeassistant.components.rainmachine import DOMAIN
+from homeassistant.components.rainmachine.services import (
+    CONF_WEATHER,
+    SERVICE_NAME_PAUSE_WATERING,
+    SERVICE_NAME_PUSH_FLOW_METER_DATA,
+    SERVICE_NAME_PUSH_WEATHER_DATA,
+    SERVICE_NAME_RESTRICT_WATERING,
+    SERVICE_NAME_STOP_ALL,
+    SERVICE_NAME_UNPAUSE_WATERING,
+    SERVICE_NAME_UNRESTRICT_WATERING,
+)
+from homeassistant.const import CONF_DEVICE_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import device_registry as dr
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture(name="device_id")
+def device_id_fixture(
+    hass: HomeAssistant, config_entry: MockConfigEntry, controller_mac: str
+) -> str:
+    """Define a fixture for the RainMachine device registry ID."""
+    device_registry = dr.async_get(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, controller_mac)},
+    )
+    return device_entry.id
+
+
+async def test_services_registered(
+    hass: HomeAssistant, setup_rainmachine: None
+) -> None:
+    """Test that the services are registered during setup."""
+    for service_name in (
+        SERVICE_NAME_PAUSE_WATERING,
+        SERVICE_NAME_PUSH_FLOW_METER_DATA,
+        SERVICE_NAME_PUSH_WEATHER_DATA,
+        SERVICE_NAME_RESTRICT_WATERING,
+        SERVICE_NAME_STOP_ALL,
+        SERVICE_NAME_UNPAUSE_WATERING,
+        SERVICE_NAME_UNRESTRICT_WATERING,
+    ):
+        assert hass.services.has_service(DOMAIN, service_name)
+
+
+@pytest.mark.parametrize(
+    ("service_name", "service_data", "method", "expected_args", "expected_kwargs"),
+    [
+        (
+            SERVICE_NAME_PAUSE_WATERING,
+            {"seconds": 90},
+            "watering.pause_all",
+            (90,),
+            {},
+        ),
+        (
+            SERVICE_NAME_PUSH_FLOW_METER_DATA,
+            {"value": 100},
+            "watering.post_flowmeter",
+            (),
+            {"value": 100.0},
+        ),
+        (
+            SERVICE_NAME_PUSH_FLOW_METER_DATA,
+            {"value": 100, "unit_of_measurement": "gal"},
+            "watering.post_flowmeter",
+            (),
+            {"value": 100.0, "units": "gal"},
+        ),
+        (
+            SERVICE_NAME_PUSH_WEATHER_DATA,
+            {"temperature": 18.5},
+            "parsers.post_data",
+            ({CONF_WEATHER: [{"temperature": 18.5}]},),
+            {},
+        ),
+        (SERVICE_NAME_STOP_ALL, {}, "watering.stop_all", (), {}),
+        (SERVICE_NAME_UNPAUSE_WATERING, {}, "watering.unpause_all", (), {}),
+    ],
+)
+async def test_service_calls(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    controller: AsyncMock,
+    setup_rainmachine: None,
+    device_id: str,
+    service_name: str,
+    service_data: dict,
+    method: str,
+    expected_args: tuple,
+    expected_kwargs: dict,
+) -> None:
+    """Test that each service calls the expected controller method with arguments."""
+    await hass.services.async_call(
+        DOMAIN,
+        service_name,
+        {CONF_DEVICE_ID: device_id, **service_data},
+        blocking=True,
+    )
+
+    mock = controller
+    for attr in method.split("."):
+        mock = getattr(mock, attr)
+    mock.assert_awaited_once_with(*expected_args, **expected_kwargs)
+
+
+async def test_restrict_and_unrestrict_watering(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    controller: AsyncMock,
+    setup_rainmachine: None,
+    device_id: str,
+) -> None:
+    """Test restrict/unrestrict watering set the expected rain delay duration.
+
+    Both services call ``restrictions.set_universal``, so the duration is what
+    distinguishes them: restrict passes the requested period, unrestrict passes 0.
+    """
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_NAME_RESTRICT_WATERING,
+        {CONF_DEVICE_ID: device_id, "duration": {"minutes": 30}},
+        blocking=True,
+    )
+    controller.restrictions.set_universal.assert_awaited_once()
+    assert (
+        controller.restrictions.set_universal.call_args.args[0]["rainDelayDuration"]
+        == 1800.0
+    )
+
+    controller.restrictions.set_universal.reset_mock()
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_NAME_UNRESTRICT_WATERING,
+        {CONF_DEVICE_ID: device_id},
+        blocking=True,
+    )
+    controller.restrictions.set_universal.assert_awaited_once()
+    assert (
+        controller.restrictions.set_universal.call_args.args[0]["rainDelayDuration"]
+        == 0
+    )
+
+
+async def test_service_call_controller_error(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    controller: AsyncMock,
+    setup_rainmachine: None,
+    device_id: str,
+) -> None:
+    """Test that a controller error is wrapped in a HomeAssistantError."""
+    controller.watering.stop_all.side_effect = RainMachineError("error")
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_NAME_STOP_ALL,
+            {CONF_DEVICE_ID: device_id},
+            blocking=True,
+        )
+
+
+async def test_service_call_invalid_device_id(
+    hass: HomeAssistant, setup_rainmachine: None
+) -> None:
+    """Test that an unknown device ID raises a ServiceValidationError."""
+    with pytest.raises(ServiceValidationError) as err:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_NAME_STOP_ALL,
+            {CONF_DEVICE_ID: "abcd1234"},
+            blocking=True,
+        )
+
+    assert err.value.translation_key == "invalid_device_id"
+
+
+async def test_service_call_non_rainmachine_device(
+    hass: HomeAssistant, setup_rainmachine: None
+) -> None:
+    """Test that a non-RainMachine device raises a ServiceValidationError."""
+    other_entry = MockConfigEntry(domain="other")
+    other_entry.add_to_hass(hass)
+    device_registry = dr.async_get(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=other_entry.entry_id,
+        identifiers={("other", "abcd1234")},
+    )
+
+    with pytest.raises(ServiceValidationError) as err:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_NAME_STOP_ALL,
+            {CONF_DEVICE_ID: device_entry.id},
+            blocking=True,
+        )
+
+    assert err.value.translation_key == "no_controller_for_device_id"
+
+
+async def test_service_call_controller_not_loaded(
+    hass: HomeAssistant, setup_rainmachine: None
+) -> None:
+    """Test that an unloaded controller raises a ServiceValidationError."""
+    unloaded_entry = MockConfigEntry(domain=DOMAIN)
+    unloaded_entry.add_to_hass(hass)
+    device_registry = dr.async_get(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=unloaded_entry.entry_id,
+        identifiers={(DOMAIN, "00:11:22:33:44:55")},
+    )
+
+    with pytest.raises(ServiceValidationError) as err:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_NAME_STOP_ALL,
+            {CONF_DEVICE_ID: device_entry.id},
+            blocking=True,
+        )
+
+    assert err.value.translation_key == "controller_not_ready"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Register the RainMachine services in `async_setup` instead of `async_setup_entry`.
This is the pattern tracked by home-assistant/epics#65: services registered in
`async_setup_entry` only exist while a config entry is loaded, which prevents Home
Assistant from validating automations that reference them when no entry is set up,
and causes the services to be re-registered/removed on every entry load/unload.

Changes:
- Move all service constants, schemas and handlers into a new `services.py`, with an
  `async_setup_services(hass)` helper that `async_setup` calls once (mirrors the
  existing `guardian` integration).
- Add `CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)`.
- Service handlers now resolve the target controller from `call.hass` and raise
  `ServiceValidationError` (with translation keys) for an invalid device ID, a
  device that is not a RainMachine controller, or a controller whose entry is not
  loaded — instead of the previous `ValueError` / `AttributeError`.
- Move `async_update_programs_and_zones` to `coordinator.py` (used by both `switch`
  and the services) to avoid a circular import.
- Services are no longer deregistered on unload, and the
  `home-assistant-service-registered-in-setup-entry` pylint disable is removed.

There are no functional changes to the services themselves, no new dependencies, and
no manifest changes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170744
- This PR is related to issue: home-assistant/epics#65
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
