### PR TITLE
Fix Duco box device removal on partial node refreshes

### DIFF
--- a/homeassistant/components/duco/const.py
+++ b/homeassistant/components/duco/const.py
@@ -7,3 +7,4 @@ from homeassistant.const import Platform
 DOMAIN = "duco"
 PLATFORMS = [Platform.FAN, Platform.SENSOR]
 SCAN_INTERVAL = timedelta(seconds=10)
+BOX_NODE_ID = 1

--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -24,14 +24,13 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN
+from .const import BOX_NODE_ID, DOMAIN
 from .coordinator import DucoConfigEntry, DucoCoordinator
 from .entity import DucoEntity
 
 _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
-BOX_NODE_ID = 1
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -159,6 +159,8 @@ async def async_setup_entry(
         # The firmware removes deregistered RF/wired nodes automatically.
         # BSRH box sensors that are physically unplugged from the PCB are
         # not deregistered by the firmware and will never appear here as stale.
+        # The BOX node can transiently disappear from the API response, so keep
+        # node 1 to avoid removing the main controller device.
         stale_node_ids = {
             node_id
             for node_id in known_nodes - coordinator.data.nodes.keys()

--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -31,6 +31,7 @@ from .entity import DucoEntity
 _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
+BOX_NODE_ID = 1
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -158,7 +159,11 @@ async def async_setup_entry(
         # The firmware removes deregistered RF/wired nodes automatically.
         # BSRH box sensors that are physically unplugged from the PCB are
         # not deregistered by the firmware and will never appear here as stale.
-        stale_node_ids = known_nodes - coordinator.data.nodes.keys()
+        stale_node_ids = {
+            node_id
+            for node_id in known_nodes - coordinator.data.nodes.keys()
+            if node_id != BOX_NODE_ID
+        }
         if stale_node_ids:
             device_reg = dr.async_get(hass)
             mac = entry.unique_id

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -18,6 +18,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.duco.const import DOMAIN, SCAN_INTERVAL
+from homeassistant.components.duco.sensor import BOX_NODE_ID
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -234,7 +235,7 @@ async def test_box_node_not_removed_on_transient_incomplete_node_list(
     assert hass.states.get("fan.living") is not None
 
     mock_duco_client.async_get_nodes.return_value = [
-        node for node in mock_sensor_nodes if node.node_id != 1
+        node for node in mock_sensor_nodes if node.node_id != BOX_NODE_ID
     ]
 
     freezer.tick(SCAN_INTERVAL)

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -223,29 +223,15 @@ async def test_box_node_not_removed_on_transient_incomplete_node_list(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test BOX-linked entities survive a transient node list without node 1."""
-    diagnostic_entity_id = entity_registry.async_get_entity_id(
-        Platform.SENSOR,
-        DOMAIN,
-        f"{mock_config_entry.unique_id}_1_ventilation_diagnostic",
-    )
-
     await setup_platform_integration(
         hass, mock_config_entry, [Platform.FAN, Platform.SENSOR]
     )
-
-    if diagnostic_entity_id is None:
-        diagnostic_entity_id = entity_registry.async_get_entity_id(
-            Platform.SENSOR,
-            DOMAIN,
-            f"{mock_config_entry.unique_id}_1_ventilation_diagnostic",
-        )
 
     box_device = device_registry.async_get_device(
         identifiers={(DOMAIN, f"{mock_config_entry.unique_id}_1")}
     )
     assert box_device is not None
     assert hass.states.get("fan.living") is not None
-    assert diagnostic_entity_id is not None
 
     mock_duco_client.async_get_nodes.return_value = [
         node for node in mock_sensor_nodes if node.node_id != 1
@@ -265,8 +251,6 @@ async def test_box_node_not_removed_on_transient_incomplete_node_list(
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
 
-    assert entity_registry.async_get(diagnostic_entity_id) is not None
-
     mock_duco_client.async_get_nodes.return_value = mock_sensor_nodes
 
     freezer.tick(SCAN_INTERVAL)
@@ -276,8 +260,6 @@ async def test_box_node_not_removed_on_transient_incomplete_node_list(
     state = hass.states.get("fan.living")
     assert state is not None
     assert state.state != STATE_UNAVAILABLE
-
-    assert entity_registry.async_get(diagnostic_entity_id) is not None
 
 
 @pytest.mark.usefixtures("init_integration")

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -212,6 +212,74 @@ async def test_deregistered_node_removes_device(
     assert device is None
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_box_node_not_removed_on_transient_incomplete_node_list(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_duco_client: AsyncMock,
+    mock_sensor_nodes: list[Node],
+    freezer: FrozenDateTimeFactory,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test BOX-linked entities survive a transient node list without node 1."""
+    diagnostic_entity_id = entity_registry.async_get_entity_id(
+        Platform.SENSOR,
+        DOMAIN,
+        f"{mock_config_entry.unique_id}_1_ventilation_diagnostic",
+    )
+
+    await setup_platform_integration(
+        hass, mock_config_entry, [Platform.FAN, Platform.SENSOR]
+    )
+
+    if diagnostic_entity_id is None:
+        diagnostic_entity_id = entity_registry.async_get_entity_id(
+            Platform.SENSOR,
+            DOMAIN,
+            f"{mock_config_entry.unique_id}_1_ventilation_diagnostic",
+        )
+
+    box_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{mock_config_entry.unique_id}_1")}
+    )
+    assert box_device is not None
+    assert hass.states.get("fan.living") is not None
+    assert diagnostic_entity_id is not None
+
+    mock_duco_client.async_get_nodes.return_value = [
+        node for node in mock_sensor_nodes if node.node_id != 1
+    ]
+
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert (
+        device_registry.async_get_device(
+            identifiers={(DOMAIN, f"{mock_config_entry.unique_id}_1")}
+        )
+        is not None
+    )
+    state = hass.states.get("fan.living")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+    assert entity_registry.async_get(diagnostic_entity_id) is not None
+
+    mock_duco_client.async_get_nodes.return_value = mock_sensor_nodes
+
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get("fan.living")
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+
+    assert entity_registry.async_get(diagnostic_entity_id) is not None
+
+
 @pytest.mark.usefixtures("init_integration")
 async def test_unknown_node_type_logs_warning_and_creates_no_entities(
     hass: HomeAssistant,

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -17,8 +17,7 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.duco.const import DOMAIN, SCAN_INTERVAL
-from homeassistant.components.duco.sensor import BOX_NODE_ID
+from homeassistant.components.duco.const import BOX_NODE_ID, DOMAIN, SCAN_INTERVAL
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -229,7 +228,7 @@ async def test_box_node_not_removed_on_transient_incomplete_node_list(
     )
 
     box_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{mock_config_entry.unique_id}_1")}
+        identifiers={(DOMAIN, f"{mock_config_entry.unique_id}_{BOX_NODE_ID}")}
     )
     assert box_device is not None
     assert hass.states.get("fan.living") is not None
@@ -244,7 +243,7 @@ async def test_box_node_not_removed_on_transient_incomplete_node_list(
 
     assert (
         device_registry.async_get_device(
-            identifiers={(DOMAIN, f"{mock_config_entry.unique_id}_1")}
+            identifiers={(DOMAIN, f"{mock_config_entry.unique_id}_{BOX_NODE_ID}")}
         )
         is not None
     )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Exclude node 1 from automatic stale-device cleanup so transiently incomplete node lists do not remove the Duco box device.
- Add a regression test that verifies the box device and fan entity survive a partial refresh and recover on the next successful update.
- Move the shared Duco box node ID constant to `const.py` so platform modules and tests use one integration-level source of truth.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
