### PR TITLE
Refactor Blink config flow to use dedicated session

### DIFF
--- a/homeassistant/components/blink/config_flow.py
+++ b/homeassistant/components/blink/config_flow.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 import logging
 from typing import Any
 
+import aiohttp
 from blinkpy.auth import Auth, BlinkTwoFARequiredError, LoginError, TokenRefreshFailed
 from blinkpy.blinkpy import Blink, BlinkSetupError
 import voluptuous as vol
@@ -17,8 +18,6 @@ from homeassistant.config_entries import (
 from homeassistant.const import CONF_PASSWORD, CONF_PIN, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
-import aiohttp
 
 from .const import DOMAIN, HARDWARE_ID
 

--- a/homeassistant/components/blink/config_flow.py
+++ b/homeassistant/components/blink/config_flow.py
@@ -18,6 +18,7 @@ from homeassistant.const import CONF_PASSWORD, CONF_PIN, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import aiohttp
 
 from .const import DOMAIN, HARDWARE_ID
 
@@ -50,12 +51,16 @@ class BlinkConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def _handle_user_input(self, user_input: dict[str, Any]):
         """Handle user input."""
+        # Use a dedicated session with a real CookieJar.
+        # The shared HA aiohttp session may drop OAuth cookies between steps,
+        # causing silent 2FA failures on some Blink account configurations.
+        session = aiohttp.ClientSession(cookie_jar=aiohttp.CookieJar(unsafe=True))
         self.auth = Auth(
             {**user_input, "hardware_id": HARDWARE_ID},
             no_prompt=True,
-            session=async_get_clientsession(self.hass),
+            session=session,
         )
-        self.blink = Blink(session=async_get_clientsession(self.hass))
+        self.blink = Blink(session=session)
         self.blink.auth = self.auth
         await self.async_set_unique_id(user_input[CONF_USERNAME])
         if self.source not in (SOURCE_REAUTH, SOURCE_RECONFIGURE):

--- a/homeassistant/components/blink/config_flow.py
+++ b/homeassistant/components/blink/config_flow.py
@@ -47,6 +47,7 @@ class BlinkConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize the blink flow."""
         self.auth: Auth | None = None
         self.blink: Blink | None = None
+        self._blink_session: aiohttp.ClientSession | None = None
 
     async def _handle_user_input(self, user_input: dict[str, Any]):
         """Handle user input."""

--- a/homeassistant/components/blink/config_flow.py
+++ b/homeassistant/components/blink/config_flow.py
@@ -18,6 +18,7 @@ from homeassistant.config_entries import (
 from homeassistant.const import CONF_PASSWORD, CONF_PIN, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
 from .const import DOMAIN, HARDWARE_ID
 
@@ -54,7 +55,10 @@ class BlinkConfigFlow(ConfigFlow, domain=DOMAIN):
         # Use a dedicated session with a real CookieJar.
         # The shared HA aiohttp session may drop OAuth cookies between steps,
         # causing silent 2FA failures on some Blink account configurations.
-        self._blink_session = aiohttp.ClientSession(cookie_jar=aiohttp.CookieJar(unsafe=True))
+        # async_create_clientsession handles lifecycle management automatically.
+        self._blink_session = async_create_clientsession(
+            self.hass, cookie_jar=aiohttp.CookieJar(unsafe=True)
+        )
         self.auth = Auth(
             {**user_input, "hardware_id": HARDWARE_ID},
             no_prompt=True,
@@ -197,9 +201,6 @@ class BlinkConfigFlow(ConfigFlow, domain=DOMAIN):
     def _async_finish_flow(self) -> ConfigFlowResult:
         """Finish with setup."""
         assert self.auth
-        # Close the dedicated OAuth session; blinkpy will use its own session going forward.
-        if hasattr(self, "_blink_session") and not self._blink_session.closed:
-            self.hass.async_create_task(self._blink_session.close())
 
         if self.source in (SOURCE_REAUTH, SOURCE_RECONFIGURE):
             return self.async_update_reload_and_abort(

--- a/homeassistant/components/blink/config_flow.py
+++ b/homeassistant/components/blink/config_flow.py
@@ -53,13 +53,13 @@ class BlinkConfigFlow(ConfigFlow, domain=DOMAIN):
         # Use a dedicated session with a real CookieJar.
         # The shared HA aiohttp session may drop OAuth cookies between steps,
         # causing silent 2FA failures on some Blink account configurations.
-        session = aiohttp.ClientSession(cookie_jar=aiohttp.CookieJar(unsafe=True))
+        self._blink_session = aiohttp.ClientSession(cookie_jar=aiohttp.CookieJar(unsafe=True))
         self.auth = Auth(
             {**user_input, "hardware_id": HARDWARE_ID},
             no_prompt=True,
-            session=session,
+            session=self._blink_session,
         )
-        self.blink = Blink(session=session)
+        self.blink = Blink(session=self._blink_session)
         self.blink.auth = self.auth
         await self.async_set_unique_id(user_input[CONF_USERNAME])
         if self.source not in (SOURCE_REAUTH, SOURCE_RECONFIGURE):
@@ -196,6 +196,9 @@ class BlinkConfigFlow(ConfigFlow, domain=DOMAIN):
     def _async_finish_flow(self) -> ConfigFlowResult:
         """Finish with setup."""
         assert self.auth
+        # Close the dedicated OAuth session; blinkpy will use its own session going forward.
+        if hasattr(self, "_blink_session") and not self._blink_session.closed:
+            self.hass.async_create_task(self._blink_session.close())
 
         if self.source in (SOURCE_REAUTH, SOURCE_RECONFIGURE):
             return self.async_update_reload_and_abort(


### PR DESCRIPTION
Updated the Blink integration to use a dedicated aiohttp session with a CookieJar to prevent OAuth cookie drops during user input handling.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
No breaking changes


## Proposed change
The Blink integration currently passes HA's shared `aiohttp` session (`async_get_clientsession`) to both the `Auth` and `Blink` objects in `_handle_user_input`. This shared session can silently drop or isolate cookies between OAuth steps, causing 2FA authentication to fail even when credentials are correct.

This fix creates a dedicated `aiohttp.ClientSession` with `CookieJar(unsafe=True)` scoped to the Blink auth flow, ensuring cookie continuity across all OAuth steps.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes home-assistant/core#XXXXX
- This PR is related to issue: fronzbot/blinkpy#1217
- Link to documentation pull request: N/A (no user-visible configuration change)
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

**Context:** diagnosed by tracing the full OAuth sequence with `WARNING`-level logging on each step. The failure was consistently reproduced on HA 2026.5.0 (Docker) with a Blink account using mandatory SMS 2FA. After the fix, the 2FA PIN form is correctly displayed and the integration sets up successfully.

A companion fix for `blinkpy` (handling HTTP 202 as a 2FA-required response) is submitted separately: fronzbot/blinkpy#YYYY.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.


# PR description — home-assistant/core

**Title:** `fix(blink): use dedicated aiohttp session with CookieJar for OAuth flow`

---

## Summary

The Blink integration currently passes HA's shared `aiohttp` session (`async_get_clientsession`) to both the `Auth` and `Blink` objects. This shared session can silently drop or isolate cookies between OAuth steps, causing 2FA authentication to fail even when credentials are correct.

This fix creates a dedicated `aiohttp.ClientSession` with `CookieJar(unsafe=True)` for the duration of the Blink auth flow.

## Changes

**`homeassistant/components/blink/config_flow.py`**

```python
# Before
self.auth = Auth(
    {**user_input, "hardware_id": HARDWARE_ID},
    no_prompt=True,
    session=async_get_clientsession(self.hass),
)
self.blink = Blink(session=async_get_clientsession(self.hass))

# After
session = aiohttp.ClientSession(cookie_jar=aiohttp.CookieJar(unsafe=True))
self.auth = Auth(
    {**user_input, "hardware_id": HARDWARE_ID},
    no_prompt=True,
    session=session,
)
self.blink = Blink(session=session)
```

## Context

Diagnosed while investigating Blink 2FA failures (blinkpy issue [#1217](https://github.com/fronzbot/blinkpy/issues/1217)).

The shared HA session uses a common cookie jar across all integrations. During the Blink OAuth flow (which spans multiple sequential HTTP requests with cookie continuity requirements), cookies were being lost between the signin step and the 2FA verification step, resulting in an `empty_cookies` error from Blink's API.

A dedicated session ensures cookie isolation and persistence for the full auth flow, matching the behaviour expected by blinkpy's OAuth implementation.

## Testing

Tested on:
- Home Assistant 2026.5.0 (Docker)
- Blink account with mandatory SMS 2FA
- Previously failing: `Login failed` / `ConfigEntryNotReady` loop
- After fix: 2FA form displayed correctly, PIN accepted, integration active

## Related

- blinkpy issue: fronzbot/blinkpy#1217
- blinkpy PR: https://github.com/fronzbot/blinkpy/pull/1228

