### PR TITLE
Remove name fields from opentherm_gw config flow

### DIFF
--- a/homeassistant/components/opentherm_gw/__init__.py
+++ b/homeassistant/components/opentherm_gw/__init__.py
@@ -8,13 +8,7 @@ import pyotgw.vars as gw_vars
 from serial import SerialException
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    CONF_DEVICE,
-    CONF_ID,
-    CONF_NAME,
-    EVENT_HOMEASSISTANT_STOP,
-    Platform,
-)
+from homeassistant.const import CONF_DEVICE, CONF_ID, EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
@@ -100,7 +94,6 @@ class OpenThermGatewayHub:
         self.hass = hass
         self.device_path = config_entry.data[CONF_DEVICE]
         self.hub_id = config_entry.data[CONF_ID]
-        self.name = config_entry.data[CONF_NAME]
         self.options = config_entry.options
         self.config_entry_id = config_entry.entry_id
         self.update_signal = f"{DATA_OPENTHERM_GW}_{self.hub_id}_update"

--- a/homeassistant/components/opentherm_gw/config_flow.py
+++ b/homeassistant/components/opentherm_gw/config_flow.py
@@ -54,7 +54,7 @@ class OpenThermGwConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle config flow initiation."""
         if info:
             device = info[CONF_DEVICE]
-            gw_id = info[CONF_ID]
+            gw_id = cv.slugify(info[CONF_ID])
 
             entries = [e.data for e in self._async_current_entries()]
 
@@ -98,7 +98,7 @@ class OpenThermGwConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_DEVICE): str,
-                    vol.Required(CONF_ID): vol.All(str, cv.slug),
+                    vol.Required(CONF_ID): str,
                 }
             ),
             errors=errors or {},

--- a/homeassistant/components/opentherm_gw/config_flow.py
+++ b/homeassistant/components/opentherm_gw/config_flow.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     PRECISION_WHOLE,
 )
 from homeassistant.core import callback
+from homeassistant.helpers import config_validation as cv
 
 from . import DOMAIN
 from .const import (
@@ -97,7 +98,7 @@ class OpenThermGwConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_DEVICE): str,
-                    vol.Required(CONF_ID): str,
+                    vol.Required(CONF_ID): vol.All(str, cv.slug),
                 }
             ),
             errors=errors or {},

--- a/homeassistant/components/opentherm_gw/config_flow.py
+++ b/homeassistant/components/opentherm_gw/config_flow.py
@@ -17,13 +17,11 @@ from homeassistant.config_entries import (
 from homeassistant.const import (
     CONF_DEVICE,
     CONF_ID,
-    CONF_NAME,
     PRECISION_HALVES,
     PRECISION_TENTHS,
     PRECISION_WHOLE,
 )
 from homeassistant.core import callback
-from homeassistant.helpers import config_validation as cv
 
 from . import DOMAIN
 from .const import (
@@ -54,9 +52,8 @@ class OpenThermGwConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle config flow initiation."""
         if info:
-            name = info[CONF_NAME]
             device = info[CONF_DEVICE]
-            gw_id = cv.slugify(info.get(CONF_ID, name))
+            gw_id = info[CONF_ID]
 
             entries = [e.data for e in self._async_current_entries()]
 
@@ -83,7 +80,7 @@ class OpenThermGwConfigFlow(ConfigFlow, domain=DOMAIN):
             except ConnectionError, SerialException:
                 return self._show_form({"base": "cannot_connect"})
 
-            return self._create_entry(gw_id, name, device)
+            return self._create_entry(gw_id, device)
 
         return self._show_form()
 
@@ -99,20 +96,17 @@ class OpenThermGwConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="init",
             data_schema=vol.Schema(
                 {
-                    # Name field is no longer allowed in config flow schemas
-                    # pylint: disable-next=home-assistant-config-flow-name-field
-                    vol.Required(CONF_NAME): str,
                     vol.Required(CONF_DEVICE): str,
-                    vol.Optional(CONF_ID): str,
+                    vol.Required(CONF_ID): str,
                 }
             ),
             errors=errors or {},
         )
 
-    def _create_entry(self, gw_id, name, device):
+    def _create_entry(self, gw_id, device):
         """Create entry for the OpenTherm Gateway device."""
         return self.async_create_entry(
-            title=name, data={CONF_ID: gw_id, CONF_DEVICE: device, CONF_NAME: name}
+            title="OpenTherm Gateway", data={CONF_ID: gw_id, CONF_DEVICE: device}
         )
 
 

--- a/homeassistant/components/opentherm_gw/strings.json
+++ b/homeassistant/components/opentherm_gw/strings.json
@@ -14,8 +14,7 @@
       "init": {
         "data": {
           "device": "Path or URL",
-          "id": "ID",
-          "name": "[%key:common::config_flow::data::name%]"
+          "id": "ID"
         }
       }
     }

--- a/tests/components/opentherm_gw/test_config_flow.py
+++ b/tests/components/opentherm_gw/test_config_flow.py
@@ -13,13 +13,7 @@ from homeassistant.components.opentherm_gw.const import (
     CONF_TEMPORARY_OVRD_MODE,
     DOMAIN,
 )
-from homeassistant.const import (
-    CONF_DEVICE,
-    CONF_ID,
-    CONF_NAME,
-    PRECISION_HALVES,
-    PRECISION_TENTHS,
-)
+from homeassistant.const import CONF_DEVICE, CONF_ID, PRECISION_HALVES, PRECISION_TENTHS
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -37,14 +31,13 @@ async def test_form_user(hass: HomeAssistant, mock_pyotgw: MagicMock) -> None:
     assert result["errors"] == {}
 
     result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_NAME: "Test Entry 1", CONF_DEVICE: "/dev/ttyUSB0"}
+        result["flow_id"], {CONF_DEVICE: "/dev/ttyUSB0", CONF_ID: "test_entry_1"}
     )
     await hass.async_block_till_done()
 
     assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "Test Entry 1"
+    assert result2["title"] == "OpenTherm Gateway"
     assert result2["data"] == {
-        CONF_NAME: "Test Entry 1",
         CONF_DEVICE: "/dev/ttyUSB0",
         CONF_ID: "test_entry_1",
     }
@@ -68,18 +61,18 @@ async def test_form_duplicate_entries(
     )
 
     result1 = await hass.config_entries.flow.async_configure(
-        flow1["flow_id"], {CONF_NAME: "Test Entry 1", CONF_DEVICE: "/dev/ttyUSB0"}
+        flow1["flow_id"], {CONF_DEVICE: "/dev/ttyUSB0", CONF_ID: "test_entry_1"}
     )
     assert result1["type"] is FlowResultType.CREATE_ENTRY
 
     result2 = await hass.config_entries.flow.async_configure(
-        flow2["flow_id"], {CONF_NAME: "Test Entry 1", CONF_DEVICE: "/dev/ttyUSB1"}
+        flow2["flow_id"], {CONF_DEVICE: "/dev/ttyUSB1", CONF_ID: "test_entry_1"}
     )
     assert result2["type"] is FlowResultType.FORM
     assert result2["errors"] == {"base": "id_exists"}
 
     result3 = await hass.config_entries.flow.async_configure(
-        flow3["flow_id"], {CONF_NAME: "Test Entry 2", CONF_DEVICE: "/dev/ttyUSB0"}
+        flow3["flow_id"], {CONF_DEVICE: "/dev/ttyUSB0", CONF_ID: "test_entry_2"}
     )
     assert result3["type"] is FlowResultType.FORM
     assert result3["errors"] == {"base": "already_configured"}
@@ -101,7 +94,7 @@ async def test_form_connection_timeout(
 
     result = await hass.config_entries.flow.async_configure(
         flow["flow_id"],
-        {CONF_NAME: "Test Entry 1", CONF_DEVICE: "socket://192.0.2.254:1234"},
+        {CONF_DEVICE: "socket://192.0.2.254:1234", CONF_ID: "test_entry_1"},
     )
 
     assert result["type"] is FlowResultType.FORM
@@ -122,7 +115,7 @@ async def test_form_connection_error(
     mock_pyotgw.return_value.connect.side_effect = SerialException
 
     result = await hass.config_entries.flow.async_configure(
-        flow["flow_id"], {CONF_NAME: "Test Entry 1", CONF_DEVICE: "/dev/ttyUSB0"}
+        flow["flow_id"], {CONF_DEVICE: "/dev/ttyUSB0", CONF_ID: "test_entry_1"}
     )
 
     assert result["type"] is FlowResultType.FORM
@@ -137,7 +130,6 @@ async def test_options_form(hass: HomeAssistant, mock_pyotgw: MagicMock) -> None
         domain=DOMAIN,
         title="Mock Gateway",
         data={
-            CONF_NAME: "Mock Gateway",
             CONF_DEVICE: "/dev/null",
             CONF_ID: "mock_gateway",
         },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove name fields from opentherm_gw config flow as per home-assistant/epics#47

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #168946
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#45780
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
