### PR TITLE
Add daily summaries and application attributes to playing_time sensor

### DIFF
--- a/homeassistant/components/nintendo_parental_controls/sensor.py
+++ b/homeassistant/components/nintendo_parental_controls/sensor.py
@@ -3,8 +3,8 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
-import logging
 from enum import StrEnum
+import logging
 from typing import Any
 
 from pynintendoparental.player import Player
@@ -103,7 +103,9 @@ def _build_daily_attributes(device: Device) -> dict | None:
         app_times: dict[str, int] = {}
         if is_today:
             players = (
-                today_summary.get("devicePlayers")  # legacy schema (Switch / Switch Lite)
+                today_summary.get(
+                    "devicePlayers"
+                )  # legacy schema (Switch / Switch Lite)
                 or today_summary.get("players")  # updated schema (Switch 2)
                 or []
             )

--- a/homeassistant/components/nintendo_parental_controls/sensor.py
+++ b/homeassistant/components/nintendo_parental_controls/sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
+import logging
 from enum import StrEnum
 from typing import Any
 
@@ -25,7 +26,6 @@ from .entity import Device, NintendoDevice
 # Coordinator is used to centralize the data updates
 PARALLEL_UPDATES = 0
 
-import logging
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -104,20 +104,19 @@ def _build_daily_attributes(device: Device) -> dict | None:
         if is_today:
             players = (
                 today_summary.get("devicePlayers")  # legacy schema (Switch / Switch Lite)
-                or today_summary.get("players")     # updated schema (Switch 2)
+                or today_summary.get("players")  # updated schema (Switch 2)
                 or []
             )
             for player in players:
                 apps_in_player = (
-                    player.get("playedApps")     # legacy schema
-                    or player.get("playedGames") # updated schema (Switch 2)
+                    player.get("playedApps")  # legacy schema
+                    or player.get("playedGames")  # updated schema (Switch 2)
                     or []
                 )
                 for app_entry in apps_in_player:
-                    app_id = (
-                        app_entry.get("applicationId")
-                        or (app_entry.get("meta") or {}).get("applicationId")
-                    )
+                    app_id = app_entry.get("applicationId") or (
+                        app_entry.get("meta") or {}
+                    ).get("applicationId")
                     if app_id:
                         key = app_id.upper()
                         app_times[key] = max(
@@ -132,7 +131,9 @@ def _build_daily_attributes(device: Device) -> dict | None:
             apps = apps.values()
         for app in apps:
             try:
-                today_time = app_times.get(app.application_id.upper(), 0) if is_today else 0
+                today_time = (
+                    app_times.get(app.application_id.upper(), 0) if is_today else 0
+                )
                 applications.append(
                     {
                         "name": app.name,
@@ -155,8 +156,6 @@ def _build_daily_attributes(device: Device) -> dict | None:
                     device.device_id,
                     exc_info=True,
                 )
-
-        return {"daily": daily, "applications": applications}
     except Exception:  # noqa: BLE001
         _LOGGER.debug(
             "Failed to build daily attributes for device %s",
@@ -164,6 +163,8 @@ def _build_daily_attributes(device: Device) -> dict | None:
             exc_info=True,
         )
         return None
+    else:
+        return {"daily": daily, "applications": applications}
 
 
 DEVICE_SENSOR_DESCRIPTIONS: tuple[

--- a/homeassistant/components/nintendo_parental_controls/sensor.py
+++ b/homeassistant/components/nintendo_parental_controls/sensor.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
+from typing import Any
 
 from pynintendoparental.player import Player
 
@@ -39,6 +40,7 @@ class NintendoParentalControlsDeviceSensorEntityDescription(SensorEntityDescript
 
     value_fn: Callable[[Device], datetime | int | float | None]
     available_fn: Callable[[Device], bool] = lambda device: True
+    attributes_fn: Callable[[Device], dict | None] = lambda device: None
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -46,6 +48,109 @@ class NintendoParentalControlsPlayerSensorEntityDescription(SensorEntityDescript
     """Description for Nintendo parental controls player sensor entities."""
 
     value_fn: Callable[[Player], int | float | None]
+
+
+def _build_daily_attributes(device: Device) -> dict | None:
+    """Build daily summaries and applications attributes.
+
+    Exposes the last 5 days of play history and a full list of applications
+    with today's playtime per app.
+
+    Supports both the legacy daily-summary API schema (Switch, Switch Lite)
+    and the updated schema introduced with Switch 2, where player data uses
+    ``players``/``playedGames`` instead of ``devicePlayers``/``playedApps``.
+
+    When multiple players are active simultaneously, Nintendo reports the same
+    console playtime for each player. To avoid multiplying the actual playtime,
+    ``max()`` is used instead of summing across players.
+    """
+    try:
+        if not device.daily_summaries or not isinstance(device.daily_summaries, list):
+            return None
+
+        today_str = datetime.now().strftime("%Y-%m-%d")
+        today_summary = device.daily_summaries[0] if device.daily_summaries else None
+        is_today = today_summary and today_summary.get("date") == today_str
+
+        daily = [
+            {
+                "date": s.get("date"),
+                "playingTime": s.get("playingTime"),
+                "playedApps": [
+                    {
+                        "title": a.get("title"),
+                        "applicationId": a.get("applicationId"),
+                        "imageUri": a.get("imageUri", {}),
+                        "playingTime": a.get("playingTime"),
+                        "firstPlayDate": a.get("firstPlayDate"),
+                        "playingDays": a.get("playingDays"),
+                        "shopUri": a.get("shopUri"),
+                        "hasUgc": a.get("hasUgc"),
+                    }
+                    for a in s.get("playedApps", [])
+                ],
+            }
+            for s in device.daily_summaries[:5]
+        ]
+
+        # Build per-app playtime from today's player data.
+        # Use max() across players because Nintendo reports the same console
+        # playtime identically for every player who was active simultaneously.
+        app_times: dict[str, int] = {}
+        if is_today and today_summary:
+            players = (
+                today_summary.get("devicePlayers")  # legacy schema (Switch / Switch Lite)
+                or today_summary.get("players")     # updated schema (Switch 2)
+                or []
+            )
+            for player in players:
+                apps_in_player = (
+                    player.get("playedApps")     # legacy schema
+                    or player.get("playedGames") # updated schema (Switch 2)
+                    or []
+                )
+                for app_entry in apps_in_player:
+                    app_id = (
+                        app_entry.get("applicationId")
+                        or (app_entry.get("meta") or {}).get("applicationId")
+                    )
+                    if app_id:
+                        key = app_id.upper()
+                        app_times[key] = max(
+                            app_times.get(key, 0),
+                            app_entry.get("playingTime", 0),
+                        )
+
+        # ``device.applications`` is a dict in newer pynintendoparental versions.
+        applications = []
+        apps = device.applications
+        if isinstance(apps, dict):
+            apps = apps.values()
+        for app in apps:
+            try:
+                today_time = app_times.get(app.application_id.upper(), 0) if is_today else 0
+                applications.append(
+                    {
+                        "name": app.name,
+                        "application_id": app.application_id,
+                        "image_url": app.image_url,
+                        "today_time_played": today_time,
+                        "playing_days": app.playing_days,
+                        "first_played_date": (
+                            app.first_played_date.strftime("%Y-%m-%d")
+                            if app.first_played_date
+                            else None
+                        ),
+                        "shop_url": app.shop_url,
+                        "has_ugc": app.has_ugc,
+                    }
+                )
+            except Exception:  # noqa: BLE001
+                pass
+
+        return {"daily": daily, "applications": applications}
+    except Exception:  # noqa: BLE001
+        return None
 
 
 DEVICE_SENSOR_DESCRIPTIONS: tuple[
@@ -58,6 +163,7 @@ DEVICE_SENSOR_DESCRIPTIONS: tuple[
         device_class=SensorDeviceClass.DURATION,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda device: device.today_playing_time,
+        attributes_fn=_build_daily_attributes,
     ),
     NintendoParentalControlsDeviceSensorEntityDescription(
         key=NintendoParentalControlsSensor.TIME_REMAINING,
@@ -139,6 +245,11 @@ class NintendoParentalControlsDeviceSensorEntity(NintendoDevice, SensorEntity):
     def available(self) -> bool:
         """Return if the sensor is available."""
         return super().available and self.entity_description.available_fn(self._device)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return extra state attributes."""
+        return self.entity_description.attributes_fn(self._device)
 
 
 class NintendoParentalControlsPlayerSensorEntity(NintendoDevice, SensorEntity):

--- a/homeassistant/components/nintendo_parental_controls/sensor.py
+++ b/homeassistant/components/nintendo_parental_controls/sensor.py
@@ -17,12 +17,16 @@ from homeassistant.components.sensor import (
 from homeassistant.const import UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util import dt as dt_util
 
 from .coordinator import NintendoParentalControlsConfigEntry, NintendoUpdateCoordinator
 from .entity import Device, NintendoDevice
 
 # Coordinator is used to centralize the data updates
 PARALLEL_UPDATES = 0
+
+import logging
+_LOGGER = logging.getLogger(__name__)
 
 
 class NintendoParentalControlsSensor(StrEnum):
@@ -68,9 +72,9 @@ def _build_daily_attributes(device: Device) -> dict | None:
         if not device.daily_summaries or not isinstance(device.daily_summaries, list):
             return None
 
-        today_str = datetime.now().strftime("%Y-%m-%d")
-        today_summary = device.daily_summaries[0] if device.daily_summaries else None
-        is_today = today_summary and today_summary.get("date") == today_str
+        today_str = dt_util.now().strftime("%Y-%m-%d")
+        today_summary = device.daily_summaries[0]
+        is_today = today_summary.get("date") == today_str
 
         daily = [
             {
@@ -97,7 +101,7 @@ def _build_daily_attributes(device: Device) -> dict | None:
         # Use max() across players because Nintendo reports the same console
         # playtime identically for every player who was active simultaneously.
         app_times: dict[str, int] = {}
-        if is_today and today_summary:
+        if is_today:
             players = (
                 today_summary.get("devicePlayers")  # legacy schema (Switch / Switch Lite)
                 or today_summary.get("players")     # updated schema (Switch 2)
@@ -146,10 +150,19 @@ def _build_daily_attributes(device: Device) -> dict | None:
                     }
                 )
             except Exception:  # noqa: BLE001
-                pass
+                _LOGGER.debug(
+                    "Failed to process application data for device %s",
+                    device.device_id,
+                    exc_info=True,
+                )
 
         return {"daily": daily, "applications": applications}
     except Exception:  # noqa: BLE001
+        _LOGGER.debug(
+            "Failed to build daily attributes for device %s",
+            device.device_id,
+            exc_info=True,
+        )
         return None
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The `playing_time` sensor for Nintendo Parental Controls currently only exposes a bare minute value. The underlying `pynintendoparental` library already fetches `device.daily_summaries` and `device.applications`, but none of this data is passed through as sensor attributes.

This PR adds an `attributes_fn` field to `NintendoParentalControlsDeviceSensorEntityDescription` and a `_build_daily_attributes` function that exposes:
- Last 5 days of play history (`daily`)
- Full application list with today's playtime per app (`applications`)

Key implementation details:
- Supports both the legacy API schema (Switch / Switch Lite: `devicePlayers`/`playedApps`) and the updated schema introduced with Switch 2 (`players`/`playedGames`/`meta.applicationId`)
- Uses `max()` instead of summing across players, because Nintendo reports the same console playtime identically for every player active simultaneously — summing would multiply the actual playtime by the number of players
- `device.applications` is handled as both dict and iterable for compatibility with newer `pynintendoparental` versions
- No library changes required

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: home-assistant/feature-requests#3733
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr