### PR TITLE
Bump blinkpy to 0.25.5

### DIFF
--- a/homeassistant/components/blink/config_flow.py
+++ b/homeassistant/components/blink/config_flow.py
@@ -27,15 +27,17 @@ _LOGGER = logging.getLogger(__name__)
 async def validate_input(blink: Blink) -> None:
     """Validate the user input allows us to connect."""
     try:
-        await blink.start()
+        result = await blink.start()
     except (LoginError, TokenRefreshFailed) as err:
         raise InvalidAuth from err
+    if not result:
+        raise InvalidAuth
 
 
-async def _send_blink_2fa_pin(blink: Blink, pin: str | None) -> bool:
+async def _send_blink_2fa_pin(blink: Blink, pin: str | None) -> None:
     """Send 2FA pin to blink servers."""
-    await blink.send_2fa_code(pin)
-    return True
+    if not await blink.send_2fa_code(pin):
+        raise BlinkSetupError
 
 
 class BlinkConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -97,6 +99,7 @@ class BlinkConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle 2FA step."""
         errors = {}
         if user_input is not None:
+            assert self.blink is not None
             try:
                 await _send_blink_2fa_pin(self.blink, user_input.get(CONF_PIN))
             except BlinkSetupError:

--- a/homeassistant/components/blink/manifest.json
+++ b/homeassistant/components/blink/manifest.json
@@ -21,5 +21,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "loggers": ["blinkpy"],
-  "requirements": ["blinkpy==0.25.2"]
+  "requirements": ["blinkpy==0.25.5"]
 }

--- a/homeassistant/components/blink/strings.json
+++ b/homeassistant/components/blink/strings.json
@@ -2,7 +2,8 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -666,7 +666,7 @@ bleak==3.0.2
 blebox-uniapi==2.5.4
 
 # homeassistant.components.blink
-blinkpy==0.25.2
+blinkpy==0.25.5
 
 # homeassistant.components.bitcoin
 blockchain==1.4.4

--- a/tests/components/blink/test_config_flow.py
+++ b/tests/components/blink/test_config_flow.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from blinkpy.auth import BlinkTwoFARequiredError, LoginError, TokenRefreshFailed
 from blinkpy.blinkpy import BlinkSetupError
 
@@ -39,10 +41,6 @@ async def test_form_2fa(hass: HomeAssistant) -> None:
             return_value=True,
         ),
         patch(
-            "homeassistant.components.blink.config_flow.Blink.setup_urls",
-            return_value=True,
-        ),
-        patch(
             "homeassistant.components.blink.async_setup_entry", return_value=True
         ) as mock_setup_entry,
     ):
@@ -57,9 +55,18 @@ async def test_form_2fa(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_2fa_connect_error(hass: HomeAssistant) -> None:
-    """Test we report a connect error during 2fa setup."""
-
+@pytest.mark.parametrize(
+    ("side_effect", "error_key"),
+    [
+        pytest.param(BlinkSetupError, "cannot_connect", id="connect_error"),
+        pytest.param(TokenRefreshFailed, "invalid_access_token", id="invalid_key"),
+        pytest.param(Exception, "unknown", id="unknown_error"),
+    ],
+)
+async def test_form_2fa_error(
+    hass: HomeAssistant, side_effect: type[Exception], error_key: str
+) -> None:
+    """Test we report errors during 2fa setup."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -80,7 +87,7 @@ async def test_form_2fa_connect_error(hass: HomeAssistant) -> None:
         patch("homeassistant.components.blink.config_flow.Blink.start"),
         patch(
             "homeassistant.components.blink.config_flow.Blink.send_2fa_code",
-            side_effect=BlinkSetupError,
+            side_effect=side_effect,
         ),
         patch(
             "homeassistant.components.blink.async_setup_entry",
@@ -92,85 +99,7 @@ async def test_form_2fa_connect_error(hass: HomeAssistant) -> None:
         )
 
     assert result3["type"] is FlowResultType.FORM
-    assert result3["errors"] == {"base": "cannot_connect"}
-
-
-async def test_form_2fa_invalid_key(hass: HomeAssistant) -> None:
-    """Test we report an error if key is invalid."""
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    with patch(
-        "homeassistant.components.blink.config_flow.Blink.start",
-        side_effect=BlinkTwoFARequiredError,
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {"username": "blink@example.com", "password": "example"},
-        )
-
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == "2fa"
-
-    with (
-        patch(
-            "homeassistant.components.blink.config_flow.Blink.start",
-        ),
-        patch(
-            "homeassistant.components.blink.config_flow.Blink.send_2fa_code",
-            side_effect=TokenRefreshFailed,
-        ),
-        patch(
-            "homeassistant.components.blink.async_setup_entry",
-            return_value=True,
-        ),
-    ):
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"], {"pin": "1234"}
-        )
-
-    assert result3["type"] is FlowResultType.FORM
-    assert result3["errors"] == {"base": "invalid_access_token"}
-
-
-async def test_form_2fa_unknown_error(hass: HomeAssistant) -> None:
-    """Test we report an unknown error during 2fa setup."""
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    with patch(
-        "homeassistant.components.blink.config_flow.Blink.start",
-        side_effect=BlinkTwoFARequiredError,
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {"username": "blink@example.com", "password": "example"},
-        )
-
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == "2fa"
-
-    with (
-        patch("homeassistant.components.blink.config_flow.Blink.start"),
-        patch(
-            "homeassistant.components.blink.config_flow.Blink.send_2fa_code",
-            side_effect=Exception,
-        ),
-        patch(
-            "homeassistant.components.blink.async_setup_entry",
-            return_value=True,
-        ),
-    ):
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"], {"pin": "1234"}
-        )
-
-    assert result3["type"] is FlowResultType.FORM
-    assert result3["errors"] == {"base": "unknown"}
+    assert result3["errors"] == {"base": error_key}
 
 
 async def test_form_invalid_auth(hass: HomeAssistant) -> None:
@@ -219,3 +148,152 @@ async def test_reauth_shows_user_step(hass: HomeAssistant) -> None:
     result = await mock_entry.start_reauth_flow(hass)
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
+
+
+async def test_reauth_completes(hass: HomeAssistant) -> None:
+    """Test successful reauth updates the entry and reloads."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"username": "blink@example.com", "password": "invalid_password"},
+    )
+    mock_entry.add_to_hass(hass)
+    result = await mock_entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    with (
+        patch(
+            "homeassistant.components.blink.config_flow.Blink.start",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.blink.async_setup_entry", return_value=True
+        ),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"username": "blink@example.com", "password": "new_password"},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.ABORT
+    assert result2["reason"] == "reauth_successful"
+
+
+async def test_form_user(hass: HomeAssistant) -> None:
+    """Test successful setup without 2FA."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with (
+        patch(
+            "homeassistant.components.blink.config_flow.Blink.start",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.blink.async_setup_entry", return_value=True
+        ) as mock_setup_entry,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"username": "blink@example.com", "password": "example"},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "blink"
+    assert result2["result"].unique_id == "blink@example.com"
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_start_failed(hass: HomeAssistant) -> None:
+    """Test we handle when blink.start() returns False without raising."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.blink.config_flow.Blink.start",
+        return_value=False,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"username": "blink@example.com", "password": "example"}
+        )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_2fa_send_failed(hass: HomeAssistant) -> None:
+    """Test we handle when send_2fa_code returns False."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.blink.config_flow.Blink.start",
+        side_effect=BlinkTwoFARequiredError,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"username": "blink@example.com", "password": "example"},
+        )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "2fa"
+
+    with patch(
+        "homeassistant.components.blink.config_flow.Blink.send_2fa_code",
+        return_value=False,
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"], {"pin": "1234"}
+        )
+
+    assert result3["type"] is FlowResultType.FORM
+    assert result3["errors"] == {"base": "cannot_connect"}
+
+
+async def test_reconfigure_shows_form(hass: HomeAssistant) -> None:
+    """Test reconfigure shows the reconfigure form."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"username": "blink@example.com", "password": "old_password"},
+    )
+    mock_entry.add_to_hass(hass)
+    result = await mock_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+
+async def test_reconfigure_completes(hass: HomeAssistant) -> None:
+    """Test successful reconfiguration updates the entry and reloads."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"username": "blink@example.com", "password": "old_password"},
+    )
+    mock_entry.add_to_hass(hass)
+    result = await mock_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    with (
+        patch(
+            "homeassistant.components.blink.config_flow.Blink.start",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.blink.async_setup_entry", return_value=True
+        ),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"username": "blink@example.com", "password": "new_password"},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.ABORT
+    assert result2["reason"] == "reconfigure_successful"

--- a/tests/components/blink/test_config_flow.py
+++ b/tests/components/blink/test_config_flow.py
@@ -2,10 +2,9 @@
 
 from unittest.mock import patch
 
-import pytest
-
 from blinkpy.auth import BlinkTwoFARequiredError, LoginError, TokenRefreshFailed
 from blinkpy.blinkpy import BlinkSetupError
+import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.blink import DOMAIN
@@ -166,9 +165,7 @@ async def test_reauth_completes(hass: HomeAssistant) -> None:
             "homeassistant.components.blink.config_flow.Blink.start",
             return_value=True,
         ),
-        patch(
-            "homeassistant.components.blink.async_setup_entry", return_value=True
-        ),
+        patch("homeassistant.components.blink.async_setup_entry", return_value=True),
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -285,9 +282,7 @@ async def test_reconfigure_completes(hass: HomeAssistant) -> None:
             "homeassistant.components.blink.config_flow.Blink.start",
             return_value=True,
         ),
-        patch(
-            "homeassistant.components.blink.async_setup_entry", return_value=True
-        ),
+        patch("homeassistant.components.blink.async_setup_entry", return_value=True),
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/components/blink/test_config_flow.py
+++ b/tests/components/blink/test_config_flow.py
@@ -175,6 +175,7 @@ async def test_reauth_completes(hass: HomeAssistant) -> None:
 
     assert result2["type"] is FlowResultType.ABORT
     assert result2["reason"] == "reauth_successful"
+    assert mock_entry.data["password"] == "new_password"
 
 
 async def test_form_user(hass: HomeAssistant) -> None:
@@ -292,3 +293,4 @@ async def test_reconfigure_completes(hass: HomeAssistant) -> None:
 
     assert result2["type"] is FlowResultType.ABORT
     assert result2["reason"] == "reconfigure_successful"
+    assert mock_entry.data["password"] == "new_password"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bumps `blinkpy` from 0.25.2 to 0.25.5.

Additionally fixes auth error handling in the config flow:
- `validate_input` now checks the return value of `blink.start()` and raises `InvalidAuth` if it returns falsy (previously a falsy return was silently ignored).
- `_send_blink_2fa_pin` now raises `BlinkSetupError` when `send_2fa_code` returns falsy instead of returning `True` unconditionally.
- Added `reconfigure_successful` abort message to `strings.json`.
- Improved test coverage: merged duplicate 2FA error tests into a parametrized test, added tests for invalid auth and unknown errors at startup, and added reauth/reconfigure flow tests.

Diff: https://github.com/fronzbot/blinkpy/compare/v0.25.2...v0.25.5

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: https://github.com/home-assistant/core/issues/166494
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
