### PR TITLE
feat(overkiz): fire event on execution failure for retry logic

### DIFF
--- a/homeassistant/components/overkiz/const.py
+++ b/homeassistant/components/overkiz/const.py
@@ -40,6 +40,7 @@ CONF_API_TYPE: Final = "api_type"
 CONF_HUB: Final = "hub"
 DEFAULT_SERVER: Final = Server.SOMFY_EUROPE
 DEFAULT_HOST: Final = "gateway-xxxx-xxxx-xxxx.local:8443"
+EVENT_EXECUTION_FAILED: Final = "overkiz_execution_failed"
 
 UPDATE_INTERVAL: Final = timedelta(seconds=30)
 UPDATE_INTERVAL_LOCAL: Final = timedelta(seconds=5)

--- a/homeassistant/components/overkiz/coordinator.py
+++ b/homeassistant/components/overkiz/coordinator.py
@@ -9,15 +9,23 @@ from aiohttp import ClientConnectorError, ServerDisconnectedError
 from pyoverkiz.client import OverkizClient
 from pyoverkiz.enums import EventName, ExecutionState, Protocol
 from pyoverkiz.exceptions import (
-    BadCredentialsException,
-    InvalidEventListenerIdException,
-    MaintenanceException,
-    NotAuthenticatedException,
-    ServiceUnavailableException,
-    TooManyConcurrentRequestsException,
-    TooManyRequestsException,
+    BadCredentialsError,
+    InvalidEventListenerIdError,
+    MaintenanceError,
+    NotAuthenticatedError,
+    ServiceUnavailableError,
+    TooManyConcurrentRequestsError,
+    TooManyRequestsError,
 )
-from pyoverkiz.models import Device, Event, Place
+from pyoverkiz.models import (
+    Device,
+    DeviceEvent,
+    DeviceRemovedEvent,
+    DeviceStateChangedEvent,
+    ExecutionRegisteredEvent,
+    ExecutionStateChangedEvent,
+    Place,
+)
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -36,8 +44,9 @@ from .const import (
     UPDATE_INTERVAL,
 )
 
+# Events are a discriminated union; each handler narrows to its own subtype.
 EVENT_HANDLERS: Registry[
-    str, Callable[[OverkizDataUpdateCoordinator, Event], Coroutine[Any, Any, None]]
+    str, Callable[[OverkizDataUpdateCoordinator, Any], Coroutine[Any, Any, None]]
 ] = Registry()
 
 
@@ -84,17 +93,17 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
         """Fetch Overkiz data via event listener."""
         try:
             events = await self.client.fetch_events()
-        except (BadCredentialsException, NotAuthenticatedException) as exception:
+        except (BadCredentialsError, NotAuthenticatedError) as exception:
             raise ConfigEntryAuthFailed("Invalid authentication.") from exception
-        except TooManyConcurrentRequestsException as exception:
+        except TooManyConcurrentRequestsError as exception:
             raise UpdateFailed("Too many concurrent requests.") from exception
-        except TooManyRequestsException as exception:
+        except TooManyRequestsError as exception:
             raise UpdateFailed("Too many requests, try again later.") from exception
-        except MaintenanceException as exception:
+        except MaintenanceError as exception:
             raise UpdateFailed("Server is down for maintenance.") from exception
-        except ServiceUnavailableException as exception:
+        except ServiceUnavailableError as exception:
             raise UpdateFailed("Server is unavailable.") from exception
-        except InvalidEventListenerIdException as exception:
+        except InvalidEventListenerIdError as exception:
             raise UpdateFailed(exception) from exception
         except (TimeoutError, ClientConnectorError) as exception:
             LOGGER.debug("Failed to connect", exc_info=True)
@@ -106,9 +115,9 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
             try:
                 await self.client.login()
                 self.devices = await self._get_devices()
-            except (BadCredentialsException, NotAuthenticatedException) as exception:
+            except (BadCredentialsError, NotAuthenticatedError) as exception:
                 raise ConfigEntryAuthFailed("Invalid authentication.") from exception
-            except TooManyRequestsException as exception:
+            except TooManyRequestsError as exception:
                 raise UpdateFailed("Too many requests, try again later.") from exception
 
             return self.devices
@@ -150,7 +159,7 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
 
 @EVENT_HANDLERS.register(EventName.DEVICE_AVAILABLE)
 async def on_device_available(
-    coordinator: OverkizDataUpdateCoordinator, event: Event
+    coordinator: OverkizDataUpdateCoordinator, event: DeviceEvent
 ) -> None:
     """Handle device available event."""
     if event.device_url and event.device_url in coordinator.devices:
@@ -160,7 +169,7 @@ async def on_device_available(
 @EVENT_HANDLERS.register(EventName.DEVICE_UNAVAILABLE)
 @EVENT_HANDLERS.register(EventName.DEVICE_DISABLED)
 async def on_device_unavailable_disabled(
-    coordinator: OverkizDataUpdateCoordinator, event: Event
+    coordinator: OverkizDataUpdateCoordinator, event: DeviceEvent
 ) -> None:
     """Handle device unavailable / disabled event."""
     if event.device_url and event.device_url in coordinator.devices:
@@ -170,7 +179,7 @@ async def on_device_unavailable_disabled(
 @EVENT_HANDLERS.register(EventName.DEVICE_CREATED)
 @EVENT_HANDLERS.register(EventName.DEVICE_UPDATED)
 async def on_device_created_updated(
-    coordinator: OverkizDataUpdateCoordinator, event: Event
+    coordinator: OverkizDataUpdateCoordinator, event: DeviceEvent
 ) -> None:
     """Handle device unavailable / disabled event."""
     coordinator.hass.async_create_task(
@@ -180,7 +189,7 @@ async def on_device_created_updated(
 
 @EVENT_HANDLERS.register(EventName.DEVICE_STATE_CHANGED)
 async def on_device_state_changed(
-    coordinator: OverkizDataUpdateCoordinator, event: Event
+    coordinator: OverkizDataUpdateCoordinator, event: DeviceStateChangedEvent
 ) -> None:
     """Handle device state changed event."""
     if not event.device_url or event.device_url not in coordinator.devices:
@@ -193,7 +202,7 @@ async def on_device_state_changed(
 
 @EVENT_HANDLERS.register(EventName.DEVICE_REMOVED)
 async def on_device_removed(
-    coordinator: OverkizDataUpdateCoordinator, event: Event
+    coordinator: OverkizDataUpdateCoordinator, event: DeviceRemovedEvent
 ) -> None:
     """Handle device removed event."""
     if not event.device_url:
@@ -213,7 +222,7 @@ async def on_device_removed(
 
 @EVENT_HANDLERS.register(EventName.EXECUTION_REGISTERED)
 async def on_execution_registered(
-    coordinator: OverkizDataUpdateCoordinator, event: Event
+    coordinator: OverkizDataUpdateCoordinator, event: ExecutionRegisteredEvent
 ) -> None:
     """Handle execution registered event."""
     if event.exec_id and event.exec_id not in coordinator.executions:
@@ -225,7 +234,7 @@ async def on_execution_registered(
 
 @EVENT_HANDLERS.register(EventName.EXECUTION_STATE_CHANGED)
 async def on_execution_state_changed(
-    coordinator: OverkizDataUpdateCoordinator, event: Event
+    coordinator: OverkizDataUpdateCoordinator, event: ExecutionStateChangedEvent
 ) -> None:
     """Handle execution changed event."""
     if event.exec_id not in coordinator.executions:

--- a/homeassistant/components/overkiz/coordinator.py
+++ b/homeassistant/components/overkiz/coordinator.py
@@ -234,7 +234,7 @@ async def on_execution_state_changed(
     execution = coordinator.executions[event.exec_id]
 
     if event.new_state == ExecutionState.FAILED:
-        failure_type = getattr(event, "failure_type", None) or "unknown"
+        failure_type = event.failure_type or "unknown"
         LOGGER.warning(
             "Execution %s failed for device %s (command: %s, failure_type: %s)",
             event.exec_id,
@@ -249,7 +249,7 @@ async def on_execution_state_changed(
                 "device_url": execution.get("device_url", "unknown"),
                 "command_name": execution.get("command_name", "unknown"),
                 "failure_type": failure_type,
-                "failure_type_code": getattr(event, "failure_type_code", None),
+                "failure_type_code": event.failure_type_code,
             },
         )
 

--- a/homeassistant/components/overkiz/coordinator.py
+++ b/homeassistant/components/overkiz/coordinator.py
@@ -234,7 +234,7 @@ async def on_execution_state_changed(
     execution = coordinator.executions[event.exec_id]
 
     if event.new_state == ExecutionState.FAILED:
-        failure_type = getattr(event, "failure_type", "unknown")
+        failure_type = getattr(event, "failure_type", None) or "unknown"
         LOGGER.warning(
             "Execution %s failed for device %s (command: %s, failure_type: %s)",
             event.exec_id,

--- a/homeassistant/components/overkiz/coordinator.py
+++ b/homeassistant/components/overkiz/coordinator.py
@@ -28,7 +28,7 @@ from homeassistant.util.decorator import Registry
 if TYPE_CHECKING:
     from . import OverkizDataConfigEntry
 
-from .const import DOMAIN, IGNORED_OVERKIZ_DEVICES, LOGGER, UPDATE_INTERVAL
+from .const import DOMAIN, EVENT_EXECUTION_FAILED, IGNORED_OVERKIZ_DEVICES, LOGGER, UPDATE_INTERVAL
 
 EVENT_HANDLERS: Registry[
     str, Callable[[OverkizDataUpdateCoordinator, Event], Coroutine[Any, Any, None]]
@@ -222,8 +222,29 @@ async def on_execution_state_changed(
     coordinator: OverkizDataUpdateCoordinator, event: Event
 ) -> None:
     """Handle execution changed event."""
-    if event.exec_id in coordinator.executions and event.new_state in [
-        ExecutionState.COMPLETED,
-        ExecutionState.FAILED,
-    ]:
+    if event.exec_id not in coordinator.executions:
+        return
+
+    execution = coordinator.executions[event.exec_id]
+
+    if event.new_state == ExecutionState.FAILED:
+        LOGGER.warning(
+            "Execution %s failed for device %s (command: %s, failure_type: %s)",
+            event.exec_id,
+            execution.get("device_url", "unknown"),
+            execution.get("command_name", "unknown"),
+            getattr(event, "failure_type", "unknown"),
+        )
+        coordinator.hass.bus.async_fire(
+            EVENT_EXECUTION_FAILED,
+            {
+                "exec_id": event.exec_id,
+                "device_url": execution.get("device_url", "unknown"),
+                "command_name": execution.get("command_name", "unknown"),
+                "failure_type": getattr(event, "failure_type", "unknown"),
+                "failure_type_code": getattr(event, "failure_type_code", None),
+            },
+        )
+
+    if event.new_state in [ExecutionState.COMPLETED, ExecutionState.FAILED]:
         del coordinator.executions[event.exec_id]

--- a/homeassistant/components/overkiz/coordinator.py
+++ b/homeassistant/components/overkiz/coordinator.py
@@ -234,12 +234,13 @@ async def on_execution_state_changed(
     execution = coordinator.executions[event.exec_id]
 
     if event.new_state == ExecutionState.FAILED:
+        failure_type = getattr(event, "failure_type", None) or "unknown"
         LOGGER.warning(
             "Execution %s failed for device %s (command: %s, failure_type: %s)",
             event.exec_id,
             execution.get("device_url", "unknown"),
             execution.get("command_name", "unknown"),
-            getattr(event, "failure_type", None) or "unknown",
+            failure_type,
         )
         coordinator.hass.bus.async_fire(
             EVENT_EXECUTION_FAILED,
@@ -247,7 +248,7 @@ async def on_execution_state_changed(
                 "exec_id": event.exec_id,
                 "device_url": execution.get("device_url", "unknown"),
                 "command_name": execution.get("command_name", "unknown"),
-                "failure_type": getattr(event, "failure_type", None) or "unknown",
+                "failure_type": failure_type,
                 "failure_type_code": getattr(event, "failure_type_code", None),
             },
         )

--- a/homeassistant/components/overkiz/coordinator.py
+++ b/homeassistant/components/overkiz/coordinator.py
@@ -234,7 +234,7 @@ async def on_execution_state_changed(
     execution = coordinator.executions[event.exec_id]
 
     if event.new_state == ExecutionState.FAILED:
-        failure_type = getattr(event, "failure_type", None) or "unknown"
+        failure_type = getattr(event, "failure_type", "unknown")
         LOGGER.warning(
             "Execution %s failed for device %s (command: %s, failure_type: %s)",
             event.exec_id,

--- a/homeassistant/components/overkiz/coordinator.py
+++ b/homeassistant/components/overkiz/coordinator.py
@@ -28,7 +28,13 @@ from homeassistant.util.decorator import Registry
 if TYPE_CHECKING:
     from . import OverkizDataConfigEntry
 
-from .const import DOMAIN, EVENT_EXECUTION_FAILED, IGNORED_OVERKIZ_DEVICES, LOGGER, UPDATE_INTERVAL
+from .const import (
+    DOMAIN,
+    EVENT_EXECUTION_FAILED,
+    IGNORED_OVERKIZ_DEVICES,
+    LOGGER,
+    UPDATE_INTERVAL,
+)
 
 EVENT_HANDLERS: Registry[
     str, Callable[[OverkizDataUpdateCoordinator, Event], Coroutine[Any, Any, None]]
@@ -233,7 +239,7 @@ async def on_execution_state_changed(
             event.exec_id,
             execution.get("device_url", "unknown"),
             execution.get("command_name", "unknown"),
-            getattr(event, "failure_type", "unknown"),
+            getattr(event, "failure_type", None) or "unknown",
         )
         coordinator.hass.bus.async_fire(
             EVENT_EXECUTION_FAILED,
@@ -241,7 +247,7 @@ async def on_execution_state_changed(
                 "exec_id": event.exec_id,
                 "device_url": execution.get("device_url", "unknown"),
                 "command_name": execution.get("command_name", "unknown"),
-                "failure_type": getattr(event, "failure_type", "unknown"),
+                "failure_type": getattr(event, "failure_type", None) or "unknown",
                 "failure_type_code": getattr(event, "failure_type_code", None),
             },
         )

--- a/tests/components/overkiz/helpers.py
+++ b/tests/components/overkiz/helpers.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from typing import Any
 
 from freezegun.api import FrozenDateTimeFactory
+from pyoverkiz.enums import FailureType
 from pyoverkiz.models import Event
 
 from homeassistant.components.overkiz.const import UPDATE_INTERVAL
@@ -38,7 +39,7 @@ def build_event(
     exec_id: str | None = None,
     new_state: str | None = None,
     failure_type: str | None = None,
-    failure_type_code: str | None = None,
+    failure_type_code: FailureType | None = None,
     **extra_kwargs: Any,
 ) -> Event:
     """Create a pyoverkiz event object with a test-friendly interface."""

--- a/tests/components/overkiz/helpers.py
+++ b/tests/components/overkiz/helpers.py
@@ -37,6 +37,8 @@ def build_event(
     device_states: list[dict[str, Any]] | None = None,
     exec_id: str | None = None,
     new_state: str | None = None,
+    failure_type: str | None = None,
+    failure_type_code: str | None = None,
     **extra_kwargs: Any,
 ) -> Event:
     """Create a pyoverkiz event object with a test-friendly interface."""
@@ -46,6 +48,8 @@ def build_event(
         device_states=device_states,
         exec_id=exec_id,
         new_state=new_state,
+        failure_type=failure_type,
+        failure_type_code=failure_type_code,
         **extra_kwargs,
     )
 

--- a/tests/components/overkiz/helpers.py
+++ b/tests/components/overkiz/helpers.py
@@ -37,6 +37,7 @@ def build_event(
     device_states: list[dict[str, Any]] | None = None,
     exec_id: str | None = None,
     new_state: str | None = None,
+    **extra_kwargs: Any,
 ) -> Event:
     """Create a pyoverkiz event object with a test-friendly interface."""
     return Event(
@@ -45,6 +46,7 @@ def build_event(
         device_states=device_states,
         exec_id=exec_id,
         new_state=new_state,
+        **extra_kwargs,
     )
 
 

--- a/tests/components/overkiz/helpers.py
+++ b/tests/components/overkiz/helpers.py
@@ -4,8 +4,16 @@ from datetime import timedelta
 from typing import Any
 
 from freezegun.api import FrozenDateTimeFactory
-from pyoverkiz.enums import FailureType
-from pyoverkiz.models import Event
+from pyoverkiz.enums import DataType, EventName, ExecutionState, FailureType
+from pyoverkiz.models import (
+    DeviceAvailableEvent,
+    DeviceRemovedEvent,
+    DeviceStateChangedEvent,
+    DeviceUnavailableEvent,
+    Event,
+    EventState,
+    ExecutionStateChangedEvent,
+)
 
 from homeassistant.components.overkiz.const import UPDATE_INTERVAL
 from homeassistant.core import HomeAssistant
@@ -23,12 +31,14 @@ def assert_command_call(
     parameters: list[Any] | None = None,
 ) -> None:
     """Assert the latest command sent through the mocked Overkiz client."""
-    assert mock_client.execute_command.await_count == 1
-    args = mock_client.execute_command.await_args.args
-    assert args[0] == device_url
-    assert args[1].name == command_name
-    assert args[1].parameters == (parameters or [])
-    assert args[2] == "Home Assistant"
+    assert mock_client.execute_action_group.await_count == 1
+    kwargs = mock_client.execute_action_group.await_args.kwargs
+    assert kwargs["label"] == "Home Assistant"
+    actions = kwargs["actions"]
+    assert len(actions) == 1
+    assert actions[0].device_url == device_url
+    assert actions[0].commands[0].name == command_name
+    assert actions[0].commands[0].parameters == (parameters or [])
 
 
 def build_event(
@@ -52,6 +62,51 @@ def build_event(
         failure_type=failure_type,
         failure_type_code=failure_type_code,
         **extra_kwargs,
+    )
+
+
+def device_state_changed_event(
+    device_url: str, device_states: list[dict[str, Any]]
+) -> DeviceStateChangedEvent:
+    """Build a DEVICE_STATE_CHANGED event with the given device states."""
+    return DeviceStateChangedEvent(
+        name=EventName.DEVICE_STATE_CHANGED,
+        device_url=device_url,
+        device_states=[
+            EventState(
+                name=state["name"], type=DataType(state["type"]), value=state["value"]
+            )
+            for state in device_states
+        ],
+    )
+
+
+def device_available_event(device_url: str) -> DeviceAvailableEvent:
+    """Build a DEVICE_AVAILABLE event for the given device."""
+    return DeviceAvailableEvent(name=EventName.DEVICE_AVAILABLE, device_url=device_url)
+
+
+def device_unavailable_event(device_url: str) -> DeviceUnavailableEvent:
+    """Build a DEVICE_UNAVAILABLE event for the given device."""
+    return DeviceUnavailableEvent(
+        name=EventName.DEVICE_UNAVAILABLE, device_url=device_url
+    )
+
+
+def device_removed_event(device_url: str) -> DeviceRemovedEvent:
+    """Build a DEVICE_REMOVED event for the given device."""
+    return DeviceRemovedEvent(name=EventName.DEVICE_REMOVED, device_url=device_url)
+
+
+def execution_state_changed_event(
+    exec_id: str, new_state: ExecutionState, old_state: ExecutionState
+) -> ExecutionStateChangedEvent:
+    """Build an EXECUTION_STATE_CHANGED event."""
+    return ExecutionStateChangedEvent(
+        name=EventName.EXECUTION_STATE_CHANGED,
+        exec_id=exec_id,
+        new_state=new_state,
+        old_state=old_state,
     )
 
 

--- a/tests/components/overkiz/test_coordinator.py
+++ b/tests/components/overkiz/test_coordinator.py
@@ -198,3 +198,39 @@ async def test_execution_failure_uses_unknown_fallbacks(
     assert event_data["command_name"] == "unknown"
     assert event_data["failure_type"] == "unknown"
     assert event_data["failure_type_code"] is None
+
+
+async def test_execution_completed_cleans_up_without_event(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+) -> None:
+    """When an execution completes, it is cleaned up without firing a failure event."""
+    await setup_overkiz_integration(fixture=SHUTTER.fixture)
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    coordinator = entry.runtime_data.coordinator
+    coordinator.executions["exec-1"] = {
+        "device_url": SHUTTER.device_url,
+        "command_name": "setClosure",
+    }
+
+    events = async_capture_events(hass, EVENT_EXECUTION_FAILED)
+
+    mock_client.queue_events(
+        [
+            build_event(
+                EventName.EXECUTION_STATE_CHANGED.value,
+                device_url=SHUTTER.device_url,
+                exec_id="exec-1",
+                new_state=ExecutionState.COMPLETED.value,
+            )
+        ]
+    )
+    await coordinator.async_refresh()
+
+    # No failure event should be fired for a successful execution
+    assert len(events) == 0
+
+    # Execution is cleaned up after completion
+    assert "exec-1" not in coordinator.executions

--- a/tests/components/overkiz/test_coordinator.py
+++ b/tests/components/overkiz/test_coordinator.py
@@ -200,3 +200,4 @@ async def test_execution_failure_uses_unknown_fallbacks(
     assert event_data["device_url"] == "unknown"
     assert event_data["command_name"] == "unknown"
     assert event_data["failure_type"] == "unknown"
+    assert event_data["failure_type_code"] is None

--- a/tests/components/overkiz/test_coordinator.py
+++ b/tests/components/overkiz/test_coordinator.py
@@ -118,6 +118,7 @@ async def test_execution_failure_fires_event(
                 exec_id="exec-1",
                 new_state=ExecutionState.FAILED.value,
                 failure_type="TRANSMISSION_ERROR",
+                failure_type_code="CODE_42",
             )
         ]
     )
@@ -129,7 +130,7 @@ async def test_execution_failure_fires_event(
     assert event_data["device_url"] == SHUTTER.device_url
     assert event_data["command_name"] == "setClosure"
     assert event_data["failure_type"] == "TRANSMISSION_ERROR"
-    assert event_data["failure_type_code"] is None
+    assert event_data["failure_type_code"] == "CODE_42"
 
     # Execution is cleaned up after failure
     assert "exec-1" not in coordinator.executions

--- a/tests/components/overkiz/test_coordinator.py
+++ b/tests/components/overkiz/test_coordinator.py
@@ -96,7 +96,6 @@ async def test_execution_failure_fires_event(
     hass: HomeAssistant,
     setup_overkiz_integration: SetupOverkizIntegration,
     mock_client: MockOverkizClient,
-    freezer: FrozenDateTimeFactory,
 ) -> None:
     """When an execution fails, an overkiz_execution_failed event is fired."""
     await setup_overkiz_integration(fixture=SHUTTER.fixture)
@@ -140,7 +139,6 @@ async def test_execution_failure_unknown_exec_id_is_ignored(
     hass: HomeAssistant,
     setup_overkiz_integration: SetupOverkizIntegration,
     mock_client: MockOverkizClient,
-    freezer: FrozenDateTimeFactory,
 ) -> None:
     """An execution state change for an unknown exec_id is silently ignored."""
     await setup_overkiz_integration(fixture=SHUTTER.fixture)
@@ -171,7 +169,6 @@ async def test_execution_failure_uses_unknown_fallbacks(
     hass: HomeAssistant,
     setup_overkiz_integration: SetupOverkizIntegration,
     mock_client: MockOverkizClient,
-    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Missing failure metadata falls back to 'unknown'."""
     await setup_overkiz_integration(fixture=SHUTTER.fixture)

--- a/tests/components/overkiz/test_coordinator.py
+++ b/tests/components/overkiz/test_coordinator.py
@@ -1,9 +1,10 @@
 """Tests for the Overkiz data update coordinator."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from aiohttp import ClientConnectorError
 from freezegun.api import FrozenDateTimeFactory
+from pyoverkiz.enums import EventName, ExecutionState
 from pyoverkiz.exceptions import (
     InvalidEventListenerIdException,
     MaintenanceException,
@@ -13,18 +14,29 @@ from pyoverkiz.exceptions import (
 )
 import pytest
 
-from homeassistant.components.overkiz.const import UPDATE_INTERVAL
+from homeassistant.components.overkiz.const import (
+    DOMAIN,
+    EVENT_EXECUTION_FAILED,
+    UPDATE_INTERVAL,
+)
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 
 from .conftest import FixtureDevice, MockOverkizClient, SetupOverkizIntegration
+from .helpers import build_event, async_deliver_events
 
-from tests.common import async_fire_time_changed
+from tests.common import async_capture_events, async_fire_time_changed
 
 TEMPERATURE_SENSOR = FixtureDevice(
     "setup/cloud_nexity_rail_din_europe.json",
     "io://1234-5678-1698/15702199#2",
     "sensor.maple_residence_garden_radiator_bathroom_temperature_sensor_temperature",
+)
+
+SHUTTER = FixtureDevice(
+    "setup/cloud_somfy_tahoma_switch_europe.json",
+    "io://1234-5678-1698/0",
+    "cover.somfy_connected_roller_shutter",
 )
 
 
@@ -78,3 +90,125 @@ async def test_transient_error_is_retried(
     await hass.async_block_till_done()
 
     assert hass.states.get(TEMPERATURE_SENSOR.entity_id).state == initial_state.state
+
+
+async def test_execution_failure_fires_event(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """When an execution fails, an overkiz_execution_failed event is fired."""
+    await setup_overkiz_integration(fixture=SHUTTER.fixture)
+
+    # Pre-populate the coordinator's execution tracking
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    coordinator = entry.runtime_data.coordinator
+    coordinator.executions["exec-1"] = {
+        "device_url": SHUTTER.device_url,
+        "command_name": "setClosure",
+    }
+
+    events = async_capture_events(hass, EVENT_EXECUTION_FAILED)
+
+    with patch.object(coordinator._logger, "warning") as mock_warning:
+        await async_deliver_events(
+            hass,
+            freezer,
+            mock_client,
+            [
+                build_event(
+                    EventName.EXECUTION_STATE_CHANGED.value,
+                    device_url=SHUTTER.device_url,
+                    exec_id="exec-1",
+                    new_state=ExecutionState.FAILED.value,
+                    failure_type="TRANSMISSION_ERROR",
+                )
+            ],
+        )
+
+    assert mock_warning.called
+    warning_msg = mock_warning.call_args[0][0]
+    assert "exec-1" in warning_msg
+    assert "TRANSMISSION_ERROR" in warning_msg
+
+    assert len(events) == 1
+    event_data = events[0].data
+    assert event_data["exec_id"] == "exec-1"
+    assert event_data["device_url"] == SHUTTER.device_url
+    assert event_data["command_name"] == "setClosure"
+    assert event_data["failure_type"] == "TRANSMISSION_ERROR"
+    assert event_data["failure_type_code"] is None
+
+    # Execution is cleaned up after failure
+    assert "exec-1" not in coordinator.executions
+
+
+async def test_execution_failure_unknown_exec_id_is_ignored(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """An execution state change for an unknown exec_id is silently ignored."""
+    await setup_overkiz_integration(fixture=SHUTTER.fixture)
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    coordinator = entry.runtime_data.coordinator
+
+    events = async_capture_events(hass, EVENT_EXECUTION_FAILED)
+
+    await async_deliver_events(
+        hass,
+        freezer,
+        mock_client,
+        [
+            build_event(
+                EventName.EXECUTION_STATE_CHANGED.value,
+                device_url=SHUTTER.device_url,
+                exec_id="unknown-exec-id",
+                new_state=ExecutionState.FAILED.value,
+            )
+        ],
+    )
+
+    # No event should be fired for unknown executions
+    assert len(events) == 0
+    assert "unknown-exec-id" not in coordinator.executions
+
+
+async def test_execution_failure_uses_unknown_fallbacks(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Missing failure metadata falls back to 'unknown'."""
+    await setup_overkiz_integration(fixture=SHUTTER.fixture)
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    coordinator = entry.runtime_data.coordinator
+    coordinator.executions["exec-1"] = {}
+
+    events = async_capture_events(hass, EVENT_EXECUTION_FAILED)
+
+    await async_deliver_events(
+        hass,
+        freezer,
+        mock_client,
+        [
+            build_event(
+                EventName.EXECUTION_STATE_CHANGED.value,
+                device_url=SHUTTER.device_url,
+                exec_id="exec-1",
+                new_state=ExecutionState.FAILED.value,
+            )
+        ],
+    )
+
+    assert len(events) == 1
+    event_data = events[0].data
+    assert event_data["exec_id"] == "exec-1"
+    assert event_data["device_url"] == "unknown"
+    assert event_data["command_name"] == "unknown"
+    assert event_data["failure_type"] == "unknown"

--- a/tests/components/overkiz/test_coordinator.py
+++ b/tests/components/overkiz/test_coordinator.py
@@ -23,7 +23,7 @@ from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 
 from .conftest import FixtureDevice, MockOverkizClient, SetupOverkizIntegration
-from .helpers import build_event, async_deliver_events
+from .helpers import async_deliver_events, build_event
 
 from tests.common import async_capture_events, async_fire_time_changed
 

--- a/tests/components/overkiz/test_coordinator.py
+++ b/tests/components/overkiz/test_coordinator.py
@@ -1,6 +1,6 @@
 """Tests for the Overkiz data update coordinator."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 from aiohttp import ClientConnectorError
 from freezegun.api import FrozenDateTimeFactory
@@ -23,7 +23,7 @@ from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 
 from .conftest import FixtureDevice, MockOverkizClient, SetupOverkizIntegration
-from .helpers import async_deliver_events, build_event
+from .helpers import build_event
 
 from tests.common import async_capture_events, async_fire_time_changed
 
@@ -111,26 +111,18 @@ async def test_execution_failure_fires_event(
 
     events = async_capture_events(hass, EVENT_EXECUTION_FAILED)
 
-    with patch.object(coordinator._logger, "warning") as mock_warning:
-        await async_deliver_events(
-            hass,
-            freezer,
-            mock_client,
-            [
-                build_event(
-                    EventName.EXECUTION_STATE_CHANGED.value,
-                    device_url=SHUTTER.device_url,
-                    exec_id="exec-1",
-                    new_state=ExecutionState.FAILED.value,
-                    failure_type="TRANSMISSION_ERROR",
-                )
-            ],
-        )
-
-    assert mock_warning.called
-    warning_msg = mock_warning.call_args[0][0]
-    assert "exec-1" in warning_msg
-    assert "TRANSMISSION_ERROR" in warning_msg
+    mock_client.queue_events(
+        [
+            build_event(
+                EventName.EXECUTION_STATE_CHANGED.value,
+                device_url=SHUTTER.device_url,
+                exec_id="exec-1",
+                new_state=ExecutionState.FAILED.value,
+                failure_type="TRANSMISSION_ERROR",
+            )
+        ]
+    )
+    await coordinator.async_refresh()
 
     assert len(events) == 1
     event_data = events[0].data
@@ -158,10 +150,7 @@ async def test_execution_failure_unknown_exec_id_is_ignored(
 
     events = async_capture_events(hass, EVENT_EXECUTION_FAILED)
 
-    await async_deliver_events(
-        hass,
-        freezer,
-        mock_client,
+    mock_client.queue_events(
         [
             build_event(
                 EventName.EXECUTION_STATE_CHANGED.value,
@@ -169,8 +158,9 @@ async def test_execution_failure_unknown_exec_id_is_ignored(
                 exec_id="unknown-exec-id",
                 new_state=ExecutionState.FAILED.value,
             )
-        ],
+        ]
     )
+    await coordinator.async_refresh()
 
     # No event should be fired for unknown executions
     assert len(events) == 0
@@ -192,10 +182,7 @@ async def test_execution_failure_uses_unknown_fallbacks(
 
     events = async_capture_events(hass, EVENT_EXECUTION_FAILED)
 
-    await async_deliver_events(
-        hass,
-        freezer,
-        mock_client,
+    mock_client.queue_events(
         [
             build_event(
                 EventName.EXECUTION_STATE_CHANGED.value,
@@ -203,8 +190,9 @@ async def test_execution_failure_uses_unknown_fallbacks(
                 exec_id="exec-1",
                 new_state=ExecutionState.FAILED.value,
             )
-        ],
+        ]
     )
+    await coordinator.async_refresh()
 
     assert len(events) == 1
     event_data = events[0].data

--- a/tests/components/overkiz/test_coordinator.py
+++ b/tests/components/overkiz/test_coordinator.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 
 from aiohttp import ClientConnectorError
 from freezegun.api import FrozenDateTimeFactory
-from pyoverkiz.enums import EventName, ExecutionState
+from pyoverkiz.enums import EventName, ExecutionState, FailureType
 from pyoverkiz.exceptions import (
     InvalidEventListenerIdException,
     MaintenanceException,
@@ -118,7 +118,7 @@ async def test_execution_failure_fires_event(
                 exec_id="exec-1",
                 new_state=ExecutionState.FAILED.value,
                 failure_type="TRANSMISSION_ERROR",
-                failure_type_code="CODE_42",
+                failure_type_code=FailureType.ERROR_WHILE_EXECUTING,
             )
         ]
     )
@@ -130,7 +130,7 @@ async def test_execution_failure_fires_event(
     assert event_data["device_url"] == SHUTTER.device_url
     assert event_data["command_name"] == "setClosure"
     assert event_data["failure_type"] == "TRANSMISSION_ERROR"
-    assert event_data["failure_type_code"] == "CODE_42"
+    assert event_data["failure_type_code"] == FailureType.ERROR_WHILE_EXECUTING
 
     # Execution is cleaned up after failure
     assert "exec-1" not in coordinator.executions

--- a/tests/components/overkiz/test_coordinator.py
+++ b/tests/components/overkiz/test_coordinator.py
@@ -6,11 +6,11 @@ from aiohttp import ClientConnectorError
 from freezegun.api import FrozenDateTimeFactory
 from pyoverkiz.enums import EventName, ExecutionState, FailureType
 from pyoverkiz.exceptions import (
-    InvalidEventListenerIdException,
-    MaintenanceException,
-    ServiceUnavailableException,
-    TooManyConcurrentRequestsException,
-    TooManyRequestsException,
+    InvalidEventListenerIdError,
+    MaintenanceError,
+    ServiceUnavailableError,
+    TooManyConcurrentRequestsError,
+    TooManyRequestsError,
 )
 import pytest
 
@@ -43,11 +43,11 @@ SHUTTER = FixtureDevice(
 @pytest.mark.parametrize(
     "exception",
     [
-        TooManyConcurrentRequestsException("Too many concurrent requests"),
-        TooManyRequestsException("Too many requests"),
-        MaintenanceException("Server is down for maintenance"),
-        ServiceUnavailableException("Server is unavailable"),
-        InvalidEventListenerIdException("Invalid event listener id"),
+        TooManyConcurrentRequestsError("Too many concurrent requests"),
+        TooManyRequestsError("Too many requests"),
+        MaintenanceError("Server is down for maintenance"),
+        ServiceUnavailableError("Server is unavailable"),
+        InvalidEventListenerIdError("Invalid event listener id"),
         TimeoutError("Timed out"),
         ClientConnectorError(Mock(), Mock()),
     ],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Overkiz integration silently discards execution failures from the Overkiz API. When a command fails (motor unreachable, radio interference), `on_execution_state_changed` in `coordinator.py` just removes the `exec_id` from the tracking dict — no log entry, no HA event, no way for automations to react.

This PR adds a warning log and fires an `overkiz_execution_failed` event on the HA event bus when `ExecutionState.FAILED` is received. The event carries all available failure metadata (`device_url`, `command_name`, `failure_type`, `failure_type_code`) so users can build retry automations without relying on position polling (which produces false positives when shutters are manually operated with a physical remote).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
