### PR TITLE
Add KEBA P40 integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -949,6 +949,8 @@ CLAUDE.md @home-assistant/core
 /homeassistant/components/karakeep/ @sli-cka
 /tests/components/karakeep/ @sli-cka
 /homeassistant/components/keba/ @dannerph
+/homeassistant/components/keba_p40/ @lpostiglione
+/tests/components/keba_p40/ @lpostiglione
 /homeassistant/components/keenetic_ndms2/ @foxel
 /tests/components/keenetic_ndms2/ @foxel
 /homeassistant/components/kef/ @basnijholt

--- a/homeassistant/brands/keba.json
+++ b/homeassistant/brands/keba.json
@@ -1,0 +1,5 @@
+{
+  "domain": "keba",
+  "name": "KEBA",
+  "integrations": ["keba", "keba_p40"]
+}

--- a/homeassistant/components/keba_p40/__init__.py
+++ b/homeassistant/components/keba_p40/__init__.py
@@ -1,0 +1,31 @@
+"""The KEBA P40 integration."""
+
+from keba_kecontact_p40 import KebaP40Client
+
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import PLATFORMS
+from .coordinator import KebaP40ConfigEntry, KebaP40DataUpdateCoordinator
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: KebaP40ConfigEntry) -> bool:
+    """Set up KEBA P40 from a config entry."""
+    client = KebaP40Client(
+        entry.data[CONF_HOST],
+        entry.data[CONF_PASSWORD],
+        session=async_get_clientsession(hass, verify_ssl=False),
+        port=entry.data[CONF_PORT],
+    )
+    assert entry.unique_id is not None
+    coordinator = KebaP40DataUpdateCoordinator(hass, entry, client, entry.unique_id)
+    await coordinator.async_config_entry_first_refresh()
+    entry.runtime_data = coordinator
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: KebaP40ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/keba_p40/config_flow.py
+++ b/homeassistant/components/keba_p40/config_flow.py
@@ -1,0 +1,77 @@
+"""Config flow for the KEBA P40 integration."""
+
+from typing import Any, override
+
+from keba_kecontact_p40 import (
+    KebaP40AuthError,
+    KebaP40Client,
+    KebaP40ConnectionError,
+    KebaP40Error,
+)
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.selector import (
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
+
+from .const import DEFAULT_PORT, DOMAIN
+
+USER_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+        vol.Required(CONF_PASSWORD): TextSelector(
+            TextSelectorConfig(
+                type=TextSelectorType.PASSWORD,
+                autocomplete="current-password",
+            )
+        ),
+    }
+)
+
+
+class KebaP40ConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for KEBA P40."""
+
+    @override
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            client = KebaP40Client(
+                user_input[CONF_HOST],
+                user_input[CONF_PASSWORD],
+                session=async_get_clientsession(self.hass, verify_ssl=False),
+                port=user_input[CONF_PORT],
+            )
+            try:
+                await client.login()
+                wallboxes = await client.get_wallboxes()
+            except KebaP40AuthError:
+                errors["base"] = "invalid_auth"
+            except KebaP40ConnectionError:
+                errors["base"] = "cannot_connect"
+            except KebaP40Error:
+                errors["base"] = "unknown"
+            else:
+                if not wallboxes:
+                    errors["base"] = "no_wallbox"
+                else:
+                    wallbox = wallboxes[0]
+                    await self.async_set_unique_id(wallbox.serial_number)
+                    self._abort_if_unique_id_configured()
+                    return self.async_create_entry(
+                        title=wallbox.alias or wallbox.model or "KEBA P40",
+                        data=user_input,
+                    )
+
+        return self.async_show_form(
+            step_id="user", data_schema=USER_SCHEMA, errors=errors
+        )

--- a/homeassistant/components/keba_p40/const.py
+++ b/homeassistant/components/keba_p40/const.py
@@ -1,0 +1,12 @@
+"""Constants for the KEBA P40 integration."""
+
+from datetime import timedelta
+
+from homeassistant.const import Platform
+
+DOMAIN = "keba_p40"
+MANUFACTURER = "KEBA"
+DEFAULT_PORT = 8443
+SCAN_INTERVAL = timedelta(seconds=30)
+
+PLATFORMS: list[Platform] = [Platform.SENSOR]

--- a/homeassistant/components/keba_p40/coordinator.py
+++ b/homeassistant/components/keba_p40/coordinator.py
@@ -1,0 +1,72 @@
+"""Data update coordinator for KEBA P40."""
+
+from dataclasses import dataclass
+import logging
+from typing import override
+
+from keba_kecontact_p40 import (
+    KebaP40AuthError,
+    KebaP40Client,
+    KebaP40Error,
+    LoadManagement,
+    Wallbox,
+)
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN, SCAN_INTERVAL
+
+_LOGGER = logging.getLogger(__name__)
+
+type KebaP40ConfigEntry = ConfigEntry[KebaP40DataUpdateCoordinator]
+
+
+@dataclass
+class KebaP40Data:
+    """Polled data for one wallbox."""
+
+    wallbox: Wallbox
+    load_management: LoadManagement
+
+
+class KebaP40DataUpdateCoordinator(DataUpdateCoordinator[KebaP40Data]):
+    """Coordinator that polls one KEBA P40 wallbox."""
+
+    config_entry: KebaP40ConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: KebaP40ConfigEntry,
+        client: KebaP40Client,
+        serial: str,
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=entry,
+            name=DOMAIN,
+            update_interval=SCAN_INTERVAL,
+        )
+        self.client = client
+        self.serial = serial
+
+    @override
+    async def _async_update_data(self) -> KebaP40Data:
+        """Fetch the latest wallbox state and load-management bounds."""
+        try:
+            wallbox = await self.client.get_wallbox(self.serial)
+            load_management = await self.client.get_load_management()
+        except KebaP40AuthError as err:
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN, translation_key="auth_failed"
+            ) from err
+        except KebaP40Error as err:
+            raise UpdateFailed(
+                translation_domain=DOMAIN, translation_key="update_failed"
+            ) from err
+        return KebaP40Data(wallbox=wallbox, load_management=load_management)

--- a/homeassistant/components/keba_p40/entity.py
+++ b/homeassistant/components/keba_p40/entity.py
@@ -1,0 +1,51 @@
+"""Base entity for KEBA P40."""
+
+from typing import override
+
+from keba_kecontact_p40 import Wallbox, WallboxState
+
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import EntityDescription
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, MANUFACTURER
+from .coordinator import KebaP40DataUpdateCoordinator
+
+
+class KebaP40Entity(CoordinatorEntity[KebaP40DataUpdateCoordinator]):
+    """Base class for all KEBA P40 entities."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: KebaP40DataUpdateCoordinator,
+        description: EntityDescription,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.serial}_{description.key}"
+        wallbox = coordinator.data.wallbox
+        data = coordinator.config_entry.data
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.serial)},
+            manufacturer=MANUFACTURER,
+            name=wallbox.alias or wallbox.model,
+            model=wallbox.model,
+            sw_version=wallbox.firmware_version,
+            serial_number=coordinator.serial,
+            configuration_url=f"https://{data[CONF_HOST]}:{data[CONF_PORT]}",
+        )
+
+    @property
+    def _wallbox(self) -> Wallbox:
+        """Return the current wallbox data."""
+        return self.coordinator.data.wallbox
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return True unless polling failed or the wallbox is offline."""
+        return super().available and self._wallbox.state is not WallboxState.OFFLINE

--- a/homeassistant/components/keba_p40/manifest.json
+++ b/homeassistant/components/keba_p40/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "keba_p40",
+  "name": "KEBA P40",
+  "codeowners": ["@lpostiglione"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/keba_p40",
+  "integration_type": "device",
+  "iot_class": "local_polling",
+  "loggers": ["keba_kecontact_p40"],
+  "quality_scale": "bronze",
+  "requirements": ["keba-kecontact-p40==0.1.0"]
+}

--- a/homeassistant/components/keba_p40/quality_scale.yaml
+++ b/homeassistant/components/keba_p40/quality_scale.yaml
@@ -1,0 +1,79 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: Integration provides no custom service actions.
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow: done
+  config-flow-test-coverage: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: Integration provides no custom service actions.
+  docs-conditions:
+    status: exempt
+    comment: This integration does not have any conditions.
+  docs-triggers:
+    status: exempt
+    comment: This integration does not have any triggers.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  entity-event-setup:
+    status: exempt
+    comment: >-
+      Entities use a DataUpdateCoordinator and do not subscribe to external
+      events.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: Integration provides no custom service actions.
+  config-entry-unloading: done
+  docs-configuration-parameters:
+    status: exempt
+    comment: The integration has no options flow.
+  docs-installation-parameters: done
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: done
+  reauthentication-flow: todo
+  test-coverage: done
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery: todo
+  discovery-update-info: todo
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices:
+    status: exempt
+    comment: One config entry maps to a single wallbox.
+  entity-category: done
+  entity-device-class: done
+  entity-disabled-by-default: done
+  entity-translations: done
+  exception-translations: done
+  icon-translations: todo
+  reconfiguration-flow: todo
+  repair-issues: todo
+  stale-devices:
+    status: exempt
+    comment: One config entry maps to a single wallbox.
+  # Platinum
+  async-dependency: done
+  inject-websession: done
+  strict-typing: todo

--- a/homeassistant/components/keba_p40/sensor.py
+++ b/homeassistant/components/keba_p40/sensor.py
@@ -1,0 +1,228 @@
+"""Sensor platform for KEBA P40."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import override
+
+from keba_kecontact_p40 import Wallbox, WallboxState
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import (
+    PERCENTAGE,
+    EntityCategory,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfTemperature,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.typing import StateType
+
+from .coordinator import KebaP40ConfigEntry
+from .entity import KebaP40Entity
+
+PARALLEL_UPDATES = 0
+
+
+def _line_current(wallbox: Wallbox, index: int) -> float | None:
+    if wallbox.meter is None or len(wallbox.meter.lines) <= index:
+        return None
+    value = wallbox.meter.lines[index].current_ma
+    return None if value is None else value / 1000
+
+
+def _line_voltage(wallbox: Wallbox, index: int) -> int | None:
+    if wallbox.meter is None or len(wallbox.meter.lines) <= index:
+        return None
+    return wallbox.meter.lines[index].voltage_v
+
+
+@dataclass(frozen=True, kw_only=True)
+class KebaP40SensorDescription(SensorEntityDescription):
+    """Describes a KEBA P40 sensor."""
+
+    value_fn: Callable[[Wallbox], StateType]
+
+
+SENSORS: tuple[KebaP40SensorDescription, ...] = (
+    KebaP40SensorDescription(
+        key="status",
+        translation_key="status",
+        device_class=SensorDeviceClass.ENUM,
+        options=[state.value.lower() for state in WallboxState],
+        value_fn=lambda wb: wb.state.value.lower() if wb.state else None,
+    ),
+    KebaP40SensorDescription(
+        key="power",
+        translation_key="power",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        value_fn=lambda wb: (
+            None
+            if wb.meter is None or wb.meter.power_mw is None
+            else wb.meter.power_mw / 1000
+        ),
+    ),
+    KebaP40SensorDescription(
+        key="energy",
+        translation_key="energy",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
+        value_fn=lambda wb: (
+            None
+            if wb.meter is None or wb.meter.energy_mwh is None
+            else wb.meter.energy_mwh / 1_000_000
+        ),
+    ),
+    KebaP40SensorDescription(
+        key="current_offered",
+        translation_key="current_offered",
+        device_class=SensorDeviceClass.CURRENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        value_fn=lambda wb: (
+            None
+            if wb.meter is None or wb.meter.current_offered_ma is None
+            else wb.meter.current_offered_ma / 1000
+        ),
+    ),
+    KebaP40SensorDescription(
+        key="temperature",
+        translation_key="temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda wb: (
+            None
+            if wb.meter is None or wb.meter.temperature_centi_c is None
+            else wb.meter.temperature_centi_c / 100
+        ),
+    ),
+    KebaP40SensorDescription(
+        key="power_factor",
+        translation_key="power_factor",
+        device_class=SensorDeviceClass.POWER_FACTOR,
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda wb: (
+            None
+            if wb.meter is None or wb.meter.power_factor is None
+            else wb.meter.power_factor / 10
+        ),
+    ),
+    KebaP40SensorDescription(
+        key="max_current",
+        translation_key="max_current",
+        device_class=SensorDeviceClass.CURRENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda wb: (
+            None if wb.max_current_ma is None else wb.max_current_ma / 1000
+        ),
+    ),
+    KebaP40SensorDescription(
+        key="error_code",
+        translation_key="error_code",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda wb: wb.error_code,
+    ),
+    KebaP40SensorDescription(
+        key="voltage_l1",
+        translation_key="voltage_l1",
+        device_class=SensorDeviceClass.VOLTAGE,
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+        value_fn=lambda wb: _line_voltage(wb, 0),
+    ),
+    KebaP40SensorDescription(
+        key="voltage_l2",
+        translation_key="voltage_l2",
+        device_class=SensorDeviceClass.VOLTAGE,
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+        value_fn=lambda wb: _line_voltage(wb, 1),
+    ),
+    KebaP40SensorDescription(
+        key="voltage_l3",
+        translation_key="voltage_l3",
+        device_class=SensorDeviceClass.VOLTAGE,
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+        value_fn=lambda wb: _line_voltage(wb, 2),
+    ),
+    KebaP40SensorDescription(
+        key="current_l1",
+        translation_key="current_l1",
+        device_class=SensorDeviceClass.CURRENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        entity_registry_enabled_default=False,
+        value_fn=lambda wb: _line_current(wb, 0),
+    ),
+    KebaP40SensorDescription(
+        key="current_l2",
+        translation_key="current_l2",
+        device_class=SensorDeviceClass.CURRENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        entity_registry_enabled_default=False,
+        value_fn=lambda wb: _line_current(wb, 1),
+    ),
+    KebaP40SensorDescription(
+        key="current_l3",
+        translation_key="current_l3",
+        device_class=SensorDeviceClass.CURRENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        entity_registry_enabled_default=False,
+        value_fn=lambda wb: _line_current(wb, 2),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: KebaP40ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the KEBA P40 sensors."""
+    coordinator = entry.runtime_data
+    async_add_entities(
+        KebaP40Sensor(coordinator, description) for description in SENSORS
+    )
+
+
+class KebaP40Sensor(KebaP40Entity, SensorEntity):
+    """A KEBA P40 sensor."""
+
+    entity_description: KebaP40SensorDescription
+
+    @property
+    @override
+    def native_value(self) -> StateType:
+        """Return the sensor value."""
+        return self.entity_description.value_fn(self._wallbox)

--- a/homeassistant/components/keba_p40/strings.json
+++ b/homeassistant/components/keba_p40/strings.json
@@ -1,0 +1,64 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "no_wallbox": "No wallbox was found on this device.",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "password": "[%key:common::config_flow::data::password%]",
+          "port": "[%key:common::config_flow::data::port%]"
+        },
+        "data_description": {
+          "host": "The IP address or hostname of your KEBA P40 wallbox.",
+          "password": "The password for the wallbox 'admin' web/REST user.",
+          "port": "The REST API port (default 8443)."
+        }
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "current_l1": { "name": "Current L1" },
+      "current_l2": { "name": "Current L2" },
+      "current_l3": { "name": "Current L3" },
+      "current_offered": { "name": "Current offered" },
+      "energy": { "name": "Energy" },
+      "error_code": { "name": "Error code" },
+      "max_current": { "name": "Maximum current" },
+      "power": { "name": "Power" },
+      "power_factor": { "name": "Power factor" },
+      "status": {
+        "name": "Status",
+        "state": {
+          "charging": "Charging",
+          "degraded": "Degraded",
+          "idle": "Idle",
+          "installer_mode": "Installer mode",
+          "offline": "Offline",
+          "ready_for_charging": "Ready for charging",
+          "recover_from_error": "Recovering from error",
+          "suspended": "Suspended",
+          "token_programming_mode": "Token programming mode",
+          "unavailable": "Unavailable",
+          "unrecoverable_error": "Unrecoverable error"
+        }
+      },
+      "temperature": { "name": "Temperature" },
+      "voltage_l1": { "name": "Voltage L1" },
+      "voltage_l2": { "name": "Voltage L2" },
+      "voltage_l3": { "name": "Voltage L3" }
+    }
+  },
+  "exceptions": {
+    "auth_failed": { "message": "Authentication with the KEBA P40 failed." },
+    "update_failed": { "message": "Error communicating with the KEBA P40." }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -391,6 +391,7 @@ FLOWS = {
         "jvc_projector",
         "kaleidescape",
         "karakeep",
+        "keba_p40",
         "keenetic_ndms2",
         "kegtron",
         "keymitt_ble",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -3513,10 +3513,21 @@
       "iot_class": "local_polling"
     },
     "keba": {
-      "name": "Keba Charging Station",
-      "integration_type": "hub",
-      "config_flow": false,
-      "iot_class": "local_polling"
+      "name": "KEBA",
+      "integrations": {
+        "keba": {
+          "integration_type": "hub",
+          "config_flow": false,
+          "iot_class": "local_polling",
+          "name": "Keba Charging Station"
+        },
+        "keba_p40": {
+          "integration_type": "device",
+          "config_flow": true,
+          "iot_class": "local_polling",
+          "name": "KEBA P40"
+        }
+      }
     },
     "keenetic_ndms2": {
       "name": "Keenetic NDMS2 Router",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1419,6 +1419,9 @@ justnimbus==0.7.4
 # homeassistant.components.kaiterra
 kaiterra-async-client==1.1.0
 
+# homeassistant.components.keba_p40
+keba-kecontact-p40==0.1.0
+
 # homeassistant.components.keba
 keba-kecontact==1.3.0
 

--- a/tests/components/keba_p40/__init__.py
+++ b/tests/components/keba_p40/__init__.py
@@ -1,0 +1,12 @@
+"""Tests for the KEBA P40 integration."""
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+    """Add the config entry and set up the integration."""
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/components/keba_p40/conftest.py
+++ b/tests/components/keba_p40/conftest.py
@@ -1,0 +1,75 @@
+"""Fixtures for KEBA P40 tests."""
+
+from collections.abc import Generator
+import json
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from keba_kecontact_p40 import LoadManagement, Wallbox
+import pytest
+
+from homeassistant.components.keba_p40.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
+
+from tests.common import MockConfigEntry, load_fixture
+
+
+@pytest.fixture
+def mock_wallbox() -> Wallbox:
+    """Return a parsed Wallbox from the fixture."""
+    data: dict[str, Any] = json.loads(load_fixture("wallbox.json", DOMAIN))
+    return Wallbox.from_api(data)
+
+
+@pytest.fixture
+def mock_load_management() -> LoadManagement:
+    """Return parsed load management from the fixture."""
+    data: dict[str, Any] = json.loads(load_fixture("lmgmt.json", DOMAIN))
+    return LoadManagement.from_api(data)
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a mocked config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Garage",
+        unique_id="21900042",
+        data={
+            CONF_HOST: "1.2.3.4",
+            CONF_PORT: 8443,
+            CONF_PASSWORD: "hunter2",
+        },
+    )
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.keba_p40.async_setup_entry", return_value=True
+    ) as mock_setup:
+        yield mock_setup
+
+
+@pytest.fixture
+def mock_client(
+    mock_wallbox: Wallbox, mock_load_management: LoadManagement
+) -> Generator[AsyncMock]:
+    """Mock the KebaP40Client used by both the config flow and setup."""
+    with (
+        patch(
+            "homeassistant.components.keba_p40.config_flow.KebaP40Client",
+            autospec=True,
+        ) as client_class,
+        patch(
+            "homeassistant.components.keba_p40.KebaP40Client",
+            new=client_class,
+        ),
+    ):
+        client = client_class.return_value
+        client.login = AsyncMock(return_value=None)
+        client.get_wallboxes = AsyncMock(return_value=[mock_wallbox])
+        client.get_wallbox = AsyncMock(return_value=mock_wallbox)
+        client.get_load_management = AsyncMock(return_value=mock_load_management)
+        yield client

--- a/tests/components/keba_p40/fixtures/lmgmt.json
+++ b/tests/components/keba_p40/fixtures/lmgmt.json
@@ -1,0 +1,7 @@
+{
+  "configs": [
+    { "key": "max_available_current", "value": 32000 },
+    { "key": "min_default_current", "value": 6000 },
+    { "key": "load_management", "value": true }
+  ]
+}

--- a/tests/components/keba_p40/fixtures/wallbox.json
+++ b/tests/components/keba_p40/fixtures/wallbox.json
@@ -1,0 +1,33 @@
+{
+  "serialNumber": "21900042",
+  "number": 1,
+  "model": "P40 Pro",
+  "alias": "Garage",
+  "firmwareVersion": "1.2.3",
+  "firmwareVersionMetering": "4.5.6",
+  "firmwareVersionSafety": "7.8.9",
+  "ipAddress": "192.168.1.50",
+  "state": "CHARGING",
+  "vehiclePlugged": true,
+  "sessionActive": true,
+  "maxCurrent": 32000,
+  "maxPhases": 3,
+  "phaseUsed": "L1_L2_L3",
+  "permanentlyLocked": false,
+  "reserved": false,
+  "authorizationEnabled": true,
+  "errorCode": "0",
+  "meter": {
+    "meterValue": 1706672700,
+    "totalActivePower": 11040000,
+    "totalPowerFactor": 999,
+    "phasesSupported": 3,
+    "currentOffered": 16000,
+    "temperature": 2416,
+    "lines": [
+      { "socketPhase": "L1", "current": 16000, "voltage": 230 },
+      { "socketPhase": "L2", "current": 16000, "voltage": 231 },
+      { "socketPhase": "L3", "current": 16000, "voltage": 229 }
+    ]
+  }
+}

--- a/tests/components/keba_p40/snapshots/test_sensor.ambr
+++ b/tests/components/keba_p40/snapshots/test_sensor.ambr
@@ -1,0 +1,819 @@
+# serializer version: 1
+# name: test_sensors[sensor.garage_current_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.garage_current_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current L1',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+    'original_icon': None,
+    'original_name': 'Current L1',
+    'platform': 'keba_p40',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'current_l1',
+    'unique_id': '21900042_current_l1',
+    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+  })
+# ---
+# name: test_sensors[sensor.garage_current_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'current',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Current L1',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garage_current_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '16.0',
+  })
+# ---
+# name: test_sensors[sensor.garage_current_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.garage_current_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current L2',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+    'original_icon': None,
+    'original_name': 'Current L2',
+    'platform': 'keba_p40',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'current_l2',
+    'unique_id': '21900042_current_l2',
+    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+  })
+# ---
+# name: test_sensors[sensor.garage_current_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'current',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Current L2',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garage_current_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '16.0',
+  })
+# ---
+# name: test_sensors[sensor.garage_current_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.garage_current_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current L3',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+    'original_icon': None,
+    'original_name': 'Current L3',
+    'platform': 'keba_p40',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'current_l3',
+    'unique_id': '21900042_current_l3',
+    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+  })
+# ---
+# name: test_sensors[sensor.garage_current_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'current',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Current L3',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garage_current_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '16.0',
+  })
+# ---
+# name: test_sensors[sensor.garage_current_offered-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.garage_current_offered',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current offered',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+    'original_icon': None,
+    'original_name': 'Current offered',
+    'platform': 'keba_p40',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'current_offered',
+    'unique_id': '21900042_current_offered',
+    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+  })
+# ---
+# name: test_sensors[sensor.garage_current_offered-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'current',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Current offered',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garage_current_offered',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '16.0',
+  })
+# ---
+# name: test_sensors[sensor.garage_energy-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.garage_energy',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Energy',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': None,
+    'original_name': 'Energy',
+    'platform': 'keba_p40',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'energy',
+    'unique_id': '21900042_energy',
+    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+  })
+# ---
+# name: test_sensors[sensor.garage_energy-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'energy',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Energy',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garage_energy',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1706.6727',
+  })
+# ---
+# name: test_sensors[sensor.garage_error_code-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.garage_error_code',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Error code',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Error code',
+    'platform': 'keba_p40',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'error_code',
+    'unique_id': '21900042_error_code',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.garage_error_code-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Error code',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garage_error_code',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensors[sensor.garage_maximum_current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.garage_maximum_current',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Maximum current',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+    'original_icon': None,
+    'original_name': 'Maximum current',
+    'platform': 'keba_p40',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'max_current',
+    'unique_id': '21900042_max_current',
+    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+  })
+# ---
+# name: test_sensors[sensor.garage_maximum_current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'current',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Maximum current',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garage_maximum_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '32.0',
+  })
+# ---
+# name: test_sensors[sensor.garage_power-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.garage_power',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Power',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Power',
+    'platform': 'keba_p40',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power',
+    'unique_id': '21900042_power',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+  })
+# ---
+# name: test_sensors[sensor.garage_power-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Power',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garage_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '11040.0',
+  })
+# ---
+# name: test_sensors[sensor.garage_power_factor-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.garage_power_factor',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Power factor',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.POWER_FACTOR: 'power_factor'>,
+    'original_icon': None,
+    'original_name': 'Power factor',
+    'platform': 'keba_p40',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_factor',
+    'unique_id': '21900042_power_factor',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[sensor.garage_power_factor-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power_factor',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Power factor',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garage_power_factor',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '99.9',
+  })
+# ---
+# name: test_sensors[sensor.garage_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'charging',
+        'idle',
+        'ready_for_charging',
+        'recover_from_error',
+        'installer_mode',
+        'suspended',
+        'token_programming_mode',
+        'unrecoverable_error',
+        'unavailable',
+        'offline',
+        'degraded',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.garage_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Status',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Status',
+    'platform': 'keba_p40',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'status',
+    'unique_id': '21900042_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.garage_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Status',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'charging',
+        'idle',
+        'ready_for_charging',
+        'recover_from_error',
+        'installer_mode',
+        'suspended',
+        'token_programming_mode',
+        'unrecoverable_error',
+        'unavailable',
+        'offline',
+        'degraded',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garage_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'charging',
+  })
+# ---
+# name: test_sensors[sensor.garage_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.garage_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'keba_p40',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'temperature',
+    'unique_id': '21900042_temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[sensor.garage_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Temperature',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garage_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '24.16',
+  })
+# ---
+# name: test_sensors[sensor.garage_voltage_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.garage_voltage_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Voltage L1',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': None,
+    'original_name': 'Voltage L1',
+    'platform': 'keba_p40',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'voltage_l1',
+    'unique_id': '21900042_voltage_l1',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_sensors[sensor.garage_voltage_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'voltage',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Voltage L1',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garage_voltage_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '230',
+  })
+# ---
+# name: test_sensors[sensor.garage_voltage_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.garage_voltage_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Voltage L2',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': None,
+    'original_name': 'Voltage L2',
+    'platform': 'keba_p40',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'voltage_l2',
+    'unique_id': '21900042_voltage_l2',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_sensors[sensor.garage_voltage_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'voltage',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Voltage L2',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garage_voltage_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '231',
+  })
+# ---
+# name: test_sensors[sensor.garage_voltage_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.garage_voltage_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Voltage L3',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': None,
+    'original_name': 'Voltage L3',
+    'platform': 'keba_p40',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'voltage_l3',
+    'unique_id': '21900042_voltage_l3',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_sensors[sensor.garage_voltage_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'voltage',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Voltage L3',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garage_voltage_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '229',
+  })
+# ---

--- a/tests/components/keba_p40/test_config_flow.py
+++ b/tests/components/keba_p40/test_config_flow.py
@@ -1,0 +1,100 @@
+"""Tests for the KEBA P40 config flow."""
+
+from unittest.mock import AsyncMock
+
+from keba_kecontact_p40 import KebaP40AuthError, KebaP40ConnectionError, KebaP40Error
+import pytest
+
+from homeassistant.components.keba_p40.const import DOMAIN
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+USER_INPUT = {CONF_HOST: "1.2.3.4", CONF_PORT: 8443, CONF_PASSWORD: "hunter2"}
+
+
+@pytest.mark.usefixtures("mock_client", "mock_setup_entry")
+async def test_user_flow_success(hass: HomeAssistant) -> None:
+    """Test a successful user flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert not result["errors"]
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Garage"
+    assert result["data"] == USER_INPUT
+    assert result["result"].unique_id == "21900042"
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        (KebaP40AuthError, "invalid_auth"),
+        (KebaP40ConnectionError, "cannot_connect"),
+        (KebaP40Error, "unknown"),
+    ],
+)
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_user_flow_errors(
+    hass: HomeAssistant,
+    mock_client: AsyncMock,
+    error: type[Exception],
+    expected: str,
+) -> None:
+    """Test the user flow surfaces errors then recovers."""
+    mock_client.login.side_effect = error
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": expected}
+
+    mock_client.login.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+@pytest.mark.usefixtures("mock_client", "mock_setup_entry")
+async def test_already_configured(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test we abort if the wallbox is already configured."""
+    mock_config_entry.add_to_hass(hass)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_user_flow_no_wallbox(
+    hass: HomeAssistant,
+    mock_client: AsyncMock,
+) -> None:
+    """Test the user flow handles an empty wallbox list."""
+    mock_client.get_wallboxes.return_value = []
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "no_wallbox"}

--- a/tests/components/keba_p40/test_init.py
+++ b/tests/components/keba_p40/test_init.py
@@ -1,0 +1,48 @@
+"""Tests for KEBA P40 setup and teardown."""
+
+from unittest.mock import AsyncMock
+
+from keba_kecontact_p40 import KebaP40AuthError, KebaP40ConnectionError
+import pytest
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.usefixtures("mock_client")
+async def test_setup_and_unload(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test a config entry sets up and unloads."""
+    await setup_integration(hass, mock_config_entry)
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_setup_connection_error_retries(
+    hass: HomeAssistant,
+    mock_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a connection error puts the entry in SETUP_RETRY."""
+    mock_client.get_wallbox.side_effect = KebaP40ConnectionError
+    await setup_integration(hass, mock_config_entry)
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_auth_error_triggers_reauth(
+    hass: HomeAssistant,
+    mock_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test an auth error puts the entry in SETUP_ERROR."""
+    mock_client.get_wallbox.side_effect = KebaP40AuthError
+    await setup_integration(hass, mock_config_entry)
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR

--- a/tests/components/keba_p40/test_sensor.py
+++ b/tests/components/keba_p40/test_sensor.py
@@ -1,0 +1,52 @@
+"""Tests for KEBA P40 sensors."""
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from keba_kecontact_p40 import Wallbox
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.keba_p40.const import DOMAIN
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, async_load_fixture, snapshot_platform
+
+
+@pytest.mark.usefixtures("mock_client", "entity_registry_enabled_by_default")
+async def test_sensors(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the KEBA P40 sensors via snapshot."""
+    with patch("homeassistant.components.keba_p40.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_line_sensors_none_without_lines(
+    hass: HomeAssistant,
+    mock_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test line current/voltage sensors return None when meter has no lines."""
+    data: dict[str, Any] = json.loads(
+        await async_load_fixture(hass, "wallbox.json", DOMAIN)
+    )
+    data["meter"]["lines"] = []
+    wallbox_no_lines = Wallbox.from_api(data)
+    mock_client.get_wallbox.return_value = wallbox_no_lines
+    with patch("homeassistant.components.keba_p40.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    assert hass.states.get("sensor.garage_voltage_l1").state == "unknown"
+    assert hass.states.get("sensor.garage_current_l1").state == "unknown"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds a new `keba_p40` integration for **KEBA P40 / P40 Pro** wallboxes. It talks to the device's **local REST API** (v3.0.3) over HTTPS on port 8443 with JWT authentication, polling the wallbox every 30 seconds via a `DataUpdateCoordinator`.

All protocol, HTTP and JWT logic lives in a new dedicated, async PyPI library — [`keba-kecontact-p40`](https://github.com/lpostiglione/keba-kecontact-p40) (MIT, public CI, tagged release, `py.typed`) — so the integration itself is a thin wrapper.

Per review feedback, this initial PR is limited to a **single platform**:
- **sensor** – status, power, energy, current offered, temperature, power factor, maximum current, error code, and per-phase voltage/current (per-phase and diagnostic sensors are disabled by default)

The remaining platforms (`binary_sensor`, `switch`, `select`, `number`, `lock`) are ready and will follow in separate per-platform PRs once this one lands.

The existing legacy `keba` (P30) integration is left completely untouched; both are grouped under a single "KEBA" brand via `homeassistant/brands/keba.json`.

The integration targets the **Bronze** quality scale and ships with 100% test coverage and a `quality_scale.yaml`.

### Why a separate integration (not an extension of `keba`)

The P40 speaks a completely different protocol from the P30 — a local HTTPS REST API (this PR) versus the P30's UDP-based protocol — and exposes a substantially larger and different sensor/feature set. Folding both device families into the existing `keba` integration would constrain the P40's data model and risk limiting its sensors as P40 firmware evolves. The author/maintainer of the existing `keba` integration, @dannerph, reached the same conclusion ([comment](https://github.com/dannerph/homeassistant-keba/pull/58#issuecomment-4325932024)): given how significantly the P40 differs, sharing one integration is not the best option. A dedicated `keba_p40` integration keeps each device family's model clean; the shared `homeassistant/brands/keba.json` still groups both under one "KEBA" brand in the UI.

### Scope

As requested in review, the PR was trimmed to the `sensor` platform. The scope is otherwise kept deliberately tight — no diagnostics, no custom services, no reauthentication, and no discovery — all reserved for follow-up PRs. The branch has also been rebased onto current `dev` (new `docs-triggers`/`docs-conditions` quality-scale rules, explicit `@override`, updated snapshot serialization).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45784
- Link to developer documentation pull request: 
- Link to frontend pull request: 

New supporting library (**new dependency**, initial release): https://github.com/lpostiglione/keba-kecontact-p40 — `keba-kecontact-p40==0.1.0` ([release notes](https://github.com/lpostiglione/keba-kecontact-p40/releases/tag/v0.1.0)), published to PyPI. As this is the dependency's first release, there is no prior version to diff against.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

