### PR TITLE
Ensure opentherm_gw boiler and thermostat manufacturers are strings

### DIFF
--- a/homeassistant/components/opentherm_gw/__init__.py
+++ b/homeassistant/components/opentherm_gw/__init__.py
@@ -161,8 +161,8 @@ class OpenThermGatewayHub:
 
             dev_reg.async_update_device(
                 boiler_device.id,
-                manufacturer=status[OpenThermDataSource.BOILER].get(
-                    gw_vars.DATA_SLAVE_MEMBERID
+                manufacturer=str(
+                    status[OpenThermDataSource.BOILER].get(gw_vars.DATA_SLAVE_MEMBERID)
                 ),
                 model_id=status[OpenThermDataSource.BOILER].get(
                     gw_vars.DATA_SLAVE_PRODUCT_TYPE
@@ -177,8 +177,10 @@ class OpenThermGatewayHub:
 
             dev_reg.async_update_device(
                 thermostat_device.id,
-                manufacturer=status[OpenThermDataSource.THERMOSTAT].get(
-                    gw_vars.DATA_MASTER_MEMBERID
+                manufacturer=str(
+                    status[OpenThermDataSource.THERMOSTAT].get(
+                        gw_vars.DATA_MASTER_MEMBERID
+                    )
                 ),
                 model_id=status[OpenThermDataSource.THERMOSTAT].get(
                     gw_vars.DATA_MASTER_PRODUCT_TYPE

--- a/homeassistant/components/opentherm_gw/__init__.py
+++ b/homeassistant/components/opentherm_gw/__init__.py
@@ -159,11 +159,14 @@ class OpenThermGatewayHub:
             _LOGGER.debug("Received report: %s", status)
             async_dispatcher_send(self.hass, self.update_signal, status)
 
+            boiler_manufacturer = status[OpenThermDataSource.BOILER].get(
+                gw_vars.DATA_SLAVE_MEMBERID
+            )
             dev_reg.async_update_device(
                 boiler_device.id,
-                manufacturer=str(
-                    status[OpenThermDataSource.BOILER].get(gw_vars.DATA_SLAVE_MEMBERID)
-                ),
+                manufacturer=str(boiler_manufacturer)
+                if boiler_manufacturer is not None
+                else None,
                 model_id=status[OpenThermDataSource.BOILER].get(
                     gw_vars.DATA_SLAVE_PRODUCT_TYPE
                 ),
@@ -175,13 +178,14 @@ class OpenThermGatewayHub:
                 ),
             )
 
+            thermostat_manufacturer = status[OpenThermDataSource.THERMOSTAT].get(
+                gw_vars.DATA_MASTER_MEMBERID
+            )
             dev_reg.async_update_device(
                 thermostat_device.id,
-                manufacturer=str(
-                    status[OpenThermDataSource.THERMOSTAT].get(
-                        gw_vars.DATA_MASTER_MEMBERID
-                    )
-                ),
+                manufacturer=str(thermostat_manufacturer)
+                if thermostat_manufacturer is not None
+                else None,
                 model_id=status[OpenThermDataSource.THERMOSTAT].get(
                     gw_vars.DATA_MASTER_PRODUCT_TYPE
                 ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure the opentherm_gw boiler and thermostat device manufacturers are string values.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #173144
- This PR is related to issue: #173144
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
