### PR TITLE
Wait for ESPHome bluetooth proxy connection at startup

### DIFF
--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -166,7 +166,7 @@ class RuntimeEntryData:
     )
     loaded_platforms: set[Platform] = field(default_factory=set)
     platform_load_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
-    # Set once the first connection has finished setting up the BLE scanner.
+    # Set once the first connection has finished scanner setup or teardown.
     first_connect_done: asyncio.Event = field(default_factory=asyncio.Event)
     _storage_contents: StoreData | None = None
     _pending_storage: Callable[[], StoreData] | None = None

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -166,6 +166,11 @@ class RuntimeEntryData:
     )
     loaded_platforms: set[Platform] = field(default_factory=set)
     platform_load_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    # Set after the first successful connection finishes setting up (including
+    # the Bluetooth scanner). Used at startup to wait for a Bluetooth proxy to
+    # register its scanner before setup completes so it does not miss the first
+    # active scan window.
+    first_connect_done: asyncio.Event = field(default_factory=asyncio.Event)
     _storage_contents: StoreData | None = None
     _pending_storage: Callable[[], StoreData] | None = None
     assist_pipeline_update_callbacks: list[CALLBACK_TYPE] = field(default_factory=list)

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -166,10 +166,7 @@ class RuntimeEntryData:
     )
     loaded_platforms: set[Platform] = field(default_factory=set)
     platform_load_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
-    # Set after the first successful connection finishes setting up (including
-    # the Bluetooth scanner). Used at startup to wait for a Bluetooth proxy to
-    # register its scanner before setup completes so it does not miss the first
-    # active scan window.
+    # Set once the first connection has finished setting up the BLE scanner.
     first_connect_done: asyncio.Event = field(default_factory=asyncio.Event)
     _storage_contents: StoreData | None = None
     _pending_storage: Callable[[], StoreData] | None = None

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -108,9 +108,7 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-# How long to wait at startup for a Bluetooth proxy to connect and register its
-# scanner before letting setup finish, so it is not a late joiner that misses the
-# first active scan window.
+# Max time to wait at startup for a BLE proxy to register its scanner.
 STARTUP_SCANNER_WAIT: Final = 3.0
 
 LOG_LEVEL_TO_LOGGER = {
@@ -684,7 +682,6 @@ class ESPHomeManager:
                 hass, device_info.bluetooth_mac_address or device_info.mac_address
             )
 
-        # Release any startup wait now that the scanner (if any) is registered.
         entry_data.first_connect_done.set()
 
         if device_info.voice_assistant_feature_flags_compat(api_version) and (
@@ -998,9 +995,7 @@ class ESPHomeManager:
 
         await reconnect_logic.start()
 
-        # If the cached device info says this is a Bluetooth proxy, wait briefly for
-        # the connection so the scanner is registered before setup finishes. Otherwise
-        # it would be a late joiner that misses the first active scan window at startup.
+        # Wait for a cached BLE proxy to register its scanner before finishing setup.
         if (
             device_info := entry_data.device_info
         ) is not None and device_info.bluetooth_proxy_feature_flags_compat(

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -1,11 +1,13 @@
 """Manager for esphome devices."""
 
+import asyncio
 import base64
+import contextlib
 from functools import partial
 import logging
 import secrets
 import struct
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any, Final, NamedTuple
 
 from aioesphomeapi import (
     APIClient,
@@ -105,6 +107,11 @@ if TYPE_CHECKING:
 
 
 _LOGGER = logging.getLogger(__name__)
+
+# How long to wait at startup for a Bluetooth proxy to connect and register its
+# scanner before letting setup finish, so it is not a late joiner that misses the
+# first active scan window.
+STARTUP_SCANNER_WAIT: Final = 3.0
 
 LOG_LEVEL_TO_LOGGER = {
     LogLevel.LOG_LEVEL_NONE: logging.DEBUG,
@@ -677,6 +684,9 @@ class ESPHomeManager:
                 hass, device_info.bluetooth_mac_address or device_info.mac_address
             )
 
+        # Release any startup wait now that the scanner (if any) is registered.
+        entry_data.first_connect_done.set()
+
         if device_info.voice_assistant_feature_flags_compat(api_version) and (
             Platform.ASSIST_SATELLITE not in entry_data.loaded_platforms
         ):
@@ -987,6 +997,18 @@ class ESPHomeManager:
                 )
 
         await reconnect_logic.start()
+
+        # If the cached device info says this is a Bluetooth proxy, wait briefly for
+        # the connection so the scanner is registered before setup finishes. Otherwise
+        # it would be a late joiner that misses the first active scan window at startup.
+        if (
+            device_info := entry_data.device_info
+        ) is not None and device_info.bluetooth_proxy_feature_flags_compat(
+            entry_data.api_version
+        ):
+            with contextlib.suppress(TimeoutError):
+                async with asyncio.timeout(STARTUP_SCANNER_WAIT):
+                    await entry_data.first_connect_done.wait()
 
 
 @callback

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import base64
-import contextlib
 from functools import partial
 import logging
 import secrets
@@ -1001,9 +1000,14 @@ class ESPHomeManager:
         ) is not None and device_info.bluetooth_proxy_feature_flags_compat(
             entry_data.api_version
         ):
-            with contextlib.suppress(TimeoutError):
+            try:
                 async with asyncio.timeout(STARTUP_SCANNER_WAIT):
                     await entry_data.first_connect_done.wait()
+            except TimeoutError:
+                _LOGGER.debug(
+                    "%s: Timed out waiting for Bluetooth scanner to register",
+                    self.host,
+                )
 
 
 @callback

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -9,7 +9,9 @@ from unittest.mock import AsyncMock, Mock, call, patch
 from aioesphomeapi import (
     APIClient,
     APIConnectionError,
+    APIVersion,
     AreaInfo,
+    BluetoothProxyFeature,
     DeviceInfo,
     EncryptionPlaintextAPIError,
     ExecuteServiceResponse,
@@ -3274,3 +3276,124 @@ async def test_service_registration_response_types(
         hass.services.supports_response(DOMAIN, "test_status_service")
         == SupportsResponse.NONE
     )
+
+
+def _create_cached_bluetooth_proxy_entry(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    bluetooth_proxy_feature_flags: BluetoothProxyFeature,
+) -> tuple[MockConfigEntry, DeviceInfo]:
+    """Create an entry with cached device info so setup knows the proxy state."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="11:22:33:44:55:aa",
+        data={
+            CONF_HOST: "test.local",
+            CONF_PORT: 6053,
+            CONF_PASSWORD: "",
+            CONF_BLUETOOTH_MAC_ADDRESS: "AA:BB:CC:DD:EE:FC",
+        },
+    )
+    entry.add_to_hass(hass)
+    device_info = DeviceInfo(
+        name="test",
+        mac_address="11:22:33:44:55:AA",
+        bluetooth_mac_address="AA:BB:CC:DD:EE:FC",
+        bluetooth_proxy_feature_flags=bluetooth_proxy_feature_flags,
+    )
+    storage_key = f"{DOMAIN}.{entry.entry_id}"
+    hass_storage[storage_key] = {
+        "version": 1,
+        "minor_version": 1,
+        "key": storage_key,
+        "data": {
+            "device_info": device_info.to_dict(),
+            "api_version": APIVersion(1, 9).to_dict(),
+        },
+    }
+    return entry, device_info
+
+
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_bluetooth_proxy_waits_for_scanner_at_startup(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test setup waits for a cached bluetooth proxy to register its scanner."""
+    entry, device_info = _create_cached_bluetooth_proxy_entry(
+        hass, hass_storage, BluetoothProxyFeature.PASSIVE_SCAN
+    )
+    connect_event = asyncio.Event()
+    reached_connect = asyncio.Event()
+
+    async def _block_until_released() -> tuple[DeviceInfo, list[Any], list[Any]]:
+        reached_connect.set()
+        await connect_event.wait()
+        return (device_info, [], [])
+
+    mock_client.device_info_and_list_entities = _block_until_released
+
+    setup_task = hass.async_create_task(hass.config_entries.async_setup(entry.entry_id))
+    async with asyncio.timeout(2):
+        await reached_connect.wait()
+
+    # Setup must still be waiting for the scanner to be registered.
+    assert not setup_task.done()
+
+    connect_event.set()
+    async with asyncio.timeout(2):
+        assert await setup_task is True
+    assert entry.runtime_data.first_connect_done.is_set()
+
+
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_bluetooth_proxy_startup_wait_times_out(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test setup finishes if a cached bluetooth proxy never connects."""
+    entry, device_info = _create_cached_bluetooth_proxy_entry(
+        hass, hass_storage, BluetoothProxyFeature.PASSIVE_SCAN
+    )
+    connect_event = asyncio.Event()
+
+    async def _never_returns() -> tuple[DeviceInfo, list[Any], list[Any]]:
+        await connect_event.wait()
+        return (device_info, [], [])
+
+    mock_client.device_info_and_list_entities = _never_returns
+
+    with patch("homeassistant.components.esphome.manager.STARTUP_SCANNER_WAIT", 0.05):
+        async with asyncio.timeout(2):
+            assert await hass.config_entries.async_setup(entry.entry_id) is True
+
+    connect_event.set()
+    await hass.async_block_till_done()
+
+
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_non_bluetooth_device_does_not_wait_at_startup(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test setup does not wait for a device that is not a bluetooth proxy."""
+    entry, device_info = _create_cached_bluetooth_proxy_entry(
+        hass, hass_storage, BluetoothProxyFeature(0)
+    )
+    connect_event = asyncio.Event()
+
+    async def _never_returns() -> tuple[DeviceInfo, list[Any], list[Any]]:
+        await connect_event.wait()
+        return (device_info, [], [])
+
+    mock_client.device_info_and_list_entities = _never_returns
+
+    # The connection is blocked, but without proxy flags setup must not wait.
+    async with asyncio.timeout(2):
+        assert await hass.config_entries.async_setup(entry.entry_id) is True
+
+    connect_event.set()
+    await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change
ESPHome registers its Bluetooth proxy scanner only after the device reconnects in the background, so on a Home Assistant restart `async_setup_entry` returns before the scanner exists; the proxy is then a late joiner that can miss the first active scan window, and anything making active connections at startup may find no connectable scanner yet.

When the cached device info says the device is a Bluetooth proxy, setup now waits a few seconds for the first connection so the scanner is registered before setup finishes. We know this without connecting because the bluetooth proxy feature flags are persisted in the cached device info. Non bluetooth devices never wait, and an offline proxy simply hits the timeout and continues.

This also helps devices that make active connections at startup pick a better scanner. Without the wait, a device may connect through whichever proxy registers first even if it has a worse signal, which forces a slow connection path; waiting up to 3s for the closer proxy is usually faster overall than connecting through a weaker scanner.

Shelly has the same late registration pattern and is handled in a separate PR.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/Bluetooth-Devices/habluetooth/issues/527
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
