### PR TITLE
Fix uncaught Duco diagnostics client errors

### DIFF
--- a/homeassistant/components/duco/diagnostics.py
+++ b/homeassistant/components/duco/diagnostics.py
@@ -3,7 +3,7 @@
 from dataclasses import asdict
 from typing import Any
 
-from duco_connectivity.exceptions import DucoConnectionError
+from duco_connectivity.exceptions import DucoConnectionError, DucoError
 
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.const import CONF_HOST
@@ -51,6 +51,12 @@ async def async_get_config_entry_diagnostics(
         raise HomeAssistantError(
             translation_domain=DOMAIN,
             translation_key="connection_error",
+        ) from err
+    except DucoError as err:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="api_error",
+            translation_placeholders={"error": repr(err)},
         ) from err
 
     api_info: dict[str, Any] = {"public_api_version": api_info_obj.public_api_version}

--- a/tests/components/duco/test_diagnostics.py
+++ b/tests/components/duco/test_diagnostics.py
@@ -4,7 +4,12 @@ from dataclasses import replace
 from http import HTTPStatus
 from unittest.mock import AsyncMock
 
-from duco_connectivity import ApiInfo, DucoConnectionError
+from duco_connectivity import ApiInfo
+from duco_connectivity.exceptions import (
+    DucoConnectionError,
+    DucoError,
+    DucoResponseError,
+)
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -34,25 +39,40 @@ async def test_diagnostics(
 
 @pytest.mark.usefixtures("init_integration")
 @pytest.mark.parametrize(
-    "failing_method",
+    ("failing_method", "raised_error"),
     [
-        "async_get_api_info",
-        "async_get_lan_info",
-        "async_get_diagnostics",
-        "async_get_write_requests_remaining",
+        pytest.param(
+            "async_get_api_info",
+            DucoConnectionError("Server disconnected"),
+            id="api-info-connection-error",
+        ),
+        pytest.param(
+            "async_get_lan_info",
+            DucoConnectionError("Server disconnected"),
+            id="lan-info-connection-error",
+        ),
+        pytest.param(
+            "async_get_diagnostics",
+            DucoResponseError(500, "/info", "bad response"),
+            id="diagnostics-response-error",
+        ),
+        pytest.param(
+            "async_get_write_requests_remaining",
+            DucoResponseError(500, "/info", "bad response"),
+            id="write-budget-response-error",
+        ),
     ],
 )
-async def test_diagnostics_connection_error(
+async def test_diagnostics_client_error(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     mock_config_entry: MockConfigEntry,
     mock_duco_client: AsyncMock,
     failing_method: str,
+    raised_error: DucoError,
 ) -> None:
-    """Test that a connection error during diagnostics returns a 500 response."""
-    getattr(mock_duco_client, failing_method).side_effect = DucoConnectionError(
-        "Server disconnected"
-    )
+    """Test that client errors during diagnostics return a 500 response."""
+    getattr(mock_duco_client, failing_method).side_effect = raised_error
     assert await async_setup_component(hass, DIAGNOSTICS_DOMAIN, {})
     await hass.async_block_till_done()
     client = await hass_client()

--- a/tests/components/duco/test_diagnostics.py
+++ b/tests/components/duco/test_diagnostics.py
@@ -14,12 +14,41 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.diagnostics import DOMAIN as DIAGNOSTICS_DOMAIN
+from homeassistant.components.duco.diagnostics import async_get_config_entry_diagnostics
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
+
+CLIENT_ERROR_CASES = [
+    pytest.param(
+        "async_get_api_info",
+        DucoConnectionError("Server disconnected"),
+        "connection_error",
+        id="api-info-connection-error",
+    ),
+    pytest.param(
+        "async_get_lan_info",
+        DucoConnectionError("Server disconnected"),
+        "connection_error",
+        id="lan-info-connection-error",
+    ),
+    pytest.param(
+        "async_get_diagnostics",
+        DucoResponseError(500, "/info", "bad response"),
+        "api_error",
+        id="diagnostics-response-error",
+    ),
+    pytest.param(
+        "async_get_write_requests_remaining",
+        DucoResponseError(500, "/info", "bad response"),
+        "api_error",
+        id="write-budget-response-error",
+    ),
+]
 
 
 @pytest.mark.usefixtures("init_integration")
@@ -39,29 +68,8 @@ async def test_diagnostics(
 
 @pytest.mark.usefixtures("init_integration")
 @pytest.mark.parametrize(
-    ("failing_method", "raised_error"),
-    [
-        pytest.param(
-            "async_get_api_info",
-            DucoConnectionError("Server disconnected"),
-            id="api-info-connection-error",
-        ),
-        pytest.param(
-            "async_get_lan_info",
-            DucoConnectionError("Server disconnected"),
-            id="lan-info-connection-error",
-        ),
-        pytest.param(
-            "async_get_diagnostics",
-            DucoResponseError(500, "/info", "bad response"),
-            id="diagnostics-response-error",
-        ),
-        pytest.param(
-            "async_get_write_requests_remaining",
-            DucoResponseError(500, "/info", "bad response"),
-            id="write-budget-response-error",
-        ),
-    ],
+    ("failing_method", "raised_error", "translation_key"),
+    CLIENT_ERROR_CASES,
 )
 async def test_diagnostics_client_error(
     hass: HomeAssistant,
@@ -70,8 +78,10 @@ async def test_diagnostics_client_error(
     mock_duco_client: AsyncMock,
     failing_method: str,
     raised_error: DucoError,
+    translation_key: str,
 ) -> None:
     """Test that client errors during diagnostics return a 500 response."""
+    del translation_key
     getattr(mock_duco_client, failing_method).side_effect = raised_error
     assert await async_setup_component(hass, DIAGNOSTICS_DOMAIN, {})
     await hass.async_block_till_done()
@@ -82,6 +92,28 @@ async def test_diagnostics_client_error(
     assert response.status == HTTPStatus.INTERNAL_SERVER_ERROR
 
 
+@pytest.mark.usefixtures("init_integration")
+@pytest.mark.parametrize(
+    ("failing_method", "raised_error", "translation_key"),
+    CLIENT_ERROR_CASES,
+)
+async def test_diagnostics_client_error_translation_key(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_duco_client: AsyncMock,
+    failing_method: str,
+    raised_error: DucoError,
+    translation_key: str,
+) -> None:
+    """Test that diagnostics client errors map to the expected translation key."""
+    getattr(mock_duco_client, failing_method).side_effect = raised_error
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await async_get_config_entry_diagnostics(hass, mock_config_entry)
+
+    assert exc_info.value.translation_key == translation_key
+
+
 async def test_diagnostics_without_optional_software_version(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -90,7 +122,7 @@ async def test_diagnostics_without_optional_software_version(
 ) -> None:
     """Test that an optional software version is omitted from diagnostics."""
     # BoardInfo is a frozen dataclass, so the mock must be updated before
-    # integration setup — the coordinator stores board_info during async_setup.
+    # integration setup - the coordinator stores board_info during async_setup.
     mock_duco_client.async_get_board_info.return_value = replace(
         mock_duco_client.async_get_board_info.return_value,
         software_version=None,

--- a/tests/components/duco/test_diagnostics.py
+++ b/tests/components/duco/test_diagnostics.py
@@ -14,9 +14,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.diagnostics import DOMAIN as DIAGNOSTICS_DOMAIN
-from homeassistant.components.duco.diagnostics import async_get_config_entry_diagnostics
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -27,25 +25,21 @@ CLIENT_ERROR_CASES = [
     pytest.param(
         "async_get_api_info",
         DucoConnectionError("Server disconnected"),
-        "connection_error",
         id="api-info-connection-error",
     ),
     pytest.param(
         "async_get_lan_info",
         DucoConnectionError("Server disconnected"),
-        "connection_error",
         id="lan-info-connection-error",
     ),
     pytest.param(
         "async_get_diagnostics",
         DucoResponseError(500, "/info", "bad response"),
-        "api_error",
         id="diagnostics-response-error",
     ),
     pytest.param(
         "async_get_write_requests_remaining",
         DucoResponseError(500, "/info", "bad response"),
-        "api_error",
         id="write-budget-response-error",
     ),
 ]
@@ -68,7 +62,7 @@ async def test_diagnostics(
 
 @pytest.mark.usefixtures("init_integration")
 @pytest.mark.parametrize(
-    ("failing_method", "raised_error", "translation_key"),
+    ("failing_method", "raised_error"),
     CLIENT_ERROR_CASES,
 )
 async def test_diagnostics_client_error(
@@ -78,10 +72,8 @@ async def test_diagnostics_client_error(
     mock_duco_client: AsyncMock,
     failing_method: str,
     raised_error: DucoError,
-    translation_key: str,
 ) -> None:
     """Test that client errors during diagnostics return a 500 response."""
-    del translation_key
     getattr(mock_duco_client, failing_method).side_effect = raised_error
     assert await async_setup_component(hass, DIAGNOSTICS_DOMAIN, {})
     await hass.async_block_till_done()
@@ -90,28 +82,6 @@ async def test_diagnostics_client_error(
         f"/api/diagnostics/config_entry/{mock_config_entry.entry_id}"
     )
     assert response.status == HTTPStatus.INTERNAL_SERVER_ERROR
-
-
-@pytest.mark.usefixtures("init_integration")
-@pytest.mark.parametrize(
-    ("failing_method", "raised_error", "translation_key"),
-    CLIENT_ERROR_CASES,
-)
-async def test_diagnostics_client_error_translation_key(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_duco_client: AsyncMock,
-    failing_method: str,
-    raised_error: DucoError,
-    translation_key: str,
-) -> None:
-    """Test that diagnostics client errors map to the expected translation key."""
-    getattr(mock_duco_client, failing_method).side_effect = raised_error
-
-    with pytest.raises(HomeAssistantError) as exc_info:
-        await async_get_config_entry_diagnostics(hass, mock_config_entry)
-
-    assert exc_info.value.translation_key == translation_key
 
 
 async def test_diagnostics_without_optional_software_version(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Catch broader Duco client exceptions in diagnostics so API-side failures such as `DucoResponseError` do not bubble out of the diagnostics endpoint unchecked.

Also extend the diagnostics regression test to cover both connection failures and response failures across the affected client calls.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
