### PR TITLE
Support streaming updates for V1 Roborock devices

### DIFF
--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -1,5 +1,6 @@
 """Roborock Coordinator."""
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
@@ -21,7 +22,7 @@ from roborock.roborock_message import (
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_CONNECTIONS
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -117,6 +118,7 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceState | None]):
         # to the base class. This is reset on successful data update.
         self._last_update_success_time: datetime | None = None
         self._has_connected_locally: bool = False
+        self._unsubs: list[Callable[[], None]] = []
 
     @cached_property
     def dock_device_info(self) -> DeviceInfo:
@@ -170,6 +172,15 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceState | None]):
         else:
             # Force a map refresh on first setup
             self.last_home_update = dt_util.utcnow() - IMAGE_CACHE_INTERVAL
+
+        self._unsubs.append(
+            self.properties_api.status.add_update_listener(self._handle_trait_update)
+        )
+        self._unsubs.append(
+            self.properties_api.consumables.add_update_listener(
+                self._handle_trait_update
+            )
+        )
 
     async def update_map(self) -> None:
         """Update the currently selected map."""
@@ -268,12 +279,7 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceState | None]):
         self.last_update_state = self.properties_api.status.state_name
         self._last_update_success_time = dt_util.utcnow()
         _LOGGER.debug("Data update successful %s", self._last_update_success_time)
-        return DeviceState(
-            status=self.properties_api.status,
-            dnd_timer=self.properties_api.dnd,
-            consumable=self.properties_api.consumables,
-            clean_summary=self.properties_api.clean_summary,
-        )
+        return self._device_state
 
     def _should_suppress_update_failure(self) -> bool:
         """Determine if we should suppress update failure reporting.
@@ -291,6 +297,31 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceState | None]):
         failure_duration = dt_util.utcnow() - self._last_update_success_time
         _LOGGER.debug("Update failure duration: %s", failure_duration)
         return failure_duration < MIN_UNAVAILABLE_DURATION
+
+    @property
+    def _device_state(self) -> DeviceState:
+        """Return the current device state."""
+        return DeviceState(
+            status=self.properties_api.status,
+            dnd_timer=self.properties_api.dnd,
+            consumable=self.properties_api.consumables,
+            clean_summary=self.properties_api.clean_summary,
+        )
+
+    @callback
+    def _handle_trait_update(self) -> None:
+        """Handle trait updates from push notifications."""
+        _LOGGER.debug("Trait updated, updating coordinator data")
+        self.async_set_updated_data(self._device_state)
+        # We optimize streaming updates to catch state transitions immediately, but
+        # secondary updates (like refreshing the map) can happen on their own interval.
+
+    async def async_shutdown(self) -> None:
+        """Shutdown coordinator and unsubscribe update listeners."""
+        await super().async_shutdown()
+        for unsub in self._unsubs:
+            unsub()
+        self._unsubs.clear()
 
     async def get_routines(self) -> list[HomeDataScene]:
         """Get routines."""

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -709,3 +709,35 @@ async def test_all_devices_disabled(
         )
         assert device_entry is not None
         assert device_entry.disabled
+
+
+@pytest.mark.parametrize("platforms", [[Platform.SENSOR]])
+async def test_v1_streaming_updates(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    fake_vacuum: FakeDevice,
+) -> None:
+    """Test that V1 push updates update entity states immediately."""
+    assert setup_entry.state is ConfigEntryState.LOADED
+
+    sensor_entity_id = "sensor.roborock_s7_maxv_battery"
+    state = hass.states.get(sensor_entity_id)
+    assert state is not None
+    assert state.state == "100"
+
+    # Verify that add_update_listener was called on the mock status trait
+    status_trait = fake_vacuum.v1_properties.status
+    assert status_trait.add_update_listener.called
+
+    # Get the registered callback
+    callback_func = status_trait.add_update_listener.call_args[0][0]  # type: ignore[union-attr]
+
+    # Update a status attribute and trigger the callback
+    status_trait.battery = 85
+    callback_func()
+    await hass.async_block_till_done()
+
+    # Check if the state was updated in Home Assistant immediately
+    state = hass.states.get(sensor_entity_id)
+    assert state is not None
+    assert state.state == "85"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, the Roborock integration uses polling to fetch status and consumable state for V1 devices. The underlying `python-roborock` library natively supports push-based updates for both status and consumables on V1 devices and exposes update listeners on these traits.

This PR adds streaming/push updates support to the `RoborockDataUpdateCoordinator` for V1 devices by registering update listeners on the `status` and `consumables` traits. This allows state transitions (e.g. state, battery, and consumables changes) to propagate immediately to the Home Assistant entity state without waiting for the polling intervals. Map refreshes are left to occur on their own background polling intervals to optimize performance.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #160182
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
