### PR TITLE
Refactor Landis+Gyr heat meter to use the HA standard SerialPortSelector

### DIFF
--- a/homeassistant/components/landisgyr_heat_meter/config_flow.py
+++ b/homeassistant/components/landisgyr_heat_meter/config_flow.py
@@ -8,21 +8,19 @@ import serialx
 import ultraheat_api
 import voluptuous as vol
 
-from homeassistant.components import usb
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_DEVICE
-from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.selector import SerialPortSelector
 
 from .const import DOMAIN, ULTRAHEAT_TIMEOUT
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_MANUAL_PATH = "Enter Manually"
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_DEVICE): str,
+        vol.Required(CONF_DEVICE): SerialPortSelector(),
     }
 )
 
@@ -39,9 +37,6 @@ class LandisgyrConfigFlow(ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
-            if user_input[CONF_DEVICE] == CONF_MANUAL_PATH:
-                return await self.async_step_setup_serial_manual_path()
-
             dev_path = user_input[CONF_DEVICE]
             _LOGGER.debug("Using this path : %s", dev_path)
 
@@ -50,30 +45,8 @@ class LandisgyrConfigFlow(ConfigFlow, domain=DOMAIN):
             except CannotConnect:
                 errors["base"] = "cannot_connect"
 
-        ports = await get_usb_ports(self.hass)
-        ports[CONF_MANUAL_PATH] = CONF_MANUAL_PATH
-
-        schema = vol.Schema({vol.Required(CONF_DEVICE): vol.In(ports)})
-        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
-
-    async def async_step_setup_serial_manual_path(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Set path manually."""
-        errors = {}
-
-        if user_input is not None:
-            dev_path = user_input[CONF_DEVICE]
-            try:
-                return await self.validate_and_create_entry(dev_path)
-            except CannotConnect:
-                errors["base"] = "cannot_connect"
-
-        schema = vol.Schema({vol.Required(CONF_DEVICE): str})
         return self.async_show_form(
-            step_id="setup_serial_manual_path",
-            data_schema=schema,
-            errors=errors,
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
         )
 
     async def validate_and_create_entry(self, dev_path):
@@ -109,25 +82,6 @@ class LandisgyrConfigFlow(ConfigFlow, domain=DOMAIN):
 
         _LOGGER.debug("Successfully connected to %s. Got data: %s", port, data)
         return data.model, data.device_number
-
-
-async def get_usb_ports(hass: HomeAssistant) -> dict[str, str]:
-    """Return a dict of USB ports and their friendly names."""
-    ports = await usb.async_scan_serial_ports(hass)
-    port_descriptions = {}
-    for port in ports:
-        if isinstance(port, usb.USBDevice):
-            human_name = usb.human_readable_device_name(
-                port.device,
-                port.serial_number,
-                port.manufacturer,
-                port.description,
-                port.vid,
-                port.pid,
-            )
-            port_descriptions[port.device] = human_name
-
-    return port_descriptions
 
 
 class CannotConnect(HomeAssistantError):

--- a/homeassistant/components/landisgyr_heat_meter/const.py
+++ b/homeassistant/components/landisgyr_heat_meter/const.py
@@ -4,5 +4,5 @@ from datetime import timedelta
 
 DOMAIN = "landisgyr_heat_meter"
 
-ULTRAHEAT_TIMEOUT = 30  # reading the IR port can take some time
+ULTRAHEAT_TIMEOUT = 60  # reading the IR port can take some time
 POLLING_INTERVAL = timedelta(days=1)  # Polling is only daily to prevent battery drain.

--- a/homeassistant/components/landisgyr_heat_meter/manifest.json
+++ b/homeassistant/components/landisgyr_heat_meter/manifest.json
@@ -3,7 +3,6 @@
   "name": "Landis+Gyr Heat Meter",
   "codeowners": ["@vpathuis"],
   "config_flow": true,
-  "dependencies": ["usb"],
   "documentation": "https://www.home-assistant.io/integrations/landisgyr_heat_meter",
   "integration_type": "device",
   "iot_class": "local_polling",

--- a/homeassistant/components/landisgyr_heat_meter/manifest.json
+++ b/homeassistant/components/landisgyr_heat_meter/manifest.json
@@ -3,6 +3,7 @@
   "name": "Landis+Gyr Heat Meter",
   "codeowners": ["@vpathuis"],
   "config_flow": true,
+  "dependencies": ["usb"],
   "documentation": "https://www.home-assistant.io/integrations/landisgyr_heat_meter",
   "integration_type": "device",
   "iot_class": "local_polling",

--- a/homeassistant/components/landisgyr_heat_meter/strings.json
+++ b/homeassistant/components/landisgyr_heat_meter/strings.json
@@ -7,11 +7,6 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },
     "step": {
-      "setup_serial_manual_path": {
-        "data": {
-          "device": "[%key:common::config_flow::data::usb_path%]"
-        }
-      },
       "user": {
         "data": {
           "device": "Select device"

--- a/tests/components/landisgyr_heat_meter/test_config_flow.py
+++ b/tests/components/landisgyr_heat_meter/test_config_flow.py
@@ -8,7 +8,6 @@ import serialx
 
 from homeassistant import config_entries
 from homeassistant.components.landisgyr_heat_meter import DOMAIN
-from homeassistant.components.usb import USBDevice
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -22,18 +21,6 @@ API_HEAT_METER_SERVICE = (
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
 
-def mock_serial_port() -> USBDevice:
-    """Mock of a serial port."""
-    return USBDevice(
-        device="/dev/ttyUSB1234",
-        vid="162E",
-        pid="269C",
-        serial_number="1234",
-        manufacturer="Virtual serial port",
-        description="Some serial port",
-    )
-
-
 @dataclass
 class MockUltraheatRead:
     """Mock of the response from the read method of the Ultraheat API."""
@@ -43,8 +30,8 @@ class MockUltraheatRead:
 
 
 @patch(API_HEAT_METER_SERVICE)
-async def test_manual_entry(mock_heat_meter, hass: HomeAssistant) -> None:
-    """Test manual entry."""
+async def test_user_flow_success(mock_heat_meter, hass: HomeAssistant) -> None:
+    """Test successful user flow."""
 
     mock_heat_meter().read.return_value = MockUltraheatRead("LUGCUH50", "123456789")
 
@@ -53,14 +40,6 @@ async def test_manual_entry(mock_heat_meter, hass: HomeAssistant) -> None:
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
-    assert result["errors"] == {}
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"device": "Enter Manually"}
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "setup_serial_manual_path"
     assert result["errors"] == {}
 
     result = await hass.config_entries.flow.async_configure(
@@ -77,38 +56,10 @@ async def test_manual_entry(mock_heat_meter, hass: HomeAssistant) -> None:
 
 
 @patch(API_HEAT_METER_SERVICE)
-@patch(
-    "homeassistant.components.landisgyr_heat_meter.config_flow.usb.async_scan_serial_ports",
-    return_value=[mock_serial_port()],
-)
-async def test_list_entry(mock_port, mock_heat_meter, hass: HomeAssistant) -> None:
-    """Test select from list entry."""
-
-    mock_heat_meter().read.return_value = MockUltraheatRead("LUGCUH50", "123456789")
-    port = mock_serial_port()
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
-    assert result["errors"] == {}
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"device": port.device}
-    )
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "LUGCUH50"
-    assert result["data"] == {
-        "device": port.device,
-        "model": "LUGCUH50",
-        "device_number": "123456789",
-    }
-
-
-@patch(API_HEAT_METER_SERVICE)
-async def test_manual_entry_fail(mock_heat_meter, hass: HomeAssistant) -> None:
-    """Test manual entry fails."""
+async def test_user_flow_cannot_connect_oserror(
+    mock_heat_meter, hass: HomeAssistant
+) -> None:
+    """Test connection failure due to OSError."""
 
     mock_heat_meter().read.side_effect = OSError("device unavailable")
 
@@ -117,62 +68,43 @@ async def test_manual_entry_fail(mock_heat_meter, hass: HomeAssistant) -> None:
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
-    assert result["errors"] == {}
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"device": "Enter Manually"}
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "setup_serial_manual_path"
-    assert result["errors"] == {}
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"device": "/dev/ttyUSB0"}
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "setup_serial_manual_path"
+    assert result["step_id"] == "user"
     assert result["errors"] == {"base": "cannot_connect"}
 
 
 @patch(API_HEAT_METER_SERVICE)
-@patch(
-    "homeassistant.components.landisgyr_heat_meter.config_flow.usb.async_scan_serial_ports",
-    return_value=[mock_serial_port()],
-)
-async def test_list_entry_fail(mock_port, mock_heat_meter, hass: HomeAssistant) -> None:
-    """Test select from list entry fails."""
+async def test_user_flow_cannot_connect_serial_exception(
+    mock_heat_meter, hass: HomeAssistant
+) -> None:
+    """Test connection failure due to serialx.SerialException."""
 
     mock_heat_meter().read.side_effect = serialx.SerialException("connection failed")
-    port = mock_serial_port()
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
-    assert result["errors"] == {}
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"device": port.device}
+        result["flow_id"], {"device": "/dev/ttyUSB0"}
     )
+
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "cannot_connect"}
 
 
 @patch(API_HEAT_METER_SERVICE)
-@patch(
-    "homeassistant.components.landisgyr_heat_meter.config_flow.usb.async_scan_serial_ports",
-    return_value=[mock_serial_port()],
-)
-async def test_already_configured(
-    mock_port, mock_heat_meter, hass: HomeAssistant
-) -> None:
+async def test_already_configured(mock_heat_meter, hass: HomeAssistant) -> None:
     """Test we abort if the Heat Meter is already configured."""
 
-    # create and add existing entry
     entry_data = {
         "device": "/dev/USB0",
         "model": "LUGCUH50",
@@ -184,16 +116,14 @@ async def test_already_configured(
     await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
-    # run flow and see if it aborts
     mock_heat_meter().read.return_value = MockUltraheatRead("LUGCUH50", "123456789")
-    port = mock_serial_port()
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"device": port.device}
+        result["flow_id"], {"device": "/dev/ttyUSB0"}
     )
 
     assert result["type"] is FlowResultType.ABORT

--- a/tests/components/landisgyr_heat_meter/test_config_flow.py
+++ b/tests/components/landisgyr_heat_meter/test_config_flow.py
@@ -68,6 +68,7 @@ async def test_user_flow_cannot_connect_oserror(
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
+    assert result["errors"] == {}
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"device": "/dev/ttyUSB0"}
@@ -91,6 +92,7 @@ async def test_user_flow_cannot_connect_serial_exception(
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
+    assert result["errors"] == {}
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"device": "/dev/ttyUSB0"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use HA’s standard SerialPortSelector instead of a custom USB port scan. 
This lets users now also pick serial ports exposed via ESPHome proxies, not just local USB devices. Removes the manual path step and the usb dependency since this is covered by the SerialPortSelector.
Setup validation timeout increased to 60s.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
