### PR TITLE
Return all matches for duplicate names in GetLiveContext

### DIFF
--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -1301,6 +1301,10 @@ class GetLiveContextTool(Tool):
                     name=name_filter,
                     area_name=area_filter,
                     domains=domain_filter,
+                    # This tool only returns context, so multiple entities
+                    # sharing a name (e.g. "AC" in two areas) should all be
+                    # returned rather than failing as an ambiguous match.
+                    allow_duplicate_names=True,
                 ),
                 states=exposed_states,
             )

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -837,6 +837,23 @@ async def test_get_live_context_tool_filter(
         original_name="Front Door",
         suggested_object_id="front_door",
     )
+    # Two entities sharing the same name in different areas
+    office_ac = entity_registry.async_get_or_create(
+        "climate",
+        "test",
+        "office_ac",
+        original_name="AC",
+        device_id=office_device.id,
+        suggested_object_id="office_ac",
+    )
+    kitchen_ac = entity_registry.async_get_or_create(
+        "climate",
+        "test",
+        "kitchen_ac",
+        original_name="AC",
+        device_id=kitchen_device.id,
+        suggested_object_id="kitchen_ac",
+    )
     entity_registry.async_update_entity(
         kitchen_light.entity_id, aliases=[er.COMPUTED_NAME, "Cooking Lamp"]
     )
@@ -846,6 +863,8 @@ async def test_get_live_context_tool_filter(
         kitchen_light.entity_id,
         office_switch.entity_id,
         front_door.entity_id,
+        office_ac.entity_id,
+        kitchen_ac.entity_id,
     ):
         async_expose_entity(hass, "conversation", entity_id, True)
 
@@ -853,6 +872,8 @@ async def test_get_live_context_tool_filter(
     hass.states.async_set(kitchen_light.entity_id, "off")
     hass.states.async_set(office_switch.entity_id, "on")
     hass.states.async_set(front_door.entity_id, "locked")
+    hass.states.async_set(office_ac.entity_id, "cool")
+    hass.states.async_set(kitchen_ac.entity_id, "heat")
 
     api = await llm.async_get_api(hass, "assist", llm_context)
 
@@ -1050,13 +1071,38 @@ async def test_get_live_context_tool_filter(
     result = await api.async_call_tool(
         llm.ToolInput(
             tool_name="GetLiveContext",
-            tool_args={"domain": "climate"},
+            tool_args={"domain": "fan"},
         )
     )
     assert result == {
         "success": False,
-        "error": "No exposed entities found in domain(s): climate",
+        "error": "No exposed entities found in domain(s): fan",
     }
+
+    # Entities sharing a name are all returned rather than failing as an
+    # ambiguous match, since this tool only returns context.
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="GetLiveContext",
+            tool_args={"name": "AC"},
+        )
+    )
+    assert result["success"] is True
+    assert result["result"].count("domain: climate") == 2
+    assert "Office" in result["result"]
+    assert "Kitchen" in result["result"]
+
+    # Combining a shared name with an area narrows to the single match
+    result = await api.async_call_tool(
+        llm.ToolInput(
+            tool_name="GetLiveContext",
+            tool_args={"name": "AC", "area": "Kitchen"},
+        )
+    )
+    assert result["success"] is True
+    assert result["result"].count("domain: climate") == 1
+    assert "Kitchen" in result["result"]
+    assert "Office" not in result["result"]
 
 
 async def test_script_tool(


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `GetLiveContext` LLM tool used the target matcher's default
`allow_duplicate_names=False`. That default makes sense for **action**
intents (e.g. "turn on the AC"), where two entities sharing a name is
genuinely ambiguous. But `GetLiveContext` is **read-only** — it only
gathers state for the model to reason over and never performs an action.

As a result, when more than one exposed entity shared a name (e.g. an
`AC` climate entity in two areas), the matcher returned
`MatchFailedReason.DUPLICATE_NAME`, and since `_live_context_match_error`
has no branch for that reason it surfaced the generic, unhelpful error
`No entities matched the provided filter` — even though both entities
were exposed and matched the name.

This passes `allow_duplicate_names=True` so duplicate-named entities are
all returned, letting the model reason about (and disambiguate between)
all of them. Combining `name` with an `area`/`domain` filter still
narrows the result as before. With duplicates allowed, the only failure
reasons reachable from this tool (`DOMAIN`, `NAME`, `AREA`,
`INVALID_AREA`) all already have specific, actionable messages, so the
generic fallback is no longer reached here.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: `https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure`

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

https://claude.ai/code/session_01E2ncZRmFUDUEuF78FUU9gp

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2ncZRmFUDUEuF78FUU9gp)_